### PR TITLE
Toolbar builder buttons refactoring

### DIFF
--- a/app/helpers/application_helper/button/instance_pause.rb
+++ b/app/helpers/application_helper/button/instance_pause.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::InstancePause < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.is_available?(:pause)
+  end
+end

--- a/app/helpers/application_helper/button/instance_shelve.rb
+++ b/app/helpers/application_helper/button/instance_shelve.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::InstanceShelve < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.is_available?(:shelve)
+  end
+end

--- a/app/helpers/application_helper/button/instance_shelve_offload.rb
+++ b/app/helpers/application_helper/button/instance_shelve_offload.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::InstanceShelveOffload < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.is_available?(:shelve_offload)
+  end
+end

--- a/app/helpers/application_helper/button/instance_start.rb
+++ b/app/helpers/application_helper/button/instance_start.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::InstanceStart < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.is_available?(:start)
+  end
+end

--- a/app/helpers/application_helper/button/instance_stop.rb
+++ b/app/helpers/application_helper/button/instance_stop.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::InstanceStop < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.is_available?(:stop)
+  end
+end

--- a/app/helpers/application_helper/button/instance_suspend.rb
+++ b/app/helpers/application_helper/button/instance_suspend.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::InstanceSuspend < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.is_available?(:suspend)
+  end
+end

--- a/app/helpers/application_helper/button/vm_start.rb
+++ b/app/helpers/application_helper/button/vm_start.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::VmStart < ApplicationHelper::Button::Basic
+  needs_record
+
+  def calculate_properties
+    self[:title] = @error_message if disabled?
+  end
+
+  def skip?
+    !@record.is_available?(:start)
+  end
+
+  def disabled?
+    !!(@error_message = @record.is_available_now_error_message(:start))
+  end
+end

--- a/app/helpers/application_helper/button/vm_suspend.rb
+++ b/app/helpers/application_helper/button/vm_suspend.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::VmSuspend < ApplicationHelper::Button::Basic
+  needs_record
+
+  def calculate_properties
+    self[:title] = @error_message if disabled?
+  end
+
+  def skip?
+    !@record.is_available?(:suspend)
+  end
+
+  def disabled?
+    !!(@error_message = @record.is_available_now_error_message(:suspend))
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -13,7 +13,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Stop this Instance'),
             N_('Stop'),
             :image   => "guest_shutdown",
-            :confirm => N_("Stop this Instance?")),
+            :confirm => N_("Stop this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceStop),
           included_class.button(
             :instance_start,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -29,7 +29,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Pause this Instance'),
             N_('Pause'),
             :image   => "power_pause",
-            :confirm => N_("Pause this Instance?")),
+            :confirm => N_("Pause this Instance?"),
+            :klass   => ApplicationHelper::Button::InstancePause),
           included_class.button(
             :instance_suspend,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -53,7 +53,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Shelve Offload this Instance'),
             N_('Shelve Offload'),
             :image   => "power_shelve_offload",
-            :confirm => N_("Shelve Offload this Instance?")),
+            :confirm => N_("Shelve Offload this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceShelveOffload),
           included_class.button(
             :instance_resume,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -45,7 +45,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Shelve this Instance'),
             N_('Shelve'),
             :image   => "power_shelve",
-            :confirm => N_("Shelve this Instance?")),
+            :confirm => N_("Shelve this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceShelve),
           included_class.button(
             :instance_shelve_offload,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -37,7 +37,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Suspend this Instance'),
             N_('Suspend'),
             :image   => "suspend",
-            :confirm => N_("Suspend this Instance?")),
+            :confirm => N_("Suspend this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceSuspend),
           included_class.button(
             :instance_shelve,
             nil,

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -21,7 +21,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Start this Instance'),
             N_('Start'),
             :image   => "power_on",
-            :confirm => N_("Start this Instance?")),
+            :confirm => N_("Start this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceStart),
           included_class.button(
             :instance_pause,
             nil,
@@ -56,7 +57,8 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Resume this Instance'),
             N_('Resume'),
             :image   => "power_resume",
-            :confirm => N_("Resume this Instance?")),
+            :confirm => N_("Resume this Instance?"),
+            :klass   => ApplicationHelper::Button::InstanceStart),
           included_class.separator,
           included_class.button(
             :instance_guest_restart,

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -185,7 +185,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Power On this VM'),
           N_('Power On'),
           :image   => "power_on",
-          :confirm => N_("Power On this VM?")),
+          :confirm => N_("Power On this VM?"),
+          :klass   => ApplicationHelper::Button::VmStart),
         button(
           :vm_stop,
           nil,

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -201,7 +201,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Suspend this VM'),
           N_('Suspend'),
           :image   => "power_suspend",
-          :confirm => N_("Suspend this VM?")),
+          :confirm => N_("Suspend this VM?"),
+          :klass   => ApplicationHelper::Button::VmSuspend),
         button(
           :vm_reset,
           nil,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -831,8 +831,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:reboot_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
-      when "instance_stop"
-        return true unless @record.is_available?(:stop)
       when "vm_suspend", "instance_suspend"
         return true unless @record.is_available?(:suspend)
       when "instance_shelve"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -829,8 +829,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:reboot_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
-      when "vm_suspend", "instance_suspend"
-        return true unless @record.is_available?(:suspend)
       when "instance_shelve"
         return true unless @record.is_available?(:shelve)
       when "instance_shelve_offload"
@@ -1263,8 +1261,6 @@ class ApplicationHelper::ToolbarBuilder
         return @record.is_available_now_error_message(:shutdown_guest) if @record.is_available_now_error_message(:shutdown_guest)
       when "vm_guest_restart"
         return @record.is_available_now_error_message(:reboot_guest) if @record.is_available_now_error_message(:reboot_guest)
-      when "vm_suspend"
-        return @record.is_available_now_error_message(:suspend) if @record.is_available_now_error_message(:suspend)
       when "instance_retire", "instance_retire_now"
         return N_("Instance is already retired") if @record.retired
       when "vm_timeline"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -821,8 +821,6 @@ class ApplicationHelper::ToolbarBuilder
       case id
       when "vm_collect_running_processes"
         return true if (@record.retired || @record.current_state == "never") && !@record.is_available?(:collect_running_processes)
-      when "vm_guest_startup", "vm_start", "instance_start", "instance_resume"
-        return true unless @record.is_available?(:start)
       when "vm_guest_standby"
         return true unless @record.is_available?(:standby_guest)
       when "vm_guest_shutdown", "instance_guest_shutdown"
@@ -1261,8 +1259,6 @@ class ApplicationHelper::ToolbarBuilder
         if @record.current_state != "on"
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
-      when "vm_guest_startup", "vm_start"
-        return @record.is_available_now_error_message(:start) if @record.is_available_now_error_message(:start)
       when "vm_guest_standby"
         return @record.is_available_now_error_message(:standby_guest) if @record.is_available_now_error_message(:standby_guest)
       when "vm_guest_shutdown"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -829,10 +829,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:reboot_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
-      when "instance_shelve"
-        return true unless @record.is_available?(:shelve)
-      when "instance_shelve_offload"
-        return true unless @record.is_available?(:shelve_offload)
       when "instance_terminate"
         return true unless @record.is_available?(:terminate)
       when "vm_policy_sim", "vm_protect"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -835,8 +835,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:shelve)
       when "instance_shelve_offload"
         return true unless @record.is_available?(:shelve_offload)
-      when "instance_pause"
-        return true unless @record.is_available?(:pause)
       when "instance_terminate"
         return true unless @record.is_available?(:terminate)
       when "vm_policy_sim", "vm_protect"

--- a/spec/helpers/application_helper/buttons/instance_pause_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_pause_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstancePause do
+  describe '#skip?' do
+    context "when record is pausable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:pause).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not pausable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:pause).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_shelve_offload_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_shelve_offload_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstanceShelveOffload do
+  describe '#skip?' do
+    context "when record is shelve_offloadable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:shelve_offload).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not shelve_offloadable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:shelve_offload).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_shelve_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_shelve_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstanceShelve do
+  describe '#skip?' do
+    context "when record is shelveable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:shelve).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not shelveable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:shelve).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_start_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstanceStart do
+  describe '#skip?' do
+    context "when record is stopable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:start).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not stopable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:start).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+
+    context "when record has no error message" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available_now_error_message).and_return(false)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_stop_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_stop_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstanceStop do
+  describe '#skip?' do
+    context "when record is stopable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:stop).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not stopable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:stop).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/instance_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_suspend_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::InstanceSuspend do
+  describe '#skip?' do
+    context "when record is suspendable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:suspend).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not suspendable" do
+      before do
+        @record = FactoryGirl.create(:vm_openstack)
+        allow(@record).to receive(:is_available?).with(:suspend).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_start_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::VmStart do
+  describe '#skip?' do
+    context "when record is startable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available?).with(:start).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not startable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available?).with(:start).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+
+    context "when record has no error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available_now_error_message).and_return(false)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "when record has an error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        message = "xx stop message"
+        allow(@record).to receive(:is_available_now_error_message).with(:start).and_return(message)
+      end
+
+      it "disables the button and returns the stop error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_suspend_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::VmSuspend do
+  describe '#skip?' do
+    context "when record is suspendable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available?).with(:suspend).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not suspendable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available?).with(:suspend).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+
+    context "when record has no error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:is_available_now_error_message).and_return(false)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "when record has an error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        message = "xx stop message"
+        allow(@record).to receive(:is_available_now_error_message).with(:suspend).and_return(message)
+      end
+
+      it "disables the button and returns the stop error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -365,7 +365,6 @@ describe ApplicationHelper do
      "repo_protect",
      "resource_pool_protect",
      "vm_check_compliance",
-     "vm_guest_startup",
      "vm_guest_shutdown",
      "vm_guest_standby",
      "vm_guest_restart",
@@ -1162,17 +1161,6 @@ describe ApplicationHelper do
         end
       end
 
-      context "and id = vm_start" do
-        before { @id = "vm_start" }
-
-        it "hides the start button" do
-          @record = FactoryGirl.create(:vm_amazon)
-          allow(@record).to receive_messages(:retired => false, :current_state => "terminated")
-          result = build_toolbar_hide_button(@id)
-          expect(result).to be_truthy
-        end
-      end
-
       context "and id = vm_collect_running_processes" do
         before do
           @id = "vm_collect_running_processes"
@@ -1210,24 +1198,6 @@ describe ApplicationHelper do
         it "and @lastaction = drift_history" do
           @lastaction = "drift_history"
           expect(subject).to be_falsey
-        end
-      end
-
-      ["vm_guest_startup", "vm_start"].each do |id|
-        context "and id = #{id}" do
-          before do
-            @id = id
-            allow(@record).to receive(:is_available?).with(:start).and_return(true)
-          end
-
-          it "and !@record.is_available?(:start)" do
-            allow(@record).to receive(:is_available?).with(:start).and_return(false)
-            expect(subject).to be_truthy
-          end
-
-          it "and @record.is_available?(:start)" do
-            expect(subject).to be_falsey
-          end
         end
       end
 
@@ -2227,24 +2197,6 @@ describe ApplicationHelper do
         end
 
         it_behaves_like 'vm not powered on', "The web-based console is not available because the VM is not powered on"
-      end
-
-      context "and id = vm_guest_startup" do
-        before do
-          @id = "vm_guest_startup"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'start'
-        it_behaves_like 'default case'
-      end
-
-      context "and id = vm_start" do
-        before do
-          @id = "vm_start"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'start'
-        it_behaves_like 'default case'
       end
 
       context "and id = vm_guest_standby" do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1249,22 +1249,6 @@ describe ApplicationHelper do
         end
       end
 
-      context "and id = vm_suspend" do
-        before do
-          @id = "vm_suspend"
-          allow(@record).to receive(:is_available?).with(:suspend).and_return(true)
-        end
-
-        it "and !@record.is_available?(:suspend)" do
-          allow(@record).to receive(:is_available?).with(:suspend).and_return(false)
-          expect(subject).to be_truthy
-        end
-
-        it "and @record.is_available?(:suspend)" do
-          expect(subject).to be_falsey
-        end
-      end
-
       ["vm_policy_sim", "vm_protect"].each do |id|
         context "and id = #{id}" do
           before do
@@ -2223,15 +2207,6 @@ describe ApplicationHelper do
           allow(@record).to receive(:is_available_now_error_message).and_return(false)
         end
         it_behaves_like 'record with error message', 'reboot_guest'
-        it_behaves_like 'default case'
-      end
-
-      context "and id = vm_suspend" do
-        before do
-          @id = "vm_suspend"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'suspend'
         it_behaves_like 'default case'
       end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Purpose is to move toolbar buttons from helper (app/helpers/application_helper/toolbar_builder.rb) to separate classes. Divide button into more than one classes if its necessary.

`instance_stop` moved to class `InstanceStop`
`instance_start, instance_resume` these two are sharing one class `InstanceStart`
`vm_start` moved to separate class `VmStart`
`vm_guest_startup` removed, because we dont use it anymore.
`instance_pause` moved to separate class
`instance_suspend` divided into `VmSuspend` and `InstanceSuspend`
`instance_shelve` moved to separate class
`instance_shelve_offload` moved to separate class


Parent issue: #6259
Parent PR: #9540
