### PR TITLE
[WIP] Automate - Added builtin method for parse_event_stream.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_event_stream.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Process.class/__methods__/parse_event_stream.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: parse_event_stream
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: builtin
+  inputs: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Process.class/parse_event_stream.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Process.class/parse_event_stream.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: parse_event_stream
+    inherits: 
+    description: 
+  fields:
+  - meth1:
+      value: parse_event_stream

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -192,7 +192,7 @@ module MiqAeEngine
       ATTRIBUTE_LIST.detect { |attr| vendor = detect_vendor(obj.workspace.root[attr], attr) }
       if vendor
         $miq_ae_logger.info("Setting prepend_namespace to: #{vendor}")
-        obj.workspace.prepend_namespace = vendor
+        obj.workspace.prepend_namespace = vendor.downcase
       end
     end
     private_class_method :prepend_vendor
@@ -201,14 +201,46 @@ module MiqAeEngine
       return unless src_obj
       case attr
       when "orchestration_stack"
-        src_obj.type.split('::')[2]
+        src_obj.ext_management_system.try(:provider_name)
       when "miq_host_provision"
         "vmware"
       when "miq_request", "miq_provision", "vm_migrate_task"
-        src_obj.source.try(:vendor)
+        src_obj.source.try(:provider_name)
       when "vm"
-        src_obj.try(:vendor)
+        src_obj.try(:provider_name)
+      end
+    end
 
+    def self.emsevent_provider_name(event_stream)
+      return nil if event_stream.ext_management_system.nil?
+      event_stream.ext_management_system.try(:provider_name)
+    end
+    private_class_method :emsevent_provider_name
+
+    def self.emsevent_manager_type(event_stream)
+      return nil if event_stream.ext_management_system.nil?
+      manager_type = event_stream.ext_management_system.try(:manager_type).downcase
+      manager_type == "infra" ? INFRASTRUCTURE : manager_type
+    end
+    private_class_method :emsevent_manager_type
+
+    def self.emsevent?(event_stream)
+      event_stream.object_class.name.casecmp("emsevent").zero?
+    end
+    private_class_method :emsevent?
+
+    def self.miq_parse_event_stream(obj, _attr)
+      event_stream = obj.workspace.root['event_stream']
+      raise "Event Stream object not found" if event_stream.nil?
+
+      if emsevent?(event_stream)
+        provider_name = emsevent_provider_name(event_stream)
+        raise "EMS event - Invalid provider" if provider_name.blank?
+        manager_type = emsevent_manager_type(event_stream)
+        raise "EMS event - Invalid manager type" if manager_type.blank?
+        obj.workspace.root['event_path'] = "/#{provider_name}/EMSEvent/#{manager_type}/Event"
+      else
+        obj.workspace.root['event_path'] = "/System/Event/#{event_stream.event_namespace}/#{event_stream.source}"
       end
     end
   end

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -208,6 +208,7 @@ module MiqAeEngine
         src_obj.source.try(:vendor)
       when "vm"
         src_obj.try(:vendor)
+
       end
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceExtManagementSystem < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_service_inflector_mixin"
+    include MiqAeServiceInflectorMixin
+
     expose :storages,             :association => true
     expose :hosts,                :association => true
     expose :vms,                  :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -4,6 +4,8 @@ module MiqAeMethodService
     include MiqAeServiceEmsOperationsMixin
     require_relative "mixins/miq_ae_service_retirement_mixin"
     include MiqAeServiceRetirementMixin
+    require_relative "mixins/miq_ae_service_inflector_mixin"
+    include MiqAeServiceInflectorMixin
 
     expose :ext_management_system, :association => true
     expose :storage,               :association => true

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_inflector_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_inflector_mixin.rb
@@ -1,0 +1,7 @@
+module MiqAeServiceInflectorMixin
+  extend ActiveSupport::Concern
+  included do
+    expose :provider_name
+    expose :manager_type
+  end
+end

--- a/spec/automation/unit/builtin_method_validation/parse_event_stream_spec.rb
+++ b/spec/automation/unit/builtin_method_validation/parse_event_stream_spec.rb
@@ -1,0 +1,45 @@
+describe "parse_event_stream" do
+  let(:inst)          { "/System/Process/parse_event_stream" }
+  let(:user)          { FactoryGirl.create(:user_with_group) }
+  let(:ems)           { FactoryGirl.create(:ems_vmware_with_authentication, :zone => FactoryGirl.create(:zone)) }
+  let(:vm)            { FactoryGirl.create(:vm_vmware, :ext_management_system => ems) }
+  let(:miq_event)     { FactoryGirl.create(:miq_event, :event_type => "some_event") }
+  let(:request_event) { FactoryGirl.create(:request_event) }
+  let(:custom_event)  { FactoryGirl.create(:custom_event) }
+  let(:ems_event) do
+    FactoryGirl.create(:ems_event, :vm_or_template => vm, :ext_management_system => ems)
+  end
+  let(:ems_event_no_source) do
+    FactoryGirl.create(:ems_event, :vm_or_template => vm, :ext_management_system => nil)
+  end
+
+  it "invalid event stream" do
+    expect { MiqAeEngine.instantiate(inst, user) }
+      .to raise_error(MiqAeException::AbortInstantiation, "Event Stream object not found")
+  end
+
+  it "for emsevents" do
+    ws = MiqAeEngine.instantiate("#{inst}?EmsEvent::event_stream=#{ems_event.id}", user)
+    expect(ws.root["event_path"]).to eq("/Vmware/EMSEvent/infrastructure/Event")
+  end
+
+  it "for emsevents with an invalid ems" do
+    expect { MiqAeEngine.instantiate("#{inst}?EmsEvent::event_stream=#{ems_event_no_source.id}", user) }
+      .to raise_error(MiqAeException::AbortInstantiation, "EMS event - Invalid provider")
+  end
+
+  it "for miqevents" do
+    ws = MiqAeEngine.instantiate("#{inst}?MiqEvent::event_stream=#{miq_event.id}", user)
+    expect(ws.root["event_path"]).to eq("/System/Event/MiqEvent/")
+  end
+
+  it "for request events" do
+    ws = MiqAeEngine.instantiate("#{inst}?RequestEvent::event_stream=#{request_event.id}", user)
+    expect(ws.root["event_path"]).to eq("/System/Event/RequestEvent/")
+  end
+
+  it "custom events" do
+    ws = MiqAeEngine.instantiate("#{inst}?CustomEvent::event_stream=#{custom_event.id}", user)
+    expect(ws.root["event_path"]).to eq("/System/Event/CustomEvent/")
+  end
+end

--- a/spec/automation/unit/builtin_method_validation/parse_provider_category_spec.rb
+++ b/spec/automation/unit/builtin_method_validation/parse_provider_category_spec.rb
@@ -35,7 +35,7 @@ describe "parse_provider_category" do
 
   let(:cloud_ems) { FactoryGirl.create(:ems_amazon_with_authentication) }
   let(:cloud_vm)  { FactoryGirl.create(:vm_amazon, :ems_id => cloud_ems.id, :evm_owner => user) }
-  let(:stack)     { FactoryGirl.create(:orchestration_stack_amazon) }
+  let(:stack)     { FactoryGirl.create(:orchestration_stack_amazon, :ext_management_system => cloud_ems) }
 
   let(:cloud_vm_template) do
     FactoryGirl.create(:template_amazon,

--- a/spec/factories/custom_event.rb
+++ b/spec/factories/custom_event.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :custom_event
+end

--- a/spec/factories/request_event.rb
+++ b/spec/factories/request_event.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :request_event
+end


### PR DESCRIPTION
The vendor specific EMS event class and instances have been moved into the pluggable provider automate domains.  

The ManageIQ domain /system/process/event instance uses substitution for the event namespace, class and instance values as shown below: 
rel5 value:
/System/Event/${/#event_stream.event_namespace}/${/#event_stream.source}/${/#event_type}

There are 4 types of event namespaces:
CustomEvent
EMSEvent
MIQEvent
RequestEvent

All EMSEvent type events have to be rerouted to the vendor specific domains /vendor_name/event/manager_type class. 
The behavior for the remaining event namespaces are unchanged.

The ManageIQ domain /system/process/event instance has been changed to:
${/#event_path}/${/#event_type}
The parse_event_stream builtin method sets the root object event_path attribute value based on the event type.
