### PR TITLE
Add back a space char. Otherwise one gets "-4 days ago".

### DIFF
--- a/app/helpers/textual_mixins/textual_refresh_status.rb
+++ b/app/helpers/textual_mixins/textual_refresh_status.rb
@@ -3,7 +3,7 @@ module TextualMixins::TextualRefreshStatus
     last_refresh_status = @ems.last_refresh_status.titleize
     if @ems.last_refresh_date
       last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << _(" -%{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
+      last_refresh_status << _(" - %{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
     end
     {
       :label => _("Last Refresh"),


### PR DESCRIPTION
There used to be a space between '-' and 'x days ago'. Now this ready '-4 days ago', which is wrong. 
Re-introducing the space.

Before:
![bildschirmfoto 2016-08-01 um 15 32 22](https://cloud.githubusercontent.com/assets/208246/17295717/c1db5cc8-57fd-11e6-936e-1176f1edbbe7.png)

After:

![bildschirmfoto 2016-08-01 um 15 35 18](https://cloud.githubusercontent.com/assets/208246/17295719/c5627822-57fd-11e6-9bc3-a1efd8758a72.png)

@miq-bot add_label ui, bug
@miq-bot assign @himdel 