### PR TITLE
Show provider status color by bearer type authentication on container topology

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -264,6 +264,10 @@ module AuthenticationMixin
     return status == :valid, details
   end
 
+  def default_authentication
+    authentication_type(default_authentication_type)
+  end
+
   private
 
   def authentication_check_no_validation(type, options)

--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -79,7 +79,7 @@ class ContainerTopologyService < TopologyService
     elsif entity.kind_of?(ContainerReplicator)
       status = (entity.current_replicas == entity.replicas) ? 'OK' : 'Warning'
     elsif entity.kind_of?(ManageIQ::Providers::ContainerManager)
-      status = entity.authentications.empty? ? 'Unknown' : entity.authentications.first.status.capitalize
+      status = entity.authentications.empty? ? 'Unknown' : entity.default_authentication.status.capitalize
     else
       status = 'Unknown'
     end

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
 
   factory :authentication_status_error, :parent => :authentication do
     status      "Error"
+    authtype    "bearer"
   end
 
   factory :authentication_ipmi, :parent => :authentication do


### PR DESCRIPTION
The status ring on the provider icon should be colored according to the `bearer` authentication of that provider. Note that since recently, we cannot create a provider with invalid credentials so there isnt a chance that `find_by_authtype('bearer')` will return `nil` (right? @yaacov )

@miq-bot add_label ui, topology, providers/containers

@abonas Please review
cc @simon3z 