### PR TITLE
Refactor API specs with expect_result_resources_to_match_key_data

### DIFF
--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -101,11 +101,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", [request1_url, request2_url])
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/Automation request #{request1.id} approved/i, /Automation request #{request2.id} approved/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/Automation request #{request1.id} approved/i),
+          },
+          {
+            "message" => a_string_matching(/Automation request #{request2.id} approved/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
 
     it "supports denying multiple requests" do
@@ -116,11 +122,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", [request1_url, request2_url])
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/Automation request #{request1.id} denied/i, /Automation request #{request2.id} denied/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/Automation request #{request1.id} denied/i,),
+          },
+          {
+            "message" => a_string_matching(/Automation request #{request2.id} denied/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 end

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -99,19 +99,22 @@ describe ApiController do
       run_post(automation_requests_url, gen_request(:approve, [{"href" => request1_url, "reason" => "approve reason"},
                                                                {"href" => request2_url, "reason" => "approve reason"}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [request1_url, request2_url])
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Automation request #{request1.id} approved/i),
+            "success" => true,
+            "href"    => a_string_matching(request1_url)
           },
           {
             "message" => a_string_matching(/Automation request #{request2.id} approved/i),
+            "success" => true,
+            "href"    => a_string_matching(request2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "supports denying multiple requests" do
@@ -120,19 +123,22 @@ describe ApiController do
       run_post(automation_requests_url, gen_request(:deny, [{"href" => request1_url, "reason" => "deny reason"},
                                                             {"href" => request2_url, "reason" => "deny reason"}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", [request1_url, request2_url])
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Automation request #{request1.id} denied/i,),
+            "success" => true,
+            "href"    => a_string_matching(request1_url)
           },
           {
             "message" => a_string_matching(/Automation request #{request2.id} denied/i),
+            "success" => true,
+            "href"    => a_string_matching(request2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -62,19 +62,22 @@ RSpec.describe "Instances API" do
 
       run_post(instances_url, gen_request(:terminate, [{"href" => instance1_url}, {"href" => instance2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
             "message" => a_string_matching(/#{instance1.id}.* terminating/i),
+            "success" => true,
+            "href"    => a_string_matching(instance1_url)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{instance2.id}.* terminating/i),
+            "success" => true,
+            "href"    => a_string_matching(instance2_url)
           )
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -64,11 +64,17 @@ RSpec.describe "Instances API" do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :instances_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/#{instance1.id}.* terminating/i, /#{instance2.id}.* terminating/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message" => a_string_matching(/#{instance1.id}.* terminating/i),
+          ),
+          a_hash_including(
+            "message" => a_string_matching(/#{instance2.id}.* terminating/i),
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -279,11 +279,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :provreqs_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/Provision request #{provreq1.id} approved/i, /Provision request #{provreq2.id} approved/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/Provision request #{provreq1.id} approved/i),
+          },
+          {
+            "message" => a_string_matching(/Provision request #{provreq2.id} approved/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
 
     it "supports denying multiple requests" do
@@ -293,11 +299,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :provreqs_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/Provision request #{provreq1.id} denied/i, /Provision request #{provreq2.id} denied/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/Provision request #{provreq1.id} denied/i),
+          },
+          {
+            "message" => a_string_matching(/Provision request #{provreq2.id} denied/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -277,19 +277,22 @@ describe ApiController do
 
       run_post(provision_requests_url, gen_request(:approve, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :provreqs_list)
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Provision request #{provreq1.id} approved/i),
+            "success" => true,
+            "href"    => a_string_matching(provreq1_url)
           },
           {
             "message" => a_string_matching(/Provision request #{provreq2.id} approved/i),
+            "success" => true,
+            "href"    => a_string_matching(provreq2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "supports denying multiple requests" do
@@ -297,19 +300,22 @@ describe ApiController do
 
       run_post(provision_requests_url, gen_request(:deny, [{"href" => provreq1_url}, {"href" => provreq2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :provreqs_list)
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Provision request #{provreq1.id} denied/i),
+            "success" => true,
+            "href"    => a_string_matching(provreq1_url)
           },
           {
             "message" => a_string_matching(/Provision request #{provreq2.id} denied/i),
+            "success" => true,
+            "href"    => a_string_matching(provreq2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -123,11 +123,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :svcreqs_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/Service request #{svcreq1.id} approved/i, /Service request #{svcreq2.id} approved/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/Service request #{svcreq1.id} approved/i),
+          },
+          {
+            "message" => a_string_matching(/Service request #{svcreq2.id} approved/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
 
     it "supports denying multiple requests" do
@@ -138,11 +144,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :svcreqs_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/Service request #{svcreq1.id} denied/i, /Service request #{svcreq2.id} denied/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/Service request #{svcreq1.id} denied/i),
+          },
+          {
+            "message" => a_string_matching(/Service request #{svcreq2.id} denied/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -121,19 +121,22 @@ describe ApiController do
       run_post(service_requests_url, gen_request(:approve, [{"href" => svcreq1_url, "reason" => "approve reason"},
                                                             {"href" => svcreq2_url, "reason" => "approve reason"}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :svcreqs_list)
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Service request #{svcreq1.id} approved/i),
+            "success" => true,
+            "href"    => a_string_matching(svcreq1_url)
           },
           {
             "message" => a_string_matching(/Service request #{svcreq2.id} approved/i),
+            "success" => true,
+            "href"    => a_string_matching(svcreq2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "supports denying multiple requests" do
@@ -142,19 +145,22 @@ describe ApiController do
       run_post(service_requests_url, gen_request(:deny, [{"href" => svcreq1_url, "reason" => "deny reason"},
                                                          {"href" => svcreq2_url, "reason" => "deny reason"}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :svcreqs_list)
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/Service request #{svcreq1.id} denied/i),
+            "success" => true,
+            "href"    => a_string_matching(svcreq1_url)
           },
           {
             "message" => a_string_matching(/Service request #{svcreq2.id} denied/i),
+            "success" => true,
+            "href"    => a_string_matching(svcreq2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -878,19 +878,22 @@ describe ApiController do
                            [{"href" => vm1_url, "event_type" => "etype1", "event_message" => "emsg1"},
                             {"href" => vm2_url, "event_type" => "etype2", "event_message" => "emsg2"}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/adding event .*etype1/i),
+            "success" => true,
+            "href"    => a_string_matching(vm1_url)
           },
           {
             "message" => a_string_matching(/adding event .*etype2/i),
+            "success" => true,
+            "href"    => a_string_matching(vm2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -924,19 +927,22 @@ describe ApiController do
 
       run_post(vms_url, gen_request(:retire, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
       expected = {
         "results" => a_collection_containing_exactly(
           {
             "message" => a_string_matching(/#{vm1.id}.* retiring/i),
+            "success" => true,
+            "href"    => a_string_matching(vm1_url)
           },
           {
             "message" => a_string_matching(/#{vm2.id}.* retiring/ii),
+            "success" => true,
+            "href"    => a_string_matching(vm2_url)
           }
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
 
     it "in the future" do
@@ -978,19 +984,22 @@ describe ApiController do
 
       run_post(vms_url, gen_request(:reset, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* resetting/i),
+            "success" => true,
+            "href"    => a_string_matching(vm1_url)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* resetting/i),
+            "success" => true,
+            "href"    => a_string_matching(vm2_url)
           )
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -1024,19 +1033,22 @@ describe ApiController do
 
       run_post(vms_url, gen_request(:shutdown_guest, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* shutting down/i),
+            "success" => true,
+            "href"    => a_string_matching(vm1_url)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* shutting down/i),
+            "success" => true,
+            "href"    => a_string_matching(vm2_url)
           )
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -1070,19 +1082,22 @@ describe ApiController do
 
       run_post(vms_url, gen_request(:refresh, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* refreshing/i),
+            "success" => true,
+            "href"    => a_string_matching(vm1_url)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* refreshing/i),
+            "success" => true,
+            "href"    => a_string_matching(vm2_url)
           )
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 
@@ -1116,19 +1131,22 @@ describe ApiController do
 
       run_post(vms_url, gen_request(:reboot_guest, [{"href" => vm1_url}, {"href" => vm2_url}]))
 
-      expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
             "message" => a_string_matching(/#{vm1.id}.* rebooting/i,),
+            "success" => true,
+            "href"    => a_string_matching(vm1_url)
           ),
           a_hash_including(
             "message" => a_string_matching(/#{vm2.id}.* rebooting/i),
+            "success" => true,
+            "href"    => a_string_matching(vm2_url)
           )
         )
       }
       expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -880,8 +880,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :vms_list)
-      expect_result_resources_to_match_key_data("results", "message",
-                                                [/adding event .*etype1/i, /adding event .*etype2/i])
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/adding event .*etype1/i),
+          },
+          {
+            "message" => a_string_matching(/adding event .*etype2/i),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 
@@ -917,11 +926,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :vms_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/#{vm1.id}.* retiring/i, /#{vm2.id}.* retiring/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          {
+            "message" => a_string_matching(/#{vm1.id}.* retiring/i),
+          },
+          {
+            "message" => a_string_matching(/#{vm2.id}.* retiring/ii),
+          }
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
 
     it "in the future" do
@@ -965,11 +980,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :vms_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/#{vm1.id}.* resetting/i, /#{vm2.id}.* resetting/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message" => a_string_matching(/#{vm1.id}.* resetting/i),
+          ),
+          a_hash_including(
+            "message" => a_string_matching(/#{vm2.id}.* resetting/i),
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 
@@ -1005,11 +1026,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :vms_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/#{vm1.id}.* shutting down/i, /#{vm2.id}.* shutting down/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message" => a_string_matching(/#{vm1.id}.* shutting down/i),
+          ),
+          a_hash_including(
+            "message" => a_string_matching(/#{vm2.id}.* shutting down/i),
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 
@@ -1045,11 +1072,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :vms_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/#{vm1.id}.* refreshing/i, /#{vm2.id}.* refreshing/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message" => a_string_matching(/#{vm1.id}.* refreshing/i),
+          ),
+          a_hash_including(
+            "message" => a_string_matching(/#{vm2.id}.* refreshing/i),
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 
@@ -1085,11 +1118,17 @@ describe ApiController do
 
       expect_multiple_action_result(2)
       expect_result_resources_to_include_hrefs("results", :vms_list)
-      expect_result_resources_to_match_key_data(
-        "results",
-        "message",
-        [/#{vm1.id}.* rebooting/i, /#{vm2.id}.* rebooting/i]
-      )
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including(
+            "message" => a_string_matching(/#{vm1.id}.* rebooting/i,),
+          ),
+          a_hash_including(
+            "message" => a_string_matching(/#{vm2.id}.* rebooting/i),
+          )
+        )
+      }
+      expect(response.parsed_body).to include(expected)
     end
   end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -195,11 +195,6 @@ module ApiSpecHelper
     end
   end
 
-  def expect_result_resources_to_match_key_data(collection, key, values)
-    value_list = fetch_value(values)
-    expect(response.parsed_body).to include(collection => value_list.collect { |v| a_hash_including(key => v) })
-  end
-
   def expect_result_to_have_keys(keys)
     expect(response.parsed_body).to include(*keys)
   end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -197,12 +197,7 @@ module ApiSpecHelper
 
   def expect_result_resources_to_match_key_data(collection, key, values)
     value_list = fetch_value(values)
-    expect(response.parsed_body).to have_key(collection)
-    expect(response.parsed_body[collection].size).to eq(value_list.size)
-    value_list.zip(response.parsed_body[collection]) do |value, hash|
-      expect(hash).to have_key(key)
-      expect(hash[key]).to match(value)
-    end
+    expect(response.parsed_body).to include(collection => value_list.collect { |v| a_hash_including(key => v) })
   end
 
   def expect_result_to_have_keys(keys)


### PR DESCRIPTION
Purpose or Intent
-----------------
This PR refactors this helper which was iterating over every single key/value pair in the response body into a single expectation for better feedback (failures will render a full diff of the response body vs expected). It goes further in refactoring the tests which used this helper, which included multiple expectations on the response body into single ones for greater readability and test feedback.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 