### PR TITLE
Refactor tenant_identity method to reduce duplication.

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -3,6 +3,7 @@ class ContainerGroup < ApplicationRecord
   include CustomAttributeMixin
   include MiqPolicyMixin
   include NewWithTypeStiMixin
+  include TenantIdentityMixin
 
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :restart_policy, :dns_policy
@@ -67,14 +68,6 @@ class ContainerGroup < ApplicationRecord
     when :policy_events
       # TODO: implement policy events and its relationship
       ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
-    end
-  end
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
     end
   end
 

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -2,6 +2,8 @@ class ContainerImage < ApplicationRecord
   include ComplianceMixin
   include MiqPolicyMixin
   include ScanningMixin
+  include TenantIdentityMixin
+
 
   DOCKER_IMAGE_PREFIX = "docker://"
 
@@ -62,14 +64,6 @@ class ContainerImage < ApplicationRecord
     # TODO: update smart state infrastructure with a better name
     # than scan_via_miq_vm
     scan_via_miq_vm(miq_cnt_group, ost)
-  end
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
-    end
   end
 
   def raise_creation_event

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -2,6 +2,7 @@ class ContainerNode < ApplicationRecord
   include ComplianceMixin
   include MiqPolicyMixin
   include NewWithTypeStiMixin
+  include TenantIdentityMixin
 
   # :name, :uid, :creation_timestamp, :resource_version
   belongs_to :ext_management_system, :foreign_key => "ems_id"
@@ -57,14 +58,6 @@ class ContainerNode < ApplicationRecord
     when :policy_events
       # TODO: implement policy events and its relationship
       ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
-    end
-  end
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
     end
   end
 

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -2,6 +2,7 @@ class ContainerReplicator < ApplicationRecord
   include ComplianceMixin
   include CustomAttributeMixin
   include MiqPolicyMixin
+  include TenantIdentityMixin
 
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :container_groups
@@ -32,14 +33,6 @@ class ContainerReplicator < ApplicationRecord
     when :policy_events
       # TODO: implement policy events and its relationship
       ["#{events_table_name(assoc)}.ems_id = ?", ems_id]
-    end
-  end
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
     end
   end
 

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -3,6 +3,7 @@ class EmsCluster < ApplicationRecord
   include_concern 'CapacityPlanning'
   include EventMixin
   include VirtualTotalMixin
+  include TenantIdentityMixin
 
   acts_as_miq_taggable
 
@@ -55,14 +56,6 @@ class EmsCluster < ApplicationRecord
   include Metric::CiMixin
   include MiqPolicyMixin
   include AsyncDeleteMixin
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
-    end
-  end
 
   #
   # Provider Object methods

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -15,6 +15,7 @@ require 'HostScanProfiles'
 class Host < ApplicationRecord
   include NewWithTypeStiMixin
   include VirtualTotalMixin
+  include TenantIdentityMixin
 
   VENDOR_TYPES = {
     # DB            Displayed
@@ -197,14 +198,6 @@ class Host < ApplicationRecord
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
-  end
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
-    end
   end
 
   def make_smart

--- a/app/models/mixins/tenant_identity_mixin.rb
+++ b/app/models/mixins/tenant_identity_mixin.rb
@@ -1,0 +1,11 @@
+module TenantIdentityMixin
+  extend ActiveSupport::Concern
+
+  def tenant_identity
+    if ext_management_system
+      ext_management_system.tenant_identity
+    else
+      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
+    end
+  end
+end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -7,6 +7,7 @@ class OrchestrationStack < ApplicationRecord
   include ProcessTasksMixin
   include_concern 'RetirementManagement'
   include VirtualTotalMixin
+  include TenantIdentityMixin
 
   acts_as_miq_taggable
 
@@ -45,14 +46,6 @@ class OrchestrationStack < ApplicationRecord
 
   def service
     direct_service.try(:root_service)
-  end
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
-    end
   end
 
   def indirect_vms

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -1,5 +1,6 @@
 class ResourcePool < ApplicationRecord
   include VirtualTotalMixin
+  include TenantIdentityMixin
 
   acts_as_miq_taggable
 
@@ -31,14 +32,6 @@ class ResourcePool < ApplicationRecord
   virtual_column :v_direct_vms,            :type => :integer, :uses => :all_relationships
   virtual_total  :v_total_vms,             :all_vms,          :uses => :all_relationships
   virtual_total  :v_total_miq_templates,   :all_miq_templates, :uses => :all_relationships
-
-  def tenant_identity
-    if ext_management_system
-      ext_management_system.tenant_identity
-    else
-      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
-    end
-  end
 
   def hidden?
     is_default?

--- a/spec/models/mixins/tenant_identity_mixin_spec.rb
+++ b/spec/models/mixins/tenant_identity_mixin_spec.rb
@@ -1,0 +1,27 @@
+describe TenantIdentityMixin do
+  describe '#tenant_identity' do
+    let(:admin)      { FactoryGirl.create(:user_with_group, :userid => "admin") }
+    let(:tenant)     { FactoryGirl.create(:tenant) }
+    let(:ems)        { FactoryGirl.create(:ext_management_system, :tenant => tenant) }
+    let(:test_class) { :container_group }
+
+    subject          { @test_instance.tenant_identity }
+    before           { admin }
+
+    it "has tenant from provider" do
+      @test_instance = FactoryGirl.create(test_class, :ext_management_system => ems)
+
+      expect(subject).to                eq(admin)
+      expect(subject.current_group).to  eq(ems.tenant.default_miq_group)
+      expect(subject.current_tenant).to eq(ems.tenant)
+    end
+
+    it "without a provider, has tenant from root tenant" do
+      @test_instance = FactoryGirl.create(test_class)
+
+      expect(subject).to                eq(admin)
+      expect(subject.current_group).to  eq(Tenant.root_tenant.default_miq_group)
+      expect(subject.current_tenant).to eq(Tenant.root_tenant)
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Put tenant_identity method into its own module to reduce code duplication.

Links
-----
Fix #9931.