### PR TITLE
Cross linking between openstack Vms and container nodes though provider id

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -149,8 +149,9 @@ module ManageIQ::Providers::Kubernetes
     def scheme_to_provider_mapping
       @scheme_to_provider_mapping ||= begin
         {
-          'gce' => ['ManageIQ::Providers::Google::CloudManager'.safe_constantize, :name],
-          'aws' => ['ManageIQ::Providers::Amazon::CloudManager'.safe_constantize, :uid_ems],
+          'gce'       => ['ManageIQ::Providers::Google::CloudManager'.safe_constantize, :name],
+          'aws'       => ['ManageIQ::Providers::Amazon::CloudManager'.safe_constantize, :uid_ems],
+          'openstack' => ['ManageIQ::Providers::Openstack::CloudManager'.safe_constantize, :uid_ems]
         }.reject { |_key, (provider, _name)| provider.nil? }
       end
     end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -645,6 +645,14 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                                  :ext_management_system => @ems)
       end
 
+      it "cross links openstack through provider id" do
+        @node[:identity_infra] = "openstack:///openstack_id"
+        @ems = FactoryGirl.create(:ems_openstack)
+        @vm = FactoryGirl.create(:vm_openstack,
+                                 :uid_ems               => 'openstack_id',
+                                 :ext_management_system => @ems)
+      end
+
       it 'cross links with missing data in ProviderID' do
         @node[:identity_infra] = "gce:////instance_id/"
         @ems = FactoryGirl.create(:ems_google,


### PR DESCRIPTION
BZ - https://bugzilla.redhat.com/show_bug.cgi?id=1355911

Im unsure if we should remove the option to cross link thorugh `bios_uuid`

@simon3z @enoodle Please review