### PR TITLE
Add a down migration for the replication exclude table key change

### DIFF
--- a/db/migrate/20160607141857_change_exclude_table_settings_key.rb
+++ b/db/migrate/20160607141857_change_exclude_table_settings_key.rb
@@ -3,10 +3,16 @@ class ChangeExcludeTableSettingsKey < ActiveRecord::Migration[5.0]
     serialize :value
   end
 
+  OLD_KEY = "/workers/worker_base/replication_worker/replication/exclude_tables".freeze
+  NEW_KEY = "/replication/exclude_tables".freeze
+
   def up
     say_with_time("Moving exclude tables configuration") do
-      changes = SettingsChange.where(:key => "/workers/worker_base/replication_worker/replication/exclude_tables")
-      changes.each { |change| change.update_attributes!(:key => "/replication/exclude_tables") }
+      SettingsChange.where(:key => OLD_KEY).update_all(:key => NEW_KEY)
     end
+  end
+
+  def down
+    SettingsChange.where(:key => NEW_KEY).update_all(:key => OLD_KEY)
   end
 end

--- a/spec/migrations/20160607141857_change_exclude_table_settings_key_spec.rb
+++ b/spec/migrations/20160607141857_change_exclude_table_settings_key_spec.rb
@@ -5,22 +5,37 @@ describe ChangeExcludeTableSettingsKey do
 
   migration_context :up do
     it "changes the key for the exclude tables" do
-      settings_change_stub.create!(
-        :resource_type => "MiqServer",
-        :key           => "/workers/worker_base/replication_worker/replication/exclude_tables",
-        :value         => %w(table1 table2 table3)
-      )
-
-      settings_change_stub.create!(
-        :resource_type => "MiqServer",
-        :key           => "/workers/worker_base/replication_worker/replication/exclude_tables",
-        :value         => %w(table1 table3)
-      )
+      insert_test_records(described_class::OLD_KEY)
 
       migrate
 
-      expect(settings_change_stub.where(:key => "/replication/exclude_tables").count).to eq 2
-      expect(settings_change_stub.where(:key => "/workers/worker_base/replication_worker/replication/exclude_tables").count).to eq 0
+      expect(settings_change_stub.where(:key => described_class::NEW_KEY).count).to eq 2
+      expect(settings_change_stub.where(:key => described_class::OLD_KEY).count).to eq 0
     end
+  end
+
+  migration_context :down do
+    it "changes the key for the exclude tables" do
+      insert_test_records(described_class::NEW_KEY)
+
+      migrate
+
+      expect(settings_change_stub.where(:key => described_class::OLD_KEY).count).to eq 2
+      expect(settings_change_stub.where(:key => described_class::NEW_KEY).count).to eq 0
+    end
+  end
+
+  def insert_test_records(key)
+    settings_change_stub.create!(
+      :resource_type => "MiqServer",
+      :key           => key,
+      :value         => %w(table1 table2 table3)
+    )
+
+    settings_change_stub.create!(
+      :resource_type => "MiqServer",
+      :key           => key,
+      :value         => %w(table1 table3)
+    )
   end
 end


### PR DESCRIPTION
This will move the changes to the replication excludes back to the replication worker location.

@Fryguy as reqested.