### PR TITLE
livemetrics support select

### DIFF
--- a/app/models/live_metric.rb
+++ b/app/models/live_metric.rb
@@ -9,7 +9,7 @@ class LiveMetric < ActsAsArModel
     processed = process_conditions(raw_query[:conditions])
     resource = fetch_resource(processed[:resource_type], processed[:resource_id])
     ext_options = raw_query[:ext_options]
-    filtered_cols = ext_options ? ext_options[:only_cols] : nil
+    filtered_cols = raw_query[:select] || ext_options ? ext_options[:only_cols] : nil
     if resource.nil?
       []
     else


### PR DESCRIPTION
While `options[:ext_options][:only_cols]` is still scattered throughout our code, I'm making the transition to the rails standard`options[:select]`.

This is in follow up to #9430 

Not modifying `generator.rb` because that will break some reports. Need to get more tests into there to ensure the failures will be reflected in tests.

/cc @lucasponce