### PR TITLE
Add the option to hide 'OpenShift Origin' deployment type

### DIFF
--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -25,7 +25,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
     var initializeDeploymentWizard = function () {
       $scope.data = {
         providerName: '',
-        providerType: 'openshiftOrigin',
+        providerType: 'openshiftEnterprise',
         provisionOn: 'existingVms',
         masterCount: 0,
         nodeCount: 0,
@@ -38,6 +38,7 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
 
       $scope.data.existingProviders = $scope.deploymentData.providers;
       $scope.data.newVmProviders = $scope.deploymentData.provision;
+      $scope.originAvailable = $scope.deploymentData.deployment_types.includes("origin");
       $scope.deployProviderReady = true;
     };
 

--- a/app/views/static/deploy_containers_provider/deploy-provider-details-general.html.haml
+++ b/app/views/static/deploy_containers_provider/deploy-provider-details-general.html.haml
@@ -7,7 +7,7 @@
         %input#new-provider-name{:name => "name", "ng-change" => "updateProviderName()", "ng-model" => "data.providerName", :required => "", :type => "text"}/
       %div{"pf-form-group" => "", "pf-input-class" => "miq-radio-input-class", "pf-label" => _("Type"),
       "pf-label-class" => "miq-input-label-class", :required => ""}
-        %label.radio
+        %label.radio{"ng-if" => "originAvailable"}
           %input{"ng-model" => "data.providerType", :type => "radio", :value => "openshiftOrigin"}
             = _("OpenShift Origin")
         %label.radio


### PR DESCRIPTION
Useful for downstream/productization purposes.

upstream:
![upstream](https://cloud.githubusercontent.com/assets/6347577/17084869/f9f821fe-51d1-11e6-9c63-595628a32da4.png)

downstream (no Origin):
![no-origin](https://cloud.githubusercontent.com/assets/6347577/17084873/054ba710-51d2-11e6-9034-fa66884798ee.png)
