### PR TITLE
[WIP] dont pass ids to rbac

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -177,6 +177,10 @@ module Rbac
       if targets.nil?
         scope = apply_scope(klass, scope)
       elsif targets.kind_of?(Array)
+        Vmdb::Deprecation.deprecation_warning(":targets =>[#{targets.first.kind_of?(Numeric) ? "Integers" : "Objects"}]",
+                                              "Pass actual scopes to rbac",
+                                              caller(5)) unless Rails.env.production? ##
+        raise "fix me" unless options[:array_ok]
         if targets.first.kind_of?(Numeric)
           target_ids = targets
           # assume klass is passed in
@@ -262,7 +266,8 @@ module Rbac
     end
 
     def filtered_object(object, options = {})
-      filtered([object], options).first
+      # array ok for now
+      filtered([object], options.merge(:array_ok => true)).first
     end
 
     private


### PR DESCRIPTION
Instead of executing a query and then executing it again with rbac. call with a scope and let rbac execute it.

todo:
- [ ] fix load_ar_objs (2 reference)
- [ ] fix load_ar_obj (2 definitions, 24 calls)
- [ ] get_selected_hosts
- [ ] ...

This will probably be a long running PR.
It is intentionally throwing exceptions so we can find all the calls that we want to change.
