### PR TITLE
Update deprecation warning to E-release

### DIFF
--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -1,7 +1,7 @@
 module Vmdb
   class Deprecation
     def self.instance
-      @instance ||= ActiveSupport::Deprecation.new("D-release", "ManageIQ").tap { |d| d.behavior = default_behavior }
+      @instance ||= ActiveSupport::Deprecation.new("E-release", "ManageIQ").tap { |d| d.behavior = default_behavior }
     end
 
     def self.method_missing(method_name, *args, &block)


### PR DESCRIPTION
Updates our deprecation wrapper to the next release cycle, since we are now working towards Euwe

I think this is right, and I believe this should be put in Darga...?

@miq-bot add_labels core, darga/yes
@miq-bot assign Fryguy, bdunne