### PR TITLE
[WIP] Convert Dialog Edit tree to use TreeBuilder

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -162,6 +162,27 @@ class MiqAeCustomizationController < ApplicationController
     tree_select
   end
 
+  def edit_dialog_node_data(node)
+    nodes = x_node.split('xx-')
+    case nodes.length
+    when 1
+      {:type => 'root'}
+    when 2
+      {:type => 'tab',
+       :data => @edit[:new][:tabs].find{ |x| x[:id] == nodes.last.to_i},
+       :children => @edit[:new][:tabs].find{ |x| x[:id] == nodes.last.to_i}[:groups]}
+    when 3
+      {:type => 'group',
+       :data => @edit[:new][:tabs].find{ |x| x[:id] == nodes[1].delete('_').to_i}[:groups].find{ |x| x[:id] == nodes.last.to_i},
+       :children => @edit[:new][:tabs].find{ |x| x[:id] == nodes[1].delete('_').to_i}[:groups].find{ |x| x[:id] == nodes.last.to_i}[:fields],
+       :parent_id => nodes[1].delete('_').to_i}
+    when 4
+      {:type => 'field',
+       :data => @edit[:new][:tabs].find{ |x| x[:id] == nodes[1].delete('_').to_i}[:groups].find{ |x| x[:id] == nodes[2].delete('_').to_i}[:fields].find{ |x| x[:id] == nodes.last.to_i},
+       :parent_id => nodes[2].delete('_').to_i}
+    end
+  end
+
   private
 
   def features
@@ -208,7 +229,10 @@ class MiqAeCustomizationController < ApplicationController
       trees[:ab]           = ab_build_tree                if replace_trees.include?(:ab)
       trees[:old_dialogs]  = old_dialogs_build_tree       if replace_trees.include?(:old_dialogs)
       trees[:dialogs]      = dialog_build_tree            if replace_trees.include?(:dialogs)
-      trees[:dialog_edit]  = dialog_edit_build_tree       if replace_trees.include?(:dialog_edit)
+      if replace_trees.include?(:dialog_edit)
+        get_field_types if @edit[:field_types].nil?
+        trees[:dialog_edit]  = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
+      end
     end
 
     @explorer = true

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -1246,7 +1246,6 @@ module MiqAeCustomizationController::Dialogs
     get_field_types if @edit[:field_types].nil?
     @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
     x_node_set("root", :dialog_edit_tree)     # always set it to root for edit tree
-
     session[:edit] = @edit
   end
 

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -20,12 +20,12 @@ module MiqAeCustomizationController::Dialogs
     dialog_get_form_vars
 
     # dialog_edit_set_form_vars
-    dialog_edit_build_tree
+    #dialog_edit_build_tree
     dialog_sort_values if (params[:field_data_typ] || params[:field_sort_by] ||
         params[:field_sort_order]) && @edit[:field_sort_by].to_s != "none"
     @_params[:typ] = ""
     get_field_types
-
+    @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
     # Use JS to update the display
     render :update do |page|
       page << javascript_prologue
@@ -149,7 +149,6 @@ module MiqAeCustomizationController::Dialogs
     if valid
       @sb[:node_typ] = params[:typ]
       @sb[:edit_typ] = "add"
-      # dialog_edit_build_tree(:dialog_edit,:dialog_edit_tree)
       nodes = x_node.split('_')
 
       case params[:typ]
@@ -295,7 +294,9 @@ module MiqAeCustomizationController::Dialogs
         self.x_node = "#{nodes[0]}_#{nodes[1]}_#{nodes[2]}"
       end
     end
-    dialog_edit_build_tree
+    #dialog_edit_build_tree
+    get_field_types if @edit[:field_types].nil?
+    @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
     @sb[:edit_typ] = nil
     replace_right_cell(x_node, [:dialog_edit])
   end
@@ -417,7 +418,10 @@ module MiqAeCustomizationController::Dialogs
 
     parent[name] = temp
 
-    dialog_edit_build_tree
+    #dialog_edit_build_tree
+    get_field_types if @edit[:field_types].nil?
+    @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
+
     render :update do |page|
       page << javascript_prologue
       session[:changed] = changed = (@edit[:new] != @edit[:current])
@@ -1108,7 +1112,9 @@ module MiqAeCustomizationController::Dialogs
 
       @sb[:node_typ] = "element" if params[:action] != "dialog_form_field_changed"
     end
-    dialog_edit_build_tree
+    #dialog_edit_build_tree
+    get_field_types if @edit[:field_types].nil?
+    @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
     session[:changed] = (@edit[:new] != @edit[:current])
     session[:edit] = @edit
   end
@@ -1251,7 +1257,9 @@ module MiqAeCustomizationController::Dialogs
     end
 
     @edit[:current] = copy_hash(@edit[:new])
-    dialog_edit_build_tree
+    #dialog_edit_build_tree
+    get_field_types if @edit[:field_types].nil?
+    @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
     x_node_set("root", :dialog_edit_tree)     # always set it to root for edit tree
 
     session[:edit] = @edit

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -138,7 +138,7 @@ module MiqAeCustomizationController::Dialogs
     replace_right_cell(x_node)
   end
 
-  # add resource to a dialog
+  # TODO add resource to a dialog
   def dialog_res_add
     id = params[:id].strip == "" ? "new" : params[:id]
     return unless load_edit("dialog_edit__#{id}", "replace_cell__explorer")
@@ -300,21 +300,13 @@ module MiqAeCustomizationController::Dialogs
     @sb[:edit_typ] = nil
     replace_right_cell(x_node, [:dialog_edit])
   end
-
+# TODO remove selected node with toolbar button
   def dialog_resource_remove
     assert_privileges("dialog_resource_remove")
     # need to set widget_id using curr_pos and id of the element in @edit[:new]
-    nodes = x_node.split('_')
-    selected_node = nodes.last.split('-')
-    @_params[:widget_id] = "#{selected_node.last}_#{selected_node.first}"
-    case nodes.length
-    when 2
-      @_params[:typ] = "tab"
-    when 3
-      @_params[:typ] = "box"
-    when 4
-      @_params[:typ] = "element"
-    end
+    nodes = edit_dialog_node_data(x_node)
+    #selected_node = nodes.last.split('-')
+    @_params[:widget_id] = nodes[:data][:id]
     dialog_res_remove
   end
 
@@ -323,55 +315,56 @@ module MiqAeCustomizationController::Dialogs
     id = params[:id].strip == "" ? "new" : params[:id]
     return unless load_edit("dialog_edit__#{id}", "replace_cell__explorer")
     @record = @edit[:dialog]
-    nodes = x_node.split('_')
-    if nodes.length == 1 || params[:typ] == "tab"     # Remove tab was pressed
+    nodes = edit_dialog_node_data(x_node)
+    if nodes[:type] == 'root'     # Remove tab was pressed
       # need to delete tab and it's groups/fields
       idx = nil
       @edit[:new][:tabs].each_with_index do |tab, i|
-        idx = i if tab[:id] == params[:widget_id].split('_').last.to_i
+        idx = i if tab[:id] == params[:widget_id].to_i
       end
-      # if object hasn't been added to db yet, use current position to delete the selected widget
+      # TODO if object hasn't been added to db yet, use current position to delete the selected widget
       idx = params[:widget_id].split('_').first.to_i if idx.nil?
       # saving in sandbox before deleting, to be used if discard button is pressed
       @sb[:tabs] = copy_array(@edit[:new][:tabs])
       @edit[:new][:tabs].delete_at(idx) if idx
-    elsif nodes.length == 2 || params[:typ] == "box"    # Remove group was pressed
+    elsif nodes[:type] == 'tab'   # Remove group was pressed
       # need to delete group and it's fields
       idx = nil
-      groups = @edit[:new][:tabs][nodes[1].split('-').last.to_i][:groups]
+      groups = nodes[:children]
       groups.each_with_index do |group, i|
-        idx = i if group[:id] == params[:widget_id].split('_').last.to_i
+        idx = i if group[:id] == params[:widget_id].to_i
       end
-      # if object hasn't been added to db yet, use current position to delete the selected widget
+      # TODO if object hasn't been added to db yet, use current position to delete the selected widget
       idx = params[:widget_id].split('_').first.to_i if idx.nil?
       # saving in sandbox before deleting, to be used if discard button is pressed
       @sb[:groups] = groups
       groups.delete_at(idx) if idx
-    elsif nodes.length == 3 || params[:typ] == "element"    # Remove field was pressed
+    elsif nodes[:type] == 'group' # Remove field was pressed
       # need to delete field
       idx = nil
-      fields = @edit[:new][:tabs][nodes[1].split('-').last.to_i][:groups][nodes[2].split('-').last.to_i][:fields]
+      fields = nodes[:children]
       fields.each_with_index do |field, i|
-        idx = i if field[:id] == params[:widget_id].split('_').last.to_i
+        idx = i if field[:id] == params[:widget_id].to_i
       end
-      # if object hasn't been added to db yet, use current position to delete the selected widget
+      # TODO if object hasn't been added to db yet, use current position to delete the selected widget
       idx = params[:widget_id].split('_').first.to_i if idx.nil?
       # saving in sandbox before deleting, to be used if discard button is pressed
       @sb[:fields] = fields
       fields.delete_at(idx) if idx
     end
-    if params[:typ]
-      nodes = x_node.split('_')
-      nodes.pop
-      self.x_node = nodes.join("_")
-      @sb[:node_typ] = nil
-    end
+    # TODO set active node
+    #if params[:typ]
+    #  nodes = x_node.split('_')
+    #  nodes.pop
+    #  self.x_node = nodes.join("_")
+    #  @sb[:node_typ] = nil
+    #end
     dialog_edit_set_form_vars
 
     replace_right_cell(x_node, [:dialog_edit])
   end
 
-  # Reorder dialog resources
+  # TODO Reorder dialog resources
   def dialog_res_reorder
     return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
     @record = @edit[:dialog]
@@ -1029,90 +1022,77 @@ module MiqAeCustomizationController::Dialogs
     @edit = session[:edit]
     @record = @edit[:dialog]
     @in_a_form = true
-    nodes = x_node.split('_')
-
-    if nodes.length == 1
-      # @edit[:new][:label] = @record.label
-      # @edit[:new][:description] = @record.description
+    nodes = x_node.split('xx-')
+    object = edit_dialog_node_data(x_node)
+    case object[:type]
+    when 'root'
       @sb[:node_typ] = nil if params[:action] != "dialog_form_field_changed"
-
-    elsif nodes.length == 2
-      # set name/description for selected tab
-      ids = nodes[1].split('-')
-      tab = @edit[:new][:tabs][ids.last.to_i]
-      @edit[:tab_label]       = tab[:label]
-      @edit[:tab_description] = tab[:description]
+    when 'tab'
+      @edit[:tab_label]       = object[:data][:label]
+      @edit[:tab_description] = object[:data][:description]
       @sb[:node_typ] = "tab" if params[:action] != "dialog_form_field_changed"
-
-    elsif nodes.length == 3
-      ids = nodes[2].split('-')
-      group = @edit[:new][:tabs][nodes[1].split('-').last.to_i][:groups][ids.last.to_i]
-      # set name/description for selected group
-      @edit[:group_label]       = group[:label]
-      @edit[:group_description] = group[:description]
+    when 'group'
+      @edit[:group_label]       = object[:data][:label]
+      @edit[:group_description] = object[:data][:description]
       @sb[:node_typ] = "box" if params[:action] != "dialog_form_field_changed"
-
-    elsif nodes.length == 4
-      # set name/description for selected field
-      ids = nodes[3].split('-')
-      get_field_types
-      field = @edit[:new][:tabs][nodes[1].split('-').last.to_i][:groups][nodes[2].split('-').last.to_i][:fields][ids.last.to_i]
+    when 'field'
+      get_field_types if @edit[:field_types].empty?
       @edit.update(
-        :field_label                => field[:label],
-        :field_name                 => field[:name],
-        :field_description          => field[:description],
-        :field_typ                  => field[:typ],
-        :field_dynamic              => field[:dynamic],
-        :field_default_value        => field[:default_value],
-        :field_read_only            => field[:read_only],
-        :field_visible              => field[:visible],
-        :field_reconfigurable       => field[:reconfigurable],
-        :field_required             => field[:required],
-        :field_trigger_auto_refresh => field[:trigger_auto_refresh]
-      )
+        :field_label                => object[:data][:label],
+        :field_name                 => object[:data][:name],
+        :field_description          => object[:data][:description],
+        :field_typ                  => object[:data][:typ],
+        :field_dynamic              => object[:data][:dynamic],
+        :field_default_value        => object[:data][:default_value],
+        :field_read_only            => object[:data][:read_only],
+        :field_visible              => object[:data][:visible],
+        :field_reconfigurable       => object[:data][:reconfigurable],
+        :field_required             => object[:data][:required],
+        :field_trigger_auto_refresh => object[:data][:trigger_auto_refresh]
+       )
 
-      if %w(DialogFieldTextBox DialogFieldTextAreaBox).include?(field[:typ])
-        @edit[:field_protected]      = field[:protected]
-        @edit[:field_validator_type] = field[:validator_type]
-        @edit[:field_validator_rule] = field[:validator_rule]
-        @edit[:field_data_typ]       = field[:data_typ]
-        @edit[:field_visible]        = field[:visible]
+      if %w(DialogFieldTextBox DialogFieldTextAreaBox).include?(object[:data][:typ])
+        @edit[:field_protected]      = object[:data][:protected]
+        @edit[:field_validator_type] = object[:data][:validator_type]
+        @edit[:field_validator_rule] = object[:data][:validator_rule]
+        @edit[:field_data_typ]       = object[:data][:data_typ]
+        @edit[:field_visible]        = object[:data][:visible]
       end
 
-      if field[:typ].include?('Text')
-        @edit[:field_required]             = field[:required]
-        @edit[:field_visible]              = field[:visible]
+      if object[:data][:typ].include?('Text')
+        @edit[:field_required]             = object[:data][:required]
+        @edit[:field_visible]              = object[:data][:visible]
       end
 
-      if field[:typ].include?("TagControl")
-        @edit[:field_single_value] = field[:single_value]
-        @edit[:field_category]     = field[:category]
+      if object[:data][:typ].include?("TagControl")
+        @edit[:field_single_value] = object[:data][:single_value]
+        @edit[:field_category]     = object[:data][:category]
       end
 
-      if dynamic_field?(field)
+      if dynamic_field?(object[:data])
         @edit.update(
-          :field_load_on_init        => field[:load_on_init],
-          :field_show_refresh_button => field[:show_refresh_button],
-          :field_entry_point         => field[:entry_point],
-          :field_auto_refresh        => field[:auto_refresh]
+            :field_load_on_init        => object[:data][:load_on_init],
+            :field_show_refresh_button => object[:data][:show_refresh_button],
+            :field_entry_point         => object[:data][:entry_point],
+            :field_auto_refresh        => object[:data][:auto_refresh]
         )
       end
 
-      if %w(DialogFieldTagControl DialogFieldDropDownList DialogFieldRadioButton).include?(field[:typ])
+      if %w(DialogFieldTagControl DialogFieldDropDownList DialogFieldRadioButton).include?(object[:data][:typ])
         @edit.update(
-          :field_required   => field[:required],
-          :field_sort_by    => field[:sort_by] ? field[:sort_by].to_s : "description",
-          :field_sort_order => field[:sort_order] ? field[:sort_order].to_s : "ascending",
-          :field_data_typ   => field[:data_typ],
-          :field_values     => field[:values] ? copy_array(field[:values]) : []
+            :field_required   => object[:data][:required],
+            :field_sort_by    => object[:data][:sort_by] ? object[:data][:sort_by].to_s : "description",
+            :field_sort_order => object[:data][:sort_order] ? object[:data][:sort_order].to_s : "ascending",
+            :field_data_typ   => object[:data][:data_typ],
+            :field_values     => object[:data][:values] ? copy_array(object[:data][:values]) : []
         )
-      elsif %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(field[:typ])
-        @edit[:field_past_dates] = field[:past_dates]
+      elsif %w(DialogFieldDateControl DialogFieldDateTimeControl).include?(object[:data][:typ])
+        @edit[:field_past_dates] = object[:data][:past_dates]
       end
 
       @sb[:node_typ] = "element" if params[:action] != "dialog_form_field_changed"
     end
-    #dialog_edit_build_tree
+    #dialog_edbit_build_tree
     get_field_types if @edit[:field_types].nil?
     @dialog_edit_tree = TreeBuilderDialogEdit.new(:dialog_edit, :edit_dialog_tree, @sb, true, @edit)
     session[:changed] = (@edit[:new] != @edit[:current])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -626,7 +626,7 @@ class ApplicationHelper::ToolbarBuilder
       return true unless @edit
       return true if id == "dialog_res_discard" && @sb[:edit_typ] != "add"
       return true if id == "dialog_resource_remove" && (@sb[:edit_typ] == "add" || x_node == "root")
-      nodes = x_node.split('_')
+      nodes = x_node.split('xx-')
       return true if id == "dialog_add_tab" && (nodes.length > 2)
       return true if id == "dialog_add_box" && (nodes.length < 2 || nodes.length > 3)
       return true if id == "dialog_add_element" && (nodes.length < 3 || nodes.length > 4)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -218,6 +218,7 @@ class TreeBuilder
     root[:title], root[:tooltip], icon, options = root_options
     root[:icon] = ActionController::Base.helpers.image_path("100/#{icon || 'folder'}.png")
     root[:cfmeNoClick] = options[:cfmeNoClick] if options.present? && options.key?(:cfmeNoClick)
+    root[:activate] = options[:activate] if options.present? && options.key?(:activate)
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_dialog_edit.rb
+++ b/app/presenters/tree_builder_dialog_edit.rb
@@ -29,11 +29,11 @@ class TreeBuilderDialogEdit < TreeBuilder
 
   def x_get_tree_roots(count_only = false, _options)
     nodes = @root[:new][:tabs].map do |node|
-      {:id => "root_#{node[:id]}",
+      {:id => node[:id].to_s,
        :text => t = node[:label] || _('[New Tab]'),
        :image => "dialog_tab",
        :tip => t,
-       :expand => true,
+       #:expand => true,
        :children => node[:groups].present? ? node[:groups] : []
       }
     end
@@ -43,11 +43,11 @@ class TreeBuilderDialogEdit < TreeBuilder
   def x_get_tree_hash_kids(parent, count_only)
     nodes = parent[:children].map do |node|
       if node[:fields].present?
-        {:id => "#{parent[:id]}_#{node[:id]}",
+        {:id => node[:id].to_s,
          :text => node[:label] || _('[New Box]'),
          :image => "dialog_group",
          :tip => node[:description] || node[:label],
-         :expand => true,
+         #:expand => true,
          :children => node[:fields].present? ? node[:fields] : []
         }
       else
@@ -56,11 +56,11 @@ class TreeBuilderDialogEdit < TreeBuilder
                         else
                           "#{@root[:field_types][node[:typ]]}: #{node[:description]}"
                         end
-        {:id => "#{parent[:id]}_#{node[:id]}",
+        {:id => node[:id].to_s,
          :text => node[:label] || _('[New Element]'),
          :image => "dialog_field",
          :tip => field_tooltip,
-         :expand => true,
+         #:expand => true,
          :children => []
         }
       end

--- a/app/presenters/tree_builder_dialog_edit.rb
+++ b/app/presenters/tree_builder_dialog_edit.rb
@@ -24,7 +24,7 @@ class TreeBuilderDialogEdit < TreeBuilder
   end
 
   def root_options
-    ["#{@root[:new][:label] || _('[New Dialog]')}", @root[:new][:description] || @root[:new][:label], "dialog"]
+    ["#{@root[:new][:label] || _('[New Dialog]')}", @root[:new][:description] || @root[:new][:label], "dialog", {:activate => true}]
   end
 
   def x_get_tree_roots(count_only = false, _options)

--- a/app/presenters/tree_builder_dialog_edit.rb
+++ b/app/presenters/tree_builder_dialog_edit.rb
@@ -1,0 +1,70 @@
+class TreeBuilderDialogEdit < TreeBuilder
+  has_kids_for Hash, [:x_get_tree_hash_kids]
+
+  def initialize(name, type, sandbox, build = true, root = nil)
+    @root = root
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options(_tree_name)
+    {:full_ids => true, :lazy => false}
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:id_prefix                   => "de_",
+                  :autoload                    => true,
+                  :url                         => '/vm/show/',
+                  :open_close_all_on_dbl_click => true,
+                  :cookie_id_prefix            => "edit_treeOpenStatex",
+                  :exp_tree                    =>  true,
+                  :onclick                     => "miqOnClickSelectDlgEditTreeNode",)
+  end
+
+  def root_options
+    ["#{@root[:new][:label] || _('[New Dialog]')}", @root[:new][:description] || @root[:new][:label], "dialog"]
+  end
+
+  def x_get_tree_roots(count_only = false, _options)
+    nodes = @root[:new][:tabs].map do |node|
+      {:id => "root_#{node[:id]}",
+       :text => t = node[:label] || _('[New Tab]'),
+       :image => "dialog_tab",
+       :tip => t,
+       :expand => true,
+       :children => node[:groups].present? ? node[:groups] : []
+      }
+    end
+    count_only ? nodes.size : nodes
+  end
+
+  def x_get_tree_hash_kids(parent, count_only)
+    nodes = parent[:children].map do |node|
+      if node[:fields].present?
+        {:id => "#{parent[:id]}_#{node[:id]}",
+         :text => node[:label] || _('[New Box]'),
+         :image => "dialog_group",
+         :tip => node[:description] || node[:label],
+         :expand => true,
+         :children => node[:fields].present? ? node[:fields] : []
+        }
+      else
+        field_tooltip = if node[:description].nil?
+                          "#{@root[:field_types][node[:typ]]}: #{node[:label]}"
+                        else
+                          "#{@root[:field_types][node[:typ]]}: #{node[:description]}"
+                        end
+        {:id => "#{parent[:id]}_#{node[:id]}",
+         :text => node[:label] || _('[New Element]'),
+         :image => "dialog_field",
+         :tip => field_tooltip,
+         :expand => true,
+         :children => []
+        }
+      end
+    end
+    count_only ? nodes.size : nodes
+  end
+end

--- a/app/presenters/tree_builder_dialog_edit.rb
+++ b/app/presenters/tree_builder_dialog_edit.rb
@@ -9,7 +9,7 @@ class TreeBuilderDialogEdit < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true, :lazy => false}
+    {:full_ids => true, :lazy => false, :open_all => true}
   end
 
   def set_locals_for_render
@@ -36,9 +36,6 @@ class TreeBuilderDialogEdit < TreeBuilder
        :expand => true,
        :children => node[:groups].present? ? node[:groups] : []
       }
-    end
-    nodes.each do |node|
-      open_node(node[:id])
     end
     count_only ? nodes.size : nodes
   end
@@ -67,9 +64,6 @@ class TreeBuilderDialogEdit < TreeBuilder
          :children => []
         }
       end
-    end
-    nodes.each do |node|
-      open_node(node[:id])
     end
     count_only ? nodes.size : nodes
   end

--- a/app/presenters/tree_builder_dialog_edit.rb
+++ b/app/presenters/tree_builder_dialog_edit.rb
@@ -29,25 +29,28 @@ class TreeBuilderDialogEdit < TreeBuilder
 
   def x_get_tree_roots(count_only = false, _options)
     nodes = @root[:new][:tabs].map do |node|
-      {:id => node[:id].to_s,
+      {:id => node[:id].nil? ? 'new' : node[:id].to_s,
        :text => t = node[:label] || _('[New Tab]'),
        :image => "dialog_tab",
        :tip => t,
-       #:expand => true,
+       :expand => true,
        :children => node[:groups].present? ? node[:groups] : []
       }
+    end
+    nodes.each do |node|
+      open_node(node[:id])
     end
     count_only ? nodes.size : nodes
   end
 
   def x_get_tree_hash_kids(parent, count_only)
     nodes = parent[:children].map do |node|
-      if node[:fields].present?
-        {:id => node[:id].to_s,
+      if node.key?(:fields)
+        {:id => node[:id].nil? ? 'new' : node[:id].to_s,
          :text => node[:label] || _('[New Box]'),
          :image => "dialog_group",
          :tip => node[:description] || node[:label],
-         #:expand => true,
+         :expand => true,
          :children => node[:fields].present? ? node[:fields] : []
         }
       else
@@ -56,14 +59,17 @@ class TreeBuilderDialogEdit < TreeBuilder
                         else
                           "#{@root[:field_types][node[:typ]]}: #{node[:description]}"
                         end
-        {:id => node[:id].to_s,
+        {:id => node[:id].nil? ? 'new' : node[:id].to_s,
          :text => node[:label] || _('[New Element]'),
          :image => "dialog_field",
          :tip => field_tooltip,
-         #:expand => true,
+         :expand => true,
          :children => []
         }
       end
+    end
+    nodes.each do |node|
+      open_node(node[:id])
     end
     count_only ? nodes.size : nodes
   end

--- a/app/presenters/tree_builder_policy_simulation_results.rb
+++ b/app/presenters/tree_builder_policy_simulation_results.rb
@@ -1,0 +1,120 @@
+class TreeBuilderPolicySimulationResults < TreeBuilder
+  # exp_build_string method needed
+  include ApplicationController::ExpressionHtml
+
+  has_kids_for Hash, [:x_get_tree_hash_kids]
+
+  def initialize(name, type, sandbox, build = true, root = nil)
+    @root = root
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options(_tree_name)
+    {:full_ids => true, :lazy => false}
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:id_prefix                   => "rsop_",
+                  :autoload                    => true,
+                  :cfme_no_click               => true,
+                  :onclick                     => false,
+                  :open_close_all_on_dbl_click => true,)
+  end
+
+  def root_options
+    event = MiqEventDefinition.find(@root[:event_value])
+    [_("Policy Simulation Results for Event [%{description}]") % {:description => event.description},
+     nil,
+     "event-#{event.name}",
+     {:cfmeNoClick => true}]
+  end
+
+  def node_icon(result)
+    case result
+    when 'allow' then 'checkmark'
+    when 'N/A'   then 'na'
+    else 'x'
+    end
+  end
+
+  def vm_nodes(data)
+    data.sort_by! { |a| a[:name].downcase }.map do |node|
+      {:id       => node[:id],
+       :text     => "<strong>VM:</strong> #{node[:name]}".html_safe,
+       :image    => 'vm',
+       :profiles => node[:profiles]}
+    end
+  end
+
+  def profile_nodes(data)
+    data.sort_by { |a| a[:name].downcase }.map do |node|
+      {:id       => node[:id],
+       :text     => "<strong>#{_('Profile:')}</strong> #{node[:description]}".html_safe,
+       :image    => node_icon(node[:result]),
+       :policies => node[:policies]}
+    end
+  end
+
+  def policy_nodes(data)
+    data.sort_by { |a| a[:name].downcase }.map do |node|
+      active_caption = node[:active] ? "" : _( "(Inactive)")
+      {:id         => node['id'],
+       :text       => "<strong>#{_('Policy')}#{active_caption}:</strong> #{node[:description]}".html_safe,
+       :image      => node_icon(node[:result]),
+       :conditions => node[:conditions],
+       :actions    => node[:actions],
+       :scope      => node[:scope]}
+    end
+  end
+
+  def action_nodes(data)
+    data.map do |node|
+      {:id    => node[:id],
+       :text  => "<strong>#{_('Action:')}</strong> #{node[:description]}".html_safe,
+       :image => node_icon(node[:result])}
+    end
+  end
+
+  def condition_nodes(data)
+    data.map do |node|
+      {:id         => node[:id],
+       :text       => "<strong>#{_('Condition:')}</strong> #{node[:description]}".html_safe,
+       :image      => node_icon(node[:result]),
+       :expression => node[:expression]}
+    end
+  end
+
+  def scope_node(data)
+    name, tip = exp_build_string(data)
+    {:id    => nil,
+     :text  => "<strong>#{_('Scope:')}</strong> <span class='ws-wrap'>#{name}".html_safe,
+     :tip   => tip.html_safe,
+     :image => node_icon(data[:result])}
+  end
+
+  def expression_node(data)
+    name, tip = exp_build_string(data)
+    {:id    => nil,
+     :text  => "<strong>#{_('Expression:')}</strong> <span class='ws-wrap'>#{name}".html_safe,
+     :tip   => tip.html_safe,
+     :image => 'na'}
+  end
+
+  def x_get_tree_roots(count_only = false, _options = nil)
+    count_only_or_objects(count_only, vm_nodes(@root[:results]))
+  end
+
+  def x_get_tree_hash_kids(parent, count_only)
+    kids = []
+    kids.concat(profile_nodes(parent[:profiles])) if parent[:profiles].present?
+    kids.concat(policy_nodes(parent[:policies])) if parent[:policies].present?
+    kids.concat(condition_nodes(parent[:conditions])) if parent[:conditions].present?
+    kids.push(scope_node(parent[:scope])) if parent[:scope].present?
+    kids.push(expression_node(parent[:expression])) if parent[:expression].present?
+    kids.concat(action_nodes(parent[:actions])) if parent[:actions].present?
+    count_only_or_objects(count_only, kids)
+  end
+end

--- a/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
+++ b/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
@@ -9,7 +9,7 @@
         -# Div to hold the actual tree
         #dialog_edit_tree_div{:style => "width: 100%; height: 100%"}
           #dialog_edit_treebox{:style => "width: 100%; height: 100%; color: #000; overflow: hidden;"}
-          = render(:partial => "layouts/dynatree",
+          -#= render(:partial => "layouts/dynatree",
             :locals         => {:tree_id  =>  "dialog_edit_treebox",
               :tree_name                  =>  "dialog_edit_tree",
               :json_tree                  =>  @dialog_edit_tree,
@@ -22,3 +22,4 @@
               :tree_state                 =>  true,
               :cookie_id_prefix           => "edit_treeOpenStatex",
               :multi_lines                =>  true})
+          = render(:partial => 'shared/tree', :locals => {:tree => @dialog_edit_tree, :name => @dialog_edit_tree.name})

--- a/app/views/miq_ae_customization/_dialog_form.html.haml
+++ b/app/views/miq_ae_customization/_dialog_form.html.haml
@@ -1,21 +1,20 @@
-- nodes = x_node.split('_')
+- node = controller.edit_dialog_node_data(x_node)
 = render :partial => "layouts/flash_msg"
 #form_div
   = hidden_field_tag(:ignore_form_changes)
-  - if nodes.length == 1 && @sb[:node_typ].blank?
+  - if node[:type] == 'root' && @sb[:node_typ].blank?
     -# dialog info form fields
     = render :partial => 'dialog_info_form'
-    = render :partial => 'dialog_resources', :locals => {:typ => "tabs", :parent_id => nil}
-  - elsif (nodes.length == 2 && @sb[:node_typ] != "box") || (nodes.length == 1 && @sb[:node_typ] == "tab")
+    = render :partial => 'dialog_resources', :locals => {:typ => "tabs", :data => node[:children], :parent_id => nil}
+  - elsif (node[:type] == 'tab' && @sb[:node_typ] != "box") || (node[:type] == 'root' && @sb[:node_typ] == "tab")
     -# dialog tab form fields
     = render :partial => 'dialog_tab_form'
-    = render :partial => 'dialog_resources', :locals => {:typ => "boxes", :parent_id => nodes.last.split('-').last}
-  - elsif (nodes.length == 3 && @sb[:node_typ] != "element") || (nodes.length == 2 && @sb[:node_typ] == "box")
+    = render :partial => 'dialog_resources', :locals => {:typ => "boxes", :data => node[:children], :parent_id => node[:parent_id]}
+  - elsif (node[:type] == 'group' && @sb[:node_typ] != "element") || (node[:type] == 'tab' && @sb[:node_typ] == "box")
     -# dialog group form fields
     = render :partial => 'dialog_group_form'
-    - parent_id = nodes.length == 3 ? "#{nodes[1].split('-').last}_#{nodes[2].split('-').last}" : "#{nodes[1].split('-').last}_#{@edit[:new][:tabs][nodes[1].split('-').last.to_i][:groups].length - 1}"
-    = render :partial => 'dialog_resources', :locals => {:typ => "elements", :parent_id => parent_id}
-  - elsif nodes.length == 4 || (nodes.length == 3 && @sb[:node_typ] == "element")
+    = render :partial => 'dialog_resources', :locals => {:typ => "elements", :data => node[:children], :parent_id => node[:parent_id]}
+  - elsif node[:type] == 'field' || (node[:type] == 'group' && @sb[:node_typ] == "element")
     -# dialog field form fields
     = hidden_div_if(!@edit[:ae_tree_select], :id => 'ae_tree_select_div') do
       = render :partial => 'layouts/ae_tree_select'

--- a/app/views/miq_ae_customization/_dialog_res_remove.html.haml
+++ b/app/views/miq_ae_customization/_dialog_res_remove.html.haml
@@ -5,10 +5,10 @@
   {:controller => "miq_ae_customization",
    :action     => "dialog_res_remove",
    :id         => @record.id || 'new',
-   :widget_id  => "#{curr_pos}_#{obj[:id]}"},
+   :widget_id  => obj[:id]},
   "data-miq_sparkle_on" => true,
   :remote               => true,
   "data-method"         => :post,
-  :id                   => "#{parent_id}_#{obj[:id]}_close",
+  :id                   => obj[:id],
   :title                => _("Remove this %{type}") % {:type => typ.capitalize.singularize},
   :class                => "fa fa-close pull-right")

--- a/app/views/miq_ae_customization/_dialog_resources.html.haml
+++ b/app/views/miq_ae_customization/_dialog_resources.html.haml
@@ -1,18 +1,11 @@
-- parent_id ||= nil
+- data ||= nil
 #form_widgets_div
   %hr
   %h3
     = typ.capitalize
   .row#modules
     .col-md-4#col1
-      - objects = @edit[:new][:tabs]
-      - if parent_id
-        - ids = parent_id.split('_')
-        - case ids.length
-        - when 1
-          - objects = !@edit[:new][:tabs][ids.first.to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups] : nil
-        - when 2
-          - objects = !@edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i].blank? ? @edit[:new][:tabs][ids.first.to_i][:groups][ids[1].to_i][:fields] : nil
+      - objects = data.nil? ? @edit[:new][:tabs] : data
       - if objects.blank?
         = _("No %{types} found.") % {:types => typ.pluralize.capitalize}
       - else


### PR DESCRIPTION
## Purpose or Intent

Convert Dialog Edit tree to use TreeBuilder. Refactoring.

Form related methods:
- [ ] dialog_res_add
- [ ] dialog_res_discard
- [ ] dialog_res_remove
- [ ] dialog_edit
## Steps for Testing/QA

Automate -> Customization -> Service Dialogs -> Add new or Edit one

@miq-bot  add_label ui, refactoring, wip
