### PR TITLE
Fix miq-observe with interval

### DIFF
--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -64,11 +64,15 @@ $(document).ready(function () {
   };
 
   var observeWithInterval = function(el, parms) {
+    if (el.data('isObserved')) {
+      return;
+    }
+    el.data('isObserved', true);
+
     var interval = parms.interval;
     var url = parms.url;
     var submit = parms.submit;
 
-    el.off(); // Use jQuery to turn off observe_field, prevents multi ajax transactions
     el.observe_field(interval, function () {
       var oneTrans = this.getAttribute('data-miq_send_one_trans'); // Grab one trans URL, if present
       if (typeof submit != "undefined") {


### PR DESCRIPTION
`miq-observe` with an interval set uses jquery.observe_field to watch the element for changes, but attaches the handler on every focus. Code to remove it before that was there, but ineffective since `observe_field` does not use events.

This splits the logic into separate `observeWithInterval` and `observeOnChange` functions (1st commit), and changes `observeWithInterval` to remember that it was already initialized on each element and not initialize again (2nd commit).

To verify.. go to `Configuration > Settings > Region` - click the region line to edit .. click on the input, click elsewhere, click on the input, click elsewhere, click on the input, write a single letter. **Before** - this will generate 3 requests, **after**, only one.

(This happens in darga too..)

https://bugzilla.redhat.com/show_bug.cgi?id=1359934

Cc @martinpovolny..