### PR TITLE
Fix breadcrumb url creation in orchestration stack controller

### DIFF
--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -8,6 +8,10 @@ class OrchestrationStackController < ApplicationController
     ManageIQ::Providers::CloudManager::OrchestrationStack
   end
 
+  def self.table_name
+    @table_name ||= "orchestration_stack"
+  end
+
   def index
     redirect_to :action => 'show_list'
   end

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -52,6 +52,19 @@ describe OrchestrationStackController do
     end
   end
 
+  describe "#show_list" do
+    context "orchestration stack listing" do
+      before do
+        get :show_list
+      end
+
+      it "correctly constructs breadcrumb url" do
+        expect(session[:breadcrumbs]).not_to be_empty
+        expect(session[:breadcrumbs].first[:url]).to eq("/orchestration_stack/show_list")
+      end
+    end
+  end
+
   describe "#stacks_ot_info" do
     it "returns all the orchestration template attributes" do
       stack = FactoryGirl.create(:orchestration_stack_cloud_with_template)


### PR DESCRIPTION
This is to fix the following error when for example canceling retirement of orchestration stack:

```
ActionController::RoutingError (No route matches [GET]
"/manageiq/providers/cloud_manager/orchestration_stack/show_list"):
...
```

The problem is also present in darga.

https://bugzilla.redhat.com/show_bug.cgi?id=1360417