### PR TITLE
TreeBuilderPolicy & PolicyProfile - don't automatically expand *all* the nodes

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -275,10 +275,6 @@ class TreeBuilder
 
     node = x_build_single_node(object, pid, options)
 
-    if [:policy_profile_tree, :policy_tree].include?(options[:tree])
-      open_node(node[:key])
-    end
-
     # Process the node's children
     node[:expand] = Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) || !!options[:open_all]
     if object[:load_children] ||

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -65,9 +65,6 @@ class TreeBuilderPolicy < TreeBuilder
       mode = parent[:id]
       objects = compliance_control_kids(mode)
 
-      # Push folder node ids onto open_nodes array
-      objects.each { |o| open_node("xx-#{mode}_xx-#{o[:id]}") }
-
       return count_only_or_objects(count_only, objects)
     end
 


### PR DESCRIPTION
Before this, all the nodes in `policy_tree` and `policy_profile_tree` would be automatically expanded..

With this, only the top level in `policy_profile` is expanded, and the first 3 in `policy`.

@dclarizio you mentioned you're not seeing it in darga, but the code is definitely there so..?