### PR TITLE
Fix enabling of toolbar button in drift history screen

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -410,7 +410,7 @@ function miqUpdateButtons(obj, button_div) {
   var count = 0;
 
   if (typeof obj.id != "undefined") {
-    $("input[id^='" + obj.id + "']").each(function () {
+    $("input[id^='check_']").each(function () {
       if (this.checked && !this.disabled) {
         count++;
       }


### PR DESCRIPTION
How to reproduce the problem:
1. Virtual machine summary -> Drift History
2. Select two or more items from the drift history screen
3. See the toolbar button to perform the history compare never gets enabled

miqUpdateButtons() would always call `miqSetButtons()` with the count of 1, i.e. buttons with
`onwhen='2+'` would never become enabled.