### PR TITLE
Fix handling of region_number early in db creation

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -125,9 +125,8 @@ module ArRegion
     end
 
     def region_number_from_sequence
+      return unless connection.data_source_exists?("miq_databases")
       id_to_region(connection.select_value("SELECT last_value FROM miq_databases_id_seq"))
-    rescue ActiveRecord::StatementInvalid # sequence does not exist yet
-      nil
     end
 
     private

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -169,12 +169,13 @@ describe "AR Regions extension" do
     end
 
     def reject_db_sequence_lookup
-      allow(VmOrTemplate.connection).to receive(:select_value)
-        .at_least(:once).with("SELECT last_value FROM miq_databases_id_seq")
-        .and_raise(ActiveRecord::StatementInvalid, "not defined yet", nil)
+      allow(VmOrTemplate.connection).to receive(:data_source_exists?)
+        .at_least(:once).with("miq_databases").and_return(false)
     end
 
     def db_sequence_lookup(sequence = nil)
+      allow(VmOrTemplate.connection).to receive(:data_source_exists?)
+        .at_least(:once).with("miq_databases").and_return(true)
       allow(VmOrTemplate.connection).to receive(:select_value)
         .at_least(:once).with("SELECT last_value FROM miq_databases_id_seq")
         .and_return(ArRegion::DEFAULT_RAILS_SEQUENCE_FACTOR * sequence + 1)


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix db migration failing without a REGION file


> Long story short...The rubyrep helper models were querying the database for the region number, blowing up (which was rescued properly), and then caching that as REGION 0...this was happening before the migrations began
Once the models were removed, then the check ended up happening inside the giant transaction for a migration, but transactions on the PG side don't like when things blow up


Removing rubyrep triggered the issue

cc @Fryguy @carbonin 

Links
-----
* https://github.com/ManageIQ/manageiq/pull/9696