### PR TITLE
Renice workers after they fork

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -320,6 +320,7 @@ class MiqWorker < ApplicationRecord
   def self.after_fork
     close_pg_sockets_inherited_from_parent
     DRb.stop_service
+    renice(Process.pid)
   end
 
   # When we fork, the children inherits the parent's file descriptors
@@ -512,8 +513,8 @@ class MiqWorker < ApplicationRecord
                          end
   end
 
-  def self.nice_prefix
-    @nice_prefix ||= "nice -n #{nice_increment}"
+  def self.renice(pid)
+    AwesomeSpawn.run("renice", :params =>  {:n => nice_increment, :p => pid })
   end
 
   def self.nice_increment

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -22,6 +22,13 @@ describe MiqWorker do
     end
   end
 
+  it "renice" do
+    allow(AwesomeSpawn).to receive(:launch)
+    allow(described_class).to receive(:worker_settings).and_return(:nice_delta => 5)
+    result = described_class.renice(123)
+    expect(result.command_line).to eq "renice -n 5 -p 123"
+  end
+
   context ".has_required_role?" do
     def check_has_required_role(worker_role_names, expected_result)
       allow(described_class).to receive(:required_roles).and_return(worker_role_names)


### PR DESCRIPTION
Purpose or Intent
-----------------

Before we changed from spawn to fork [1],
we'd spawn the process with a nice prefix [2],
which gave the kernel some hints for CPU scheduling
of our processes.  A higher "nice" value for a process
is nicer to other processes.

This niceness wasn't brought over from spawn to fork.

Links
-----

https://bugzilla.redhat.com/show_bug.cgi?id=1353700

[1] #3593
[2] b0caa42


Steps for Testing/QA
--------------------

```
[root@new-host-4 vmdb]# ps -afxo pid,ni,command | grep -i "[Mm]iq"
13400   0 MIQ Server
13556   7  \_ MIQ: MiqEventHandler id: 23, queue: ems
13565  10  \_ MIQ: MiqGenericWorker id: 24, queue: generic
13573  10  \_ MIQ: MiqGenericWorker id: 25, queue: generic
13583   1  \_ MIQ: MiqPriorityWorker id: 26, queue: generic
13588   1  \_ MIQ: MiqPriorityWorker id: 27, queue: generic
13601   7  \_ MIQ: MiqReportingWorker id: 28, queue: reporting
13609   7  \_ MIQ: MiqReportingWorker id: 29, queue: reporting
13618   3  \_ MIQ: MiqScheduleWorker id: 30
13642   1  \_ puma 3.3.0 (tcp://127.0.0.1:5000) [MIQ: Web Server Worker]
13674   1  \_ puma 3.3.0 (tcp://127.0.0.1:3000) [MIQ: Web Server Worker]
13689   1  \_ puma 3.3.0 (tcp://127.0.0.1:4000) [MIQ: Web Server Worker]
```

The second column value was 0 before.
