### PR TITLE
C3 charts yaxis C&U

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1658,10 +1658,19 @@ function chartData(type, data, data2) {
     return;
   }
 
-  // set maximum count of x axis tick labels
-  if (_.isObject(data.miq) && data.miq.performance) {
-    data.axis.x.tick.centered = true;
-    data.axis.x.tick.culling = { max: 5 };
+
+  if (_.isObject(data.miq)) {
+    // set maximum count of x axis tick labels for C&U charts
+    if (data.miq.performance_chart) {
+      data.axis.x.tick.centered = true;
+      data.axis.x.tick.culling = { max: 5 };
+    }
+
+    // small C&U charts have very limited height
+    if (data.miq.flat_chart) {
+      var max = _.max(_.flatten(_.tail(data.data.columns).map(_.tail)));
+      data.axis.y.tick.values = [0, max];
+    }
   }
 
   // set formating function for tooltip and y tick labels

--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -11,6 +11,7 @@ function load_c3_charts() {
 
         chart_id += "_2";
         if (typeof (data.xml2) !== "undefined") {
+          data.xml2.miq.flat_chart = true;
           load_c3_chart(data.xml2, chart_id, 100);
         }
       }

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -49,15 +49,14 @@ module ReportFormatter
       mri.chart = {
         :miqChart => type,
         :data     => {:columns => [], :names => {}},
-        :axis     => {},
+        :axis     => {:x => {:tick => {}}, :y => {:tick => {}}},
         :tooltip  => {}
       }
 
       if chart_is_2d?
-        mri.chart[:axis] = {
-          :x => {
-            :categories => []
-          }
+        mri.chart[:axis][:x] = {
+          :categories => [],
+          :tick       => {}
         }
       end
 
@@ -130,7 +129,7 @@ module ReportFormatter
       # set x axis type to timeseries and remove categories
       mri.chart[:axis][:x] = {:type => 'timeseries', :tick => {}}
       # set flag for performance chart
-      mri.chart[:miq] = {:performance => true}
+      mri.chart[:miq] = {:performance_chart => true}
       # this conditions are taken from build_performance_chart_area method from chart_commons.rb
       if mri.db.include?("Daily") || (mri.where_clause && mri.where_clause.include?("daily"))
         # set format for parsing


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix overlapping Y axis labels in small C&U charts. In this PR i change Y axis labels in small C&U charts, so they show only two values. Zero and maximum from displayed data.

Screenshots
-----------------
Before:
![screenshot from 2016-07-26 11-04-19](https://cloud.githubusercontent.com/assets/9535558/17132144/bda95826-5320-11e6-938e-f402c7abbd16.png)
After:
![screenshot from 2016-07-26 11-02-38](https://cloud.githubusercontent.com/assets/9535558/17132148/c16cf33c-5320-11e6-8785-e320b19b1a6a.png)
