### PR TITLE
Fix report scheduler timer_types

### DIFF
--- a/app/views/report/_schedule_form_timer.html.haml
+++ b/app/views/report/_schedule_form_timer.html.haml
@@ -7,7 +7,7 @@
       %label.control-label.col-md-2
         = _('Run')
       .col-md-8
-        - timer_types = [_("Once"), _("Hourly"), _("Daily"), _("Weekly"), _("Monthly")]
+        - timer_types = [[_("Once"), "Once"], [_("Hourly"), "Hourly"], [_("Daily"), "Daily"], [_("Weekly"), "Weekly"], [_("Monthly"), "Monthly"]]
         - timer_types.shift if x_active_tree == :widgets_tree
         = select_tag("timer_typ",
           options_for_select(timer_types, @edit[:new][:timer_typ]),


### PR DESCRIPTION
To reproduce the problem:
1. With non-English locale set, go to Cloud Intel -> Reports -> Schedules
2. Click 'Add a new schedule' in toolbar button
3. Change the schedule frequency to something else (Daily, Hourly, ...)

The `timer_types` submitted with the form must not be translated, otherwise the form submission
would fail for non-English locales:

```
HTTP parse error, malformed request (): #<Puma::HttpParserError:
Invalid HTTP format, parsing fails.>
...
```

The problem also shows in darga.