### PR TITLE
Order the authentications display order by authtype

### DIFF
--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -26,7 +26,7 @@ module EmsContainerHelper::TextualSummary
     authentications = @ems.authentications
     return [{:label => _("Default Authentication"), :title => t = _("None"), :value => t}] if authentications.blank?
 
-    authentications.collect do |auth|
+    authentications.order(:authtype).collect do |auth|
       label =
         case auth.authtype
         when "default" then _("Default")


### PR DESCRIPTION
**Description**
Order the authentications display order by authtype

**Screenshot**
![sort-asc](https://cloud.githubusercontent.com/assets/2181522/17101630/50cb0ac6-527e-11e6-8f8e-8826ee61b4fd.png)

**Issue**
https://github.com/ManageIQ/manageiq/issues/10027