### PR TITLE
C&U charts menu stuck when zero VMs

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -715,9 +715,6 @@ function miqBuildChartMenuEx(col, row, _value, category, series, chart_set, char
 
 // Handle chart context menu clicks
 function miqChartMenuClick(itemId) {
-  // remove the event handler that closes the menu
-  $(document).off('click.close_popup');
-
   if ($('#menu_div').length) {
     $('#menu_div').hide();
   }


### PR DESCRIPTION
Purpose or Intent
-----------------
Parent Issue: #10072 
When there are no running VMs Chart Interactivity menu does not hide.
I fixed it by removing line which removes event handler which closes the popup menu. I think that this line is not necessary, because we remove this event handler in `onclick` function
https://github.com/ManageIQ/manageiq/blob/master/app/assets/javascripts/miq_c3.js#L48
@himdel please review