### PR TITLE
Increase value_max_bytes option for memcache dalli client to 10 megabytes. In addition expose the default memcache limit for values (1M) for memcache_server_opts in settings.yml

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -17,7 +17,7 @@ else
   if session_store == :mem_cache_store
     require 'dalli'
     session_options = session_options.merge(
-      :cache        => Dalli::Client.new(Settings.session.memcache_server, :namespace => "MIQ:VMDB"),
+      :cache        => Dalli::Client.new(Settings.session.memcache_server, :namespace => "MIQ:VMDB", :value_max_bytes => 10.megabytes),
       :expire_after => 24.hours,
       :key          => "_vmdb_session",
     )

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1022,7 +1022,7 @@
 :session:
   :interval: 60
   :memcache_server: 127.0.0.1:11211
-  :memcache_server_opts: "-l 127.0.0.1"
+  :memcache_server_opts: "-l 127.0.0.1 -I 1M"
   :show_login_info: true
   :timeout: 3600
 :smartproxy_deploy:


### PR DESCRIPTION
Purpose or Intent
-----------------
This is a workaround for issue #10074 - increasing the `value_max_bytes` used by the ruby memcached client, dalli, to 10 MB parameter so it's unlikely to be the one preventing a large session from being saved into memcached.  Additionally, the default value for memcached itself, 1 M, is now visibly exposed as `-I 1M` in the existing `memcache_server_opts` settings.yml, allowing for a single place to configure memcached to allow a larger than 1 M session.  Changing it to `-I 2 M` will allow a session size of up to 2 MB, etc..

It is straightforward and may prove useful to others.

Links
----
https://github.com/ManageIQ/manageiq/issues/10074