### PR TITLE
Fix %{:customer_name} typo in miq_group_center toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_group_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_group_center.rb
@@ -32,7 +32,7 @@ class ApplicationHelper::Toolbar::MiqGroupCenter < ApplicationHelper::Toolbar::B
           :rbac_group_tags_edit,
           'pficon pficon-edit fa-lg',
           t = proc do
-            _('Edit \'%{:customer_name}\' Tags for this Group') % {:customer_name => @view_context.session[:customer_name]}
+            _('Edit \'%{customer_name}\' Tags for this Group') % {:customer_name => @view_context.session[:customer_name]}
           end,
           t),
       ]


### PR DESCRIPTION
In Configuration > Access Control > Groups > *, the policy toolbar contains `Edit '%{:customer_name}' Tags for this Group`... clearly a typo..

@mzazrivec ;)