### PR TITLE
Fix position bug in host show view

### DIFF
--- a/app/views/layouts/listnav/_host.html.haml
+++ b/app/views/layouts/listnav/_host.html.haml
@@ -11,16 +11,15 @@
         - height = 78
       = render_quadicon(@record, :mode => :icon, :size => 72, :height => height, :typ => :listnav)
 
-      %div{:style => "margin-top: -23px; line-height: 13px;"}
-        %center{:style => "color: #000;"}
-          - unless @record.vmm_product.nil?
-            = h(@record.vmm_product)
-          - unless @record.vmm_version.nil?
-            &nbsp;
-            = h(@record.vmm_version)
-          - unless @record.vmm_buildnumber.nil?
-            %br
-            = h(@record.vmm_buildnumber)
+      %div{:style => "text-align:center"}
+        - unless @record.vmm_product.nil?
+          = h(@record.vmm_product)
+        - unless @record.vmm_version.nil?
+          &nbsp;
+          = h(@record.vmm_version)
+        - unless @record.vmm_buildnumber.nil?
+          %br
+          = h(@record.vmm_buildnumber)
 
     = miq_accordion_panel(_("Properties"), false, "host_prop") do
       %ul.nav.nav-pills.nav-stacked


### PR DESCRIPTION
Purpose or Intent
-----------------
For some reason on the /hosts/show screen, the label beneath the quadicon was rendered with negative margin, causing it to display behind the quadicon. This change fixes that by removing the inline style. The deprecated `center` tag was also removed.

**Before**
![screen shot 2016-07-29 at 1 48 05 pm](https://cloud.githubusercontent.com/assets/39493/17263029/8e8f154c-5593-11e6-9af1-2b55afda6f8c.png)

**After**
![screen shot 2016-07-29 at 1 45 05 pm](https://cloud.githubusercontent.com/assets/39493/17263035/96826006-5593-11e6-89ca-1546d176872a.png)




