### PR TITLE
[WIP] Convert settings visualtab to Angular

### DIFF
--- a/app/assets/javascripts/controllers/configuration/my_settings_visuals_controller.js
+++ b/app/assets/javascripts/controllers/configuration/my_settings_visuals_controller.js
@@ -1,4 +1,4 @@
-ManageIQ.angular.app.controller('mySettingsVisualsController', ['$http', '$scope', 'miqService', '$timeout', function($http, $scope, miqService, $timeout) {
+ManageIQ.angular.app.controller('mySettingsVisualsController', ['$http', '$scope', 'miqService', function($http, $scope, miqService) {
     var init = function() {
         $scope.afterGet = false;
         $scope.hideCancel = true;

--- a/app/assets/javascripts/controllers/configuration/my_settings_visuals_controller.js
+++ b/app/assets/javascripts/controllers/configuration/my_settings_visuals_controller.js
@@ -26,7 +26,7 @@ ManageIQ.angular.app.controller('mySettingsVisualsController', ['$http', '$scope
 
         ManageIQ.angular.scope = $scope;
 
-        $http.get('/configuration/get_visual_settings').success(function(data) {
+        $http.get('/configuration/visual_settings').success(function(data) {
             $scope.mySettingsModel = data;
             $scope.modelCopy = angular.copy( $scope.mySettingsModel );
             $scope.afterGet = true;

--- a/app/assets/javascripts/controllers/configuration/my_settings_visuals_controller.js
+++ b/app/assets/javascripts/controllers/configuration/my_settings_visuals_controller.js
@@ -1,0 +1,53 @@
+ManageIQ.angular.app.controller('mySettingsVisualsController', ['$http', '$scope', 'miqService', '$timeout', function($http, $scope, miqService, $timeout) {
+    var init = function() {
+        $scope.afterGet = false;
+        $scope.hideCancel = true;
+        miqService.sparkleOn();
+        $scope.mySettingsModel = {
+            ems: true,
+            ems_cloud: true,
+            host: true,
+            storage: true,
+            vm: true,
+            miq_template: true,
+            quad_truncate: 'f',
+            startpage: '',
+            perpage_grid: '5',
+            perpage_tile: '5',
+            perpage_list: '5',
+            perpage_reports: '5',
+            display_reporttheme: '',
+            display_timezone: '',
+            display_locale: ''
+        };
+
+        $scope.model = 'mySettingsModel';
+        $scope.newRecord = false;
+
+        ManageIQ.angular.scope = $scope;
+
+        $http.get('/configuration/get_visual_settings').success(function(data) {
+            $scope.mySettingsModel = data;
+            $scope.modelCopy = angular.copy( $scope.mySettingsModel );
+            $scope.afterGet = true;
+            miqService.sparkleOff();
+        });
+    };
+
+    $scope.resetClicked = function() {
+        $scope.$broadcast ('resetClicked');
+        $scope.mySettingsModel = angular.copy( $scope.modelCopy );
+        $scope.angularForm.$setPristine(true);
+        miqService.miqFlash("warn", __("All changes have been reset"));
+    };
+
+    $scope.saveClicked = function() {
+        miqService.sparkleOn();
+        var url = '/configuration/set_visual_settings';
+        miqService.miqAjaxButton(url, miqService.serializeModel($scope.mySettingsModel));
+        miqService.sparkleOff();
+        $scope.angularForm.$setPristine(true);
+    };
+
+    init();
+}]);

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -523,6 +523,33 @@ class ConfigurationController < ApplicationController
     end
   end
 
+  def visual_settings
+    # TODO: Placeholder for REST api to get visual settings
+    visual_settings = {
+      :ems                 => true,
+      :ems_cloud           => true,
+      :host                => true,
+      :storage             => true,
+      :vm                  => true,
+      :miq_template        => true,
+      :quad_truncate       => 'f',
+      :startpage           => '',
+      :perpage_grid        => '5',
+      :perpage_tile        => '5',
+      :perpage_list        => '20',
+      :perpage_reports     => '20',
+      :display_reporttheme => '',
+      :display_timezone    => '',
+      :display_locale      => ''
+    }
+
+    render :json => visual_settings
+  end
+
+  def set_visual_settings
+    # TODO: Placeholder for REST api to set visual settings
+  end
+
   private ############################
 
   # copy single selected Object

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -72,7 +72,7 @@
             %h3
               = _('Display Settings')
             - [[_("Chart Theme"), "display_reporttheme", Charting.chart_themes_for_select, false],
-               [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES                   , true],
+               [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES,                    true],
                [_("Locale"), "display_locale",      [[_("Global Default"), "default"]] + FastGettext.human_available_locales, false]].each do |display_settings|
               .form-group
                 %label.col-md-3.control-label

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -1,97 +1,90 @@
-- url = url_for(:action => "form_field_changed")
-- url_json = {:url => url_for(:action => "form_field_changed")}.to_json
-= render :partial => "layouts/flash_msg"
-
 #tab_div
-  = form_tag({:action => "update"},
-             :id     => "config_form",
-             :class  => "form-horizontal",
-             :method => :post) do
-    .row
-      .col-md-12.col-lg-6
-        %fieldset
-          %h3
-            = _('Grid/Tile Icons')
-          -# render condition                                 title                                      check_box label & checked T/F
-          -# Host Item is commented (condition set as false) until we have host item quads
-          - [[role_allows?(:feature => "ems_infra_show_list"), ui_lookup(:table => "ems_infra"),          "ems"],
-             [role_allows?(:feature => "ems_cloud_show_list"), ui_lookup(:table => "ems_cloud"),          "ems_cloud"],
-             [role_allows?(:feature => "host_show_list"),      _("Host"),                                 "host"],
-             [role_allows?(:feature => "storage_show_list"),   ui_lookup(:table => "storages"),           "storage"],
-             [true,                                           _("VM"),                                   "vm"],
-             [true,                                           _("Template"),                             "miq_template"]].each do |icons_checkbox|
-            - if icons_checkbox[0]
+  .form-horizontal{:id => 'start_form_div'}
+    %form#form_div{:name           => 'angularForm',
+                   'ng-controller' => 'mySettingsVisualsController',
+                   'ng-show'       => 'afterGet',
+                   :novalidate     => true}
+      = render :partial => "layouts/flash_msg"
+      .row
+        .col-md-12.col-lg-6
+          %fieldset
+            %h3
+              = _('Grid/Tile Icons')
+            -# render condition                                 title                                      check_box label & checked T/F
+            -# Host Item is commented (condition set as false) until we have host item quads
+            - [[role_allows?(:feature => "ems_infra_show_list"), ui_lookup(:table => "ems_infra"),          "ems"],
+               [role_allows?(:feature => "ems_cloud_show_list"), ui_lookup(:table => "ems_cloud"),          "ems_cloud"],
+               [role_allows?(:feature => "host_show_list"),      _("Host"),                                 "host"],
+               [role_allows?(:feature => "storage_show_list"),   ui_lookup(:table => "storages"),           "storage"],
+               [true,                                           _("VM"),                                   "vm"],
+               [true,                                           _("Template"),                             "miq_template"]].each do |icons_checkbox|
+              - if icons_checkbox[0]
+                .form-group
+                  %label.col-md-3.control-label
+                    = _("Show %{title} Quadrants") % {:title => icons_checkbox[1]}
+                  .col-md-8
+                    %input.form-control{:type         => 'checkbox',
+                                        :name         => "quadicons_#{icons_checkbox[2]}",
+                                        'ng-model'    => "mySettingsModel.#{icons_checkbox[2].to_sym}",
+                                        'bs-switch'   => ''}
+            .form-group
+              %label.col-md-3.control-label
+                = _('Truncate Long Text')
+              .col-md-8
+                = select_tag("quad_truncate",
+                             options_for_select([[_("Front (...1234)"), "f"],
+                                                 [_("Middle (AB...34)"), "m"],
+                                                 [_("Back (ABCD...)"), "b"]], nil),
+                             'ng-model'                    => 'mySettingsModel.quad_truncate',
+                             "selectpicker-for-select-tag" => "",
+                             :class                        => 'selectpicker')
+          %fieldset
+            %h3
+              = _('Start Page')
+            .form-group
+              %label.col-md-3.control-label
+                = _('Show at Login')
+              .col-md-8
+                = select_tag("start_page",
+                             options_for_select(session[:start_pages], nil),
+                             'ng-model'                    => 'mySettingsModel.startpage',
+                             "data-live-search"            => "true",
+                             "selectpicker-for-select-tag" => "",
+                             :class                        => "selectpicker")
+        .col-md-12.col-lg-6
+          %fieldset
+            %h3
+              = _('Default Items Per Page')
+            - [[_("Grid View"), "perpage_grid"],
+               [_("Tile View"), "perpage_tile"],
+               [_("List View"), "perpage_list"],
+               [_("Reports"),   "perpage_reports"]].each do |item_per_page|
               .form-group
                 %label.col-md-3.control-label
-                  = _("Show %{title} Quadrants") % {:title => icons_checkbox[1]}
+                  = _(item_per_page[0])
                 .col-md-8
-                  = check_box_tag("quadicons_#{icons_checkbox[2]}",
-                                  true,
-                                  @edit[:new][:quadicons][icons_checkbox[2].to_sym], :data => {:on_text => 'Yes', :off_text => 'No'})
-                :javascript
-                  miqInitBootstrapSwitch("quadicons_#{icons_checkbox[2]}", "#{url}")
-          .form-group
-            %label.col-md-3.control-label
-              = _('Truncate Long Text')
-            .col-md-8
-              = select_tag("quad_truncate",
-                           options_for_select([[_("Front (...1234)"), "f"],
-                                               [_("Middle (AB...34)"), "m"],
-                                               [_("Back (ABCD...)"), "b"]],
-                           @edit[:new][:display][:quad_truncate]),
-                           :class    => "selectpicker")
+                  = select_tag(_(item_per_page[1]),
+                               options_for_select(PPCHOICES, nil),
+                               'ng-model'                    => "mySettingsModel.#{item_per_page[1]}",
+                               "selectpicker-for-select-tag" => "",
+                               :class                        => "selectpicker")
+          %fieldset
+            %h3
+              = _('Display Settings')
+            - [[_("Chart Theme"), "display_reporttheme", Charting.chart_themes_for_select, false],
+               [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES                   , true],
+               [_("Locale"), "display_locale",      [[_("Global Default"), "default"]] + FastGettext.human_available_locales, false]].each do |display_settings|
+              .form-group
+                %label.col-md-3.control-label
+                  = display_settings[0]
+                .col-md-8
+                  = select_tag(display_settings[1],
+                               options_for_select(display_settings[2], nil),
+                               'ng-model'                    => "mySettingsModel.#{display_settings[1]}",
+                               'data-live-search'            => display_settings[3],
+                               "selectpicker-for-select-tag" => "",
+                               :class                        => 'selectpicker')
+      = render :partial => 'layouts/angular/x_edit_buttons_angular'
 
-            :javascript
-              miqSelectPickerEvent("quad_truncate", "#{url}")
-        %fieldset
-          %h3
-            = _('Start Page')
-          .form-group
-            %label.col-md-3.control-label
-              = _('Show at Login')
-            .col-md-8
-              = select_tag("start_page",
-                           options_for_select(session[:start_pages], @edit[:new][:display][:startpage]),
-                           "data-live-search" => "true",
-                           :class             => "selectpicker")
-
-            :javascript
-              miqSelectPickerEvent("start_page", "#{url}")
-      .col-md-12.col-lg-6
-        %fieldset
-          %h3
-            = _('Default Items Per Page')
-          - [[_("Grid View"), "perpage_grid",    :grid],
-             [_("Tile View"), "perpage_tile",    :tile],
-             [_("List View"), "perpage_list",    :list],
-             [_("Reports"),   "perpage_reports", :reports]].each do |item_per_page|
-            .form-group
-              %label.col-md-3.control-label
-                = _(item_per_page[0])
-              .col-md-8
-                = select_tag(_(item_per_page[1]),
-                             options_for_select(PPCHOICES, @edit[:new][:perpage][item_per_page[2]]),
-                           :class    => "selectpicker")
-
-            :javascript
-              miqSelectPickerEvent("#{item_per_page[1]}", "#{url}")
-        %fieldset
-          %h3
-            = _('Display Settings')
-          - [[_("Chart Theme"), "display_reporttheme", Charting.chart_themes_for_select, :reporttheme, false],
-             [_("Time Zone"),   "display_timezone",    ALL_TIMEZONES,                    :timezone, true],
-             [_("Locale"), "display_locale",      [[_("Global Default"), "default"]] + FastGettext.human_available_locales, :locale, false]].each do |display_settings|
-            .form-group
-              %label.col-md-3.control-label
-                = display_settings[0]
-              .col-md-8
-                = select_tag(display_settings[1],
-                             options_for_select(display_settings[2], @edit[:new][:display][display_settings[3]]),
-                             'data-live-search' => display_settings[4],
-                             :class             => "selectpicker")
-
-              :javascript
-                miqInitSelectPicker();
-                miqSelectPickerEvent("#{display_settings[1]}", "#{url}")
-
-    = render :partial => '/layouts/form_buttons'
+:javascript
+  miq_bootstrap('#form_div');

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -48,4 +48,5 @@
                :class => "btn btn-default",
                :alt   => _("Cancel"),
                :title => _("Cancel"),
-               "ng-click" => "cancelClicked($event)")
+               "ng-click" => "cancelClicked($event)",
+               "ng-hide"  => "hideCancel")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,6 +449,7 @@ Vmdb::Application.routes.draw do
         timeprofile_copy
         timeprofile_edit
         timeprofile_new
+        get_visual_settings
       ),
       :post => %w(
         button
@@ -462,6 +463,7 @@ Vmdb::Application.routes.draw do
         tree_autoload_dynatree
         update
         view_selected
+        set_visual_settings
       )
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,7 +449,7 @@ Vmdb::Application.routes.draw do
         timeprofile_copy
         timeprofile_edit
         timeprofile_new
-        get_visual_settings
+        visual_settings
       ),
       :post => %w(
         button

--- a/spec/javascripts/controllers/configuration/my_settings_visuals_controller_spec.js
+++ b/spec/javascripts/controllers/configuration/my_settings_visuals_controller_spec.js
@@ -1,0 +1,107 @@
+describe('mySettingsVisualsController', function() {
+    var $scope, $controller, $httpBackend, miqService;
+
+    beforeEach(module('ManageIQ'));
+
+    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
+        miqService = _miqService_;
+        spyOn(miqService, 'showButtons');
+        spyOn(miqService, 'hideButtons');
+        spyOn(miqService, 'miqAjaxButton');
+        spyOn(miqService, 'sparkleOn');
+        spyOn(miqService, 'sparkleOff');
+        $scope = $rootScope.$new();
+        spyOn($scope, '$broadcast');
+
+        var mySettingsModel = {
+                ems: true,
+                ems_cloud: true,
+                host: true,
+                storage: true,
+                vm: true,
+                miq_template: true,
+                quad_truncate: 'f',
+                startpage: 'testing',
+                perpage_grid: '5',
+                perpage_tile: '5',
+                perpage_list: '5',
+                perpage_reports: '5',
+                display_reporttheme: '',
+                display_timezone: '',
+                display_locale: ''
+        };
+
+        $scope.mySettingsModel = mySettingsModel;
+
+        $httpBackend = _$httpBackend_;
+
+        $httpBackend.whenGET('/configuration/get_visual_settings').respond(mySettingsModel);
+        $controller = _$controller_('mySettingsVisualsController', {
+            $scope: $scope,
+            miqService: miqService
+        });
+    }));
+
+    afterEach(function() {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('initialization', function() {
+        beforeEach(function() {
+            $httpBackend.flush();
+            $scope.angularForm = {
+                $setPristine: function (value){}
+            };
+        });
+        
+        if('when the page is initialized', function() {
+            expect($scope.mySettingsModel.startpage).toEqual('testing');
+        });
+    });
+
+    describe('#saveClicked', function() {
+        beforeEach(function() {
+            $httpBackend.flush();
+            $scope.angularForm = {
+                $setPristine: function (value){}
+            };
+            $scope.saveClicked();
+        });
+
+        it('turns the spinner on via the miqService', function() {
+            expect(miqService.sparkleOn).toHaveBeenCalled();
+        });
+
+        it('turns the spinner on twice', function() {
+            expect(miqService.sparkleOn.calls.count()).toBe(2);
+        });
+
+        it('delegates to miqService.miqAjaxButton', function() {
+            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/configuration/set_visual_settings', miqService.serializeModel($scope.mySettingsModel));
+        });
+    });
+
+    describe('#resetClicked', function() {
+        beforeEach(function() {
+            $httpBackend.flush();
+            $scope.angularForm = {
+                $setPristine: function (value){}
+            };
+            $scope.mySettingsModel.ems = false;
+            $scope.mySettingsModel.perpage_grid = 20;
+            $scope.mySettingsModel.startpage = 'updatedpagehere';
+            $scope.resetClicked();
+        });
+
+        it('turns the spinner on via the miqService', function() {
+            expect(miqService.sparkleOn).toHaveBeenCalled();
+        });
+
+        it('expect values to reset', function() {
+            expect($scope.mySettingsModel.ems).toEqual(true);
+            expect($scope.mySettingsModel.perpage_grid).toEqual('5');
+            expect($scope.mySettingsModel.startpage).toEqual('testing');
+        });
+    });
+});


### PR DESCRIPTION
## Purpose or Intent

This covers converting the settings/visual tab to Angular, removing @edit variables from the haml, adding the js controller and tests.  The settings visual tab is functionally identical to what is there today.  

The GET/POST for retrieving and saving configuration settings are stubbed out in preparation for an API developer to fill out the backend work.
## Steps for Testing/QA

> Review the configuration/visual settings page to make sure all functionality matches the existing site.
