### PR TITLE
js: shim Array.includes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require miq_global
 //= require es6-shim
+//= require array-includes
 //= require fetch
 //= require jquery
 //= require jquery_overrides

--- a/bower.json
+++ b/bower.json
@@ -43,6 +43,7 @@
     "es6-shim": "^0.35.0",
     "phantomjs-polyfill": "^0.0.2",
     "fetch": "^1.0.0",
-    "codemirror": "^5.16.0"
+    "codemirror": "^5.16.0",
+    "array-includes": "^1.0.0"
   }
 }


### PR DESCRIPTION
`Array.includes` is already used in our code, but supported only by newer browsers.

(initially introduced in ES6, but not covered by es6-shim, only es7-shim which we can't use)

Shimming by `array-includes` (which is what es7-shim uses anyway).

Should fix the `TypeError: whitelist.includes is not a function` in older browsers