### PR TITLE
[DARGA] List ansible jobs under Configuration Management

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2382,7 +2382,9 @@ module ApplicationController::CiProcessing
 
   def configuration_job_delete
     assert_privileges("configuration_job_delete")
-    delete_elements(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job, :process_configuration_jobs, 'configuration_job')
+    delete_elements(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job,
+                    :process_configuration_jobs,
+                    'configuration_job')
   end
 
   # Delete all selected or single displayed datastore(s)
@@ -2425,7 +2427,7 @@ module ApplicationController::CiProcessing
   def delete_elements(model_class, destroy_method, model_name = nil)
     elements = []
     model_name ||= model_class.table_name
-    if @lastaction == "show_list" || (@lastaction == "show" && @layout != model_name.singularize)  # showing a list
+    if @lastaction == "show_list" || (@lastaction == "show" && @layout != model_name.singularize) # showing a list
       elements = find_checked_items
       if elements.empty?
         add_flash(_("No %{model} were selected for deletion") %

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2434,8 +2434,11 @@ module ApplicationController::CiProcessing
           {:model => ui_lookup(:tables => model_name)}, :error)
       end
       send(destroy_method, elements, "destroy") unless elements.empty?
-      add_flash(_("Delete initiated for %{count_model} from the CFME Database") %
-        {:count_model => pluralize(elements.length, ui_lookup(:table => model_class.table_name))}) unless flash_errors?
+      add_flash(n_("Delete initiated for %{count} %{model} from the CFME Database",
+                   "Delete initiated for %{count} %{models} from the CFME Database", elements.length) %
+        {:count  => elements.length,
+         :model  => ui_lookup(:table => model_name),
+         :models => ui_lookup(:tables => model_name)}) unless flash_errors?
     else # showing 1 element, delete it
       if params[:id].nil? || model_class.find_by_id(params[:id]).nil?
         add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:table => model_name)}, :error)

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -32,19 +32,19 @@ class ConfigurationJobController < ApplicationController
     drop_breadcrumb({:name => _("Configuration_Jobs"),
                      :url  => "/configuration_job/show_list?page=#{@current_page}&refresh=y"}, true)
     case @display
-      when "download_pdf", "main", "summary_only"
-        get_tagdata(@configuration_job)
-        drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @configuration_job.name},
-                        :url  => "/configuration_job/show/#{@configuration_job.id}")
-        @showtype = "main"
-        set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+    when "download_pdf", "main", "summary_only"
+      get_tagdata(@configuration_job)
+      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @configuration_job.name},
+                      :url  => "/configuration_job/show/#{@configuration_job.id}")
+      @showtype = "main"
+      set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
     when "security_groups"
-        title = ui_lookup(:tables => "security_group")
-        kls   = SecurityGroup
-        drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @configuration_job.name, :title => title},
-                        :url  => "/configuration_job/show/#{@configuration_job.id}?display=#{@display}")
-        @view, @pages = get_view(kls, :parent => @configuration_job)  # Get the records (into a view) and the paginator
-        @showtype = @display
+      title = ui_lookup(:tables => "security_group")
+      kls   = SecurityGroup
+      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @configuration_job.name, :title => title},
+                      :url  => "/configuration_job/show/#{@configuration_job.id}?display=#{@display}")
+      @view, @pages = get_view(kls, :parent => @configuration_job) # Get the records (into a view) and the paginator
+      @showtype = @display
     end
 
     # Came in from outside show_list partial
@@ -72,19 +72,18 @@ class ConfigurationJobController < ApplicationController
   # handle buttons pressed on the button bar
   # handle buttons pressed on the button bar
   def button
-    @edit = session[:edit]                          # Restore @edit for adv search box
-    params[:page] = @current_page if @current_page.nil?   # Save current page for list refresh
+    @edit = session[:edit] # Restore @edit for adv search box
+    params[:page] = @current_page if @current_page.nil? # Save current page for list refresh
 
-    params[:page] = @current_page if @current_page.nil?                     # Save current page for list refresh
+    params[:page] = @current_page if @current_page.nil? # Save current page for list refresh
     @refresh_div = "main_div" # Default div for button.rjs to refresh
     case params[:pressed]
-      when "configuration_job_delete"
-        configuration_job_delete
-      when "configuration_job_tag"
-        tag(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job)
+    when "configuration_job_delete"
+      configuration_job_delete
+    when "configuration_job_tag"
+      tag(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job)
     end
-    return if %w(configuration_job_tag).include?(params[:pressed]) &&
-      @flash_array.nil? # Tag screen showing, so return
+    return if %w(configuration_job_tag).include?(params[:pressed]) && @flash_array.nil? # Tag screen showing, so return
 
     if @flash_array.nil? && !@refresh_partial # if no button handler ran, show not implemented msg
       add_flash(_("Button not yet implemented"), :error)
@@ -98,12 +97,10 @@ class ConfigurationJobController < ApplicationController
 
     if !@flash_array.nil? && params[:pressed] == "configurations_job_delete" && @single_delete
       javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
+    elsif @refresh_div == "main_div" && @lastaction == "show_list"
+      replace_gtl_main_div
     else
-      if @refresh_div == "main_div" && @lastaction == "show_list"
-        replace_gtl_main_div
-      else
-        render_flash
-      end
+      render_flash
     end
   end
 

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -38,13 +38,6 @@ class ConfigurationJobController < ApplicationController
                       :url  => "/configuration_job/show/#{@configuration_job.id}")
       @showtype = "main"
       set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
-    when "security_groups"
-      title = ui_lookup(:tables => "security_group")
-      kls   = SecurityGroup
-      drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @configuration_job.name, :title => title},
-                      :url  => "/configuration_job/show/#{@configuration_job.id}?display=#{@display}")
-      @view, @pages = get_view(kls, :parent => @configuration_job) # Get the records (into a view) and the paginator
-      @showtype = @display
     end
 
     # Came in from outside show_list partial
@@ -57,16 +50,8 @@ class ConfigurationJobController < ApplicationController
     process_show_list
   end
 
-  def outputs
-    show_association('outputs', _('Outputs'), 'output', :outputs, OrchestrationStackOutput)
-  end
-
   def parameters
     show_association('parameters', _('Parameters'), 'parameter', :parameters, OrchestrationStackParameter)
-  end
-
-  def resources
-    show_association('resources', _('Resources'), 'resource', :resources, OrchestrationStackResource)
   end
 
   # handle buttons pressed on the button bar

--- a/app/controllers/configuration_job_controller.rb
+++ b/app/controllers/configuration_job_controller.rb
@@ -1,0 +1,121 @@
+class ConfigurationJobController < ApplicationController
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.model
+    ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job
+  end
+
+  def self.table_name
+    @table_name ||= "configuration_job"
+  end
+
+  def ems_path(*args)
+    ems_configprovider_path(*args)
+  end
+
+  def index
+    redirect_to :action => 'show_list'
+  end
+
+  def show
+    return if perfmenu_click?
+    @display = params[:display] || "main" unless control_selected?
+
+    @lastaction = "show"
+    @configuration_job = @record = identify_record(params[:id])
+    return if record_no_longer_exists?(@configuration_job)
+
+    @gtl_url = "/show"
+    drop_breadcrumb({:name => _("Configuration_Jobs"),
+                     :url  => "/configuration_job/show_list?page=#{@current_page}&refresh=y"}, true)
+    case @display
+      when "download_pdf", "main", "summary_only"
+        get_tagdata(@configuration_job)
+        drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @configuration_job.name},
+                        :url  => "/configuration_job/show/#{@configuration_job.id}")
+        @showtype = "main"
+        set_summary_pdf_data if %w(download_pdf summary_only).include?(@display)
+    when "security_groups"
+        title = ui_lookup(:tables => "security_group")
+        kls   = SecurityGroup
+        drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => @configuration_job.name, :title => title},
+                        :url  => "/configuration_job/show/#{@configuration_job.id}?display=#{@display}")
+        @view, @pages = get_view(kls, :parent => @configuration_job)  # Get the records (into a view) and the paginator
+        @showtype = @display
+    end
+
+    # Came in from outside show_list partial
+    if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]
+      replace_gtl_main_div
+    end
+  end
+
+  def show_list
+    process_show_list
+  end
+
+  def outputs
+    show_association('outputs', _('Outputs'), 'output', :outputs, OrchestrationStackOutput)
+  end
+
+  def parameters
+    show_association('parameters', _('Parameters'), 'parameter', :parameters, OrchestrationStackParameter)
+  end
+
+  def resources
+    show_association('resources', _('Resources'), 'resource', :resources, OrchestrationStackResource)
+  end
+
+  # handle buttons pressed on the button bar
+  # handle buttons pressed on the button bar
+  def button
+    @edit = session[:edit]                          # Restore @edit for adv search box
+    params[:page] = @current_page if @current_page.nil?   # Save current page for list refresh
+
+    params[:page] = @current_page if @current_page.nil?                     # Save current page for list refresh
+    @refresh_div = "main_div" # Default div for button.rjs to refresh
+    case params[:pressed]
+      when "configuration_job_delete"
+        configuration_job_delete
+      when "configuration_job_tag"
+        tag(ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job)
+    end
+    return if %w(configuration_job_tag).include?(params[:pressed]) &&
+      @flash_array.nil? # Tag screen showing, so return
+
+    if @flash_array.nil? && !@refresh_partial # if no button handler ran, show not implemented msg
+      add_flash(_("Button not yet implemented"), :error)
+      @refresh_partial = "layouts/flash_msg"
+      @refresh_div = "flash_msg_div"
+    elsif @flash_array && @lastaction == "show"
+      @configuration_job = @record = identify_record(params[:id])
+      @refresh_partial = "layouts/flash_msg"
+      @refresh_div = "flash_msg_div"
+    end
+
+    if !@flash_array.nil? && params[:pressed] == "configurations_job_delete" && @single_delete
+      javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
+    else
+      if @refresh_div == "main_div" && @lastaction == "show_list"
+        replace_gtl_main_div
+      else
+        render_flash
+      end
+    end
+  end
+
+  def get_session_data
+    @title      = _("Job")
+    @layout     = "configuration_job"
+    @lastaction = session[:configuration_job_lastaction]
+    @display    = session[:configuration_job_display]
+  end
+
+  def set_session_data
+    session[:configuration_job_lastaction] = @lastaction
+    session[:configuration_job_display]    = @display unless @display.nil?
+  end
+end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -79,6 +79,9 @@ module EmsCommon
     elsif @display == "orchestration_stacks" || session[:display] == "orchestration_stacks" && params[:display].nil?
       title = _("Stacks")
       view_setup_helper(OrchestrationStack, title, title.singularize)
+    elsif @display == "configuration_jobs" || session[:display] == "configuration_jobs" && params[:display].nil?
+      title = _("Configuration Jobs")
+      view_setup_helper(ConfigurationJob, title, title.singularize)
     elsif @display == "persistent_volumes" || session[:display] == "persistent_volumes" && params[:display].nil?
       title = ui_lookup(:tables => "persistent_volumes")
       view_setup_helper(PersistentVolume, title, title.singularize, :persistent_volumes)

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -5,6 +5,10 @@ class OrchestrationStackController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def self.model
+    ManageIQ::Providers::CloudManager::OrchestrationStack
+  end
+
   def index
     redirect_to :action => 'show_list'
   end

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -452,19 +452,20 @@ class ProviderForemanController < ApplicationController
     if params[:button]
       @miq_after_onload = "miqAjax('/#{controller_name}/x_button?pressed=#{params[:button]}');"
     end
+
+    build_accordions_and_trees
+
     params.instance_variable_get(:@parameters).merge!(session[:exp_parms]) if session[:exp_parms]  # Grab any explorer parm overrides
     session.delete(:exp_parms)
     @in_a_form = false
+
     if params[:id] # If a tree node id came in, show in one of the trees
       nodetype, id = params[:id].split("-")
       # treebuilder initializes x_node to root first time in locals_for_render,
       # need to set this here to force & activate node when link is clicked outside of explorer.
       @reselect_node = self.x_node = "#{nodetype}-#{to_cid(id)}"
+      get_node_info(x_node)
     end
-
-    @sb[:open_tree_nodes] ||= []
-    build_accordions_and_trees
-
     render :layout => "application"
   end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -77,12 +77,13 @@ class ServiceController < ApplicationController
       return
     end
 
+    build_accordions_and_trees
+
     if params[:id]  # If a tree node id came in, show in one of the trees
       nodetype, id = params[:id].split("-")
       self.x_node = "#{nodetype}-#{to_cid(id)}"
+      get_node_info(x_node)
     end
-
-    build_accordions_and_trees
 
     params.instance_variable_get(:@parameters).merge!(session[:exp_parms]) if session[:exp_parms]  # Grab any explorer parm overrides
     session.delete(:exp_parms)

--- a/app/decorators/manageiq/providers/ansible_tower/configuration_manager/job_decorator.rb
+++ b/app/decorators/manageiq/providers/ansible_tower/configuration_manager/job_decorator.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::AnsibleTower::ConfigurationManager::JobDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    '100/orchestration_stack.png'
+  end
+end

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -1,0 +1,10 @@
+class ManageIQ::Providers::CloudManager::OrchestrationStackDecorator < Draper::Decorator
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/orchestration_stack.png"
+  end
+end
+

--- a/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
+++ b/app/decorators/manageiq/providers/cloud_manager/orchestration_stack_decorator.rb
@@ -7,4 +7,3 @@ class ManageIQ::Providers::CloudManager::OrchestrationStackDecorator < Draper::D
     "100/orchestration_stack.png"
   end
 end
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -910,10 +910,10 @@ module ApplicationHelper
 
   def controller_for_stack(model)
     case model.to_s
-      when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job"
-        "configuration_job"
-      else
-        model.name.underscore
+    when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job"
+      "configuration_job"
+    else
+      model.name.underscore
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -343,7 +343,9 @@ module ApplicationHelper
     when "MiqWorker"
       controller = request.parameters[:controller]
       action = "diagnostics_worker_selected"
-    when "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource"
+    when "OrchestrationStackOutput", "OrchestrationStackParameter", "OrchestrationStackResource",
+        "ManageIQ::Providers::CloudManager::OrchestrationStack",
+        "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job"
       controller = request.parameters[:controller]
     when "ContainerVolume"
       controller = "persistent_volume"
@@ -833,7 +835,7 @@ module ApplicationHelper
        ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
        resource_pool ems_infra ontap_storage_system ontap_storage_volume
        ontap_file_share snia_local_file_system ontap_logical_disk
-       orchestration_stack cim_base_storage_extent storage storage_manager).include?(@layout)
+       orchestration_stack cim_base_storage_extent storage storage_manager configuration_job).include?(@layout)
   end
 
   # Do we show or hide the clear_search link in the list view title
@@ -903,6 +905,15 @@ module ApplicationHelper
       "vm_infra"
     else
       "vm_or_template"
+    end
+  end
+
+  def controller_for_stack(model)
+    case model.to_s
+      when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job"
+        "configuration_job"
+      else
+        model.name.underscore
     end
   end
 
@@ -1088,7 +1099,7 @@ module ApplicationHelper
   GTL_VIEW_LAYOUTS = %w(action availability_zone auth_key_pair_cloud
                         cim_base_storage_extent cloud_object_store_container
                         cloud_object_store_object cloud_tenant cloud_volume cloud_volume_snapshot
-                        condition container_group container_route container_project
+                        configuration_job condition container_group container_route container_project
                         container_replicator container_image container_image_registry
                         container_topology container_dashboard middleware_topology persistent_volume container_build
                         container_node container_service ems_cloud ems_cluster ems_container ems_infra event
@@ -1137,7 +1148,7 @@ module ApplicationHelper
          ems_infra host miq_template offline orchestration_stack persistent_volume ems_middleware
          middleware_server middleware_deployment
          ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
-         resource_pool retired service templates vm).include?(@layout) && !@in_a_form
+         resource_pool retired service templates vm configuration_job).include?(@layout) && !@in_a_form
       "show_list"
     elsif @compare
       "compare_sections"
@@ -1152,7 +1163,7 @@ module ApplicationHelper
              ems_middleware middleware_server middleware_deployment flavor
              ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
              host miq_schedule miq_template policy ontap_file_share ontap_logical_disk
-             ontap_storage_system ontap_storage_volume orchestration_stack resource_pool
+             ontap_storage_system ontap_storage_volume orchestration_stack resource_pool configuration_job
              scan_profile service snia_local_file_system storage_manager timeline).include?(@layout)
       @layout
     end
@@ -1165,7 +1176,7 @@ module ApplicationHelper
                      ems_cloud ems_cluster ems_container ems_infra flavor host miq_template offline
                      ontap_file_share ontap_logical_disk ontap_storage_system ontap_storage_volume
                      ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
-                     orchestration_stack resource_pool retired service
+                     orchestration_stack resource_pool retired service configuration_job
                      snia_local_file_system storage_manager templates vm)
     (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
       (@explorer && x_tree && tree_with_advanced_search? && !@record)

--- a/app/helpers/application_helper/toolbar/configuration_job_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_job_center.rb
@@ -1,0 +1,34 @@
+class ApplicationHelper::Toolbar::ConfigurationJobCenter < ApplicationHelper::Toolbar::Basic
+  button_group('configuration_job_vmdb', [
+    select(
+      :configuration_job_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :configuration_job_delete,
+          'pficon pficon-delete fa-lg',
+          t = N_('Remove this Job from the VMDB'),
+          t,
+          :url_parms => "&refresh=y",
+          :confirm   => N_("Warning: This Job and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Job?")),
+      ]
+    ),
+  ])
+  button_group('configuration_job_policy', [
+    select(
+      :configuration_job_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :configuration_job_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Job'),
+          N_('Edit Tags')),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/configuration_jobs_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_jobs_center.rb
@@ -1,0 +1,41 @@
+class ApplicationHelper::Toolbar::ConfigurationJobsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('configuration_job_vmdb', [
+    select(
+      :configuration_job_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :configuration_job_delete,
+          'pficon pficon-delete fa-lg',
+          N_('Remove selected Jobs from the VMDB'),
+          N_('Remove Jobs from the VMDB'),
+          :url_parms => "main_div",
+          :confirm   => N_("Warning: The selected Jobs and ALL of their components will be permanently removed from the Virtual Management Database. Are you sure you want to remove the selected Jobs?"),
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+  button_group('configuration_job_policy', [
+    select(
+      :configuration_job_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :configuration_job_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for the selected Jobs'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -469,7 +469,7 @@ class ApplicationHelper::ToolbarChooser
       # show_list and show screens
       unless @in_a_form
         if %w(auth_key_pair_cloud availability_zone cloud_object_store_object cloud_object_store_container cloud_tenant
-              cloud_volume cloud_volume_snapshot container_group container_node container_service ems_cloud ems_cluster
+              cloud_volume cloud_volume_snapshot configuration_job container_group container_node container_service ems_cloud ems_cluster
               ems_container ems_middleware container_project container_route container_replicator container_image
               ems_network security_group floating_ip cloud_subnet network_router network_topology network_port cloud_network
               container_image_registry ems_infra flavor host container_build

--- a/app/helpers/configuration_job_helper.rb
+++ b/app/helpers/configuration_job_helper.rb
@@ -1,0 +1,3 @@
+module ConfigurationJobHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module  ConfigurationJobHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(service security_groups parameters outputs resources)
+    %i(provider service security_groups parameters outputs resources)
   end
 
   #
@@ -42,14 +42,15 @@ module  ConfigurationJobHelper::TextualSummary
     h
   end
 
-  def textual_job_template
-    template = @record.try(:configuration_script)
-    return nil if template.nil?
-    label = ui_lookup(:table => "configuration_scripts")
-    h = {:label => label, :image => "configuration_scripts", :value => template.name}
-    if role_allows(:feature => "configuration_scripts_view")
-      h[:title] = _("Show this Configuration Script")
-      h[:link] = url_for(:action => 'show', :id => @configuration_job, :display => 'configuration_script')
+  def textual_provider
+    h = {:label => _("Provider"), :image => "vendor-ansible_tower_configuration"}
+    provider = @record.ext_management_system
+    if provider.nil?
+      h[:value] = _("None")
+    else
+      h[:value] = provider.name
+      h[:title] = _("Show this Parent Provider")
+      h[:link]  = url_for(:controller => 'provider_foreman', :action => 'explorer', :id => "at-#{to_cid(provider.id)}")
     end
     h
   end

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -1,7 +1,4 @@
 module ConfigurationJobHelper::TextualSummary
-  include TextualMixins::TextualDescription
-  include TextualMixins::TextualGroupTags
-  include TextualMixins::TextualName
   #
   # Groups
   #
@@ -29,6 +26,21 @@ module ConfigurationJobHelper::TextualSummary
     @record.status_reason
   end
 
+  def textual_group_tags
+    %i(tags)
+  end
+
+  #
+  # Items
+  #
+
+  def textual_name
+    @record.name
+  end
+
+  def textual_description
+    @record.description
+  end
   def textual_service
     h = {:label => _("Service"), :image => "service"}
     service = @record.service

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module ConfigurationJobHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(provider service security_groups parameters outputs resources)
+    %i(provider service parameters status)
   end
 
   #
@@ -55,36 +55,12 @@ module ConfigurationJobHelper::TextualSummary
     h
   end
 
-  def textual_security_groups
-    @record.security_groups
-  end
-
   def textual_parameters
     num   = @record.number_of(:parameters)
     h     = {:label => _("Parameters"), :image => "parameter", :value => num}
     if num > 0
       h[:link]  = url_for(:controller => controller.controller_name, :action => 'parameters', :id => @record)
       h[:title] = _("Show all parameters")
-    end
-    h
-  end
-
-  def textual_outputs
-    num   = @record.number_of(:outputs)
-    h     = {:label => _("Outputs"), :image => "output", :value => num}
-    if num > 0
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'outputs', :id => @record)
-      h[:title] = _("Show all outputs")
-    end
-    h
-  end
-
-  def textual_resources
-    num   = @record.number_of(:resources)
-    h     = {:label => _("Resources"), :image => "resource", :value => num}
-    if num > 0
-      h[:link]  = url_for(:controller => controller.controller_name, :action => 'resources', :id => @record)
-      h[:title] = _("Show all resources")
     end
     h
   end

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -1,4 +1,4 @@
-module  ConfigurationJobHelper::TextualSummary
+module ConfigurationJobHelper::TextualSummary
   include TextualMixins::TextualDescription
   include TextualMixins::TextualGroupTags
   include TextualMixins::TextualName

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -1,0 +1,90 @@
+module  ConfigurationJobHelper::TextualSummary
+  include TextualMixins::TextualDescription
+  include TextualMixins::TextualGroupTags
+  include TextualMixins::TextualName
+  #
+  # Groups
+  #
+
+  def textual_group_properties
+    %i(name description type status status_reason)
+  end
+
+  def textual_group_relationships
+    %i(service security_groups parameters outputs resources)
+  end
+
+  #
+  # Items
+  #
+  def textual_type
+    ui_lookup(:model => @record.type)
+  end
+
+  def textual_status
+    @record.status
+  end
+
+  def textual_status_reason
+    @record.status_reason
+  end
+
+  def textual_service
+    h = {:label => _("Service"), :image => "service"}
+    service = @record.service
+    if service.nil?
+      h[:value] = _("None")
+    else
+      h[:value] = service.name
+      h[:title] = _("Show this Service")
+      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => service)
+    end
+    h
+  end
+
+  def textual_job_template
+    template = @record.try(:configuration_script)
+    return nil if template.nil?
+    label = ui_lookup(:table => "configuration_scripts")
+    h = {:label => label, :image => "configuration_scripts", :value => template.name}
+    if role_allows(:feature => "configuration_scripts_view")
+      h[:title] = _("Show this Configuration Script")
+      h[:link] = url_for(:action => 'show', :id => @configuration_job, :display => 'configuration_script')
+    end
+    h
+  end
+
+  def textual_security_groups
+    @record.security_groups
+  end
+
+  def textual_parameters
+    num   = @record.number_of(:parameters)
+    h     = {:label => _("Parameters"), :image => "parameter", :value => num}
+    if num > 0
+      h[:link]  = url_for(:controller => controller.controller_name, :action => 'parameters', :id => @record)
+      h[:title] = _("Show all parameters")
+    end
+    h
+  end
+
+  def textual_outputs
+    num   = @record.number_of(:outputs)
+    h     = {:label => _("Outputs"), :image => "output", :value => num}
+    if num > 0
+      h[:link]  = url_for(:controller => controller.controller_name, :action => 'outputs', :id => @record)
+      h[:title] = _("Show all outputs")
+    end
+    h
+  end
+
+  def textual_resources
+    num   = @record.number_of(:resources)
+    h     = {:label => _("Resources"), :image => "resource", :value => num}
+    if num > 0
+      h[:link]  = url_for(:controller => controller.controller_name, :action => 'resources', :id => @record)
+      h[:title] = _("Show all resources")
+    end
+    h
+  end
+end

--- a/app/helpers/configuration_job_helper/textual_summary.rb
+++ b/app/helpers/configuration_job_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module  ConfigurationJobHelper::TextualSummary
     else
       h[:value] = service.name
       h[:title] = _("Show this Service")
-      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => service)
+      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => to_cid(service.id))
     end
     h
   end

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -104,21 +104,6 @@ module ServiceHelper::TextualSummary
     } if parent
   end
 
-  def textual_orchestration_stack
-    @record.try(:orchestration_stack)
-  end
-
-  def textual_job
-    job = @record.try(:job)
-    {
-      :label => _("Job"),
-      :image => "orchestration_stack",
-      :value => job.name,
-      :title => _("Show this Service's Job"),
-      :link  => url_for(:controller => 'configuration_job', :action => 'show', :id => job.id)
-    } if job
-  end
-
   def textual_owner
     @record.evm_owner.try(:name)
   end

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -104,6 +104,21 @@ module ServiceHelper::TextualSummary
     } if parent
   end
 
+  def textual_orchestration_stack
+    @record.try(:orchestration_stack)
+  end
+
+  def textual_job
+    job = @record.try(:job)
+    {
+      :label => _("Job"),
+      :image => "orchestration_stack",
+      :value => job.name,
+      :title => _("Show this Service's Job"),
+      :link  => url_for(:controller => 'configuration_job', :action => 'show', :id => job.id)
+    } if job
+  end
+
   def textual_owner
     @record.evm_owner.try(:name)
   end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -185,6 +185,10 @@ class MiqRegion < ApplicationRecord
     ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::MiddlewareManager }
   end
 
+  def ems_configproviders
+    ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::ConfigurationManager }
+  end
+
   def assigned_roles
     miq_servers.collect(&:assigned_roles).flatten.uniq.compact
   end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -154,6 +154,10 @@ class Zone < ApplicationRecord
     ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::MiddlewareManager }
   end
 
+  def ems_configproviders
+    ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::ConfigurationManager }
+  end
+
   def ems_clouds
     ext_management_systems.select { |e| e.kind_of? EmsCloud }
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -13,7 +13,8 @@ module Menu
       def configuration_menu_section
         Menu::Section.new(:conf, N_("Configuration"), 'fa fa-cog  fa-2x', [
           Menu::Item.new('provider_foreman', N_('Configuration Management'), 'provider_foreman_explorer',
-                         {:feature => 'provider_foreman_explorer', :any => true}, '/provider_foreman/explorer')
+                         {:feature => 'provider_foreman_explorer', :any => true}, '/provider_foreman/explorer'),
+          Menu::Item.new('configuration_job', N_('Jobs'), 'configuration_job', {:feature => 'configuration_job_show_list'}, '/configuration_job'),
         ])
       end
 

--- a/app/views/configuration_job/_main.html.haml
+++ b/app/views/configuration_job/_main.html.haml
@@ -1,0 +1,7 @@
+= render :partial => "layouts/flash_msg"
+.row
+  .col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+  .col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/app/views/configuration_job/show.html.haml
+++ b/app/views/configuration_job/show.html.haml
@@ -1,0 +1,8 @@
+#main_div
+  - case @showtype
+  - when "details"
+    = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
+  - when "item"
+    = render(:partial => "layouts/item")
+  - else
+    = render :partial => 'main'

--- a/app/views/configuration_job/show_list.html.haml
+++ b/app/views/configuration_job/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/app/views/layouts/listnav/_configuration_job.html.haml
+++ b/app/views/layouts/listnav/_configuration_job.html.haml
@@ -14,16 +14,14 @@
       %ul.nav.nav-pills.nav-stacked
         - if role_allows(:feature => "provider_foreman_view") && @record.ext_management_system
           %li
-            - l = [ui_lookup(:model => @record.ext_management_system.class.to_s), ui_lookup(:table => "job")]
             = link_to("#{ui_lookup(:model => @record.ext_management_system.class.to_s)}: #{@record.ext_management_system.name}",
               {:controller => "provider_foreman", :action => 'explorer', :id => "at-#{to_cid(@record.ext_management_system.id)}"},
-              :title => _("Show parent %s for this %s") % l)
+              :title => _("Show parent %s for this Job") % ui_lookup(:model => @record.ext_management_system.class.to_s))
         - if role_allows(:feature => "service_view") && @record.ext_management_system
           %li
-            - l = [ui_lookup(:table => "service"), ui_lookup(:table => "job")]
             = link_to("#{ui_lookup(:table => "service")}: #{@record.service.name}",
               {:controller => "service", :action => 'show', :id => to_cid(@record.service.id)},
-              :title => _("Show service %s for this %s") % l)
+              :title => _("Show service %s for this Job") % ui_lookup(:table => "service"))
         = li_link(:count => @record.number_of(:parameters),
           :text          => _("Parameters"),
           :action        => 'parameters',

--- a/app/views/layouts/listnav/_configuration_job.html.haml
+++ b/app/views/layouts/listnav/_configuration_job.html.haml
@@ -1,0 +1,42 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render_quadicon(@record, :mode => :icon, :size => 72, :typ => :listnav)
+
+    = miq_accordion_panel(_("Properties"), false, "stack_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        %li
+          = link_to_with_icon(_('Summary'),
+            {:action => 'show', :id => @record, :display => 'main'},
+            :title => _("Show Summary"))
+
+    = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        - if role_allows(:feature => "ems_infra_show") && @record.ext_management_system
+          %li
+            - l = [ui_lookup(:table => "provider"), ui_lookup(:table => "job")]
+            = link_to("#{ui_lookup(:table => "ext_management_system")}: #{@record.ext_management_system.name}",
+              {:controller => "provider_foreman", :action => 'explorer', :id => ("at-#{to_cid(@record.ext_management_system.id)}")},
+              :title => _("Show parent %s for this %s") % l)
+
+        - if role_allows(:feature => "security_group_show_list")
+          = li_link(:count => @record.number_of(:security_groups),
+            :text          => _("Security Groups"),
+            :record_id     => @record.id,
+            :display       => 'security_groups',
+            :title         => _("Show all Security Groups"))
+        = li_link(:count => @record.number_of(:parameters),
+          :text          => _("Parameters"),
+          :action        => 'parameters',
+          :record_id     => @record.id,
+          :title         => _("Show all Parameters"))
+        = li_link(:count => @record.number_of(:outputs),
+          :text          => _("Outputs"),
+          :action        => 'outputs',
+          :record_id     => @record.id,
+          :title         => _("Show all Outputs"))
+        = li_link(:count => @record.number_of(:resources),
+          :text          => _("Resources"),
+          :action        => 'resources',
+          :record_id     => @record.id,
+          :title         => _("Show all Resources"))

--- a/app/views/layouts/listnav/_configuration_job.html.haml
+++ b/app/views/layouts/listnav/_configuration_job.html.haml
@@ -12,19 +12,18 @@
 
     = miq_accordion_panel(_("Relationships"), false, "stack_rel") do
       %ul.nav.nav-pills.nav-stacked
-        - if role_allows(:feature => "ems_infra_show") && @record.ext_management_system
+        - if role_allows(:feature => "provider_foreman_view") && @record.ext_management_system
           %li
-            - l = [ui_lookup(:table => "provider"), ui_lookup(:table => "job")]
-            = link_to("#{ui_lookup(:table => "ext_management_system")}: #{@record.ext_management_system.name}",
-              {:controller => "provider_foreman", :action => 'explorer', :id => ("at-#{to_cid(@record.ext_management_system.id)}")},
+            - l = [ui_lookup(:model => @record.ext_management_system.class.to_s), ui_lookup(:table => "job")]
+            = link_to("#{ui_lookup(:model => @record.ext_management_system.class.to_s)}: #{@record.ext_management_system.name}",
+              {:controller => "provider_foreman", :action => 'explorer', :id => "at-#{to_cid(@record.ext_management_system.id)}"},
               :title => _("Show parent %s for this %s") % l)
-
-        - if role_allows(:feature => "security_group_show_list")
-          = li_link(:count => @record.number_of(:security_groups),
-            :text          => _("Security Groups"),
-            :record_id     => @record.id,
-            :display       => 'security_groups',
-            :title         => _("Show all Security Groups"))
+        - if role_allows(:feature => "service_view") && @record.ext_management_system
+          %li
+            - l = [ui_lookup(:table => "service"), ui_lookup(:table => "job")]
+            = link_to("#{ui_lookup(:table => "service")}: #{@record.service.name}",
+              {:controller => "service", :action => 'show', :id => to_cid(@record.service.id)},
+              :title => _("Show service %s for this %s") % l)
         = li_link(:count => @record.number_of(:parameters),
           :text          => _("Parameters"),
           :action        => 'parameters',

--- a/app/views/layouts/listnav/_configuration_job.html.haml
+++ b/app/views/layouts/listnav/_configuration_job.html.haml
@@ -27,13 +27,3 @@
           :action        => 'parameters',
           :record_id     => @record.id,
           :title         => _("Show all Parameters"))
-        = li_link(:count => @record.number_of(:outputs),
-          :text          => _("Outputs"),
-          :action        => 'outputs',
-          :record_id     => @record.id,
-          :title         => _("Show all Outputs"))
-        = li_link(:count => @record.number_of(:resources),
-          :text          => _("Resources"),
-          :action        => 'resources',
-          :record_id     => @record.id,
-          :title         => _("Show all Resources"))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -733,7 +733,7 @@ en:
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem: Configured System (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Configured System (Foreman)
-      ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job:         Configuration Job (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job:         Ansible Tower Job
       ManageIQ::Providers::CloudManager:                                    Cloud Provider
       ManageIQ::Providers::CloudManager::Vm:                                Instance
       ManageIQ::Providers::Google::CloudManager::Vm:                        Instance (Google)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -733,6 +733,7 @@ en:
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem: Configured System (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Configured System (Foreman)
+      ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job:         Configuration Job (Ansible Tower)
       ManageIQ::Providers::CloudManager:                                    Cloud Provider
       ManageIQ::Providers::CloudManager::Vm:                                Instance
       ManageIQ::Providers::Google::CloudManager::Vm:                        Instance (Google)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,7 +302,6 @@ Vmdb::Application.routes.draw do
         save_post
     },
 
-
     :consumption                  => {
       :get => %w(
         show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,6 +270,45 @@ Vmdb::Application.routes.draw do
       )
     },
 
+    :configuration_job      => {
+      :get  => %w(
+        download_data
+        index
+        outputs
+        parameters
+        resources
+        show
+        show_list
+        tagging_edit
+        protect
+      ),
+      :post => %w(
+        button
+        outputs
+        listnav_search_selected
+        panel_control
+        parameters
+        quick_search
+        resources
+        sections_field_changed
+        show
+        show_list
+        protect
+        tagging_edit
+        tag_edit_form_field_changed
+      ) +
+        adv_search_post +
+        exp_post +
+        save_post
+    },
+
+
+    :consumption                  => {
+      :get => %w(
+        show
+      )
+    },
+
     :cloud_object_store_container => {
       :get => %w(
         download_data

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4291,6 +4291,48 @@
           :description: Edit Job Templates Tags
           :feature_type: control
           :identifier: configuration_script_tag
+# Configuration Jobs
+- :name: Configuration Jobs
+  :description: Everything under Configuration Jobs
+  :feature_type: node
+  :identifier: configuration_job
+  :children:
+  - :name: View
+    :description: View Configuration Jobs
+    :feature_type: view
+    :identifier: configuration_job_view
+    :children:
+    - :name: List
+      :description: Display Lists of Configuration Jobs
+      :feature_type: view
+      :identifier: configuration_job_show_list
+    - :name: Show
+      :description: Display Individual Configuration Jobs
+      :feature_type: view
+      :identifier: configuration_job_show
+  - :name: Modify
+    :description: Modify Configuration Job
+    :feature_type: admin
+    :identifier: configuration_job_admin
+    :children:
+    - :name: Remove
+      :description: Remove Configuration Jobs from the VMDB
+      :feature_type: admin
+      :identifier: configuration_job_delete
+    - :name: Edit
+      :description: Edit Configuration Job
+      :feature_type: admin
+      :identifier: configuration_job_edit
+  - :name: Operate
+    :description: Perform Operations on Configuration Jobs
+    :feature_type: control
+    :identifier: configuration_job_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Configuration Jobs
+      :feature_type: control
+      :identifier: configuration_job_tag
+
 - :name: All VM and Instance Access Rules
   :description: All VM and Instance Access Rules
   :feature_type: node

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -33,6 +33,7 @@
   - ems_infra
   - container_dashboard
   - ems_container
+  - configuration_job
   - container_project
   - container_route
   - container_service

--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job.yaml
@@ -21,8 +21,8 @@ db: ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job
 cols:
 - name
 - type
-- draft
-- description
+- ems_ref
+- status
 - created_at
 - updated_at
 
@@ -33,17 +33,17 @@ include:
 col_order:
 - name
 - type
-- draft
-- description
+- ems_ref
+- status
 - created_at
 - updated_at
 
 # Column titles, in order
 headers:
-- Name
-- Template Type
-- Draft
-- Description
+- Template Name
+- Type
+- Id
+- Status
 - Created On
 - Updated On
 

--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job.yaml
@@ -1,0 +1,86 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Orchestration Templates
+
+# Menu name
+name: Orchestration Template
+
+# Main DB table report is based on
+db: ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job
+
+# Columns to fetch from the main table
+cols:
+- name
+- type
+- draft
+- description
+- created_at
+- updated_at
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+
+# Order of columns (from all tables)
+col_order:
+- name
+- type
+- draft
+- description
+- created_at
+- updated_at
+
+# Column titles, in order
+headers:
+- Name
+- Template Type
+- Draft
+- Description
+- Created On
+- Updated On
+
+col_formats:
+-
+- :model_name
+- :boolean_yes_no
+-
+-
+-
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
+++ b/product/views/ManageIQ_Providers_CloudManager_OrchestrationStack.yaml
@@ -1,0 +1,100 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Orchestration Stack
+
+# Menu name
+name: OrchestrationStack
+
+# Main DB table report is based on
+db: ManageIQ::Providers::CloudManager::OrchestrationStack
+
+# Columns to fetch from the main table
+cols:
+- name
+- type
+- status
+- status_reason
+- total_vms
+- total_security_groups
+- total_cloud_networks
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  ext_management_system:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+  :ext_management_system: {}
+
+# Order of columns (from all tables)
+col_order:
+- name
+- ext_management_system.name
+- type
+- status
+- status_reason
+- total_vms
+- total_security_groups
+- total_cloud_networks
+
+# Column titles, in order
+headers:
+- Name
+- Provider
+- Type
+- Status
+- Status Reason
+- Instances
+- Security Groups
+- Cloud Networks
+
+# Condition(s) string for the SQL query
+conditions: 
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph: 
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims: 
+
+col_formats:
+-
+-
+- :model_name
+-
+-
+-
+-
+-

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -1,0 +1,79 @@
+include CompressedIds
+
+describe ConfigurationJobController do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+
+  before(:each) do
+    set_user_privileges user
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  render_views
+
+  describe '#show' do
+    context "instances" do
+      let(:record) { FactoryGirl.create(:ansible_tower_job) }
+
+      before do
+        session[:settings] = {
+        }
+        get :show, :params => {:id => record.id}
+      end
+
+      it "renders the listnav" do
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:partial => "layouts/listnav/_configuration_job")
+      end
+    end
+  end
+
+  context "#tags_edit" do
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @cj = FactoryGirl.create(:ansible_tower_job, :name => "testJob")
+      user = FactoryGirl.create(:user, :userid => 'testuser')
+      set_user_privileges user
+      allow(@cj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryGirl.create(:classification_tag,
+                                 :name   => "tag1",
+                                 :parent => classification)
+      @tag2 = FactoryGirl.create(:classification_tag,
+                                 :name   => "tag2",
+                                 :parent => classification)
+      allow(Classification).to receive(:find_assigned_entries).with(@cj).and_return([@tag1, @tag2])
+      session[:tag_db] = "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job"
+      edit = {
+        :key        => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job_edit_tags__#{@cj.id}",
+        :tagging    => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job",
+        :object_ids => [@cj.id],
+        :current    => {:assignments => []},
+        :new        => {:assignments => [@tag1.id, @tag2.id]}
+      }
+      session[:edit] = edit
+    end
+
+    after(:each) do
+      expect(response.status).to eq(200)
+    end
+
+    it "builds tagging screen" do
+      post :button, :params => { :pressed => "configuration_job_tag", :format => :js, :id => @cj.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "cancels tags edit" do
+      session[:breadcrumbs] = [{:url => "configuration_job/show/#{@cj.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @cj.id }
+      expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
+      expect(assigns(:edit)).to be_nil
+    end
+
+    it "save tags" do
+      session[:breadcrumbs] = [{:url => "configuration_job/show/#{@cj.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @cj.id }
+      expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
+      expect(assigns(:edit)).to be_nil
+    end
+  end
+end

--- a/spec/controllers/ops_controller/settings/rbac_roles_spec.rb
+++ b/spec/controllers/ops_controller/settings/rbac_roles_spec.rb
@@ -44,7 +44,7 @@ describe OpsController do
         expect do |b|
           controller.send(:recurse_sections_and_features, '_tab_conf', &b)
         end.to yield_successive_args(
-          ["provider_foreman_explorer",include("provider_foreman_view")],
+          ["provider_foreman_explorer", include("provider_foreman_view")],
           ["configuration_job", include("configuration_job")])
       end
     end

--- a/spec/controllers/ops_controller/settings/rbac_roles_spec.rb
+++ b/spec/controllers/ops_controller/settings/rbac_roles_spec.rb
@@ -44,8 +44,8 @@ describe OpsController do
         expect do |b|
           controller.send(:recurse_sections_and_features, '_tab_conf', &b)
         end.to yield_successive_args(
-                 ["provider_foreman_explorer",include("provider_foreman_view")],
-                 ["configuration_job", include("configuration_job")])
+          ["provider_foreman_explorer",include("provider_foreman_view")],
+          ["configuration_job", include("configuration_job")])
       end
     end
     context '"vm" feature node' do

--- a/spec/controllers/ops_controller/settings/rbac_roles_spec.rb
+++ b/spec/controllers/ops_controller/settings/rbac_roles_spec.rb
@@ -43,7 +43,9 @@ describe OpsController do
       it 'yields features including "provider_foreman_view"' do
         expect do |b|
           controller.send(:recurse_sections_and_features, '_tab_conf', &b)
-        end.to yield_with_args('provider_foreman_explorer', include('provider_foreman_view'))
+        end.to yield_successive_args(
+                 ["provider_foreman_explorer",include("provider_foreman_view")],
+                 ["configuration_job", include("configuration_job")])
       end
     end
     context '"vm" feature node' do


### PR DESCRIPTION
Purpose or Intent
-----------------

Display the Ansible Tower Job List in the Configuration / Jobs page
Move the list of Ansible Jobs from Cloud/Orchestration Stacks to their own controller - new menu item under Configuration Management.

Links
-----

Darga port for https://github.com/ManageIQ/manageiq/pull/9809

https://www.pivotaltracker.com/n/projects/1613907/stories/123185481
https://bugzilla.redhat.com/show_bug.cgi?id=1344654
https://bugzilla.redhat.com/show_bug.cgi?id=1349426
