### PR TITLE
Fix unclickable snapshots in snapshot tree

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -586,7 +586,8 @@ function miqTreeEventSafeEval(func) {
                   'miqOnClickServerRoles',
                   'miqOnClickGenealogyTree',
                   'miqOnCheckSections',
-                  'miqOnCheckCUFilters'];
+                  'miqOnCheckCUFilters',
+                  'miqOnClickSnapshotTree'];
 
   if (whitelist.includes(func)) {
     return window[func];


### PR DESCRIPTION
The new improvement in app/assets/javascripts/miq_dynatree.js causes the snapshots to be un-clickable because miqOnClickSnapshotTree was not part of the "whitelisted" functions.
Added it to whitelist.