### PR TITLE
Added rh-repmgr95, without it postgres95 would not start properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
                    rh-postgresql95-postgresql-devel  \
                    rh-postgresql95-postgresql-pglogical-output \
                    rh-postgresql95-postgresql-pglogical \
+                   rh-repmgr95             \
                    readline-devel          \
                    sqlite-devel            \
                    sysvinit-tools          \


### PR DESCRIPTION
PR #9815 added postgres95, and build succeeds, however the postgres would not start due to a missing dependency of rh-repmgr95.

hence this commit adds it to the rpm list in the Dockerfile

Signed-off-by: Barak Azulay <bazulay@redhat.com>