### PR TITLE
Post refresh hook to queue mapping of Cloud Tenants

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -31,6 +31,7 @@ module ManageIQ::Providers
 
     include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
+    include CloudTenantMixin
 
     supports_not :discovery
 
@@ -57,6 +58,10 @@ module ManageIQ::Providers
         stop_event_monitor_queue
         network_manager.stop_event_monitor_queue if respond_to?(:network_manager) && network_manager
       end
+    end
+
+    def supports_cloud_tenants?
+      false
     end
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -31,6 +31,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager
   end
 
+  def supports_cloud_tenants?
+    true
+  end
+
   def self.ems_type
     @ems_type ||= "openstack".freeze
   end

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresher.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers
     end
 
     def post_process_refresh_classes
-      [Vm]
+      [Vm, CloudTenant]
     end
   end
 end

--- a/app/models/mixins/cloud_tenant_mixin.rb
+++ b/app/models/mixins/cloud_tenant_mixin.rb
@@ -1,0 +1,8 @@
+module CloudTenantMixin
+  extend ActiveSupport::Concern
+
+  # TODO(lpichler) add synchronization
+  def sync_cloud_tenants_with_tenants
+    return unless supports_cloud_tenants?
+  end
+end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -851,5 +851,12 @@ module Openstack
         expect(CloudService.where(:executable_name => executable_name).count).to eq count
       end
     end
+
+    def expect_sync_cloud_tenants_with_tenants_is_queued
+      sync_cloud_tenant = MiqQueue.last
+
+      expect(sync_cloud_tenant.method_name).to eq("sync_cloud_tenants_with_tenants")
+      expect(sync_cloud_tenant.state).to eq(MiqQueue::STATE_READY)
+    end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_kilo_keystone_v3_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_kilo_keystone_v3_spec.rb
@@ -16,6 +16,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
       end
 
       assert_common
+
+      expect_sync_cloud_tenants_with_tenants_is_queued
     end
   end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb
@@ -16,6 +16,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
       end
 
       assert_common
+
+      expect_sync_cloud_tenants_with_tenants_is_queued
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Add to MiqQueue method that will handle the mapping of CloudTenants

Method will be synchronize CloudTenants with Tenants in Miq,
for now it is empty. 

This PR is just about adding method to queue.

Links
-----
https://www.pivotaltracker.com/story/show/126309503
