### PR TITLE
Refactor private image collection for Azure

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -146,7 +146,7 @@ module ManageIQ::Providers
       end
 
       def get_images
-        images = gather_data_for_this_region(@sas, 'list_private_images')
+        images = gather_data_for_this_region(@sas, 'list_all_private_images')
         process_collection(images, :vms) { |image| parse_image(image) }
       end
 

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -26,6 +26,8 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
       arm_service.send(method_name).select do |resource|
         resource.try(:location) == @ems.provider_region
       end.flatten
+    elsif method_name.to_s == 'list_all_private_images' # requires special handling
+      arm_service.send(method_name, :location => @ems.provider_region)
     else
       resource_groups.collect do |resource_group|
         arm_service.send(method_name, resource_group.name).select do |resource|

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -8,7 +8,7 @@ gem "activerecord",            "~> 5.0.0" # used by appliance_console
 gem "activesupport",           "~> 5.0.0"
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.4",            :require => false
-gem "azure-armrest",           "=0.2.7",            :require => false
+gem "azure-armrest",           "=0.2.8",            :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -73,7 +73,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   def expected_table_counts
     {
       :ext_management_system         => 2,
-      :flavor                        => 53,
+      :flavor                        => 63,
       :availability_zone             => 1,
       :vm_or_template                => 9,
       :vm                            => 8,
@@ -93,7 +93,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :security_group                => 8,
       :network_port                  => 10,
       :cloud_network                 => 6,
-      :floating_ip                   => 11,
+      :floating_ip                   => 10,
       :network_router                => 0,
       :cloud_subnet                  => 6,
     }
@@ -294,7 +294,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
     expect(v.hardware.guest_devices.size).to eql(0)
     expect(v.hardware.nics.size).to eql(0)
-    floating_ip   = ManageIQ::Providers::Azure::NetworkManager::FloatingIp.where(:address => "13.92.253.245").first
+    floating_ip   = ManageIQ::Providers::Azure::NetworkManager::FloatingIp.where(:address => "40.117.32.144").first
     cloud_network = ManageIQ::Providers::Azure::NetworkManager::CloudNetwork.where(:name => "miq-azure-test1").first
     cloud_subnet  = cloud_network.cloud_subnets.first
     expect(v.floating_ip).to eql(floating_ip)
@@ -309,7 +309,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     network = v.hardware.networks.where(:description => "public").first
     expect(network).to have_attributes(
       :description => "public",
-      :ipaddress   => "13.92.253.245",
+      :ipaddress   => "40.117.32.144",
       :hostname    => "ipconfig1"
     )
     network = v.hardware.networks.where(:description => "private").first
@@ -553,7 +553,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   def assert_specific_nic_and_ip
     nic_group  = 'miq-azure-test1' # EastUS
     ip_group   = 'miq-azure-test4' # Also EastUS
-    ip_address = '40.76.5.200'
+    ip_address = '13.82.28.187'
 
     nic_name = "/subscriptions/#{@subscription_id}/resourceGroups"\
                "/#{nic_group}/providers/Microsoft.Network"\

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -4,7 +4,7 @@ http_interactions:
     method: post
     uri: https://login.windows.net/AZURE_TENANT_ID/oauth2/token
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
     headers:
       Accept:
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Length:
       - '186'
       Content-Type:
@@ -32,35 +32,34 @@ http_interactions:
       - "-1"
       Server:
       - Microsoft-IIS/8.5
-      X-Ms-Request-Id:
-      - 2e44dcfd-d274-4a1f-a600-952706c9dd02
-      Client-Request-Id:
-      - 13018be8-6bf1-4a17-8bfb-18db46b932bc
-      X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_185
-      X-Content-Type-Options:
-      - nosniff
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 4acf7974-7d27-4f1c-9fc8-02266d1b6e67
+      Client-Request-Id:
+      - a61ee94c-fa19-4b55-abcb-bbfbbe1279f0
+      X-Ms-Responsehealth:
+      - TargetId=ESTSFE_IN_45;Action=None;Category=None;Health=0;Load=17;
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AAABAAAAiL9Kn2Z27UubvWFPbm0gLYVOpXRYFsGmrDBdNIbJENQYOgthAKKMtR1D5H4_s2z5JDr3SIOrUq7dPbW3i80UXrI_pLRRXd__Ls8TB9uA4OAqKGnecFSKIZWlMZnL5puf-wWSdKsFxENQcZyzFgM9ZhlMn-45zVBgI7mBzeVMNoV7eS37wXWk6fF2H0H1j445IAA;
+      - esctx=AAABAAAA0TWEUN3YUUq5vuCvmnaQichMrVLSdGNl3ZoxpDv8oLIeHR9Bs-5Udnwm3NiAlPVO8RtGO0W71B4clcoIwwNnhrfYObUp415ziktThyT5Rzak307IxT3coEzy_QUnvNM8sxHsAGlHv0290GxhLPMiMR-wr3uKNvwYiL8z3uYRIDVWb21QYP0GyJUaZY5okLwlIAA;
         domain=.login.windows.net; path=/; secure; HttpOnly
-      - flight-uxoptin=true; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 20 May 2016 19:35:24 GMT
+      - Fri, 22 Jul 2016 16:48:36 GMT
       Content-Length:
-      - '1247'
+      - '1412'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","scope":"user_impersonation","expires_in":"3599","expires_on":"1463776525","not_before":"1463772625","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"3600","expires_on":"1469209718","not_before":"1469205818","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ"}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:25 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -73,11 +72,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -96,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14997'
       X-Ms-Request-Id:
-      - 50add8f2-de8a-4412-b27e-03daf6d9e640
+      - dea77373-6ade-4b27-86aa-e2bcf17a71ac
       X-Ms-Correlation-Request-Id:
-      - 50add8f2-de8a-4412-b27e-03daf6d9e640
+      - dea77373-6ade-4b27-86aa-e2bcf17a71ac
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193525Z:50add8f2-de8a-4412-b27e-03daf6d9e640
+      - NORTHCENTRALUS:20160722T164838Z:dea77373-6ade-4b27-86aa-e2bcf17a71ac
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:25 GMT
+      - Fri, 22 Jul 2016 16:48:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01"}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:25 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames?api-version=2015-01-01
@@ -125,11 +124,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -146,24 +145,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14946'
       X-Ms-Request-Id:
-      - c353b6d6-1819-4a30-ae16-6a9a0b4ee9f2
+      - b2e2519d-0742-4d20-b359-bda8693d2594
       X-Ms-Correlation-Request-Id:
-      - c353b6d6-1819-4a30-ae16-6a9a0b4ee9f2
+      - b2e2519d-0742-4d20-b359-bda8693d2594
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193526Z:c353b6d6-1819-4a30-ae16-6a9a0b4ee9f2
+      - NORTHCENTRALUS:20160722T164838Z:b2e2519d-0742-4d20-b359-bda8693d2594
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:25 GMT
+      - Fri, 22 Jul 2016 16:48:38 GMT
       Content-Length:
-      - '3190'
+      - '3977'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat","tagName":"redhat","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat/tagValues/True","tagValue":"True","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName","tagName":"displayName","count":{"type":"Total","value":19},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterVirtualMachine","tagValue":"OpenShiftMasterVirtualMachine","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/DeployOpenShift","tagValue":"DeployOpenShift","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodes","tagValue":"OpenShiftNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/PrepNodes","tagValue":"PrepNodes","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/KeyVault","tagValue":"KeyVault","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLB","tagValue":"OpenShiftNodeLB","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterNetworkInterface","tagValue":"OpenShiftMasterNetworkInterface","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeNetworkInterfaces","tagValue":"OpenShiftNodeNetworkInterfaces","count":{"type":"Total","value":3}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftNodeLBPublicIP","tagValue":"OpenShiftNodeLBPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterPublicIP","tagValue":"OpenShiftMasterPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualNetwork","tagValue":"VirtualNetwork","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccounts","tagValue":"StorageAccounts","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand","tagName":"on-demand","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/on-demand/tagValues/true","tagValue":"true","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test","tagName":"rlt_test","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test/tagValues/b","tagValue":"b","count":{"type":"Total","value":1}}]}]}'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName","tagName":"displayName","count":{"type":"Total","value":75},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/KeyVault","tagValue":"KeyVault","count":{"type":"Total","value":2}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualMachine","tagValue":"VirtualMachine","count":{"type":"Total","value":15}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualMachineCustomScriptExtension","tagValue":"VirtualMachineCustomScriptExtension","count":{"type":"Total","value":15}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/NetworkInterface","tagValue":"NetworkInterface","count":{"type":"Total","value":15}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/NetworkSecurityGroup","tagValue":"NetworkSecurityGroup","count":{"type":"Total","value":6}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/PublicIPAddress","tagValue":"PublicIPAddress","count":{"type":"Total","value":6}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/VirtualNetwork","tagValue":"VirtualNetwork","count":{"type":"Total","value":4}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccount","tagValue":"StorageAccount","count":{"type":"Total","value":9}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/OpenShiftMasterPublicIP","tagValue":"OpenShiftMasterPublicIP","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/displayName/tagValues/StorageAccounts","tagValue":"StorageAccounts","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/autoShutdownSchedule","tagName":"autoShutdownSchedule","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/autoShutdownSchedule/tagValues/21:00
+        -> 0600, Saturday, Sunday","tagValue":"21:00 -> 0600, Saturday, Sunday","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat","tagName":"redhat","count":{"type":"Total","value":2},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat/tagValues/True","tagValue":"True","count":{"type":"Total","value":1}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/redhat/tagValues/VirtualMachine","tagValue":"VirtualMachine","count":{"type":"Total","value":1}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/Shutdown","tagName":"Shutdown","count":{"type":"Total","value":12},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/Shutdown/tagValues/true","tagValue":"true","count":{"type":"Total","value":12}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/dmulford","tagName":"dmulford","count":{"type":"Total","value":0},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/dmulford/tagValues/true","tagValue":"true","count":{"type":"Total","value":0}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/description","tagName":"description","count":{"type":"Total","value":2},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/description/tagValues/jClouds
+        managed VMs","tagValue":"jClouds managed VMs","count":{"type":"Total","value":2}}]},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test","tagName":"rlt_test","count":{"type":"Total","value":1},"values":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/tagNames/rlt_test/tagValues/b","tagValue":"b","count":{"type":"Total","value":1}}]}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:26 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -176,11 +177,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -199,25 +200,40 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - 1afdcca9-6264-416f-817c-164e564f2aad
+      - 4c929ffb-276a-49c3-ad92-7fbc51a23a5a
       X-Ms-Correlation-Request-Id:
-      - 1afdcca9-6264-416f-817c-164e564f2aad
+      - 4c929ffb-276a-49c3-ad92-7fbc51a23a5a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193527Z:1afdcca9-6264-416f-817c-164e564f2aad
+      - NORTHCENTRALUS:20160722T164839Z:4c929ffb-276a-49c3-ad92-7fbc51a23a5a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:27 GMT
+      - Fri, 22 Jul 2016 16:48:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
         US","North Europe","Central US","East US","West Europe","East Asia","Southeast
         Asia","Japan East","Japan West","West US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":["West
         US (Partner)"],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":["West
-        US (Partner)"],"apiVersions":["2016-03-25"]}]},{"namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["West
-        US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US (Partner)"],"apiVersions":["2016-03-25"]}]},{"namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US","West US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]}]},{"namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","West US (Partner)"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-03-01"]}]},{"namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]},{"namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","West US (Partner)"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-04-01"]}]},{"namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US (Partner)"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-06-15"]}]},{"namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US","West US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -243,222 +259,275 @@ http_interactions:
         US","West US","South Central US","North Europe","East Asia","Japan East","West
         Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
         South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-04-01","2015-10-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2015-07-01-preview","2015-07-01"]}]},{"namespace":"Microsoft.Automation","resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}]},{"namespace":"Microsoft.Archive","resourceTypes":[{"resourceType":"collections","locations":["East
+        US 2"],"apiVersions":["2016-06-01-preview"]},{"resourceType":"collections/archives","locations":["East
+        US 2"],"apiVersions":["2016-06-01-preview"]},{"resourceType":"collections/operations","locations":["East
+        US 2"],"apiVersions":["2016-06-01-preview"]}]},{"namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-04-01","2015-10-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2015-07-01-preview","2015-07-01"]}]},{"namespace":"Microsoft.Automation","resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Australia Southeast","Central India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Central US","North Europe","Canada Central","Australia Southeast","Central
+        India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Australia Southeast","Central India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Central US","North Europe","Canada Central","Australia Southeast","Central
+        India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Central India","Australia Southeast"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Australia Southeast","Central India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","Canada Central","Australia Southeast","Central
+        India"],"apiVersions":["2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
         Central US"],"apiVersions":["2015-10-31","2015-01-01-preview"]}]},{"namespace":"Microsoft.Batch","resourceTypes":[{"resourceType":"batchAccounts","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Southeast Asia","South Central US","Australia East","South India","Central
-        India","West India","Canada Central","Canada East","UK South 2","UK North"],"apiVersions":["2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        India","West India","Canada Central","Canada East","UK South 2","UK North","West
+        Central US","West US 2"],"apiVersions":["2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Southeast Asia","South Central US","Australia East","South India","Central
-        India","West India","Canada Central","Canada East","UK South 2","UK North"],"apiVersions":["2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        India","West India","Canada Central","Canada East","UK South 2","UK North","West
+        Central US","West US 2"],"apiVersions":["2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Southeast Asia","South Central US","Australia East","South India","Central
-        India","West India","Canada Central","Canada East","UK South 2","UK North"],"apiVersions":["2015-12-01","2015-09-01"]}]},{"namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        India","West India","Canada Central","Canada East","UK South 2","UK North","West
+        Central US","West US 2"],"apiVersions":["2015-12-01","2015-09-01"]}]},{"namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US (Partner)","West US"],"apiVersions":["2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-07-02"]}]},{"namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}]},{"namespace":"Microsoft.Cache","resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","Canada Central","Canada East","UK North","UK South 2","South India"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        India","Canada Central","Canada East","UK North","UK South 2","West US 2","West
+        Central US","South India"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
-        India","South India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        India","South India","Canada Central","Canada East","UK North","UK South 2","West
+        US 2","West Central US"],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2","West US 2","West
+        Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operations","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Central
-        US","East US","East US 2","North Central US","South Central US","West US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
-        South","Australia East","Australia Southeast"],"apiVersions":["2016-04-02","2015-06-01"]}]},{"namespace":"Microsoft.CertificateRegistration","resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}]},{"namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
-        US","East US 2","North Central US","North Europe","West Europe","Brazil South","UK
-        North","UK South 2","Canada Central","Canada East","West US","Central US","South
+        India","Canada Central","Canada East","UK North","UK South 2","West US 2","West
+        Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US"],"apiVersions":["2016-04-02","2015-06-01"]}]},{"namespace":"Microsoft.CertificateRegistration","resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}]},{"namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK North","UK South 2","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","South India","Central India","West India","East
-        US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
-        US","East US 2","North Central US","North Europe","West Europe","Brazil South","UK
-        North","UK South 2","Canada Central","Canada East","West US","Central US","South
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK North","UK South 2","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","South India","Central India","West India","East
-        US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
-        East","West US","Central US","East Asia","Southeast Asia","North Europe","West
-        Europe","UK North","UK South 2","Japan East","Japan West","Brazil South","Australia
-        East","Australia Southeast","South India","Central India","West India","East
-        US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]}]},{"namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK North","UK South 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"reservedIps","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}]},{"namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","East US 2 (Stage)","North Central US (Stage)","UK North","UK
-        South 2","Canada Central","Canada East"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        India","West India","East US 2 (Stage)","North Central US (Stage)"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}]},{"namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}]},{"namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","East US 2 (Stage)","North Central US (Stage)","UK North","UK South
+        2"],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
-        India","East US 2 (Stage)","North Central US (Stage)","East US","East US 2","North
-        Central US","North Europe","West Europe","Brazil South","UK North","UK South
-        2","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        India","East US 2 (Stage)","North Central US (Stage)","West US 2","West Central
+        US","East US","East US 2","North Central US","North Europe","West Europe","Brazil
+        South","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
-        India","East US 2 (Stage)","North Central US (Stage)","East US","East US 2","North
-        Central US","North Europe","West Europe","Brazil South","UK North","UK South
-        2","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}]},{"namespace":"Microsoft.ClassicInfrastructureMigrate","resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        India","East US 2 (Stage)","North Central US (Stage)","West US 2","West Central
+        US","East US","East US 2","North Central US","North Europe","West Europe","Brazil
+        South","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-01-beta","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}]},{"namespace":"Microsoft.ClassicInfrastructureMigrate","resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.CognitiveServices","resourceTypes":[{"resourceType":"accounts","locations":["West
+        India","South India"],"apiVersions":["2015-06-15"]}]},{"namespace":"Microsoft.CognitiveServices","resourceTypes":[{"resourceType":"accounts","locations":["Global","West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/publishers","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"disks","locations":["Southeast
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"disks","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","West US"],"apiVersions":["2016-04-30-preview"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        India","Canada Central","Canada East","UK North","UK South 2","West US 2","West
+        Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
-        India","Canada Central","Canada East"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","Canada Central","Canada East","UK North","UK South 2","West US 2","West
+        Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.ContainerService","resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US"],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
-        Central US","West Europe","North Europe","East US"],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-30","2015-11-01-preview"]}]},{"namespace":"Microsoft.CortanaAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["West
+        Central US","West Europe","North Europe","East US"],"apiVersions":["2016-03-30","2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-30","2015-11-01-preview"]}]},{"namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","West US (Partner)"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-04-08"]}]},{"namespace":"Microsoft.CortanaAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","Japan
         East","East Asia"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
@@ -476,13 +545,13 @@ http_interactions:
         US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
         US","North Europe","East US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}]},{"namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.DataLakeStore","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.DataLakeStore","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","East US"],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01-preview"]}]},{"namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":["East
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast"],"apiVersions":["2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":["East
         US","North Europe","East Asia","West US","West Europe","Southeast Asia","Japan
@@ -500,13 +569,16 @@ http_interactions:
         Asia","South Central US","West US","West Europe"],"apiVersions":["2016-05-15","2015-05-21-preview"]}]},{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
-        Central US","Central US","Japan East","Japan West","North Central US"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["West
+        Central US","Central US","Japan East","Japan West","North Central US","Canada
+        Central","Canada East"],"apiVersions":["2016-03-31","2016-03-19","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
-        Central US","Central US","Japan East","Japan West","North Central US"],"apiVersions":["2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["West
+        Central US","Central US","Japan East","Japan West","North Central US","Canada
+        Central","Canada East"],"apiVersions":["2016-03-31","2016-03-19","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["West
         US","North Europe","West Europe","East US","East US 2","East Asia","Southeast
         Asia","Australia East","Australia Southeast","Central India","South India","South
-        Central US","Central US","Japan East","Japan West","North Central US"],"apiVersions":["2015-04-08","2014-04-01"]}]},{"namespace":"Microsoft.DomainRegistration","resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}]},{"namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        Central US","Central US","Japan East","Japan West","North Central US","Canada
+        Central","Canada East"],"apiVersions":["2016-03-31","2016-03-19","2015-04-08","2014-04-01"]}]},{"namespace":"Microsoft.DomainRegistration","resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}]},{"namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
@@ -523,16 +595,19 @@ http_interactions:
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North
         Europe","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}]},{"namespace":"Microsoft.EventHub","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
-        East","Japan West","North Europe","West Europe","Central India","South India","West
-        India"],"apiVersions":["2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2014-09-01"]}]},{"namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}]},{"namespace":"Microsoft.Gallery","resourceTypes":[{"resourceType":"myareas","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas/areas","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/galleryitems","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas/galleryitems","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas/areas/galleryitems","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"enroll","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"galleryitems","locations":[],"apiVersions":["2016-03-01-preview","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-03-01-preview","2014-04-01-preview"]},{"resourceType":"retrieveresourcesbyid","locations":[],"apiVersions":["2016-03-01-preview","2014-04-01-preview"]},{"resourceType":"generateartifactaccessuri","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2016-03-01-preview"]}]},{"namespace":"Microsoft.HDInsight","resourceTypes":[{"resourceType":"clusters","locations":["East
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East"],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2014-09-01"]}]},{"namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}]},{"namespace":"Microsoft.Gallery","resourceTypes":[{"resourceType":"myareas","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas/areas","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/galleryitems","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas/galleryitems","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"myareas/areas/areas/galleryitems","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"enroll","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"galleryitems","locations":[],"apiVersions":["2016-03-01-preview","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-03-01-preview","2014-04-01-preview"]},{"resourceType":"retrieveresourcesbyid","locations":[],"apiVersions":["2016-03-01-preview","2014-04-01-preview"]},{"resourceType":"generateartifactaccessuri","locations":[],"apiVersions":["2016-03-01-preview"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2016-03-01-preview"]}]},{"namespace":"Microsoft.HDInsight","resourceTypes":[{"resourceType":"clusters","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["West
         US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["West
         US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["West
         US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["West
+        US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["West
         US","Central US"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["West
         US","Central US"],"apiVersions":["2015-03-01-preview"]}]},{"namespace":"microsoft.insights","resourceTypes":[{"resourceType":"components","locations":["Central
         US"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["Central
@@ -548,96 +623,128 @@ http_interactions:
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
-        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
-        East","Japan West","North Central US","South Central US","East US 2","Canada
-        East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
-        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"metricDefinitions","locations":["West
-        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
-        East","Japan West","North Central US","South Central US","East US 2","Canada
-        East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
-        South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","West US 2","West Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","Japan East","Japan West","North Central US","South
+        Central US","East US 2","Canada East","Canada Central","Central US","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"metricDefinitions","locations":["West
+        US","Brazil South","East US","West US 2","West Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","North Central
+        US","South Central US","East US 2","Canada East","Canada Central","Central
+        US","Australia East","Australia Southeast","South India","Central India","West
+        India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Canada
         East","Canada Central","Central US","Australia East","Australia Southeast","Brazil
         South","South India","Central India","West India","UK North","UK South 2"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
-        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
-        West","North Central US","South Central US","East US 2","Canada East","Canada
-        Central","Central US","Australia East","Australia Southeast","Brazil South","South
-        India","Central India","West India","North Europe"],"apiVersions":["2016-06-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil
+        South","Australia East","Australia Southeast","Central India","South India","West
+        India","Canada Central","Canada East"],"apiVersions":["2016-06-01"]}]},{"namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
-        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
-        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01","2014-12-19-preview"]}]},{"namespace":"Microsoft.Logic","resourceTypes":[{"resourceType":"workflows","locations":["North
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01","2014-12-19-preview"]}]},{"namespace":"Microsoft.Logic","resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview"]}]},{"namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview"]}]},{"namespace":"Microsoft.MachineLearning","resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia"],"apiVersions":["2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia"],"apiVersions":["2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia"],"apiVersions":["2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia"],"apiVersions":["2016-05-01-preview"]}]},{"namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}]},{"namespace":"Microsoft.Media","resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","East US 2","Central
+        US","Brazil South","Central India","West India","South India","South Central
+        US","UK North","UK South 2","Canada Central","Canada East"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"expressRouteCircuits","locations":["West
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-11-30","2015-11-15-preview","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2015-11-01","2015-04-28-preview"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]}]},{"namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West India","Canada Central","Canada East","UK North","UK South 2","West
+        Central US","West US 2"],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]}]},{"namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
         East","Japan West","North Europe","West Europe"],"apiVersions":["2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
@@ -653,17 +760,23 @@ http_interactions:
         East","Australia Southeast","Central US","East US","East US 2","West US","North
         Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
         East","Japan West","North Europe","West Europe"],"apiVersions":["2014-09-01"]}]},{"namespace":"Microsoft.OperationalInsights","resourceTypes":[{"resourceType":"workspaces","locations":["East
-        US","West Europe","Southeast Asia","Australia Southeast"],"apiVersions":["2015-11-01-preview","2015-03-20"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"linkTargets","locations":["East
-        US"],"apiVersions":["2015-03-20","2014-10-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]}]},{"namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast"],"apiVersions":["2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20","2014-10-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]}]},{"namespace":"Microsoft.OperationsManagement","resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast"],"apiVersions":["2015-11-01-preview"]}]},{"namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["East
         US","South Central US","North Central US","East US 2","West US","West Europe","North
-        Europe","Brazil South","Southeast Asia","Australia Southeast"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["East
+        Europe","Brazil South","Southeast Asia","Australia Southeast","East US (Stage)","South
+        Central US (Stage)"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["East
         US","South Central US","North Central US","East US 2","West US","West Europe","North
-        Europe","Brazil South","Southeast Asia","Australia Southeast"],"apiVersions":["2016-01-29"]}]},{"namespace":"Microsoft.ProjectOxford","resourceTypes":[{"resourceType":"accounts","locations":["West
+        Europe","Brazil South","Southeast Asia","Australia Southeast","East US (Stage)","South
+        Central US (Stage)"],"apiVersions":["2016-01-29"]}]},{"namespace":"Microsoft.ProjectOxford","resourceTypes":[{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2016-02-01-preview"]}]},{"namespace":"Microsoft.RecoveryServices","resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
-        India"],"apiVersions":["2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}]},{"namespace":"Microsoft.RemoteApp","resourceTypes":[{"resourceType":"collections","locations":["Australia
+        India"],"apiVersions":["2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["Southeast
+        Asia"],"apiVersions":["2016-06-01"]}]},{"namespace":"Microsoft.RemoteApp","resourceTypes":[{"resourceType":"collections","locations":["Australia
         East","Australia Southeast","Brazil South","Central US","East Asia","East
         US","East US 2","Japan East","Japan West","North Central US","North Europe","Southeast
         Asia","South Central US","West Europe","West US"],"apiVersions":["2014-09-01"]},{"resourceType":"collections/applications","locations":["Australia
@@ -674,27 +787,32 @@ http_interactions:
         US","East US 2","Japan East","Japan West","North Central US","North Europe","Southeast
         Asia","South Central US","West Europe","West US"],"apiVersions":["2014-09-01"]},{"resourceType":"accounts","locations":["West
         US"],"apiVersions":["2014-09-01"]},{"resourceType":"templateImages","locations":["West
-        US"],"apiVersions":["2014-09-01"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
-        US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
-        US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
-        South","Australia Southeast","Australia East","West India","South India","Central
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
-        US","East Asia","Southeast Asia","East US","East US 2","West US","North Central
-        US","South Central US","North Europe","West Europe","Japan East","Japan West","Brazil
-        South","Australia Southeast","Australia East","West India","South India","Central
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        US"],"apiVersions":["2014-09-01"]}]},{"namespace":"Microsoft.ResourceHealth","resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK North","UK South 2"],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK North","UK South 2"],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}]},{"namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
-        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
-        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
-        India","West India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK North","UK South 2"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}]},{"namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
@@ -728,203 +846,260 @@ http_interactions:
         US","East US","North Europe","West Europe"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"gateways","locations":["Central
         US","East US","North Europe","West Europe"],"apiVersions":["2015-07-01-preview"]},{"resourceType":"nodes","locations":["Central
         US","East US","North Europe","West Europe"],"apiVersions":["2015-07-01-preview"]}]},{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","East Asia","Southeast Asia","Brazil South","Japan
-        East","Japan West","North Europe","West Europe","Central India","South India","West
-        India","Canada Central","Canada East"],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2014-09-01"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["West
-        US","East US","East US 2","Central US","West Europe","Australia East","Australia
-        Southeast","North Central US","Japan West","South Central US"],"apiVersions":["2016-03-01","2016-01-01-beta","2015-01-01-alpha"]}]},{"namespace":"Microsoft.Sql","resourceTypes":[{"resourceType":"operations","locations":["East
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East"],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-01","2014-09-01"]}]},{"namespace":"Microsoft.ServiceFabric","resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","Australia East","Australia Southeast","North Central
+        US","East Asia","Southeast Asia","Japan West","Japan East","South India","West
+        India","Central India","Brazil South","South Central US","Canada Central","Canada
+        East"],"apiVersions":["2016-03-01","2016-01-01-beta","2015-01-01-alpha"]}]},{"namespace":"Microsoft.Sql","resourceTypes":[{"resourceType":"operations","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/capabilities","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"checkNameAvailability","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers","locations":["North
-        Europe","East US","West US","South Central US","East US 2","Central US","North
-        Central US","East Asia","Southeast Asia","Japan West","Japan East","West Europe","Brazil
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Central
+        US","East US","West US","South Central US","East US 2","North Central US","East
+        Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/serviceObjectives","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/communicationLinks","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/administrators","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/administratorOperationResults","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/recoverableDatabases","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/import","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/importExportOperationResults","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/operationResults","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/firewallrules","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/connectionPolicies","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["West
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["East
+        US","West US","South Central US","East US 2","Central US","North Central US","East
+        Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
+        South","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["West
         Europe","West US","South Central US","East US 2","Central US","North Central
         US","East US","East Asia","Southeast Asia","Japan West","Japan East","North
         Europe","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["West
+        India","South India","Canada Central","Canada East","West US 2","West Central
+        US","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["West
         US","South Central US","East US 2","Central US","North Central US","East US","East
         Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["West
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["West
         US","South Central US","East US 2","Central US","North Central US","East US","East
         Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["West
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["West
         US","South Central US","East US 2","Central US","North Central US","East US","East
         Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/resourcepools","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/resourcepools","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/usages","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/usages","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/metrics","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/topQueries","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/advisors","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/advisors","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/databases/extensions","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["East
         US","West US","South Central US","East US 2","Central US","North Central US","East
         Asia","Southeast Asia","Japan West","Japan East","West Europe","North Europe","Brazil
         South","Australia East","Australia Southeast","Central India","West India","South
-        India","Canada Central","Canada East","UK North","UK South 2"],"apiVersions":["2015-05-01-preview"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["West
+        US","South Central US","East US 2","Central US","North Central US","East US","East
+        Asia","Southeast Asia","Japan West","Japan East","North Europe","West Europe","Brazil
+        South","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","West US 2","West Central US","UK North","UK
+        South 2"],"apiVersions":["2015-05-01-preview"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","East US 2 (Stage)","West US","West Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","Central
         US","North Europe","Brazil South","Australia East","Australia Southeast","South
-        India","Central India","West India","Canada East","Canada Central","UK North","UK
-        South 2"],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        India","Central India","West India","Canada East","Canada Central","West US
+        2","West Central US","UK North","UK South 2"],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","East US 2 (Stage)","West Europe","North Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","East
         US 2","Central US","Australia East","Australia Southeast","Brazil South","South
-        India","Central India","West India","Canada East","Canada Central","UK North","UK
-        South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        India","Central India","West India","Canada East","Canada Central","West US
+        2","West Central US","UK North","UK South 2"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","East US 2 (Stage)","West Europe","North Europe","East Asia","Southeast
         Asia","Japan East","Japan West","North Central US","South Central US","East
         US 2","Central US","Australia East","Australia Southeast","Brazil South","South
-        India","Central India","West India","Canada East","Canada Central","UK North","UK
-        South 2"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        India","Central India","West India","Canada East","Canada Central","West US
+        2","West Central US","UK North","UK South 2"],"apiVersions":["2014-04-01"]}]},{"namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
         US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
         Asia","South Central US","East Asia","Japan West","North Central US","East
         US","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
@@ -955,251 +1130,288 @@ http_interactions:
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"managedHostingEnvironments","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"managedHostingEnvironments","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"apiManagementAccounts","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/powerAppsRegistrations","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"apiManagementAccounts","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-08-01-preview","2015-08-01-beta","2015-08-01-alpha"]},{"resourceType":"apiManagementAccounts/connections","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/powerAppsRegistrations","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/connectionAcls","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-08-01-preview","2015-08-01-beta","2015-08-01-alpha"]},{"resourceType":"apiManagementAccounts/connections","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections/connectionAcls","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/connectionAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connectionAcls","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections/connectionAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apiAcls","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connectionAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/apiAcls","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apiAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/apiAcls","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections","locations":["South
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","West US","East
         US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
         US","Brazil South","Australia East","Australia Southeast","West India","Central
-        India","South India","Canada Central","Canada East","MSFT West US","MSFT East
-        US","MSFT East Asia","MSFT North Europe","East US 2 (Stage)","East Asia (Stage)","Central
-        US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"connections","locations":["North
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/localizedDefinitions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","West US","East
+        US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
+        US","Brazil South","Australia East","Australia Southeast","West India","Central
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"apiManagementAccounts/apis/connections","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","West US","East
+        US","Japan West","Japan East","East Asia","East US 2","North Central US","Central
+        US","Brazil South","Australia East","Australia Southeast","West India","Central
+        India","South India","Canada Central","Canada East","West Central US","West
+        US 2","MSFT West US","MSFT East US","MSFT East Asia","MSFT North Europe","East
+        US 2 (Stage)","East Asia (Stage)","Central US (Stage)","North Central US (Stage)"],"apiVersions":["2015-11-01-rc","2015-11-01-preview"]},{"resourceType":"connections","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
-        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview"]}]},{"namespace":"NewRelic.APM","resourceTypes":[{"resourceType":"accounts","locations":["North
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2016-06-01","2015-08-01-preview"]}]},{"namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]}]},{"namespace":"NewRelic.APM","resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
-        Asia","East Asia"],"apiVersions":["2014-10-01","2014-04-01"]}]},{"namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","East Asia"],"apiVersions":["2014-10-01","2014-04-01"]}]},{"namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West US (Partner)"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-05-17"]}]},{"namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US","West US (Partner)"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2016-07-18","2016-06-01"]}]},{"namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US","West US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-01-01"]}]},{"namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-01-01"]}]},{"namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2015-01-01"]}]},{"namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US (Partner)","East US","Central US","North Central US","South Central US","West
+        US","North Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","Australia East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}]},{"namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
         South","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","Southeast Asia","West Europe","West
         US","Australia Southeast","Australia East","South Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
         South","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","Southeast Asia","West Europe","West
         US","Australia Southeast","Australia East","South Central US"],"apiVersions":["2014-04-01"]}]},{"namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["West
-        US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]}]}'
+        US (Partner)","Central US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}]},{"namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe","West US (Partner)"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":["West
+        US (Partner)"],"apiVersions":["2015-06-15"]}]}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:27 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1209,11 +1421,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1230,22 +1442,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 60d98a2d-183c-4a81-894f-c0fd9bc17a97
+      - cc59075c-12aa-41f1-8cb6-47c641e1f44a
       X-Ms-Correlation-Request-Id:
-      - 60d98a2d-183c-4a81-894f-c0fd9bc17a97
+      - cc59075c-12aa-41f1-8cb6-47c641e1f44a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193528Z:60d98a2d-183c-4a81-894f-c0fd9bc17a97
+      - NORTHCENTRALUS:20160722T164839Z:cc59075c-12aa-41f1-8cb6-47c641e1f44a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:27 GMT
+      - Fri, 22 Jul 2016 16:48:39 GMT
       Content-Length:
       - '750'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2","name":"miq-azure-test2","location":"centralus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3","name":"miq-azure-test3","location":"westus","properties":{"provisioningState":"Succeeded"}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:28 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2016-03-30
@@ -1258,11 +1470,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1283,20 +1495,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - fa118e05-3942-4d00-b538-80dfcff75ada
+      - 1838a9c9-ce6f-4313-b3a7-e3e02702da84
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14961'
+      - '14947'
       X-Ms-Correlation-Request-Id:
-      - f8537400-ae76-4e43-887a-7c97cbeb3c4d
+      - cb9a5e30-0655-4e44-9020-5ba3986f7533
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193529Z:f8537400-ae76-4e43-887a-7c97cbeb3c4d
+      - NORTHCENTRALUS:20160722T164840Z:cb9a5e30-0655-4e44-9020-5ba3986f7533
       Date:
-      - Fri, 20 May 2016 19:35:28 GMT
+      - Fri, 22 Jul 2016 16:48:40 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n
@@ -1311,9 +1523,18 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
         4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
         8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
         \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
         1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
@@ -1329,39 +1550,6 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
         8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
-        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
-        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
-        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
-        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 2\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
-        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 4\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
-        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
-        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
-        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
-        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
-        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
-        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
-        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
-        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
         1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 2\r\n
@@ -1392,6 +1580,45 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
         20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 40\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
         1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 2\r\n
@@ -1446,6 +1673,21 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
         20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 40\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
         8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
@@ -1460,10 +1702,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 16\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:29 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1473,11 +1715,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1494,17 +1736,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14961'
       X-Ms-Request-Id:
-      - 96d242a7-3f73-447d-8136-42c3b96a01b6
+      - 893e9d15-46b6-4e1d-9531-43467bf8ee5a
       X-Ms-Correlation-Request-Id:
-      - 96d242a7-3f73-447d-8136-42c3b96a01b6
+      - 893e9d15-46b6-4e1d-9531-43467bf8ee5a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193531Z:96d242a7-3f73-447d-8136-42c3b96a01b6
+      - NORTHCENTRALUS:20160722T164840Z:893e9d15-46b6-4e1d-9531-43467bf8ee5a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:30 GMT
+      - Fri, 22 Jul 2016 16:48:40 GMT
       Content-Length:
       - '44143'
     body:
@@ -1519,10 +1761,10 @@ http_interactions:
         Contains a numeric digit\\r\\n4) Contains a special character.\"\r\n  }\r\n}"}]}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"Microsoft.Storage/storageAccounts/spec0deply1stor"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010","name":"Microsoft.WindowsServer2012R2Datacenter-20160222104010","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A1"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg241"},"networkSecurityGroupName":{"type":"String","value":"miqtestwinimg3696"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqtestwinimg6202"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.5830069Z","duration":"PT10M55.2480986S","correlationId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg241"},{"id":"Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},{"id":"Microsoft.Network/publicIpAddresses/miqtestwinimg6202"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646","name":"Microsoft.WindowsServer2012R2Datacenter-20160222101646","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-winimg"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-winimg724"},"networkSecurityGroupName":{"type":"String","value":"miq-test-winimg"},"adminPassword":{"type":"SecureString"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miq-test-winimg"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.8666296Z","duration":"PT10M47.5658692S","correlationId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg"},{"id":"Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-winimg724"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-winimg"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-winimg"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019","name":"Microsoft.WindowsServer2012R2Datacenter-20160218113019","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-win12"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miqazuretest19881"},"networkInterfaceName":{"type":"String","value":"miq-test-win12610"},"networkSecurityGroupName":{"type":"String","value":"miq-test-win12"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest14047"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.18.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.18.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-win12"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.8337856Z","duration":"PT11M9.8080785S","correlationId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-win12"},{"id":"Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-win12610"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-win12"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-win12"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest19881"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest14047"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651","name":"Canonical.UbuntuServer1510-20160218112651","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-ubuntu1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest16487"},"virtualNetworkName":{"type":"String","value":"miqazuretest18687"},"networkInterfaceName":{"type":"String","value":"miq-test-ubuntu1989"},"networkSecurityGroupName":{"type":"String","value":"miq-test-ubuntu1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest16487"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.17.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.17.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-ubuntu1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.2528115Z","duration":"PT4M10.3614981S","correlationId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-ubuntu1"},{"id":"Microsoft.Network/virtualNetworks/miqazuretest18687"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest16487"}]}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:31 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1532,11 +1774,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1553,27 +1795,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
+      - '14959'
       X-Ms-Request-Id:
-      - 1c1500b0-7d79-4674-aad2-acc96242f91a
+      - 94ee75e2-ca7a-43ff-a95c-19ea16edcfbf
       X-Ms-Correlation-Request-Id:
-      - 1c1500b0-7d79-4674-aad2-acc96242f91a
+      - 94ee75e2-ca7a-43ff-a95c-19ea16edcfbf
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193531Z:1c1500b0-7d79-4674-aad2-acc96242f91a
+      - NORTHCENTRALUS:20160722T164841Z:94ee75e2-ca7a-43ff-a95c-19ea16edcfbf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:30 GMT
+      - Fri, 22 Jul 2016 16:48:40 GMT
       Content-Length:
       - '12'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:31 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1583,11 +1825,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1604,27 +1846,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14957'
       X-Ms-Request-Id:
-      - a30e8366-1807-4225-b641-ada5ce97e5fa
+      - aaa41598-4603-4c95-8d22-af37bded5a65
       X-Ms-Correlation-Request-Id:
-      - a30e8366-1807-4225-b641-ada5ce97e5fa
+      - aaa41598-4603-4c95-8d22-af37bded5a65
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193532Z:a30e8366-1807-4225-b641-ada5ce97e5fa
+      - NORTHCENTRALUS:20160722T164841Z:aaa41598-4603-4c95-8d22-af37bded5a65
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:31 GMT
+      - Fri, 22 Jul 2016 16:48:40 GMT
       Content-Length:
       - '1284'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations/9F5B589CD174DDD3","operationId":"9F5B589CD174DDD3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.3271271Z","duration":"PT2.0080487S","trackingId":"f712a792-6f75-4bf1-b01a-fefd65afc50e","serviceRequestId":"da737f57-474c-454c-a750-884421e3f2f8","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqmismatch1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-20160417102731/operations/08587381044319043881","operationId":"08587381044319043881","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-05-17T16:27:37.6273566Z","duration":"PT0.1814503S","trackingId":"710ac6bf-c100-4a10-a51c-21fd87fc0138","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:32 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1634,11 +1876,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1655,17 +1897,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14969'
       X-Ms-Request-Id:
-      - 5148ab6b-4c54-4b94-8346-87b5ef22b01b
+      - d6b68425-68a1-4962-b913-9d8a0b74605b
       X-Ms-Correlation-Request-Id:
-      - 5148ab6b-4c54-4b94-8346-87b5ef22b01b
+      - d6b68425-68a1-4962-b913-9d8a0b74605b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193533Z:5148ab6b-4c54-4b94-8346-87b5ef22b01b
+      - NORTHCENTRALUS:20160722T164842Z:d6b68425-68a1-4962-b913-9d8a0b74605b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:33 GMT
+      - Fri, 22 Jul 2016 16:48:41 GMT
       Content-Length:
       - '2551'
     body:
@@ -1676,10 +1918,10 @@ http_interactions:
         an uppercase character\r\n2) Contains a lowercase character\r\n3) Contains
         a numeric digit\r\n4) Contains a special character."}},"targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/anym","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"anym"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/F9F20A47A97EE080","operationId":"F9F20A47A97EE080","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:22.487592Z","duration":"PT0.9167668S","trackingId":"61348482-004f-46c0-88b3-65e3154b74ee","serviceRequestId":"170c3cfe-fffa-47ab-8e8b-815ece2e94e1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/anym-nic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"anym-nic"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/failedme/operations/3DCCD9CF9359AFF8","operationId":"3DCCD9CF9359AFF8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-19T20:51:21.4774538Z","duration":"PT12.4116622S","trackingId":"f38c5a77-b7dc-456d-811b-344f369b4484","serviceRequestId":"5205ab85-5f20-4302-bace-181cfd212c3e","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/myVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"myVNET"}}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:33 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -1689,11 +1931,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -1710,24 +1952,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14955'
       X-Ms-Request-Id:
-      - a1de127f-8b64-48a1-bb8d-8b1f626b3864
+      - 5dba6495-908b-4f60-9512-a1bf65cfaeae
       X-Ms-Correlation-Request-Id:
-      - a1de127f-8b64-48a1-bb8d-8b1f626b3864
+      - 5dba6495-908b-4f60-9512-a1bf65cfaeae
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193533Z:a1de127f-8b64-48a1-bb8d-8b1f626b3864
+      - NORTHCENTRALUS:20160722T164842Z:5dba6495-908b-4f60-9512-a1bf65cfaeae
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:33 GMT
+      - Fri, 22 Jul 2016 16:48:42 GMT
       Content-Length:
       - '6866'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:34 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:43 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json
@@ -1748,34 +1990,36 @@ http_interactions:
     headers:
       Content-Security-Policy:
       - default-src 'none'; style-src 'unsafe-inline'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
       Strict-Transport-Security:
       - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
       Etag:
       - '"1021dc2f239b171860016cf42167f9e9660a8c84"'
       Content-Type:
       - text/plain; charset=utf-8
       Cache-Control:
       - max-age=300
+      X-Geo-Block-List:
+      - ''
       X-Github-Request-Id:
-      - 17EB2C22:68C7:FA632:573F6623
+      - 17EB2822:7187:27671CF:57924E0D
       Content-Length:
       - '10366'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 20 May 2016 19:35:34 GMT
+      - Fri, 22 Jul 2016 16:48:43 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1837-DFW
+      - cache-ord1723-ORD
       X-Cache:
       - HIT
       X-Cache-Hits:
@@ -1785,11 +2029,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - d7ec315da0371643b4a97ea17ad444aaff142e04
+      - c2f4f6741604853c3b16b0f317ba1cc04f932d05
       Expires:
-      - Fri, 20 May 2016 19:40:34 GMT
+      - Fri, 22 Jul 2016 16:53:43 GMT
       Source-Age:
-      - '227'
+      - '94'
     body:
       encoding: UTF-8
       string: |
@@ -2137,10 +2381,10 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:34 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2150,11 +2394,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2171,24 +2415,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14948'
       X-Ms-Request-Id:
-      - ab3aebbf-15c8-4ff6-959b-fd2216847c13
+      - e384098e-880f-4f98-ad5a-416c003fc295
       X-Ms-Correlation-Request-Id:
-      - ab3aebbf-15c8-4ff6-959b-fd2216847c13
+      - e384098e-880f-4f98-ad5a-416c003fc295
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193535Z:ab3aebbf-15c8-4ff6-959b-fd2216847c13
+      - NORTHCENTRALUS:20160722T164844Z:e384098e-880f-4f98-ad5a-416c003fc295
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:34 GMT
+      - Fri, 22 Jul 2016 16:48:43 GMT
       Content-Length:
       - '801'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:35 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:44 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json
@@ -2209,34 +2453,36 @@ http_interactions:
     headers:
       Content-Security-Policy:
       - default-src 'none'; style-src 'unsafe-inline'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
       Strict-Transport-Security:
       - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
       Etag:
       - '"eae0aec440cc458684ae7e987726f237c9fcbfa4"'
       Content-Type:
       - text/plain; charset=utf-8
       Cache-Control:
       - max-age=300
+      X-Geo-Block-List:
+      - ''
       X-Github-Request-Id:
-      - 17EB2C1F:452F:A57F6:573F6623
+      - 17EB281F:3C54:2D8232A:57924E0D
       Content-Length:
       - '3830'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 20 May 2016 19:35:35 GMT
+      - Fri, 22 Jul 2016 16:48:44 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1844-DFW
+      - cache-ord1736-ORD
       X-Cache:
       - HIT
       X-Cache-Hits:
@@ -2246,11 +2492,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - b3ea39b9a2a74a171ea45083ea2f6df19ccf6c72
+      - df7d74e112c27465b30b67513accdb85265a0cb1
       Expires:
-      - Fri, 20 May 2016 19:40:35 GMT
+      - Fri, 22 Jul 2016 16:53:44 GMT
       Source-Age:
-      - '227'
+      - '94'
     body:
       encoding: UTF-8
       string: |
@@ -2389,10 +2635,10 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:35 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2402,11 +2648,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2423,27 +2669,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14945'
       X-Ms-Request-Id:
-      - a7adc5a6-d0b6-48ad-80cd-78304174252b
+      - 134243ee-585a-48ac-bf03-038caacb12da
       X-Ms-Correlation-Request-Id:
-      - a7adc5a6-d0b6-48ad-80cd-78304174252b
+      - 134243ee-585a-48ac-bf03-038caacb12da
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193536Z:a7adc5a6-d0b6-48ad-80cd-78304174252b
+      - NORTHCENTRALUS:20160722T164844Z:134243ee-585a-48ac-bf03-038caacb12da
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:35 GMT
+      - Fri, 22 Jul 2016 16:48:44 GMT
       Content-Length:
       - '6166'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:06.7915034Z","duration":"PT3M1.4329712S","trackingId":"b747ec27-f04a-4dc5-a097-03b78d06b4f3","serviceRequestId":"0b164261-eee1-422e-b558-7cb959e795eb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:48:05.2174686Z","duration":"PT7M35.1627165S","trackingId":"dc765fff-be2e-485c-b812-26cbaf08492c","serviceRequestId":"b4e8ecc8-2e94-4423-b928-2c29900ed123","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/3FD73BA3A618D357","operationId":"3FD73BA3A618D357","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:29.9601151Z","duration":"PT2.604551S","trackingId":"280b442e-2010-45a6-b9b2-ac761d5dee7d","serviceRequestId":"ebbe21b7-a988-4950-9675-0d063e84b60e","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg241"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:18.3026417Z","duration":"PT4.8364985S","trackingId":"7d2f970a-57fc-40b4-9152-2c3c883d58c0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/6CCA0B3A82197571","operationId":"6CCA0B3A82197571","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.0300385Z","duration":"PT13.4143548S","trackingId":"0830ff7f-fb77-44f0-a393-6003873380e8","serviceRequestId":"ea9c728c-70ba-4de3-a55c-8cf6cd310ca0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqtestwinimg3696"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/291C0AC5D4F88BDB","operationId":"291C0AC5D4F88BDB","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:27.2645854Z","duration":"PT13.7950357S","trackingId":"bfd21915-f13e-4ece-a48c-19a5a9a58fcd","serviceRequestId":"60371f22-c3c6-4256-b204-0efc36c51aae","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqtestwinimg6202","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqtestwinimg6202"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:40:14.3483638Z","duration":"PT0.8769498S","trackingId":"54ee2082-f487-4f98-b5da-08f4fb8450ac","serviceRequestId":"be9cbe15-c8b2-47cb-84b0-3714669ff588","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222104010/operations/08587429420731427531","operationId":"08587429420731427531","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:51:07.53375Z","duration":"PT0.5447355S","trackingId":"d4fae0de-498c-4177-8239-46a0f58e2ebf","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:36 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2453,11 +2699,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2474,27 +2720,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14938'
       X-Ms-Request-Id:
-      - 1c1f81fb-8dce-4592-9436-9d9c66068c22
+      - 5034a0f9-d91a-4245-b864-aa947819eb77
       X-Ms-Correlation-Request-Id:
-      - 1c1f81fb-8dce-4592-9436-9d9c66068c22
+      - 5034a0f9-d91a-4245-b864-aa947819eb77
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193537Z:1c1f81fb-8dce-4592-9436-9d9c66068c22
+      - NORTHCENTRALUS:20160722T164844Z:5034a0f9-d91a-4245-b864-aa947819eb77
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:37 GMT
+      - Fri, 22 Jul 2016 16:48:44 GMT
       Content-Length:
       - '6161'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/5ED9A3C729C70499","operationId":"5ED9A3C729C70499","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.1806556Z","duration":"PT3M14.7317782S","trackingId":"2e8bc5df-290e-4427-9d7e-b07dc8b56157","serviceRequestId":"e6051ebe-75e3-4280-ad61-5c4928614ad2","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-winimg/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/A92DBB77E06CA985","operationId":"A92DBB77E06CA985","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:24:20.3730557Z","duration":"PT7M15.3472227S","trackingId":"b15735ed-1f9c-4235-8554-0359a94d8021","serviceRequestId":"b90d407e-ca03-4efe-ac8c-a40133c4521a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/FAC43E00E60F40D6","operationId":"FAC43E00E60F40D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:04.9686575Z","duration":"PT1.7424043S","trackingId":"9cd93d46-01d3-4fcb-9d33-32d362efad6b","serviceRequestId":"5b900931-b60d-4e18-8e0e-ea23472a6911","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-winimg724"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/4A34D86BCACDE87A","operationId":"4A34D86BCACDE87A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.172193Z","duration":"PT13.1694927S","trackingId":"f1189e74-dc7c-4a8e-9f87-f125c87fac6e","serviceRequestId":"f4510097-ff5e-4476-9d16-ef1b3233a77d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-winimg","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/857E6EBF700A64F8","operationId":"857E6EBF700A64F8","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-22T16:17:03.1483554Z","duration":"PT13.0919048S","trackingId":"ca1bda1a-fda1-4270-8442-a3145bfbe1f2","serviceRequestId":"7f2145f1-40af-4b08-addc-8356a4ddc063","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-winimg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:51.1217903Z","duration":"PT1.1217779S","trackingId":"76e77bc0-53a4-4df3-a941-4c5e007b6a66","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-22T16:16:50.9535836Z","duration":"PT0.9351894S","trackingId":"de79265b-c4a2-457b-807a-9e98060a82f6","serviceRequestId":"7b6a15e6-3c9c-4f56-8a0b-6476821c3449","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160222101646/operations/08587429434771769170","operationId":"08587429434771769170","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-22T16:27:35.7888649Z","duration":"PT0.5055897S","trackingId":"d03c7b95-d9d8-48bb-a526-41e9651ad971","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:37 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2016-02-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2016-06-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2504,11 +2750,164 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14906'
+      X-Ms-Request-Id:
+      - ad93ad2c-cbf1-49f2-9937-dd5e1fa769aa
+      X-Ms-Correlation-Request-Id:
+      - ad93ad2c-cbf1-49f2-9937-dd5e1fa769aa
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160722T164845Z:ad93ad2c-cbf1-49f2-9937-dd5e1fa769aa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 22 Jul 2016 16:48:45 GMT
+      Content-Length:
+      - '6818'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","serviceRequestId":"57d6085f-2656-460f-9fdc-391f3813ba9b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","serviceRequestId":"9e20cfcf-cf82-4053-8a96-ba1a60126341","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","serviceRequestId":"fac0cc26-0839-4302-9536-69cff4273fb9","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","serviceRequestId":"82cddf5c-1792-4498-9ed5-ccdfaf52d93c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","serviceRequestId":"f082fd2f-3170-4f36-b9ff-a635e33f5fcf","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","serviceRequestId":"7df6e0cb-b78b-47ff-b479-90a1aee5a885","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","serviceRequestId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14946'
+      X-Ms-Request-Id:
+      - 1042ad99-7b05-4b5d-b7f4-8d24f9f74e30
+      X-Ms-Correlation-Request-Id:
+      - 1042ad99-7b05-4b5d-b7f4-8d24f9f74e30
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160722T164845Z:1042ad99-7b05-4b5d-b7f4-8d24f9f74e30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 22 Jul 2016 16:48:45 GMT
+      Content-Length:
+      - '7718'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","serviceRequestId":"9df73a78-c24e-444a-82cb-ec8632cb8775","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","serviceRequestId":"21e68a17-9e60-4b90-b988-c524ac8db616","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","serviceRequestId":"2d4bd016-1a2d-4e33-ac21-27105e650564","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","serviceRequestId":"edf1e84f-f9ac-4254-85fa-93f2dd649032","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","serviceRequestId":"5803f928-b459-4872-b035-ae900c9c3eee","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","serviceRequestId":"cd05b456-afab-41a8-8952-43c02b657253","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:48:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14960'
+      X-Ms-Request-Id:
+      - e36601e3-f6ee-4551-9f49-ab1b41ac4848
+      X-Ms-Correlation-Request-Id:
+      - e36601e3-f6ee-4551-9f49-ab1b41ac4848
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160722T164846Z:e36601e3-f6ee-4551-9f49-ab1b41ac4848
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 22 Jul 2016 16:48:45 GMT
+      Content-Length:
+      - '7609'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","serviceRequestId":"b592f413-95b5-42cb-84a1-817ab3f09275","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","serviceRequestId":"e29ef1dc-4e0b-4a92-84f2-a3a746643bcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","serviceRequestId":"c065af43-94f0-421b-a773-737f6584f645","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","serviceRequestId":"12a02fc5-02a7-4d40-a4b5-903a8dc79922","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","serviceRequestId":"cd42e571-c085-4c3e-b89a-d86568b2e289","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","serviceRequestId":"57c68449-35f3-409e-8f51-f4cd9b65a3ab","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:48:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2527,175 +2926,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14958'
       X-Ms-Request-Id:
-      - 0f6789fa-eed0-4b2e-8c89-b30a9326a0fa
+      - ff7e4992-a5d6-4588-bfde-10fa4915cf3a
       X-Ms-Correlation-Request-Id:
-      - 0f6789fa-eed0-4b2e-8c89-b30a9326a0fa
+      - ff7e4992-a5d6-4588-bfde-10fa4915cf3a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193537Z:0f6789fa-eed0-4b2e-8c89-b30a9326a0fa
+      - NORTHCENTRALUS:20160722T164846Z:ff7e4992-a5d6-4588-bfde-10fa4915cf3a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:37 GMT
-      Content-Length:
-      - '6818'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","serviceRequestId":"57d6085f-2656-460f-9fdc-391f3813ba9b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","serviceRequestId":"9e20cfcf-cf82-4053-8a96-ba1a60126341","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","serviceRequestId":"fac0cc26-0839-4302-9536-69cff4273fb9","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","serviceRequestId":"82cddf5c-1792-4498-9ed5-ccdfaf52d93c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","serviceRequestId":"f082fd2f-3170-4f36-b9ff-a635e33f5fcf","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","serviceRequestId":"7df6e0cb-b78b-47ff-b479-90a1aee5a885","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","serviceRequestId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations?api-version=2016-02-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14962'
-      X-Ms-Request-Id:
-      - c9009d63-a408-4aba-a324-efe206760fb7
-      X-Ms-Correlation-Request-Id:
-      - c9009d63-a408-4aba-a324-efe206760fb7
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193538Z:c9009d63-a408-4aba-a324-efe206760fb7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 20 May 2016 19:35:37 GMT
-      Content-Length:
-      - '7718'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/15838BCFE46760A1","operationId":"15838BCFE46760A1","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:28.6222483Z","duration":"PT3M20.660116S","trackingId":"a6653508-59b3-4e4a-b796-f1cf431a9162","serviceRequestId":"9df73a78-c24e-444a-82cb-ec8632cb8775","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-win12/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/DDBEEC376EA09F7E","operationId":"DDBEEC376EA09F7E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:38:07.8075094Z","duration":"PT7M9.35647S","trackingId":"943dac3c-a98b-465d-b759-06506e599546","serviceRequestId":"21e68a17-9e60-4b90-b988-c524ac8db616","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.5055633Z","duration":"PT0.6114738S","trackingId":"1b754371-18ec-4517-bd38-46c9d2ef975d","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:58.3710882Z","duration":"PT0.4790524S","trackingId":"9dfcf1d7-6e4a-4a73-b17e-13b2afdf9d6b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/7F5153152761DD05","operationId":"7F5153152761DD05","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:38.3445066Z","duration":"PT1.6145978S","trackingId":"861a701b-3964-4754-954c-cb21d5e93db8","serviceRequestId":"2d4bd016-1a2d-4e33-ac21-27105e650564","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-win12610"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/F97EC162743B5FF4","operationId":"F97EC162743B5FF4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:57.7800754Z","duration":"PT34.9812759S","trackingId":"92865cda-40cb-41c9-9317-d864b2b3c309","serviceRequestId":"2697b0c7-b8eb-4759-b72f-f0d104416b0d","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/EA21060B6C976C52","operationId":"EA21060B6C976C52","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.6308058Z","duration":"PT13.8442357S","trackingId":"e950697d-0ec6-40f5-8d14-7bfae0ecabf5","serviceRequestId":"edf1e84f-f9ac-4254-85fa-93f2dd649032","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-win12","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/61B1466BCE99F9D3","operationId":"61B1466BCE99F9D3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.4233646Z","duration":"PT13.6985797S","trackingId":"fd76215f-8c01-4e2a-8068-636237270be4","serviceRequestId":"5803f928-b459-4872-b035-ae900c9c3eee","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest19881"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/58705CE1AC7417FE","operationId":"58705CE1AC7417FE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:30:36.5145163Z","duration":"PT13.7848628S","trackingId":"31027583-c7fb-4302-9bbe-9d1f79502a4c","serviceRequestId":"cd05b456-afab-41a8-8952-43c02b657253","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-win12"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-20160218113019/operations/08587432846644519702","operationId":"08587432846644519702","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:41:30.7434262Z","duration":"PT2.0330234S","trackingId":"1bf25585-8cf8-4c99-9078-aa6f5c036128","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations?api-version=2016-02-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - a332a181-5471-4d95-a2cd-8aa9ed6d3c3f
-      X-Ms-Correlation-Request-Id:
-      - a332a181-5471-4d95-a2cd-8aa9ed6d3c3f
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193539Z:a332a181-5471-4d95-a2cd-8aa9ed6d3c3f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 20 May 2016 19:35:38 GMT
-      Content-Length:
-      - '7609'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/056F4B33F11A3099","operationId":"056F4B33F11A3099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:01.4236054Z","duration":"PT1M23.6187466S","trackingId":"70c620a7-2c3c-4743-ae6f-e3836270f2f1","serviceRequestId":"b592f413-95b5-42cb-84a1-817ab3f09275","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-ubuntu1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/62E621EEEC5E62EE","operationId":"62E621EEEC5E62EE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:29:37.7414996Z","duration":"PT2M9.3834226S","trackingId":"48044c61-7a07-4aff-be71-aeacc2471e7b","serviceRequestId":"e29ef1dc-4e0b-4a92-84f2-a3a746643bcd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.2125225Z","duration":"PT0.642269S","trackingId":"51ea1626-1a59-4e23-8590-445c4ca176d0","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/34A4347ECF2A45BE","operationId":"34A4347ECF2A45BE","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:28.1112967Z","duration":"PT0.5497549S","trackingId":"ce1e6b19-7951-4c73-9005-20fe16d36036","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/8F3051FDE964A700","operationId":"8F3051FDE964A700","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:09.9030716Z","duration":"PT2.0210551S","trackingId":"ed583a8c-7b18-4b99-a285-f09a67c14a3b","serviceRequestId":"c065af43-94f0-421b-a773-737f6584f645","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-ubuntu1989"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/9D251C6DB1BEEA3B","operationId":"9D251C6DB1BEEA3B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:27.4794736Z","duration":"PT33.3813549S","trackingId":"f9366eee-29f7-42e3-b0fe-1f577c8ae55c","serviceRequestId":"b9a1c908-4fb2-41d1-b086-bfe318b0132c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/7CE1E6C413F108AC","operationId":"7CE1E6C413F108AC","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.7755462Z","duration":"PT13.6793163S","trackingId":"ca83e042-a8c6-4ffb-9f2c-2e4a9f1bbd7c","serviceRequestId":"12a02fc5-02a7-4d40-a4b5-903a8dc79922","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/76F60549C9B601F7","operationId":"76F60549C9B601F7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.0295771Z","duration":"PT12.9355177S","trackingId":"7fb0a493-ee8a-4d59-86f3-f435a2e1deba","serviceRequestId":"cd42e571-c085-4c3e-b89a-d86568b2e289","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-ubuntu1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-ubuntu1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/E142660DAD24486A","operationId":"E142660DAD24486A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:27:07.101236Z","duration":"PT12.9593617S","trackingId":"68e1b6fa-040c-450f-bd16-0426d5af0f9f","serviceRequestId":"57c68449-35f3-409e-8f51-f4cd9b65a3ab","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miqazuretest18687"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1510-20160218112651/operations/08587432848725863745","operationId":"08587432848725863745","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:31:03.1079152Z","duration":"PT1.6252469S","trackingId":"229c4e55-24ce-4126-b6ff-de2aba268ff3","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2016-02-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - d8bd661d-fd26-439f-9f51-fa9c7107edf0
-      X-Ms-Correlation-Request-Id:
-      - d8bd661d-fd26-439f-9f51-fa9c7107edf0
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193539Z:d8bd661d-fd26-439f-9f51-fa9c7107edf0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 20 May 2016 19:35:39 GMT
+      - Fri, 22 Jul 2016 16:48:45 GMT
       Content-Length:
       - '7624'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:39 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
@@ -2708,11 +2954,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2729,25 +2975,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1b45db4a-5de8-4e36-ae7b-2fcc7ba0a742
+      - 966a95a3-0f22-4268-acf6-04a64eb50cb3
       X-Ms-Correlation-Request-Id:
-      - 1b45db4a-5de8-4e36-ae7b-2fcc7ba0a742
+      - 966a95a3-0f22-4268-acf6-04a64eb50cb3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193541Z:1b45db4a-5de8-4e36-ae7b-2fcc7ba0a742
+      - NORTHCENTRALUS:20160722T164848Z:966a95a3-0f22-4268-acf6-04a64eb50cb3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:40 GMT
+      - Fri, 22 Jul 2016 16:48:47 GMT
       Content-Length:
-      - '18305'
+      - '18619'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"properties":{"vmId":"796c5bcc-338a-448d-b61c-165279a7fb3e","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.1","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-centos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-centos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"03e8467b-baab-4867-9cc4-157336b7e2e4","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-rhel1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-rhel1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest18686.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"c4d577ae-4be8-41c1-84f8-642320910a5e","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"15.10","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-ubuntu1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest16487.blob.core.windows.net/vhds/miq-test-ubuntu12016218112647.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-ubuntu1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest16487.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"6e555b88-3fd4-4b72-a404-4bba5d11de93","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-win12","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-win122016218113014.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-win12","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"e17a95b0-f4fb-4196-93c5-0c8be7d5c536","hardwareProfile":{"vmSize":"Basic_A1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-winimg","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-winimg","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"d7022008-f6b1-4f4c-8be8-e2d677ef3261","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm0","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"4d1502d5-351a-42f4-8569-22284f906d68","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm1","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"9b746cf3-2e11-4c65-8bd5-4c83b7d9a5a4","hardwareProfile":{"vmSize":"Standard_A1"},"storageProfile":{"imageReference":{"publisher":"canonical","offer":"ubuntuserver","sku":"16.04.0-LTS","version":"16.04.201604203"},"osDisk":{"osType":"Linux","name":"miqazuretest26611","createOption":"FromImage","vhd":{"uri":"https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_8021743a-5957-4dc1-a645-ca210d5d7fc5.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqmismatch1","adminUsername":"dberger","customData":"CiNjbG91ZC1jb25maWcKICB3cml0ZV9maWxlczoKICAgIC0gcGF0aDogL3Rlc3QudHh0CiAgICAgIHBlcm1pc3Npb25zOiAiMDY0NCIKICAgICAgb3duZXI6ICJkYmVyZ2VyIgogICAgICBjb250ZW50OiB8CiAgICAgICAgSGVsbG8gV29ybGQK","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1"}]},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"440f18d3-d4a7-4660-a7fa-ec955e248c9c","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET1"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"CoreOS","offer":"CoreOS","sku":"Alpha","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-coreos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadWrite"},"dataDisks":[{"lun":0,"name":"Test-DataDisk1","createOption":"Attach","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadOnly"}]},"osProfile":{"computerName":"miqazure-coreos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"properties":{},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235"}]},"provisioningState":"Failed"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{}},{"properties":{"vmId":"dacd39ce-d7f9-4acd-8b78-49cac347d6e0","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"jf-metrics-2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/jf-metrics-220164216051.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"jf-metrics-2","adminUsername":"jfrey","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"046acf8d-a861-4ec8-99ee-d14d63da19ca","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"jf-metrics-3","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/jf-metrics-32016410105739.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"jf-metrics-3","adminUsername":"jfrey","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"26b70d9d-1022-41b0-aa94-75c2dd526e4a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux1","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux1201621814595.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus"},{"properties":{"vmId":"4ed26e6d-edf8-4868-a174-4daf1ec8713a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux2201621815529.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux2","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus"}]}'
+      string: '{"value":[{"properties":{"vmId":"796c5bcc-338a-448d-b61c-165279a7fb3e","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.1","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-centos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-centos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","name":"miqazure-centos1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"03e8467b-baab-4867-9cc4-157336b7e2e4","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-rhel1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-rhel1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest18686.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","name":"miq-test-rhel1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"c4d577ae-4be8-41c1-84f8-642320910a5e","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"15.10","version":"latest"},"osDisk":{"osType":"Linux","name":"miq-test-ubuntu1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest16487.blob.core.windows.net/vhds/miq-test-ubuntu12016218112647.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-ubuntu1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest16487.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1","name":"miq-test-ubuntu1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"6e555b88-3fd4-4b72-a404-4bba5d11de93","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-win12","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-win122016218113014.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-win12","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12","name":"miq-test-win12","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"e17a95b0-f4fb-4196-93c5-0c8be7d5c536","hardwareProfile":{"vmSize":"Basic_A1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"miq-test-winimg","createOption":"FromImage","vhd":{"uri":"https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miq-test-winimg","adminUsername":"dberger","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazuretest14047.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg","name":"miq-test-winimg","type":"Microsoft.Compute/virtualMachines","location":"eastus"},{"properties":{"vmId":"d7022008-f6b1-4f4c-8be8-e2d677ef3261","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm0","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","name":"spec0deply1vm0","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"4d1502d5-351a-42f4-8569-22284f906d68","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS"},"hardwareProfile":{"vmSize":"Standard_D1"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"osdisk","createOption":"FromImage","vhd":{"uri":"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"spec0deply1vm1","adminUsername":"deploy1admin","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"http://spec0deply1stor.blob.core.windows.net"}},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","name":"spec0deply1vm1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"9b746cf3-2e11-4c65-8bd5-4c83b7d9a5a4","hardwareProfile":{"vmSize":"Standard_A1"},"storageProfile":{"imageReference":{"publisher":"canonical","offer":"ubuntuserver","sku":"16.04.0-LTS","version":"16.04.201604203"},"osDisk":{"osType":"Linux","name":"miqazuretest26611","createOption":"FromImage","vhd":{"uri":"https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_8021743a-5957-4dc1-a645-ca210d5d7fc5.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqmismatch1","adminUsername":"dberger","customData":"CiNjbG91ZC1jb25maWcKICB3cml0ZV9maWxlczoKICAgIC0gcGF0aDogL3Rlc3QudHh0CiAgICAgIHBlcm1pc3Npb25zOiAiMDY0NCIKICAgICAgb3duZXI6ICJkYmVyZ2VyIgogICAgICBjb250ZW50OiB8CiAgICAgICAgSGVsbG8gV29ybGQK","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1"}]},"provisioningState":"Succeeded"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/miqmismatch1","name":"miqmismatch1","type":"Microsoft.Compute/virtualMachines","location":"eastus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"440f18d3-d4a7-4660-a7fa-ec955e248c9c","availabilitySet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET1"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"CoreOS","offer":"CoreOS","sku":"Alpha","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-coreos1","createOption":"FromImage","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadWrite"},"dataDisks":[{"lun":0,"name":"Test-DataDisk1","createOption":"Attach","vhd":{"uri":"https://miqazuretest32946.blob.core.windows.net/vhds/miqazure-coreos12016218151822.vhd"},"caching":"ReadOnly"}]},"osProfile":{"computerName":"miqazure-coreos1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"properties":{},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235"}]},"provisioningState":"Failed"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1","name":"miqazure-coreos1","type":"Microsoft.Compute/virtualMachines","location":"westus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"dacd39ce-d7f9-4acd-8b78-49cac347d6e0","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"MicrosoftWindowsServer","offer":"WindowsServer","sku":"2012-R2-Datacenter","version":"latest"},"osDisk":{"osType":"Windows","name":"jf-metrics-2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/jf-metrics-220164216051.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"jf-metrics-2","adminUsername":"jfrey","windowsConfiguration":{"provisionVMAgent":true,"enableAutomaticUpdates":true},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2","name":"jf-metrics-2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"046acf8d-a861-4ec8-99ee-d14d63da19ca","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"osType":"Linux","name":"jf-metrics-3","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/jf-metrics-32016410105739.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"jf-metrics-3","adminUsername":"jfrey","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3","name":"jf-metrics-3","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"26b70d9d-1022-41b0-aa94-75c2dd526e4a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux1","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux1201621814595.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux1","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1","name":"miqazure-oraclelinux1","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}},{"properties":{"vmId":"4ed26e6d-edf8-4868-a174-4daf1ec8713a","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"Oracle","offer":"Oracle-Linux-7","sku":"OL70","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-oraclelinux2","createOption":"FromImage","vhd":{"uri":"https://miqazureshared1.blob.core.windows.net/vhds/miqazure-oraclelinux2201621815529.vhd"},"caching":"ReadWrite"},"dataDisks":[]},"osProfile":{"computerName":"miqazure-oraclelinux2","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"https://miqazureshared1.blob.core.windows.net/"}},"provisioningState":"Succeeded"},"resources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2/extensions/Microsoft.Insights.VMDiagnosticsSettings"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2","name":"miqazure-oraclelinux2","type":"Microsoft.Compute/virtualMachines","location":"centralus","tags":{"Shutdown":"true"}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:41 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-07-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2757,11 +3003,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2778,25 +3024,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 047eaa0f-e472-4f9b-8744-9004d0533f37
+      - 71faf441-f4ba-4a7b-a5da-f8f49f373523
       X-Ms-Correlation-Request-Id:
-      - 047eaa0f-e472-4f9b-8744-9004d0533f37
+      - 71faf441-f4ba-4a7b-a5da-f8f49f373523
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193543Z:047eaa0f-e472-4f9b-8744-9004d0533f37
+      - NORTHCENTRALUS:20160722T164850Z:71faf441-f4ba-4a7b-a5da-f8f49f373523
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:42 GMT
+      - Fri, 22 Jul 2016 16:48:50 GMT
       Content-Length:
-      - '27684'
+      - '27426'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}}},{"name":"rhel--westu-3742715939-nic","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"07a6cbb0-6f40-4cc0-8b59-c6e373022308","ipConfigurations":[{"name":"ipconfig1463067665324","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false}},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-12-CE-C0","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}}},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}}},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}}},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}}},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}}},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-6F-F4","enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"}}},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}}},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}}},{"name":"jf-metrics-1130","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c8e67ef0-66f4-46b2-9341-f9c885b63950","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1"}}},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"}}},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-77-CE","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"}}},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}}},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-11-C3","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}}},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}}}]}'
+      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"rhel--westu-3742715939-nic","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"07a6cbb0-6f40-4cc0-8b59-c6e373022308","ipConfigurations":[{"name":"ipconfig1463067665324","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"8d354bcd-59e3-45fb-9171-428cafae93c6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"8d354bcd-59e3-45fb-9171-428cafae93c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-11-0E-FE","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"9e3fd1af-9dce-4b74-aee7-e6cead0e9055\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"9e3fd1af-9dce-4b74-aee7-e6cead0e9055\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"63557a74-22c4-4817-a4da-d76f4ad5a952\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"63557a74-22c4-4817-a4da-d76f4ad5a952\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-11-26-62","enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"f09089c2-d946-4a37-a29a-97b6ec9b806c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"f09089c2-d946-4a37-a29a-97b6ec9b806c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"8b8de9ba-b1fc-4e79-b6b6-691338830a27\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"8b8de9ba-b1fc-4e79-b6b6-691338830a27\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-1130","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c8e67ef0-66f4-46b2-9341-f9c885b63950","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"29e68017-1548-4d7b-95f7-c9c906707ec8\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"29e68017-1548-4d7b-95f7-c9c906707ec8\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}},"type":"Microsoft.Network/networkInterfaces"}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:43 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2016-07-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2806,11 +3052,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2827,22 +3073,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e15ce54f-de2e-4ed3-8145-c6d7fe90b2c3
+      - b2a6b9d2-ff8b-4175-a251-7b3095aba66b
       X-Ms-Correlation-Request-Id:
-      - e15ce54f-de2e-4ed3-8145-c6d7fe90b2c3
+      - b2a6b9d2-ff8b-4175-a251-7b3095aba66b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193545Z:e15ce54f-de2e-4ed3-8145-c6d7fe90b2c3
+      - NORTHCENTRALUS:20160722T164852Z:b2a6b9d2-ff8b-4175-a251-7b3095aba66b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:44 GMT
+      - Fri, 22 Jul 2016 16:48:52 GMT
       Content-Length:
-      - '12056'
+      - '11516'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}}},{"name":"rhel--westu-3742715939-pip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip","etag":"W/\"b4539336-af86-4417-a6b5-0c3936f3272d\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ea971f95-f711-48c1-8876-859bc3c1543a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"rhel--westu-3742715939-pip","fqdn":"rhel--westu-3742715939-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"e68a3d66-4215-4cf1-8f0f-65364da57c65\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"13.92.253.245","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"8c14171e-afdb-469f-be79-e3c1c006be91\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"e28a3b72-79ab-428e-9bd3-85a775af8e03\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg","etag":"W/\"a091b576-4b02-4f33-81e8-6161b046fee5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"410a657e-4107-4cf0-9447-1efd44e2363a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"}}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"v-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp","etag":"W/\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b2dff9bd-173c-4e3e-b531-3e0e340bc07d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1","etag":"W/\"be35748a-21e4-426c-bc81-fd064427e2bc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d2e64d4-f867-49da-9c32-a566b2d35968","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}}},{"name":"miq-delete-me","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miq-delete-me","etag":"W/\"5171fcd1-f597-45d4-9f8e-59eac23f6f99\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fc52242e-2505-4f33-ad3e-0042acc24b12","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","ipAddress":"40.76.5.200","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"4d0cbf71-c0d1-415d-a467-bb05ca49c343\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","ipAddress":"40.86.82.249","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"2e9bb8e1-94a8-4472-9407-3b9236cad91b\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"d13a8a44-f2c2-457a-a3e3-12dad359d25f\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","ipAddress":"13.67.185.16","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}}}]}'
+      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}}},{"name":"rhel--westu-3742715939-pip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip","etag":"W/\"b4539336-af86-4417-a6b5-0c3936f3272d\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ea971f95-f711-48c1-8876-859bc3c1543a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"rhel--westu-3742715939-pip","fqdn":"rhel--westu-3742715939-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"25276273-b3a6-41f0-9136-b11694fc60f5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"40.117.32.144","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"4893f2bf-6f84-4873-b9b2-e0df627c879d\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg","etag":"W/\"a091b576-4b02-4f33-81e8-6161b046fee5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"410a657e-4107-4cf0-9447-1efd44e2363a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"}}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"v-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp","etag":"W/\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b2dff9bd-173c-4e3e-b531-3e0e340bc07d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1","etag":"W/\"be35748a-21e4-426c-bc81-fd064427e2bc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d2e64d4-f867-49da-9c32-a566b2d35968","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"c2f73c3c-f05d-4701-8e65-6d4a42c98335\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","ipAddress":"13.82.28.187","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:45 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2016-03-30
@@ -2855,11 +3101,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2880,42 +3126,42 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - 321fedfa-39ec-449f-aeb5-6cee2ed0012d
+      - 2864ca45-d996-435e-9f41-565b02b462e4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14947'
       X-Ms-Correlation-Request-Id:
-      - e41c6f54-bc7b-4192-a9f0-0c65e5219db6
+      - ebb50df8-662f-478b-b062-f76cae5f314d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193546Z:e41c6f54-bc7b-4192-a9f0-0c65e5219db6
+      - NORTHCENTRALUS:20160722T164852Z:ebb50df8-662f-478b-b062-f76cae5f314d
       Date:
-      - Fri, 20 May 2016 19:35:45 GMT
+      - Fri, 22 Jul 2016 16:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-20T19:35:47+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-07-22T16:48:50+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-04-22T19:08:11.7898141+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-04-22T19:08:11.8523162+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:46 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2016-03-30
@@ -2928,11 +3174,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -2953,50 +3199,50 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - e7651015-b73c-4bff-9836-40477a76e2f0
+      - 9b2c9470-d79d-48d0-91c7-44c8ebe1190f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14924'
       X-Ms-Correlation-Request-Id:
-      - 4ab42341-7838-4272-a637-420c0ce780ed
+      - 0371b75d-dd05-4dec-9942-983c4eb7adba
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193546Z:4ab42341-7838-4272-a637-420c0ce780ed
+      - NORTHCENTRALUS:20160722T164853Z:0371b75d-dd05-4dec-9942-983c4eb7adba
       Date:
-      - Fri, 20 May 2016 19:35:46 GMT
+      - Fri, 22 Jul 2016 16:48:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
         \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
         \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
         \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2016-05-20T19:35:42+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        \       \"time\": \"2016-07-22T16:48:30+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
         [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3.7\",\r\n        \"status\": {\r\n          \"code\":
-        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Ready\"\r\n        }\r\n      }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n
-        \     \"name\": \"miq-test-rhel1\",\r\n      \"statuses\": [\r\n        {\r\n
+        \       \"typeHandlerVersion\": \"2.3.9007\",\r\n        \"status\": {\r\n
         \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
-        \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \         \"time\": \"2016-05-09T16:45:14.7963153+00:00\"\r\n        }\r\n
-        \     ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-07-22T16:39:40.2204168+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
         \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
-        \"2.3.7\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n        }\r\n
-        \     ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"2.3.9007\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
         \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
-        \"Provisioning succeeded\",\r\n      \"time\": \"2016-05-09T16:48:15.5786655+00:00\"\r\n
+        \"Provisioning succeeded\",\r\n      \"time\": \"2016-07-22T16:41:51.7985348+00:00\"\r\n
         \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:47 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1/instanceView?api-version=2016-03-30
@@ -3009,11 +3255,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3034,41 +3280,41 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - 48c0d1fb-753f-4beb-80bc-d303f830d000
+      - 5f0d7845-de8c-4c95-9854-597382857fba
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14958'
+      - '14943'
       X-Ms-Correlation-Request-Id:
-      - a87d1085-fd21-4b32-a5fb-d079c461ea7b
+      - affc1eea-1cd6-4fb3-8ade-537ac65b3050
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193547Z:a87d1085-fd21-4b32-a5fb-d079c461ea7b
+      - NORTHCENTRALUS:20160722T164853Z:affc1eea-1cd6-4fb3-8ade-537ac65b3050
       Date:
-      - Fri, 20 May 2016 19:35:47 GMT
+      - Fri, 22 Jul 2016 16:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-20T19:35:48+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-07-22T16:48:51+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-ubuntu1\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-04-22T19:23:41.3113968+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-06-22T22:00:05.1385021+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e/miq-test-ubuntu1.c4d577ae-4be8-41c1-84f8-642320910a5e.screenshot.bmp\",\r\n
         \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e/miq-test-ubuntu1.c4d577ae-4be8-41c1-84f8-642320910a5e.serialconsole.log\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-04-22T19:23:41.3582826+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-06-22T22:00:05.2009767+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:47 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-win12/instanceView?api-version=2016-03-30
@@ -3081,11 +3327,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3106,40 +3352,40 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - a798792f-754f-4a42-8267-833b45c5880e
+      - 5fefe02c-f1a6-4437-a363-67ceed71f0d4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14937'
       X-Ms-Correlation-Request-Id:
-      - f45a083b-cbde-4135-9c2d-991a6be2f4ce
+      - 9938f990-7535-4a08-bf65-280f87458398
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193548Z:f45a083b-cbde-4135-9c2d-991a6be2f4ce
+      - NORTHCENTRALUS:20160722T164853Z:9938f990-7535-4a08-bf65-280f87458398
       Date:
-      - Fri, 20 May 2016 19:35:47 GMT
+      - Fri, 22 Jul 2016 16:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-20T19:35:49+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-07-22T16:48:51+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-win12\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-04-19T23:42:07.2666832+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-07-20T02:08:55.5672858+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93/miq-test-win12.6e555b88-3fd4-4b72-a404-4bba5d11de93.screenshot.bmp\"\r\n
         \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
         \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-04-19T23:42:07.3291564+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-07-20T02:08:55.629779+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:48 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg/instanceView?api-version=2016-03-30
@@ -3152,11 +3398,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3177,26 +3423,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - 06fcc372-70f4-4c0c-a134-f4bcde5ee61c
+      - aadab177-a164-416a-90e4-4848eff858fd
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14905'
       X-Ms-Correlation-Request-Id:
-      - ca0464bf-8242-476b-9d10-dcbbbd5a97b3
+      - 3a5930b8-7a2c-4f13-8b37-7ad71c45c531
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193548Z:ca0464bf-8242-476b-9d10-dcbbbd5a97b3
+      - NORTHCENTRALUS:20160722T164854Z:3a5930b8-7a2c-4f13-8b37-7ad71c45c531
       Date:
-      - Fri, 20 May 2016 19:35:48 GMT
+      - Fri, 22 Jul 2016 16:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-05-20T19:35:49+00:00\"\r\n
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2016-07-22T16:48:52+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-winimg\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
@@ -3212,7 +3458,7 @@ http_interactions:
         \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
         \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:48 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2016-03-30
@@ -3225,11 +3471,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3250,40 +3496,40 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - f8d4a1be-3b02-4fde-9c8a-720a3420243f
+      - 6f7f7273-8f04-48b3-bd2d-39adc1399d00
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14962'
+      - '14943'
       X-Ms-Correlation-Request-Id:
-      - 324f4474-586b-476d-9ec0-77b14ae17cec
+      - 241e32c0-e03a-4c71-936a-26523f274e14
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193549Z:324f4474-586b-476d-9ec0-77b14ae17cec
+      - NORTHCENTRALUS:20160722T164854Z:241e32c0-e03a-4c71-936a-26523f274e14
       Date:
-      - Fri, 20 May 2016 19:35:49 GMT
+      - Fri, 22 Jul 2016 16:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-20T19:35:50+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-07-22T16:48:52+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-04-05T14:09:42.6331105+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:19:11.7323078+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\"\r\n
         \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-04-05T14:09:42.679986+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-06-22T21:19:11.7791886+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:49 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2016-03-30
@@ -3296,11 +3542,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3321,40 +3567,40 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - 1d164423-017b-4c73-a3d7-6c6ef217a067
+      - cee82a1f-cdeb-46d2-8208-273d10e07b4e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14957'
       X-Ms-Correlation-Request-Id:
-      - 2d505472-f52d-4ede-b7e4-41f2c5945243
+      - e3831460-066d-4cbb-b812-33b653101545
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193549Z:2d505472-f52d-4ede-b7e4-41f2c5945243
+      - NORTHCENTRALUS:20160722T164854Z:e3831460-066d-4cbb-b812-33b653101545
       Date:
-      - Fri, 20 May 2016 19:35:49 GMT
+      - Fri, 22 Jul 2016 16:48:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
         \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
         \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-05-20T19:35:50+00:00\"\r\n
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2016-07-22T16:48:53+00:00\"\r\n
         \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
         \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-04-05T14:11:54.9456196+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:19:35.4977707+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
         \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.screenshot.bmp\"\r\n
         \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
         \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-04-05T14:11:55.0081046+00:00\"\r\n    },\r\n    {\r\n
+        \     \"time\": \"2016-06-22T21:19:35.5602838+00:00\"\r\n    },\r\n    {\r\n
         \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
         \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:50 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/miqmismatch1/instanceView?api-version=2016-03-30
@@ -3367,11 +3613,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3392,41 +3638,41 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131074723991005484
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131106129317687862
       X-Ms-Request-Id:
-      - e64b95e3-3cff-48a8-91b9-526a5eacdbbf
+      - 14fb0e41-a2a4-40eb-b375-cb3b1e66e93c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14966'
       X-Ms-Correlation-Request-Id:
-      - 8218019e-2544-4f67-b49b-e7f1a608788a
+      - 765de515-ce66-46bc-ae97-9e801cd91503
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193550Z:8218019e-2544-4f67-b49b-e7f1a608788a
+      - NORTHCENTRALUS:20160722T164855Z:765de515-ce66-46bc-ae97-9e801cd91503
       Date:
-      - Fri, 20 May 2016 19:35:49 GMT
+      - Fri, 22 Jul 2016 16:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.1.3\",\r\n    \"statuses\":
         [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n        \"level\":
         \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
-        \"Guest Agent is running\",\r\n        \"time\": \"2016-05-20T19:35:41+00:00\"\r\n
+        \"Guest Agent is running\",\r\n        \"time\": \"2016-07-22T16:48:33+00:00\"\r\n
         \     }\r\n    ],\r\n    \"extensionHandlers\": []\r\n  },\r\n  \"disks\":
         [\r\n    {\r\n      \"name\": \"miqazuretest26611\",\r\n      \"statuses\":
         [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-05-17T20:16:27.004737+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2016-07-22T16:46:14.9704198+00:00\"\r\n
         \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
         \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
-        \"Provisioning succeeded\",\r\n      \"time\": \"2016-05-17T20:18:31.9093759+00:00\"\r\n
+        \"Provisioning succeeded\",\r\n      \"time\": \"2016-07-22T16:47:08.7047918+00:00\"\r\n
         \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
         \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:50 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3436,11 +3682,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -3450,36 +3696,29 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dc7895f5-83a6-4e36-8cc5-3f263ff3fce0
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - 35fa64fc-615c-46ce-9a92-57a45f2828e3
       X-Ms-Correlation-Request-Id:
-      - dc7895f5-83a6-4e36-8cc5-3f263ff3fce0
+      - 35fa64fc-615c-46ce-9a92-57a45f2828e3
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193551Z:dc7895f5-83a6-4e36-8cc5-3f263ff3fce0
+      - NORTHCENTRALUS:20160722T164855Z:35fa64fc-615c-46ce-9a92-57a45f2828e3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:51 GMT
+      - Fri, 22 Jul 2016 16:48:55 GMT
+      Content-Length:
+      - '6840'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","kind":"Storage","location":"eastus","name":"miqazuretest14047","properties":{"creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","kind":"Storage","location":"eastus","name":"miqazuretest16487","properties":{"creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","kind":"Storage","location":"eastus","name":"miqazuretest18686","properties":{"creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","kind":"Storage","location":"eastus","name":"spec0deply1stor","properties":{"creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
-
-'
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/cli374271593924959008","kind":"Storage","location":"westus","name":"cli374271593924959008","properties":{"creationTime":"2016-05-12T15:39:54.4351309Z","primaryEndpoints":{"blob":"https://cli374271593924959008.blob.core.windows.net/","file":"https://cli374271593924959008.file.core.windows.net/","queue":"https://cli374271593924959008.queue.core.windows.net/","table":"https://cli374271593924959008.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","kind":"Storage","location":"centralus","name":"miqazureshared1","properties":{"creationTime":"2016-03-18T20:42:52.4980850Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/"},"primaryLocation":"centralus","provisioningState":"Succeeded","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"},"secondaryLocation":"eastus2","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_RAGRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","kind":"Storage","location":"eastus","name":"miqazuretest14047","properties":{"creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","kind":"Storage","location":"eastus","name":"miqazuretest16487","properties":{"creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","kind":"Storage","location":"eastus","name":"miqazuretest18686","properties":{"creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","kind":"Storage","location":"eastus","name":"miqazuretest26611","properties":{"creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","kind":"Storage","location":"westus","name":"miqazuretest32946","properties":{"creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest39555","kind":"Storage","location":"eastus","name":"miqazuretest39555","properties":{"creationTime":"2016-04-21T17:46:50.8278568Z","primaryEndpoints":{"blob":"https://miqazuretest39555.blob.core.windows.net/","file":"https://miqazuretest39555.file.core.windows.net/","queue":"https://miqazuretest39555.queue.core.windows.net/","table":"https://miqazuretest39555.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","kind":"Storage","location":"eastus","name":"spec0deply1stor","properties":{"creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:51 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:55 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2016-01-01
@@ -3492,11 +3731,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
       Content-Length:
       - '0'
   response:
@@ -3517,27 +3756,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 77af0eb0-32b9-4879-8280-3cc0a8e4a13d
+      - ac2ee203-7a14-4d03-95bc-6e93ae99bbab
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - 77af0eb0-32b9-4879-8280-3cc0a8e4a13d
+      - ac2ee203-7a14-4d03-95bc-6e93ae99bbab
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193551Z:77af0eb0-32b9-4879-8280-3cc0a8e4a13d
+      - NORTHCENTRALUS:20160722T164855Z:ac2ee203-7a14-4d03-95bc-6e93ae99bbab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:51 GMT
+      - Fri, 22 Jul 2016 16:48:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w=="},{"keyName":"key2","permissions":"Full","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:51 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:56 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -3550,15 +3789,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:51 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:k6ehWpq0cJ/rSYN+j7k+PATerv3bUvVT0ejJCqVsIxE=
+      - SharedKey miqazuretest14047:fIL+2L9HN1NqCRs9Btf+pRVwp5iwm6pw3oNiibO5gmM=
   response:
     status:
       code: 200
@@ -3571,11 +3812,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a1753477-0001-0013-4dce-b2139e000000
+      - af506822-0001-0097-7a38-e445b6000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:51 GMT
+      - Fri, 22 Jul 2016 16:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3607,26 +3848,32 @@ http_interactions:
         NDA6MzEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzBBRURC
         NTBBQiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
         cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
-        aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05h
-        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAx
-        NiAxNjowNDo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNjkz
-        NTgyRkJENTg0IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
-        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
-        b3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5zeXN0ZW08
-        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIg
-        MjAxNiAxNzowODowMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQz
-        NTI3NDg2NTE2QkY4IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
-        YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
-        L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT52aGRz
-        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFy
-        IDIwMTYgMTc6MzA6NTkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhE
-        MzRGNTMxMjc2NDlFRSI8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVh
-        c2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFz
-        ZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGll
-        cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
-        dW1lcmF0aW9uUmVzdWx0cz4=
+        aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Y29waWVzPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTcgSnVuIDIwMTYg
+        MTQ6MDk6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzk2QjhG
+        MTE4M0QzMiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0
+        YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9w
+        ZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBBcHIg
+        MjAxNiAxNjowNDo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQz
+        NjkzNTgyRkJENTg0IjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFz
+        ZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNl
+        RHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVz
+        PjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1lPjxQ
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTc6
+        MDg6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzQ4NjUx
+        NkJGOCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
+        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
+        aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48
+        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3
+        OjMwOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUzMTI3
+        NjQ5RUUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlv
+        bj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250
+        YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlv
+        blJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:52 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:56 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e?comp=list&restype=container
@@ -3639,15 +3886,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:52 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:30K8zhCfZuuf62ZrgQ8zCzZAT6rcXtGXSzVMmeytgcA=
+      - SharedKey miqazuretest14047:r1ssaVjuPo079Hs4EAT7Y+1eF8qUR2ZAML3X0DaShnU=
   response:
     status:
       code: 200
@@ -3660,11 +3909,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 693028b0-0001-00a7-02ce-b21f9c000000
+      - 8352d3e2-0001-003f-1938-e491a3000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:52 GMT
+      - Fri, 22 Jul 2016 16:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3699,7 +3948,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:52 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:56 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-6e555b88-3fd4-4b72-a404-4bba5d11de93?comp=list&restype=container
@@ -3712,15 +3961,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:52 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:p3Z5G6OVjT6K/bas8EZ1QDjkTtCK89ch12ou4+SiWdc=
+      - SharedKey miqazuretest14047:JQa/brUiNCcehPrUmRJcxYhTAqBjjqBhlNWfOkelEUs=
   response:
     status:
       code: 200
@@ -3733,11 +3984,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6f3e40c8-0001-005e-28ce-b2d57c000000
+      - 675f3214-0001-0037-6a38-e48ad0000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:53 GMT
+      - Fri, 22 Jul 2016 16:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3748,8 +3999,8 @@ http_interactions:
         ZDQtNGI3Mi1hNDA0LTRiYmE1ZDExZGU5MyI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXdpbjEyLjZlNTU1Yjg4LTNmZDQtNGI3Mi1hNDA0LTRiYmE1
         ZDExZGU5My5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5UdWUsIDE5IEFwciAyMDE2IDIzOjM5OjI2IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzY4QUJEN0ZGQ0U5RDwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5XZWQsIDIwIEp1bCAyMDE2IDAyOjA2OjQ2IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEM0IwNDI4MEVGQjAzNDwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -3760,7 +4011,7 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
         ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:53 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:56 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-b97ff488-e114-40ed-8d7a-f4500d73eec0?comp=list&restype=container
@@ -3773,15 +4024,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:53 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:p9Azuu1U9TcjD5lXTS1Uvca5SmnuBulC93hnMcXvVDA=
+      - SharedKey miqazuretest14047:PAvc0FQcWrttvY0/XDlzDppNJ6BOLLMkPG+Rhez0yfs=
   response:
     status:
       code: 200
@@ -3794,11 +4047,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3519fc37-0001-0096-30ce-b2444b000000
+      - c5a363f5-0001-00bb-4a38-e4c78b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:52 GMT
+      - Fri, 22 Jul 2016 16:48:54 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3821,7 +4074,7 @@ http_interactions:
         c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:53 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:57 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqtestwi-e17a95b0-f4fb-4196-93c5-0c8be7d5c536?comp=list&restype=container
@@ -3834,15 +4087,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:53 GMT
+      - Fri, 22 Jul 2016 16:48:57 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:6SX1V1xkO2h6p56dGvNooHEi5ddu3BDi4WP2r+0ceMM=
+      - SharedKey miqazuretest14047:FKkQ2pLFkVirH18xihoS8FlXj89z2XePbFmOD3riuJQ=
   response:
     status:
       code: 200
@@ -3855,11 +4110,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - bdb540af-0001-0056-6cce-b2ce0f000000
+      - f4be0681-0001-012a-3c38-e4156f000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:53 GMT
+      - Fri, 22 Jul 2016 16:48:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3870,7 +4125,69 @@ http_interactions:
         ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNiI+PEJsb2JzIC8+PE5leHRNYXJr
         ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:54 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:57 GMT
+- request:
+    method: get
+    uri: https://miqazuretest14047.blob.core.windows.net/copies?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:48:57 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest14047:bicDk4DoVgBPgZeJ0Zh/arns8oblk3oAPBTvBxiOGmE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4b70bb9c-0001-0032-3738-e47eaf000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:48:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJjb3BpZXMiPjxCbG9icz48QmxvYj48TmFtZT50ZXN0LXdpbjJr
+        MTItY29waWVkLXsxMjM0NX08L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
+        aWZpZWQ+RnJpLCAxNyBKdW4gMjAxNiAxNDoxMzozMCBHTVQ8L0xhc3QtTW9k
+        aWZpZWQ+PEV0YWc+MHg4RDM5NkI5OEYyOUQ3NEM8L0V0YWc+PENvbnRlbnQt
+        TGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
+        Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
+        bnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+
+        PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1u
+        dW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
+        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
+        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5l
+        eHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:48:57 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -3883,15 +4200,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:54 GMT
+      - Fri, 22 Jul 2016 16:48:57 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:hxFSGLGYIrn3xMLVHUhECzHRJyB1CccXyKT516HQ3eg=
+      - SharedKey miqazuretest14047:M+zIE94eEV9yaip4kzsY1uzjSBUku65nORv8dhdbgk0=
   response:
     status:
       code: 200
@@ -3904,72 +4223,173 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d2850a18-0001-0035-46ce-b2882a000000
+      - 359c160a-0001-0106-6738-e49752000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:53 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
         bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
         enVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
-        ZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmJyb25hZ2hy
-        c3BlYzNfMDM0YzkzOGItZWFhOS00Mzk5LThlZDItY2I3MjE2ZmFiZjBiLnZo
-        ZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDI4IEFw
-        ciAyMDE2IDE0OjEyOjQ5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzZGNkYyRTI5OTYyRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5
+        ZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmJyb25hZ2hm
+        aXA3MTRhLjBkNGMxZTc1LTRlYTEtNDQ2Ny05NDMzLTc5YzcwNGFjOTc5ZS5z
+        dGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAy
+        MiBKdWwgMjAxNiAxNjo0ODo0NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+
+        MHg4RDNCMjUwMEI1MUU1Q0Q8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwv
+        Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
+        dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
+        b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmJlTmZkREpsSWh5MlpE
+        WW84S05tNkE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
+        dGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JU
+        eXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNl
+        U3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Js
+        b2I+PEJsb2I+PE5hbWU+YnJvbmFnaGZpcDcxNGFfNGE2M2RmOTktOWY3My00
+        YjhkLTkyM2YtZGMwNjYxN2Q2NjBkLnZoZDwvTmFtZT48UHJvcGVydGllcz48
+        TGFzdC1Nb2RpZmllZD5GcmksIDIyIEp1bCAyMDE2IDE2OjQ4OjU1IEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0IyNTAxMUYyMjIwMzwvRXRhZz48
+        Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTAzPC94LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+
+        PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
+        bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9M
+        ZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        YnJvbmFnaG5vcG9ydC5hZmQxNDZjYy1iYTBmLTQ1YmQtODkyOC0wOGU0Mzc3
+        NzEyMmYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVk
+        PkZyaSwgMjIgSnVsIDIwMTYgMTY6NDg6NTUgR01UPC9MYXN0LU1vZGlmaWVk
+        PjxFdGFnPjB4OEQzQjI1MDExQTc5OTkwPC9FdGFnPjxDb250ZW50LUxlbmd0
+        aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5yOTRIUUQz
+        bmEvVlNrVHNLUUZoN3F3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2hub3BvcnRfOTk0M2E0OTkt
+        YjJlYy00MWUzLTlhODUtYzE0NDk0ZjE4Y2VjLnZoZDwvTmFtZT48UHJvcGVy
+        dGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIyIEp1bCAyMDE2IDE2OjQ4OjU0
+        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0IyNTAxMTUxMjc2OTwv
+        RXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxl
+        bmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwv
+        Q29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFu
+        Z3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09
+        PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bv
+        c2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+ODQ8L3gtbXMt
+        YmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9i
+        VHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
+        dGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5p
+        dGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48
+        TmFtZT5icm9uYWdocmV1c2VpcC41NDk2ZmFhZi0xOGE3LTRhNWUtOTYxZC0w
+        OTI2ZTBlZGU2MDUuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPkZyaSwgMjIgSnVsIDIwMTYgMTY6NDg6NDYgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzQjI1MDBDODk5RjVBPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBw
+        bGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQt
+        RW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT43
+        U2FPa1hTNjAveExtYnZkbi9IZDlRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1D
+        b250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+Qmxv
+        Y2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
+        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
+        b3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2hyZXVzZWlwX2Mz
+        M2E2NTQ5LWNjNGQtNGUzZi05NDVkLTI4YjZjYTA4ODBmMC52aGQ8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMiBKdWwgMjAxNiAx
+        Njo0ODo1MyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNCMjUwMTA1
+        MTA1RkM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92
+        UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjkx
+        PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxv
+        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9u
+        PmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+YnJvbmFnaHJzcGVjM18wMzRjOTM4Yi1lYWE5LTQzOTkt
+        OGVkMi1jYjcyMTZmYWJmMGIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
+        LU1vZGlmaWVkPlRodSwgMjggQXByIDIwMTYgMTQ6MTI6NDkgR01UPC9MYXN0
+        LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkY2RjJFMjk5NjJGPC9FdGFnPjxDb250
+        ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250
+        ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5
+        cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxD
+        b250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQt
+        TUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48
+        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMzwveC1tcy1ibG9iLXNlcXVl
+        bmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFz
+        ZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZh
+        aWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+
+        PE5hbWU+YnJvbmFnaHRlc3QyM19lMjM2MDlmYi05YzdjLTQxM2MtOWJlNi05
+        YTBlMWM5Y2RiZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPkZyaSwgMTMgTWF5IDIwMTYgMjE6MTE6NDggR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzN0I3MzMyNzI4RTNDPC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5i
+        cm9uYWdod2l0aHNfNzNiOWE5NWEtZGRlMS00M2I1LTgxMzktMmJiMDQ2NWQz
+        OTFhLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUs
+        IDI4IEFwciAyMDE2IDE0OjU2OjM1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
+        Zz4weDhEMzZGNzU0QjRCODRFNjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2
+        MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxp
+        Y2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVu
+        Y29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZ
+        aFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29u
+        dHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48Qmxv
+        YlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tl
+        ZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0
+        YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YndlaXRlc3Rf
+        MDAwMi40YmEzZjczNi0xYmFhLTQwZWEtYTIxNy0xYmQ5MDY1ZDk1ZTguc3Rh
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIg
+        SnVsIDIwMTYgMTY6NDg6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzQjI1MDBEOTdDREUzPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5vdzMreDREOFl6ZUpKY01F
+        QXBJYkd3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlw
+        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
+        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
+        PjxCbG9iPjxOYW1lPmJ3ZWl0ZXN0XzAwMDJfYTE1NmJlOWMtMmZiZS00MWVi
+        LTk1NjQtZmJjYjI1NTNlZTMzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFz
+        dC1Nb2RpZmllZD5GcmksIDIyIEp1bCAyMDE2IDE2OjQ4OjU1IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEM0IyNTAxMUUyMTg5MTwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29u
+        dGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1U
+        eXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48
+        Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50
+        LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+
+        PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NTg5PC94LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExl
+        YXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVh
+        c2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFz
+        ZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c2Vj
+        dGVzdDJfODRhZDdiMmItOTEwMC00MGRiLTg5OTctYTMxOTEyY2YyN2MxLnZo
+        ZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDIwIEFw
+        ciAyMDE2IDE4OjE4OjI2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzY5NDgyQTkyN0Y5NTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5
         MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
         L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZO
         T1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
         PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1u
-        dW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
-        PlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
-        YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
-        L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2h0ZXN0MjNf
-        ZTIzNjA5ZmItOWM3Yy00MTNjLTliZTYtOWEwZTFjOWNkYmQ3LnZoZDwvTmFt
-        ZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDEzIE1heSAyMDE2
-        IDIxOjExOjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzdCNzMz
-        MjcyOEUzQzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9D
-        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
-        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
-        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZL
-        L3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
-        ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
-        MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJs
-        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
-        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVh
-        LWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3Bl
-        cnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1Njoz
-        NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8
-        L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1M
-        ZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08
-        L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxh
-        bmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9
-        PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNw
-        b3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMt
-        YmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9i
-        VHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFz
-        ZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9C
-        bG9iPjxCbG9iPjxOYW1lPnNlY3Rlc3QyXzg0YWQ3YjJiLTkxMDAtNDBkYi04
-        OTk3LWEzMTkxMmNmMjdjMS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3Qt
-        TW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAxNiAxODoxODoyNiBHTVQ8L0xhc3Qt
-        TW9kaWZpZWQ+PEV0YWc+MHg4RDM2OTQ4MkE5MjdGOTU8L0V0YWc+PENvbnRl
-        bnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRl
-        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
-        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
-        bnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1N
-        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4
-        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5j
-        ZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VT
-        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
-        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+
-        PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+        dW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+
+        UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVh
+        c2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwv
+        UHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51
+        bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:54 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:57 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -3982,15 +4402,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:54 GMT
+      - Fri, 22 Jul 2016 16:48:57 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:LeJMB8JpBKk42n+eryqjmtqN8eaqYOCh8mow/J187U8=
+      - SharedKey miqazuretest14047:rw14Sft4pCOWZaKv5UtURkLTeYTevL79U8TV7bBIBtE=
   response:
     status:
       code: 200
@@ -4003,11 +4425,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8267137d-0001-004d-44ce-b2e09d000000
+      - d958f518-0001-00af-1e38-e404ef000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:54 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4044,7 +4466,7 @@ http_interactions:
         L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1
         bHRzPg==
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:54 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:58 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4057,15 +4479,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:54 GMT
+      - Fri, 22 Jul 2016 16:48:58 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:d3mmuEoeCf+NEtmzjKwnxj5pv8n1qsvwAVzDPzhJjb4=
+      - SharedKey miqazuretest14047:dme7B1rnGyfFde+krvhWiBdMh/1gDFHhoJVNm5dM/OY=
   response:
     status:
       code: 200
@@ -4078,11 +4502,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c643ac59-0001-0044-59ce-b2fa13000000
+      - f387f29c-0001-001b-5138-e408ed000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:54 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4091,26 +4515,26 @@ http_interactions:
         enVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2lu
         MTIuNmU1NTViODgtM2ZkNC00YjcyLWE0MDQtNGJiYTVkMTFkZTkzLnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEFw
-        ciAyMDE2IDIzOjM5OjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzY4QUJFQkEyRDY0NDwvRXRhZz48Q29udGVudC1MZW5ndGg+NDIzOTwvQ29u
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDIwIEp1
+        bCAyMDE2IDAyOjA3OjA5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        M0IwNDI4RUFGQjE0QTwvRXRhZz48Q29udGVudC1MZW5ndGg+OTgxNDwvQ29u
         dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
         dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
-        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pm5IL0ZtVUJOSFUrSjBUc3Ro
-        cjlxb3c9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmdQQWFnSzdlTlFGam01aWpK
+        dzNZSXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
         dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
         PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
         dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
         PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luMTIyMDE2MjE4MTEzMDE0LnZoZDwv
-        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEFwciAy
-        MDE2IDIzOjQwOjIyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzY4
-        QUJGOTgxODdDMTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDIwIEp1bCAy
+        MDE2IDAyOjA3OjI4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Iw
+        NDI5QTA3QkIwNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
         PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
         dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
         PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6
         UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
         b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
-        ZXI+Mjc0PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5Q
+        ZXI+MjkzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5Q
         YWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VT
         dGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1
         cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48
@@ -4190,7 +4614,7 @@ http_interactions:
         ZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:55 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:58 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
@@ -4203,15 +4627,19 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:55 GMT
+      - Fri, 22 Jul 2016 16:48:58 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:RN5nvI1Dm5lOM6V3zAM9naRHdYirgvRHJT4hRVquWt4=
+      - SharedKey miqazuretest14047:FynbNP8LmL7KHAisnmdayT6fvImUCJIutp9jB+OVaV8=
   response:
     status:
       code: 200
@@ -4232,7 +4660,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4e3a9645-0001-004c-55ce-b2e160000000
+      - d0d77303-0001-0013-7638-e4139e000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4256,12 +4684,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 27 Apr 2016 19:35:14 GMT
       Date:
-      - Fri, 20 May 2016 19:35:54 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:55 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:58 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghtest23_e23609fb-9c7c-413c-9be6-9a0e1c9cdbd7.vhd
@@ -4274,15 +4702,19 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:55 GMT
+      - Fri, 22 Jul 2016 16:48:58 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:yeFMB4D3lCbmwSkXUpuUVR46wi315miOz5OuygYuymA=
+      - SharedKey miqazuretest14047:0Tpw56VjeyeIrMgTmDolClkolou6ge8LvcBM38HF6lo=
   response:
     status:
       code: 200
@@ -4303,7 +4735,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5026d3b3-0001-0108-78ce-b27b59000000
+      - 64b63069-0001-0033-5538-e47f52000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4327,12 +4759,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 13 May 2016 21:02:19 GMT
       Date:
-      - Fri, 20 May 2016 19:35:55 GMT
+      - Fri, 22 Jul 2016 16:48:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:56 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:59 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
@@ -4345,15 +4777,19 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:56 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:+0BAXCLjzTeEqgZDpU+JOIGczHZb4Iu0wXTTFJX141k=
+      - SharedKey miqazuretest14047:yk90dh8WbCGTU2pDWbiHBMBuNlCS/kq7dW0jz8ZEVRU=
   response:
     status:
       code: 200
@@ -4374,7 +4810,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f45e539c-0001-010f-74ce-b28ddc000000
+      - 4c285cb5-0001-002b-0238-e452c7000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4398,12 +4834,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Thu, 28 Apr 2016 14:17:59 GMT
       Date:
-      - Fri, 20 May 2016 19:35:56 GMT
+      - Fri, 22 Jul 2016 16:48:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:56 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:59 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
@@ -4416,15 +4852,19 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:56 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:6aZBskr6X9bEAqaD5WeoHwpQRjBTkM/4CHvOYJssenI=
+      - SharedKey miqazuretest14047:63b/a+zMJbTm8Gwl8q3ouAMn7WszOun7203ewYfWgWo=
   response:
     status:
       code: 200
@@ -4445,7 +4885,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 432ca935-0001-008b-6bce-b29da1000000
+      - defeecb3-0001-0073-7638-e456bc000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4469,12 +4909,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 20 Apr 2016 16:04:56 GMT
       Date:
-      - Fri, 20 May 2016 19:35:56 GMT
+      - Fri, 22 Jul 2016 16:48:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:57 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:59 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -4487,15 +4927,19 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:57 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:3QzQJ6Mx49C58R0dW/vjyPqsnegd1y06y0X3AkothRY=
+      - SharedKey miqazuretest14047:2C5Vu78qAHSyBB3jiUvGAXQkRy7JBsII+qCYNzwWG7o=
   response:
     status:
       code: 200
@@ -4516,7 +4960,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ea1c21ec-0001-002f-6dce-b2a745000000
+      - d19b643d-0001-00a7-8038-e41f9c000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -4548,12 +4992,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 17:08:02 GMT
       Date:
-      - Fri, 20 May 2016 19:35:56 GMT
+      - Fri, 22 Jul 2016 16:48:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:58 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:59 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -4566,15 +5010,19 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:58 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:YeD9pnFjyK/gbbCyUHYUhWbUkf9LOlOqohw1rHvjvv4=
+      - SharedKey miqazuretest14047:K7oCilAwh6E5x3/tQZ3IBoktWyCQlLByzhs0mD7JdPM=
   response:
     status:
       code: 200
@@ -4595,7 +5043,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9ad72bf1-0001-0113-15ce-b255cb000000
+      - fe9bbb2e-0001-00ef-0938-e42d01000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Write-Protection:
@@ -4619,12 +5067,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Mar 2016 16:17:06 GMT
       Date:
-      - Fri, 20 May 2016 19:35:57 GMT
+      - Fri, 22 Jul 2016 16:48:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:58 GMT
+  recorded_at: Fri, 22 Jul 2016 16:48:59 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2016-01-01
@@ -4637,11 +5085,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
       Content-Length:
       - '0'
   response:
@@ -4662,27 +5110,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d71b4c9d-8ec2-4524-ae1b-4845de838eb8
+      - a3262109-9b45-4b3d-b08a-4a058460e065
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - d71b4c9d-8ec2-4524-ae1b-4845de838eb8
+      - a3262109-9b45-4b3d-b08a-4a058460e065
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193558Z:d71b4c9d-8ec2-4524-ae1b-4845de838eb8
+      - NORTHCENTRALUS:20160722T164900Z:a3262109-9b45-4b3d-b08a-4a058460e065
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:35:58 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ=="},{"keyName":"key2","permissions":"Full","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:59 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:00 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -4695,15 +5143,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:59 GMT
+      - Fri, 22 Jul 2016 16:49:00 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:mRIvu/6aRaCRj0RkXUZk0rYeXZtIZJIr8/SGDF4UCp4=
+      - SharedKey miqazuretest16487:yuBuOhdKqlk9F0Kz55fp4+2W0w0nYgGb94HXGRGSytc=
   response:
     status:
       code: 200
@@ -4716,11 +5166,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ea5e526d-0001-00bf-3fce-b23209000000
+      - 0665a9f3-0001-008e-6638-e469de000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:58 GMT
+      - Fri, 22 Jul 2016 16:48:58 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4742,7 +5192,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:35:59 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:00 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-miqtestub-c4d577ae-4be8-41c1-84f8-642320910a5e?comp=list&restype=container
@@ -4755,15 +5205,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:35:59 GMT
+      - Fri, 22 Jul 2016 16:49:00 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:fdGvUtemCDjwctkForOjP5O6MOxql+ek97FUs7Lg7XE=
+      - SharedKey miqazuretest16487:yVRcJUlcDyNJCuI+4+Tq9zDLTIW/QA9kUochOGVlhRA=
   response:
     status:
       code: 200
@@ -4776,11 +5228,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 22163aa6-0001-00b2-64ce-b2dd05000000
+      - 4b9a48f9-0001-0036-0238-e48b2d000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:35:59 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4791,8 +5243,8 @@ http_interactions:
         ZTgtNDFjMS04NGY4LTY0MjMyMDkxMGE1ZSI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXVidW50dTEuYzRkNTc3YWUtNGJlOC00MWMxLTg0ZjgtNjQy
         MzIwOTEwYTVlLnNjcmVlbnNob3QuYm1wPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
-        YXN0LU1vZGlmaWVkPkZyaSwgMjIgQXByIDIwMTYgMTk6MjE6MjkgR01UPC9M
-        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkFFMzRFQUYzODUyPC9FdGFnPjxD
+        YXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTY6NDggR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODFDNDdCNzFDPC9FdGFnPjxD
         b250ZW50LUxlbmd0aD42MTQ5MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
         LVR5cGU+aW1hZ2UvYm1wPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
         bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
@@ -4803,19 +5255,19 @@ http_interactions:
         YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEt
         dGVzdC11YnVudHUxLmM0ZDU3N2FlLTRiZTgtNDFjMS04NGY4LTY0MjMyMDkx
         MGE1ZS5zZXJpYWxjb25zb2xlLmxvZzwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5GcmksIDIyIEFwciAyMDE2IDE5OjIxOjI5IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzZBRTM0RTY0MTREQjwvRXRhZz48Q29u
-        dGVudC1MZW5ndGg+MTMzMTIwPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
-        eXBlPnRleHQvcGxhaW48L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGlu
-        ZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1IC8+PENhY2hl
-        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
-        c2VxdWVuY2UtbnVtYmVyPjA8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
-        PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
-        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
-        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJr
-        ZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+        dC1Nb2RpZmllZD5XZWQsIDIyIEp1biAyMDE2IDIxOjU2OjQ4IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzlBRTgxQkZGMDNGRTwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+MTI0ODc2ODwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT50ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNo
+        ZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj4wPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
+        PjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVu
+        bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xl
+        YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFy
+        a2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:00 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:00 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -4828,15 +5280,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:00 GMT
+      - Fri, 22 Jul 2016 16:49:00 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:u1qKdnaSL9xjTgoVI4EubsoytLbAUGcdyhG0Ra2lUJg=
+      - SharedKey miqazuretest16487:pgE3LDWPDVu1y6qzwRZYXHHBAtzLNcciNwrqJDRd+OU=
   response:
     status:
       code: 200
@@ -4849,11 +5303,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9ae6743e-0001-0092-60ce-b2b1c9000000
+      - 4bbd5cf5-0001-00ce-4738-e44030000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:00 GMT
+      - Fri, 22 Jul 2016 16:48:58 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4862,33 +5316,33 @@ http_interactions:
         enVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1
         bnR1MS5jNGQ1NzdhZS00YmU4LTQxYzEtODRmOC02NDIzMjA5MTBhNWUuc3Rh
-        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIg
-        QXByIDIwMTYgMTk6MjE6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzNkFFMzREOTBCNzU0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY3PC9D
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIg
+        SnVuIDIwMTYgMjE6NTc6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzOUFFODI2NjgyQTA1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY2PC9D
         b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
         LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
-        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+U2dDM3RnVGcwOENGOVYw
-        ckYzVEdHUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WlVyb1NISk1HTFRDZkRw
+        OSt0dkNyUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
         ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
         cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
         dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
         Yj48QmxvYj48TmFtZT5taXEtdGVzdC11YnVudHUxMjAxNjIxODExMjY0Ny52
-        aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMiBB
-        cHIgMjAxNiAxOToyMTo1NyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
-        RDM2QUUzNUVERDRGMDU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3Mjgw
+        aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMiBK
+        dW4gMjAxNiAyMTo1NzozMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDM5QUU4MzcwQkY5MEM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3Mjgw
         NTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
         L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVw
         N3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
         PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1u
-        dW1iZXI+OTc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBl
-        PlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFz
-        ZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNl
-        RHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVz
-        PjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJl
-        c3VsdHM+
+        dW1iZXI+MjY0PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVh
+        c2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFz
+        ZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGll
+        cz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25S
+        ZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:00 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:01 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2016-01-01
@@ -4901,11 +5355,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
       Content-Length:
       - '0'
   response:
@@ -4926,27 +5380,27 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dfabb73a-5a1c-4323-b674-5ccce543cbde
+      - 20a14f30-e14c-4d3f-a4ae-1397c569fed8
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1194'
       X-Ms-Correlation-Request-Id:
-      - dfabb73a-5a1c-4323-b674-5ccce543cbde
+      - 20a14f30-e14c-4d3f-a4ae-1397c569fed8
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193601Z:dfabb73a-5a1c-4323-b674-5ccce543cbde
+      - NORTHCENTRALUS:20160722T164901Z:20a14f30-e14c-4d3f-a4ae-1397c569fed8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:36:00 GMT
+      - Fri, 22 Jul 2016 16:49:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw=="},{"keyName":"key2","permissions":"Full","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:01 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:01 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -4959,15 +5413,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:01 GMT
+      - Fri, 22 Jul 2016 16:49:01 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:hdOspVNSZ46YCZnZEWhJ2vaIjvv/PWT7PVuKmwZzKLo=
+      - SharedKey miqazuretest18686:3jlJpZelLqBr3Jy2EeS2KL36Xw3+jyYOL8QIN795DWI=
   response:
     status:
       code: 200
@@ -4980,11 +5436,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0004f97f-0001-00de-65ce-b276d6000000
+      - c5a4acc3-0001-0016-4c38-e4e7e1000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:00 GMT
+      - Fri, 22 Jul 2016 16:49:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5006,7 +5462,7 @@ http_interactions:
         b250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJh
         dGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:01 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:01 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4?comp=list&restype=container
@@ -5019,15 +5475,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:01 GMT
+      - Fri, 22 Jul 2016 16:49:01 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:9qZBxacU//fhOdJ68AkfW81EqPj0mLBo9cEpSM7eslA=
+      - SharedKey miqazuretest18686:BHU+9CL1jjY8iybWx5XFgoQ6cJG46UWpkQ/uMLo7yvk=
   response:
     status:
       code: 200
@@ -5040,11 +5498,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b3a669f2-0001-006e-61ce-b28f56000000
+      - 2dfda3ed-0001-000e-3538-e4ca74000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:01 GMT
+      - Fri, 22 Jul 2016 16:48:59 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5055,8 +5513,8 @@ http_interactions:
         YWItNDg2Ny05Y2M0LTE1NzMzNmI3ZTJlNCI+PEJsb2JzPjxCbG9iPjxOYW1l
         Pm1pcS10ZXN0LXJoZWwxLjAzZTg0NjdiLWJhYWItNDg2Ny05Y2M0LTE1NzMz
         NmI3ZTJlNC5zY3JlZW5zaG90LmJtcDwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5GcmksIDIwIE1heSAyMDE2IDE5OjM1OjUyIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzgwRTVGNDNDQ0MwMTwvRXRhZz48Q29u
+        dC1Nb2RpZmllZD5GcmksIDIyIEp1bCAyMDE2IDE2OjQ4OjE0IEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEM0IyNEZGOTYwODAwMjwvRXRhZz48Q29u
         dGVudC1MZW5ndGg+NjE0OTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmltYWdlL2JtcDwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
         IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUt
@@ -5067,9 +5525,9 @@ http_interactions:
         ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRl
         c3QtcmhlbDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0
         LnNlcmlhbGNvbnNvbGUubG9nPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPkZyaSwgMjAgTWF5IDIwMTYgMTM6MTk6NDkgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzODBCMTZCQkQ3NzQ3PC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD43NjgwMDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
+        ZGlmaWVkPkZyaSwgMjIgSnVsIDIwMTYgMTY6NDM6MTQgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzQjI0RjQ2NTkwMUM1PC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4zNjM1MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT50
         ZXh0L3BsYWluPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
         Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1Db250
         cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
@@ -5079,7 +5537,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:02 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:02 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5092,15 +5550,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:02 GMT
+      - Fri, 22 Jul 2016 16:49:02 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:Yc6cYOiUHagaBj4xaaBImPTyDvQMfEgSORPD6PwzxCA=
+      - SharedKey miqazuretest18686:0zXtIkVRyDNknQsRd2N5kYSjrQAYeo0hCgRH+uWHLXU=
   response:
     status:
       code: 200
@@ -5113,11 +5573,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d0fbe56f-0001-0011-51ce-b21164000000
+      - 3028b98d-0001-00f6-1838-e40169000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:01 GMT
+      - Fri, 22 Jul 2016 16:49:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5126,36 +5586,36 @@ http_interactions:
         enVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
         ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtcmhl
         bDEuMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0LnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIwIE1h
-        eSAyMDE2IDE5OjM1OjQyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzgwRTVFRTIyNDgzQTwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIyIEp1
+        bCAyMDE2IDE2OjQ4OjU0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        M0IyNTAxMTM2RTI1MjwvRXRhZz48Q29udGVudC1MZW5ndGg+Njg2PC9Db250
         ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
         cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VWQ3cThZSzFXZGV4cHRZcVk5
-        ckRhdz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WTM2SG9raVNaKzJRTi9JZWo1
+        ZnN3QT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
         LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
         PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
         ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
         QmxvYj48TmFtZT5taXEtdGVzdC1yaGVsMTIwMTYyMTgxMTIyNDMudmhkPC9O
-        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjAgTWF5IDIw
-        MTYgMTk6MzU6MjEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzODBF
-        NUUyMThBMTgzPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIgSnVsIDIw
+        MTYgMTY6NDg6NDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQjI1
+        MDBCODI3NzZBPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwv
         Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
         dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
         b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmRRTCtYSGpGTlBkb01F
         d2VJNjNmd1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
         dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjE2MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        PjMwNjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
         ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
         dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
         dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
         bG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0
         cz4=
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:02 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:02 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611/listKeys?api-version=2016-01-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -5165,11 +5625,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
       Content-Length:
       - '0'
   response:
@@ -5190,30 +5650,30 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1d66ab8a-4082-477c-addc-021b2979c3ad
+      - c64e869c-b0b4-4bca-885c-888689f5e442
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1196'
       X-Ms-Correlation-Request-Id:
-      - 1d66ab8a-4082-477c-addc-021b2979c3ad
+      - c64e869c-b0b4-4bca-885c-888689f5e442
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193602Z:1d66ab8a-4082-477c-addc-021b2979c3ad
+      - NORTHCENTRALUS:20160722T164902Z:c64e869c-b0b4-4bca-885c-888689f5e442
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:36:02 GMT
+      - Fri, 22 Jul 2016 16:49:02 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ=="},{"keyName":"key2","permissions":"Full","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}]}
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"Hh1rIrLFYOsfGuufnXsDBIZhDPUM0RWfl1XnZojGXRDo2TRjpQFisw3U7OfrizJ0J7fcN1535PrBniNUt/sVcw=="},{"keyName":"key2","permissions":"Full","value":"EZOKcIq7u+qCjHAIWfhDG0VGJe6sez+D+lYt5cbevX1njlWq+Z2lkffcTOsR/Pe4cDZg4OBCO1SymcWm3A35RA=="}]}
 
 '
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:02 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:02 GMT
 - request:
     method: get
-    uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
+    uri: https://miqazuretest26611.blob.core.windows.net/?comp=list
     body:
       encoding: US-ASCII
       string: ''
@@ -5223,15 +5683,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:02 GMT
+      - Fri, 22 Jul 2016 16:49:02 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:VX65r0l7X9m2wCKFswcQQRm1fuDLdrLueZRBk0CNaRQ=
+      - SharedKey miqazuretest26611:nG0UF73eXqxKke3m5KSnFioupkcsOcb0MFhQbWyw2CI=
   response:
     status:
       code: 200
@@ -5244,11 +5706,918 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8f217357-0001-00ec-43ce-b22e06000000
+      - f429334b-0001-0104-6738-e47b98000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:02 GMT
+      - Fri, 22 Jul 2016 16:49:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFp
+        bmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1qZm1ldHJp
+        Y3MtOTA0Y2M5ODEtZmE0ZC00ZGFmLWI4YjEtZGZjMGYwMTkzOGI1PC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYg
+        MTg6MDI6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzcyQjNE
+        Qzk5NTRCRCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0
+        YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9w
+        ZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkg
+        MjAxNiAxODo0Mzo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQz
+        N0U4MzJFMjMwNEVEIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFz
+        ZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNl
+        RHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVz
+        PjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJv
+        cGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDAyIE1heSAyMDE2IDE4OjAy
+        OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM3MkIzRENCNjBC
+        NTEiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGll
+        cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
+        dW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:03 GMT
+- request:
+    method: get
+    uri: https://miqazuretest26611.blob.core.windows.net/bootdiagnostics-jfmetrics-904cc981-fa4d-4daf-b8b1-dfc0f01938b5?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:03 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest26611:RiN633ag6o3Rb2Anx6D/P7GuLkZplllf7ZxZZzsQFxs=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - c6efdf20-0001-0112-0138-e4ba06000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJib290ZGlhZ25vc3RpY3MtamZtZXRyaWNzLTkwNGNjOTgxLWZh
+        NGQtNGRhZi1iOGIxLWRmYzBmMDE5MzhiNSI+PEJsb2JzPjxCbG9iPjxOYW1l
+        PmpmLW1ldHJpY3MtMS45MDRjYzk4MS1mYTRkLTRkYWYtYjhiMS1kZmMwZjAx
+        OTM4YjUuc2NyZWVuc2hvdC5ibXA8L05hbWU+PFByb3BlcnRpZXM+PExhc3Qt
+        TW9kaWZpZWQ+TW9uLCAwMiBNYXkgMjAxNiAxOTo1OTowNiBHTVQ8L0xhc3Qt
+        TW9kaWZpZWQ+PEV0YWc+MHg4RDM3MkM0MzgwRkMxNjI8L0V0YWc+PENvbnRl
+        bnQtTGVuZ3RoPjYxNDkxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5pbWFnZS9ibXA8L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAv
+        PjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1IC8+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjA8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJs
+        b2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
+        Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:03 GMT
+- request:
+    method: get
+    uri: https://miqazuretest26611.blob.core.windows.net/manageiq?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:03 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest26611:jIWOJByhmFqTIlY+/fhEhyzFSKIOzq+BBr9tepNRR5k=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 5af6357b-0001-0007-5438-e43eca000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPm1pcW1pc21h
+        dGNoMS45Yjc0NmNmMy0yZTExLTRjNjUtOGJkNS00YzgzYjdkOWE1YTQuc3Rh
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIg
+        SnVsIDIwMTYgMTY6NDg6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzQjI1MDEzNjJDOEJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4yNDY8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT43NjZrQW9jaFBNU1duTGxG
+        R2lXTE9BPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlw
+        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
+        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
+        PjxCbG9iPjxOYW1lPm1pcW1pc21hdGNoMV81NzMwMmVlZS00NDJlLTRkYzUt
+        OWIxMC04OTBlYjI5Njc0Y2QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
+        LU1vZGlmaWVkPlR1ZSwgMTcgTWF5IDIwMTYgMTk6MTU6NDQgR01UPC9MYXN0
+        LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0U4N0E1NTY0N0E1PC9FdGFnPjxDb250
+        ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRl
+        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
+        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1N
+        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4
+        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5j
+        ZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VT
+        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
+        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxO
+        YW1lPm1pcW1pc21hdGNoMV84MDIxNzQzYS01OTU3LTRkYzEtYTY0NS1jYTIx
+        MGQ1ZDdmYzUudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVk
+        PkZyaSwgMjIgSnVsIDIwMTYgMTY6NDg6NTkgR01UPC9MYXN0LU1vZGlmaWVk
+        PjxFdGFnPjB4OEQzQjI1MDE0NDU5NkI3PC9FdGFnPjxDb250ZW50LUxlbmd0
+        aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
+        cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
+        dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
+        PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hl
+        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjExNTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
+        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VT
+        dGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48
+        L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcW1pc21hdGNoMV84
+        MThhMWYyNy0wMWE2LTQ3ZGEtYTY1NS1kOWI3Mjk0ODM0YjUudmhkPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTcgTWF5IDIwMTYg
+        MTk6NTc6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0U4RDg5
+        N0VGQzhBPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtX
+        ZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8
+        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9u
+        UmVzdWx0cz4=
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:03 GMT
+- request:
+    method: get
+    uri: https://miqazuretest26611.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:03 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest26611:PqCvJfb1QKEdSNe3tVyIq0P8rC9iQ8wNLSO4fjpsVSE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9ed7a00e-0001-0051-2f38-e4d6ba000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+amYtbWV0cmljcy0x
+        MjAxNjQyMTQxMjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPk1vbiwgMDIgTWF5IDIwMTYgMjA6MDE6NTUgR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzNzJDNDlDQ0UzMUNGPC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0
+        TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:04 GMT
+- request:
+    method: head
+    uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_57302eee-442e-4dc5-9b10-890eb29674cd.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:04 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest26611:58wiwyMuLvLDpPS1n2iO/x3IqOObHWhCBO+hk5Da3Ks=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Tue, 17 May 2016 19:15:44 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D37E87A55647A5"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - ab2134e7-0001-005f-5738-e43ab1000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - 6b0ee745-43fd-429e-905a-6a17b52b9434
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr04.blob.core.windows.net/r-b39f27a8b8c64d52b05eac6a62ebad85-r2/Ubuntu-16_04-LTS-amd64-server-20160420.3-en-us-30GB?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=5jG5r878nDOc8EkQnpfaUq9uSR7TyXDM%2BSPP5ntEAFw%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Tue, 17 May 2016 18:43:47 GMT
+      Date:
+      - Fri, 22 Jul 2016 16:49:02 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:04 GMT
+- request:
+    method: head
+    uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_818a1f27-01a6-47da-a655-d9b7294834b5.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:04 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest26611:2ZA3inUJZ4Lk893Uqj8vy96zk2FXU/5Xc8Lpo7cBWtI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Tue, 17 May 2016 19:57:55 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D37E8D897EFC8A"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1b2e4879-0001-0080-2c38-e46be5000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 98fe8115-0771-49ae-955b-5a794d0908d0
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr04.blob.core.windows.net/r-b39f27a8b8c64d52b05eac6a62ebad85-r2/Ubuntu-16_04-LTS-amd64-server-20160420.3-en-us-30GB?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=5jG5r878nDOc8EkQnpfaUq9uSR7TyXDM%2BSPP5ntEAFw%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Tue, 17 May 2016 19:19:19 GMT
+      Date:
+      - Fri, 22 Jul 2016 16:49:02 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:04 GMT
+- request:
+    method: head
+    uri: https://miqazuretest26611.blob.core.windows.net/vhds/jf-metrics-120164214120.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:04 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest26611:Dyrz+N4IN23zvrZZ0UtaqUvQQ9T6EL33tva0kMzVg+M=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 02 May 2016 20:01:55 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D372C49CCE31CF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - faa3ccf8-0001-00a2-1438-e405d3000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '4'
+      X-Ms-Copy-Id:
+      - f84da2eb-c18a-4247-a7d6-4101240bf7f2
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr04.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=4nmIc5Zc2qmDJgN%2B04ix8pVl5oTfuDZwDqPR8xeAy9o%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 02 May 2016 18:02:01 GMT
+      Date:
+      - Fri, 22 Jul 2016 16:49:02 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:04 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest39555/listKeys?api-version=2016-01-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ffc0bb33-7e34-447a-b3f5-9a5d78360ec6
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1193'
+      X-Ms-Correlation-Request-Id:
+      - ffc0bb33-7e34-447a-b3f5-9a5d78360ec6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160722T164905Z:ffc0bb33-7e34-447a-b3f5-9a5d78360ec6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 22 Jul 2016 16:49:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"XXzZhws8/ROT4GWSZBotMq2VamtPsrvOPvubnOkq/MEebDzyzRHYRbmSe0kj8tFqlXhcGcRYHjA1y5t60ZA/MA=="},{"keyName":"key2","permissions":"Full","value":"nDWROyzta5977mQW/VDcfludJw+92bZABBDaA2/EswU/n0ljqGAhqifJaF0erzhGhxfhXbPMADgNdA6PKbUKLw=="}]}
+
+'
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:05 GMT
+- request:
+    method: get
+    uri: https://miqazuretest39555.blob.core.windows.net/?comp=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:05 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest39555:d1cK7eFNcOj8/Jb55+bePHVsotHX+PXb9zm8qgCidpE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - fa179a0d-0001-0074-1138-e4d904000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QzOTU1NS5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFp
+        bmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXFkZWxl
+        dGUtYWQ3MjY0M2QtYTI3Zi00MDg3LWJmZWMtMWZjOTI5MTdkODc5PC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMjEgQXByIDIwMTYg
+        MTc6NDc6MzIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzZBMEQw
+        NDMyNUQ4RCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0
+        YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9w
+        ZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFt
+        ZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDIxIEFwciAyMDE2
+        IDE3OjQ3OjMzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM2QTBE
+        MDQ2NTU1RjciPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIg
+        Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:05 GMT
+- request:
+    method: get
+    uri: https://miqazuretest39555.blob.core.windows.net/bootdiagnostics-miqdelete-ad72643d-a27f-4087-bfec-1fc92917d879?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:05 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest39555:PC/pLKxb/lVa8ngQ4rnEJeyFgYooFSYSnyynjgGlwp4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - caea28e7-0001-005d-1e38-e4af46000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QzOTU1NS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJib290ZGlhZ25vc3RpY3MtbWlxZGVsZXRlLWFkNzI2NDNkLWEy
+        N2YtNDA4Ny1iZmVjLTFmYzkyOTE3ZDg3OSI+PEJsb2JzPjxCbG9iPjxOYW1l
+        Pm1pcS1kZWxldGUtbWUuYWQ3MjY0M2QtYTI3Zi00MDg3LWJmZWMtMWZjOTI5
+        MTdkODc5LnNjcmVlbnNob3QuYm1wPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
+        LU1vZGlmaWVkPlRodSwgMjEgQXByIDIwMTYgMTg6MTA6MjQgR01UPC9MYXN0
+        LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkExMDM1QzcxNzhEPC9FdGFnPjxDb250
+        ZW50LUxlbmd0aD42MTQ5MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+aW1hZ2UvYm1wPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1D
+        b250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNl
+        cXVlbmNlLW51bWJlcj4wPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxC
+        bG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9j
+        a2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNl
+        U3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtZGVs
+        ZXRlLW1lLmFkNzI2NDNkLWEyN2YtNDA4Ny1iZmVjLTFmYzkyOTE3ZDg3OS5z
+        ZXJpYWxjb25zb2xlLmxvZzwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2Rp
+        ZmllZD5UaHUsIDIxIEFwciAyMDE2IDE3OjUyOjI0IEdNVDwvTGFzdC1Nb2Rp
+        ZmllZD48RXRhZz4weDhEMzZBMERCMURGNzgxRjwvRXRhZz48Q29udGVudC1M
+        ZW5ndGg+NTA2ODg8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+dGV4
+        dC9wbGFpbjwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2FjaGUtQ29udHJv
+        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5j
+        ZS1udW1iZXI+MDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5
+        cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
+        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwv
+        RW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:05 GMT
+- request:
+    method: get
+    uri: https://miqazuretest39555.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:05 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest39555:tavO6Z9o9K3Pnxko4A/Cw3BRoYmwOHPFLhmtudQCn0k=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - a542c05b-0001-0082-6338-e4fe12000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZXRlc3QzOTU1NS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWlu
+        ZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLWRlbGV0ZS1t
+        ZTIwMTYzMjExMTQ2MzUudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPlRodSwgMjEgQXByIDIwMTYgMTg6MTI6NDEgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzNkExMDg3NzdBOTREPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
+        Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
+        bnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+
+        PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1u
+        dW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
+        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
+        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5l
+        eHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:06 GMT
+- request:
+    method: head
+    uri: https://miqazuretest39555.blob.core.windows.net/vhds/miq-delete-me2016321114635.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:06 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest39555:21EbpnFHQR+hHX+sEvh3HnpaCbwAr4YV8sbc3qigouA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Thu, 21 Apr 2016 18:12:41 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36A108777A94D"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 68dbc101-0001-007f-3438-e4c170000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Write-Protection:
+      - 'false'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 0a7f30d0-b24f-40d5-95e8-5cef2a1fb91c
+      X-Ms-Copy-Source:
+      - https://rdfepirv2bl3prdstr01.blob.core.windows.net/b39f27a8b8c64d52b05eac6a62ebad85/Ubuntu-14_04_4-LTS-amd64-server-20160406-en-us-30GB?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=zXeoPP%2BYzJvLB95dUshu1IUA5bueMQHsueBx%2BZUiSQU%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Thu, 21 Apr 2016 17:47:33 GMT
+      Date:
+      - Fri, 22 Jul 2016 16:49:04 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:06 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2016-01-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d44948b5-9c84-4a6f-b6bc-f171ee122623
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - d44948b5-9c84-4a6f-b6bc-f171ee122623
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160722T164906Z:d44948b5-9c84-4a6f-b6bc-f171ee122623
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Fri, 22 Jul 2016 16:49:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ=="},{"keyName":"key2","permissions":"Full","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw=="}]}
+
+'
+    http_version: 
+  recorded_at: Fri, 22 Jul 2016 16:49:06 GMT
+- request:
+    method: get
+    uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Fri, 22 Jul 2016 16:49:06 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey spec0deply1stor:6+xAQl6qYrQS3xxkFAvgiO8tqcZhHdGU+80kc00M6sc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7f30f24f-0001-013d-5138-e4d50c000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Fri, 22 Jul 2016 16:49:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5276,7 +6645,7 @@ http_interactions:
         b3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2Vy
         IC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:03 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:06 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68?comp=list&restype=container
@@ -5289,15 +6658,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:03 GMT
+      - Fri, 22 Jul 2016 16:49:06 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:PjZVKDETyPKQIk+A4HCKwLu9DHFjWfpjgbjyDs2fD5s=
+      - SharedKey spec0deply1stor:8qKwZijQSSktkI491grH59eZ3+5LLZ9/kgcSC3uwAnU=
   response:
     status:
       code: 200
@@ -5310,11 +6681,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 681e042e-0001-000c-5ace-b2c88e000000
+      - 88e3321f-0001-0045-3438-e4fbee000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:02 GMT
+      - Fri, 22 Jul 2016 16:49:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5337,7 +6708,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:03 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:07 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261?comp=list&restype=container
@@ -5350,15 +6721,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:03 GMT
+      - Fri, 22 Jul 2016 16:49:07 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:UTM3FbevdGuu2WnwH39hOf/wxJgBZKRBDLH3XwsjEDg=
+      - SharedKey spec0deply1stor:I5KaQVXXJxxkO7otftxXZVdEdEUmuIf+wl/I7EwFXqs=
   response:
     status:
       code: 200
@@ -5371,11 +6744,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c9ac684c-0001-0014-5cce-b2e51b000000
+      - c178a518-0001-0071-7d38-e45446000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:03 GMT
+      - Fri, 22 Jul 2016 16:49:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5398,7 +6771,7 @@ http_interactions:
         dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIg
         Lz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:04 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:07 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5411,15 +6784,17 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - ''
       X-Ms-Date:
-      - Fri, 20 May 2016 19:36:04 GMT
+      - Fri, 22 Jul 2016 16:49:07 GMT
       X-Ms-Version:
       - '2015-02-21'
+      Auth-String:
+      - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:Xsi71rDSdvaeiT7amU3rte/JWoHoCVcb5TyFbXLasTs=
+      - SharedKey spec0deply1stor:4rrtDT9bqRu/ACcoaahkXCybMMams91StyJzYWZCEZM=
   response:
     status:
       code: 200
@@ -5432,11 +6807,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a0c265a3-0001-00e4-02ce-b23575000000
+      - 7495d6c2-0001-002d-0538-e4a5bf000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Fri, 20 May 2016 19:36:03 GMT
+      - Fri, 22 Jul 2016 16:49:06 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5494,10 +6869,10 @@ http_interactions:
         PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4
         dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:04 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-07-01
     body:
       encoding: US-ASCII
       string: ''
@@ -5507,67 +6882,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fb61f4dc-fda5-4a84-ab0e-3ed36db3110c
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Correlation-Request-Id:
-      - fb61f4dc-fda5-4a84-ab0e-3ed36db3110c
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193605Z:fb61f4dc-fda5-4a84-ab0e-3ed36db3110c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 20 May 2016 19:36:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[]}
-
-'
-    http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -5584,15 +6903,15 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3a14f3bf-1e5d-4930-8deb-c55a54638eed
+      - 71600e65-7f38-4509-abe4-d566619d5bfc
       X-Ms-Correlation-Request-Id:
-      - 3a14f3bf-1e5d-4930-8deb-c55a54638eed
+      - 71600e65-7f38-4509-abe4-d566619d5bfc
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193610Z:3a14f3bf-1e5d-4930-8deb-c55a54638eed
+      - NORTHCENTRALUS:20160722T164912Z:71600e65-7f38-4509-abe4-d566619d5bfc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:36:09 GMT
+      - Fri, 22 Jul 2016 16:49:11 GMT
       Content-Length:
       - '55827'
     body:
@@ -5671,10 +6990,10 @@ http_interactions:
         outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"238bff51-a9d4-4331-9e2e-c04dcdc8532e\"","properties":{"provisioningState":"Succeeded","description":"Deny
         all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993"}]}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:10 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/virtualNetworks?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/virtualNetworks?api-version=2016-07-01
     body:
       encoding: US-ASCII
       string: ''
@@ -5684,11 +7003,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -5705,25 +7024,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - af203342-410e-4013-80fd-a64079269f1a
+      - 60955086-0945-4123-9782-2050ac19b6e1
       X-Ms-Correlation-Request-Id:
-      - af203342-410e-4013-80fd-a64079269f1a
+      - 60955086-0945-4123-9782-2050ac19b6e1
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193612Z:af203342-410e-4013-80fd-a64079269f1a
+      - NORTHCENTRALUS:20160722T164914Z:60955086-0945-4123-9782-2050ac19b6e1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:36:12 GMT
+      - Fri, 22 Jul 2016 16:49:13 GMT
       Content-Length:
-      - '10413'
+      - '10845'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miq-azure-test3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8b01d08a-ea11-45f6-85b2-b7a200de06dd","addressSpace":{"addressPrefixes":["10.20.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.20.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}]}}]}},{"name":"rhel--westu-3742715939-vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet","etag":"W/\"179be2fb-a232-43fb-9a33-d75a5062a066\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"5abc00cb-33e5-4879-b2c4-3bb32e466ab5","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"rhel--westu-3742715939-snet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet","etag":"W/\"179be2fb-a232-43fb-9a33-d75a5062a066\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.1.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}]}}]}},{"name":"miq-azure-test1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","etag":"W/\"0f86710b-e306-406d-9ae6-932fcd17e9dc\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915","addressSpace":{"addressPrefixes":["10.16.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default","etag":"W/\"0f86710b-e306-406d-9ae6-932fcd17e9dc\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.16.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}]}}]}},{"name":"miqazuretest18687","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","etag":"W/\"90e05db2-0da6-4768-a07a-da2e928f143d\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"87a78829-3e13-4a97-9b81-486d93ce6439","addressSpace":{"addressPrefixes":["10.17.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default","etag":"W/\"90e05db2-0da6-4768-a07a-da2e928f143d\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.17.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazuretest19881","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","etag":"W/\"ade5c8a7-0552-4003-b771-998e0aa8b49e\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"9787e570-7ff0-4152-a0ab-da6fa10ba46e","addressSpace":{"addressPrefixes":["10.18.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default","etag":"W/\"ade5c8a7-0552-4003-b771-998e0aa8b49e\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.18.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}]}}]}},{"name":"spec0deply1vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"0bb1f005-1af2-4d4b-966a-89aaf6daefca","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"Subnet-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1"}]}}]}},{"name":"miq-azure-test2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2","etag":"W/\"56d2f57d-5269-4414-97a0-df2887aefd88\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f950a3cf-749a-49d5-a7fb-33a400b0e93c","addressSpace":{"addressPrefixes":["172.25.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default","etag":"W/\"56d2f57d-5269-4414-97a0-df2887aefd88\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.25.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}]}}]}},{"name":"miqazuretest33606","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606","etag":"W/\"5364e401-4c75-4693-81c3-3a44e6cb5475\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"865401e7-9dcb-43f0-b9f0-48a20c2bf5f2","addressSpace":{"addressPrefixes":["172.23.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default","etag":"W/\"5364e401-4c75-4693-81c3-3a44e6cb5475\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.23.0.0/24"}}]}},{"name":"miqazure-sharedvn1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1","etag":"W/\"0c54641c-6be9-400a-bf10-3822f04902b9\"","type":"Microsoft.Network/virtualNetworks","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f83aa7be-47d0-485b-a614-0c1432fbe518","addressSpace":{"addressPrefixes":["10.19.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default","etag":"W/\"0c54641c-6be9-400a-bf10-3822f04902b9\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.19.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}]}}]}}]}'
+      string: '{"value":[{"name":"miq-azure-test3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"8b01d08a-ea11-45f6-85b2-b7a200de06dd","addressSpace":{"addressPrefixes":["10.20.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default","etag":"W/\"2d52b8ec-2224-43c4-8985-dc95cef5c620\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.20.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"rhel--westu-3742715939-vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet","etag":"W/\"179be2fb-a232-43fb-9a33-d75a5062a066\"","type":"Microsoft.Network/virtualNetworks","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"5abc00cb-33e5-4879-b2c4-3bb32e466ab5","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"dhcpOptions":{"dnsServers":[]},"subnets":[{"name":"rhel--westu-3742715939-snet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet","etag":"W/\"179be2fb-a232-43fb-9a33-d75a5062a066\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.1.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"miq-azure-test1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","etag":"W/\"5e24e338-c827-4ee2-bf82-4f8a236202db\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915","addressSpace":{"addressPrefixes":["10.16.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default","etag":"W/\"5e24e338-c827-4ee2-bf82-4f8a236202db\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.16.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"miqazuretest18687","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687","etag":"W/\"cf1d321e-b93f-48ef-8dab-4cedad14c719\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"87a78829-3e13-4a97-9b81-486d93ce6439","addressSpace":{"addressPrefixes":["10.17.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default","etag":"W/\"cf1d321e-b93f-48ef-8dab-4cedad14c719\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.17.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"miqazuretest19881","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881","etag":"W/\"85d7cde9-6816-4152-9acb-fe437b29e5c1\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"9787e570-7ff0-4152-a0ab-da6fa10ba46e","addressSpace":{"addressPrefixes":["10.18.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default","etag":"W/\"85d7cde9-6816-4152-9acb-fe437b29e5c1\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.18.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"spec0deply1vnet","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"0bb1f005-1af2-4d4b-966a-89aaf6daefca","addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"Subnet-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1","etag":"W/\"faeb44c8-b1d7-4efb-9551-a713405cde5a\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.0.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"miq-azure-test2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2","etag":"W/\"56d2f57d-5269-4414-97a0-df2887aefd88\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f950a3cf-749a-49d5-a7fb-33a400b0e93c","addressSpace":{"addressPrefixes":["172.25.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default","etag":"W/\"56d2f57d-5269-4414-97a0-df2887aefd88\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.25.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"miqazuretest33606","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606","etag":"W/\"5364e401-4c75-4693-81c3-3a44e6cb5475\"","type":"Microsoft.Network/virtualNetworks","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"865401e7-9dcb-43f0-b9f0-48a20c2bf5f2","addressSpace":{"addressPrefixes":["172.23.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default","etag":"W/\"5364e401-4c75-4693-81c3-3a44e6cb5475\"","properties":{"provisioningState":"Succeeded","addressPrefix":"172.23.0.0/24","serviceTunnels":[]}}],"virtualNetworkPeerings":[]}},{"name":"miqazure-sharedvn1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1","etag":"W/\"5829b2fc-48f3-4f96-a100-72f725d9dd06\"","type":"Microsoft.Network/virtualNetworks","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f83aa7be-47d0-485b-a614-0c1432fbe518","addressSpace":{"addressPrefixes":["10.19.0.0/16"]},"subnets":[{"name":"default","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default","etag":"W/\"5829b2fc-48f3-4f96-a100-72f725d9dd06\"","properties":{"provisioningState":"Succeeded","addressPrefix":"10.19.0.0/24","ipConfigurations":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}],"serviceTunnels":[]}}],"virtualNetworkPeerings":[]}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:12 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2016-07-01
     body:
       encoding: US-ASCII
       string: ''
@@ -5733,11 +7052,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -5754,25 +7073,25 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 672d2c1b-0849-4545-9880-0fb4ed7afee4
+      - 42b60f5a-2c14-4d82-bd03-7bf2bc0ecb26
       X-Ms-Correlation-Request-Id:
-      - 672d2c1b-0849-4545-9880-0fb4ed7afee4
+      - 42b60f5a-2c14-4d82-bd03-7bf2bc0ecb26
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193613Z:672d2c1b-0849-4545-9880-0fb4ed7afee4
+      - NORTHCENTRALUS:20160722T164916Z:42b60f5a-2c14-4d82-bd03-7bf2bc0ecb26
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:36:13 GMT
+      - Fri, 22 Jul 2016 16:49:15 GMT
       Content-Length:
-      - '27684'
+      - '27426'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"80f07452-bed5-4b56-b1fb-7a68d0f3011c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}}},{"name":"rhel--westu-3742715939-nic","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","type":"Microsoft.Network/networkInterfaces","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"07a6cbb0-6f40-4cc0-8b59-c6e373022308","ipConfigurations":[{"name":"ipconfig1463067665324","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false}},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"41938171-1b02-4bd5-b4c4-92a25b399c5a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-12-CE-C0","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}}},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"d684c53e-f9ac-4f9a-8692-10bd28c74f9e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}}},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"5006ee72-85ab-43c7-ba20-b2e86de2c9ae\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}}},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}}},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}}},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"983f6d15-3374-4515-80e7-d6fad785d109\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"ba02bb81-acf9-4b29-b013-a3edfe64e0a4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-6F-F4","enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"}}},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"298826cf-4629-466b-aacf-f752015c101c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}}},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"92bde856-e663-4de1-8ca7-068103585381\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}}},{"name":"jf-metrics-1130","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","type":"Microsoft.Network/networkInterfaces","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c8e67ef0-66f4-46b2-9341-f9c885b63950","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1"}}},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"892c6803-747f-4bf0-bc94-30cca9be2922\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"}}},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"7d6f2559-f141-4fae-994a-5eb146318fb0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-77-CE","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"}}},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"aee9ddc9-efc8-4b65-bfc1-523f783c17bd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}}},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"037e7c90-c155-41dd-b5cb-7c4e41a8c323\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"macAddress":"00-0D-3A-90-11-C3","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}}},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","type":"Microsoft.Network/networkInterfaces","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}}}]}'
+      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"rhel--westu-3742715939-nic","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"07a6cbb0-6f40-4cc0-8b59-c6e373022308","ipConfigurations":[{"name":"ipconfig1463067665324","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324","etag":"W/\"3390d874-8cf6-46f2-806f-6eef87d9af48\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/rhel--westu-3742715939-vnet/subnets/rhel--westu-3742715939-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"8d354bcd-59e3-45fb-9171-428cafae93c6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"8d354bcd-59e3-45fb-9171-428cafae93c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-11-0E-FE","enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"9e3fd1af-9dce-4b74-aee7-e6cead0e9055\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"9e3fd1af-9dce-4b74-aee7-e6cead0e9055\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg724","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"bef7b677-30b7-460b-a6e3-3004f093da99","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1","etag":"W/\"890c589e-07f2-4c8e-8524-268e24646fef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-winimg"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"63557a74-22c4-4817-a4da-d76f4ad5a952\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"63557a74-22c4-4817-a4da-d76f4ad5a952\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-11-26-62","enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"f09089c2-d946-4a37-a29a-97b6ec9b806c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"f09089c2-d946-4a37-a29a-97b6ec9b806c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"8b8de9ba-b1fc-4e79-b6b6-691338830a27\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"8b8de9ba-b1fc-4e79-b6b6-691338830a27\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"axylcc5sdjfu1ftkrgvpnwxpzc.bx.internal.cloudapp.net"},"enableIPForwarding":false,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-1130","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c8e67ef0-66f4-46b2-9341-f9c885b63950","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1","etag":"W/\"3c21f9df-9880-417d-acd0-ea0792c8f9c6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"29e68017-1548-4d7b-95f7-c9c906707ec8\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"29e68017-1548-4d7b-95f7-c9c906707ec8\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-sharednic1-dyn","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","location":"centralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e1344ec7-08bf-487b-84d5-51b9c70e7ddc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-sharednic1-dyn/ipConfigurations/ipconfig1","etag":"W/\"251b8b0e-235b-4dbb-9f63-36d76ca42595\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"x0ttv4gqi3nurjqubqkdf45fda.gx.internal.cloudapp.net"},"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"}},"type":"Microsoft.Network/networkInterfaces"}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:14 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2016-07-01
     body:
       encoding: US-ASCII
       string: ''
@@ -5782,11 +7101,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      - rest-client/2.0.0.rc1 (darwin15.4.0 x86_64) ruby/2.3.1p112
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjM3NzI2MjUsIm5iZiI6MTQ2Mzc3MjYyNSwiZXhwIjoxNDYzNzc2NTI1LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ2ZXIiOiIxLjAifQ.Z68q2_6V98H5YoavP0Wm2YAItuD8gSVzaBgOnQ069-8KFhV5qHEDHSCacqaejZa8xprFOmqymnCMVfVLFxHjaOWhWmOaaFvZ5APm2-r_l0Q8YvxkNxCXek8UvYkO1Vfw2dMRc8x4K0-_mACfJEM9Oonx-3agNgu2nRsvQ5g1TY49YQrXBThUwoPOIR-5i43c9qYojiTW1DLqRSSZLM4aPwxOI0nto-K7uTHM-ETsBbwaJZSmF6EAOK9TCueTduIT9b2eUnMBB0pHdroKMmDfRVqE9RbzLNfWH9Fvx03Tx0VyoyVKIFdjiZp59r1haLoKsQ2tnG8HmC2jBRhMOCRWmg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE0NjkyMDU4MTgsIm5iZiI6MTQ2OTIwNTgxOCwiZXhwIjoxNDY5MjA5NzE4LCJhcHBpZCI6ImZjMWMyMjI1LTA2NWYtNGJhOC04M2Q5LWQ4NjY2MmY1NzhhZiIsImFwcGlkYWNyIjoiMSIsImdyb3VwcyI6WyI0MDczODk4Ni0zYzgyLTRjZjEtOTlmYy0xMzQ1N2UzMzMyZmMiLCIwZDAxNDNlYS0zMzllLTQyZTAtYTI0ZS1iNWE4ZmM2OWZmMTQiLCJkNjVmMmU1ZC1mYmZiLTQxNTMtODZiMi01OTc5YjRlNmI1OTIiXSwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1LyIsIm9pZCI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInN1YiI6IjMwNmViNDJhLTM1ODUtNGEzNy05NWI3LTM4YmMwZTk4MjhkMiIsInRpZCI6Ijc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NSIsInZlciI6IjEuMCJ9.ccPcm6e1L7CkvqGe6Mwz1LlJ02AzzbwtyVgEWzzf8GeSnesYl4hVWcZekK_LR8InoeJ7xtk7UMxUS27hbx68AMpTo3_dIq_FDgD95PXOTb7mdN8i2X2arhb73SHBAad6Nkky4nWcsbvp4NNDIiHN_mh0xvN0ufLNPxXVAzADAhwf8dZ5WJoQU-uRwAfRe3DjqQlHrG2W3_9bng_BCheyA0NW7czvclEp5yev_Q8tHerRNz_YQMWHJEp0EcmcH5jFxex6k7mkFgHetXqI2KXcK0SZOJTLEVjF5GfMWzCyxDcOPDfDtx9AvN-1zekoEp6abjW7tuE9CXqWJ3L2Mz7-MQ
   response:
     status:
       code: 200
@@ -5803,20 +7122,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a2cd8568-dff3-404b-8be0-4a48051ca95a
+      - ca5c5f6a-d860-490b-81d1-c6e62bb109ad
       X-Ms-Correlation-Request-Id:
-      - a2cd8568-dff3-404b-8be0-4a48051ca95a
+      - ca5c5f6a-d860-490b-81d1-c6e62bb109ad
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160520T193615Z:a2cd8568-dff3-404b-8be0-4a48051ca95a
+      - NORTHCENTRALUS:20160722T164918Z:ca5c5f6a-d860-490b-81d1-c6e62bb109ad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 20 May 2016 19:36:14 GMT
+      - Fri, 22 Jul 2016 16:49:17 GMT
       Content-Length:
-      - '12056'
+      - '11516'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}}},{"name":"rhel--westu-3742715939-pip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip","etag":"W/\"b4539336-af86-4417-a6b5-0c3936f3272d\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ea971f95-f711-48c1-8876-859bc3c1543a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"rhel--westu-3742715939-pip","fqdn":"rhel--westu-3742715939-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"e68a3d66-4215-4cf1-8f0f-65364da57c65\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"13.92.253.245","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"8c14171e-afdb-469f-be79-e3c1c006be91\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"e28a3b72-79ab-428e-9bd3-85a775af8e03\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg","etag":"W/\"a091b576-4b02-4f33-81e8-6161b046fee5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"410a657e-4107-4cf0-9447-1efd44e2363a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"}}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"v-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp","etag":"W/\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b2dff9bd-173c-4e3e-b531-3e0e340bc07d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1","etag":"W/\"be35748a-21e4-426c-bc81-fd064427e2bc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d2e64d4-f867-49da-9c32-a566b2d35968","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}}},{"name":"miq-delete-me","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miq-delete-me","etag":"W/\"5171fcd1-f597-45d4-9f8e-59eac23f6f99\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fc52242e-2505-4f33-ad3e-0042acc24b12","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"6b106d89-0a5b-4ad2-bd4f-7b5171dae4f8\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","ipAddress":"40.76.5.200","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"4d0cbf71-c0d1-415d-a467-bb05ca49c343\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","ipAddress":"40.86.82.249","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"2e9bb8e1-94a8-4472-9407-3b9236cad91b\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"d13a8a44-f2c2-457a-a3e3-12dad359d25f\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","ipAddress":"13.67.185.16","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}}}]}'
+      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}}},{"name":"rhel--westu-3742715939-pip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/rhel--westu-3742715939-pip","etag":"W/\"b4539336-af86-4417-a6b5-0c3936f3272d\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ea971f95-f711-48c1-8876-859bc3c1543a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"rhel--westu-3742715939-pip","fqdn":"rhel--westu-3742715939-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/rhel--westu-3742715939-nic/ipConfigurations/ipconfig1463067665324"}}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"25276273-b3a6-41f0-9136-b11694fc60f5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"40.117.32.144","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"4893f2bf-6f84-4873-b9b2-e0df627c879d\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}}},{"name":"miq-test-winimg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-winimg","etag":"W/\"a091b576-4b02-4f33-81e8-6161b046fee5\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"410a657e-4107-4cf0-9447-1efd44e2363a","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg724/ipConfigurations/ipconfig1"}}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2a8946e1-71ed-4bfe-82ea-cd4d376968be\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"v-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/v-publicIp","etag":"W/\"b26818ee-2ba3-4a65-8596-d48438ac9e0a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b2dff9bd-173c-4e3e-b531-3e0e340bc07d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/Hyper-V/providers/Microsoft.Network/networkInterfaces/ya-test296/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-1","etag":"W/\"be35748a-21e4-426c-bc81-fd064427e2bc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d2e64d4-f867-49da-9c32-a566b2d35968","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-1130/ipConfigurations/ipconfig1"}}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"c2f73c3c-f05d-4701-8e65-6d4a42c98335\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","ipAddress":"13.82.28.187","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","type":"Microsoft.Network/publicIPAddresses","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}}}]}'
     http_version: 
-  recorded_at: Fri, 20 May 2016 19:36:16 GMT
+  recorded_at: Fri, 22 Jul 2016 16:49:18 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This replaces `list_private_images` with `list_all_private_images`. The latter was backported into azure-armrest 0.2.8. It's main advantage is that it makes a single call to get all storage accounts instead of iterating over every resource group, which was causing too many requests, and thus failing in regions with high numbers of resource groups.

This also addresses https://bugzilla.redhat.com/show_bug.cgi?id=1342649

I updated the VCR cassette as well.