### PR TITLE
[WIP] Modeling VMware vApp

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -426,7 +426,7 @@ module QuadiconHelper
   # Renders a quadicon for resource_pools
   #
   def render_resource_pool_quadicon(item, options)
-    img = item.vapp ? "vapp.png" : "resource_pool.png"
+    img = item.kind_of?(VirtualApp) ? "vapp.png" : "resource_pool.png"
     size = options[:size]
     width = options[:size] == 150 ? 54 : 35
     output = []

--- a/app/models/ems_refresh/vc_updates.rb
+++ b/app/models/ems_refresh/vc_updates.rb
@@ -278,10 +278,30 @@ module EmsRefresh::VcUpdates
       "config.storageDevice.scsiTopology.adapter[*].target[*].transport.address",
       "config.storageDevice.scsiTopology.adapter[*].target[*].transport.iScsiAlias",
       "config.storageDevice.scsiTopology.adapter[*].target[*].transport.iScsiName",
+    ],
+
+    :ems_refresh_vapp        => [
+      "MOR",
+      "datastore",
+      "name",
+      "network",
+      "parent", # Used by ManageIQ::Providers::Vmware::InfraManager::RefreshParser::Filter#ems_metadata_inv_by_*
+      "resourcePool",
+      "resourcePool.ManagedObjectReference",
+      "summary.config.cpuAllocation.expandableReservation",
+      "summary.config.cpuAllocation.limit",
+      "summary.config.cpuAllocation.reservation",
+      "summary.config.cpuAllocation.shares.level",
+      "summary.config.cpuAllocation.shares.shares",
+      "summary.config.memoryAllocation.expandableReservation",
+      "summary.config.memoryAllocation.limit",
+      "summary.config.memoryAllocation.reservation",
+      "summary.config.memoryAllocation.shares.level",
+      "summary.config.memoryAllocation.shares.shares",
+      "vm",
+      "vm.ManagedObjectReference",
     ]
   }
-  # Virtual Apps are treated like Resource Pools
-  VIM_SELECTOR_SPEC[:ems_refresh_vapp] = VIM_SELECTOR_SPEC[:ems_refresh_rp].dup
 
   OBJ_TYPE_TO_TYPE_AND_CLASS = {
     'VirtualMachine' => [:vm,   VmOrTemplate],

--- a/app/models/lan.rb
+++ b/app/models/lan.rb
@@ -8,4 +8,7 @@ class Lan < ApplicationRecord
 
   # TODO: Should this go through switch and not guest devices?
   has_many :hosts,             :through => :guest_devices
+
+  has_many :lan_virtual_apps
+  has_many :virtual_apps, :through => :lan_virtual_apps
 end

--- a/app/models/lan_virtual_app.rb
+++ b/app/models/lan_virtual_app.rb
@@ -1,0 +1,4 @@
+class LanVirtualApp < ApplicationRecord
+  belongs_to :lan
+  belongs_to :virtual_app
+end

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -13,6 +13,7 @@ module ManageIQ::Providers
     require_nested :ProvisionViaPxe
     require_nested :ProvisionWorkflow
     require_nested :Template
+    require_nested :VirtualApp
     require_nested :Vm
 
     include VimConnectMixin

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1297,12 +1297,18 @@ module ManageIQ::Providers
 
           # :is_default will be set later as we don't know until we find out who the parent is.
 
+          type = if mor.vimType == "VirtualApp"
+                   ManageIQ::Providers::Vmware::InfraManager::VirtualApp.name
+                 else
+                   ResourcePool.name
+                 end
+
           new_result = {
             :ems_ref               => mor,
             :ems_ref_obj           => mor,
             :uid_ems               => mor,
             :name                  => URI.decode(data["name"].to_s),
-            :vapp                  => mor.vimType == "VirtualApp",
+            :type                  => type,
 
             :memory_reserve        => memory["reservation"],
             :memory_reserve_expand => memory["expandableReservation"].to_s.downcase == "true",

--- a/app/models/manageiq/providers/vmware/infra_manager/virtual_app.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/virtual_app.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::InfraManager::VirtualApp < VirtualApp
+end

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -1,6 +1,7 @@
 class ResourcePool < ApplicationRecord
   include VirtualTotalMixin
   include TenantIdentityMixin
+  include NewWithTypeStiMixin
 
   acts_as_miq_taggable
 

--- a/app/models/virtual_app.rb
+++ b/app/models/virtual_app.rb
@@ -1,0 +1,2 @@
+class VirtualApp < ResourcePool
+end

--- a/app/models/virtual_app.rb
+++ b/app/models/virtual_app.rb
@@ -1,2 +1,4 @@
 class VirtualApp < ResourcePool
+  has_many :lan_virtual_apps
+  has_many :lans, :through => :lan_virtual_apps
 end

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -39,7 +39,7 @@ class TreeBuilderDatacenter < TreeBuilder
     if @root.kind_of?(EmsCluster)
       [@root.name, _("Cluster: %{name}") % {:name => @root.name}, "cluster"]
     elsif @root.kind_of?(ResourcePool)
-      [@root.name, _("Resource Pool: %{name}") % {:name => @root.name}, @root.vapp ? "vapp" : "resource_pool"]
+      [@root.name, _("Resource Pool: %{name}") % {:name => @root.name}, @root.kind_of?(VirtualApp) ? "vapp" : "resource_pool"]
     end
   end
 

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -93,7 +93,7 @@ class TreeNodeBuilder
                                                 "#{ui_lookup(:table => "host")}: #{object.name}")
     when IsoDatastore         then generic_node(object.name, "isodatastore.png")
     when IsoImage             then generic_node(object.name, "isoimage.png")
-    when ResourcePool         then generic_node(object.name, object.vapp ? "vapp.png" : "resource_pool.png")
+    when ResourcePool         then resource_pool_node(object)
 
     when Vm                   then vm_node(object)
     when Lan                  then generic_node(object.name,
@@ -329,6 +329,16 @@ class TreeNodeBuilder
     else # normal Folders
       normal_folder_node
     end
+  end
+
+  def resource_pool_node(object)
+    object_img = if object.kind_of?(VirtualApp)
+                   "vapp.png"
+                 else
+                   "resource_pool.png"
+                 end
+
+    generic_node(object.name, object_img)
   end
 
   def miq_scsi_target(iscsi_name, target)

--- a/db/migrate/20160726175949_add_sti_to_resource_pools.rb
+++ b/db/migrate/20160726175949_add_sti_to_resource_pools.rb
@@ -1,0 +1,9 @@
+class AddStiToResourcePools < ActiveRecord::Migration[5.0]
+  def up
+    add_column :resource_pools, :type, :string
+  end
+
+  def down
+    remove_column :resource_pools, :type
+  end
+end

--- a/db/migrate/20160726183315_remove_vapp_from_resource_pools.rb
+++ b/db/migrate/20160726183315_remove_vapp_from_resource_pools.rb
@@ -1,0 +1,16 @@
+class RemoveVappFromResourcePools < ActiveRecord::Migration[5.0]
+  VMWARE_INFRA_VAPP_CLASS = 'ManageIQ::Providers::Vmware::InfraManager::VirtualApp'.freeze
+  class ResourcePool < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    ResourcePool.where(:vapp => true).update_all(:type => VMWARE_INFRA_VAPP_CLASS)
+    remove_column :resource_pools, :vapp
+  end
+
+  def down
+    add_column :resource_pools, :vapp, :boolean
+    ResourcePool.where(:type => VMWARE_INFRA_VAPP_CLASS).update_all(:vapp => true)
+  end
+end

--- a/db/migrate/20160802192052_create_lan_virtual_apps.rb
+++ b/db/migrate/20160802192052_create_lan_virtual_apps.rb
@@ -1,0 +1,8 @@
+class CreateLanVirtualApps < ActiveRecord::Migration[5.0]
+  def change
+    create_table :lan_virtual_apps do |t|
+      t.belongs_to :lan, :index => true
+      t.belongs_to :virtual_app, :index => true
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1464,6 +1464,10 @@ key_pairs_vms:
 - authentication_id
 - vm_id
 - id
+lan_virtual_apps:
+- id
+- lan_id
+- virtual_app_id
 lans:
 - id
 - switch_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5964,7 +5964,6 @@ resource_pools:
 - cpu_shares_level
 - is_default
 - ems_ref_obj
-- vapp
 - ems_ref
 - type
 rss_feeds:

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5966,6 +5966,7 @@ resource_pools:
 - ems_ref_obj
 - vapp
 - ems_ref
+- type
 rss_feeds:
 - id
 - name

--- a/gems/pending/VMwareWebService/VimPropMaps.rb
+++ b/gems/pending/VMwareWebService/VimPropMaps.rb
@@ -93,7 +93,16 @@ module VimPropMaps
     :VirtualApp       => {
       :baseName => "@virtualApps",
       :keyPath  => nil, # by mor only
-      :props    => ["name", "summary.config", "resourcePool", "owner", "parent", "vm"] # childConfiguration currently has a problem updating.  See FB3269
+      :props    => [ # childConfiguration currently has a problem updating.  See FB3269
+        "datastore",
+        "name",
+        "network",
+        "summary.config",
+        "resourcePool",
+        "owner",
+        "parent",
+        "vm"
+      ]
     }
   }
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-virtual_app.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-virtual_app.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Vmware_InfraManager_VirtualApp < MiqAeServiceVirtualApp
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_virtual_app.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_virtual_app.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceVirtualApp < MiqAeServiceModelBase
+  end
+end

--- a/spec/factories/resource_pool.rb
+++ b/spec/factories/resource_pool.rb
@@ -12,4 +12,6 @@ FactoryGirl.define do
       rp.add_child(FactoryGirl.create(:vm_vmware))
     end
   end
+
+  factory :virtualapp, :parent => :resource_pool, :class => "VirtualApp"
 end

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -732,35 +732,43 @@ describe QuadiconHelper do
   end
 
   describe "#render_resource_pool_quadicon" do
-    let(:item) { FactoryGirl.create(:resource_pool) }
-    let(:options) { {:mode => :icon} }
-    subject(:quadicon) { helper.render_resource_pool_quadicon(item, options) }
+    context "resource_pool" do
+      let(:item) { FactoryGirl.create(:resource_pool) }
+      let(:options) { {:mode => :icon} }
+      subject(:quadicon) { helper.render_resource_pool_quadicon(item, options) }
 
-    include_examples :shield_img_with_policies
+      include_examples :shield_img_with_policies
 
-    it 'has a vapp image when vapp' do
-      item.vapp = true
+      context "when type is not listnav" do
+        it 'has a link to nowhere when embedded' do
+          @embedded = true
 
-      expect(subject).to have_selector('img[src*="vapp"]')
-    end
+          expect(subject).to have_selector("a")
+          expect(subject).to include('href=""')
+        end
 
-    context "when type is not listnav" do
-      it 'has a link to nowhere when embedded' do
-        @embedded = true
-
-        expect(subject).to have_selector("a")
-        expect(subject).to include('href=""')
+        it 'links to the item when not embedded' do
+          @embedded = false
+          cid = ApplicationRecord.compress_id(item.id)
+          expect(subject).to have_selector("a[href*='resource_pool/show/#{cid}']")
+        end
       end
 
-      it 'links to the item when not embedded' do
-        @embedded = false
-        cid = ApplicationRecord.compress_id(item.id)
-        expect(subject).to have_selector("a[href*='resource_pool/show/#{cid}']")
+      context "when type is listnav" do
+        include_examples :no_link_for_listnav
       end
     end
 
-    context "when type is listnav" do
-      include_examples :no_link_for_listnav
+    context "vapp" do
+      let(:item) { FactoryGirl.create(:virtualapp) }
+      let(:options) { {:mode => :icon} }
+      subject(:quadicon) { helper.render_resource_pool_quadicon(item, options) }
+
+      include_examples :shield_img_with_policies
+
+      it 'has a vapp image when vapp' do
+        expect(subject).to have_selector('img[src*="vapp"]')
+      end
     end
   end
 

--- a/spec/migrations/20160726183315_remove_vapp_from_resource_pools_spec.rb
+++ b/spec/migrations/20160726183315_remove_vapp_from_resource_pools_spec.rb
@@ -1,0 +1,23 @@
+require_migration
+
+describe RemoveVappFromResourcePools do
+  let(:resource_pool_stub) { migration_stub(:ResourcePool) }
+
+  migration_context :up do
+    it 'migrates resource pools to vapps' do
+      resource_pool = resource_pool_stub.create!(:name => "resource_pool", :vapp => false)
+      vapp          = resource_pool_stub.create!(:name => "vapp", :vapp => true)
+
+      migrate
+
+      expect(resource_pool.reload).to have_attributes(:type => nil)
+      expect(vapp.reload).to          have_attributes(:type => 'ManageIQ::Providers::Vmware::InfraManager::VirtualApp')
+    end
+  end
+
+  migration_context :down do
+    it 'migrates vapps to resource pools' do
+      migrate
+    end
+  end
+end

--- a/spec/presenters/tree_builder_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_datacenter_spec.rb
@@ -50,7 +50,7 @@ describe TreeBuilderDatacenter do
         root = @datacenter_tree.send(:root_options)
         expect(root[0]).to eq(@datacenter_tree.instance_variable_get(:@root).name)
         expect(root[1]).to eq("Resource Pool: #{@datacenter_tree.instance_variable_get(:@root).name}")
-        expect(root[2]).to eq(@datacenter_tree.instance_variable_get(:@root).vapp ? "vapp" : "resource_pool")
+        expect(root[2]).to eq(@datacenter_tree.instance_variable_get(:@root).kind_of?(VirtualApp) ? "vapp" : "resource_pool")
     end
     it 'returns right kind of children' do
       kids = @datacenter_tree.send(:x_get_tree_roots, false)


### PR DESCRIPTION
Purpose or Intent
-----------------
Start discussion on how best to model VMware vApps.  Currently they are differentiated by a `vapp` boolean of the `ResourcePool` model.

This drops the `vapp` column and adds a `ManageIQ::Providers::Vmware::InfraManager::Vapp` subclass of `ResourcePool`

In VMware a `VirtualApp` extends the `ResourcePool` class and adds a number of associations (e.g.: `datastore`, `network`) and critically additional methods (e.g.: `CloneVapp_Task`, `PowerOnVapp_Task`, `SuspendVapp_Task`)

Links
-----
* https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.VirtualApp.html