### PR TITLE
Fix dialogue field order

### DIFF
--- a/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
+++ b/app/views/miq_ae_customization/_dialog_field_form_dynamic_options.html.haml
@@ -6,7 +6,13 @@
                       @edit[:field_entry_point],
                       :class => "form-control",
                       :onFocus => 'miqShowAE_Tree("field_entry_point");')
-
+.form-group
+  %label.col-md-2.control-label
+    = _('Show Refresh Button')
+  .col-md-8
+    = check_box_tag('field_show_refresh_button', '1',
+                  @edit[:field_show_refresh_button],
+                  'data-miq_observe_checkbox' => {:url => url}.to_json)
 - if @edit[:field_show_refresh_button] # show only if field_show_refresh_button is on
   .form-group
     %label.col-md-2.control-label
@@ -15,13 +21,6 @@
       = check_box_tag('field_load_on_init', '1',
                       @edit[:field_load_on_init],
                       'data-miq_observe_checkbox' => {:url => url}.to_json)
-.form-group
-  %label.col-md-2.control-label
-    = _('Show Refresh Button')
-  .col-md-8
-    = check_box_tag('field_show_refresh_button', '1',
-                  @edit[:field_show_refresh_button],
-                  'data-miq_observe_checkbox' => {:url => url}.to_json)
 .form-group
   %label.col-md-2.control-label
     = _('Auto refresh')


### PR DESCRIPTION
'Load Values on Init' depends on 'Show Refresh Button' so this moves load values to be underneath the refresh. 
After:
![boptions](https://cloud.githubusercontent.com/assets/16326669/17215767/0248a086-54ac-11e6-99a0-312b6e7d905f.png)
Before: 
![aoptions](https://cloud.githubusercontent.com/assets/16326669/17215766/024630bc-54ac-11e6-86dc-2817806951a4.png)

@miq-bot add_label refactoring
@miq-bot add_label ui
@miq-bot assign @gmcculloug
