### PR TITLE
[WIP] RelationshipMixin: Improve performance of Relationships parent

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -140,6 +140,16 @@ module RelationshipMixin
     Relationship.resource_pairs(parent_rels(*args))
   end
 
+  # return a scope of all of the parents of this record
+  def parents_scope(*args)
+    options = args.extract_options!
+    if options[:of_type].nil? || options[:of_type].kind_of?(Array)
+      raise ArgumentError, ":of_type required as a single parameter"
+    end
+    klass = options[:of_type].constantize
+    klass.where(:id => parent_rels(options).select(:resource_id))
+  end
+
   # Returns the number of parents of the record
   def parent_count(*args)
     parent_rels(*args).size

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -755,8 +755,9 @@ class VmOrTemplate < ApplicationRecord
   alias_method :owning_blue_folder, :parent_blue_folder
 
   def parent_blue_folders(*args)
-    f = parent_blue_folder
-    f.nil? ? [] : f.folder_path_objs(*args)
+    with_relationship_type('ems_metadata') do
+      parents_scope(:of_type => "EmsFolder").folder_path_objs("ems_metadata", *args)
+    end
   end
 
   def under_blue_folder?(folder)


### PR DESCRIPTION
~~extracted #10299 - waiting to merge that to decide what would be the best to read here~~ MERGED

**Theme:**

Speed up `Capture.perf_capture_timer` (142s)
by speeding up `MiqAlert.target_needs_realtime_capture?` (105s)
by speeding up "detection if a resource has an alert" (105s)
by speeding up "get tags for a resource and it's parents (including blue folder)" (100s)
by speeding up "get parents for a resource" (~50% time, 80% queries)

**Goal of this PR:**

Speed up the time it takes to lookup a vm's parents by making it quicker to query ancestors/relationships. This speeds up `parent_blue_folder` and `parent_resource_pool`

https://bugzilla.redhat.com/show_bug.cgi?id=1346988
https://bugzilla.redhat.com/show_bug.cgi?id=1346999
## TL;DR

19% faster, 26% fewer objects, 17% fewer queries, 30% fewer rows returned.
## before

| ms | bytes | objects | queries | query (ms) | rows | `comments` |
| --: | --: | --: | --: | --: | --: | --- |
| 139,250.5 | 439,519,495* | 146,637,247 | 82,206 | 44,212.9 | 101,046 | `before` |
| 1,773.5 |  |  | 11 | 863.0 | 11,045 | `...Metric::Targets.capture_infra_targets` |
| 444.8 |  |  | 202 | 134.9 |  | `..Metric::Capture.calc_targets_by_rollup_parent` |
| 106.5 |  |  | 80 | 21.0 |  | `..Metric::Capture.calc_tasks_by_rollup_parent` |
| 101,671.1 |  |  | 60,223 | 29,461.1 | 90,000 | `..Metric::Capture.filter_perf_capture_now` |
| 7,350.9 |  |  | 5,221 | 5,908.7 | 10,000 | `...SELECT "taggings"."id" AS t0_r0, "taggings"."taggable_id" AS t0_r1, "taggings"."tag_id" AS t0_r2, "ta` |
| 4,896.8 |  |  | 10,000 | 3,701.4 | 25,000 | `...SELECT "relationships".*` |
| 10,203.7 |  |  | 30,000 | 6,794.4 | 30,000 | `...SELECT  "relationships".*` |
| 4,701.8 |  |  | 10,000 | 3,002.7 | 20,000 | `...SELECT "ems_folders".*` |
| 2,307.0 |  |  | 5,000 | 1,666.4 | 5,000 | `...SELECT "resource_pools".*` |
| 35,133.3 |  |  | 21,684 | 13,716.2 |  | `..Metric::Capture.queue_captures` |
- Memory usage does not reflect 71,630,466 freed objects. 
## after

| ms | bytes | objects | queries | query (ms) | rows | `comments` |
| --: | --: | --: | --: | --: | --: | --- |
| 112,703.9 | 245,611,833* | 108,651,445 | 57,206 | 36,877.4 | 71,046 | `after` |
| 1,828.7 |  |  | 11 | 877.2 | 11,045 | `...Metric::Targets.capture_infra_targets` |
| 441.7 |  |  | 202 | 132.4 |  | `..Metric::Capture.calc_targets_by_rollup_parent` |
| 112.1 |  |  | 80 | 24.1 |  | `..Metric::Capture.calc_tasks_by_rollup_parent` |
| 74,396.0 |  |  | 35,223 | 22,228.2 | 60,000 | `..Metric::Capture.filter_perf_capture_now` |
| 6,055.6 |  |  | 5,221 | 3,984.9 | 10,000 | `...SELECT "taggings"."id" AS t0_r0, "taggings"."taggable_id" AS t0_r1, "taggings"."tag_id" AS t0_r2, "ta` |
| 3,879.3 |  |  | 10,000 | 2,511.9 | 20,000 | `...SELECT "relationships"."ancestry"` |
| 6,282.9 |  |  | 10,000 | 5,148.0 | 10,000 | `...SELECT  "relationships".*` |
| 3,627.2 |  |  | 5,000 | 2,496.6 | 15,000 | `...SELECT "ems_folders".*` |
| 2,382.3 |  |  | 5,000 | 1,719.6 | 5,000 | `...SELECT  "resource_pools".*` |
| 35,785.4 |  |  | 21,684 | 13,598.4 |  | `..Metric::Capture.queue_captures` |
- Memory usage does not reflect 52,462,392 freed objects. 

I tried to cut out cruft from tables. let me know if you need more info
