### PR TITLE
Adjust load values on init to be underneath show refresh

### DIFF
--- a/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
@@ -8,13 +8,6 @@
                       :onFocus => 'miqShowAE_Tree("field_entry_point");')
 
 - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
-  .form-group
-    %label.col-md-2.control-label
-      = _('Load Values on Init')
-    .col-md-8
-      = check_box_tag('field_load_on_init', '1',
-                      @edit[:field_load_on_init],
-                      'data-miq_observe_checkbox' => {:url => url}.to_json)
 .form-group
   %label.col-md-2.control-label
     = _('Show Refresh Button')
@@ -22,6 +15,13 @@
     = check_box_tag('field_show_refresh_button', '1',
                   @edit[:field_show_refresh_button],
                   'data-miq_observe_checkbox' => {:url => url}.to_json)
+.form-group
+  %label.col-md-2.control-label
+    = _('Load Values on Init')
+  .col-md-8
+    = check_box_tag('field_load_on_init', '1',
+                    @edit[:field_load_on_init],
+                    'data-miq_observe_checkbox' => {:url => url}.to_json)
 .form-group
   %label.col-md-2.control-label
     = _('Auto refresh')


### PR DESCRIPTION
'Load Values on Init' depends on 'Show Refresh Button' so this moves load values to be underneath the refresh. 

