### PR TITLE
Make TreeBuilderPolicy and TreeBuilderPolicyProfile not lazy

### DIFF
--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -5,7 +5,8 @@ class TreeBuilderPolicy < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true}
+    {:full_ids => true,
+     :lazy     => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -6,7 +6,8 @@ class TreeBuilderPolicyProfile < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true}
+    {:full_ids => true,
+     :lazy     => false}
   end
 
   def set_locals_for_render

--- a/spec/presenters/tree_builder_policy_profile_spec.rb
+++ b/spec/presenters/tree_builder_policy_profile_spec.rb
@@ -1,0 +1,9 @@
+describe TreeBuilderPolicyProfile do
+  context '#tree_init_options' do
+    it "is explicitly not lazy" do
+      tree = TreeBuilderPolicyProfile.new(:policy_profile_tree, :policy_profile, {}, true)
+      options = tree.instance_variable_get(:@options)
+      expect(options[:lazy]).to eq(false)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_policy_spec.rb
+++ b/spec/presenters/tree_builder_policy_spec.rb
@@ -1,0 +1,9 @@
+describe TreeBuilderPolicy do
+  context '#tree_init_options' do
+    it "is explicitly not lazy" do
+      tree = TreeBuilderPolicy.new(:policy_tree, :policy, {}, true)
+      options = tree.instance_variable_get(:@options)
+      expect(options[:lazy]).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Trees using the `:parents` feature (to get all the parents, instead of just the immediate one) rely on those methods not being called lazily for it to work. 

This makes TreeBuilderPolicy and TreeBuilderPolicyProfile explicitly not lazy.

Fixes #10080 
https://bugzilla.redhat.com/show_bug.cgi?id=1360818
https://bugzilla.redhat.com/show_bug.cgi?id=1360901