### PR TITLE
remove route.rb reload! error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2620,20 +2620,22 @@ Vmdb::Application.routes.draw do
   # Enablement for the REST API
 
   # Semantic Versioning Regex for API, i.e. vMajor.minor.patch[-pre]
-  API_VERSION_REGEX = /v[\d]+(\.[\da-zA-Z]+)*(\-[\da-zA-Z]+)?/
+  API_VERSION_REGEX = /v[\d]+(\.[\da-zA-Z]+)*(\-[\da-zA-Z]+)?/ unless defined?(API_VERSION_REGEX)
 
   # OPTIONS requests for REST API pre-flight checks
   match '/api/*path' => 'api#handle_options_request', :via => [:options]
 
   get '/api(/:version)' => 'api#show_entrypoint', :format => 'json', :version => API_VERSION_REGEX
 
-  API_ACTIONS = {
-    :get    => "show",
-    :post   => "update",
-    :put    => "update",
-    :patch  => "update",
-    :delete => "destroy"
-  }.freeze
+  unless defined?(API_ACTIONS)
+    API_ACTIONS = {
+      :get    => "show",
+      :post   => "update",
+      :put    => "update",
+      :patch  => "update",
+      :delete => "destroy"
+    }.freeze
+  end
 
   def action_for(verb)
     "api##{API_ACTIONS[verb]}"


### PR DESCRIPTION
When I type `reload!` in rails console, I get a warning.
This removes the warning.

It also creates a couple hundred fewer objects when creating the routes. (minimal)
To test I verified the following from the command line

```bash
bundle exec ruby tools/rest_api.rb -v get vms
```

before:

```
manageiq/config/routes.rb:2623: warning: already initialized constant API_VERSION_REGEX
manageiq/config/routes.rb:2623: warning: previous definition of API_VERSION_REGEX was here
manageiq/config/routes.rb:2630: warning: already initialized constant API_ACTIONS
manageiq/config/routes.rb:2630: warning: previous definition of API_ACTIONS was here
```

after:

```
... silence ...
```