### PR TITLE
Maintain yml file with list of available standby databases

### DIFF
--- a/lib/failover_databases.rb
+++ b/lib/failover_databases.rb
@@ -9,7 +9,7 @@ class FailoverDatabases
     if File.exist?(FAILOVER_DATABASES_YAML_FILE)
       begin
         YAML.load(File.read(FAILOVER_DATABASES_YAML_FILE))
-      rescue => err
+      rescue IOError => err
         _log.error("#{err.class}: #{err}")
         _log.error(err.backtrace.join("\n"))
         []
@@ -52,7 +52,7 @@ class FailoverDatabases
     File.open(FAILOVER_DATABASES_YAML_FILE, 'w+') do |file|
       file.write(result.to_yaml)
     end
-  rescue => err
+  rescue IOError => err
     _log.error("#{err.class}: #{err}")
     _log.error(err.backtrace.join("\n"))
     raise

--- a/lib/failover_databases.rb
+++ b/lib/failover_databases.rb
@@ -8,7 +8,7 @@ class FailoverDatabases
   def self.all_databases
     if File.exist?(FAILOVER_DATABASES_YAML_FILE)
       begin
-        YAML.load(File.read(FAILOVER_DATABASES_YAML_FILE))
+        YAML.load_file(FAILOVER_DATABASES_YAML_FILE)
       rescue IOError => err
         _log.error("#{err.class}: #{err}")
         _log.error(err.backtrace.join("\n"))
@@ -20,19 +20,11 @@ class FailoverDatabases
   end
 
   def self.standby_databases
-    result = []
-    all_databases.each do |record|
-      result << record if record["type"] == 'standby'
-    end
-    result
+    all_databases.select { |record| record["type"] == 'standby' }
   end
 
   def self.active_standby_databases
-    result = []
-    all_databases.each do |record|
-      result << record if record["type"] == 'standby' && record["active"] == true
-    end
-    result
+    all_databases.select { |record| record["type"] == 'standby' && record["active"] == true }
   end
 
   def self.query_repmgr
@@ -49,9 +41,7 @@ class FailoverDatabases
   private_class_method :query_repmgr
 
   def self.write_file(result)
-    File.open(FAILOVER_DATABASES_YAML_FILE, 'w+') do |file|
-      file.write(result.to_yaml)
-    end
+    File.write(FAILOVER_DATABASES_YAML_FILE, result.to_yaml)
   rescue IOError => err
     _log.error("#{err.class}: #{err}")
     _log.error(err.backtrace.join("\n"))

--- a/lib/failover_databases.rb
+++ b/lib/failover_databases.rb
@@ -1,0 +1,55 @@
+class FailoverDatabases
+
+  FAILOVER_DATABASES_YAML_FILE = Rails.root.join("config", "failover_databases.yaml")
+
+  def self.refresh_databases_list
+    query_replication_manager
+  end
+
+  def self.all_databases
+    if  File.exist?(FAILOVER_DATABASES_YAML_FILE)
+      begin
+        YAML.load(File.read(FAILOVER_DATABASES_YAML_FILE))
+      rescue =>err
+        _log.error("#{err.class}: #{err}")
+        _log.error(err.backtrace.join("\n"))
+        []
+      end
+    else
+      query_replication_manager
+    end
+  end
+
+  def self.standby_databases
+    result = []
+    all_databases.each do   |record|
+      result << record if record["type"] == 'standby'  
+    end
+    result
+  end
+
+  def self.standby_and_active_databases
+    result = []
+    all_databases.each do   |record|
+      result << record if record["type"] == 'standby' && record["active"] == true
+    end
+    result
+  end
+
+  def self.query_replication_manager
+    connection = ApplicationRecord.connection
+    return if !(connection.table_exists? "repmgr_miq.repl_nodes")
+    result = []
+    connection.execute("SELECT * FROM repmgr_miq.repl_nodes").each do |data|
+      result << data
+    end
+    File.open(FAILOVER_DATABASES_YAML_FILE, 'w+') do |file|
+      file.write(result.to_yaml)
+    end
+    result
+  rescue => err
+    _log.error("#{err.class}: #{err}")
+    _log.error(err.backtrace.join("\n"))
+  end
+  private_class_method :query_replication_manager
+end

--- a/lib/failover_databases.rb
+++ b/lib/failover_databases.rb
@@ -1,5 +1,5 @@
 class FailoverDatabases
-  FAILOVER_DATABASES_YAML_FILE = Rails.root.join("config", "failover_databases.yml")
+  FAILOVER_DATABASES_YAML_FILE = Rails.root.join("config", "failover_databases.yml").freeze
 
   def self.refresh_databases_list
     query_repmgr

--- a/lib/failover_databases.rb
+++ b/lib/failover_databases.rb
@@ -36,6 +36,7 @@ class FailoverDatabases
         result << record.symbolize_keys.merge(dsn)
       end
       write_file(result)
+      _log.info("List standby databases in #{FAILOVER_DATABASES_YAML_FILE} replaced.")
     end
     result
   end

--- a/lib/failover_databases.rb
+++ b/lib/failover_databases.rb
@@ -1,8 +1,8 @@
 class FailoverDatabases
-  FAILOVER_DATABASES_YAML_FILE = Rails.root.join("config", "failover_databases.yaml")
+  FAILOVER_DATABASES_YAML_FILE = Rails.root.join("config", "failover_databases.yml")
 
   def self.refresh_databases_list
-    query_replication_manager
+    query_repmgr
   end
 
   def self.all_databases
@@ -15,7 +15,7 @@ class FailoverDatabases
         []
       end
     else
-      query_replication_manager
+      query_repmgr
     end
   end
 
@@ -27,7 +27,7 @@ class FailoverDatabases
     result
   end
 
-  def self.standby_and_active_databases
+  def self.active_standby_databases
     result = []
     all_databases.each do |record|
       result << record if record["type"] == 'standby' && record["active"] == true
@@ -35,7 +35,7 @@ class FailoverDatabases
     result
   end
 
-  def self.query_replication_manager
+  def self.query_repmgr
     connection = ApplicationRecord.connection
     result = []
     if connection.table_exists? "repmgr_miq.repl_nodes"
@@ -46,7 +46,7 @@ class FailoverDatabases
     end
     result
   end
-  private_class_method :query_replication_manager
+  private_class_method :query_repmgr
 
   def self.write_file(result)
     File.open(FAILOVER_DATABASES_YAML_FILE, 'w+') do |file|

--- a/spec/lib/failover_databases_spec.rb
+++ b/spec/lib/failover_databases_spec.rb
@@ -100,13 +100,13 @@ describe FailoverDatabases do
   end
 
   def new_record
-    {"id" => 4, "type" => "standby", "active" => true} 
+    {"id" => 4, "type" => "standby", "active" => true}
   end
 
   def add_new_record
     connection = ApplicationRecord.connection
     connection.execute(<<-SQL)
-      INSERT INTO 
+      INSERT INTO
         repmgr_miq.repl_nodes(id, type, active)
       VALUES
         (4, 'standby', 'true')
@@ -114,7 +114,7 @@ describe FailoverDatabases do
   end
 
   def remove_file
-    if File.exists?(described_class::FAILOVER_DATABASES_YAML_FILE)
+    if File.exist?(described_class::FAILOVER_DATABASES_YAML_FILE)
       File.delete(described_class::FAILOVER_DATABASES_YAML_FILE)
     end
   end

--- a/spec/lib/failover_databases_spec.rb
+++ b/spec/lib/failover_databases_spec.rb
@@ -1,0 +1,136 @@
+describe FailoverDatabases do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  before(:all) do
+    @connection = ApplicationRecord.connection_pool.checkout
+    clean_up
+    
+    @connection.execute("CREATE SCHEMA repmgr_miq")
+
+    @connection.execute(<<-SQL)
+      CREATE TABLE repmgr_miq.repl_nodes (
+      id integer NOT NULL,
+      type text NOT NULL,
+      active boolean DEFAULT true NOT NULL,
+      CONSTRAINT repl_nodes_type_check CHECK ((type = ANY (ARRAY['master'::text, 'standby'::text, 'witness'::text]))))
+    SQL
+
+    @connection.execute(<<-SQL)
+      ALTER TABLE ONLY repmgr_miq.repl_nodes
+      ADD CONSTRAINT repl_nodes_pkey PRIMARY KEY (id)
+    SQL
+
+    @connection.execute(<<-SQL)
+      INSERT INTO 
+        repmgr_miq.repl_nodes(id, type, active)
+      VALUES 
+        (2, 'master', 'true'),
+        (1, 'standby', 'true'),
+        (3, 'standby', 'false')
+    SQL
+  end
+
+  after (:each) do
+    remove_file  
+  end
+
+  after(:all) do
+    clean_up
+    ApplicationRecord.connection_pool.checkin(@connection)
+  end
+
+  describe ".all_databases" do
+    it "returns list of all available databases saved in yaml file" do
+      list = described_class.all_databases
+
+      expect(list.size).to be 3
+      expect(list).to match_array(initial_db_records)
+    end
+
+    it "create yaml file with list of available databases if file did not exist" do
+      expect(File.exist?(described_class::FAILOVER_DATABASES_YAML_FILE)).to be false
+
+      described_class.all_databases
+      expect(File.exist?(described_class::FAILOVER_DATABASES_YAML_FILE)).to be true
+    end
+
+    it "if yaml file exists, it loads list of databases from existing file" do
+      list = described_class.all_databases
+      expect(list.size).to be 3
+
+      add_new_record
+      
+      described_class.all_databases
+      expect(list.size).to be 3
+      expect(list).to match_array(initial_db_records)
+    end
+  end
+
+  describe ".refresh_databases_list" do
+    it "override existing yaml file and returns updated list of databases" do
+      list = described_class.all_databases
+      expect(list.size).to be 3
+
+      add_new_record
+
+      list = described_class.refresh_databases_list
+      expect(list.size).to be 4
+      expect(list).to include new_record
+    end
+  end
+  
+  describe ".standby_databases" do
+    it "returns list of databases in standby mode" do
+      list = described_class.standby_databases
+      expect(list.size).to eq 2
+    end
+  end
+
+  describe ".standby_and_active_databases" do
+    it "returns list of active databases in standby mode" do
+      list = described_class.standby_and_active_databases
+      expect(list.size).to eq 1
+    end
+  end
+  
+  def initial_db_records
+    [{"id"   => 1, "type" => "standby", "active" => true}, 
+     {"id"   => 2, "type" => "master", "active" => true},
+     {"id"   => 3, "type" => "standby", "active" => false}]  
+  end
+
+  def new_record
+    {"id"   => 4, "type" => "standby", "active" => true}  
+  end
+
+  def add_new_record
+    connection = ApplicationRecord.connection
+    connection.execute(<<-SQL)
+      INSERT INTO 
+        repmgr_miq.repl_nodes(id, type, active)
+      VALUES 
+        (4, 'standby', 'true')
+    SQL
+  end
+
+  def remove_file
+    begin
+      File.delete(described_class::FAILOVER_DATABASES_YAML_FILE)
+    rescue Exception
+      # ignore
+    end
+  end
+
+  def remove_schema
+    begin
+      @connection.execute("DROP SCHEMA repmgr_miq cascade")
+    rescue Exception
+      # ignore
+    end
+  end
+
+  def clean_up
+    remove_file
+    remove_schema
+  end
+end

--- a/spec/lib/failover_databases_spec.rb
+++ b/spec/lib/failover_databases_spec.rb
@@ -86,9 +86,9 @@ describe FailoverDatabases do
     end
   end
 
-  describe ".standby_and_active_databases" do
+  describe ".active_standby_databases" do
     it "returns list of active databases in standby mode" do
-      list = described_class.standby_and_active_databases
+      list = described_class.active_standby_databases
       expect(list.size).to eq 1
     end
   end

--- a/spec/lib/failover_databases_spec.rb
+++ b/spec/lib/failover_databases_spec.rb
@@ -4,7 +4,7 @@ describe FailoverDatabases do
   before(:all) do
     @connection = ApplicationRecord.connection_pool.checkout
     clean_up
-    
+
     @connection.execute("CREATE SCHEMA repmgr_miq")
 
     @connection.execute(<<-SQL)
@@ -21,17 +21,17 @@ describe FailoverDatabases do
     SQL
 
     @connection.execute(<<-SQL)
-      INSERT INTO 
+      INSERT INTO
         repmgr_miq.repl_nodes(id, type, active)
-      VALUES 
+      VALUES
         (2, 'master', 'true'),
         (1, 'standby', 'true'),
         (3, 'standby', 'false')
     SQL
   end
 
-  after (:each) do
-    remove_file  
+  after(:each) do
+    remove_file
   end
 
   after(:all) do
@@ -59,7 +59,7 @@ describe FailoverDatabases do
       expect(list.size).to be 3
 
       add_new_record
-      
+
       described_class.all_databases
       expect(list.size).to be 3
       expect(list).to match_array(initial_db_records)
@@ -78,7 +78,7 @@ describe FailoverDatabases do
       expect(list).to include new_record
     end
   end
-  
+
   describe ".standby_databases" do
     it "returns list of databases in standby mode" do
       list = described_class.standby_databases
@@ -92,15 +92,15 @@ describe FailoverDatabases do
       expect(list.size).to eq 1
     end
   end
-  
+
   def initial_db_records
-    [{"id"   => 1, "type" => "standby", "active" => true}, 
+    [{"id"   => 1, "type" => "standby", "active" => true},
      {"id"   => 2, "type" => "master", "active" => true},
-     {"id"   => 3, "type" => "standby", "active" => false}]  
+     {"id"   => 3, "type" => "standby", "active" => false}]
   end
 
   def new_record
-    {"id"   => 4, "type" => "standby", "active" => true}  
+    {"id" => 4, "type" => "standby", "active" => true} 
   end
 
   def add_new_record
@@ -108,24 +108,20 @@ describe FailoverDatabases do
     connection.execute(<<-SQL)
       INSERT INTO 
         repmgr_miq.repl_nodes(id, type, active)
-      VALUES 
+      VALUES
         (4, 'standby', 'true')
     SQL
   end
 
   def remove_file
-    begin
+    if File.exists?(described_class::FAILOVER_DATABASES_YAML_FILE)
       File.delete(described_class::FAILOVER_DATABASES_YAML_FILE)
-    rescue Exception
-      # ignore
     end
   end
 
   def remove_schema
-    begin
+    if @connection.table_exists? "repmgr_miq.repl_nodes"
       @connection.execute("DROP SCHEMA repmgr_miq cascade")
-    rescue Exception
-      # ignore
     end
   end
 


### PR DESCRIPTION
In failover scenario, information of available standby database servers should exist outside of database. 

in this PR:
Created class to maintain ```/config/failover_databases.yml``` file with information of available standby databases. List of available standby retrieved by querying replication management schema ```repmgr_miq```.

Sample ```failover_databases.yml```:
```
---
- :type: master
  :active: true
  :host: 1.1.1.1
  :user: root
  :dbname: vmdb_test
- :type: standby
  :active: true
  :host: 2.2.2.2
  :user: root
  :dbname: vmdb_test
- :type: standby
  :active: false
  :host: 3.3.3.3
  :user: root
  :dbname: vmdb_test
```

\cc @Fryguy @carbonin 
