### PR TITLE
Added new methods to the MiqAeDomain class

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2518,10 +2518,9 @@ class MiqAeClassController < ApplicationController
     domain_toggle(false)
   end
 
-  def domain_toggle_lock(domain_id, lock_value)
-    domain        = MiqAeNamespace.find_by_id(domain_id)
-    domain.system = lock_value
-    domain.save!
+  def domain_toggle_lock(domain_id, lock)
+    domain = MiqAeDomain.find(domain_id)
+    lock ? domain.lock_contents! : domain.unlock_contents!
   end
 
   def get_instance_node_info(id)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -711,10 +711,12 @@ class ApplicationHelper::ToolbarBuilder
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
       case id
       when "miq_ae_domain_lock"
-        return true unless editable_domain?(@record)
+        return true unless @record.editable_properties? && !@record.contents_locked?
       when "miq_ae_domain_unlock"
-        return true if editable_domain?(@record) || @record.priority.to_i == 0
-      when "miq_ae_domain_edit", "miq_ae_namespace_edit", "miq_ae_instance_copy", "miq_ae_method_copy"
+        return true unless @record.editable_properties? && @record.contents_locked?
+      when "miq_ae_domain_edit"
+        return false unless @record.editable_properties?
+      when "miq_ae_namespace_edit", "miq_ae_instance_copy", "miq_ae_method_copy"
         return false unless editable_domain?(@record)
       else
         return true unless editable_domain?(@record)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -711,9 +711,9 @@ class ApplicationHelper::ToolbarBuilder
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
       case id
       when "miq_ae_domain_lock"
-        return true unless @record.editable_properties? && !@record.contents_locked?
+        return true unless @record.lockable?
       when "miq_ae_domain_unlock"
-        return true unless @record.editable_properties? && @record.contents_locked?
+        return true unless @record.unlockable?
       when "miq_ae_domain_edit"
         return false unless @record.editable_properties?
       when "miq_ae_namespace_edit", "miq_ae_instance_copy", "miq_ae_method_copy"

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -53,6 +53,14 @@ class MiqAeDomain < MiqAeNamespace
     system
   end
 
+  def lockable?
+    editable_properties? && !contents_locked?
+  end
+
+  def unlockable?
+    editable_properties? && contents_locked?
+  end
+
   def editable_properties?
     # TODO: In the new design will use SOURCE != SYSTEM
     name != 'ManageIQ'

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -49,6 +49,19 @@ class MiqAeDomain < MiqAeNamespace
     save!
   end
 
+  def contents_locked?
+    system
+  end
+
+  def editable_properties?
+    name != 'ManageIQ'
+  end
+
+  def editable_contents?(user = User.current_user)
+    return false if name == 'ManageIQ'
+    editable?(user)
+  end
+
   def version
     version_field = about_class.try(:ae_fields).try(:detect) { |fld| fld.name == 'version' }
     version_field.try(:default_value)

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -54,10 +54,12 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def editable_properties?
+    # TODO: In the new design will use SOURCE != SYSTEM
     name != 'ManageIQ'
   end
 
   def editable_contents?(user = User.current_user)
+    # TODO: In the new design will use SOURCE != SYSTEM
     return false if name == 'ManageIQ'
     editable?(user)
   end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -190,6 +190,32 @@ describe MiqAeDomain do
     end
   end
 
+  context "lockable" do
+    it "a user domain should be lockable" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      expect(dom.lockable?).to be_truthy
+    end
+
+    it "a locked user domain should not be lockable" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      dom.lock_contents!
+      expect(dom.lockable?).to be_falsey
+    end
+  end
+
+  context "unlockable" do
+    it "a locked user domain should be unlockable" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      dom.lock_contents!
+      expect(dom.unlockable?).to be_truthy
+    end
+
+    it "a unlocked user domain should not be unlockable" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      expect(dom.unlockable?).to be_falsey
+    end
+  end
+
   context "git enabled domains" do
     let(:commit_time) { Time.now.utc }
     let(:commit_time_new) { Time.now.utc + 1.hour }

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -171,7 +171,6 @@ describe MiqAeDomain do
       dom = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
       expect(dom.contents_locked?).to be_truthy
     end
-
   end
 
   context "editable contents for a domain" do

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -138,6 +138,59 @@ describe MiqAeDomain do
     end
   end
 
+  context "editable properties for a domain" do
+    it "manageiq domain can't change properties" do
+      dom = FactoryGirl.create(:miq_ae_domain, :name => "ManageIQ", :tenant => @user.current_tenant)
+      expect(dom.editable_properties?).to be_falsey
+    end
+
+    it "user domain can change properties" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_properties?).to be_truthy
+    end
+
+    it "git domain cannot change properties" do
+      dom = FactoryGirl.create(:miq_ae_git_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_properties?).to be_truthy
+    end
+  end
+
+  context "lock contents" do
+    it "contents_locked? should be false for user domain" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      expect(dom.contents_locked?).to be_falsey
+    end
+
+    it "contents_locked? should be true for user domain after its locked" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      dom.lock_contents!
+      expect(dom.contents_locked?).to be_truthy
+    end
+
+    it "contents_locked? should be true for user domain" do
+      dom = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
+      expect(dom.contents_locked?).to be_truthy
+    end
+
+  end
+
+  context "editable contents for a domain" do
+    it "system domain can't change contents" do
+      dom = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_contents?(@user)).to be_falsey
+    end
+
+    it "user domain can change contents" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_contents?(@user)).to be_truthy
+    end
+
+    it "git domain cannot change contents" do
+      dom = FactoryGirl.create(:miq_ae_git_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_contents?(@user)).to be_falsey
+    end
+  end
+
   context "git enabled domains" do
     let(:commit_time) { Time.now.utc }
     let(:commit_time_new) { Time.now.utc + 1.hour }


### PR DESCRIPTION
Purpose or Intent
-----------------
Adding new methods to check if the domain contents or properties are editable. These functions are needed for pluggable provider domains and also for Git based domains. 
- contents_locked?
- editable_properties?
- editable_contents?
- lockable?
- unlockable?

The controller code has been modified to use these new functions.