### PR TITLE
Update Switch's relationship from host to hosts in automate.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_switch.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_switch.rb
@@ -1,6 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceSwitch < MiqAeServiceModelBase
-    expose :host,          :association => true
+    expose :hosts,         :association => true
     expose :guest_devices, :association => true
     expose :lans,          :association => true
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_switch_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_switch_spec.rb
@@ -1,0 +1,15 @@
+module MiqAeServiceSwitchSpec
+  describe MiqAeMethodService::MiqAeServiceSwitch do
+    it "#hosts" do
+      expect(described_class.instance_methods).to include(:hosts)
+    end
+
+    it "#guest_devices" do
+      expect(described_class.instance_methods).to include(:guest_devices)
+    end
+
+    it "#lans" do
+      expect(described_class.instance_methods).to include(:lans)
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
This relationship change from host to hosts in Switch model was done in PR https://github.com/ManageIQ/manageiq/pull/7542.
This patch updates the service model relationships to match.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1360829

Steps for Testing/QA
--------------------
In rails console:
```
 $evm = MiqAeMethodService::MiqAeService.new(MiqAeEngine::MiqAeWorkspaceRuntime.new)
 s = $evm.vmdb(:switch).first
 s.hosts
```