### PR TITLE
Add VMware catalog parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.1.0"
 gem "fog-google",                     "~>0.3.0",       :require => false
-gem "fog-vcloud-director",            "~>0.1.2",       :require => false
+gem "fog-vcloud-director",            "~>0.1.3",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :Template
   require_nested :Vm
 
   def self.ems_type

--- a/app/models/manageiq/providers/vmware/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/template.rb
@@ -1,0 +1,10 @@
+class ManageIQ::Providers::Vmware::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    connection.catalog_items.get_single_catalog_item(ems_ref)
+  end
+
+  def validate_smartstate_analysis
+    validate_unsupported("Smartstate Analysis")
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -137,6 +137,8 @@
   :refresh_interval: 24.hours
   :scvmm:
     :refresh_interval: 15.minutes
+  :vmware_cloud:
+    :get_public_images: false
 :event_handling:
   :bottleneck_event_groups:
     :Capacity:

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager-template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager-template.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Vmware_CloudManager_Template < MiqAeServiceManageIQ_Providers_CloudManager_Template
+  end
+end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -50,6 +50,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       assert_specific_orchestration_stack
       assert_table_counts
       assert_ems
+      assert_specific_template
       assert_specific_vm_powered_on
       assert_specific_vm_powered_off
     end
@@ -70,20 +71,20 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(OrchestrationStackResource.count).to eq(0)
     expect(SecurityGroup.count).to eq(0)
     expect(FirewallRule.count).to eq(0)
-    expect(VmOrTemplate.count).to eq(3)
-    expect(Vm.count).to eq(3)
-    expect(MiqTemplate.count).to eq(0)
+    expect(VmOrTemplate.count).to eq(5)
+    expect(Vm.count).to eq(2)
+    expect(MiqTemplate.count).to eq(3)
 
     expect(CustomAttribute.count).to eq(0)
-    expect(Disk.count).to eq(3)
+    expect(Disk.count).to eq(2)
     expect(GuestDevice.count).to eq(0)
-    expect(Hardware.count).to eq(3)
-    expect(OperatingSystem.count).to eq(3)
+    expect(Hardware.count).to eq(2)
+    expect(OperatingSystem.count).to eq(2)
     expect(Snapshot.count).to eq(0)
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(0)
-    expect(MiqQueue.count).to eq(3)
+    expect(MiqQueue.count).to eq(5)
   end
 
   def assert_ems
@@ -98,21 +99,56 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(@ems.key_pairs.size).to eq(0)
     expect(@ems.cloud_networks.size).to eq(0)
     expect(@ems.security_groups.size).to eq(0)
-    expect(@ems.vms_and_templates.size).to eq(3)
-    expect(@ems.vms.size).to eq(3)
-    expect(@ems.miq_templates.size).to eq(0)
+    expect(@ems.vms_and_templates.size).to eq(5)
+    expect(@ems.vms.size).to eq(2)
+    expect(@ems.miq_templates.size).to eq(3)
     expect(@ems.orchestration_stacks.size).to eq(2)
 
     expect(@ems.direct_orchestration_stacks.size).to eq(2)
   end
 
+  def assert_specific_template
+    @template = ManageIQ::Providers::Vmware::CloudManager::Template.where(:name => "Small VM").first
+    expect(@template).not_to be_nil
+    expect(@template).to have_attributes(
+      :template              => true,
+      :ems_ref               => "vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92",
+      :ems_ref_obj           => nil,
+      :uid_ems               => "vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92",
+      :vendor                => "vmware",
+      :power_state           => "never",
+      :publicly_available    => false,
+      :location              => "unknown",
+      :tools_status          => nil,
+      :boot_time             => nil,
+      :standby_action        => nil,
+      :connection_state      => nil,
+      :cpu_affinity          => nil,
+      :memory_reserve        => nil,
+      :memory_reserve_expand => nil,
+      :memory_limit          => nil,
+      :memory_shares         => nil,
+      :memory_shares_level   => nil,
+      :cpu_reserve           => nil,
+      :cpu_reserve_expand    => nil,
+      :cpu_limit             => nil,
+      :cpu_shares            => nil,
+      :cpu_shares_level      => nil
+    )
+
+    expect(@template.ext_management_system).to eq(@ems)
+    expect(@template.operating_system).to be_nil
+    expect(@template.custom_attributes.size).to eq(0)
+    expect(@template.snapshots.size).to eq(0)
+  end
+
   def assert_specific_vm_powered_on
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "RHEL-7-2gb-1gb").first
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "Damn Small Linux").first
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82",
+      :ems_ref               => "vm-07fe0493-dbca-453b-8a2d-cd71f43291a4",
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82",
+      :uid_ems               => "vm-07fe0493-dbca-453b-8a2d-cd71f43291a4",
       :vendor                => "vmware",
       :power_state           => "on",
       :location              => "unknown",
@@ -143,7 +179,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.security_groups.size).to eq(0)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "Red Hat Enterprise Linux 7 (64-bit)",
+      :product_name => "Debian GNU/Linux 4 (32-bit)",
     )
     expect(v.custom_attributes.size).to eq(0)
     expect(v.snapshots.size).to eq(0)
@@ -151,14 +187,14 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware).to have_attributes(
       :config_version       => nil,
       :virtual_hw_version   => nil,
-      :guest_os             => "Red Hat Enterprise Linux 7 (64-bit)",
-      :guest_os_full_name   => "Red Hat Enterprise Linux 7 (64-bit)",
+      :guest_os             => "Debian GNU/Linux 4 (32-bit)",
+      :guest_os_full_name   => "Debian GNU/Linux 4 (32-bit)",
       :cpu_sockets          => 1,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
       :annotation           => nil,
-      :memory_mb            => 1024,
+      :memory_mb            => 256,
       :host_id              => nil,
       :cpu_speed            => nil,
       :cpu_type             => nil,
@@ -172,9 +208,9 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :cpu_total_cores      => 1,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
-      :disk_capacity        => 2_147_483_648,
+      :disk_capacity        => 268_435_456,
       :memory_console       => nil,
-      :bitness              => 64,
+      :bitness              => 32,
       :virtualization_type  => nil,
       :root_device_type     => nil,
     )
@@ -183,20 +219,20 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware.disks.first).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
-      :controller_type => "SCSI Controller",
-      :size            => 2_147_483_648,
+      :controller_type => "IDE Controller",
+      :size            => 268_435_456,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
   end
 
   def assert_specific_vm_powered_off
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "VM02").first
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "TTYLinux").first
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a",
+      :ems_ref               => "vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290",
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a",
+      :uid_ems               => "vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290",
       :vendor                => "vmware",
       :power_state           => "off",
       :location              => "unknown",
@@ -227,7 +263,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.security_groups.size).to eq(0)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "Red Hat Enterprise Linux 7 (64-bit)",
+      :product_name => "Other Linux (32-bit)",
     )
 
     expect(v.custom_attributes.size).to eq(0)
@@ -236,14 +272,14 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware).to have_attributes(
       :config_version       => nil,
       :virtual_hw_version   => nil,
-      :guest_os             => "Red Hat Enterprise Linux 7 (64-bit)",
-      :guest_os_full_name   => "Red Hat Enterprise Linux 7 (64-bit)",
+      :guest_os             => "Other Linux (32-bit)",
+      :guest_os_full_name   => "Other Linux (32-bit)",
       :cpu_sockets          => 1,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
       :annotation           => nil,
-      :memory_mb            => 1024,
+      :memory_mb            => 32,
       :host_id              => nil,
       :cpu_speed            => nil,
       :cpu_type             => nil,
@@ -257,9 +293,9 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :cpu_total_cores      => 1,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
-      :disk_capacity        => 2_147_483_648,
+      :disk_capacity        => 33_554_432,
       :memory_console       => nil,
-      :bitness              => 64,
+      :bitness              => 32,
       :virtualization_type  => nil,
       :root_device_type     => nil,
     )
@@ -268,8 +304,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware.disks.first).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
-      :controller_type => "SCSI Controller",
-      :size            => 2_147_483_648,
+      :controller_type => "IDE Controller",
+      :size            => 33_554_432,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
@@ -277,11 +313,11 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack
     @orchestration_stack1 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
-                            .find_by(:name => "vApp_admin_2")
+                            .find_by(:name => "vApp_system_7")
     @orchestration_stack2 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
-                            .find_by(:name => "vApp_admin_3")
-    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "RHEL-7-2gb-1gb").first
-    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "VM02").first
+                            .find_by(:name => "Tiny01")
+    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "Damn Small Linux").first
+    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.where(:name => "TTYLinux").first
 
     expect(vm1.orchestration_stack).to eq(@orchestration_stack1)
     expect(vm2.orchestration_stack).to eq(@orchestration_stack2)

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
@@ -19,15 +19,15 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Tue, 26 Jul 2016 11:20:47 GMT
+      - Mon, 01 Aug 2016 14:29:20 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 855af38a-b26d-48fa-a62a-8e1d338fe4df
+      - d688d86e-32ff-4e6b-88a2-61cce4e2b548
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
       Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '87'
+      - '64'
       Content-Type:
       - application/vnd.vmware.vcloud.session+xml;version=5.1
       Content-Length:
@@ -46,7 +46,7 @@ http_interactions:
             <Link rel="down:extensibility" href="https://10.30.2.2/api/extensibility" type="application/vnd.vmware.vcloud.apiextensibility+xml"/>
         </Session>
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:08 GMT
+  recorded_at: Mon, 01 Aug 2016 14:29:45 GMT
 - request:
     method: get
     uri: https://VMWARE_CLOUD_HOST/api/org
@@ -59,22 +59,22 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Tue, 26 Jul 2016 11:20:47 GMT
+      - Mon, 01 Aug 2016 14:29:20 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 558408db-d0ec-44dc-b7ea-29e1cf26e1eb
+      - f5d49589-2747-48cc-a634-2cc98c0b33dd
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
       Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '12'
+      - '8'
       Content-Type:
       - application/vnd.vmware.vcloud.orglist+xml;version=5.1
       Vary:
@@ -89,7 +89,7 @@ http_interactions:
             <Org href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
         </OrgList>
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:08 GMT
+  recorded_at: Mon, 01 Aug 2016 14:29:45 GMT
 - request:
     method: get
     uri: https://VMWARE_CLOUD_HOST/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3
@@ -102,22 +102,22 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Tue, 26 Jul 2016 11:20:47 GMT
+      - Mon, 01 Aug 2016 14:29:21 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 08ab5a27-f2a4-42dd-9c45-1a8d179e56c2
+      - 5889cfa9-e4a8-445e-b675-475be3352650
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
       Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '95'
+      - '68'
       Content-Type:
       - application/vnd.vmware.vcloud.org+xml;version=5.1
       Vary:
@@ -142,7 +142,7 @@ http_interactions:
             <FullName>Testers we ARE</FullName>
         </Org>
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:08 GMT
+  recorded_at: Mon, 01 Aug 2016 14:29:46 GMT
 - request:
     method: get
     uri: https://VMWARE_CLOUD_HOST/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865
@@ -155,28 +155,28 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Tue, 26 Jul 2016 11:20:47 GMT
+      - Mon, 01 Aug 2016 14:29:22 GMT
       X-Vmware-Vcloud-Request-Id:
-      - f080f93e-8bbc-42a9-8484-03252f9cd9e0
+      - e5831331-ab77-471b-ad17-06c4ea860440
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
       Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '299'
+      - '67'
       Content-Type:
       - application/vnd.vmware.vcloud.vdc+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '5407'
+      - '5958'
     body:
       encoding: UTF-8
       string: |
@@ -214,14 +214,17 @@ http_interactions:
                     <Allocated>0</Allocated>
                     <Limit>4096</Limit>
                     <Reserved>0</Reserved>
-                    <Used>1024</Used>
-                    <Overhead>40</Overhead>
+                    <Used>256</Used>
+                    <Overhead>31</Overhead>
                 </Memory>
             </ComputeCapacity>
             <ResourceEntities>
-                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-45960e96-d7f3-4273-9ca8-4261fbf6e6b0" name="vApp_admin_2" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" name="vApp_admin_2" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" name="vApp_admin_3" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" name="vApp_system_5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" name="Tiny01" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-fc4bc4dc-be1e-472e-acf5-914a5b5f08f1" name="vApp_system_7" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://10.30.2.2/api/disk/e455d16d-f65e-49c3-8114-5811ac570465" name="D-linux" type="application/vnd.vmware.vcloud.disk+xml"/>
             </ResourceEntities>
             <AvailableNetworks>
                 <Network href="https://10.30.2.2/api/network/44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected" type="application/vnd.vmware.vcloud.network+xml"/>
@@ -246,10 +249,10 @@ http_interactions:
             </VdcStorageProfiles>
         </Vdc>
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:09 GMT
+  recorded_at: Mon, 01 Aug 2016 14:29:47 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0
     body:
       encoding: US-ASCII
       string: ''
@@ -259,22 +262,22 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Tue, 26 Jul 2016 11:20:48 GMT
+      - Mon, 01 Aug 2016 14:29:22 GMT
       X-Vmware-Vcloud-Request-Id:
-      - ac3212f2-3602-429f-9e7e-f066a57bfaf9
+      - 8de03da1-5273-4829-b6ce-f816ec5bd554
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
       Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '205'
+      - '139'
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       Vary:
@@ -283,160 +286,156 @@ http_interactions:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="true" status="4" name="vApp_admin_2" id="urn:vcloud:vapp:5111b069-3174-45a1-98d1-c1e6e9847414" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOff" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/powerOff"/>
-            <Link rel="power:reboot" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/reboot"/>
-            <Link rel="power:reset" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/reset"/>
-            <Link rel="power:shutdown" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/shutdown"/>
-            <Link rel="power:suspend" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/suspend"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="undeploy" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/99b8b1a9-740e-4882-aa1c-6ef447fe3a40" name="test-direct-connected" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="Tiny01" id="urn:vcloud:vapp:b74cbaa5-0680-4a9b-a623-1335cb62fff0" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
+            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/power/action/powerOn"/>
+            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
             <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/disableDownload"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/ovf" type="text/xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
             <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
                 <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/startupSection/">
+            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="RHEL-7-2gb-1gb" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="TTYLinux" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="test-direct-connected">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="test-direct-connected">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/99b8b1a9-740e-4882-aa1c-6ef447fe3a40/action/reset"/>
-                    <Description/>
+                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="VM Network">
+                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c/action/reset"/>
+                    <Description>The VM Network network</Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>10.30.2.1</Gateway>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
-                                <Dns1>8.8.8.8</Dns1>
-                                <Dns2>8.8.4.4</Dns2>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>10.30.2.51</StartAddress>
-                                        <EndAddress>10.30.2.60</EndAddress>
+                                        <StartAddress>192.168.254.100</StartAddress>
+                                        <EndAddress>192.168.254.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="https://10.30.2.2/api/admin/network/44e44269-2fd3-4764-a071-cd8fe752b88b" id="44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected"/>
-                        <FenceMode>bridged</FenceMode>
+                        <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <DhcpService>
+                                <IsEnabled>false</IsEnabled>
+                                <DefaultLeaseTime>3600</DefaultLeaseTime>
+                                <MaxLeaseTime>7200</MaxLeaseTime>
+                            </DhcpService>
+                        </Features>
                     </Configuration>
-                    <IsDeployed>true</IsDeployed>
+                    <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                 <ovf:Info>Snapshot information section</ovf:Info>
             </SnapshotSection>
-            <DateCreated>2016-07-25T13:45:11.107+02:00</DateCreated>
+            <DateCreated>2016-08-01T14:50:04.300+02:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://10.30.2.2/api/admin/user/17d06c5f-f2fe-4767-8006-ebfa36b12c44" name="system" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="true" status="4" name="RHEL-7-2gb-1gb" id="urn:vcloud:vm:ec7dd6cb-2f33-4c1c-a714-083a032d4a82" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOff" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/powerOff"/>
-                    <Link rel="power:reboot" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/reboot"/>
-                    <Link rel="power:reset" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/reset"/>
-                    <Link rel="power:shutdown" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/shutdown"/>
-                    <Link rel="power:suspend" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/suspend"/>
-                    <Link rel="undeploy" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/screen"/>
-                    <Link rel="screen:acquireTicket" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/screen/action/acquireTicket"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="installVmwareTools" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/installVMwareTools"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/reconfigureVm" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
+                <Vm needsCustomization="true" deployed="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/screen"/>
+                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="upgrade" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/upgradeHardwareVersion"/>
+                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/reconfigureVm" name="TTYLinux" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description>Created by: Mike Laverick
+        Blog: www.mikelaverick.com
+        Twitter: @mike_laverick
+
+        Services Enabled: SSH, FTP, HTTP
+        ROOT Password: password</Description>
                     <Tasks>
-                        <Task cancelRequested="false" endTime="2016-07-25T13:46:52.023+02:00" expiryTime="2016-10-23T13:46:47.730+02:00" operation="Running Virtual Machine RHEL-7-2gb-1gb(ec7dd6cb-2f33-4c1c-a714-083a032d4a82)" operationName="vappDeploy" serviceNamespace="com.vmware.vcloud" startTime="2016-07-25T13:46:47.730+02:00" status="error" name="task" id="urn:vcloud:task:14b1721e-0fd5-4a77-b0ac-5d9fca98c2e9" href="https://10.30.2.2/api/task/14b1721e-0fd5-4a77-b0ac-5d9fca98c2e9" type="application/vnd.vmware.vcloud.task+xml">
-                            <Owner href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                            <Error majorErrorCode="500" message="[ b503e7b8-1d3f-495d-9c52-91c756d4a7b5 ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
-                            <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+                        <Task cancelRequested="false" endTime="2016-08-01T14:52:08.033+02:00" expiryTime="2016-10-30T14:52:03.663+01:00" operation="Running Virtual Machine TTYLinux(f4625547-9bba-4ec9-bcd8-7cb3c5ca0290)" operationName="vappDeploy" serviceNamespace="com.vmware.vcloud" startTime="2016-08-01T14:52:03.663+02:00" status="error" name="task" id="urn:vcloud:task:a34139b4-ac8a-4646-888a-10321a7bedd3" href="https://10.30.2.2/api/task/a34139b4-ac8a-4646-888a-10321a7bedd3" type="application/vnd.vmware.vcloud.task+xml">
+                            <Owner href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" name="TTYLinux" type="application/vnd.vmware.vcloud.vm+xml"/>
+                            <Error majorErrorCode="500" message="[ ec9a97fe-334e-41ce-bf18-0e3a6a6ad57f ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
+                            <User href="https://10.30.2.2/api/admin/user/02c9f8e7-ee85-4a4b-b457-d6ec0d8c21c7" name="system" type="application/vnd.vmware.admin.user+xml"/>
                             <Organization href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
-                            <Details>  [ b503e7b8-1d3f-495d-9c52-91c756d4a7b5 ] Unable to perform this action. Contact your cloud administr...</Details>
-                        </Task>
-                        <Task cancelRequested="false" endTime="2016-07-25T14:20:14.037+02:00" expiryTime="2016-10-23T14:20:09.747+02:00" operation="Running Virtual Machine RHEL-7-2gb-1gb(ec7dd6cb-2f33-4c1c-a714-083a032d4a82)" operationName="vappDeploy" serviceNamespace="com.vmware.vcloud" startTime="2016-07-25T14:20:09.747+02:00" status="error" name="task" id="urn:vcloud:task:2805c06b-6798-4166-b92b-5540e5e010fe" href="https://10.30.2.2/api/task/2805c06b-6798-4166-b92b-5540e5e010fe" type="application/vnd.vmware.vcloud.task+xml">
-                            <Owner href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                            <Error majorErrorCode="500" message="[ 4d95a399-eebe-4975-b00e-de5d27529eb3 ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
-                            <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-                            <Organization href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
-                            <Details>  [ 4d95a399-eebe-4975-b00e-de5d27529eb3 ] Unable to perform this action. Contact your cloud administr...</Details>
+                            <Details>  [ ec9a97fe-334e-41ce-bf18-0e3a6a6ad57f ] Unable to perform this action. Contact your cloud administr...</Details>
                         </Task>
                     </Tasks>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/">
+                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>RHEL-7-2gb-1gb</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
+                            <vssd:VirtualSystemIdentifier>TTYLinux</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:05</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:13</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="POOL" vcloud:ipAddress="10.30.2.52" vcloud:primaryNetworkConnection="true">test-direct-connected</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "test-direct-connected"</rasd:Description>
+                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
+                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
                             <rasd:Description>IDE Controller</rasd:Description>
                             <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>1</rasd:Address>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
                             <rasd:InstanceID>3</rasd:InstanceID>
                             <rasd:ResourceType>5</rasd:ResourceType>
                         </ovf:Item>
@@ -446,20 +445,11 @@ http_interactions:
                             <rasd:Description>CD/DVD Drive</rasd:Description>
                             <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
                             <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:InstanceID>3002</rasd:InstanceID>
                             <rasd:Parent>3</rasd:Parent>
                             <rasd:ResourceType>15</rasd:ResourceType>
                         </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu">
+                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu">
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
                             <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
@@ -468,72 +458,71 @@ http_interactions:
                             <rasd:ResourceType>3</rasd:ResourceType>
                             <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory">
+                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory">
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>1024 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
                             <rasd:InstanceID>5</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
                     </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="80" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel7_64Guest" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/operatingSystemSection/">
+                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="36" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="otherLinuxGuest" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Red Hat Enterprise Linux 7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
                     </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="test-direct-connected">
+                        <NetworkConnection needsCustomization="true" network="VM Network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>10.30.2.52</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:05</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:13</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>ec7dd6cb-2f33-4c1c-a714-083a032d4a82</VirtualMachineId>
+                        <VirtualMachineId>f4625547-9bba-4ec9-bcd8-7cb3c5ca0290</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>RHEL-7-2gb-1gb</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>TTYLinux-001</ComputerName>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/runtimeInfoSection">
+                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/runtimeInfoSection">
                         <ovf:Info>Specifies Runtime info</ovf:Info>
                     </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                         <ovf:Info>Snapshot information section</ovf:Info>
                     </SnapshotSection>
-                    <DateCreated>2016-07-25T13:45:15.057+02:00</DateCreated>
-                    <VAppScopedLocalId>0925daf3-3df8-47b2-9b1a-36dd1322a975</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                    <DateCreated>2016-08-01T14:50:13.840+02:00</DateCreated>
+                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
+                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
                         <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
                         <CpuHotAddEnabled>false</CpuHotAddEnabled>
                     </VmCapabilities>
@@ -542,10 +531,10 @@ http_interactions:
             </Children>
         </VApp>
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:09 GMT
+  recorded_at: Mon, 01 Aug 2016 14:29:48 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-fc4bc4dc-be1e-472e-acf5-914a5b5f08f1
     body:
       encoding: US-ASCII
       string: ''
@@ -555,22 +544,656 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Tue, 26 Jul 2016 11:20:48 GMT
+      - Mon, 01 Aug 2016 14:29:23 GMT
       X-Vmware-Vcloud-Request-Id:
-      - e98fd438-989f-47f2-a775-d2502e0fe601
+      - dac58401-f610-4a3b-ab8e-873687a1c349
       X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
+      - d9f42c1d0d36469aabf58ffc905516d2
       Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '274'
+      - '147'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHAg
+        eG1sbnM9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgeG1s
+        bnM6b3ZmPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUv
+        MSIgeG1sbnM6dnNzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93
+        c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdE
+        YXRhIiB4bWxuczpyYXNkPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93YmVt
+        L3dzY2ltLzEvY2ltLXNjaGVtYS8yL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25T
+        ZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8vd3d3LnZtd2FyZS5jb20v
+        c2NoZW1hL292ZiIgeG1sbnM6b3ZmZW52PSJodHRwOi8vc2NoZW1hcy5kbXRm
+        Lm9yZy9vdmYvZW52aXJvbm1lbnQvMSIgeG1sbnM6eHNpPSJodHRwOi8vd3d3
+        LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgb3ZmRGVzY3JpcHRv
+        clVwbG9hZGVkPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBu
+        YW1lPSJ2QXBwX3N5c3RlbV83IiBpZD0idXJuOnZjbG91ZDp2YXBwOmZjNGJj
+        NGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMSIgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUt
+        YWNmNS05MTRhNWI1ZjA4ZjEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
+        cmUudmNsb3VkLnZBcHAreG1sIiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6
+        Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hl
+        bWFzLmRtdGYub3JnL292Zi9lbnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNk
+        IGh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAu
+        MzAuMi4yL2FwaS92MS41L3NjaGVtYS9tYXN0ZXIueHNkIGh0dHA6Ly93d3cu
+        dm13YXJlLmNvbS9zY2hlbWEvb3ZmIGh0dHA6Ly93d3cudm13YXJlLmNvbS9z
+        Y2hlbWEvb3ZmIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0v
+        MS9jaW0tc2NoZW1hLzIvQ0lNX1Jlc291cmNlQWxsb2NhdGlvblNldHRpbmdE
+        YXRhIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0vMS9jaW0t
+        c2NoZW1hLzIuMjIuMC9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0dGluZ0Rh
+        dGEueHNkIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVu
+        dC8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZlbG9wZS8xL2Rz
+        cDgwMjdfMS4xLjAueHNkIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0v
+        d3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lNX1ZpcnR1YWxTeXN0ZW1TZXR0aW5n
+        RGF0YSBodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93YmVtL3dzY2ltLzEvY2lt
+        LXNjaGVtYS8yLjIyLjAvQ0lNX1ZpcnR1YWxTeXN0ZW1TZXR0aW5nRGF0YS54
+        c2QiPgogICAgPExpbmsgcmVsPSJwb3dlcjpwb3dlck9mZiIgaHJlZj0iaHR0
+        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3
+        MmUtYWNmNS05MTRhNWI1ZjA4ZjEvcG93ZXIvYWN0aW9uL3Bvd2VyT2ZmIi8+
+        CiAgICA8TGluayByZWw9InBvd2VyOnJlYm9vdCIgaHJlZj0iaHR0cHM6Ly8x
+        MC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNm
+        NS05MTRhNWI1ZjA4ZjEvcG93ZXIvYWN0aW9uL3JlYm9vdCIvPgogICAgPExp
+        bmsgcmVsPSJwb3dlcjpyZXNldCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1
+        ZjA4ZjEvcG93ZXIvYWN0aW9uL3Jlc2V0Ii8+CiAgICA8TGluayByZWw9InBv
+        d2VyOnNodXRkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
+        cC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMS9w
+        b3dlci9hY3Rpb24vc2h1dGRvd24iLz4KICAgIDxMaW5rIHJlbD0icG93ZXI6
+        c3VzcGVuZCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
+        cC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1ZjA4ZjEvcG93ZXIv
+        YWN0aW9uL3N1c3BlbmQiLz4KICAgIDxMaW5rIHJlbD0iZGVwbG95IiBocmVm
+        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJl
+        MWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMS9hY3Rpb24vZGVwbG95IiB0eXBl
+        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5kZXBsb3lWQXBwUGFy
+        YW1zK3htbCIvPgogICAgPExpbmsgcmVsPSJ1bmRlcGxveSIgaHJlZj0iaHR0
+        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3
+        MmUtYWNmNS05MTRhNWI1ZjA4ZjEvYWN0aW9uL3VuZGVwbG95IiB0eXBlPSJh
+        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC51bmRlcGxveVZBcHBQYXJh
+        bXMreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8v
+        MTAuMzAuMi4yL2FwaS9uZXR3b3JrLzNiYjk4NDVlLTY1MGEtNDUxZC05ZTJj
+        LTZiZmNjODY3ZDk1MiIgbmFtZT0iVk0gTmV0d29yayIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcE5ldHdvcmsreG1sIi8+CiAg
+        ICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
+        aS92QXBwL3ZhcHAtZmM0YmM0ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYw
+        OGYxL2NvbnRyb2xBY2Nlc3MvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
+        YXJlLnZjbG91ZC5jb250cm9sQWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVs
+        PSJjb250cm9sQWNjZXNzIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhm
+        MS9hY3Rpb24vY29udHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
+        LnZtd2FyZS52Y2xvdWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxMaW5r
+        IHJlbD0idXAiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVk
+        ZTI2YTItNThjOC00NDk0LTgyMWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGlu
+        ayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
+        L3ZhcHAtZmM0YmM0ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxIiB0
+        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwK3htbCIv
+        PgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1
+        YjVmMDhmMS9vd25lciIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQub3duZXIreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtZmM0YmM0ZGMtYmUx
+        ZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxL21ldGFkYXRhIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4KICAg
+        IDxMaW5rIHJlbD0ib3ZmIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhm
+        MS9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9ImRvd24i
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtZmM0YmM0
+        ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxL3Byb2R1Y3RTZWN0aW9u
+        cy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnByb2R1
+        Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxMaW5rIHJlbD0ic25hcHNob3Q6Y3Jl
+        YXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLWZj
+        NGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMS9hY3Rpb24vY3Jl
+        YXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgPERlc2NyaXB0
+        aW9uLz4KICAgIDxMZWFzZVNldHRpbmdzU2VjdGlvbiBocmVmPSJodHRwczov
+        LzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1h
+        Y2Y1LTkxNGE1YjVmMDhmMS9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
+        ZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAgPG92
+        ZjpJbmZvPkxlYXNlIHNldHRpbmdzIHNlY3Rpb248L292ZjpJbmZvPgogICAg
+        ICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1
+        ZjA4ZjEvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlv
+        bi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlvbit4bWwi
+        Lz4KICAgICAgICA8RGVwbG95bWVudExlYXNlSW5TZWNvbmRzPjA8L0RlcGxv
+        eW1lbnRMZWFzZUluU2Vjb25kcz4KICAgICAgICA8U3RvcmFnZUxlYXNlSW5T
+        ZWNvbmRzPjA8L1N0b3JhZ2VMZWFzZUluU2Vjb25kcz4KICAgIDwvTGVhc2VT
+        ZXR0aW5nc1NlY3Rpb24+CiAgICA8b3ZmOlN0YXJ0dXBTZWN0aW9uIHhtbG5z
+        OnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiB2
+        Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuc3Rh
+        cnR1cFNlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4y
+        LjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRh
+        NWI1ZjA4ZjEvc3RhcnR1cFNlY3Rpb24vIj4KICAgICAgICA8b3ZmOkluZm8+
+        VkFwcCBzdGFydHVwIHNlY3Rpb248L292ZjpJbmZvPgogICAgICAgIDxvdmY6
+        SXRlbSBvdmY6aWQ9IkRhbW4gU21hbGwgTGludXgiIG92ZjpvcmRlcj0iMCIg
+        b3ZmOnN0YXJ0QWN0aW9uPSJwb3dlck9uIiBvdmY6c3RhcnREZWxheT0iMCIg
+        b3ZmOnN0b3BBY3Rpb249InBvd2VyT2ZmIiBvdmY6c3RvcERlbGF5PSIwIi8+
+        CiAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkx
+        NGE1YjVmMDhmMS9zdGFydHVwU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9u
+        L3ZuZC52bXdhcmUudmNsb3VkLnN0YXJ0dXBTZWN0aW9uK3htbCIvPgogICAg
+        PC9vdmY6U3RhcnR1cFNlY3Rpb24+CiAgICA8b3ZmOk5ldHdvcmtTZWN0aW9u
+        IHhtbG5zOnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
+        MS41IiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
+        dWQubmV0d29ya1NlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8x
+        MC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNm
+        NS05MTRhNWI1ZjA4ZjEvbmV0d29ya1NlY3Rpb24vIj4KICAgICAgICA8b3Zm
+        OkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+
+        CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJWTSBOZXR3b3JrIj4K
+        ICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUgVk0gTmV0d29yayBu
+        ZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAgPC9vdmY6TmV0d29y
+        az4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAgPE5ldHdvcmtDb25m
+        aWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zh
+        cHAtZmM0YmM0ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxL25ldHdv
+        cmtDb25maWdTZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
+        ZS52Y2xvdWQubmV0d29ya0NvbmZpZ1NlY3Rpb24reG1sIiBvdmY6cmVxdWly
+        ZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOkluZm8+VGhlIGNvbmZpZ3VyYXRp
+        b24gcGFyYW1ldGVycyBmb3IgbG9naWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+
+        CiAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkx
+        NGE1YjVmMDhmMS9uZXR3b3JrQ29uZmlnU2VjdGlvbi8iIHR5cGU9ImFwcGxp
+        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtDb25maWdTZWN0aW9u
+        K3htbCIvPgogICAgICAgIDxOZXR3b3JrQ29uZmlnIG5ldHdvcmtOYW1lPSJW
+        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPExpbmsgcmVsPSJyZXBhaXIiIGhy
+        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS9hZG1pbi9uZXR3b3JrLzNiYjk4
+        NDVlLTY1MGEtNDUxZC05ZTJjLTZiZmNjODY3ZDk1Mi9hY3Rpb24vcmVzZXQi
+        Lz4KICAgICAgICAgICAgPERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5l
+        dHdvcms8L0Rlc2NyaXB0aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlv
+        bj4KICAgICAgICAgICAgICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAg
+        ICAgICA8SXBTY29wZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5o
+        ZXJpdGVkPmZhbHNlPC9Jc0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAg
+        ICAgICAgPEdhdGV3YXk+MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAg
+        ICAgICAgICAgICAgICAgICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0
+        bWFzaz4KICAgICAgICAgICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVl
+        PC9Jc0VuYWJsZWQ+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdl
+        cz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAg
+        ICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTky
+        LjE2OC4yNTQuMTAwPC9TdGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAg
+        ICAgICAgICAgICAgICAgPEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9F
+        bmRBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJh
+        bmdlPgogICAgICAgICAgICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAg
+        ICAgICAgICAgICAgICAgIDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwv
+        SXBTY29wZXM+CiAgICAgICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVk
+        PC9GZW5jZU1vZGU+CiAgICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fj
+        cm9zc0RlcGxveW1lbnRzPmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVw
+        bG95bWVudHM+CiAgICAgICAgICAgICAgICA8RmVhdHVyZXM+CiAgICAgICAg
+        ICAgICAgICAgICAgPERoY3BTZXJ2aWNlPgogICAgICAgICAgICAgICAgICAg
+        ICAgICA8SXNFbmFibGVkPmZhbHNlPC9Jc0VuYWJsZWQ+CiAgICAgICAgICAg
+        ICAgICAgICAgICAgIDxEZWZhdWx0TGVhc2VUaW1lPjM2MDA8L0RlZmF1bHRM
+        ZWFzZVRpbWU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxNYXhMZWFzZVRp
+        bWU+NzIwMDwvTWF4TGVhc2VUaW1lPgogICAgICAgICAgICAgICAgICAgIDwv
+        RGhjcFNlcnZpY2U+CiAgICAgICAgICAgICAgICA8L0ZlYXR1cmVzPgogICAg
+        ICAgICAgICA8L0NvbmZpZ3VyYXRpb24+CiAgICAgICAgICAgIDxJc0RlcGxv
+        eWVkPnRydWU8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
+        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxTbmFwc2hvdFNl
+        Y3Rpb24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1m
+        YzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1ZjA4ZjEvc25hcHNob3RT
+        ZWN0aW9uIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5z
+        bmFwc2hvdFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAg
+        ICAgICA8b3ZmOkluZm8+U25hcHNob3QgaW5mb3JtYXRpb24gc2VjdGlvbjwv
+        b3ZmOkluZm8+CiAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgIDxEYXRlQ3Jl
+        YXRlZD4yMDE2LTA4LTAxVDE0OjE1OjA1LjcwNyswMjowMDwvRGF0ZUNyZWF0
+        ZWQ+CiAgICA8T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQub3duZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczov
+        LzEwLjMwLjIuMi9hcGkvYWRtaW4vdXNlci8xN2QwNmM1Zi1mMmZlLTQ3Njct
+        ODAwNi1lYmZhMzZiMTJjNDQiIG5hbWU9InN5c3RlbSIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS5hZG1pbi51c2VyK3htbCIvPgogICAgPC9Pd25l
+        cj4KICAgIDxJbk1haW50ZW5hbmNlTW9kZT5mYWxzZTwvSW5NYWludGVuYW5j
+        ZU1vZGU+CiAgICA8Q2hpbGRyZW4+CiAgICAgICAgPFZtIG5lZWRzQ3VzdG9t
+        aXphdGlvbj0idHJ1ZSIgZGVwbG95ZWQ9InRydWUiIHN0YXR1cz0iNCIgbmFt
+        ZT0iRGFtbiBTbWFsbCBMaW51eCIgaWQ9InVybjp2Y2xvdWQ6dm06MDdmZTA0
+        OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0IiBocmVmPSJodHRwczov
+        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEy
+        ZC1jZDcxZjQzMjkxYTQiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnZtK3htbCI+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6
+        cG93ZXJPZmYiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
+        LTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9h
+        Y3Rpb24vcG93ZXJPZmYiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dl
+        cjpyZWJvb3QiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
+        LTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9h
+        Y3Rpb24vcmVib290Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6
+        cmVzZXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9hY3Rp
+        b24vcmVzZXQiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzaHV0
+        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdm
+        ZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L3Bvd2VyL2FjdGlv
+        bi9zaHV0ZG93biIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnN1
+        c3BlbmQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9hY3Rp
+        b24vc3VzcGVuZCIvPgogICAgICAgICAgICA8TGluayByZWw9InVuZGVwbG95
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvYWN0aW9uL3VuZGVwbG95
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC51bmRlcGxv
+        eVZBcHBQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0
+        OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0IiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiLz4KICAgICAgICAgICAg
+        PExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQv
+        bWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
+        Lm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9ImRvd24i
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkz
+        LWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wcm9kdWN0U2VjdGlvbnMv
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5wcm9kdWN0
+        U2VjdGlvbnMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0ic2NyZWVu
+        OnRodW1ibmFpbCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAv
+        dm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L3NjcmVl
+        biIvPgogICAgICAgICAgICA8TGluayByZWw9InNjcmVlbjphY3F1aXJlVGlj
+        a2V0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2Zl
+        MDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvc2NyZWVuL2FjdGlv
+        bi9hY3F1aXJlVGlja2V0Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0ibWVk
+        aWE6aW5zZXJ0TWVkaWEiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
+        QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9t
+        ZWRpYS9hY3Rpb24vaW5zZXJ0TWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
+        ZC52bXdhcmUudmNsb3VkLm1lZGlhSW5zZXJ0T3JFamVjdFBhcmFtcyt4bWwi
+        Lz4KICAgICAgICAgICAgPExpbmsgcmVsPSJtZWRpYTplamVjdE1lZGlhIiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1k
+        YmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvbWVkaWEvYWN0aW9uL2VqZWN0
+        TWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm1l
+        ZGlhSW5zZXJ0T3JFamVjdFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExp
+        bmsgcmVsPSJkaXNrOmF0dGFjaCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5
+        MWE0L2Rpc2svYWN0aW9uL2F0dGFjaCIgdHlwZT0iYXBwbGljYXRpb24vdm5k
+        LnZtd2FyZS52Y2xvdWQuZGlza0F0dGFjaE9yRGV0YWNoUGFyYW1zK3htbCIv
+        PgogICAgICAgICAgICA8TGluayByZWw9ImRpc2s6ZGV0YWNoIiBocmVmPSJo
+        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1
+        M2ItOGEyZC1jZDcxZjQzMjkxYTQvZGlzay9hY3Rpb24vZGV0YWNoIiB0eXBl
+        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5kaXNrQXR0YWNoT3JE
+        ZXRhY2hQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iaW5z
+        dGFsbFZtd2FyZVRvb2xzIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQv
+        YWN0aW9uL2luc3RhbGxWTXdhcmVUb29scyIvPgogICAgICAgICAgICA8TGlu
+        ayByZWw9InNuYXBzaG90OmNyZWF0ZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
+        LjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0
+        MzI5MWE0L2FjdGlvbi9jcmVhdGVTbmFwc2hvdCIgdHlwZT0iYXBwbGljYXRp
+        b24vdm5kLnZtd2FyZS52Y2xvdWQuY3JlYXRlU25hcHNob3RQYXJhbXMreG1s
+        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icmVjb25maWd1cmVWbSIgaHJl
+        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJj
+        YS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L2FjdGlvbi9yZWNvbmZpZ3VyZVZt
+        IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC52bSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
+        cmVsPSJ1cCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
+        cC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1ZjA4ZjEiIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZBcHAreG1sIi8+CiAg
+        ICAgICAgICAgIDxEZXNjcmlwdGlvbj5J4oCZdmUgY3JlYXRlZCBhbiBPVkYg
+        dmVyc2lvbiBvZiB0aGUgaGlnaGx5IHBvcHVsYXIgRGFtbiBTbWFsbCBMaW51
+        eCBkaXN0cmlidXRpb24uIE5vcm1hbGx5IHlvdSBydW4gdGhpcyBPUyB3aGlj
+        aCBpcyBvbmx5IDUwTUJzIGluIGRpc2sgc2l6ZSBmcm9tIGFuIElTTyBvciBw
+        ZW4gZHJpdmUgYnV0IEnigJl2ZSBzZWVuIG1vcmUgYW5kIG1vcmUgcGVvcGxl
+        IGV4cGVyaW1lbnRpbmcgd2l0aCB0aGUgdkNsb3VkIERpcmVjdG9yIGFuZCBy
+        ZWFsbHkgbmVlZCBzbzwvRGVzY3JpcHRpb24+CiAgICAgICAgICAgIDxUYXNr
+        cz4KICAgICAgICAgICAgICAgIDxUYXNrIGNhbmNlbFJlcXVlc3RlZD0iZmFs
+        c2UiIGVuZFRpbWU9IjIwMTYtMDgtMDFUMTQ6MTY6MDQuMTAzKzAyOjAwIiBl
+        eHBpcnlUaW1lPSIyMDE2LTEwLTMwVDE0OjE1OjU5Ljg0MCswMTowMCIgb3Bl
+        cmF0aW9uPSJSdW5uaW5nIFZpcnR1YWwgTWFjaGluZSBEYW1uIFNtYWxsIExp
+        bnV4KDA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNCkiIG9w
+        ZXJhdGlvbk5hbWU9InZhcHBEZXBsb3kiIHNlcnZpY2VOYW1lc3BhY2U9ImNv
+        bS52bXdhcmUudmNsb3VkIiBzdGFydFRpbWU9IjIwMTYtMDgtMDFUMTQ6MTU6
+        NTkuODQwKzAyOjAwIiBzdGF0dXM9ImVycm9yIiBuYW1lPSJ0YXNrIiBpZD0i
+        dXJuOnZjbG91ZDp0YXNrOjhjMzZjMzNkLTY4YWMtNDRmYS05ZmQ2LWMyMTNj
+        MjUyN2U1ZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3Rhc2svOGMz
+        NmMzM2QtNjhhYy00NGZhLTlmZDYtYzIxM2MyNTI3ZTVlIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC50YXNrK3htbCI+CiAgICAgICAg
+        ICAgICAgICAgICAgPE93bmVyIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
+        aS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFh
+        NCIgbmFtZT0iRGFtbiBTbWFsbCBMaW51eCIgdHlwZT0iYXBwbGljYXRpb24v
+        dm5kLnZtd2FyZS52Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgICAgICAg
+        ICAgPEVycm9yIG1ham9yRXJyb3JDb2RlPSI1MDAiIG1lc3NhZ2U9IlsgMjMy
+        ZmFiODctMDVmNy00YmQwLWE5MDQtZWEzZTQ1NDkxZjIwIF0gVW5hYmxlIHRv
+        IHBlcmZvcm0gdGhpcyBhY3Rpb24uIENvbnRhY3QgeW91ciBjbG91ZCBhZG1p
+        bmlzdHJhdG9yLiIgbWlub3JFcnJvckNvZGU9IklOVEVSTkFMX1NFUlZFUl9F
+        UlJPUiIvPgogICAgICAgICAgICAgICAgICAgIDxVc2VyIGhyZWY9Imh0dHBz
+        Oi8vMTAuMzAuMi4yL2FwaS9hZG1pbi91c2VyLzAyYzlmOGU3LWVlODUtNGE0
+        Yi1iNDU3LWQ2ZWMwZDhjMjFjNyIgbmFtZT0ic3lzdGVtIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICAgICAg
+        ICAgICAgICAgICAgPE9yZ2FuaXphdGlvbiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvb3JnLzQzYjRjMTU5LWYyODAtNGY3OS1hNmM2LTNiMmYyN2Ux
+        NTBjMyIgbmFtZT0idGVzdCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
+        ZS52Y2xvdWQub3JnK3htbCIvPgogICAgICAgICAgICAgICAgICAgIDxEZXRh
+        aWxzPiAgWyAyMzJmYWI4Ny0wNWY3LTRiZDAtYTkwNC1lYTNlNDU0OTFmMjAg
+        XSBVbmFibGUgdG8gcGVyZm9ybSB0aGlzIGFjdGlvbi4gQ29udGFjdCB5b3Vy
+        IGNsb3VkIGFkbWluaXN0ci4uLjwvRGV0YWlscz4KICAgICAgICAgICAgICAg
+        IDwvVGFzaz4KICAgICAgICAgICAgPC9UYXNrcz4KICAgICAgICAgICAgPG92
+        ZjpWaXJ0dWFsSGFyZHdhcmVTZWN0aW9uIHhtbG5zOnZjbG91ZD0iaHR0cDov
+        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBvdmY6dHJhbnNwb3J0PSIi
+        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
+        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBz
+        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04
+        YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uLyI+CiAg
+        ICAgICAgICAgICAgICA8b3ZmOkluZm8+VmlydHVhbCBoYXJkd2FyZSByZXF1
+        aXJlbWVudHM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpTeXN0
+        ZW0+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6RWxlbWVudE5hbWU+Vmly
+        dHVhbCBIYXJkd2FyZSBGYW1pbHk8L3Zzc2Q6RWxlbWVudE5hbWU+CiAgICAg
+        ICAgICAgICAgICAgICAgPHZzc2Q6SW5zdGFuY2VJRD4wPC92c3NkOkluc3Rh
+        bmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3Rl
+        bUlkZW50aWZpZXI+RGFtbiBTbWFsbCBMaW51eDwvdnNzZDpWaXJ0dWFsU3lz
+        dGVtSWRlbnRpZmllcj4KICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0
+        dWFsU3lzdGVtVHlwZT52bXgtMDc8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+
+        CiAgICAgICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAgICAgICAgICAgICAg
+        ICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVz
+        cz4wMDo1MDo1NjowMTowMDoxMDwvcmFzZDpBZGRyZXNzPgogICAgICAgICAg
+        ICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJl
+        c3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBdXRvbWF0
+        aWNBbGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4K
+        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91ZDpp
+        cEFkZHJlc3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtD
+        b25uZWN0aW9uPSJ0cnVlIj5WTSBOZXR3b3JrPC9yYXNkOkNvbm5lY3Rpb24+
+        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+UENOZXQz
+        MiBldGhlcm5ldCBhZGFwdGVyIG9uICJWTSBOZXR3b3JrIjwvcmFzZDpEZXNj
+        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
+        ZT5OZXR3b3JrIGFkYXB0ZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAg
+        ICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjE8L3Jhc2Q6SW5zdGFu
+        Y2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVN1YlR5
+        cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAgICAg
+        ICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291cmNl
+        VHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAg
+        ICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRk
+        cmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJh
+        c2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRp
+        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SURF
+        IENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
+        ICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6SW5zdGFuY2VJRD4K
+        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFz
+        ZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgog
+        ICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAg
+        IDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVu
+        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5IYXJk
+        IGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAg
+        PHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jhc2Q6RWxlbWVudE5h
+        bWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9zdFJlc291cmNlIHZj
+        bG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlwZT0iIiB2Y2xvdWQ6
+        Y2FwYWNpdHk9IjI1NiIvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOklu
+        c3RhbmNlSUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
+        ICAgICAgIDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVudD4KICAgICAgICAg
+        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8L3Jhc2Q6UmVzb3Vy
+        Y2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFu
+        dGl0eT4yNjg0MzU0NTY8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAg
+        ICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eVVuaXRzPmJ5dGU8
+        L3Jhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+CiAgICAgICAgICAgICAgICA8
+        L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAg
+        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3M+MTwvcmFzZDpBZGRyZXNzPgog
+        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPklERSBDb250
+        cm9sbGVyPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAg
+        IDxyYXNkOkVsZW1lbnROYW1lPklERSBDb250cm9sbGVyIDE8L3Jhc2Q6RWxl
+        bWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJ
+        RD4zPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHJh
+        c2Q6UmVzb3VyY2VUeXBlPjU8L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAg
+        ICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRl
+        bT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzT25QYXJlbnQ+
+        MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAgICAgICAgICAgICAgICAg
+        PHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxzZTwvcmFzZDpBdXRvbWF0
+        aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2Ny
+        aXB0aW9uPkNEL0RWRCBEcml2ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAg
+        ICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5DRC9EVkQgRHJpdmUg
+        MTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFz
+        ZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOklu
+        c3RhbmNlSUQ+MzAwMjwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
+        ICAgICAgIDxyYXNkOlBhcmVudD4zPC9yYXNkOlBhcmVudD4KICAgICAgICAg
+        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTU8L3Jhc2Q6UmVzb3Vy
+        Y2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAg
+        ICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpB
+        ZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAg
+        ICAgICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxz
+        ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAg
+        ICAgIDxyYXNkOkRlc2NyaXB0aW9uPkZsb3BweSBEcml2ZTwvcmFzZDpEZXNj
+        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
+        ZT5GbG9wcHkgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAg
+        ICAgICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAg
+        ICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+ODAwMDwvcmFzZDpJbnN0YW5jZUlE
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNDwv
+        cmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVt
+        PgogICAgICAgICAgICAgICAgPG92ZjpJdGVtIHZjbG91ZDp0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiIHZjbG91
+        ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvdmlydHVhbEhhcmR3YXJl
+        U2VjdGlvbi9jcHUiPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFsbG9j
+        YXRpb25Vbml0cz5oZXJ0eiAqIDEwXjY8L3Jhc2Q6QWxsb2NhdGlvblVuaXRz
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk51bWJl
+        ciBvZiBWaXJ0dWFsIENQVXM8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAg
+        ICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+MSB2aXJ0dWFsIENQVShz
+        KTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFz
+        ZDpJbnN0YW5jZUlEPjQ8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAg
+        ICAgICAgICA8cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNkOlJlc2VydmF0aW9u
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4zPC9y
+        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpW
+        aXJ0dWFsUXVhbnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+CiAgICAg
+        ICAgICAgICAgICAgICAgPHJhc2Q6V2VpZ2h0PjA8L3Jhc2Q6V2VpZ2h0Pgog
+        ICAgICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0
+        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNi
+        LThhMmQtY2Q3MWY0MzI5MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vY3B1
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
+        bSt4bWwiLz4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAg
+        ICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3Zu
+        ZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3VkOmhyZWY9Imh0
+        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUz
+        Yi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21l
+        bW9yeSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2NhdGlvblVu
+        aXRzPmJ5dGUgKiAyXjIwPC9yYXNkOkFsbG9jYXRpb25Vbml0cz4KICAgICAg
+        ICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5NZW1vcnkgU2l6ZTwv
+        cmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpF
+        bGVtZW50TmFtZT4yNTYgTUIgb2YgbWVtb3J5PC9yYXNkOkVsZW1lbnROYW1l
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+NTwvcmFz
+        ZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc2Vy
+        dmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAgICAgICAgICAgICAg
+        ICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjQ8L3Jhc2Q6UmVzb3VyY2VUeXBlPgog
+        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eT4yNTY8
+        L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAgICAgICAgICAgIDxy
+        YXNkOldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAgICAgICAgICAgICAg
+        ICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
+        aS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFh
+        NC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAg
+        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPExpbmsg
+        cmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
+        bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvdmlydHVh
+        bEhhcmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
+        cmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIi8+CiAgICAg
+        ICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAu
+        MzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNk
+        NzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+
+        CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBz
+        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04
+        YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIg
+        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
+        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2Et
+        NDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
+        L21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
+        cmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
+        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUw
+        NDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdh
+        cmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
+        ZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGlu
+        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
+        L3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0
+        dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAg
+        ICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcx
+        ZjQzMjkxYTQvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9kaXNrcyIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4
+        bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00
+        NTNiLThhMmQtY2Q3MWY0MzI5MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
+        bWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
+        c2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9
+        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFy
+        ZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0iYXBwbGljYXRpb24v
+        dm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAg
+        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
+        MC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3
+        MWY0MzI5MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbmV0d29ya0NhcmRz
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
+        bXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3du
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvdmlydHVhbEhhcmR3YXJl
+        U2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
+        d2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAg
+        ICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5
+        MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFsUG9ydHMiIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3Qr
+        eG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rp
+        b24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbiB4
+        bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEu
+        NSIgb3ZmOmlkPSI5NSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
+        bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rpb24reG1sIiB2bXc6
+        b3NUeXBlPSJkZWJpYW40R3Vlc3QiIHZjbG91ZDpocmVmPSJodHRwczovLzEw
+        LjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1j
+        ZDcxZjQzMjkxYTQvb3BlcmF0aW5nU3lzdGVtU2VjdGlvbi8iPgogICAgICAg
+        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5nIHN5
+        c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92
+        ZjpEZXNjcmlwdGlvbj5EZWJpYW4gR05VL0xpbnV4IDQgKDMyLWJpdCk8L292
+        ZjpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0
+        OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L29wZXJhdGluZ1N5c3Rl
+        bVNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
+        ZC5vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uK3htbCIvPgogICAgICAgICAgICA8
+        L292ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uPgogICAgICAgICAgICA8TmV0
+        d29ya0Nvbm5lY3Rpb25TZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
+        L2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMy
+        OTFhNC9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rp
+        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAg
+        IDxvdmY6SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3Jr
+        IGNvbm5lY3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmlt
+        YXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nv
+        bm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVj
+        dGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5l
+        dHdvcmsiPgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlv
+        bkluZGV4PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAg
+        ICAgICAgICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAg
+        ICAgICAgICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjEw
+        PC9NQUNBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NB
+        bGxvY2F0aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4K
+        ICAgICAgICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAg
+        ICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAu
+        Mi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFm
+        NDMyOTFhNC9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNl
+        Y3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb25T
+        ZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RDdXN0b21pemF0aW9uU2VjdGlv
+        biBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvZ3Vlc3RDdXN0b21pemF0
+        aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24reG1sIiBvdmY6cmVxdWly
+        ZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVjaWZp
+        ZXMgR3Vlc3QgT1MgQ3VzdG9taXphdGlvbiBTZXR0aW5nczwvb3ZmOkluZm8+
+        CiAgICAgICAgICAgICAgICA8RW5hYmxlZD5mYWxzZTwvRW5hYmxlZD4KICAg
+        ICAgICAgICAgICAgIDxDaGFuZ2VTaWQ+ZmFsc2U8L0NoYW5nZVNpZD4KICAg
+        ICAgICAgICAgICAgIDxWaXJ0dWFsTWFjaGluZUlkPjA3ZmUwNDkzLWRiY2Et
+        NDUzYi04YTJkLWNkNzFmNDMyOTFhNDwvVmlydHVhbE1hY2hpbmVJZD4KICAg
+        ICAgICAgICAgICAgIDxKb2luRG9tYWluRW5hYmxlZD5mYWxzZTwvSm9pbkRv
+        bWFpbkVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8VXNlT3JnU2V0dGluZ3M+
+        ZmFsc2U8L1VzZU9yZ1NldHRpbmdzPgogICAgICAgICAgICAgICAgPEFkbWlu
+        UGFzc3dvcmRFbmFibGVkPnRydWU8L0FkbWluUGFzc3dvcmRFbmFibGVkPgog
+        ICAgICAgICAgICAgICAgPEFkbWluUGFzc3dvcmRBdXRvPnRydWU8L0FkbWlu
+        UGFzc3dvcmRBdXRvPgogICAgICAgICAgICAgICAgPFJlc2V0UGFzc3dvcmRS
+        ZXF1aXJlZD5mYWxzZTwvUmVzZXRQYXNzd29yZFJlcXVpcmVkPgogICAgICAg
+        ICAgICAgICAgPENvbXB1dGVyTmFtZT5EYW1uU21hbGxMaS0wMDE8L0NvbXB1
+        dGVyTmFtZT4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJl
+        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJj
+        YS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L2d1ZXN0Q3VzdG9taXphdGlvblNl
+        Y3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5n
+        dWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIvPgogICAgICAgICAgICA8
+        L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxSdW50
+        aW1lSW5mb1NlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2Fy
+        ZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC52aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIg
+        dmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9ydW50aW1lSW5m
+        b1NlY3Rpb24iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmll
+        cyBSdW50aW1lIGluZm88L292ZjpJbmZvPgogICAgICAgICAgICA8L1J1bnRp
+        bWVJbmZvU2VjdGlvbj4KICAgICAgICAgICAgPFNuYXBzaG90U2VjdGlvbiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1k
+        YmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvc25hcHNob3RTZWN0aW9uIiB0
+        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zbmFwc2hvdFNl
+        Y3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAg
+        ICAgIDxvdmY6SW5mbz5TbmFwc2hvdCBpbmZvcm1hdGlvbiBzZWN0aW9uPC9v
+        dmY6SW5mbz4KICAgICAgICAgICAgPC9TbmFwc2hvdFNlY3Rpb24+CiAgICAg
+        ICAgICAgIDxEYXRlQ3JlYXRlZD4yMDE2LTA4LTAxVDE0OjE1OjE0LjA2MCsw
+        MjowMDwvRGF0ZUNyZWF0ZWQ+CiAgICAgICAgICAgIDxWQXBwU2NvcGVkTG9j
+        YWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVkTG9jYWxJZD4KICAg
+        ICAgICAgICAgPG92ZmVudjpFbnZpcm9ubWVudCB4bWxuczpuczExPSJodHRw
+        Oi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgb3ZmZW52OmlkPSIi
+        IG5zMTE6dkNlbnRlcklkPSJ2bS03NiI+CiAgICAgICAgICAgICAgICA8b3Zm
+        ZW52OlBsYXRmb3JtU2VjdGlvbj4KICAgICAgICAgICAgICAgICAgICA8b3Zm
+        ZW52OktpbmQ+Vk13YXJlIEVTWGk8L292ZmVudjpLaW5kPgogICAgICAgICAg
+        ICAgICAgICAgIDxvdmZlbnY6VmVyc2lvbj42LjAuMDwvb3ZmZW52OlZlcnNp
+        b24+CiAgICAgICAgICAgICAgICAgICAgPG92ZmVudjpWZW5kb3I+Vk13YXJl
+        LCBJbmMuPC9vdmZlbnY6VmVuZG9yPgogICAgICAgICAgICAgICAgICAgIDxv
+        dmZlbnY6TG9jYWxlPmVuPC9vdmZlbnY6TG9jYWxlPgogICAgICAgICAgICAg
+        ICAgPC9vdmZlbnY6UGxhdGZvcm1TZWN0aW9uPgogICAgICAgICAgICAgICAg
+        PHZlOkV0aGVybmV0QWRhcHRlclNlY3Rpb24geG1sbnM6dmU9Imh0dHA6Ly93
+        d3cudm13YXJlLmNvbS9zY2hlbWEvb3ZmZW52IiB4bWxucz0iaHR0cDovL3Nj
+        aGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmlyb25tZW50LzEiIHhtbG5zOm9lPSJo
+        dHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52aXJvbm1lbnQvMSI+CiAg
+        ICAgICAgICAgICAgICAgICAgPHZlOkFkYXB0ZXIgdmU6bWFjPSIwMDo1MDo1
+        NjowMTowMDoxMCIgdmU6bmV0d29yaz0iZHZzLlZDRFZTVk0gTmV0d29yay0z
+        MTM2MmE2ZC0wZTU2LTQwM2MtYjMwMy1jM2M2NjMyZWI5YjEiIHZlOnVuaXRO
+        dW1iZXI9IjciLz4KICAgCiAgICAgICAgICAgICAgICA8L3ZlOkV0aGVybmV0
+        QWRhcHRlclNlY3Rpb24+CiAgICAgICAgICAgIDwvb3ZmZW52OkVudmlyb25t
+        ZW50PgogICAgICAgICAgICA8Vm1DYXBhYmlsaXRpZXMgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThh
+        MmQtY2Q3MWY0MzI5MWE0L3ZtQ2FwYWJpbGl0aWVzLyIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRpZXNTZWN0aW9u
+        K3htbCI+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2Et
+        NDUzYi04YTJkLWNkNzFmNDMyOTFhNC92bUNhcGFiaWxpdGllcy8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2FwYWJpbGl0aWVz
+        U2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgICAgIDxNZW1vcnlIb3RBZGRF
+        bmFibGVkPmZhbHNlPC9NZW1vcnlIb3RBZGRFbmFibGVkPgogICAgICAgICAg
+        ICAgICAgPENwdUhvdEFkZEVuYWJsZWQ+ZmFsc2U8L0NwdUhvdEFkZEVuYWJs
+        ZWQ+CiAgICAgICAgICAgIDwvVm1DYXBhYmlsaXRpZXM+CiAgICAgICAgICAg
+        IDxTdG9yYWdlUHJvZmlsZSBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dmRjU3RvcmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2Qy
+        NTgyNTFlYThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
+        YXJlLnZjbG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgICAgICA8
+        L1ZtPgogICAgPC9DaGlsZHJlbj4KPC9WQXBwPgo=
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:48 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:24 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - ea2dc680-535c-4226-bd51-7868b945e8fc
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '116'
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       Vary:
@@ -579,50 +1202,1328 @@ http_interactions:
       encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="10" name="vApp_admin_3" id="urn:vcloud:vapp:bfd40328-a383-4b0e-9130-66edd590f4ab" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/power/action/powerOn"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="discardState" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/discardSuspendedState"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/dd98196c-5085-4fcb-b4f7-1a9b19a3365a" name="test-direct-connected" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="Tiny01" id="urn:vcloud:vapp:b74cbaa5-0680-4a9b-a623-1335cb62fff0" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
+            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/power/action/powerOn"/>
+            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
             <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/disableDownload"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/ovf" type="text/xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
             <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
                 <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/startupSection/">
+            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="RHEL-7-2gb-1gb" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <ovf:Item ovf:id="VM02" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="TTYLinux" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="VM Network">
+                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c/action/reset"/>
+                    <Description>The VM Network network</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.254.100</StartAddress>
+                                        <EndAddress>192.168.254.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <DhcpService>
+                                <IsEnabled>false</IsEnabled>
+                                <DefaultLeaseTime>3600</DefaultLeaseTime>
+                                <MaxLeaseTime>7200</MaxLeaseTime>
+                            </DhcpService>
+                        </Features>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                <ovf:Info>Snapshot information section</ovf:Info>
+            </SnapshotSection>
+            <DateCreated>2016-08-01T14:50:04.300+02:00</DateCreated>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://10.30.2.2/api/admin/user/17d06c5f-f2fe-4767-8006-ebfa36b12c44" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <InMaintenanceMode>false</InMaintenanceMode>
+            <Children>
+                <Vm needsCustomization="true" deployed="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/screen"/>
+                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="upgrade" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/upgradeHardwareVersion"/>
+                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/reconfigureVm" name="TTYLinux" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description>Created by: Mike Laverick
+        Blog: www.mikelaverick.com
+        Twitter: @mike_laverick
+
+        Services Enabled: SSH, FTP, HTTP
+        ROOT Password: password</Description>
+                    <Tasks>
+                        <Task cancelRequested="false" endTime="2016-08-01T14:52:08.033+02:00" expiryTime="2016-10-30T14:52:03.663+01:00" operation="Running Virtual Machine TTYLinux(f4625547-9bba-4ec9-bcd8-7cb3c5ca0290)" operationName="vappDeploy" serviceNamespace="com.vmware.vcloud" startTime="2016-08-01T14:52:03.663+02:00" status="error" name="task" id="urn:vcloud:task:a34139b4-ac8a-4646-888a-10321a7bedd3" href="https://10.30.2.2/api/task/a34139b4-ac8a-4646-888a-10321a7bedd3" type="application/vnd.vmware.vcloud.task+xml">
+                            <Owner href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" name="TTYLinux" type="application/vnd.vmware.vcloud.vm+xml"/>
+                            <Error majorErrorCode="500" message="[ ec9a97fe-334e-41ce-bf18-0e3a6a6ad57f ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
+                            <User href="https://10.30.2.2/api/admin/user/02c9f8e7-ee85-4a4b-b457-d6ec0d8c21c7" name="system" type="application/vnd.vmware.admin.user+xml"/>
+                            <Organization href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
+                            <Details>  [ ec9a97fe-334e-41ce-bf18-0e3a6a6ad57f ] Unable to perform this action. Contact your cloud administr...</Details>
+                        </Task>
+                    </Tasks>
+                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:VirtualSystemIdentifier>TTYLinux</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:13</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
+                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>1</rasd:Address>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>3002</rasd:InstanceID>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu">
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory">
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                    </ovf:VirtualHardwareSection>
+                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="36" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="otherLinuxGuest" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                    </ovf:OperatingSystemSection>
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="VM Network">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:13</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                        </NetworkConnection>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>f4625547-9bba-4ec9-bcd8-7cb3c5ca0290</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TTYLinux-001</ComputerName>
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                    </GuestCustomizationSection>
+                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/runtimeInfoSection">
+                        <ovf:Info>Specifies Runtime info</ovf:Info>
+                    </RuntimeInfoSection>
+                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                        <ovf:Info>Snapshot information section</ovf:Info>
+                    </SnapshotSection>
+                    <DateCreated>2016-08-01T14:50:13.840+02:00</DateCreated>
+                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
+                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                    </VmCapabilities>
+                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                </Vm>
+            </Children>
+        </VApp>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:49 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-fc4bc4dc-be1e-472e-acf5-914a5b5f08f1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:25 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 826270a0-05da-4f81-b851-ac5031a3bc05
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '164'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHAg
+        eG1sbnM9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgeG1s
+        bnM6b3ZmPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUv
+        MSIgeG1sbnM6dnNzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93
+        c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdE
+        YXRhIiB4bWxuczpyYXNkPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93YmVt
+        L3dzY2ltLzEvY2ltLXNjaGVtYS8yL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25T
+        ZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8vd3d3LnZtd2FyZS5jb20v
+        c2NoZW1hL292ZiIgeG1sbnM6b3ZmZW52PSJodHRwOi8vc2NoZW1hcy5kbXRm
+        Lm9yZy9vdmYvZW52aXJvbm1lbnQvMSIgeG1sbnM6eHNpPSJodHRwOi8vd3d3
+        LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgb3ZmRGVzY3JpcHRv
+        clVwbG9hZGVkPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBu
+        YW1lPSJ2QXBwX3N5c3RlbV83IiBpZD0idXJuOnZjbG91ZDp2YXBwOmZjNGJj
+        NGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMSIgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUt
+        YWNmNS05MTRhNWI1ZjA4ZjEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
+        cmUudmNsb3VkLnZBcHAreG1sIiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6
+        Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hl
+        bWFzLmRtdGYub3JnL292Zi9lbnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNk
+        IGh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAu
+        MzAuMi4yL2FwaS92MS41L3NjaGVtYS9tYXN0ZXIueHNkIGh0dHA6Ly93d3cu
+        dm13YXJlLmNvbS9zY2hlbWEvb3ZmIGh0dHA6Ly93d3cudm13YXJlLmNvbS9z
+        Y2hlbWEvb3ZmIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0v
+        MS9jaW0tc2NoZW1hLzIvQ0lNX1Jlc291cmNlQWxsb2NhdGlvblNldHRpbmdE
+        YXRhIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0vMS9jaW0t
+        c2NoZW1hLzIuMjIuMC9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0dGluZ0Rh
+        dGEueHNkIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVu
+        dC8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZlbG9wZS8xL2Rz
+        cDgwMjdfMS4xLjAueHNkIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0v
+        d3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lNX1ZpcnR1YWxTeXN0ZW1TZXR0aW5n
+        RGF0YSBodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93YmVtL3dzY2ltLzEvY2lt
+        LXNjaGVtYS8yLjIyLjAvQ0lNX1ZpcnR1YWxTeXN0ZW1TZXR0aW5nRGF0YS54
+        c2QiPgogICAgPExpbmsgcmVsPSJwb3dlcjpwb3dlck9mZiIgaHJlZj0iaHR0
+        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3
+        MmUtYWNmNS05MTRhNWI1ZjA4ZjEvcG93ZXIvYWN0aW9uL3Bvd2VyT2ZmIi8+
+        CiAgICA8TGluayByZWw9InBvd2VyOnJlYm9vdCIgaHJlZj0iaHR0cHM6Ly8x
+        MC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNm
+        NS05MTRhNWI1ZjA4ZjEvcG93ZXIvYWN0aW9uL3JlYm9vdCIvPgogICAgPExp
+        bmsgcmVsPSJwb3dlcjpyZXNldCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1
+        ZjA4ZjEvcG93ZXIvYWN0aW9uL3Jlc2V0Ii8+CiAgICA8TGluayByZWw9InBv
+        d2VyOnNodXRkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
+        cC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMS9w
+        b3dlci9hY3Rpb24vc2h1dGRvd24iLz4KICAgIDxMaW5rIHJlbD0icG93ZXI6
+        c3VzcGVuZCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
+        cC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1ZjA4ZjEvcG93ZXIv
+        YWN0aW9uL3N1c3BlbmQiLz4KICAgIDxMaW5rIHJlbD0iZGVwbG95IiBocmVm
+        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJl
+        MWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMS9hY3Rpb24vZGVwbG95IiB0eXBl
+        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5kZXBsb3lWQXBwUGFy
+        YW1zK3htbCIvPgogICAgPExpbmsgcmVsPSJ1bmRlcGxveSIgaHJlZj0iaHR0
+        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3
+        MmUtYWNmNS05MTRhNWI1ZjA4ZjEvYWN0aW9uL3VuZGVwbG95IiB0eXBlPSJh
+        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC51bmRlcGxveVZBcHBQYXJh
+        bXMreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8v
+        MTAuMzAuMi4yL2FwaS9uZXR3b3JrLzNiYjk4NDVlLTY1MGEtNDUxZC05ZTJj
+        LTZiZmNjODY3ZDk1MiIgbmFtZT0iVk0gTmV0d29yayIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcE5ldHdvcmsreG1sIi8+CiAg
+        ICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
+        aS92QXBwL3ZhcHAtZmM0YmM0ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYw
+        OGYxL2NvbnRyb2xBY2Nlc3MvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
+        YXJlLnZjbG91ZC5jb250cm9sQWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVs
+        PSJjb250cm9sQWNjZXNzIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhm
+        MS9hY3Rpb24vY29udHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
+        LnZtd2FyZS52Y2xvdWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxMaW5r
+        IHJlbD0idXAiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVk
+        ZTI2YTItNThjOC00NDk0LTgyMWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGlu
+        ayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
+        L3ZhcHAtZmM0YmM0ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxIiB0
+        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwK3htbCIv
+        PgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1
+        YjVmMDhmMS9vd25lciIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQub3duZXIreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtZmM0YmM0ZGMtYmUx
+        ZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxL21ldGFkYXRhIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4KICAg
+        IDxMaW5rIHJlbD0ib3ZmIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhm
+        MS9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9ImRvd24i
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtZmM0YmM0
+        ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxL3Byb2R1Y3RTZWN0aW9u
+        cy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnByb2R1
+        Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxMaW5rIHJlbD0ic25hcHNob3Q6Y3Jl
+        YXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLWZj
+        NGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkxNGE1YjVmMDhmMS9hY3Rpb24vY3Jl
+        YXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgPERlc2NyaXB0
+        aW9uLz4KICAgIDxMZWFzZVNldHRpbmdzU2VjdGlvbiBocmVmPSJodHRwczov
+        LzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1h
+        Y2Y1LTkxNGE1YjVmMDhmMS9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
+        ZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAgPG92
+        ZjpJbmZvPkxlYXNlIHNldHRpbmdzIHNlY3Rpb248L292ZjpJbmZvPgogICAg
+        ICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1
+        ZjA4ZjEvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlv
+        bi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlvbit4bWwi
+        Lz4KICAgICAgICA8RGVwbG95bWVudExlYXNlSW5TZWNvbmRzPjA8L0RlcGxv
+        eW1lbnRMZWFzZUluU2Vjb25kcz4KICAgICAgICA8U3RvcmFnZUxlYXNlSW5T
+        ZWNvbmRzPjA8L1N0b3JhZ2VMZWFzZUluU2Vjb25kcz4KICAgIDwvTGVhc2VT
+        ZXR0aW5nc1NlY3Rpb24+CiAgICA8b3ZmOlN0YXJ0dXBTZWN0aW9uIHhtbG5z
+        OnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiB2
+        Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuc3Rh
+        cnR1cFNlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4y
+        LjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRh
+        NWI1ZjA4ZjEvc3RhcnR1cFNlY3Rpb24vIj4KICAgICAgICA8b3ZmOkluZm8+
+        VkFwcCBzdGFydHVwIHNlY3Rpb248L292ZjpJbmZvPgogICAgICAgIDxvdmY6
+        SXRlbSBvdmY6aWQ9IkRhbW4gU21hbGwgTGludXgiIG92ZjpvcmRlcj0iMCIg
+        b3ZmOnN0YXJ0QWN0aW9uPSJwb3dlck9uIiBvdmY6c3RhcnREZWxheT0iMCIg
+        b3ZmOnN0b3BBY3Rpb249InBvd2VyT2ZmIiBvdmY6c3RvcERlbGF5PSIwIi8+
+        CiAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkx
+        NGE1YjVmMDhmMS9zdGFydHVwU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9u
+        L3ZuZC52bXdhcmUudmNsb3VkLnN0YXJ0dXBTZWN0aW9uK3htbCIvPgogICAg
+        PC9vdmY6U3RhcnR1cFNlY3Rpb24+CiAgICA8b3ZmOk5ldHdvcmtTZWN0aW9u
+        IHhtbG5zOnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
+        MS41IiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
+        dWQubmV0d29ya1NlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8x
+        MC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNm
+        NS05MTRhNWI1ZjA4ZjEvbmV0d29ya1NlY3Rpb24vIj4KICAgICAgICA8b3Zm
+        OkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+
+        CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJWTSBOZXR3b3JrIj4K
+        ICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUgVk0gTmV0d29yayBu
+        ZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAgPC9vdmY6TmV0d29y
+        az4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAgPE5ldHdvcmtDb25m
+        aWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zh
+        cHAtZmM0YmM0ZGMtYmUxZS00NzJlLWFjZjUtOTE0YTViNWYwOGYxL25ldHdv
+        cmtDb25maWdTZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
+        ZS52Y2xvdWQubmV0d29ya0NvbmZpZ1NlY3Rpb24reG1sIiBvdmY6cmVxdWly
+        ZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOkluZm8+VGhlIGNvbmZpZ3VyYXRp
+        b24gcGFyYW1ldGVycyBmb3IgbG9naWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+
+        CiAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcC92YXBwLWZjNGJjNGRjLWJlMWUtNDcyZS1hY2Y1LTkx
+        NGE1YjVmMDhmMS9uZXR3b3JrQ29uZmlnU2VjdGlvbi8iIHR5cGU9ImFwcGxp
+        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtDb25maWdTZWN0aW9u
+        K3htbCIvPgogICAgICAgIDxOZXR3b3JrQ29uZmlnIG5ldHdvcmtOYW1lPSJW
+        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPExpbmsgcmVsPSJyZXBhaXIiIGhy
+        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS9hZG1pbi9uZXR3b3JrLzNiYjk4
+        NDVlLTY1MGEtNDUxZC05ZTJjLTZiZmNjODY3ZDk1Mi9hY3Rpb24vcmVzZXQi
+        Lz4KICAgICAgICAgICAgPERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5l
+        dHdvcms8L0Rlc2NyaXB0aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlv
+        bj4KICAgICAgICAgICAgICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAg
+        ICAgICA8SXBTY29wZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5o
+        ZXJpdGVkPmZhbHNlPC9Jc0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAg
+        ICAgICAgPEdhdGV3YXk+MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAg
+        ICAgICAgICAgICAgICAgICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0
+        bWFzaz4KICAgICAgICAgICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVl
+        PC9Jc0VuYWJsZWQ+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdl
+        cz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAg
+        ICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTky
+        LjE2OC4yNTQuMTAwPC9TdGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAg
+        ICAgICAgICAgICAgICAgPEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9F
+        bmRBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJh
+        bmdlPgogICAgICAgICAgICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAg
+        ICAgICAgICAgICAgICAgIDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwv
+        SXBTY29wZXM+CiAgICAgICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVk
+        PC9GZW5jZU1vZGU+CiAgICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fj
+        cm9zc0RlcGxveW1lbnRzPmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVw
+        bG95bWVudHM+CiAgICAgICAgICAgICAgICA8RmVhdHVyZXM+CiAgICAgICAg
+        ICAgICAgICAgICAgPERoY3BTZXJ2aWNlPgogICAgICAgICAgICAgICAgICAg
+        ICAgICA8SXNFbmFibGVkPmZhbHNlPC9Jc0VuYWJsZWQ+CiAgICAgICAgICAg
+        ICAgICAgICAgICAgIDxEZWZhdWx0TGVhc2VUaW1lPjM2MDA8L0RlZmF1bHRM
+        ZWFzZVRpbWU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxNYXhMZWFzZVRp
+        bWU+NzIwMDwvTWF4TGVhc2VUaW1lPgogICAgICAgICAgICAgICAgICAgIDwv
+        RGhjcFNlcnZpY2U+CiAgICAgICAgICAgICAgICA8L0ZlYXR1cmVzPgogICAg
+        ICAgICAgICA8L0NvbmZpZ3VyYXRpb24+CiAgICAgICAgICAgIDxJc0RlcGxv
+        eWVkPnRydWU8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
+        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxTbmFwc2hvdFNl
+        Y3Rpb24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC1m
+        YzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1ZjA4ZjEvc25hcHNob3RT
+        ZWN0aW9uIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5z
+        bmFwc2hvdFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAg
+        ICAgICA8b3ZmOkluZm8+U25hcHNob3QgaW5mb3JtYXRpb24gc2VjdGlvbjwv
+        b3ZmOkluZm8+CiAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgIDxEYXRlQ3Jl
+        YXRlZD4yMDE2LTA4LTAxVDE0OjE1OjA1LjcwNyswMjowMDwvRGF0ZUNyZWF0
+        ZWQ+CiAgICA8T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQub3duZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczov
+        LzEwLjMwLjIuMi9hcGkvYWRtaW4vdXNlci8xN2QwNmM1Zi1mMmZlLTQ3Njct
+        ODAwNi1lYmZhMzZiMTJjNDQiIG5hbWU9InN5c3RlbSIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS5hZG1pbi51c2VyK3htbCIvPgogICAgPC9Pd25l
+        cj4KICAgIDxJbk1haW50ZW5hbmNlTW9kZT5mYWxzZTwvSW5NYWludGVuYW5j
+        ZU1vZGU+CiAgICA8Q2hpbGRyZW4+CiAgICAgICAgPFZtIG5lZWRzQ3VzdG9t
+        aXphdGlvbj0idHJ1ZSIgZGVwbG95ZWQ9InRydWUiIHN0YXR1cz0iNCIgbmFt
+        ZT0iRGFtbiBTbWFsbCBMaW51eCIgaWQ9InVybjp2Y2xvdWQ6dm06MDdmZTA0
+        OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0IiBocmVmPSJodHRwczov
+        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEy
+        ZC1jZDcxZjQzMjkxYTQiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnZtK3htbCI+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6
+        cG93ZXJPZmYiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
+        LTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9h
+        Y3Rpb24vcG93ZXJPZmYiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dl
+        cjpyZWJvb3QiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
+        LTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9h
+        Y3Rpb24vcmVib290Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6
+        cmVzZXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9hY3Rp
+        b24vcmVzZXQiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzaHV0
+        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdm
+        ZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L3Bvd2VyL2FjdGlv
+        bi9zaHV0ZG93biIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnN1
+        c3BlbmQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wb3dlci9hY3Rp
+        b24vc3VzcGVuZCIvPgogICAgICAgICAgICA8TGluayByZWw9InVuZGVwbG95
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvYWN0aW9uL3VuZGVwbG95
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC51bmRlcGxv
+        eVZBcHBQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0
+        OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0IiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiLz4KICAgICAgICAgICAg
+        PExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQv
+        bWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
+        Lm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9ImRvd24i
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkz
+        LWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9wcm9kdWN0U2VjdGlvbnMv
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5wcm9kdWN0
+        U2VjdGlvbnMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0ic2NyZWVu
+        OnRodW1ibmFpbCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAv
+        dm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L3NjcmVl
+        biIvPgogICAgICAgICAgICA8TGluayByZWw9InNjcmVlbjphY3F1aXJlVGlj
+        a2V0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2Zl
+        MDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvc2NyZWVuL2FjdGlv
+        bi9hY3F1aXJlVGlja2V0Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0ibWVk
+        aWE6aW5zZXJ0TWVkaWEiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
+        QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9t
+        ZWRpYS9hY3Rpb24vaW5zZXJ0TWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
+        ZC52bXdhcmUudmNsb3VkLm1lZGlhSW5zZXJ0T3JFamVjdFBhcmFtcyt4bWwi
+        Lz4KICAgICAgICAgICAgPExpbmsgcmVsPSJtZWRpYTplamVjdE1lZGlhIiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1k
+        YmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvbWVkaWEvYWN0aW9uL2VqZWN0
+        TWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm1l
+        ZGlhSW5zZXJ0T3JFamVjdFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExp
+        bmsgcmVsPSJkaXNrOmF0dGFjaCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5
+        MWE0L2Rpc2svYWN0aW9uL2F0dGFjaCIgdHlwZT0iYXBwbGljYXRpb24vdm5k
+        LnZtd2FyZS52Y2xvdWQuZGlza0F0dGFjaE9yRGV0YWNoUGFyYW1zK3htbCIv
+        PgogICAgICAgICAgICA8TGluayByZWw9ImRpc2s6ZGV0YWNoIiBocmVmPSJo
+        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1
+        M2ItOGEyZC1jZDcxZjQzMjkxYTQvZGlzay9hY3Rpb24vZGV0YWNoIiB0eXBl
+        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5kaXNrQXR0YWNoT3JE
+        ZXRhY2hQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iaW5z
+        dGFsbFZtd2FyZVRvb2xzIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQv
+        YWN0aW9uL2luc3RhbGxWTXdhcmVUb29scyIvPgogICAgICAgICAgICA8TGlu
+        ayByZWw9InNuYXBzaG90OmNyZWF0ZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
+        LjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0
+        MzI5MWE0L2FjdGlvbi9jcmVhdGVTbmFwc2hvdCIgdHlwZT0iYXBwbGljYXRp
+        b24vdm5kLnZtd2FyZS52Y2xvdWQuY3JlYXRlU25hcHNob3RQYXJhbXMreG1s
+        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icmVjb25maWd1cmVWbSIgaHJl
+        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJj
+        YS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L2FjdGlvbi9yZWNvbmZpZ3VyZVZt
+        IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC52bSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
+        cmVsPSJ1cCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
+        cC1mYzRiYzRkYy1iZTFlLTQ3MmUtYWNmNS05MTRhNWI1ZjA4ZjEiIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZBcHAreG1sIi8+CiAg
+        ICAgICAgICAgIDxEZXNjcmlwdGlvbj5J4oCZdmUgY3JlYXRlZCBhbiBPVkYg
+        dmVyc2lvbiBvZiB0aGUgaGlnaGx5IHBvcHVsYXIgRGFtbiBTbWFsbCBMaW51
+        eCBkaXN0cmlidXRpb24uIE5vcm1hbGx5IHlvdSBydW4gdGhpcyBPUyB3aGlj
+        aCBpcyBvbmx5IDUwTUJzIGluIGRpc2sgc2l6ZSBmcm9tIGFuIElTTyBvciBw
+        ZW4gZHJpdmUgYnV0IEnigJl2ZSBzZWVuIG1vcmUgYW5kIG1vcmUgcGVvcGxl
+        IGV4cGVyaW1lbnRpbmcgd2l0aCB0aGUgdkNsb3VkIERpcmVjdG9yIGFuZCBy
+        ZWFsbHkgbmVlZCBzbzwvRGVzY3JpcHRpb24+CiAgICAgICAgICAgIDxUYXNr
+        cz4KICAgICAgICAgICAgICAgIDxUYXNrIGNhbmNlbFJlcXVlc3RlZD0iZmFs
+        c2UiIGVuZFRpbWU9IjIwMTYtMDgtMDFUMTQ6MTY6MDQuMTAzKzAyOjAwIiBl
+        eHBpcnlUaW1lPSIyMDE2LTEwLTMwVDE0OjE1OjU5Ljg0MCswMTowMCIgb3Bl
+        cmF0aW9uPSJSdW5uaW5nIFZpcnR1YWwgTWFjaGluZSBEYW1uIFNtYWxsIExp
+        bnV4KDA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNCkiIG9w
+        ZXJhdGlvbk5hbWU9InZhcHBEZXBsb3kiIHNlcnZpY2VOYW1lc3BhY2U9ImNv
+        bS52bXdhcmUudmNsb3VkIiBzdGFydFRpbWU9IjIwMTYtMDgtMDFUMTQ6MTU6
+        NTkuODQwKzAyOjAwIiBzdGF0dXM9ImVycm9yIiBuYW1lPSJ0YXNrIiBpZD0i
+        dXJuOnZjbG91ZDp0YXNrOjhjMzZjMzNkLTY4YWMtNDRmYS05ZmQ2LWMyMTNj
+        MjUyN2U1ZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3Rhc2svOGMz
+        NmMzM2QtNjhhYy00NGZhLTlmZDYtYzIxM2MyNTI3ZTVlIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC50YXNrK3htbCI+CiAgICAgICAg
+        ICAgICAgICAgICAgPE93bmVyIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
+        aS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFh
+        NCIgbmFtZT0iRGFtbiBTbWFsbCBMaW51eCIgdHlwZT0iYXBwbGljYXRpb24v
+        dm5kLnZtd2FyZS52Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgICAgICAg
+        ICAgPEVycm9yIG1ham9yRXJyb3JDb2RlPSI1MDAiIG1lc3NhZ2U9IlsgMjMy
+        ZmFiODctMDVmNy00YmQwLWE5MDQtZWEzZTQ1NDkxZjIwIF0gVW5hYmxlIHRv
+        IHBlcmZvcm0gdGhpcyBhY3Rpb24uIENvbnRhY3QgeW91ciBjbG91ZCBhZG1p
+        bmlzdHJhdG9yLiIgbWlub3JFcnJvckNvZGU9IklOVEVSTkFMX1NFUlZFUl9F
+        UlJPUiIvPgogICAgICAgICAgICAgICAgICAgIDxVc2VyIGhyZWY9Imh0dHBz
+        Oi8vMTAuMzAuMi4yL2FwaS9hZG1pbi91c2VyLzAyYzlmOGU3LWVlODUtNGE0
+        Yi1iNDU3LWQ2ZWMwZDhjMjFjNyIgbmFtZT0ic3lzdGVtIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICAgICAg
+        ICAgICAgICAgICAgPE9yZ2FuaXphdGlvbiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvb3JnLzQzYjRjMTU5LWYyODAtNGY3OS1hNmM2LTNiMmYyN2Ux
+        NTBjMyIgbmFtZT0idGVzdCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
+        ZS52Y2xvdWQub3JnK3htbCIvPgogICAgICAgICAgICAgICAgICAgIDxEZXRh
+        aWxzPiAgWyAyMzJmYWI4Ny0wNWY3LTRiZDAtYTkwNC1lYTNlNDU0OTFmMjAg
+        XSBVbmFibGUgdG8gcGVyZm9ybSB0aGlzIGFjdGlvbi4gQ29udGFjdCB5b3Vy
+        IGNsb3VkIGFkbWluaXN0ci4uLjwvRGV0YWlscz4KICAgICAgICAgICAgICAg
+        IDwvVGFzaz4KICAgICAgICAgICAgPC9UYXNrcz4KICAgICAgICAgICAgPG92
+        ZjpWaXJ0dWFsSGFyZHdhcmVTZWN0aW9uIHhtbG5zOnZjbG91ZD0iaHR0cDov
+        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBvdmY6dHJhbnNwb3J0PSIi
+        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
+        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBz
+        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04
+        YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uLyI+CiAg
+        ICAgICAgICAgICAgICA8b3ZmOkluZm8+VmlydHVhbCBoYXJkd2FyZSByZXF1
+        aXJlbWVudHM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpTeXN0
+        ZW0+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6RWxlbWVudE5hbWU+Vmly
+        dHVhbCBIYXJkd2FyZSBGYW1pbHk8L3Zzc2Q6RWxlbWVudE5hbWU+CiAgICAg
+        ICAgICAgICAgICAgICAgPHZzc2Q6SW5zdGFuY2VJRD4wPC92c3NkOkluc3Rh
+        bmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3Rl
+        bUlkZW50aWZpZXI+RGFtbiBTbWFsbCBMaW51eDwvdnNzZDpWaXJ0dWFsU3lz
+        dGVtSWRlbnRpZmllcj4KICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0
+        dWFsU3lzdGVtVHlwZT52bXgtMDc8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+
+        CiAgICAgICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAgICAgICAgICAgICAg
+        ICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVz
+        cz4wMDo1MDo1NjowMTowMDoxMDwvcmFzZDpBZGRyZXNzPgogICAgICAgICAg
+        ICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJl
+        c3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBdXRvbWF0
+        aWNBbGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4K
+        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91ZDpp
+        cEFkZHJlc3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtD
+        b25uZWN0aW9uPSJ0cnVlIj5WTSBOZXR3b3JrPC9yYXNkOkNvbm5lY3Rpb24+
+        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+UENOZXQz
+        MiBldGhlcm5ldCBhZGFwdGVyIG9uICJWTSBOZXR3b3JrIjwvcmFzZDpEZXNj
+        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
+        ZT5OZXR3b3JrIGFkYXB0ZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAg
+        ICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjE8L3Jhc2Q6SW5zdGFu
+        Y2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVN1YlR5
+        cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAgICAg
+        ICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291cmNl
+        VHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAg
+        ICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRk
+        cmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJh
+        c2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRp
+        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SURF
+        IENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
+        ICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6SW5zdGFuY2VJRD4K
+        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFz
+        ZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgog
+        ICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAg
+        IDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVu
+        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5IYXJk
+        IGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAg
+        PHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jhc2Q6RWxlbWVudE5h
+        bWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9zdFJlc291cmNlIHZj
+        bG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlwZT0iIiB2Y2xvdWQ6
+        Y2FwYWNpdHk9IjI1NiIvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOklu
+        c3RhbmNlSUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
+        ICAgICAgIDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVudD4KICAgICAgICAg
+        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8L3Jhc2Q6UmVzb3Vy
+        Y2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFu
+        dGl0eT4yNjg0MzU0NTY8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAg
+        ICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eVVuaXRzPmJ5dGU8
+        L3Jhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+CiAgICAgICAgICAgICAgICA8
+        L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAg
+        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3M+MTwvcmFzZDpBZGRyZXNzPgog
+        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPklERSBDb250
+        cm9sbGVyPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAg
+        IDxyYXNkOkVsZW1lbnROYW1lPklERSBDb250cm9sbGVyIDE8L3Jhc2Q6RWxl
+        bWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJ
+        RD4zPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHJh
+        c2Q6UmVzb3VyY2VUeXBlPjU8L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAg
+        ICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRl
+        bT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzT25QYXJlbnQ+
+        MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAgICAgICAgICAgICAgICAg
+        PHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxzZTwvcmFzZDpBdXRvbWF0
+        aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2Ny
+        aXB0aW9uPkNEL0RWRCBEcml2ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAg
+        ICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5DRC9EVkQgRHJpdmUg
+        MTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFz
+        ZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOklu
+        c3RhbmNlSUQ+MzAwMjwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
+        ICAgICAgIDxyYXNkOlBhcmVudD4zPC9yYXNkOlBhcmVudD4KICAgICAgICAg
+        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTU8L3Jhc2Q6UmVzb3Vy
+        Y2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAg
+        ICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpB
+        ZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAg
+        ICAgICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxz
+        ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAg
+        ICAgIDxyYXNkOkRlc2NyaXB0aW9uPkZsb3BweSBEcml2ZTwvcmFzZDpEZXNj
+        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
+        ZT5GbG9wcHkgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAg
+        ICAgICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAg
+        ICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+ODAwMDwvcmFzZDpJbnN0YW5jZUlE
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNDwv
+        cmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVt
+        PgogICAgICAgICAgICAgICAgPG92ZjpJdGVtIHZjbG91ZDp0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiIHZjbG91
+        ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvdmlydHVhbEhhcmR3YXJl
+        U2VjdGlvbi9jcHUiPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFsbG9j
+        YXRpb25Vbml0cz5oZXJ0eiAqIDEwXjY8L3Jhc2Q6QWxsb2NhdGlvblVuaXRz
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk51bWJl
+        ciBvZiBWaXJ0dWFsIENQVXM8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAg
+        ICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+MSB2aXJ0dWFsIENQVShz
+        KTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFz
+        ZDpJbnN0YW5jZUlEPjQ8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAg
+        ICAgICAgICA8cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNkOlJlc2VydmF0aW9u
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4zPC9y
+        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpW
+        aXJ0dWFsUXVhbnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+CiAgICAg
+        ICAgICAgICAgICAgICAgPHJhc2Q6V2VpZ2h0PjA8L3Jhc2Q6V2VpZ2h0Pgog
+        ICAgICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0
+        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNi
+        LThhMmQtY2Q3MWY0MzI5MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vY3B1
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
+        bSt4bWwiLz4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAg
+        ICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3Zu
+        ZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3VkOmhyZWY9Imh0
+        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUz
+        Yi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21l
+        bW9yeSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2NhdGlvblVu
+        aXRzPmJ5dGUgKiAyXjIwPC9yYXNkOkFsbG9jYXRpb25Vbml0cz4KICAgICAg
+        ICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5NZW1vcnkgU2l6ZTwv
+        cmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpF
+        bGVtZW50TmFtZT4yNTYgTUIgb2YgbWVtb3J5PC9yYXNkOkVsZW1lbnROYW1l
+        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+NTwvcmFz
+        ZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc2Vy
+        dmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAgICAgICAgICAgICAg
+        ICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjQ8L3Jhc2Q6UmVzb3VyY2VUeXBlPgog
+        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eT4yNTY8
+        L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAgICAgICAgICAgIDxy
+        YXNkOldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAgICAgICAgICAgICAg
+        ICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
+        aS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFh
+        NC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAg
+        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPExpbmsg
+        cmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
+        bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvdmlydHVh
+        bEhhcmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
+        cmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIi8+CiAgICAg
+        ICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAu
+        MzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNk
+        NzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+
+        CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBz
+        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04
+        YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIg
+        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
+        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2Et
+        NDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
+        L21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
+        cmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
+        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUw
+        NDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFyZHdh
+        cmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
+        ZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGlu
+        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
+        L3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0
+        dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAg
+        ICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1jZDcx
+        ZjQzMjkxYTQvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9kaXNrcyIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4
+        bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00
+        NTNiLThhMmQtY2Q3MWY0MzI5MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
+        bWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
+        c2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9
+        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC92aXJ0dWFsSGFy
+        ZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0iYXBwbGljYXRpb24v
+        dm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAg
+        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
+        MC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3
+        MWY0MzI5MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbmV0d29ya0NhcmRz
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
+        bXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3du
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvdmlydHVhbEhhcmR3YXJl
+        U2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
+        d2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAg
+        ICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5
+        MWE0L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFsUG9ydHMiIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3Qr
+        eG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rp
+        b24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbiB4
+        bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEu
+        NSIgb3ZmOmlkPSI5NSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
+        bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rpb24reG1sIiB2bXc6
+        b3NUeXBlPSJkZWJpYW40R3Vlc3QiIHZjbG91ZDpocmVmPSJodHRwczovLzEw
+        LjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1kYmNhLTQ1M2ItOGEyZC1j
+        ZDcxZjQzMjkxYTQvb3BlcmF0aW5nU3lzdGVtU2VjdGlvbi8iPgogICAgICAg
+        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5nIHN5
+        c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92
+        ZjpEZXNjcmlwdGlvbj5EZWJpYW4gR05VL0xpbnV4IDQgKDMyLWJpdCk8L292
+        ZjpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0
+        OTMtZGJjYS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L29wZXJhdGluZ1N5c3Rl
+        bVNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
+        ZC5vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uK3htbCIvPgogICAgICAgICAgICA8
+        L292ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uPgogICAgICAgICAgICA8TmV0
+        d29ya0Nvbm5lY3Rpb25TZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
+        L2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMy
+        OTFhNC9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rp
+        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAg
+        IDxvdmY6SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3Jr
+        IGNvbm5lY3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmlt
+        YXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nv
+        bm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVj
+        dGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5l
+        dHdvcmsiPgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlv
+        bkluZGV4PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAg
+        ICAgICAgICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAg
+        ICAgICAgICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjEw
+        PC9NQUNBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NB
+        bGxvY2F0aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4K
+        ICAgICAgICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAg
+        ICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAu
+        Mi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFm
+        NDMyOTFhNC9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNl
+        Y3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb25T
+        ZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RDdXN0b21pemF0aW9uU2VjdGlv
+        biBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5
+        My1kYmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvZ3Vlc3RDdXN0b21pemF0
+        aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24reG1sIiBvdmY6cmVxdWly
+        ZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVjaWZp
+        ZXMgR3Vlc3QgT1MgQ3VzdG9taXphdGlvbiBTZXR0aW5nczwvb3ZmOkluZm8+
+        CiAgICAgICAgICAgICAgICA8RW5hYmxlZD5mYWxzZTwvRW5hYmxlZD4KICAg
+        ICAgICAgICAgICAgIDxDaGFuZ2VTaWQ+ZmFsc2U8L0NoYW5nZVNpZD4KICAg
+        ICAgICAgICAgICAgIDxWaXJ0dWFsTWFjaGluZUlkPjA3ZmUwNDkzLWRiY2Et
+        NDUzYi04YTJkLWNkNzFmNDMyOTFhNDwvVmlydHVhbE1hY2hpbmVJZD4KICAg
+        ICAgICAgICAgICAgIDxKb2luRG9tYWluRW5hYmxlZD5mYWxzZTwvSm9pbkRv
+        bWFpbkVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8VXNlT3JnU2V0dGluZ3M+
+        ZmFsc2U8L1VzZU9yZ1NldHRpbmdzPgogICAgICAgICAgICAgICAgPEFkbWlu
+        UGFzc3dvcmRFbmFibGVkPnRydWU8L0FkbWluUGFzc3dvcmRFbmFibGVkPgog
+        ICAgICAgICAgICAgICAgPEFkbWluUGFzc3dvcmRBdXRvPnRydWU8L0FkbWlu
+        UGFzc3dvcmRBdXRvPgogICAgICAgICAgICAgICAgPFJlc2V0UGFzc3dvcmRS
+        ZXF1aXJlZD5mYWxzZTwvUmVzZXRQYXNzd29yZFJlcXVpcmVkPgogICAgICAg
+        ICAgICAgICAgPENvbXB1dGVyTmFtZT5EYW1uU21hbGxMaS0wMDE8L0NvbXB1
+        dGVyTmFtZT4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJl
+        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJj
+        YS00NTNiLThhMmQtY2Q3MWY0MzI5MWE0L2d1ZXN0Q3VzdG9taXphdGlvblNl
+        Y3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5n
+        dWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIvPgogICAgICAgICAgICA8
+        L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxSdW50
+        aW1lSW5mb1NlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2Fy
+        ZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC52aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIg
+        dmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3
+        ZmUwNDkzLWRiY2EtNDUzYi04YTJkLWNkNzFmNDMyOTFhNC9ydW50aW1lSW5m
+        b1NlY3Rpb24iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmll
+        cyBSdW50aW1lIGluZm88L292ZjpJbmZvPgogICAgICAgICAgICA8L1J1bnRp
+        bWVJbmZvU2VjdGlvbj4KICAgICAgICAgICAgPFNuYXBzaG90U2VjdGlvbiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0wN2ZlMDQ5My1k
+        YmNhLTQ1M2ItOGEyZC1jZDcxZjQzMjkxYTQvc25hcHNob3RTZWN0aW9uIiB0
+        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zbmFwc2hvdFNl
+        Y3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAg
+        ICAgIDxvdmY6SW5mbz5TbmFwc2hvdCBpbmZvcm1hdGlvbiBzZWN0aW9uPC9v
+        dmY6SW5mbz4KICAgICAgICAgICAgPC9TbmFwc2hvdFNlY3Rpb24+CiAgICAg
+        ICAgICAgIDxEYXRlQ3JlYXRlZD4yMDE2LTA4LTAxVDE0OjE1OjE0LjA2MCsw
+        MjowMDwvRGF0ZUNyZWF0ZWQ+CiAgICAgICAgICAgIDxWQXBwU2NvcGVkTG9j
+        YWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVkTG9jYWxJZD4KICAg
+        ICAgICAgICAgPG92ZmVudjpFbnZpcm9ubWVudCB4bWxuczpuczExPSJodHRw
+        Oi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgb3ZmZW52OmlkPSIi
+        IG5zMTE6dkNlbnRlcklkPSJ2bS03NiI+CiAgICAgICAgICAgICAgICA8b3Zm
+        ZW52OlBsYXRmb3JtU2VjdGlvbj4KICAgICAgICAgICAgICAgICAgICA8b3Zm
+        ZW52OktpbmQ+Vk13YXJlIEVTWGk8L292ZmVudjpLaW5kPgogICAgICAgICAg
+        ICAgICAgICAgIDxvdmZlbnY6VmVyc2lvbj42LjAuMDwvb3ZmZW52OlZlcnNp
+        b24+CiAgICAgICAgICAgICAgICAgICAgPG92ZmVudjpWZW5kb3I+Vk13YXJl
+        LCBJbmMuPC9vdmZlbnY6VmVuZG9yPgogICAgICAgICAgICAgICAgICAgIDxv
+        dmZlbnY6TG9jYWxlPmVuPC9vdmZlbnY6TG9jYWxlPgogICAgICAgICAgICAg
+        ICAgPC9vdmZlbnY6UGxhdGZvcm1TZWN0aW9uPgogICAgICAgICAgICAgICAg
+        PHZlOkV0aGVybmV0QWRhcHRlclNlY3Rpb24geG1sbnM6dmU9Imh0dHA6Ly93
+        d3cudm13YXJlLmNvbS9zY2hlbWEvb3ZmZW52IiB4bWxucz0iaHR0cDovL3Nj
+        aGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmlyb25tZW50LzEiIHhtbG5zOm9lPSJo
+        dHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52aXJvbm1lbnQvMSI+CiAg
+        ICAgICAgICAgICAgICAgICAgPHZlOkFkYXB0ZXIgdmU6bWFjPSIwMDo1MDo1
+        NjowMTowMDoxMCIgdmU6bmV0d29yaz0iZHZzLlZDRFZTVk0gTmV0d29yay0z
+        MTM2MmE2ZC0wZTU2LTQwM2MtYjMwMy1jM2M2NjMyZWI5YjEiIHZlOnVuaXRO
+        dW1iZXI9IjciLz4KICAgCiAgICAgICAgICAgICAgICA8L3ZlOkV0aGVybmV0
+        QWRhcHRlclNlY3Rpb24+CiAgICAgICAgICAgIDwvb3ZmZW52OkVudmlyb25t
+        ZW50PgogICAgICAgICAgICA8Vm1DYXBhYmlsaXRpZXMgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMDdmZTA0OTMtZGJjYS00NTNiLThh
+        MmQtY2Q3MWY0MzI5MWE0L3ZtQ2FwYWJpbGl0aWVzLyIgdHlwZT0iYXBwbGlj
+        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRpZXNTZWN0aW9u
+        K3htbCI+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTA3ZmUwNDkzLWRiY2Et
+        NDUzYi04YTJkLWNkNzFmNDMyOTFhNC92bUNhcGFiaWxpdGllcy8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2FwYWJpbGl0aWVz
+        U2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgICAgIDxNZW1vcnlIb3RBZGRF
+        bmFibGVkPmZhbHNlPC9NZW1vcnlIb3RBZGRFbmFibGVkPgogICAgICAgICAg
+        ICAgICAgPENwdUhvdEFkZEVuYWJsZWQ+ZmFsc2U8L0NwdUhvdEFkZEVuYWJs
+        ZWQ+CiAgICAgICAgICAgIDwvVm1DYXBhYmlsaXRpZXM+CiAgICAgICAgICAg
+        IDxTdG9yYWdlUHJvZmlsZSBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
+        dmRjU3RvcmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2Qy
+        NTgyNTFlYThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
+        YXJlLnZjbG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgICAgICA8
+        L1ZtPgogICAgPC9DaGlsZHJlbj4KPC9WQXBwPgo=
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:50 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:25 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 08a49504-f21e-4b94-a0a4-3177583a8dfb
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '40'
+      Content-Type:
+      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2049'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:Description>IDE Controller</rasd:Description>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:InstanceID>2</rasd:InstanceID>
+                <rasd:ResourceType>5</rasd:ResourceType>
+            </Item>
+            <Item>
+                <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                <rasd:Description>Hard disk</rasd:Description>
+                <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"></rasd:HostResource>
+                <rasd:InstanceID>3000</rasd:InstanceID>
+                <rasd:Parent>2</rasd:Parent>
+                <rasd:ResourceType>17</rasd:ResourceType>
+                <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+            </Item>
+            <Item>
+                <rasd:Address>1</rasd:Address>
+                <rasd:Description>IDE Controller</rasd:Description>
+                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                <rasd:InstanceID>3</rasd:InstanceID>
+                <rasd:ResourceType>5</rasd:ResourceType>
+            </Item>
+        </RasdItemsList>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:50 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-07fe0493-dbca-453b-8a2d-cd71f43291a4/virtualHardwareSection/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:26 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - f3b9faff-5fea-4c0b-8a6c-33f9943ba200
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '43'
+      Content-Type:
+      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2051'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-07fe0493-dbca-453b-8a2d-cd71f43291a4/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-07fe0493-dbca-453b-8a2d-cd71f43291a4/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+            <Item>
+                <rasd:Address>0</rasd:Address>
+                <rasd:Description>IDE Controller</rasd:Description>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:InstanceID>2</rasd:InstanceID>
+                <rasd:ResourceType>5</rasd:ResourceType>
+            </Item>
+            <Item>
+                <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                <rasd:Description>Hard disk</rasd:Description>
+                <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="256"></rasd:HostResource>
+                <rasd:InstanceID>3000</rasd:InstanceID>
+                <rasd:Parent>2</rasd:Parent>
+                <rasd:ResourceType>17</rasd:ResourceType>
+                <rasd:VirtualQuantity>268435456</rasd:VirtualQuantity>
+                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+            </Item>
+            <Item>
+                <rasd:Address>1</rasd:Address>
+                <rasd:Description>IDE Controller</rasd:Description>
+                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                <rasd:InstanceID>3</rasd:InstanceID>
+                <rasd:ResourceType>5</rasd:ResourceType>
+            </Item>
+        </RasdItemsList>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:51 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:29 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - ce08ce65-0e1c-457c-a933-951f355430f4
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '64'
+      Content-Type:
+      - application/vnd.vmware.vcloud.org+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1930'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Org xmlns="http://www.vmware.com/vcloud/v1.5" name="test" id="urn:vcloud:org:43b4c159-f280-4f79-a6c6-3b2f27e150c3" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="down" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" name="test-vdc" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/tasksList/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.tasksList+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" name="firstcatalog" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="add" href="https://10.30.2.2/api/admin/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3/catalogs" type="application/vnd.vmware.admin.catalog+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/network/44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/supportedSystemsInfo/" type="application/vnd.vmware.vcloud.supportedSystemsInfo+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description/>
+            <FullName>Testers we ARE</FullName>
+        </Org>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:54 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:30 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 4bc6975d-674e-4e53-a6b5-da58e0a36615
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '26'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2081'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="firstcatalog" id="urn:vcloud:catalog:b7705e3a-14ec-43a1-bf8c-6b5df417d849" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="add" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description/>
+            <CatalogItems>
+                <CatalogItem href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" id="322441c4-d47c-4346-9188-b6044fdca875" name="vApp_system_5" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" id="90edc242-bf2a-4ee3-892f-0a3f87e6e680" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" id="e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            </CatalogItems>
+            <IsPublished>false</IsPublished>
+            <DateCreated>2016-07-14T14:54:21.233+02:00</DateCreated>
+        </Catalog>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:55 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:30 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 8fb51074-6349-4286-b6c0-e4651ac50917
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '24'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2081'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="firstcatalog" id="urn:vcloud:catalog:b7705e3a-14ec-43a1-bf8c-6b5df417d849" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="add" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description/>
+            <CatalogItems>
+                <CatalogItem href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" id="322441c4-d47c-4346-9188-b6044fdca875" name="vApp_system_5" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" id="90edc242-bf2a-4ee3-892f-0a3f87e6e680" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" id="e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            </CatalogItems>
+            <IsPublished>false</IsPublished>
+            <DateCreated>2016-07-14T14:54:21.233+02:00</DateCreated>
+        </Catalog>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:55 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:31 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - b415f2c4-516c-4ab6-b2ac-cbe3ae81aac2
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '251'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1311'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="vApp_system_5" id="urn:vcloud:catalogitem:322441c4-d47c-4346-9188-b6044fdca875" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875"/>
+            <Description/>
+            <Entity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" name="vApp_system_5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-07-29T09:48:01.087+02:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:56 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:32 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 2216a439-108f-4958-88d1-8fffb6f7625b
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '416'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_system_5" id="urn:vcloud:vapptemplate:674bc33b-c6be-4c70-9813-c9bda69839ee" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/disableDownload"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="Small VM" id="urn:vcloud:vm:2ef97da4-7b83-4d92-9cbc-a3df64eeca92" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="test-direct-connected">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:08</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>SmallVM</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>0e6c69f9-eea7-4d99-bda3-13687febaca5</VAppScopedLocalId>
+                    <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
                 <ovf:Network ovf:name="test-direct-connected">
                     <ovf:Description/>
                 </ovf:Network>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
                 <NetworkConfig networkName="test-direct-connected">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/dd98196c-5085-4fcb-b4f7-1a9b19a3365a/action/reset"/>
-                    <Link rel="syncSyslogSettings" href="https://10.30.2.2/api/admin/network/dd98196c-5085-4fcb-b4f7-1a9b19a3365a/action/syncSyslogServerSettings" type="application/vnd.vmware.vcloud.task+xml"/>
                     <Description/>
                     <Configuration>
                         <IpScopes>
@@ -641,15 +2542,10 @@ http_interactions:
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="https://10.30.2.2/api/admin/network/44e44269-2fd3-4764-a071-cd8fe752b88b" id="44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected"/>
+                        <ParentNetwork href="" name="test-direct-connected"/>
                         <FenceMode>natRouted</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                         <Features>
-                            <DhcpService>
-                                <IsEnabled>false</IsEnabled>
-                                <DefaultLeaseTime>3600</DefaultLeaseTime>
-                                <MaxLeaseTime>7200</MaxLeaseTime>
-                            </DhcpService>
                             <FirewallService>
                                 <IsEnabled>true</IsEnabled>
                                 <DefaultAction>drop</DefaultAction>
@@ -671,954 +2567,120 @@ http_interactions:
                                     <EnableLogging>false</EnableLogging>
                                 </FirewallRule>
                             </FirewallService>
-                            <NatService>
-                                <IsEnabled>true</IsEnabled>
-                                <NatType>ipTranslation</NatType>
-                                <Policy>allowTrafficIn</Policy>
-                                <NatRule>
-                                    <Id>65537</Id>
-                                    <OneToOneVmRule>
-                                        <MappingMode>automatic</MappingMode>
-                                        <VAppScopedVmId>0925daf3-3df8-47b2-9b1a-36dd1322a975</VAppScopedVmId>
-                                        <VmNicId>0</VmNicId>
-                                    </OneToOneVmRule>
-                                </NatRule>
-                            </NatService>
                         </Features>
                         <SyslogServerSettings/>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                <ovf:Info>Snapshot information section</ovf:Info>
-            </SnapshotSection>
-            <DateCreated>2016-07-26T13:16:12.387+02:00</DateCreated>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <InMaintenanceMode>false</InMaintenanceMode>
-            <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="3" name="RHEL-7-2gb-1gb" id="urn:vcloud:vm:f1756fa9-1706-47bd-95d1-2edb781acf46" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="discardState" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/discardSuspendedState"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/screen"/>
-                    <Link rel="enable" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/reconfigureVm" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>RHEL-7-2gb-1gb</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:05</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="POOL" vcloud:ipAddress="10.30.2.52" vcloud:primaryNetworkConnection="true">test-direct-connected</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "test-direct-connected"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>1024 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="80" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel7_64Guest" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Red Hat Enterprise Linux 7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="false" network="test-direct-connected">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>10.30.2.52</IpAddress>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:05</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f1756fa9-1706-47bd-95d1-2edb781acf46</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>RHEL-7-2gb-1gb</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-                    </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-07-26T13:16:21.540+02:00</DateCreated>
-                    <VAppScopedLocalId>0925daf3-3df8-47b2-9b1a-36dd1322a975</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                </Vm>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="VM02" id="urn:vcloud:vm:fc4d57de-f02f-4479-aa50-3ca1b74fd41a" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/screen"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="enable" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/reconfigureVm" name="VM02" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>VM02</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:06</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="NONE" vcloud:primaryNetworkConnection="true">none</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>1024 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="80" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel7_64Guest" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Red Hat Enterprise Linux 7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:06</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>fc4d57de-f02f-4479-aa50-3ca1b74fd41a</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>PC-VM02</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-                    </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-07-26T13:19:22.817+02:00</DateCreated>
-                    <VAppScopedLocalId>04675421-bbce-407a-b83e-09c65cdd1fc7</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                </Vm>
-            </Children>
-        </VApp>
-    http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:09 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 26 Jul 2016 11:20:48 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - ed857ebf-e5b3-444b-b068-a0beec3af2d7
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-      Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '60'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2131'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>SCSI Controller</rasd:Description>
-                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                <rasd:ResourceType>6</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"></rasd:HostResource>
-                <rasd:InstanceID>2000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:09 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 26 Jul 2016 11:20:48 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 16267046-0153-416b-bc96-a549eb91ec42
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-      Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '46'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2131'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>SCSI Controller</rasd:Description>
-                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                <rasd:ResourceType>6</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"></rasd:HostResource>
-                <rasd:InstanceID>2000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:09 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 26 Jul 2016 11:20:49 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 753c0abe-60c6-41e3-b619-47c9cd34c117
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-      Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '45'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2131'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>SCSI Controller</rasd:Description>
-                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                <rasd:ResourceType>6</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"></rasd:HostResource>
-                <rasd:InstanceID>2000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:10 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 26 Jul 2016 11:20:49 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - bbc098c1-18ba-4f5a-92bc-4c43700d34e9
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-      Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '152'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="true" status="4" name="vApp_admin_2" id="urn:vcloud:vapp:5111b069-3174-45a1-98d1-c1e6e9847414" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOff" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/powerOff"/>
-            <Link rel="power:reboot" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/reboot"/>
-            <Link rel="power:reset" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/reset"/>
-            <Link rel="power:shutdown" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/shutdown"/>
-            <Link rel="power:suspend" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/power/action/suspend"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="undeploy" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/99b8b1a9-740e-4882-aa1c-6ef447fe3a40" name="test-direct-connected" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
+                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/startupSection/">
-                <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="RHEL-7-2gb-1gb" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
-            </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/networkSection/">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="test-direct-connected">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="test-direct-connected">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/99b8b1a9-740e-4882-aa1c-6ef447fe3a40/action/reset"/>
-                    <Description/>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>10.30.2.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>8.8.8.8</Dns1>
-                                <Dns2>8.8.4.4</Dns2>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>10.30.2.51</StartAddress>
-                                        <EndAddress>10.30.2.60</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <ParentNetwork href="https://10.30.2.2/api/admin/network/44e44269-2fd3-4764-a071-cd8fe752b88b" id="44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected"/>
-                        <FenceMode>bridged</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                    </Configuration>
-                    <IsDeployed>true</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                <ovf:Info>Snapshot information section</ovf:Info>
-            </SnapshotSection>
-            <DateCreated>2016-07-25T13:45:11.107+02:00</DateCreated>
+            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:57 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:33 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - e3eb967d-0239-4ab1-a8f2-884826f492d2
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '427'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_system_5" id="urn:vcloud:vapptemplate:674bc33b-c6be-4c70-9813-c9bda69839ee" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/disableDownload"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
                 <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
-            <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="true" status="4" name="RHEL-7-2gb-1gb" id="urn:vcloud:vm:ec7dd6cb-2f33-4c1c-a714-083a032d4a82" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOff" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/powerOff"/>
-                    <Link rel="power:reboot" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/reboot"/>
-                    <Link rel="power:reset" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/reset"/>
-                    <Link rel="power:shutdown" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/shutdown"/>
-                    <Link rel="power:suspend" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/power/action/suspend"/>
-                    <Link rel="undeploy" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/screen"/>
-                    <Link rel="screen:acquireTicket" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/screen/action/acquireTicket"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="installVmwareTools" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/installVMwareTools"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/action/reconfigureVm" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-5111b069-3174-45a1-98d1-c1e6e9847414" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <Vm goldMaster="false" status="8" name="Small VM" id="urn:vcloud:vm:2ef97da4-7b83-4d92-9cbc-a3df64eeca92" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
                     <Description/>
-                    <Tasks>
-                        <Task cancelRequested="false" endTime="2016-07-25T13:46:52.023+02:00" expiryTime="2016-10-23T13:46:47.730+02:00" operation="Running Virtual Machine RHEL-7-2gb-1gb(ec7dd6cb-2f33-4c1c-a714-083a032d4a82)" operationName="vappDeploy" serviceNamespace="com.vmware.vcloud" startTime="2016-07-25T13:46:47.730+02:00" status="error" name="task" id="urn:vcloud:task:14b1721e-0fd5-4a77-b0ac-5d9fca98c2e9" href="https://10.30.2.2/api/task/14b1721e-0fd5-4a77-b0ac-5d9fca98c2e9" type="application/vnd.vmware.vcloud.task+xml">
-                            <Owner href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                            <Error majorErrorCode="500" message="[ b503e7b8-1d3f-495d-9c52-91c756d4a7b5 ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
-                            <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-                            <Organization href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
-                            <Details>  [ b503e7b8-1d3f-495d-9c52-91c756d4a7b5 ] Unable to perform this action. Contact your cloud administr...</Details>
-                        </Task>
-                        <Task cancelRequested="false" endTime="2016-07-25T14:20:14.037+02:00" expiryTime="2016-10-23T14:20:09.747+02:00" operation="Running Virtual Machine RHEL-7-2gb-1gb(ec7dd6cb-2f33-4c1c-a714-083a032d4a82)" operationName="vappDeploy" serviceNamespace="com.vmware.vcloud" startTime="2016-07-25T14:20:09.747+02:00" status="error" name="task" id="urn:vcloud:task:2805c06b-6798-4166-b92b-5540e5e010fe" href="https://10.30.2.2/api/task/2805c06b-6798-4166-b92b-5540e5e010fe" type="application/vnd.vmware.vcloud.task+xml">
-                            <Owner href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                            <Error majorErrorCode="500" message="[ 4d95a399-eebe-4975-b00e-de5d27529eb3 ] Unable to perform this action. Contact your cloud administrator." minorErrorCode="INTERNAL_SERVER_ERROR"/>
-                            <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-                            <Organization href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
-                            <Details>  [ 4d95a399-eebe-4975-b00e-de5d27529eb3 ] Unable to perform this action. Contact your cloud administr...</Details>
-                        </Task>
-                    </Tasks>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>RHEL-7-2gb-1gb</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:05</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="POOL" vcloud:ipAddress="10.30.2.52" vcloud:primaryNetworkConnection="true">test-direct-connected</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "test-direct-connected"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>1024 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="80" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel7_64Guest" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Red Hat Enterprise Linux 7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
                         <NetworkConnection needsCustomization="true" network="test-direct-connected">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>10.30.2.52</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:05</MACAddress>
+                            <MACAddress>00:50:56:01:00:08</MACAddress>
                             <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>ec7dd6cb-2f33-4c1c-a714-083a032d4a82</VirtualMachineId>
+                        <VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>RHEL-7-2gb-1gb</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>SmallVM</ComputerName>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-07-25T13:45:15.057+02:00</DateCreated>
-                    <VAppScopedLocalId>0925daf3-3df8-47b2-9b1a-36dd1322a975</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ec7dd6cb-2f33-4c1c-a714-083a032d4a82/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <VAppScopedLocalId>0e6c69f9-eea7-4d99-bda3-13687febaca5</VAppScopedLocalId>
+                    <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
                 </Vm>
             </Children>
-        </VApp>
-    http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:10 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Tue, 26 Jul 2016 11:20:49 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 28d56e51-4c40-4972-a1f8-c21983130c3f
-      X-Vcloud-Authorization:
-      - ff0456d44c2642099e45b7c929df3404
-      Set-Cookie:
-      - vcloud-token=ff0456d44c2642099e45b7c929df3404; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '261'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="10" name="vApp_admin_3" id="urn:vcloud:vapp:bfd40328-a383-4b0e-9130-66edd590f4ab" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/power/action/powerOn"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="discardState" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/discardSuspendedState"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/dd98196c-5085-4fcb-b4f7-1a9b19a3365a" name="test-direct-connected" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
-            </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/startupSection/">
-                <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="RHEL-7-2gb-1gb" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <ovf:Item ovf:id="VM02" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
-            </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkSection/">
                 <ovf:Info>The list of logical networks</ovf:Info>
                 <ovf:Network ovf:name="test-direct-connected">
                     <ovf:Description/>
                 </ovf:Network>
-                <ovf:Network ovf:name="none">
-                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
-                </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
                 <NetworkConfig networkName="test-direct-connected">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/dd98196c-5085-4fcb-b4f7-1a9b19a3365a/action/reset"/>
-                    <Link rel="syncSyslogSettings" href="https://10.30.2.2/api/admin/network/dd98196c-5085-4fcb-b4f7-1a9b19a3365a/action/syncSyslogServerSettings" type="application/vnd.vmware.vcloud.task+xml"/>
                     <Description/>
                     <Configuration>
                         <IpScopes>
@@ -1637,15 +2699,10 @@ http_interactions:
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <ParentNetwork href="https://10.30.2.2/api/admin/network/44e44269-2fd3-4764-a071-cd8fe752b88b" id="44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected"/>
+                        <ParentNetwork href="" name="test-direct-connected"/>
                         <FenceMode>natRouted</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                         <Features>
-                            <DhcpService>
-                                <IsEnabled>false</IsEnabled>
-                                <DefaultLeaseTime>3600</DefaultLeaseTime>
-                                <MaxLeaseTime>7200</MaxLeaseTime>
-                            </DhcpService>
                             <FirewallService>
                                 <IsEnabled>true</IsEnabled>
                                 <DefaultAction>drop</DefaultAction>
@@ -1667,369 +2724,1376 @@ http_interactions:
                                     <EnableLogging>false</EnableLogging>
                                 </FirewallRule>
                             </FirewallService>
-                            <NatService>
-                                <IsEnabled>true</IsEnabled>
-                                <NatType>ipTranslation</NatType>
-                                <Policy>allowTrafficIn</Policy>
-                                <NatRule>
-                                    <Id>65537</Id>
-                                    <OneToOneVmRule>
-                                        <MappingMode>automatic</MappingMode>
-                                        <VAppScopedVmId>0925daf3-3df8-47b2-9b1a-36dd1322a975</VAppScopedVmId>
-                                        <VmNicId>0</VmNicId>
-                                    </OneToOneVmRule>
-                                </NatRule>
-                            </NatService>
                         </Features>
                         <SyslogServerSettings/>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
-                <NetworkConfig networkName="none">
-                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:58 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:34 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 91e5973e-239a-4348-acb8-16828d040b38
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '390'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_system_5" id="urn:vcloud:vapptemplate:674bc33b-c6be-4c70-9813-c9bda69839ee" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/disableDownload"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="Small VM" id="urn:vcloud:vm:2ef97da4-7b83-4d92-9cbc-a3df64eeca92" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="test-direct-connected">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:08</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>SmallVM</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>0e6c69f9-eea7-4d99-bda3-13687febaca5</VAppScopedLocalId>
+                    <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="test-direct-connected">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="test-direct-connected">
+                    <Description/>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>196.254.254.254</Gateway>
-                                <Netmask>255.255.0.0</Netmask>
-                                <Dns1>196.254.254.254</Dns1>
+                                <IsInherited>true</IsInherited>
+                                <Gateway>10.30.2.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <Dns1>8.8.8.8</Dns1>
+                                <Dns2>8.8.4.4</Dns2>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>10.30.2.51</StartAddress>
+                                        <EndAddress>10.30.2.60</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <FenceMode>isolated</FenceMode>
+                        <ParentNetwork href="" name="test-direct-connected"/>
+                        <FenceMode>natRouted</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                        <Features>
+                            <FirewallService>
+                                <IsEnabled>true</IsEnabled>
+                                <DefaultAction>drop</DefaultAction>
+                                <LogDefaultAction>false</LogDefaultAction>
+                                <FirewallRule>
+                                    <IsEnabled>true</IsEnabled>
+                                    <MatchOnTranslate>false</MatchOnTranslate>
+                                    <Description>Allow all outgoing traffic</Description>
+                                    <Policy>allow</Policy>
+                                    <Protocols>
+                                        <Any>true</Any>
+                                    </Protocols>
+                                    <Port>-1</Port>
+                                    <DestinationPortRange>Any</DestinationPortRange>
+                                    <DestinationIp>external</DestinationIp>
+                                    <SourcePort>-1</SourcePort>
+                                    <SourcePortRange>Any</SourcePortRange>
+                                    <SourceIp>internal</SourceIp>
+                                    <EnableLogging>false</EnableLogging>
+                                </FirewallRule>
+                            </FirewallService>
+                        </Features>
+                        <SyslogServerSettings/>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                <ovf:Info>Snapshot information section</ovf:Info>
-            </SnapshotSection>
-            <DateCreated>2016-07-26T13:16:12.387+02:00</DateCreated>
+            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:29:59 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:36 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 100bae97-909c-45b8-acac-816ad82f7edf
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '187'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1321'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="DSL-Linux-template" id="urn:vcloud:catalogitem:90edc242-bf2a-4ee3-892f-0a3f87e6e680" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680"/>
+            <Description/>
+            <Entity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-08-01T14:04:44.247+02:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:01 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:37 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - ca8f0c80-7886-4e05-b5b2-9675eea5dc66
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '252'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHBU
+        ZW1wbGF0ZSB4bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
+        MS41IiB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
+        bnZlbG9wZS8xIiBnb2xkTWFzdGVyPSJmYWxzZSIgb3ZmRGVzY3JpcHRvclVw
+        bG9hZGVkPSJ0cnVlIiBzdGF0dXM9IjgiIG5hbWU9IkRTTC1MaW51eC10ZW1w
+        bGF0ZSIgaWQ9InVybjp2Y2xvdWQ6dmFwcHRlbXBsYXRlOjQ0YjY4NmZiLWQ0
+        YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2OCIgaHJlZj0iaHR0cHM6Ly8xMC4z
+        MC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmIt
+        ZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4IiB0eXBlPSJhcHBsaWNhdGlv
+        bi92bmQudm13YXJlLnZjbG91ZC52QXBwVGVtcGxhdGUreG1sIiB4bWxuczp4
+        c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNl
+        IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
+        L292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
+        bnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNkIGh0dHA6Ly93d3cudm13YXJl
+        LmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAuMzAuMi4yL2FwaS92MS41L3Nj
+        aGVtYS9tYXN0ZXIueHNkIj4KICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
+        dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVkZTI2YTItNThjOC00NDk0LTgy
+        MWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
+        LnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGluayByZWw9ImNhdGFsb2dJdGVt
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvY2F0YWxvZ0l0ZW0vOTBl
+        ZGMyNDItYmYyYS00ZWUzLTg5MmYtMGEzZjg3ZTZlNjgwIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jYXRhbG9nSXRlbSt4bWwiLz4K
+        ICAgIDxMaW5rIHJlbD0icmVtb3ZlIiBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJm
+        LTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgiLz4KICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92
+        YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYx
+        ODY4IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBw
+        VGVtcGxhdGUreG1sIi8+CiAgICA8TGluayByZWw9ImVuYWJsZSIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
+        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L2FjdGlv
+        bi9lbmFibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJkaXNhYmxlIiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBU
+        ZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4Njgv
+        YWN0aW9uL2Rpc2FibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJvdmYi
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdmFw
+        cFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2
+        OC9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9InN0b3Jh
+        Z2VQcm9maWxlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdmRjU3Rv
+        cmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2QyNTgyNTFl
+        YThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
+        bG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
+        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0
+        ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAw
+        OGYxODY4L293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
+        bG91ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
+        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L21ldGFk
+        YXRhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRh
+        ZGF0YSt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRi
+        Njg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L3Byb2R1Y3RTZWN0
+        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
+        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxEZXNjcmlwdGlvbi8+CiAgICA8
+        T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQub3du
+        ZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvYWRtaW4vdXNlci9kNjVmNzRiZS0yMzlmLTQ5YjctODdmZi0zOWUz
+        MTU0MTMzNTEiIG5hbWU9ImFkbWluIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
+        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPENo
+        aWxkcmVuPgogICAgICAgIDxWbSBnb2xkTWFzdGVyPSJmYWxzZSIgc3RhdHVz
+        PSI4IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiBpZD0idXJuOnZjbG91ZDp2
+        bTowZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0MzY1OTYiIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdm0tMGViMjBm
+        OTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2IiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgogICAgICAgICAgICA8
+        TGluayByZWw9InVwIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
+        cFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNm
+        Yi02NTU0MDA4ZjE4NjgiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnZBcHBUZW1wbGF0ZSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
+        cmVsPSJzdG9yYWdlUHJvZmlsZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMtNGNhYS1iNmQ4
+        LWNkMjU4MjUxZWE4ZCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1sIi8+CiAgICAgICAgICAgIDxM
+        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
+        cHBUZW1wbGF0ZS92bS0wZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0
+        MzY1OTYvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
+        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxh
+        dGUvdm0tMGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2L3By
+        b2R1Y3RTZWN0aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnByb2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgICAgICAgICAgPERl
+        c2NyaXB0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRo
+        ZSBoaWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlv
+        bi4gTm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBN
+        QnMgaW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQg
+        SeKAmXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGlu
+        ZyB3aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNv
+        PC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
+        U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBs
+        YXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1NGYwNjQzNjU5Ni9u
+        ZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1s
+        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
+        SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5l
+        Y3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0
+        d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
+        b25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBu
+        ZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5ldHdvcmsi
+        PgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4
+        PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAg
+        ICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAg
+        ICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjBmPC9NQUNB
+        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0
+        aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAg
+        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgIDwv
+        TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RD
+        dXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
+        cGkvdkFwcFRlbXBsYXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1
+        NGYwNjQzNjU5Ni9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
+        aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAg
+        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyBHdWVzdCBPUyBDdXN0b21p
+        emF0aW9uIFNldHRpbmdzPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxF
+        bmFibGVkPmZhbHNlPC9FbmFibGVkPgogICAgICAgICAgICAgICAgPENoYW5n
+        ZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgogICAgICAgICAgICAgICAgPFZpcnR1
+        YWxNYWNoaW5lSWQ+MGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2
+        NTk2PC9WaXJ0dWFsTWFjaGluZUlkPgogICAgICAgICAgICAgICAgPEpvaW5E
+        b21haW5FbmFibGVkPmZhbHNlPC9Kb2luRG9tYWluRW5hYmxlZD4KICAgICAg
+        ICAgICAgICAgIDxVc2VPcmdTZXR0aW5ncz5mYWxzZTwvVXNlT3JnU2V0dGlu
+        Z3M+CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEVuYWJsZWQ+dHJ1
+        ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8QWRt
+        aW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRtaW5QYXNzd29yZEF1dG8+CiAgICAg
+        ICAgICAgICAgICA8UmVzZXRQYXNzd29yZFJlcXVpcmVkPmZhbHNlPC9SZXNl
+        dFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8Q29tcHV0ZXJO
+        YW1lPkRhbW5TbWFsbExpLTAwMTwvQ29tcHV0ZXJOYW1lPgogICAgICAgICAg
+        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxW
+        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
+        TG9jYWxJZD4KICAgICAgICAgICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFU
+        MTQ6MDQ6NDQuMTYwKzAyOjAwPC9EYXRlQ3JlYXRlZD4KICAgICAgICA8L1Zt
+        PgogICAgPC9DaGlsZHJlbj4KICAgIDxvdmY6TmV0d29ya1NlY3Rpb24geG1s
+        bnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUi
+        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5u
+        ZXR3b3JrU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1k
+        NGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgvbmV0d29ya1NlY3Rpb24vIj4K
+        ICAgICAgICA8b3ZmOkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jr
+        czwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJW
+        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUg
+        Vk0gTmV0d29yayBuZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAg
+        PC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAg
+        PE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
+        L2FwaS92QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYt
+        NGVjNC1iM2ZiLTY1NTQwMDhmMTg2OC9uZXR3b3JrQ29uZmlnU2VjdGlvbi8i
+        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtD
+        b25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAg
+        ICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRlcnMgZm9y
+        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxOZXR3b3Jr
+        Q29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4KICAgICAgICAgICAg
+        PERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L0Rlc2NyaXB0
+        aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAg
+        ICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBTY29wZT4K
+        ICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPmZhbHNlPC9J
+        c0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPEdhdGV3YXk+
+        MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAg
+        ICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4KICAgICAgICAg
+        ICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0VuYWJsZWQ+CiAg
+        ICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAgICAgICAgICAg
+        ICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
+        ICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2OC4yNTQuMTAwPC9T
+        dGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+        PEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9FbmRBZGRyZXNzPgogICAg
+        ICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAg
+        ICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAg
+        IDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAg
+        ICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9GZW5jZU1vZGU+CiAg
+        ICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
+        PmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAg
+        ICAgICAgIDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95
+        ZWQ+ZmFsc2U8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
+        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxMZWFzZVNldHRp
+        bmdzU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRl
+        bXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02
+        NTU0MDA4ZjE4NjgvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlv
+        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgIDxvdmY6SW5m
+        bz5MZWFzZSBzZXR0aW5ncyBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICA8
+        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
+        QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1i
+        M2ZiLTY1NTQwMDhmMTg2OC9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
+        ZWN0aW9uK3htbCIvPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29uZHM+
+        Nzc3NjAwMDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9y
+        YWdlTGVhc2VFeHBpcmF0aW9uPjIwMTYtMTAtMzBUMTM6MTk6MDUuOTc3KzAx
+        OjAwPC9TdG9yYWdlTGVhc2VFeHBpcmF0aW9uPgogICAgPC9MZWFzZVNldHRp
+        bmdzU2VjdGlvbj4KICAgIDxDdXN0b21pemF0aW9uU2VjdGlvbiBnb2xkTWFz
+        dGVyPSJmYWxzZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBU
+        ZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmIt
+        NjU1NDAwOGYxODY4L2N1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBw
+        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuY3VzdG9taXphdGlvblNlY3Rp
+        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
+        Zm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rpb248L292ZjpJ
+        bmZvPgogICAgICAgIDxDdXN0b21pemVPbkluc3RhbnRpYXRlPnRydWU8L0N1
+        c3RvbWl6ZU9uSW5zdGFudGlhdGU+CiAgICA8L0N1c3RvbWl6YXRpb25TZWN0
+        aW9uPgogICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFUMTQ6MDQ6NDQuMTYw
+        KzAyOjAwPC9EYXRlQ3JlYXRlZD4KPC9WQXBwVGVtcGxhdGU+Cg==
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:03 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:39 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - bc130b08-b171-4b83-bb53-040966acdb15
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '299'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHBU
+        ZW1wbGF0ZSB4bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
+        MS41IiB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
+        bnZlbG9wZS8xIiBnb2xkTWFzdGVyPSJmYWxzZSIgb3ZmRGVzY3JpcHRvclVw
+        bG9hZGVkPSJ0cnVlIiBzdGF0dXM9IjgiIG5hbWU9IkRTTC1MaW51eC10ZW1w
+        bGF0ZSIgaWQ9InVybjp2Y2xvdWQ6dmFwcHRlbXBsYXRlOjQ0YjY4NmZiLWQ0
+        YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2OCIgaHJlZj0iaHR0cHM6Ly8xMC4z
+        MC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmIt
+        ZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4IiB0eXBlPSJhcHBsaWNhdGlv
+        bi92bmQudm13YXJlLnZjbG91ZC52QXBwVGVtcGxhdGUreG1sIiB4bWxuczp4
+        c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNl
+        IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
+        L292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
+        bnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNkIGh0dHA6Ly93d3cudm13YXJl
+        LmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAuMzAuMi4yL2FwaS92MS41L3Nj
+        aGVtYS9tYXN0ZXIueHNkIj4KICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
+        dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVkZTI2YTItNThjOC00NDk0LTgy
+        MWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
+        LnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGluayByZWw9ImNhdGFsb2dJdGVt
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvY2F0YWxvZ0l0ZW0vOTBl
+        ZGMyNDItYmYyYS00ZWUzLTg5MmYtMGEzZjg3ZTZlNjgwIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jYXRhbG9nSXRlbSt4bWwiLz4K
+        ICAgIDxMaW5rIHJlbD0icmVtb3ZlIiBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJm
+        LTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgiLz4KICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92
+        YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYx
+        ODY4IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBw
+        VGVtcGxhdGUreG1sIi8+CiAgICA8TGluayByZWw9ImVuYWJsZSIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
+        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L2FjdGlv
+        bi9lbmFibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJkaXNhYmxlIiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBU
+        ZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4Njgv
+        YWN0aW9uL2Rpc2FibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJvdmYi
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdmFw
+        cFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2
+        OC9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9InN0b3Jh
+        Z2VQcm9maWxlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdmRjU3Rv
+        cmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2QyNTgyNTFl
+        YThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
+        bG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
+        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0
+        ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAw
+        OGYxODY4L293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
+        bG91ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
+        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L21ldGFk
+        YXRhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRh
+        ZGF0YSt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRi
+        Njg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L3Byb2R1Y3RTZWN0
+        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
+        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxEZXNjcmlwdGlvbi8+CiAgICA8
+        T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQub3du
+        ZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvYWRtaW4vdXNlci9kNjVmNzRiZS0yMzlmLTQ5YjctODdmZi0zOWUz
+        MTU0MTMzNTEiIG5hbWU9ImFkbWluIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
+        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPENo
+        aWxkcmVuPgogICAgICAgIDxWbSBnb2xkTWFzdGVyPSJmYWxzZSIgc3RhdHVz
+        PSI4IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiBpZD0idXJuOnZjbG91ZDp2
+        bTowZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0MzY1OTYiIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdm0tMGViMjBm
+        OTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2IiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgogICAgICAgICAgICA8
+        TGluayByZWw9InVwIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
+        cFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNm
+        Yi02NTU0MDA4ZjE4NjgiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnZBcHBUZW1wbGF0ZSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
+        cmVsPSJzdG9yYWdlUHJvZmlsZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMtNGNhYS1iNmQ4
+        LWNkMjU4MjUxZWE4ZCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1sIi8+CiAgICAgICAgICAgIDxM
+        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
+        cHBUZW1wbGF0ZS92bS0wZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0
+        MzY1OTYvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
+        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxh
+        dGUvdm0tMGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2L3By
+        b2R1Y3RTZWN0aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnByb2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgICAgICAgICAgPERl
+        c2NyaXB0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRo
+        ZSBoaWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlv
+        bi4gTm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBN
+        QnMgaW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQg
+        SeKAmXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGlu
+        ZyB3aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNv
+        PC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
+        U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBs
+        YXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1NGYwNjQzNjU5Ni9u
+        ZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1s
+        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
+        SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5l
+        Y3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0
+        d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
+        b25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBu
+        ZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5ldHdvcmsi
+        PgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4
+        PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAg
+        ICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAg
+        ICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjBmPC9NQUNB
+        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0
+        aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAg
+        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgIDwv
+        TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RD
+        dXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
+        cGkvdkFwcFRlbXBsYXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1
+        NGYwNjQzNjU5Ni9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
+        aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAg
+        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyBHdWVzdCBPUyBDdXN0b21p
+        emF0aW9uIFNldHRpbmdzPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxF
+        bmFibGVkPmZhbHNlPC9FbmFibGVkPgogICAgICAgICAgICAgICAgPENoYW5n
+        ZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgogICAgICAgICAgICAgICAgPFZpcnR1
+        YWxNYWNoaW5lSWQ+MGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2
+        NTk2PC9WaXJ0dWFsTWFjaGluZUlkPgogICAgICAgICAgICAgICAgPEpvaW5E
+        b21haW5FbmFibGVkPmZhbHNlPC9Kb2luRG9tYWluRW5hYmxlZD4KICAgICAg
+        ICAgICAgICAgIDxVc2VPcmdTZXR0aW5ncz5mYWxzZTwvVXNlT3JnU2V0dGlu
+        Z3M+CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEVuYWJsZWQ+dHJ1
+        ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8QWRt
+        aW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRtaW5QYXNzd29yZEF1dG8+CiAgICAg
+        ICAgICAgICAgICA8UmVzZXRQYXNzd29yZFJlcXVpcmVkPmZhbHNlPC9SZXNl
+        dFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8Q29tcHV0ZXJO
+        YW1lPkRhbW5TbWFsbExpLTAwMTwvQ29tcHV0ZXJOYW1lPgogICAgICAgICAg
+        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxW
+        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
+        TG9jYWxJZD4KICAgICAgICAgICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFU
+        MTQ6MDQ6NDQuMTYwKzAyOjAwPC9EYXRlQ3JlYXRlZD4KICAgICAgICA8L1Zt
+        PgogICAgPC9DaGlsZHJlbj4KICAgIDxvdmY6TmV0d29ya1NlY3Rpb24geG1s
+        bnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUi
+        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5u
+        ZXR3b3JrU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1k
+        NGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgvbmV0d29ya1NlY3Rpb24vIj4K
+        ICAgICAgICA8b3ZmOkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jr
+        czwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJW
+        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUg
+        Vk0gTmV0d29yayBuZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAg
+        PC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAg
+        PE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
+        L2FwaS92QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYt
+        NGVjNC1iM2ZiLTY1NTQwMDhmMTg2OC9uZXR3b3JrQ29uZmlnU2VjdGlvbi8i
+        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtD
+        b25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAg
+        ICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRlcnMgZm9y
+        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxOZXR3b3Jr
+        Q29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4KICAgICAgICAgICAg
+        PERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L0Rlc2NyaXB0
+        aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAg
+        ICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBTY29wZT4K
+        ICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPmZhbHNlPC9J
+        c0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPEdhdGV3YXk+
+        MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAg
+        ICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4KICAgICAgICAg
+        ICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0VuYWJsZWQ+CiAg
+        ICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAgICAgICAgICAg
+        ICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
+        ICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2OC4yNTQuMTAwPC9T
+        dGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+        PEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9FbmRBZGRyZXNzPgogICAg
+        ICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAg
+        ICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAg
+        IDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAg
+        ICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9GZW5jZU1vZGU+CiAg
+        ICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
+        PmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAg
+        ICAgICAgIDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95
+        ZWQ+ZmFsc2U8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
+        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxMZWFzZVNldHRp
+        bmdzU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRl
+        bXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02
+        NTU0MDA4ZjE4NjgvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlv
+        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgIDxvdmY6SW5m
+        bz5MZWFzZSBzZXR0aW5ncyBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICA8
+        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
+        QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1i
+        M2ZiLTY1NTQwMDhmMTg2OC9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
+        ZWN0aW9uK3htbCIvPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29uZHM+
+        Nzc3NjAwMDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9y
+        YWdlTGVhc2VFeHBpcmF0aW9uPjIwMTYtMTAtMzBUMTM6MTk6MDUuOTc3KzAx
+        OjAwPC9TdG9yYWdlTGVhc2VFeHBpcmF0aW9uPgogICAgPC9MZWFzZVNldHRp
+        bmdzU2VjdGlvbj4KICAgIDxDdXN0b21pemF0aW9uU2VjdGlvbiBnb2xkTWFz
+        dGVyPSJmYWxzZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBU
+        ZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmIt
+        NjU1NDAwOGYxODY4L2N1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBw
+        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuY3VzdG9taXphdGlvblNlY3Rp
+        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
+        Zm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rpb248L292ZjpJ
+        bmZvPgogICAgICAgIDxDdXN0b21pemVPbkluc3RhbnRpYXRlPnRydWU8L0N1
+        c3RvbWl6ZU9uSW5zdGFudGlhdGU+CiAgICA8L0N1c3RvbWl6YXRpb25TZWN0
+        aW9uPgogICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFUMTQ6MDQ6NDQuMTYw
+        KzAyOjAwPC9EYXRlQ3JlYXRlZD4KPC9WQXBwVGVtcGxhdGU+Cg==
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:40 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - cfbdaae0-8da5-4905-b874-0030a9db06ee
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '253'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHBU
+        ZW1wbGF0ZSB4bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
+        MS41IiB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
+        bnZlbG9wZS8xIiBnb2xkTWFzdGVyPSJmYWxzZSIgb3ZmRGVzY3JpcHRvclVw
+        bG9hZGVkPSJ0cnVlIiBzdGF0dXM9IjgiIG5hbWU9IkRTTC1MaW51eC10ZW1w
+        bGF0ZSIgaWQ9InVybjp2Y2xvdWQ6dmFwcHRlbXBsYXRlOjQ0YjY4NmZiLWQ0
+        YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2OCIgaHJlZj0iaHR0cHM6Ly8xMC4z
+        MC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmIt
+        ZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4IiB0eXBlPSJhcHBsaWNhdGlv
+        bi92bmQudm13YXJlLnZjbG91ZC52QXBwVGVtcGxhdGUreG1sIiB4bWxuczp4
+        c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNl
+        IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
+        L292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
+        bnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNkIGh0dHA6Ly93d3cudm13YXJl
+        LmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAuMzAuMi4yL2FwaS92MS41L3Nj
+        aGVtYS9tYXN0ZXIueHNkIj4KICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
+        dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVkZTI2YTItNThjOC00NDk0LTgy
+        MWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
+        LnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGluayByZWw9ImNhdGFsb2dJdGVt
+        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvY2F0YWxvZ0l0ZW0vOTBl
+        ZGMyNDItYmYyYS00ZWUzLTg5MmYtMGEzZjg3ZTZlNjgwIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jYXRhbG9nSXRlbSt4bWwiLz4K
+        ICAgIDxMaW5rIHJlbD0icmVtb3ZlIiBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJm
+        LTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgiLz4KICAgIDxMaW5rIHJlbD0iZWRp
+        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92
+        YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYx
+        ODY4IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBw
+        VGVtcGxhdGUreG1sIi8+CiAgICA8TGluayByZWw9ImVuYWJsZSIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
+        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L2FjdGlv
+        bi9lbmFibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJkaXNhYmxlIiBo
+        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBU
+        ZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4Njgv
+        YWN0aW9uL2Rpc2FibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJvdmYi
+        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdmFw
+        cFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2
+        OC9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9InN0b3Jh
+        Z2VQcm9maWxlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdmRjU3Rv
+        cmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2QyNTgyNTFl
+        YThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
+        bG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
+        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0
+        ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAw
+        OGYxODY4L293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
+        bG91ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
+        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
+        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L21ldGFk
+        YXRhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRh
+        ZGF0YSt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
+        Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRi
+        Njg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L3Byb2R1Y3RTZWN0
+        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
+        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxEZXNjcmlwdGlvbi8+CiAgICA8
+        T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQub3du
+        ZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEwLjMwLjIu
+        Mi9hcGkvYWRtaW4vdXNlci9kNjVmNzRiZS0yMzlmLTQ5YjctODdmZi0zOWUz
+        MTU0MTMzNTEiIG5hbWU9ImFkbWluIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
+        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPENo
+        aWxkcmVuPgogICAgICAgIDxWbSBnb2xkTWFzdGVyPSJmYWxzZSIgc3RhdHVz
+        PSI4IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiBpZD0idXJuOnZjbG91ZDp2
+        bTowZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0MzY1OTYiIGhyZWY9
+        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdm0tMGViMjBm
+        OTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2IiB0eXBlPSJhcHBsaWNh
+        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgogICAgICAgICAgICA8
+        TGluayByZWw9InVwIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
+        cFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNm
+        Yi02NTU0MDA4ZjE4NjgiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnZBcHBUZW1wbGF0ZSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
+        cmVsPSJzdG9yYWdlUHJvZmlsZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
+        YXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMtNGNhYS1iNmQ4
+        LWNkMjU4MjUxZWE4ZCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
+        Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1sIi8+CiAgICAgICAgICAgIDxM
+        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
+        cHBUZW1wbGF0ZS92bS0wZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0
+        MzY1OTYvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
+        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxh
+        dGUvdm0tMGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2L3By
+        b2R1Y3RTZWN0aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
+        dmNsb3VkLnByb2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgICAgICAgICAgPERl
+        c2NyaXB0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRo
+        ZSBoaWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlv
+        bi4gTm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBN
+        QnMgaW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQg
+        SeKAmXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGlu
+        ZyB3aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNv
+        PC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
+        U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBs
+        YXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1NGYwNjQzNjU5Ni9u
+        ZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92
+        bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1s
+        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
+        SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5l
+        Y3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0
+        d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
+        b25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBu
+        ZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5ldHdvcmsi
+        PgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4
+        PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAg
+        ICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAg
+        ICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjBmPC9NQUNB
+        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0
+        aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAg
+        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgIDwv
+        TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RD
+        dXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
+        cGkvdkFwcFRlbXBsYXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1
+        NGYwNjQzNjU5Ni9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
+        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
+        aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAg
+        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyBHdWVzdCBPUyBDdXN0b21p
+        emF0aW9uIFNldHRpbmdzPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxF
+        bmFibGVkPmZhbHNlPC9FbmFibGVkPgogICAgICAgICAgICAgICAgPENoYW5n
+        ZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgogICAgICAgICAgICAgICAgPFZpcnR1
+        YWxNYWNoaW5lSWQ+MGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2
+        NTk2PC9WaXJ0dWFsTWFjaGluZUlkPgogICAgICAgICAgICAgICAgPEpvaW5E
+        b21haW5FbmFibGVkPmZhbHNlPC9Kb2luRG9tYWluRW5hYmxlZD4KICAgICAg
+        ICAgICAgICAgIDxVc2VPcmdTZXR0aW5ncz5mYWxzZTwvVXNlT3JnU2V0dGlu
+        Z3M+CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEVuYWJsZWQ+dHJ1
+        ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8QWRt
+        aW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRtaW5QYXNzd29yZEF1dG8+CiAgICAg
+        ICAgICAgICAgICA8UmVzZXRQYXNzd29yZFJlcXVpcmVkPmZhbHNlPC9SZXNl
+        dFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8Q29tcHV0ZXJO
+        YW1lPkRhbW5TbWFsbExpLTAwMTwvQ29tcHV0ZXJOYW1lPgogICAgICAgICAg
+        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxW
+        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
+        TG9jYWxJZD4KICAgICAgICAgICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFU
+        MTQ6MDQ6NDQuMTYwKzAyOjAwPC9EYXRlQ3JlYXRlZD4KICAgICAgICA8L1Zt
+        PgogICAgPC9DaGlsZHJlbj4KICAgIDxvdmY6TmV0d29ya1NlY3Rpb24geG1s
+        bnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUi
+        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5u
+        ZXR3b3JrU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMw
+        LjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1k
+        NGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgvbmV0d29ya1NlY3Rpb24vIj4K
+        ICAgICAgICA8b3ZmOkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jr
+        czwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJW
+        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUg
+        Vk0gTmV0d29yayBuZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAg
+        PC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAg
+        PE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
+        L2FwaS92QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYt
+        NGVjNC1iM2ZiLTY1NTQwMDhmMTg2OC9uZXR3b3JrQ29uZmlnU2VjdGlvbi8i
+        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtD
+        b25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAg
+        ICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRlcnMgZm9y
+        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxOZXR3b3Jr
+        Q29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4KICAgICAgICAgICAg
+        PERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L0Rlc2NyaXB0
+        aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAg
+        ICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBTY29wZT4K
+        ICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPmZhbHNlPC9J
+        c0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPEdhdGV3YXk+
+        MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAg
+        ICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4KICAgICAgICAg
+        ICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0VuYWJsZWQ+CiAg
+        ICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAgICAgICAgICAg
+        ICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
+        ICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2OC4yNTQuMTAwPC9T
+        dGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
+        PEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9FbmRBZGRyZXNzPgogICAg
+        ICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAg
+        ICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAg
+        IDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAg
+        ICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9GZW5jZU1vZGU+CiAg
+        ICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
+        PmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAg
+        ICAgICAgIDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95
+        ZWQ+ZmFsc2U8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
+        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxMZWFzZVNldHRp
+        bmdzU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRl
+        bXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02
+        NTU0MDA4ZjE4NjgvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBs
+        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlv
+        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgIDxvdmY6SW5m
+        bz5MZWFzZSBzZXR0aW5ncyBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICA8
+        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
+        QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1i
+        M2ZiLTY1NTQwMDhmMTg2OC9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
+        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
+        ZWN0aW9uK3htbCIvPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29uZHM+
+        Nzc3NjAwMDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9y
+        YWdlTGVhc2VFeHBpcmF0aW9uPjIwMTYtMTAtMzBUMTM6MTk6MDUuOTc3KzAx
+        OjAwPC9TdG9yYWdlTGVhc2VFeHBpcmF0aW9uPgogICAgPC9MZWFzZVNldHRp
+        bmdzU2VjdGlvbj4KICAgIDxDdXN0b21pemF0aW9uU2VjdGlvbiBnb2xkTWFz
+        dGVyPSJmYWxzZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBU
+        ZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmIt
+        NjU1NDAwOGYxODY4L2N1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBw
+        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuY3VzdG9taXphdGlvblNlY3Rp
+        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
+        Zm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rpb248L292ZjpJ
+        bmZvPgogICAgICAgIDxDdXN0b21pemVPbkluc3RhbnRpYXRlPnRydWU8L0N1
+        c3RvbWl6ZU9uSW5zdGFudGlhdGU+CiAgICA8L0N1c3RvbWl6YXRpb25TZWN0
+        aW9uPgogICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFUMTQ6MDQ6NDQuMTYw
+        KzAyOjAwPC9EYXRlQ3JlYXRlZD4KPC9WQXBwVGVtcGxhdGU+Cg==
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:05 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:41 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - ef6417a2-cdeb-4f53-9227-d58df36f56be
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '160'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1306'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="TinyLinuxVM-template" id="urn:vcloud:catalogitem:e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0"/>
+            <Entity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-08-01T14:37:56.943+02:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:07 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:43 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 13e4cf63-6935-4e93-baf4-830efb6109d4
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '250'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="TinyLinuxVM-template" id="urn:vcloud:vapptemplate:7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/disableDownload"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
                 <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
-            <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="VM02" id="urn:vcloud:vm:fc4d57de-f02f-4479-aa50-3ca1b74fd41a" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/screen"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="enable" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/action/reconfigureVm" name="VM02" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>VM02</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:06</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="NONE" vcloud:primaryNetworkConnection="true">none</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>1024 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="80" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel7_64Guest" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Red Hat Enterprise Linux 7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f289215f-5a4b-4106-b14d-8376447068e8" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description>Created by: Mike Laverick
+        Blog: www.mikelaverick.com
+        Twitter: @mike_laverick
+
+        Services Enabled: SSH, FTP, HTTP
+        ROOT Password: password</Description>
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="none">
+                        <NetworkConnection needsCustomization="true" network="VM Network">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>false</IsConnected>
-                            <MACAddress>00:50:56:01:00:06</MACAddress>
-                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
-                        </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>fc4d57de-f02f-4479-aa50-3ca1b74fd41a</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>PC-VM02</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-                    </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-07-26T13:19:22.817+02:00</DateCreated>
-                    <VAppScopedLocalId>04675421-bbce-407a-b83e-09c65cdd1fc7</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-fc4d57de-f02f-4479-aa50-3ca1b74fd41a/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                </Vm>
-                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="3" name="RHEL-7-2gb-1gb" id="urn:vcloud:vm:f1756fa9-1706-47bd-95d1-2edb781acf46" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="discardState" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/discardSuspendedState"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/screen"/>
-                    <Link rel="enable" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/enableNestedHypervisor"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/action/reconfigureVm" name="RHEL-7-2gb-1gb" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-bfd40328-a383-4b0e-9130-66edd590f4ab" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description/>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>RHEL-7-2gb-1gb</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:05</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="POOL" vcloud:ipAddress="10.30.2.52" vcloud:primaryNetworkConnection="true">test-direct-connected</rasd:Connection>
-                            <rasd:Description>Vmxnet3 ethernet adapter on "test-direct-connected"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>SCSI Controller</rasd:Description>
-                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
-                            <rasd:ResourceType>6</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="VirtualSCSI" vcloud:capacity="2048"/>
-                            <rasd:InstanceID>2000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>2147483648</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>Floppy Drive</rasd:Description>
-                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>8000</rasd:InstanceID>
-                            <rasd:ResourceType>14</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>1024 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="80" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="rhel7_64Guest" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Red Hat Enterprise Linux 7 (64-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="false" network="test-direct-connected">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IpAddress>10.30.2.52</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:05</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:12</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f1756fa9-1706-47bd-95d1-2edb781acf46</VirtualMachineId>
+                        <VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>RHEL-7-2gb-1gb</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>TTYLinux-001</ComputerName>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-07-26T13:16:21.540+02:00</DateCreated>
-                    <VAppScopedLocalId>0925daf3-3df8-47b2-9b1a-36dd1322a975</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f1756fa9-1706-47bd-95d1-2edb781acf46/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
+                    <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
                 </Vm>
             </Children>
-        </VApp>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="VM Network">
+                    <Description>The VM Network network</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.254.100</StartAddress>
+                                        <EndAddress>192.168.254.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-30T13:50:22.967+01:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+        </VAppTemplate>
     http_version: 
-  recorded_at: Tue, 26 Jul 2016 11:21:10 GMT
+  recorded_at: Mon, 01 Aug 2016 14:30:08 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:44 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 43d014f1-730c-4db2-9d12-b5ec7777adc4
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '250'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="TinyLinuxVM-template" id="urn:vcloud:vapptemplate:7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/disableDownload"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f289215f-5a4b-4106-b14d-8376447068e8" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description>Created by: Mike Laverick
+        Blog: www.mikelaverick.com
+        Twitter: @mike_laverick
+
+        Services Enabled: SSH, FTP, HTTP
+        ROOT Password: password</Description>
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="VM Network">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:12</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TTYLinux-001</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
+                    <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="VM Network">
+                    <Description>The VM Network network</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.254.100</StartAddress>
+                                        <EndAddress>192.168.254.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-30T13:50:22.967+01:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:09 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 01 Aug 2016 14:29:45 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - d13278dd-515e-4311-bcf3-3144aa136ca7
+      X-Vcloud-Authorization:
+      - d9f42c1d0d36469aabf58ffc905516d2
+      Set-Cookie:
+      - vcloud-token=d9f42c1d0d36469aabf58ffc905516d2; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '246'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="TinyLinuxVM-template" id="urn:vcloud:vapptemplate:7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6"/>
+            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/enableDownload"/>
+            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/disableDownload"/>
+            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f289215f-5a4b-4106-b14d-8376447068e8" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description>Created by: Mike Laverick
+        Blog: www.mikelaverick.com
+        Twitter: @mike_laverick
+
+        Services Enabled: SSH, FTP, HTTP
+        ROOT Password: password</Description>
+                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="VM Network">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:12</MACAddress>
+                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TTYLinux-001</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
+                    <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkSection/">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="VM Network">
+                    <ovf:Description>The VM Network network</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="VM Network">
+                    <Description>The VM Network network</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.254.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.254.100</StartAddress>
+                                        <EndAddress>192.168.254.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-30T13:50:22.967+01:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Mon, 01 Aug 2016 14:30:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Purpose or Intent
-----------------
The VMware catalog provides descriptors for vApp templates and
corresponding VM images. The hierarchy of the catalog is

```organization -> catalogs -> catalog_items -> vapp_template -> vms```

This patch traverses through the entire chain and collects all available
VM images. Public and private catalogs are available so we also
introduce a setting to allow enablement of import of both types of
catalogs (by default, only private catalogs are imported).

Spec file has been updated to test presence of catalog data. Some
limitations on the available data from VMware had to be considered (for
example, no info about the OS, bitness

@miq-bot add_label providers/vmware/cloud, enhancement, wip, gem changes