### PR TITLE
Rufus scheduler 3.0.8+ started modifying the input options hash here

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -439,7 +439,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Treat months differently since rufus doesn't support :schedule_every with X.months type of options
     sch = MiqSchedule.find(schedule_id)
     next_run = sch.next_interval_time
-    @schedules[:scheduler] << @user_scheduler.send(method, next_run, options) do |rufus_job|
+    @schedules[:scheduler] << @user_scheduler.send(method, next_run, options.dup) do |rufus_job|
       enqueue [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
     end
 
@@ -447,7 +447,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     remaining_months = ((5 * 12) / months) - 1
     remaining_months.times do
       next_run += months.months
-      @schedules[:scheduler] << @user_scheduler.send(method, next_run, options) do |rufus_job|
+      @schedules[:scheduler] << @user_scheduler.send(method, next_run, options.dup) do |rufus_job|
         enqueue [:miq_schedule_queue_scheduled_work, schedule_id, rufus_job]
       end
     end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -137,6 +137,9 @@ describe MiqScheduleWorker::Runner do
             schedules = @schedule_worker.instance_variable_get(:@schedules)
             expect(schedules[:scheduler].length).to eq(60)
           end
+          @user.jobs(:tag => "miq_schedules_1").each_with_index do |job, i|
+            expect(job.next_time).to eq(first_at + i.month)
+          end
         end
 
         it "monthly schedule starting Jan 31 will next run Feb 28" do


### PR DESCRIPTION
Rufus scheduler 3.0.8+ started modifying the input options hash here:
jmettraux/rufus-scheduler@c074a59

This commit allows schedules to parse the time using Chronic.
Unfortunately, for speed, they cache the result of the first parse in the
input options hash, causing us to schedule the same time many times!

@jrafanie wrote all of this, I just don't know how to put him as the contributor