### PR TITLE
deployment types options passed from service object

### DIFF
--- a/app/services/container_deployment_service.rb
+++ b/app/services/container_deployment_service.rb
@@ -1,8 +1,9 @@
 class ContainerDeploymentService
   def all_data
     {
-      :provision => possible_provision_providers,
-      :providers => possible_providers_and_vms
+      :deployment_types => optional_deployment_types,
+      :provision        => possible_provision_providers,
+      :providers        => possible_providers_and_vms
     }.compact
   end
 
@@ -50,5 +51,9 @@ class ContainerDeploymentService
         :id        => vm.id
       }
     end
+  end
+
+  def optional_deployment_types
+    %w(openshiftOrigin, openshiftEnterprise)
   end
 end

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -4,7 +4,7 @@ describe ApiController do
     api_basic_authorize collection_action_identifier(:container_deployments, :read, :get)
     run_get container_deployments_url + "/container_deployment_data"
     expect(response).to have_http_status(:ok)
-    expect_hash_to_have_only_keys(response.parsed_body["data"], %w(providers provision))
+    expect_hash_to_have_only_keys(response.parsed_body["data"], %w(deployment_types providers provision))
   end
 
   it "creates container deployment with POST" do


### PR DESCRIPTION
Changing deployment types to be supplied from the service object instead of hard coded.