### PR TITLE
Upgrade ansible_tower_client gem to ~>0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "activerecord-session_store",     "~>1.0.0"
 gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.1.0",   :require => false
-gem "ansible_tower_client",           "~>0.3.0",   :require => false
+gem "ansible_tower_client",           "~>0.3.1",   :require => false
 gem "aws-sdk",                        "~>2.2.19",  :require => false
 gem "color",                          "~>1.8"
 gem "dalli",                          "~>2.7.4",   :require => false


### PR DESCRIPTION
Includes fix for the following error while posting to the Ansible Tower 3.0+ REST API:
  unsupported media type "application/x-www-form-urlencoded" in request

https://bugzilla.redhat.com/show_bug.cgi?id=1348500