### PR TITLE
switch icon order in ems_container toolbar

### DIFF
--- a/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
+++ b/app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb
@@ -1,13 +1,6 @@
 class ApplicationHelper::Toolbar::DashboardSummaryToggleView < ApplicationHelper::Toolbar::Basic
   button_group('ems_container_dashboard', [
     twostate(
-      :view_topology,
-      'fa pficon-topology',
-      N_('Topology View'),
-      nil,
-      :url       => "/",
-      :url_parms => "?display=topology"),
-    twostate(
       :view_dashboard,
       'fa fa-tachometer fa-1xplus',
       N_('Dashboard View'),
@@ -21,5 +14,12 @@ class ApplicationHelper::Toolbar::DashboardSummaryToggleView < ApplicationHelper
       nil,
       :url       => "/",
       :url_parms => ""),
+    twostate(
+      :view_topology,
+      'fa pficon-topology',
+      N_('Topology View'),
+      nil,
+      :url       => "/",
+      :url_parms => "?display=topology")
   ])
 end


### PR DESCRIPTION
Topology icon moved to far right.

Before:
![screencapture-localhost-3000-ems_container-3-1470053977722](https://cloud.githubusercontent.com/assets/11256940/17293841/7d7f96ae-57fb-11e6-880a-101a2b51ca30.png)

After:
![screencapture-localhost-3000-ems_container-3-1470052335005](https://cloud.githubusercontent.com/assets/11256940/17293816/470f01ae-57fb-11e6-8b9d-b52dfa2ba1c3.png)

@serenamarie125 @dclarizio @epwinchell Please review