### PR TITLE
Add VMware refresh worker

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :RefreshParser
+  require_nested :RefreshWorker
   require_nested :Refresher
   require_nested :Vm
 

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_worker.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::Vmware::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
+  require_nested :Runner
+
+  def self.settings_name
+    :ems_refresh_worker_vmware_cloud
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::CloudManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -37,6 +37,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Openstack::CloudManager::RefreshWorker
     ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker
     ManageIQ::Providers::Openstack::InfraManager::RefreshWorker
+    ManageIQ::Providers::Vmware::CloudManager::RefreshWorker
     ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
     ManageIQ::Providers::Amazon::CloudManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
@@ -113,6 +114,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Openstack::CloudManager::RefreshWorker
     ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker
     ManageIQ::Providers::Openstack::InfraManager::RefreshWorker
+    ManageIQ::Providers::Vmware::CloudManager::RefreshWorker
     ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
     MiqScheduleWorker
     MiqPriorityWorker

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1238,6 +1238,7 @@
         :ems_refresh_worker_openstack_network: {}
         :ems_refresh_worker_redhat: {}
         :ems_refresh_worker_vmware: {}
+        :ems_refresh_worker_vmware_cloud: {}
       :event_handler:
         :cpu_usage_threshold: 0.percent
         :nice_delta: 7


### PR DESCRIPTION
Purpose or Intent
-----------------
This patch extends the VMware cloud manager with a corresponding refresh
worker introduced in #9944. Worker is registered with management
monitor allowing it to be started as part of `ems_inventory` role.

This is third PR in series based on #9412. 