### PR TITLE
Populate read only Zone text field when there is only 1 zone in region

### DIFF
--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -19,18 +19,22 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
       ManageIQ.angular.scope = $scope;
 
       if (providerForemanFormId == 'new') {
-        $scope.newRecord                            = true;
-        $scope.providerForemanModel.provtype        = '';
-        $scope.providerForemanModel.name            = '';
-        $scope.providerForemanModel.zone            = '';
-        $scope.providerForemanModel.url             = '';
-        $scope.providerForemanModel.verify_ssl    = false;
+        $scope.newRecord = true;
 
-        $scope.providerForemanModel.log_userid   = '';
-        $scope.providerForemanModel.log_password = '';
-        $scope.providerForemanModel.log_verify   = '';
-        $scope.afterGet                          = true;
-        $scope.modelCopy                         = angular.copy( $scope.providerForemanModel );
+        $http.get('/provider_foreman/provider_foreman_form_fields/' + providerForemanFormId).success(function(data) {
+          $scope.providerForemanModel.provtype = '';
+          $scope.providerForemanModel.name = '';
+          $scope.providerForemanModel.zone = data.zone;
+          $scope.providerForemanModel.url = '';
+          $scope.providerForemanModel.verify_ssl = false;
+
+          $scope.providerForemanModel.log_userid = '';
+          $scope.providerForemanModel.log_password = '';
+          $scope.providerForemanModel.log_verify = '';
+          $scope.afterGet = true;
+          $scope.modelCopy = angular.copy($scope.providerForemanModel);
+
+        });
       } else {
         $scope.newRecord = false;
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -218,6 +218,11 @@ class ProviderForemanController < ApplicationController
 
   def provider_foreman_form_fields
     assert_privileges("provider_foreman_edit_provider")
+    # set value of read only zone text box, when there is only single zone
+    return render :json => {
+                             :zone => Zone.in_my_region.size >= 1 ? Zone.in_my_region.first.name : nil
+                           } if params[:id] == "new"
+
     config_mgr = find_record(ManageIQ::Providers::ConfigurationManager, params[:id])
     provider   = config_mgr.provider
 

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -12,13 +12,22 @@ describe('providerForemanFormController', function() {
     spyOn(miqService, 'sparkleOff');
     $scope = $rootScope.$new();
 
+    var providerForemanFormResponse = {
+      name: '',
+      url: '',
+      zone: 'foo_zone',
+      verify_ssl: false,
+      log_userid: ''
+    };
+
     $httpBackend = _$httpBackend_;
-    $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/new').respond();
+    $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/new').respond(providerForemanFormResponse);
     $controller = _$controller_('providerForemanFormController', {
       $scope: $scope,
       providerForemanFormId: 'new',
       miqService: miqService
     });
+    $httpBackend.flush();
   }));
 
   afterEach(function() {
@@ -28,45 +37,28 @@ describe('providerForemanFormController', function() {
 
   describe('initialization', function() {
     describe('when the providerForemanFormId is new', function() {
-    var providerForemanFormResponse = {
-      name: '',
-      url: '',
-      zone: '',
-      verify_ssl: false,
-      log_userid: ''
-    };
-
-    beforeEach(inject(function(_$controller_) {
-      $httpBackend.whenGET('/provider_foreman/provider_foreman_form_fields/new').respond(providerForemanFormResponse);
-      $controller = _$controller_('providerForemanFormController',
-        {
-          $scope: $scope,
-          providerForemanFormId: 'new',
-          miqService: miqService
-        });
-    }));
-    it('sets the name to blank', function () {
-      expect($scope.providerForemanModel.name).toEqual('');
+      it('sets the name to blank', function () {
+        expect($scope.providerForemanModel.name).toEqual('');
+      });
+      it('sets the zone to blank', function () {
+        expect($scope.providerForemanModel.zone).toEqual('foo_zone');
+      });
+      it('sets the url to blank', function () {
+        expect($scope.providerForemanModel.url).toEqual('');
+      });
+      it('sets the verify_ssl to blank', function () {
+        expect($scope.providerForemanModel.verify_ssl).toBeFalsy();
+      });
+      it('sets the log_userid to blank', function () {
+        expect($scope.providerForemanModel.log_userid).toEqual('');
+      });
+      it('sets the log_password to blank', function () {
+        expect($scope.providerForemanModel.log_password).toEqual('');
+      });
+      it('sets the log_verify to blank', function () {
+        expect($scope.providerForemanModel.log_verify).toEqual('');
+      });
     });
-    it('sets the zone to blank', function () {
-      expect($scope.providerForemanModel.zone).toEqual('');
-    });
-    it('sets the url to blank', function () {
-      expect($scope.providerForemanModel.url).toEqual('');
-    });
-    it('sets the verify_ssl to blank', function () {
-      expect($scope.providerForemanModel.verify_ssl).toBeFalsy();
-    });
-    it('sets the log_userid to blank', function () {
-      expect($scope.providerForemanModel.log_userid).toEqual('');
-    });
-    it('sets the log_password to blank', function () {
-      expect($scope.providerForemanModel.log_password).toEqual('');
-    });
-    it('sets the log_verify to blank', function () {
-      expect($scope.providerForemanModel.log_verify).toEqual('');
-    });
-  });
 
     describe('when the providerForemanFormId is an Id', function() {
       var providerForemanFormResponse = {


### PR DESCRIPTION
Fixed code path that deals with showing zone name as readonly text field when user has only 1 zone in their region, text field was not getting populated and was marked as required field which was causing Add button to remain disabled. Adjusted/fixed failing spec test.

https://bugzilla.redhat.com/show_bug.cgi?id=1361045
https://bugzilla.redhat.com/show_bug.cgi?id=1361308

@dclarizio please review/test. To be able to recreate you should only have 1 zone in your region. This issue was introduced in https://github.com/ManageIQ/manageiq/pull/9992

before:
![before](https://cloud.githubusercontent.com/assets/3450808/17225181/e3b83534-54d1-11e6-8953-5f7c2ed79935.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/17225194/ef2bc336-54d1-11e6-8e68-ed41ee84a26e.png)


