### PR TITLE
Remove useless MiqReport initialization, RBAC spec

### DIFF
--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -889,7 +889,6 @@ describe Rbac::Filterer do
               FactoryGirl.create(:ems_event, :timestamp => Time.now.utc, :message => "Event #{i}")
             end
 
-            report = MiqReport.new(:db => "EmsEvent")
             exp = YAML.load '--- !ruby/object:MiqExpression
             exp:
               IS:


### PR DESCRIPTION
Noticed this useless assignment while recently reorganizing RBAC; separate PR to avoid unnecessary changes in the initial PR.