### PR TITLE
Launch an URL returned by an automate button

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -252,7 +252,7 @@ module ApplicationController::Buttons
   end
 
   def custom_button_done
-    url = SystemConsole.where(:vm => params[:id]).first.try(:url)
+    url = SystemConsole.find_by(:vm => params[:id]).try(:url)
 
     if url.present?
       javascript_open_window(url)

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -276,7 +276,7 @@ module ApplicationController::Buttons
       options[:target_id] = obj.id
       options[:target_kls] = obj.class.name
       dialog_initialize(button.resource_action, options)
-    elsif button.options.key?(:open_url) && button.options[:open_url]
+    elsif button.options && button.options.key?(:open_url) && button.options[:open_url]
       task_id = button.invoke_async(obj)
       initiate_wait_for_task(:task_id => task_id, :action => :custom_button_done)
     else

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -105,6 +105,7 @@ module ApplicationController::Buttons
       @edit[:new][:target_attr_name] = params[:target_attr_name] if params[:target_attr_name]
       @edit[:new][:name] = params[:name] if params[:name]
       @edit[:new][:display] = params[:display] == "1" if params[:display]
+      @edit[:new][:open_url] = params[:open_url] == "1" if params[:open_url]
       @edit[:new][:description] = params[:description] if params[:description]
       @edit[:new][:button_image] = params[:button_image].to_i if params[:button_image]
       @edit[:new][:dialog_id] = params[:dialog_id] if params[:dialog_id]
@@ -760,6 +761,7 @@ module ApplicationController::Buttons
       button[:options][:button_image] = @edit[:new][:button_image]
     end
     button[:options][:display] = @edit[:new][:display]
+    button[:options][:open_url] = @edit[:new][:open_url]
     button.visibility ||= {}
     if @edit[:new][:visibility_typ] == "role"
       roles = []
@@ -843,6 +845,7 @@ module ApplicationController::Buttons
     @edit[:new][:description] = @custom_button.description
     @edit[:new][:button_image] = @custom_button.options && @custom_button.options[:button_image] ? @custom_button.options[:button_image] : ""
     @edit[:new][:display] = @custom_button.options && @custom_button.options.key?(:display) ? @custom_button.options[:display] : true
+    @edit[:new][:open_url] = @custom_button.options && @custom_button.options.key?(:open_url) ? @custom_button.options[:open_url] : false
     @edit[:new][:object_message] = @custom_button.uri_message || "create"
     @edit[:new][:instance_name] ||= "Request"
     @edit[:current] = copy_hash(@edit[:new])

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -277,8 +277,7 @@ module ApplicationController::Buttons
       options[:target_kls] = obj.class.name
       dialog_initialize(button.resource_action, options)
     else
-      wait_for = true
-      if wait_for
+      if button.options.key?(:open_url) && button.options[:open_url]
         task_id = button.invoke_async(obj)
         initiate_wait_for_task(:task_id => task_id, :action => :custom_button_done)
       else

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -78,7 +78,6 @@ class CustomButton < ApplicationRecord
     }
   end
 
-
   def invoke_async(target)
     task_opts = {
       :action => "Calling automate for user #{userid}",

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -64,14 +64,29 @@ class CustomButton < ApplicationRecord
 
   def invoke(target)
     args = resource_action.automate_queue_hash(target, {}, User.current_user)
-    MiqQueue.put(
+    MiqQueue.put(queue_opts(target, args))
+  end
+
+  def queue_opts(target, args)
+    {
       :class_name  => 'MiqAeEngine',
       :method_name => 'deliver',
       :args        => [args],
       :role        => 'automate',
       :zone        => target.try(:my_zone),
       :priority    => MiqQueue::HIGH_PRIORITY,
-    )
+    }
+  end
+
+
+  def invoke_async(target)
+    task_opts = {
+      :action => "Calling automate for user #{userid}",
+      :userid => User.current_user
+    }
+
+    args = resource_action.automate_queue_hash(target, {}, User.current_user)
+    MiqTask.generic_action_with_callback(task_opts, queue_opts(target, args))
   end
 
   def to_export_xml(_options)

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -92,13 +92,13 @@ class Vm < VmOrTemplate
     pl
   end
 
-  def set_remote_console_url(params)
+  def set_remote_console_url(url, user_id)
     SystemConsole.where(:vm_id => id).each(&:destroy)
     console = SystemConsole.create!(
       :vm_id      => id,
-      :user       => User.find_by(:userid => params[:userid]),
+      :user       => User.find_by(:userid => user_id),
       :protocol   => 'url',
-      :url        => params[:url],
+      :url        => url,
       :url_secret => SecureRandom.hex
     )
     console.id

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -95,10 +95,11 @@ class Vm < VmOrTemplate
   def set_remote_console_url(params)
     SystemConsole.where(:vm_id => id).each(&:destroy)
     console = SystemConsole.create!(
-      :vm_id    => id,
-      :user     => User.find_by(:userid => params[:userid]),
-      :protocol => 'url',
-      :url      => params[:url]
+      :vm_id      => id,
+      :user       => User.find_by(:userid => params[:userid]),
+      :protocol   => 'url',
+      :url        => params[:url],
+      :url_secret => SecureRandom.hex
     )
     console.id
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -92,7 +92,7 @@ class Vm < VmOrTemplate
     pl
   end
 
-  def set_remote_console_url(url, user_id)
+  def remote_console_url=(url, user_id)
     SystemConsole.where(:vm_id => id).each(&:destroy)
     console = SystemConsole.create!(
       :vm_id      => id,

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -95,10 +95,10 @@ class Vm < VmOrTemplate
   def set_remote_console_url(params)
     SystemConsole.where(:vm_id => id).each(&:destroy)
     console = SystemConsole.create!(
-      :vm_id      => id,
-      :user       => User.find_by(:userid => params[:userid]),
-      :protocol   => 'url',
-      :url        => params[:url]
+      :vm_id    => id,
+      :user     => User.find_by(:userid => params[:userid]),
+      :protocol => 'url',
+      :url      => params[:url]
     )
     console.id
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -91,4 +91,15 @@ class Vm < VmOrTemplate
     end
     pl
   end
+
+  def set_remote_console_url(params)
+    SystemConsole.where(:vm_id => id).each(&:destroy)
+    console = SystemConsole.create!(
+      :vm_id      => id,
+      :user       => User.find_by(:userid => params[:userid]),
+      :protocol   => 'url',
+      :url        => params[:url]
+    )
+    console.id
+  end
 end

--- a/app/views/shared/buttons/_ab_form.html.haml
+++ b/app/views/shared/buttons/_ab_form.html.haml
@@ -48,13 +48,9 @@
       %label.control-label.col-md-2
         = _('Button Image')
       .col-md-8
-        #form-group
-          = select_tag('button_image',
+        = select_tag('button_image',
                         options_for_select([[_("No Image"), nil]] + @edit[:new][:button_images], @edit[:new][:button_image].to_s),
                         :class => "selectpicker")
-          :javascript
-            miqInitSelectPicker();
-            miqSelectPickerEvent('button_image', '#{url}')
     .form-group
       %label.control-label.col-md-2
         = _('Dialog')
@@ -63,9 +59,12 @@
                       options_for_select(([[_("<None>"), nil]]) + Array(@edit[:new][:available_dialogs].invert).sort_by { |a| a.first.downcase }, @edit[:new][:dialog_id]),
                       "data-miq_sparkle_on" => true,
                       :class => "selectpicker")
-        :javascript
-          miqInitSelectPicker();
-          miqSelectPickerEvent('dialog_id', '#{url}')
+    .form-group
+      %label.control-label.col-md-2
+        = _('Open URL')
+      .col-md-8
+        = check_box_tag("open_url", "1", @edit[:new][:open_url],
+                               "data-miq_observe_checkbox" => {:interval => '.5', :url => url}.to_json)
 
   = render(:partial => "layouts/ae_resolve_options",
     :locals         => {:resolve => @edit,
@@ -77,3 +76,4 @@
 :javascript
   miqInitSelectPicker();
   miqSelectPickerEvent("button_image", "#{url}")
+  miqSelectPickerEvent('dialog_id', '#{url}')

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -31,7 +31,7 @@
     %label.control-label.col-md-2
       = _('Open URL')
     .col-md-8
-      = h(@custom_button.options.key?(:open_url) ? @custom_button.options[:open_url] : false )
+      = h(@custom_button.options.key?(:open_url) ? @custom_button.options[:open_url] : false)
 %hr
 
 %h3

--- a/app/views/shared/buttons/_ab_show.html.haml
+++ b/app/views/shared/buttons/_ab_show.html.haml
@@ -27,6 +27,11 @@
       = _('Dialog')
     .col-md-8
       = h(@sb[:dialog_label])
+  .form-group
+    %label.control-label.col-md-2
+      = _('Open URL')
+    .col-md-8
+      = h(@custom_button.options.key?(:open_url) ? @custom_button.options[:open_url] : false )
 %hr
 
 %h3

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -1,7 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceVm < MiqAeServiceVmOrTemplate
-    def set_remote_console_url(url)
-      object_send(:set_remote_console_url, url, DRb.front.workspace.ae_user.id)
+    def remote_console_url=(url)
+      object_send(:remote_console_url=, url, DRb.front.workspace.ae_user.id)
     end
 
     def add_to_service(service)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -1,6 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceVm < MiqAeServiceVmOrTemplate
-    expose :set_remote_console_url
+    def set_remote_console_url(url)
+      object_send(:set_remote_console_url, url, DRb.front.workspace.ae_user.id)
+    end
 
     def add_to_service(service)
       raise ArgumentError, "service must be a MiqAeServiceService" unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -1,5 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceVm < MiqAeServiceVmOrTemplate
+    expose :set_remote_console_url
+
     def add_to_service(service)
       raise ArgumentError, "service must be a MiqAeServiceService" unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
       ar_method { wrap_results(Service.find_by_id(service.id).add_resource!(@object)) }

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -43,6 +43,23 @@ describe ApplicationController do
       expect { controller.send(:custom_buttons) }.to raise_error(ArgumentError)
     end
 
+    context "with a button with open_url" do
+      before :each do
+        resource_action.update_attribute(:dialog_id, nil)
+        button.update_attributes(:options => {:open_url => true})
+        expect(controller).to receive(:render)
+      end
+
+      it "Vm button" do
+        controller.instance_variable_set(:@_params, :id => vm.id, :button_id => button.id)
+        expect_any_instance_of(CustomButton).to receive(:invoke_async).with(vm)
+
+        controller.send(:custom_buttons)
+        expect(assigns(:right_cell_text)).to include(vm.name)
+        expect(controller.instance_variable_get(:@explorer)).to be_truthy
+      end
+    end
+
     context "without a resource_action dialog" do
       before :each do
         resource_action.update_attribute(:dialog_id, nil)

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -218,4 +218,13 @@ describe Vm do
       :win32_services      => [],
     })
   end
+
+  it '#set_remote_console_url' do
+    vm = FactoryGirl.create(:vm_vmware)
+    vm.set_remote_console_url(:url => url = 'http://www.redhat.com', :userid => 0)
+
+    console = SystemConsole.where(:vm_id => vm.id).first
+    expect(console.url).to eq(url)
+    expect(console.url_secret).to be
+  end
 end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -223,7 +223,7 @@ describe Vm do
     vm = FactoryGirl.create(:vm_vmware)
     vm.set_remote_console_url(:url => url = 'http://www.redhat.com', :userid => 0)
 
-    console = SystemConsole.where(:vm_id => vm.id).first
+    console = SystemConsole.find_by(:vm_id => vm.id)
     expect(console.url).to eq(url)
     expect(console.url_secret).to be
   end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -221,7 +221,7 @@ describe Vm do
 
   it '#set_remote_console_url' do
     vm = FactoryGirl.create(:vm_vmware)
-    vm.set_remote_console_url(:url => url = 'http://www.redhat.com', :userid => 0)
+    vm.set_remote_console_url(url = 'http://www.redhat.com', 1)
 
     console = SystemConsole.find_by(:vm_id => vm.id)
     expect(console.url).to eq(url)

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -221,7 +221,7 @@ describe Vm do
 
   it '#set_remote_console_url' do
     vm = FactoryGirl.create(:vm_vmware)
-    vm.set_remote_console_url(url = 'http://www.redhat.com', 1)
+    vm.send(:remote_console_url=, url = 'http://www.redhat.com', 1)
 
     console = SystemConsole.find_by(:vm_id => vm.id)
     expect(console.url).to eq(url)


### PR DESCRIPTION
## Purpose or Intent

Extension to custom buttons where: 
1. the custom button runs an automate method through the queue (using MiqTask)
2. the customer-provided automate method stuff would do some potentially complex stuff and would return an URL (through `SystemConsole` model).
3. the UI opens browser window on that URL ~~or even open a HTML5 VNC client to a provided websocket URL (not in this PR)~~.

A simple usecase is opening a custom web page that is not available immediately, but needs to be made ready by the automate script.

The greater idea is than an automate script would somehow build a chain of proxy servers for VNC connection and the ManageIQ UI would open a HTML5 VNC client that would connect through that tunnel.

![button_url](https://cloud.githubusercontent.com/assets/51095/18750761/c0eecc52-80dc-11e6-9e45-b364390197f1.png)

Example usage from automate:
1. create a custom button with the check box "Open URL" checked
2. attach a method to it with the text below:

```
  $evm.root['vm'].remote_console_url = 'http://www.redhat.com'
```

press the button.
## FIXME (for a follow up PR?)
1. When deleting from `SystemConsole` we might need to do some cleanups (websocket proxy) or 2nd level proxy (https://github.com/ManageIQ/manageiq/pull/11273). However it makes no sense to use the proxies together with this on a single VM so this is not a big issue.
2. Might need to review how user is passed through and what can be set by the `set_remote_console_url` method exposed to automate.
