### PR TITLE
[WIP] Easier runner instantiation / remove some any_instance_of(Runner) mocking

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -49,9 +49,6 @@ class MiqWorker::Runner
     @server = MiqServer.my_server(true)
 
     worker_initialization
-    after_initialize
-
-    @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
   end
 
   def worker_initialization
@@ -124,6 +121,10 @@ class MiqWorker::Runner
   end
 
   def start
+    after_initialize
+
+    @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
+
     prepare
     run
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -47,8 +47,6 @@ class MiqWorker::Runner
     $log ||= Rails.logger
 
     @server = MiqServer.my_server(true)
-
-    worker_initialization
   end
 
   def worker_initialization
@@ -121,6 +119,7 @@ class MiqWorker::Runner
   end
 
   def start
+    worker_initialization
     after_initialize
 
     @worker.release_db_connection if @worker.respond_to?(:release_db_connection)

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -51,7 +51,6 @@ class MiqWorker::Runner
 
   def worker_initialization
     starting_worker_record
-    set_process_title
 
     # Sync the config and roles early since heartbeats and logging require the configuration
     sync_active_roles
@@ -122,8 +121,6 @@ class MiqWorker::Runner
     worker_initialization
     after_initialize
 
-    @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
-
     prepare
     run
 
@@ -142,6 +139,9 @@ class MiqWorker::Runner
   end
 
   def prepare
+    set_process_title
+    @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
+
     ObjectSpace.garbage_collect
     started_worker_record
     do_wait_for_worker_monitor if self.class.wait_for_worker_monitor?

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -51,7 +51,9 @@ class MiqWorker::Runner
 
   def worker_initialization
     starting_worker_record
+  end
 
+  def startup_configuration_tasks
     # Sync the config and roles early since heartbeats and logging require the configuration
     sync_active_roles
     sync_config
@@ -119,8 +121,8 @@ class MiqWorker::Runner
 
   def start
     worker_initialization
+    startup_configuration_tasks
     after_initialize
-
     prepare
     run
 

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -18,6 +18,10 @@ module MiqWebServerRunnerMixin
   module ClassMethods
     def start_worker(*args)
       runner = self.new(*args)
+
+      # TODO: Clean this up, it's not obvious we need to do this
+      runner.worker_initialization
+      runner.after_initialize
       _log.info("URI: #{runner.worker.uri}")
 
       # Do all the SQL worker preparation in the main thread

--- a/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/event_catcher/runner_spec.rb
@@ -11,7 +11,6 @@ describe ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner do
 
     before do
       allow_any_instance_of(ManageIQ::Providers::Azure::CloudManager).to receive_messages(:authentication_check => [true, ""])
-      allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
     end
 
     describe "parse properties" do

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner_spec.rb
@@ -16,7 +16,6 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner 
   before do
     allow_any_instance_of(ManageIQ::Providers::Hawkular::MiddlewareManager)
       .to receive_messages(:authentication_check => [true, ""])
-    allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
   end
 
   context "#whitelist" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner do
   context "#event_monitor_options" do
     let(:ems)     { FactoryGirl.create(:ems_redhat, :hostname => "hostname") }
-    let(:catcher) { described_class.new(:ems_id => ems.id) }
+    let(:catcher) { described_class.new(:ems_id => ems.id).tap(&:after_initialize) }
 
     before do
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive_messages(:authentication_check => [true, ""])

--- a/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/event_catcher/runner_spec.rb
@@ -5,7 +5,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner do
 
     before do
       allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive_messages(:authentication_check => [true, ""])
-      allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
     end
 
     it "numeric port" do

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -5,7 +5,6 @@ describe MiqEmsRefreshCoreWorker::Runner do
 
     # General stubbing for testing any worker (methods called during initialize)
     @worker_record = FactoryGirl.create(:miq_ems_refresh_core_worker, :queue_name => "ems_#{@ems.id}", :miq_server => server)
-    allow_any_instance_of(described_class).to receive(:sync_active_roles)
     allow_any_instance_of(described_class).to receive(:sync_config)
     allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
     allow_any_instance_of(described_class).to receive(:heartbeat_using_drb?).and_return(false)

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -5,8 +5,6 @@ describe MiqEmsRefreshCoreWorker::Runner do
 
     # General stubbing for testing any worker (methods called during initialize)
     @worker_record = FactoryGirl.create(:miq_ems_refresh_core_worker, :queue_name => "ems_#{@ems.id}", :miq_server => server)
-    allow_any_instance_of(described_class).to receive(:sync_config)
-    allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
     allow_any_instance_of(described_class).to receive(:heartbeat_using_drb?).and_return(false)
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
 

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -12,6 +12,7 @@ describe MiqEmsRefreshCoreWorker::Runner do
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
 
     @worker = MiqEmsRefreshCoreWorker::Runner.new(:guid => @worker_record.guid, :ems_id => @ems.id)
+    @worker.after_initialize
   end
 
   context "#process_update" do

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -13,6 +13,7 @@ describe MiqScheduleWorker::Runner do
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:set_connection_pool_size)
 
       @schedule_worker = MiqScheduleWorker::Runner.new(:guid => worker_guid)
+      @schedule_worker.after_initialize
     end
 
     context "with a stuck dispatch in each zone" do

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -8,7 +8,6 @@ describe MiqScheduleWorker::Runner do
       @worker = FactoryGirl.create(:miq_schedule_worker, :guid => worker_guid, :miq_server_id => @miq_server.id)
 
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:initialize_rufus)
-      allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:sync_active_roles)
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:sync_config)
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:set_connection_pool_size)
 

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -8,8 +8,6 @@ describe MiqScheduleWorker::Runner do
       @worker = FactoryGirl.create(:miq_schedule_worker, :guid => worker_guid, :miq_server_id => @miq_server.id)
 
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:initialize_rufus)
-      allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:sync_config)
-      allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:set_connection_pool_size)
 
       @schedule_worker = MiqScheduleWorker::Runner.new(:guid => worker_guid)
       @schedule_worker.after_initialize

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -13,7 +13,6 @@ describe MiqVimBrokerWorker::Runner do
     @worker_record = FactoryGirl.create(:miq_vim_broker_worker, :guid => @worker_guid, :miq_server_id => server.id)
     @drb_uri = "drb://127.0.0.1:12345"
     allow(DRb).to receive(:uri).and_return(@drb_uri)
-    allow_any_instance_of(described_class).to receive(:sync_active_roles)
     allow_any_instance_of(described_class).to receive(:sync_config)
     allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -25,6 +25,7 @@ describe MiqVimBrokerWorker::Runner do
     expect_any_instance_of(described_class).to receive(:reset_broker_update_notification).once
     expect_any_instance_of(described_class).to receive(:reset_broker_update_sleep_interval).once
     vim_broker_worker = described_class.new(:guid => @worker_guid)
+    vim_broker_worker.after_initialize
 
     expect(vim_broker_worker.instance_variable_get(:@initial_emses_to_monitor)).to match_array @zone.ext_management_systems
 
@@ -37,6 +38,7 @@ describe MiqVimBrokerWorker::Runner do
     before(:each) do
       expect_any_instance_of(described_class).to receive(:after_initialize).once
       @vim_broker_worker = described_class.new(:guid => @worker_guid)
+      @vim_broker_worker.after_initialize
       allow(@vim_broker_worker).to receive(:worker_settings).and_return(
         :vim_broker_worker_max_wait => 60, :vim_broker_worker_max_objects => 250)
     end

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -3,7 +3,6 @@ require 'MiqVimBroker'
 
 describe MiqVimBrokerWorker::Runner do
   before(:each) do
-    _guid_2, _server_2, @zone_2 = EvmSpecHelper.create_guid_miq_server_zone
     guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
     other_ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
@@ -336,7 +335,7 @@ describe MiqVimBrokerWorker::Runner do
         end
 
         it "will not reconnect to an EMS in another zone" do
-          ems_2 = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone_2)
+          ems_2 = FactoryGirl.create(:ems_vmware_with_authentication, :zone => FactoryGirl.create(:zone))
 
           event = {
             :server   => ems_2.address,

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -25,6 +25,7 @@ describe MiqVimBrokerWorker::Runner do
     expect_any_instance_of(described_class).to receive(:reset_broker_update_notification).once
     expect_any_instance_of(described_class).to receive(:reset_broker_update_sleep_interval).once
     vim_broker_worker = described_class.new(:guid => @worker_guid)
+    vim_broker_worker.worker_initialization
     vim_broker_worker.after_initialize
 
     expect(vim_broker_worker.instance_variable_get(:@initial_emses_to_monitor)).to match_array @zone.ext_management_systems
@@ -39,6 +40,7 @@ describe MiqVimBrokerWorker::Runner do
       expect_any_instance_of(described_class).to receive(:after_initialize).once
       @vim_broker_worker = described_class.new(:guid => @worker_guid)
       @vim_broker_worker.after_initialize
+      @vim_broker_worker.worker_initialization
       allow(@vim_broker_worker).to receive(:worker_settings).and_return(
         :vim_broker_worker_max_wait => 60, :vim_broker_worker_max_objects => 250)
     end

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -13,8 +13,6 @@ describe MiqVimBrokerWorker::Runner do
     @worker_record = FactoryGirl.create(:miq_vim_broker_worker, :guid => @worker_guid, :miq_server_id => server.id)
     @drb_uri = "drb://127.0.0.1:12345"
     allow(DRb).to receive(:uri).and_return(@drb_uri)
-    allow_any_instance_of(described_class).to receive(:sync_config)
-    allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_status_ok?).and_return(true)
   end

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -1,8 +1,8 @@
 describe MiqWorker::Runner do
   context "#start" do
     before do
-      allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)
       @worker_base = MiqWorker::Runner.new
+      allow(@worker_base).to receive(:worker_initialization)
       allow(@worker_base).to receive(:prepare)
     end
 

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -1,8 +1,9 @@
 describe MiqWorker::Runner do
   context "#start" do
     before do
-      @worker_base = MiqWorker::Runner.new
-      allow(@worker_base).to receive(:worker_initialization)
+      worker = MiqWorker.create_worker_record
+      @worker_base = described_class.new(:guid => worker.guid)
+      allow(@worker_base).to receive(:startup_configuration_tasks)
       allow(@worker_base).to receive(:prepare)
     end
 


### PR DESCRIPTION
## Purpose or Intent

`allow_any_instance_of(MiqWorker::Runner).to receive(...)` in our tests is a smell, indicating it's hard to get the right instance of the `Runner` class.  While it may not seem like much, transitioning 

**From**:

`allow_any_instance_of(MiqWorker::Runner).to receive(...)`

**To**:

`allow(a_runner_instance).to receive(...)`

is a big DEAL.  If you can't tell, the second example sets an expectation for a method on a SPECIFIC `Runner` object instead of ANY `Runner` object.  This is very important.

rspec-mocks implementation of any_instance is brittle at best. Each new ruby version can break it.  See [an issue we hit with ruby 2.3.0](https://github.com/ManageIQ/manageiq/issues/5814), the [first proposed fix](https://github.com/rspec/rspec-mocks/pull/1043), and the [followup fix to the fix](https://github.com/rspec/rspec-mocks/pull/1060).

We get other benefits to detangling the `initialize` of the `Runner` object too.  It can be easier to instantiate these objects anywhere, tests, console, normal `rake evm:start`.  We should be able to better categorize the various stages of the `Runner` start code into better named buckets of logic so we can avoid having to mock the world.

This pull request starts the process of detangling to remove some of the `any_instance_of` mocking.  More removals are possible after this PR is merged.
