### PR TITLE
[DARGA] Make TreeBuilderPolicy and TreeBuilderPolicyProfile not lazy

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -276,7 +276,8 @@ class TreeBuilder
         :klass_name => self.class.name,
         :leaf       => @options[:leaf],
         :add_root   => true,
-        :open_nodes => []
+        :open_nodes => [],
+        :lazy       => true
       )
     )
   end
@@ -310,6 +311,7 @@ class TreeBuilder
   # :open_nodes             # Tree node ids of currently open nodes
   # :add_root               # If true, put a root node at the top
   # :full_ids               # stack parent id on top of each node id
+  # :lazy                   # set if tree is lazy
   def x_build_dynatree(options)
     children = x_get_tree_objects(nil, options, false, [])
 
@@ -416,7 +418,8 @@ class TreeBuilder
     if Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) ||
        options[:open_all] ||
        object[:load_children] ||
-       node[:expand]
+       node[:expand] ||
+       @options[:lazy] == false
       node[:expand] = true if options[:type] == :automate &&
                               Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key])
       kids = x_get_tree_objects(object, options, false, parents).map do |o|

--- a/app/presenters/tree_builder_policy.rb
+++ b/app/presenters/tree_builder_policy.rb
@@ -2,7 +2,8 @@ class TreeBuilderPolicy < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true}
+    {:full_ids => true,
+     :lazy     => false}
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_policy_profile.rb
+++ b/app/presenters/tree_builder_policy_profile.rb
@@ -2,7 +2,8 @@ class TreeBuilderPolicyProfile < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:full_ids => true}
+    {:full_ids => true,
+     :lazy     => false}
   end
 
   def set_locals_for_render

--- a/spec/presenters/tree_builder_ae_customization_spec.rb
+++ b/spec/presenters/tree_builder_ae_customization_spec.rb
@@ -10,6 +10,7 @@ describe TreeBuilderAeCustomization  do
         :leaf        => nil,
         :add_root    => true,
         :open_nodes  => [],
+        :lazy        => true,
         :open_all    => true,
         :active_node => "root"
       }

--- a/spec/presenters/tree_builder_policy_profile_spec.rb
+++ b/spec/presenters/tree_builder_policy_profile_spec.rb
@@ -1,0 +1,9 @@
+describe TreeBuilderPolicyProfile do
+  context '#tree_init_options' do
+    it "is explicitly not lazy" do
+      tree = TreeBuilderPolicyProfile.new(:policy_profile_tree, :policy_profile, {}, true)
+      options = tree.instance_variable_get(:@options)
+      expect(options[:lazy]).to eq(false)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_policy_spec.rb
+++ b/spec/presenters/tree_builder_policy_spec.rb
@@ -1,0 +1,9 @@
+describe TreeBuilderPolicy do
+  context '#tree_init_options' do
+    it "is explicitly not lazy" do
+      tree = TreeBuilderPolicy.new(:policy_tree, :policy, {}, true)
+      options = tree.instance_variable_get(:@options)
+      expect(options[:lazy]).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This is a darga version of https://github.com/ManageIQ/manageiq/pull/10110 - fixing #10080 by making the two affected trees explicitly non-lazy.

In addition to the master PR, this contains the change introducing the disable-lazy functionality to TreeBuilder by @ZitaNemeckova.

darga bz: https://bugzilla.redhat.com/show_bug.cgi?id=1360901