### PR TITLE
Allow constants to load from DRb threads

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -51,7 +51,13 @@ module MiqAeEngine
   end
 
   def self.deliver(*args)
-    @deliver_mutex.synchronize { deliver_block(*args) }
+    # This was added because in RAILS 5 PUMA sends multiple requests
+    # to the same processa and our DRb server implementation for Automate
+    # Methods is not thread safe. The permit_concurrent_loads  allows the
+    # DRb requests which run in different threads to load symbols.
+    ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+      @deliver_mutex.synchronize { deliver_block(*args) }
+    end
   end
 
   def self.deliver_block(*args)

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -52,9 +52,9 @@ module MiqAeEngine
 
   def self.deliver(*args)
     # This was added because in RAILS 5 PUMA sends multiple requests
-    # to the same processa and our DRb server implementation for Automate
-    # Methods is not thread safe. The permit_concurrent_loads  allows the
-    # DRb requests which run in different threads to load symbols.
+    # to the same process and our DRb server implementation for Automate
+    # Methods is not thread safe. The permit_concurrent_loads allows the
+    # DRb requests which run in different threads to load constants.
     ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
       @deliver_mutex.synchronize { deliver_block(*args) }
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
> The serialization of Automate calls done with a Mutex in PR https://github.com/ManageIQ/manageiq/pull/9903 was causing  Automate methods to hang because constants couldn't be loaded by DRb requests which are called by Automate Methods.

Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1354054
> * PR #9903 


Steps for Testing/QA
--------------------
> [Optional] Difficult to reproduce