### PR TITLE
Change column type of cpu_cores_used_cost in reports to currency

### DIFF
--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -41,6 +41,7 @@
 
     # Chargeback cost columns
     :cpu_used_cost: :currency_precision_2
+    :cpu_cores_used_cost: :currency_precision_2
     :cpu_allocated_cost: :currency_precision_2
     :cpu_allocated_metric: :general_number_precision_0
     :cpu_cost: :currency_precision_2


### PR DESCRIPTION
This adds a currency sign on the cost values in the 'cpu_cores_used_cost' column 
![screenshot from 2015-03-03 17 22 09](https://cloud.githubusercontent.com/assets/11256940/17211202/b525d7a4-54d0-11e6-8494-7d749ddd800b.png)
![screencapture-10-16-5-173-report-explorer-1469705465413](https://cloud.githubusercontent.com/assets/11256940/17211201/b524eb50-54d0-11e6-9e2f-ce15431f517b.png)
