### PR TITLE
Domain factory changes

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -39,6 +39,16 @@ class MiqAeDomain < MiqAeNamespace
     self.priority = MiqAeDomain.highest_priority(tenant) + 1 unless priority
   end
 
+  def lock
+    self.system = true
+    save
+  end
+
+  def unlock
+    self.system = false
+    save
+  end
+
   def version
     version_field = about_class.try(:ae_fields).try(:detect) { |fld| fld.name == 'version' }
     version_field.try(:default_value)

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -39,14 +39,14 @@ class MiqAeDomain < MiqAeNamespace
     self.priority = MiqAeDomain.highest_priority(tenant) + 1 unless priority
   end
 
-  def lock
+  def lock_contents!
     self.system = true
-    save
+    save!
   end
 
-  def unlock
+  def unlock_contents!
     self.system = false
-    save
+    save!
   end
 
   def version

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -108,7 +108,7 @@ describe MiqAeClassController do
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
-      d2 = FactoryGirl.create(:miq_ae_domain, :name => "domain2", :system => false)
+      d2 = FactoryGirl.create(:miq_ae_domain, :name => "domain2")
       ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => d2.id)
 
       new = {:domain => d2.id, :namespace => ns2.fqname, :overwrite_location => false}
@@ -165,7 +165,7 @@ describe MiqAeClassController do
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
 
-      d2 = FactoryGirl.create(:miq_ae_domain, :system => false)
+      d2 = FactoryGirl.create(:miq_ae_domain)
       ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => d2.id)
 
       new = {:domain => d2.id, :namespace => ns2.fqname, :override_existing => true}
@@ -402,9 +402,9 @@ describe MiqAeClassController do
   context "#delete_domain" do
     it "Should only delete editable domains" do
       set_user_privileges
-      domain1 = FactoryGirl.create(:miq_ae_domain_enabled, :system => true)
+      domain1 = FactoryGirl.create(:miq_ae_system_domain_enabled)
 
-      domain2 = FactoryGirl.create(:miq_ae_domain_enabled, :system => false)
+      domain2 = FactoryGirl.create(:miq_ae_domain_enabled)
       controller.instance_variable_set(:@_params,
                                        :miq_grid_checks => "aen-#{domain1.id}, aen-#{domain2.id}, aen-someid"
                                       )

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -1,9 +1,20 @@
 FactoryGirl.define do
   factory :miq_ae_domain_enabled, :parent => :miq_ae_domain do
+    enabled true
   end
 
   factory :miq_ae_domain_disabled, :parent => :miq_ae_domain do
     enabled false
+  end
+
+  factory :miq_ae_system_domain , :parent => :miq_ae_domain do
+    enabled false
+    system true
+  end
+
+  factory :miq_ae_system_domain_enabled , :parent => :miq_ae_domain do
+    system true
+    enabled true
   end
 
   factory :miq_ae_git_domain, :parent => :miq_ae_domain do

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -7,12 +7,12 @@ FactoryGirl.define do
     enabled false
   end
 
-  factory :miq_ae_system_domain , :parent => :miq_ae_domain do
+  factory :miq_ae_system_domain, :parent => :miq_ae_domain do
     enabled false
     system true
   end
 
-  factory :miq_ae_system_domain_enabled , :parent => :miq_ae_domain do
+  factory :miq_ae_system_domain_enabled, :parent => :miq_ae_domain do
     system true
     enabled true
   end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2908,7 +2908,7 @@ describe ApplicationHelper do
     end
 
     it "Disables buttons for Locked domain" do
-      @domain.lock
+      @domain.lock_contents!
       @domain.reload
       expect(build_toolbar_hide_button('miq_ae_class_edit')).to be_truthy
     end
@@ -2918,13 +2918,13 @@ describe ApplicationHelper do
     end
 
     it "Disables copy button when there are no Editable domains available" do
-      @domain.lock
+      @domain.lock_contents!
       @domain.reload
       expect(build_toolbar_hide_button('miq_ae_class_copy')).to be_truthy
     end
 
     it "Shows the button for domains even if locked" do
-      @domain.lock
+      @domain.lock_contents!
       @domain.reload
       @record = @domain
 
@@ -2932,14 +2932,14 @@ describe ApplicationHelper do
     end
 
     it 'Shows the button for classes when locked' do
-      @domain.lock
+      @domain.lock_contents!
       @domain.reload
 
       expect(build_toolbar_hide_button('miq_ae_instance_copy')).to be_falsey
     end
 
     it 'Shows the button for instances when locked' do
-      @domain.lock
+      @domain.lock_contents!
       @domain.reload
       miq_class = @record
       @record = FactoryGirl.build(
@@ -2951,7 +2951,7 @@ describe ApplicationHelper do
     end
 
     it 'Shows the button for methods when locked' do
-      @domain.lock
+      @domain.lock_contents!
       @domain.reload
       miq_class = @record
       @record = FactoryGirl.build(

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2908,7 +2908,7 @@ describe ApplicationHelper do
     end
 
     it "Disables buttons for Locked domain" do
-      @domain.update_attributes(:system => true)
+      @domain.lock
       @domain.reload
       expect(build_toolbar_hide_button('miq_ae_class_edit')).to be_truthy
     end
@@ -2918,13 +2918,13 @@ describe ApplicationHelper do
     end
 
     it "Disables copy button when there are no Editable domains available" do
-      @domain.update_attributes(:system => true)
+      @domain.lock
       @domain.reload
       expect(build_toolbar_hide_button('miq_ae_class_copy')).to be_truthy
     end
 
     it "Shows the button for domains even if locked" do
-      @domain.update(:system => true)
+      @domain.lock
       @domain.reload
       @record = @domain
 
@@ -2932,14 +2932,14 @@ describe ApplicationHelper do
     end
 
     it 'Shows the button for classes when locked' do
-      @domain.update(:system => true)
+      @domain.lock
       @domain.reload
 
       expect(build_toolbar_hide_button('miq_ae_instance_copy')).to be_falsey
     end
 
     it 'Shows the button for instances when locked' do
-      @domain.update(:system => true)
+      @domain.lock
       @domain.reload
       miq_class = @record
       @record = FactoryGirl.build(
@@ -2951,7 +2951,7 @@ describe ApplicationHelper do
     end
 
     it 'Shows the button for methods when locked' do
-      @domain.update(:system => true)
+      @domain.lock
       @domain.reload
       miq_class = @record
       @record = FactoryGirl.build(

--- a/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_domain_spec.rb
@@ -13,9 +13,9 @@ describe MiqAeDomain do
     yaml_file = File.join(File.dirname(__FILE__), 'data', 'domain_test.yaml')
     import_options = {'yaml_file' => yaml_file, 'preview' => false, 'domain' => '*', 'tenant_id' => root_tenant.id}
     MiqAeImport.new('*', import_options).import
-    update_domain_attributes('root', :priority => 10, :system => true, :enabled => true)
+    update_domain_attributes('root', :priority => 10, :enabled => true)
     update_domain_attributes('user', :priority => 20, :enabled => true)
-    update_domain_attributes('inert', :priority => 10, :system => true, :enabled => false)
+    update_domain_attributes('inert', :priority => 10, :enabled => false)
     update_domain_attributes('evm1', :priority => 100, :enabled => true)
     update_domain_attributes('evm2', :priority => 100, :enabled => true)
     @enabled_domains = %w(evm2 evm1 user root)
@@ -36,7 +36,7 @@ describe MiqAeDomain do
 
     it 'can set other attributes in a domain object' do
       domain = MiqAeDomain.create!(:name => 'Fred', :tenant => root_tenant)
-      expect(domain.update_attributes!(:priority => 10, :system => false)).to be_truthy
+      expect(domain.update_attributes!(:priority => 10)).to be_truthy
     end
   end
 

--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -87,7 +87,7 @@ module MiqAeServiceModelSpec
       domain
       t = MiqAeMethodService::MiqAeServiceTenant.new(tenant)
       dom = t.ae_domains.first
-      [:name, :system, :priority, :id].each do |attr|
+      [:name, :priority, :id].each do |attr|
         expect(dom.send(attr)).to eql(domain.send(attr))
       end
     end

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
@@ -181,9 +181,7 @@ describe MiqAeClass do
       @cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
       @cls2 = FactoryGirl.create(:miq_ae_class, :name => "cls2", :namespace_id => @ns1.id)
 
-      @d2 = FactoryGirl.create(:miq_ae_domain,
-                               :name      => "domain2",
-                               :priority  => 2)
+      @d2 = FactoryGirl.create(:miq_ae_domain, :name => "domain2", :priority  => 2)
       @ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => @d2.id)
     end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_class_spec.rb
@@ -64,7 +64,7 @@ describe MiqAeClass do
   end
 
   it "should return editable as false if the parent namespace is not editable" do
-    n1 = FactoryGirl.create(:miq_ae_domain, :system => true, :tenant => @user.current_tenant)
+    n1 = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     expect(c1.editable?(@user)).to be_falsey
   end
@@ -181,11 +181,9 @@ describe MiqAeClass do
       @cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
       @cls2 = FactoryGirl.create(:miq_ae_class, :name => "cls2", :namespace_id => @ns1.id)
 
-      @d2 = FactoryGirl.create(:miq_ae_namespace,
+      @d2 = FactoryGirl.create(:miq_ae_domain,
                                :name      => "domain2",
-                               :parent_id => nil,
-                               :priority  => 2,
-                               :system    => false)
+                               :priority  => 2)
       @ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => @d2.id)
     end
 
@@ -296,7 +294,7 @@ describe MiqAeClass do
 
   context "state_machine_class tests" do
     before(:each) do
-      n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :priority => 10, :system => true)
+      n1 = FactoryGirl.create(:miq_ae_system_domain, :name => 'ns1', :priority => 10)
       @c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -131,13 +131,11 @@ describe MiqAeDatastore do
     end
 
     it "#restore_attrs_for_domains" do
-      d1 = FactoryGirl.create(:miq_ae_domain, :enabled => false, :system => true,
-                              :priority => 10, :name => "DOM1")
-      d2 = FactoryGirl.create(:miq_ae_domain, :enabled => true, :system => false,
-                              :priority => 11, :name => "DOM2")
+      d1 = FactoryGirl.create(:miq_ae_system_domain, :priority => 10, :name => "DOM1")
+      d2 = FactoryGirl.create(:miq_ae_domain_enabled, :priority => 11, :name => "DOM2")
       domain_attributes = MiqAeDatastore.preserved_attrs_for_domains
-      d2.update_attributes(:priority => 6, :enabled => false, :system => true)
-      d1.update_attributes(:priority => 1, :enabled => true, :system => false)
+      d2.update_attributes(:priority => 6, :enabled => false)
+      d1.update_attributes(:priority => 1, :enabled => true)
       expect(MiqAeDatastore.preserved_attrs_for_domains).not_to eq(domain_attributes)
       MiqAeDatastore.restore_attrs_for_domains(domain_attributes)
       expect(MiqAeDatastore.preserved_attrs_for_domains).to eq(domain_attributes)

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -51,30 +51,30 @@ describe MiqAeDomain do
 
   context "any_unlocked?" do
     it "should return unlocked_domains? as true if the there are any unlocked domains available" do
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => false)
+      FactoryGirl.create(:miq_ae_system_domain)
+      FactoryGirl.create(:miq_ae_domain)
       expect(MiqAeDomain.any_unlocked?).to be_truthy
     end
 
     it "should return unlocked_domains? as false if the there are no unlocked domains available" do
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => true)
+      FactoryGirl.create(:miq_ae_system_domain)
+      FactoryGirl.create(:miq_ae_system_domain)
       expect(MiqAeDomain.any_unlocked?).to be_falsey
     end
   end
 
   context "all_unlocked" do
     it "should return all unlocked domains" do
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => false)
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd3', :priority => 10, :system => nil)
+      FactoryGirl.create(:miq_ae_system_domain)
+      FactoryGirl.create(:miq_ae_domain)
+      FactoryGirl.create(:miq_ae_domain)
       expect(MiqAeDomain.all_unlocked.count).to eq(2)
     end
 
     it "should return empty array when there are no unlocked domains" do
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd1', :priority => 10, :system => true)
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd2', :priority => 10, :system => true)
-      FactoryGirl.create(:miq_ae_namespace, :name => 'd3', :priority => 10, :system => true)
+      FactoryGirl.create(:miq_ae_system_domain)
+      FactoryGirl.create(:miq_ae_system_domain)
+      FactoryGirl.create(:miq_ae_system_domain)
       expect(MiqAeDomain.all_unlocked.count).to eq(0)
     end
   end

--- a/spec/lib/miq_automation_engine/models/miq_ae_field_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_field_spec.rb
@@ -159,7 +159,7 @@ describe MiqAeField do
     end
 
     it "should return editable as false if the parent namespace/class is not editable" do
-      n1 = FactoryGirl.create(:miq_ae_domain, :system => true, :tenant => User.current_tenant)
+      n1 = FactoryGirl.create(:miq_ae_system_domain, :tenant => User.current_tenant)
       c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       f1 = FactoryGirl.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
       expect(f1.editable?(@user)).to be_falsey

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_spec.rb
@@ -203,9 +203,7 @@ describe MiqAeInstance do
       @i1 = FactoryGirl.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance1")
       @i2 = FactoryGirl.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance2")
 
-      @d2 = FactoryGirl.create(:miq_ae_domain,
-                               :name      => "domain2",
-                               :priority  => 2)
+      @d2 = FactoryGirl.create(:miq_ae_domain, :name => "domain2", :priority => 2)
       @ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => @d2.id)
     end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_instance_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_instance_spec.rb
@@ -141,7 +141,7 @@ describe MiqAeInstance do
     end
 
     it "should return editable as false if the parent namespace/class is not editable" do
-      d1 = FactoryGirl.create(:miq_ae_domain, :system => true, :tenant => User.current_tenant)
+      d1 = FactoryGirl.create(:miq_ae_system_domain, :tenant => User.current_tenant)
       n1 = FactoryGirl.create(:miq_ae_namespace, :parent_id => d1.id)
       c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryGirl.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
@@ -203,11 +203,9 @@ describe MiqAeInstance do
       @i1 = FactoryGirl.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance1")
       @i2 = FactoryGirl.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance2")
 
-      @d2 = FactoryGirl.create(:miq_ae_namespace,
+      @d2 = FactoryGirl.create(:miq_ae_domain,
                                :name      => "domain2",
-                               :parent_id => nil,
-                               :priority  => 2,
-                               :system    => false)
+                               :priority  => 2)
       @ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => @d2.id)
     end
 
@@ -248,7 +246,7 @@ describe MiqAeInstance do
   end
 
   it "#domain" do
-    n1 = FactoryGirl.create(:miq_ae_domain, :name => 'dom1', :priority => 10, :system => true)
+    n1 = FactoryGirl.create(:miq_ae_system_domain, :name => 'dom1')
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     i1 = FactoryGirl.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
     expect(i1.domain.name).to eql('dom1')

--- a/spec/lib/miq_automation_engine/models/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_method_spec.rb
@@ -4,7 +4,7 @@ describe MiqAeMethod do
   end
 
   it "should return editable as false if the parent namespace/class is not editable" do
-    n1 = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant, :system => true)
+    n1 = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     f1 = FactoryGirl.create(:miq_ae_method,
                             :class_id => c1.id,
@@ -45,8 +45,7 @@ describe MiqAeMethod do
                                :language => "ruby",
                                :location => "inline")
 
-      @d2 = FactoryGirl.create(:miq_ae_namespace,
-                               :name => "domain2", :parent_id => nil, :priority => 2, :system => false)
+      @d2 = FactoryGirl.create(:miq_ae_domain, :name => "domain2", :priority => 2)
       @ns2 = FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => @d2.id)
     end
 
@@ -117,7 +116,7 @@ describe MiqAeMethod do
   end
 
   it "#domain" do
-    d1 = FactoryGirl.create(:miq_ae_domain, :name => 'dom1', :priority => 10, :system => true)
+    d1 = FactoryGirl.create(:miq_ae_system_domain, :name => 'dom1', :priority => 10)
     n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :parent_id => d1.id)
     c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     m1 = FactoryGirl.create(:miq_ae_method,

--- a/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_namespace_spec.rb
@@ -61,15 +61,8 @@ describe MiqAeNamespace do
     expect(n2.updated_by).to eq('system')
   end
 
-  it "should have system property as false by default" do
-    n1 = MiqAeNamespace.find_or_create_by_fqname("ns1/ns2")
-    expect(n1.system).to be_falsey
-    n2 = MiqAeNamespace.find_or_create_by_fqname("ns1")
-    expect(n2.system).to be_falsey
-  end
-
   it "should return editable as false if the parent has the system property set to true" do
-    n1 = MiqAeDomain.create!(:name => 'ns1', :tenant => @user.current_tenant, :system => true)
+    n1 = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
     expect(n1.editable?(@user)).to be_falsey
 
     n2 = MiqAeNamespace.create!(:name => 'ns2', :parent_id => n1.id)
@@ -79,12 +72,12 @@ describe MiqAeNamespace do
   end
 
   it "should return editable as true if the namespace doesn't have the system property defined" do
-    n1 = MiqAeDomain.create!(:name => 'ns1', :tenant => @user.current_tenant)
+    n1 = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
     expect(n1.editable?(@user)).to be_truthy
   end
 
   it "should raise exception if user is nil" do
-    n1 = MiqAeDomain.create!(:name => 'ns1', :tenant => @user.current_tenant)
+    n1 = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
     expect { n1.editable?(nil) }.to raise_error(ArgumentError)
   end
   it 'find_by_fqname works with and without leading slash' do

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -240,17 +240,17 @@ describe MiqAeDatastore do
     end
 
     it "domain, as directory" do
-      import_options = {'import_dir' => @export_dir, 'system' => false, 'enabled' => true}
+      import_options = {'import_dir' => @export_dir, 'enabled' => true}
       assert_export_import_roundtrip({}, import_options)
     end
 
     it "domain, as zip" do
-      options = {'zip_file' => @zip_file,  'system' => false, 'enabled' => true}
+      options = {'zip_file' => @zip_file, 'enabled' => true}
       assert_export_import_roundtrip(options, options)
     end
 
     it "domain, as yaml" do
-      options = {'yaml_file' => @yaml_file, 'system' => false, 'enabled' => true}
+      options = {'yaml_file' => @yaml_file, 'enabled' => true}
       assert_export_import_roundtrip(options, options)
     end
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
@@ -39,10 +39,10 @@ module MiqAeServiceSpec
 
     def assert_readonly_instance(automate_method_script)
       dom_obj = MiqAeDomain.find_by_name(@domain)
-      dom_obj.lock
+      dom_obj.lock_contents!
       @ae_method.update_attributes(:data => automate_method_script)
       result = invoke_ae.root(@ae_result_key)
-      dom_obj.unlock
+      dom_obj.unlock_contents!
       expect(result).to be_falsey
     end
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_spec.rb
@@ -39,10 +39,10 @@ module MiqAeServiceSpec
 
     def assert_readonly_instance(automate_method_script)
       dom_obj = MiqAeDomain.find_by_name(@domain)
-      dom_obj.update_attributes!(:system => true)
+      dom_obj.lock
       @ae_method.update_attributes(:data => automate_method_script)
       result = invoke_ae.root(@ae_result_key)
-      dom_obj.update_attributes!(:system => false)
+      dom_obj.unlock
       expect(result).to be_falsey
     end
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -441,10 +441,10 @@ describe Tenant do
 
     context "reset priority" do
       it "#reset_domain_priority_by_ordered_ids" do
-        FactoryGirl.create(:miq_ae_domain, :name => 'ManageIQ', :priority => 0,
-                           :tenant_id => root_tenant.id, :system => true)
-        FactoryGirl.create(:miq_ae_domain, :name => 'Redhat', :priority => 1,
-                           :tenant_id => root_tenant.id, :system => true)
+        FactoryGirl.create(:miq_ae_system_domain, :name => 'ManageIQ', :priority => 0,
+                           :tenant_id => root_tenant.id)
+        FactoryGirl.create(:miq_ae_system_domain, :name => 'Redhat', :priority => 1,
+                           :tenant_id => root_tenant.id)
         dom3 = FactoryGirl.create(:miq_ae_domain, :name => 'A', :tenant_id => root_tenant.id)
         dom4 = FactoryGirl.create(:miq_ae_domain, :name => 'B', :tenant_id => root_tenant.id)
 
@@ -514,11 +514,10 @@ describe Tenant do
 
     it "no editable domains available for current tenant" do
       t1_1
-      FactoryGirl.create(:miq_ae_domain,
+      FactoryGirl.create(:miq_ae_system_domain,
                          :name      => 'non_editable',
                          :priority  => 3,
-                         :tenant_id => t1_1.id,
-                         :system    => true)
+                         :tenant_id => t1_1.id)
       expect(t1_1.any_editable_domains?).to eq(false)
     end
 

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -388,18 +388,13 @@ describe TreeNodeBuilder do
     end
 
     it "should return node text with Locked in the text for Locked domain" do
-      domain = FactoryGirl.create(:miq_ae_domain,
-                                  :name   => "test1",
-                                  :system => true)
+      domain = FactoryGirl.create(:miq_ae_system_domain_enabled, :name => "test1")
       node = TreeNodeBuilder.build(domain, nil, {})
       expect(node[:title]).to eq('test1 (Locked)')
     end
 
     it "should return node text with Locked & Disabled in the text for Locked & Disabled domain" do
-      domain = FactoryGirl.create(:miq_ae_domain,
-                                  :name    => "test1",
-                                  :enabled => false,
-                                  :system  => true)
+      domain = FactoryGirl.create(:miq_ae_system_domain, :name => "test1")
       node = TreeNodeBuilder.build(domain, nil, {})
       expect(node[:title]).to eq('test1 (Locked & Disabled)')
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
> The system attribute on the domain is going to be replaced with a new attribute called source. The source would be system|remote|user. In preparation for that changing specs so that they don't directly call system attribute. This PR is built on top of PR https://github.com/ManageIQ/manageiq/pull/10044

