### PR TITLE
Corrected SmartState Analysis button class for toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -26,7 +26,7 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
           :enabled   => false,
           :onwhen    => "1+",
-          :klass     => ApplicationHelper::Button::VmInstanceScan),
+          :klass     => ApplicationHelper::Button::BasicImage),
         button(
           :vm_collect_running_processes,
           'fa fa-eyedropper fa-lg',


### PR DESCRIPTION
Purpose or Intent
-----------------
Corrected SmartState Analysis button class for toolbar.

Right now, the button is correctly disabled, but only because it fails on condition for needing record.
The button should be disabled because it is in Orphaned screen.

![screencapture-localhost-3000-vm_infra-explorer-1469535773549](https://cloud.githubusercontent.com/assets/1187051/17137635/796cbf56-533c-11e6-8647-7774809af5db.png)


Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1329654

@martinpovolny please review