### PR TITLE
Added rate assigning by tags to container projects

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -500,20 +500,23 @@ module UiConstants
   # This set of assignments was created for chargeback_rates
   ASSIGN_TOS[:chargeback_storage] = ASSIGN_TOS["Storage"]
   ASSIGN_TOS[:chargeback_compute] = {
-    "enterprise"            => N_("The Enterprise"),
-    "ext_management_system" => PostponedTranslation.new(N_("Selected %{tables}")) do
-                                 {:tables => ui_lookup(:tables => "ext_management_systems")}
-                               end,
-    "ems_cluster"           => PostponedTranslation.new(N_("Selected %{tables}")) do
-                                 {:tables => ui_lookup(:tables => "ems_cluster")}
-                               end,
-    "ems_container"         => PostponedTranslation.new(N_("Selected %{tables}")) do
-                                 {:tables => ui_lookup(:tables => "ems_container")}
-                               end,
-    "vm-tags"               => PostponedTranslation.new(N_("Tagged %{tables}")) do
-                                 {:tables => ui_lookup(:tables => "vm")}
-                               end,
-    "tenant"                => N_("Tenants")
+    "enterprise"             => N_("The Enterprise"),
+    "ext_management_system"  => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                  {:tables => ui_lookup(:tables => "ext_management_systems")}
+                                end,
+    "ems_cluster"            => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                  {:tables => ui_lookup(:tables => "ems_cluster")}
+                                end,
+    "ems_container"          => PostponedTranslation.new(N_("Selected %{tables}")) do
+                                  {:tables => ui_lookup(:tables => "ems_container")}
+                                end,
+    "vm-tags"                => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                                  {:tables => ui_lookup(:tables => "vm")}
+                                end,
+    "container_project-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                                  {:tables => ui_lookup(:tables => "container_project")}
+                                end,
+    "tenant"                 => N_("Tenants")
   }
 
   EXP_COUNT_TYPE = [N_("Count of"), "count"].freeze  # Selection for count based filters

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -74,10 +74,10 @@ class Chargeback < ActsAsArModel
     keys.push(tenant_resource.id) unless tenant_resource.nil?
     key = keys.join("_")
     return @rates[key] if @rates.key?(key)
-
     tag_list = perf.tag_names.split("|").inject([]) { |arr, t| arr << "vm/tag/managed/#{t}"; arr }
 
-    parents = [perf.parent_host, perf.parent_ems_cluster, perf.parent_storage, perf.parent_ems, @enterprise].compact
+    parents = [perf.parent_host, perf.parent_ems_cluster, perf.parent_storage, perf.parent_ems, @enterprise,
+               perf.resource.try(:container_project), perf.resource.try(:old_container_project)].compact
     parents.push(tenant_resource) unless tenant_resource.nil?
 
     @rates[key] = ChargebackRate.get_assigned_for_target(perf.resource, :tag_list => tag_list, :parents => parents)


### PR DESCRIPTION

Assign rate to tag:
![screencapture-localhost-3000-chargeback-explorer-1469715998879](https://cloud.githubusercontent.com/assets/11256940/17216240/88c8bb8c-54e8-11e6-8cc5-131536028fa4.png)
![screenshot from 2016-07-28 17-27-55](https://cloud.githubusercontent.com/assets/11256940/17216289/c21d53ca-54e8-11e6-9625-5675a663ef7c.png)

Assign tag to project:
![screenshot from 2016-07-28 17-30-40](https://cloud.githubusercontent.com/assets/11256940/17216380/1515e4a2-54e9-11e6-8736-1a72b9a000c7.png)

If that project participates in a Chargeback report the rate used for it will be the one we assigned to the tag:
![screenshot from 2016-07-28 17-32-46](https://cloud.githubusercontent.com/assets/11256940/17216442/626192d8-54e9-11e6-85d1-90245c72062e.png)


@miq-bot add_label chargeback, providers/containers

@gtanzillo Please review
cc @simon3z 
