### PR TITLE
Add zoom button to C&U charts

### DIFF
--- a/app/views/layouts/_perf_chart_js.html.haml
+++ b/app/views/layouts/_perf_chart_js.html.haml
@@ -25,6 +25,10 @@
               .card-pf-body
                 = chart_no_url(:id      => "miq_chart_#{chart_set}_#{chart_index}_2")
                 .overlay{"style" => "display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500"}
+                - if chart_data[chart_index][:zoom_url]
+                  %div
+                    %a{:href => '#', :onClick => chart_data[chart_index][:zoom_url]}
+                      %img{:src => image_path(zoom_icon(chart_data[chart_index][:zoom_url]))}
           %ul.dropdown-menu{"role"            => "menu",
                           "aria-labelledby" => "miq_chart_#{chart_set}_#{chart_index}_2",
                           "id"              => "miq_chartmenu_#{chart_set}_#{chart_index}_2",

--- a/spec/views/layouts/perf_charts_js_spec.rb
+++ b/spec/views/layouts/perf_charts_js_spec.rb
@@ -28,7 +28,7 @@ describe 'layouts/_perf_chart_js.html.haml' do
     it 'have correct structure for chart interactivity with composite chart' do
       render :partial => '/layouts/perf_chart_js.html.haml', :locals => {:chart_data => chart_data2, :chart_index => 0, :chart_set => 'candu', :charts => charts}
       expect(response).to include("div class='chart_parent' id='miq_chart_parent_candu_0'>\n<div>\n<div class='card-pf-heading'>\n<h2 class='card-pf-title'>CPU (Mhz)</h2>\n</div>\n<div class='overlay-container' style='position: relative'>\n<div class='card-pf-body'>\n<div id=\"miq_chart_candu_0\"></div>\n<div class='overlay' style='display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500'></div>\n</div>\n</div>\n</div>")
-      expect(response).to include("div class='chart_parent' id='miq_chart_parent_candu_0_2'>\n<div>\n<div class='overlay-container' style='position: relative'>\n<div class='card-pf-body'>\n<div id=\"miq_chart_candu_0_2\"></div>\n<div class='overlay' style='display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500'></div>\n</div>\n</div>\n</div>")
+      expect(response).to include("<div class='chart_parent' id='miq_chart_parent_candu_0_2'>\n<div>\n<div class='overlay-container' style='position: relative'>\n<div class='card-pf-body'>\n<div id=\"miq_chart_candu_0_2\"></div>\n<div class='overlay' style='display: none; position: absolute; top: 0; left: 0; bottom: 0; right: 0; z-index: 500'></div>\n<div>")
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Add zoom button to all C&U charts.
Parrent Issue: #10073
Before:
![screenshot from 2016-07-26 11-04-19](https://cloud.githubusercontent.com/assets/9535558/17213977/133cbc4e-54d7-11e6-98d2-48a94cfc7ddd.png)

After:
![screenshot from 2016-07-28 15-21-24](https://cloud.githubusercontent.com/assets/9535558/17213971/0a0c2470-54d7-11e6-94fa-a2cadfc2e707.png)
![screenshot from 2016-07-28 15-23-12](https://cloud.githubusercontent.com/assets/9535558/17214017/46a1fdba-54d7-11e6-8849-46fe5cce3368.png)

@dclarizio review please