### PR TITLE
Remove cpu_socket counts from google provider as there is no concept of sockets

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/refresh_parser.rb
@@ -118,7 +118,6 @@ module ManageIQ::Providers
           :description => flavor.description,
           :enabled     => !flavor.deprecated,
           :cpus        => flavor.guest_cpus,
-          :cpu_cores   => 1,
           :memory      => flavor.memory_mb * 1.megabyte,
         }
 
@@ -243,11 +242,9 @@ module ManageIQ::Providers
           :operating_system  => operating_system,
           :key_pairs         => [],
           :hardware          => {
-            :cpu_sockets          => flavor[:cpus],
-            :cpu_total_cores      => flavor[:cpu_cores],
-            :cpu_cores_per_socket => 1,
-            :memory_mb            => flavor[:memory] / 1.megabyte,
-            :disks                => [], # populated below
+            :cpu_total_cores => flavor[:cpus],
+            :memory_mb       => flavor[:memory] / 1.megabyte,
+            :disks           => [], # populated below
           }
         }
 

--- a/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
@@ -258,7 +258,6 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :description => "1 vCPU (shared physical core) and 0.6 GB RAM",
       :enabled     => true,
       :cpus        => 1,
-      :cpu_cores   => 1,
       :memory      => 643825664,
     )
 
@@ -273,7 +272,6 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :description => "Custom created machine type.",
       :enabled     => true,
       :cpus        => 1,
-      :cpu_cores   => 1,
       :memory      => 2147483648,
     )
 
@@ -325,7 +323,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :guest_os_full_name  => nil,
       :bios                => nil,
       :annotation          => nil,
-      :cpu_sockets         => 1,
+      :cpu_total_cores     => 1,
       :memory_mb           => 614,
       :bitness             => nil,
       :virtualization_type => nil
@@ -496,8 +494,8 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :guest_os_full_name => nil,
       :bios               => nil,
       :annotation         => nil,
-      :cpu_sockets        => 1,
       :memory_mb          => 614,
+      :cpu_total_cores    => 1,
       :bitness            => nil
     )
 


### PR DESCRIPTION
Purpose or Intent
-----------------
The Google provider doesn't have a concept of "sockets", only number of virtual CPUs. However the current code assigns the number of sockets to "1", which is apparently enough to display sockets in the UI. This is slightly confusing.

The UI presentation code has a check that only displays sockets if it's explicitly set; otherwise only CPU counts are displayed (see https://github.com/ManageIQ/manageiq/blob/master/app/helpers/vm_helper/textual_summary.rb#L125). Because this check exists, I removed the explicit socket count setting from the refresh code.

Fixes #10105