### PR TITLE
Prepend vendor namespace to search from method

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -5,6 +5,16 @@ module MiqAeEngine
 
   # All Class Methods beginning with miq_ are callable from the engine
   class MiqAeBuiltinMethod
+    ATTRIBUTE_LIST = %w(
+      vm
+      orchestration_stack
+      miq_request
+      miq_provision
+      miq_host_provision
+      vm_migrate_task
+      platform_category
+    ).freeze
+
     def self.miq_log_object(obj, _inputs)
       $miq_ae_logger.info("===========================================")
       $miq_ae_logger.info("Dumping Object")
@@ -47,11 +57,12 @@ module MiqAeEngine
 
     def self.miq_parse_provider_category(obj, _inputs)
       provider_category = nil
-      keys = %w(vm orchestration_stack miq_request miq_provision miq_host_provision vm_migrate_task platform_category)
-      keys.detect { |k| provider_category = category_for_key(obj, k) }
+      ATTRIBUTE_LIST.detect { |attr| provider_category = category_for_key(obj, attr) }
       $miq_ae_logger.info("Setting provider_category to: #{provider_category}")
 
       obj.workspace.root["ae_provider_category"] = provider_category || UNKNOWN
+
+      prepend_vendor(obj)
     end
 
     def self.miq_host_and_storage_least_utilized(obj, _inputs)
@@ -160,5 +171,28 @@ module MiqAeEngine
       end
     end
     private_class_method :category_for_key
+
+    def self.prepend_vendor(obj)
+      vendor = nil
+      ATTRIBUTE_LIST.detect { |attr| vendor = detect_vendor(obj.workspace.root[attr], attr) }
+      if vendor
+        $miq_ae_logger.info("Setting prepend_namespace to: #{vendor}")
+        obj.workspace.prepend_namespace = vendor
+      end
+    end
+    private_class_method :prepend_vendor
+
+    def self.detect_vendor(src_obj, attr)
+      case attr
+      when "orchestration_stack"
+        src_obj.type.split('::')[2] if src_obj
+      when "miq_host_provision"
+        "vmware" if src_obj
+      when "miq_request", "miq_provision", "vm_migrate_task"
+        src_obj.source.vendor if src_obj && src_obj.source.respond_to?(:vendor)
+      when "vm"
+        src_obj.vendor if src_obj && src_obj.respond_to?(:vendor)
+      end
+    end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -183,15 +183,16 @@ module MiqAeEngine
     private_class_method :prepend_vendor
 
     def self.detect_vendor(src_obj, attr)
+      return unless src_obj
       case attr
       when "orchestration_stack"
-        src_obj.type.split('::')[2] if src_obj
+        src_obj.type.split('::')[2]
       when "miq_host_provision"
-        "vmware" if src_obj
+        "vmware"
       when "miq_request", "miq_provision", "vm_migrate_task"
-        src_obj.source.vendor if src_obj && src_obj.source.respond_to?(:vendor)
+        src_obj.source.try(:vendor)
       when "vm"
-        src_obj.vendor if src_obj && src_obj.respond_to?(:vendor)
+        src_obj.try(:vendor)
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
For pluggable provider changes we need to be able to set the
additional namespace to search when looking for instances and
methods. If we detect a vendor we set the additional namespace
to search. This is done in a builtin method as part of parse_provider_category.
Depends on https://github.com/ManageIQ/manageiq/pull/9917
 


Links
-----
> * https://github.com/ManageIQ/manageiq/pull/9917
> * https://github.com/ManageIQ/manageiq/pull/9468


Steps for Testing/QA
--------------------
> When testing pluggable providers we should be able to locate methods and instances from vendor namespaces. e.g.
/ManageIQ_Provider/**Amazon**/Cloud/VM/Provisioning/StateMachines/Methods/check_provisioned
in favor of
/ ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods/check_provisioned

Here Amazon is the namespace that was prepended to the search, it allows us to  keep the base relationships to be the same.