### PR TITLE
Only migrate rows in the current region

### DIFF
--- a/db/migrate/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets.rb
+++ b/db/migrate/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets.rb
@@ -1,5 +1,5 @@
 class MoveNetworkPortCloudSubnetIdToNetworkPortsCloudSubnets < ActiveRecord::Migration[5.0]
-  class NetworkPort < ActiveRecord::Base
+  class NetworkPort < ApplicationRecord
     self.inheritance_column = :_type_disabled
   end
 
@@ -13,7 +13,7 @@ class MoveNetworkPortCloudSubnetIdToNetworkPortsCloudSubnets < ActiveRecord::Mig
 
   def up
     # Move NetworkPort belongs_to :cloud_subnet to NetworkPort has_many :cloud_subnets, :through => :cloud_subnet_network_port
-    NetworkPort.find_each do |network_port|
+    NetworkPort.in_my_region.find_each do |network_port|
       CloudSubnetNetworkPort.create!(
         :cloud_subnet_id => network_port.cloud_subnet_id,
         :network_port_id => network_port.id)
@@ -22,7 +22,7 @@ class MoveNetworkPortCloudSubnetIdToNetworkPortsCloudSubnets < ActiveRecord::Mig
 
   def down
     # Move NetworkPort belongs_to :cloud_subnet to NetworkPort has_many :cloud_subnets, :through => :cloud_subnet_network_port
-    NetworkPort.find_each do |network_port|
+    NetworkPort.in_my_region.find_each do |network_port|
       cloud_subnet_network_port = CloudSubnetNetworkPort.find_by(:network_port_id => network_port.id)
       if cloud_subnet_network_port
         network_port.update_attributes!(:cloud_subnet_id => cloud_subnet_network_port.cloud_subnet_id)


### PR DESCRIPTION
This was causing an issue with replication when rows which actually belonged to a region were migrated.

The new rows in the join table got an id in the global region when they should have the one assigned to them in the remote region.

This caused replication to fail with a unique constraint error when trying to replicate the new rows in the regional database.

Prior to this change the global database's `cloud_subnets_network_ports` table looked like this:
```
vmdb_production=# select * from cloud_subnets_network_ports;
       id       | cloud_subnet_id | network_port_id | address 
----------------+-----------------+-----------------+---------
 99000000000001 |               2 |               1 | 
 99000000000002 |               3 |               2 | 
 99000000000003 |               3 |               3 | 
 99000000000004 |               3 |               4 | 
 99000000000005 |               3 |               5 | 
 99000000000006 |               1 |               6 | 
 99000000000007 |               3 |               7 | 
 99000000000008 |               1 |               8 | 
 99000000000009 |               2 |               9 | 
 99000000000010 |               3 |              10 | 
(10 rows)
```

It should have looked like this:
```
vmdb_production=# select * from cloud_subnets_network_ports;
 id | cloud_subnet_id | network_port_id |    address     
----+-----------------+-----------------+----------------
  1 |               2 |               1 | 192.0.2.1
  2 |               3 |               2 | 192.0.2.2
  3 |               3 |               3 | 192.0.2.3
  4 |               3 |               4 | 192.0.2.4
  5 |               3 |               5 | 192.0.2.5
  6 |               1 |               6 | 192.0.2.6
  7 |               3 |               7 | 192.0.2.7
  8 |               1 |               8 | 192.0.2.8
  9 |               2 |               9 | 192.0.2.9
 10 |               3 |              10 | 192.0.2.10
(10 rows)
```

https://bugzilla.redhat.com/show_bug.cgi?id=1361218