### PR TITLE
Add OpenShift missing API collections

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -36,6 +36,86 @@
     - :patch
     - :delete
 :collections:
+  :container_builds:
+    :description: Container Builds
+    :identifier: container_builds
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerBuild
+  :container_deployments:
+    :description: Container Deployments
+    :identifier: container_deployments
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerDeployment
+  :container_pods:
+    :description: Container Pods
+    :identifier: container_pods
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerGroup
+  :container_images:
+    :description: Container images
+    :identifier: container_images
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerImage
+  :container_nodes:
+    :description: Container Node
+    :identifier: container_nodes
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerNode
+  :container_projects:
+    :description: Container Projects
+    :identifier: container_projects
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerProject
+  :container_replicators:
+    :description: Container Replicators
+    :identifier: container_replicators
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerReplicator
+  :container_services:
+    :description: Container Services
+    :identifier: container_services
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerService
+  :container_volumes:
+    :description: Container Volumes
+    :identifier: container_volumes
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: ContainerVolume
+  :containers:
+    :description: Containers
+    :identifier: containers
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *70174834086080
+    :klass: Container
   :accounts:
     :description: Accounts
     :options:


### PR DESCRIPTION
**Description**
Add API to return list of projects/pods/containers/services/etc from OpenShift.

https://github.com/ManageIQ/manageiq_docs/blob/master/api/reference/collections.adoc

**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1361048

**Screenshots**
Get collection
![get_collection](https://cloud.githubusercontent.com/assets/2181522/17275344/2cbb7c9a-570d-11e6-8888-e964f159cb31.jpg)

Get subcollection
![get_subcollection](https://cloud.githubusercontent.com/assets/2181522/17275345/30d9faa4-570d-11e6-8ccb-5016567b41e1.jpg)

No route to post/delete/put ...
![get_subcollection_post](https://cloud.githubusercontent.com/assets/2181522/17275346/34b1cc92-570d-11e6-85e4-017fdeba6261.jpg)

