### PR TITLE
Fix EmsCluster.total_hosts to avoid n+1

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -126,10 +126,6 @@ class EmsCluster < ApplicationRecord
   alias_method :all_miq_template_ids,   :miq_template_ids
 
   # Host relationship methods
-  def total_hosts
-    hosts.size
-  end
-
   def failover_hosts(_options = {})
     hosts.select(&:failover)
   end
@@ -164,13 +160,8 @@ class EmsCluster < ApplicationRecord
     direct_vm_ids + direct_miq_template_ids
   end
 
-  def total_direct_vms
-    direct_vm_rels.size
-  end
-
-  def total_direct_miq_templates
-    direct_miq_template_ids.size
-  end
+  virtual_total :total_direct_vms, :direct_vm_rels
+  virtual_total :total_direct_miq_templates, :direct_miq_templates
 
   def total_direct_vms_and_templates
     total_direct_vms + total_direct_miq_templates


### PR DESCRIPTION
I was looking at the data to figure out how many hosts were per cluster

```ruby
EmsCluster.group(:id)
          .select(:id, EmsCluster.arel_attribute(:total_hosts).as("total_hosts"))
          .map {|x| [x.id, x.total_hosts]} }
```

I was surprised to see an N+1

It looks like the method `total_hosts` was manually defined. I removed this and 2 other virtual totals. There are specs in `ems_cluster_spec.rb` that exercise all 3 of these methods.

before
-------

|      @ |    ms | bytes | objects |   ms- |queries | query (ms) |     rows |`comments`
|    ---:|   ---:|   ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|    0.0 |  60.6 | 1,493,715 | 19,254 |   0.0 |   21 |   9.0 |       20 |`before`
|   26.8 |   1.4 |       |       |       |    1 |   1.2 |       20 |`.SELECT "ems_clusters"."id", ((SELECT COUNT(*) FROM "hosts" WHERE "ems_clusters"."id" = "hosts"."ems_cluster_id")) AS total_hosts FROM "ems_clusters" GROUP BY "ems_clusters"."id" []`
|   29.7 |   6 |       |       |       |    20|   6 |          |`.SELECT COUNT(*) FROM "hosts" WHERE "hosts"."ems_cluster_id" = $1 [8]`

after
-----

|      @ |    ms | bytes | objects |   ms- |queries | query (ms) |     rows |`comments`
|    ---:|   ---:|   ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|    0.0 |  24.1 | 67,426 |   794 |   0.0 |    1 |   2.1 |       20 |`after`
|   21.9 |   2.1 |       |       |       |   1   |   1.1 |       20 |`.SELECT "ems_clusters"."id", ((SELECT COUNT(*) FROM "hosts" WHERE "ems_clusters"."id" = "hosts"."ems_cluster_id")) AS total_hosts FROM "ems_clusters" GROUP BY "ems_clusters"."id" []`
