### PR TITLE
cap&u dont puke when _debug

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -196,7 +196,7 @@ module Metric::Capture
         target.perf_capture_queue(interval_name, options)
       else
         _log.debug do
-          log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
+          log_target = "#{target.class.name} name: [#{target.name}], id: [#{target.id}]"
           "Skipping capture of #{log_target} -" +
             "Performance last captured on [#{target.last_perf_capture_on}] is within threshold"
         end


### PR DESCRIPTION
before:

If enabling debug mode and performing cap & u timer ( `perf_capture_timer`), it throws an error that `id` does not exist.

after:

it runs correctly.

no BZ reported for this issue. It was introduced in darga a few months ago.

/cc @chessbyte FYI minor bug that I have never triggered, but ran across while reading the code.