### PR TITLE
Tower dialog json string

### DIFF
--- a/app/services/ansible_tower_job_template_dialog_service.rb
+++ b/app/services/ansible_tower_job_template_dialog_service.rb
@@ -111,7 +111,10 @@ class AnsibleTowerJobTemplateDialogService
       :label    => "Extra Variables",
       :position => position
     ).tap do |dialog_group|
-      template.variables.each_with_index { |(key, value), index| add_variable_field(key, value, dialog_group, index) }
+      template.variables.each_with_index do |(key, value), index|
+        value = value.to_json if value.instance_of?(Hash)
+        add_variable_field(key, value, dialog_group, index)
+      end
     end
   end
 

--- a/app/services/ansible_tower_job_template_dialog_service.rb
+++ b/app/services/ansible_tower_job_template_dialog_service.rb
@@ -112,7 +112,7 @@ class AnsibleTowerJobTemplateDialogService
       :position => position
     ).tap do |dialog_group|
       template.variables.each_with_index do |(key, value), index|
-        value = value.to_json if value.instance_of?(Hash)
+        value = value.to_json if [Hash, Array].include?(value.class)
         add_variable_field(key, value, dialog_group, index)
       end
     end

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -22,7 +22,10 @@ describe AnsibleTowerJobTemplateDialogService do
         \"variable\": \"param7\", \"choices\": \"\", \"type\": \"float\"}],\"name\":\"\",\"description\":\"\"}"
       allow(template).to receive(:survey_spec).and_return(JSON.parse(survey))
 
-      allow(template).to receive(:variables).and_return('some_extra_var' => 'blah')
+      allow(template).to receive(:variables).and_return('some_extra_var'  => 'blah',
+                                                        'other_extra_var' => {'name' => 'some_value'},
+                                                        'array_extra_var' => [{'name' => 'some_value'}]
+                                                       )
       dialog = subject.create_dialog(template)
 
       expect(dialog).to have_attributes(:label => template.name, :buttons => "submit,cancel")
@@ -78,8 +81,10 @@ describe AnsibleTowerJobTemplateDialogService do
     expect(group).to have_attributes(:label => "Extra Variables", :display => "edit")
 
     fields = group.dialog_fields
-    expect(fields.size).to eq(1)
+    expect(fields.size).to eq(3)
 
     assert_field(fields[0], DialogFieldTextBox, :name => 'param_some_extra_var', :default_value => 'blah', :data_type => 'string', :read_only => true)
+    assert_field(fields[1], DialogFieldTextBox, :name => 'param_other_extra_var', :default_value => '{"name":"some_value"}', :data_type => 'string', :read_only => true)
+    assert_field(fields[2], DialogFieldTextBox, :name => 'param_array_extra_var', :default_value => '[{"name":"some_value"}]', :data_type => 'string', :read_only => true)
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
>When creating a service dialog from configuration scripts we were not 
encoding the contents of a YAML Hash or Array as JSON.  

>This fix resolves that issue by calling to_json on
variable values that are instances of a Hash or Array

>@bzwei wrote the initial code change (see Original PR in the Links section)

>This PR cherry-picks his changes and adds tests


Links
-----
> https://bugzilla.redhat.com/show_bug.cgi?id=1358048
> * [Original PR](https://github.com/ManageIQ/manageiq/pull/9986)


Steps for Testing/QA
--------------------
> https://bugzilla.redhat.com/show_bug.cgi?id=1358048

Screenshots showing the jsonified text
<img width="521" alt="screen shot 2016-07-22 at 5 09 14 pm" src="https://cloud.githubusercontent.com/assets/697347/17071356/0f3d8710-502f-11e6-86ac-3ea8e1da39a7.png">

As seen in Ansible Tower
<img width="800" alt="screen shot 2016-07-22 at 5 09 45 pm" src="https://cloud.githubusercontent.com/assets/697347/17071364/20988bea-502f-11e6-9480-7bd95d1eb33b.png">


