### PR TITLE
Fix Caching Issues for MiqDiskCache Module

### DIFF
--- a/gems/pending/disk/modules/miq_disk_cache.rb
+++ b/gems/pending/disk/modules/miq_disk_cache.rb
@@ -3,13 +3,13 @@ require_relative "../MiqDisk"
 require 'ostruct'
 
 module MiqDiskCache
-  MIN_SECTORS_TO_CACHE = 32
+  MIN_SECTORS_PER_ENTRY = 32
   DEF_LRU_HASH_ENTRIES = 100
   DEBUG_CACHE_STATS    = false
 
   attr_reader :d_size, :blockSize, :lru_hash_entries, :min_sectors_per_entry, :cache_hits, :cache_misses
 
-  def self.new(up_stream, lru_hash_entries = DEF_LRU_HASH_ENTRIES, min_sectors_per_entry = MIN_SECTORS_TO_CACHE)
+  def self.new(up_stream, lru_hash_entries = DEF_LRU_HASH_ENTRIES, min_sectors_per_entry = MIN_SECTORS_PER_ENTRY)
     raise "MiqDiskCache: Downstream Disk Module is nil" if up_stream.nil?
     @dInfo                       = OpenStruct.new
     @dInfo.lru_hash_entries      = lru_hash_entries
@@ -120,15 +120,15 @@ module MiqDiskCache
   end
 
   def entry_range(start_sector, number_sectors)
-    # Cache entries are *multiples* of MIN_SECTORS_TO_CACHE * @blocksize  in length,
-    # aligned to MIN_SECTORS_TO_CACHE * @blocksize byte boundaries.
+    # Cache entries are *multiples* of MIN_SECTORS_PER_ENTRY * @blocksize  in length,
+    # aligned to MIN_SECTORS_PER_ENTRY * @blocksize byte boundaries.
     # real_start_block is the aligned cache block based on the start_sector, and
     # real_start_sector is the disk sector for that cache block.
-    real_start_block    = start_sector / MIN_SECTORS_TO_CACHE
-    real_end_block      = (start_sector + number_sectors) / MIN_SECTORS_TO_CACHE
+    real_start_block    = start_sector / MIN_SECTORS_PER_ENTRY
+    real_end_block      = (start_sector + number_sectors) / MIN_SECTORS_PER_ENTRY
     number_cache_blocks = real_end_block - real_start_block + 1
-    sectors_to_read     = number_cache_blocks * MIN_SECTORS_TO_CACHE
-    real_start_sector   = real_start_block * MIN_SECTORS_TO_CACHE
+    sectors_to_read     = number_cache_blocks * MIN_SECTORS_PER_ENTRY
+    real_start_sector   = real_start_block * MIN_SECTORS_PER_ENTRY
     end_sector          = real_start_sector + sectors_to_read - 1
     Range.new(real_start_sector, end_sector)
   end

--- a/gems/pending/disk/modules/miq_disk_cache.rb
+++ b/gems/pending/disk/modules/miq_disk_cache.rb
@@ -120,15 +120,15 @@ module MiqDiskCache
   end
 
   def entry_range(start_sector, number_sectors)
-    # Cache entries are *multiples* of MIN_SECTORS_PER_ENTRY * @blocksize  in length,
-    # aligned to MIN_SECTORS_PER_ENTRY * @blocksize byte boundaries.
+    # Cache entries are *multiples* of @min_sectors_per_entry * @blocksize  in length,
+    # aligned to @min_sectors_per_entry * @blocksize byte boundaries.
     # real_start_block is the aligned cache block based on the start_sector, and
     # real_start_sector is the disk sector for that cache block.
-    real_start_block    = start_sector / MIN_SECTORS_PER_ENTRY
-    real_end_block      = (start_sector + number_sectors) / MIN_SECTORS_PER_ENTRY
+    real_start_block    = start_sector / @min_sectors_per_entry
+    real_end_block      = (start_sector + number_sectors) / @min_sectors_per_entry
     number_cache_blocks = real_end_block - real_start_block + 1
-    sectors_to_read     = number_cache_blocks * MIN_SECTORS_PER_ENTRY
-    real_start_sector   = real_start_block * MIN_SECTORS_PER_ENTRY
+    sectors_to_read     = number_cache_blocks * @min_sectors_per_entry
+    real_start_sector   = real_start_block * @min_sectors_per_entry
     end_sector          = real_start_sector + sectors_to_read - 1
     Range.new(real_start_sector, end_sector)
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Several caching issues have been uncovered and will be addressed here.
Similar changes have been made in MiqHyperVDisk via separate PR.

1) Cache requests where the request overlapped an existing cache entry
both at the start and end resulted in new entry duplicating the existing
entry plus the data at start and end.  This will instead be addressed by
creating new entries for the start and end and using the existing entry.
This is a performance issue.

2) Cache requests where the end of the request (but not the start) was present
in an existing cache entry used the incorrect offset into the entry for the data
returned. This is a data integrity issue.

3) The range of blocks cached for new entries was determined incorrectly.
Depending upon the request from the disk module less data might be cached than required.
This is a performance issue.

4) Concatenating cache entries with recursive calls to bread_cached used the "+"
operator exclusively. When possible this is changed to "<<" to eliminate some
temporary buffer allocation and speed things up a little.

5) Comments also added for clarity.

Links
-----
For similar changes made to MiqHyperVDisk see https://github.com/ManageIQ/manageiq/pull/9981

@roliveri @Fryguy for your review.  Thanks.