### PR TITLE
Container Node Helper: Adding Cockpit Link

### DIFF
--- a/app/controllers/container_node_controller.rb
+++ b/app/controllers/container_node_controller.rb
@@ -6,4 +6,19 @@ class ContainerNodeController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def launch_cockpit
+    node = identify_record(params[:id], ContainerNode)
+
+    if node.ipaddress
+      url = node.cockpit_url
+      render :update do |page|
+        page << javascript_prologue
+        page << "miqSparkle(false);"
+        page << "window.open('#{url}');"
+      end
+    else
+      add_flash(node.unsupported_reason(:launch_cockpit))
+      javascript_flash
+    end
+  end
 end

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -72,4 +72,13 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
       ]
     ),
   ])
+  button_group('container_cockpit_button_group', [
+    button(
+      :vm_cockpit,
+      nil,
+      N_('Open a new browser window with Cockpit for this Node.  This requires that Cockpit is pre-configured on the Node.'),
+      nil,
+      :image => "cockpit",
+      :url   => "launch_cockpit"),
+  ])
 end

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -67,4 +67,12 @@ class ContainerNode < ApplicationRecord
   def perf_rollup_parents(interval_name = nil)
     [ext_management_system] unless interval_name == 'realtime'
   end
+
+  def ipaddress
+    labels.find_by_name("kubernetes.io/hostname").try(:value)
+  end
+
+  def cockpit_url
+    URI::HTTP.build(:host => ipaddress, :port => 9090)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -566,6 +566,7 @@ Vmdb::Application.routes.draw do
         tag_edit_form_field_changed
         protect
         squash_toggle
+        launch_cockpit
       ) +
                adv_search_post +
                exp_post +


### PR DESCRIPTION
Adding a link to the cockpit console on a container node.


This is like #10083 but for the container node.

![cockpit_link](https://cloud.githubusercontent.com/assets/3123328/17648817/3193c180-622c-11e6-9982-8efb0da39fe9.png)

