### PR TITLE
Add missing button for re-checking authentication status for middleware

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -419,8 +419,9 @@ module EmsCommon
         javascript_redirect :back
         return
       end
-      if params[:pressed] == "ems_cloud_recheck_auth_status" ||
-         params[:pressed] == "ems_infra_recheck_auth_status" ||
+      if params[:pressed] == "ems_cloud_recheck_auth_status"     ||
+         params[:pressed] == "ems_infra_recheck_auth_status"     ||
+         params[:pressed] == "ems_middleware_recheck_auth_status" ||
          params[:pressed] == "ems_container_recheck_auth_status"
         @record = find_by_id_filtered(model, params[:id])
         result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),

--- a/app/helpers/application_helper/button/ems_middleware_recheck_auth_status.rb
+++ b/app/helpers/application_helper/button/ems_middleware_recheck_auth_status.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::EmsMiddlewareRecheckAuthStatus < ApplicationHelper::Button::Basic
+  def skip?
+    !@record.is_available?(:authentication_status)
+  end
+end

--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -61,4 +61,20 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
       ]
     ),
   ])
+  button_group('ems_middleware_authentication', [
+    select(
+      :ems_middleware_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :items => [
+        button(
+          :ems_middleware_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_middleware")}'),
+          N_('Re-check Authentication Status'),
+          :klass => ApplicationHelper::Button::EmsMiddlewareRecheckAuthStatus),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -71,7 +71,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
         button(
           :ems_middleware_recheck_auth_status,
           'fa fa-search fa-lg',
-          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_middleware")}'),
+          N_("Re-check Authentication Status for this #{ui_lookup(:table=>'ems_middleware')}"),
           N_('Re-check Authentication Status'),
           :klass => ApplicationHelper::Button::EmsMiddlewareRecheckAuthStatus),
       ]

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -37,6 +37,10 @@ module ManageIQ::Providers
       true
     end
 
+    def validate_authentication_status
+      {:available => true, :message => nil}
+    end
+
     # Hawkular Client
     def self.raw_connect(hostname, port, username, password)
       entrypoint = URI::HTTP.build(:host => hostname, :port => port.to_i).to_s

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3308,6 +3308,10 @@
       :description: Refresh Middleware Providers
       :feature_type: control
       :identifier: ems_middleware_refresh
+    - :name: Re-check Authentication Status
+      :description: Re-check Authentication Status of Middleware Providers
+      :feature_type: control
+      :identifier: ems_middleware_recheck_auth_status
     - :name: Edit Tags
       :description: Edit Tags of Middleware Providers
       :feature_type: control


### PR DESCRIPTION
Purpose or Intent
-----------------
Add the authentication re-check button for middleware. [As was just done for several other providers]

![recheck-auth](https://cloud.githubusercontent.com/assets/1312165/17298734/0fc062be-57c0-11e6-954f-1345ed12859c.jpg)

Links
-----
> * #8912 

