### PR TITLE
Fixed issue for automate class methods.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -453,9 +453,8 @@ module MiqAeEngine
         aem = cm[method_name] unless cm.nil?
       end
 
-      if namespace_provided.nil?
-        aem = method_override(namespace, klass, method_name, aem)
-      elsif aem.nil?
+      aem = method_override(namespace, klass, method_name, aem)
+      if aem.nil?
         method_aec = fetch_class(fq)
         aem = method_aec.ae_methods.detect { |c| c[:name] == method_name } unless method_aec.nil?
       end

--- a/spec/lib/miq_automation_engine/miq_ae_state_machine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_state_machine_spec.rb
@@ -121,5 +121,41 @@ module MiqAeStateMachineSpec
       ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
       expect(ws.root("test_root_object_attribute")).to eq("test_class_method")
     end
+
+    it "executes on_entry partially qualified class methods properly" do
+      EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
+
+      c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+      i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
+      f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
+      method_string = "/factory/method.test_class_method(status => 'Test',status_state => 'on_entry')"
+      i1.set_field_attribute(f1, method_string, :on_entry)
+      ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
+      expect(ws.root("test_root_object_attribute")).to eq("test_class_method")
+    end
+
+    it "executes method:: method properly" do
+      EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
+
+      c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+      i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
+      f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
+      method_string = "METHOD::update_provision_status(status => 'Test',status_state => 'value')"
+      i1.set_field_attribute(f1, method_string, :value)
+      ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
+      expect(ws.root("test_root_object_attribute")).to eq("update_provision_status")
+    end
+
+    it "executes class method notation method:: properly" do
+      EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
+
+      c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+      i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
+      f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
+      method_string = "METHOD::/factory/method.test_class_method(status => 'Test',status_state => 'on_entry')"
+      i1.set_field_attribute(f1, method_string, :value)
+      ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)
+      expect(ws.root("test_root_object_attribute")).to eq("test_class_method")
+    end
   end
 end


### PR DESCRIPTION
Automate has the ability to call methods using the class method notation.
This is available for state machine on_entry, on_exit, and on_error fields. 
These on_* fields would usually contain just the name of a method that resides in that class. Using the class notation, these entries can access methods in other classes. 

Class method notation:
/namespace1/namespace2/class.method

The new METHOD:: functionality is available to Automate state machine entries and can be used to call a method from a state relationship. METHOD:: can be used to call methods residing in the same class, and can access methods in other classes by using the class method notation.

state machine relationship value: 
METHOD::method_name_here
METHOD::/namespace1/namespace2/class.method

This change fixes the class notation calling in both cases described above.
  
https://bugzilla.redhat.com/show_bug.cgi?id=1359813