### PR TITLE
Fix dialog field visibility to work on load

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -28,7 +28,7 @@ var dialogFieldRefresh = {
       var responseData = JSON.parse(data.responseText);
       $('.dynamic-checkbox-' + fieldId).prop('checked', responseData.values.checked);
       dialogFieldRefresh.setReadOnly($('.dynamic-checkbox-' + fieldId), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('.dynamic-checkbox-' + fieldId), responseData.values.visible);
+      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_checkbox_refresh', data, doneFunction);
@@ -48,7 +48,7 @@ var dialogFieldRefresh = {
       }
 
       dialogFieldRefresh.setReadOnly($('.dynamic-date-' + fieldId), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('.dynamic-date-' + fieldId), responseData.values.visible);
+      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_date_refresh', data, doneFunction);
@@ -62,7 +62,7 @@ var dialogFieldRefresh = {
       var responseData = JSON.parse(data.responseText);
       dialogFieldRefresh.addOptionsToDropDownList(responseData, fieldId);
       dialogFieldRefresh.setReadOnly($('#' + fieldName), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('#field_' + fieldId + "_tr"), responseData.values.visible);
+      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
       $('#' + fieldName).selectpicker('refresh');
       $('#' + fieldName).selectpicker('val', responseData.values.checked_value);
     };
@@ -120,7 +120,7 @@ var dialogFieldRefresh = {
       var responseData = JSON.parse(data.responseText);
       $('.dynamic-text-area-' + fieldId).val(responseData.values.text);
       dialogFieldRefresh.setReadOnly($('.dynamic-text-area-' + fieldId), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('.dynamic-text-area-' + fieldId), responseData.values.visible);
+      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_text_box_refresh', data, doneFunction);
@@ -134,7 +134,7 @@ var dialogFieldRefresh = {
       var responseData = JSON.parse(data.responseText);
       $('.dynamic-text-box-' + fieldId).val(responseData.values.text);
       dialogFieldRefresh.setReadOnly($('.dynamic-text-box-' + fieldId), responseData.values.read_only);
-      dialogFieldRefresh.setVisible($('.dynamic-text-box-' + fieldId), responseData.values.visible);
+      dialogFieldRefresh.setVisible($('#field_' +fieldId + '_tr'), responseData.values.visible);
     };
 
     dialogFieldRefresh.sendRefreshRequest('dynamic_text_box_refresh', data, doneFunction);

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -56,3 +56,6 @@
         - value = wf.value(field.name) || ''
         - classification_ids = value.split(',')
         = h(Classification.where(:id => classification_ids).collect(&:description).join(', '))
+
+    :javascript
+      dialogFieldRefresh.setVisible($('#field_#{field.id}_tr'), #{field.visible});

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -139,7 +139,7 @@ describe('dialogFieldRefresh', function() {
       });
       it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
-          jasmine.objectContaining({selector: '.dynamic-checkbox-123'}),
+          jasmine.objectContaining({selector: '#field_123_tr'}),
           false
         );
       });
@@ -206,7 +206,7 @@ describe('dialogFieldRefresh', function() {
       });
       it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
-          jasmine.objectContaining({selector: '.dynamic-date-123'}),
+          jasmine.objectContaining({selector: '#field_123_tr'}),
           false
         );
       });
@@ -257,7 +257,7 @@ describe('dialogFieldRefresh', function() {
       });
       it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
-          jasmine.objectContaining({selector: '.dynamic-text-box-123'}),
+          jasmine.objectContaining({selector: '#field_123_tr'}),
           false
         );
       });
@@ -308,7 +308,7 @@ describe('dialogFieldRefresh', function() {
       });
       it('sets the visible property', function() {
         expect(dialogFieldRefresh.setVisible).toHaveBeenCalledWith(
-          jasmine.objectContaining({selector: '.dynamic-text-area-123'}),
+          jasmine.objectContaining({selector: '#field_123_tr'}),
           false
         );
       });


### PR DESCRIPTION
Replace all dialogue field setVisible calls with a more generic one for simplification and adds a call on page load so that visibility works with both automate calls and being set in model. 

@miq-bot add_label refactoring
@miq-bot add_label ui
@miq-bot assign @gmcculloug