### PR TITLE
Add power operations to VMware cloud manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.1.0"
 gem "fog-google",                     "~>0.3.0",       :require => false
-gem "fog-vcloud-director",            "~>0.1.1",       :require => false
+gem "fog-vcloud-director",            "~>0.1.2",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -64,6 +64,34 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
     self.class.raw_connect(server, port, username, password)
   end
 
+  #
+  # Operations
+  #
+
+  def vm_start(vm, _options = {})
+    vm.start
+  rescue => err
+    _log.error "vm=[#{vm.name}, error: #{err}"
+  end
+
+  def vm_stop(vm, _options = {})
+    vm.stop
+  rescue => err
+    _log.error "vm=[#{vm.name}, error: #{err}"
+  end
+
+  def vm_suspend(vm, _options = {})
+    vm.suspend
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
+  def vm_restart(vm, _options = {})
+    vm.restart
+  rescue => err
+    _log.error "vm=[#{vm.name}], error: #{err}"
+  end
+
   def translate_exception(err)
     case err
     when Fog::Compute::VcloudDirector::Unauthorized

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm.rb
@@ -1,9 +1,17 @@
 class ManageIQ::Providers::Vmware::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
+  include_concern 'Operations'
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    connection.vms.get_single_vm(uid_ems)
+  end
+
   POWER_STATES = {
-    "creating" => "powering_up",
-    "off"      => "off",
-    "on"       => "on",
-    "unknown"  => "terminated",
+    "creating"  => "powering_up",
+    "off"       => "off",
+    "on"        => "on",
+    "unknown"   => "terminated",
+    "suspended" => "suspended"
   }.freeze
 
   def self.calculate_power_state(raw_power_state)

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations
+  include_concern 'Power'
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
@@ -1,0 +1,25 @@
+module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations::Power
+  def validate_pause
+    validate_unsupported("Pause operation")
+  end
+
+  def raw_start
+    with_provider_object(&:power_on)
+    update_attributes!(:raw_power_state => "on")
+  end
+
+  def raw_stop
+    with_provider_object(&:power_off)
+    update_attributes!(:raw_power_state => "off")
+  end
+
+  def raw_suspend
+    with_provider_object(&:suspend)
+    update_attributes!(:raw_power_state => "suspended")
+  end
+
+  def raw_restart
+    with_provider_object(&:reset)
+    update_attributes!(:raw_power_state => "on")
+  end
+end

--- a/spec/factories/vm_vmware_cloud.rb
+++ b/spec/factories/vm_vmware_cloud.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :vm_vmware_cloud, :class => "ManageIQ::Providers::Vmware::CloudManager::Vm", :parent => :vm_cloud do
+    vendor "vmware"
+  end
+end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vm_spec.rb
@@ -1,0 +1,38 @@
+describe ManageIQ::Providers::Vmware::CloudManager::Vm do
+  context "#is_available?" do
+    let(:ems)                   { FactoryGirl.create(:ems_vmware_cloud) }
+    let(:vm)                    { FactoryGirl.create(:vm_vmware_cloud, :ext_management_system => ems) }
+    let(:power_state_on)        { "on" }
+    let(:power_state_suspended) { "suspended" }
+
+    context("with :start") do
+      let(:state) { :start }
+      include_examples "Vm operation is available when not powered on"
+    end
+
+    context("with :stop") do
+      let(:state) { :stop }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context("with :suspend") do
+      let(:state) { :suspend }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context("with :pause") do
+      let(:state) { :pause }
+      include_examples "Vm operation is not available"
+    end
+
+    context("with :shutdown_guest") do
+      let(:state) { :shutdown_guest }
+      include_examples "Vm operation is not available"
+    end
+
+    context("with :standby_guest") do
+      let(:state) { :standby_guest }
+      include_examples "Vm operation is not available"
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Start, stop, suspend and restart power operations are added to the
VMware cloud manager. Spec verifies that operations are properly
configured according to the current state of the VM.

@miq-bot add_label providers/vmware/cloud, enhancement