### PR TITLE
Fix some usage of the replication settings path after #9696

### DIFF
--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -2,7 +2,7 @@ require 'pg'
 
 class MiqPglogical
   REPLICATION_SET_NAME = 'miq'.freeze
-  SETTINGS_PATH = [:workers, :worker_base, :replication_worker, :replication].freeze
+  SETTINGS_PATH = [:replication].freeze
   NODE_PREFIX = "region_".freeze
 
   def initialize

--- a/spec/replication/replication_spec.rb
+++ b/spec/replication/replication_spec.rb
@@ -34,11 +34,7 @@ describe "pglogical replication" do
     master_db_config = Rails.configuration.database_configuration[Rails.env].symbolize_keys
                                                                             .merge(:database => master_db_name)
 
-    c = MiqServer.my_server.get_config
-    c.config.store_path(:workers, :worker_base, :replication_worker, :replication, :destination, master_db_config)
-    c.save
-
-    @replication_config = c.config.fetch_path(:workers, :worker_base, :replication_worker, :replication)
+    @replication_config = MiqServer.my_server.get_config.config.fetch_path(:replication)
 
     class ::MasterDb < ActiveRecord::Base; end
     MasterDb.establish_connection(master_db_config)


### PR DESCRIPTION
Use the new settings path to the excludes in the `MiqPglogical` class and in the replication specs.

It seems I missed a few things.

@Fryguy please review.