### PR TITLE
Set start date for report schedule to today

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -199,6 +199,15 @@ module ReportController::Schedules
                                   :record     => @schedule})
         page.replace("schedule_email_options_div", :partial => "schedule_email_options")
       end
+
+      # when timer_typ set to hourly set starting date to current day otherwise it's the day after
+      if params[:timer_typ] == 'Hourly'
+        @edit[:new][:timer].start_date = Time.zone.now.strftime("%m/%d/%Y")
+      else
+        @edit[:new][:timer].start_date = (Time.zone.now + 1.day).strftime("%m/%d/%Y")
+      end
+      page << "$('#miq_date_1').val('#{@edit[:new][:timer].start_date}');"
+
       changed = (@edit[:new] != @edit[:current])
       if changed != session[:changed]
         session[:changed] = changed


### PR DESCRIPTION
Purpose or Intent
-----------------
If Run is set to Hourly the starting day should be current day otherwise it should be the day after.

@miq-bot add_label ui, bug

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1207573

Steps for Testing/QA
--------------------
Cloud Intel -> Reports -> Schedules -> Configuration -> Add a new Schedule

Set Run to Hourly
