### PR TITLE
C&U charts select new date

### DIFF
--- a/app/views/layouts/_perf_options.html.haml
+++ b/app/views/layouts/_perf_options.html.haml
@@ -54,9 +54,7 @@
               h(@perf_options[:typ] == "Hourly" ? @perf_options[:hourly_date] : @perf_options[:daily_date]),
               :readonly               => "true",
               "data-miq_sparkle_on"   => true,
-              :class    => "selectpicker")
-          :javascript
-             miqSelectPickerEvent("miq_date_1", "#{url}")
+              "data-miq_observe_date" => {:url => url}.to_json)
 
         - unless @perf_options[:typ] == "Hourly"
           %dt


### PR DESCRIPTION
Purpose or Intent
-----------------
When you select date in C&U screen. you get an error.
Parent issue: #10071 

Closes #10071

How to reproduce
-----------------
Navigate through Compute -> Infrastructure -> VM/Host/Cluster -> Select VM with Utilization data -> Change date one day before