### PR TITLE
Make fix_auth great again

### DIFF
--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -5,6 +5,7 @@ require_dependency 'vmdb/settings/hash_differ'
 
 module Vmdb
   class Settings
+    # if you change, please also change over in tools/fix_auth/models.rb
     PASSWORD_FIELDS = %i(bind_pwd password amazon_secret).to_set.freeze
 
     cattr_accessor :last_loaded
@@ -20,6 +21,7 @@ module Vmdb
       activate
     end
 
+    # if you change, please also change over in tools/fix_auth/auth_config_model.rb
     def self.walk(settings = ::Settings, path = [], &block)
       settings.each do |key, value|
         new_path = path.dup << key

--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -11,8 +11,6 @@ if __FILE__ == $PROGRAM_NAME
   $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(.. gems pending))))
 end
 
-require File.expand_path('../../config/environment', __FILE__)
-
 require 'active_support/all'
 require 'active_support/concern'
 require 'fix_auth/auth_model'

--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -79,13 +79,16 @@ module FixAuth
 
   class FixSettingsChange < ActiveRecord::Base
     include FixAuth::AuthModel
+    # Sorry - duplicate of Vmdb::Settings::PASSWORD_FIELDS. Can't reference app classes from here
+    PASSWORD_FIELDS = %i(bind_pwd password amazon_secret).to_set.freeze
+
     self.table_name = "settings_changes"
     self.password_columns = %w(value)
 
     serialize :value
 
     def self.contenders
-      query = Vmdb::Settings::PASSWORD_FIELDS.collect do |field|
+      query = PASSWORD_FIELDS.collect do |field|
         "(key LIKE '%/#{field}')"
       end.join(" OR ")
 


### PR DESCRIPTION
Purpose or Intent
-----------------

We have a tool that allows users to create, migrate, and repair encryption keys (i.e.: `v2_key`) called `fix_auth`

Since this tool needs to change `database.yml` and generate a `v2_key`, it has been running outside of the rails environment.

Recently, we introduced references into the rails app and this is causing issues.
Alternatively, we can change to better support being part of the rails app.

Current Issues
--------------

1. Can not generate an encryption key. `require config/environment` blows up because there is not an encryption key.
2. `Settings` has been changed assumes gems and rails environment is available

@isimluk or @gmcculloug may be able to provide better stack traces here.

Alternate Solutions:
---------

1. Move `fix_auth` into `pending/gems` so incorrect dependencies are not added. This will be hard to test (it tests on a vmdb database) and will not solve the bad yaml issues.
2. Remove the `require config/envirnment` and add necessary `requires`.
3. Change `Settings` to not bring in all the requirements
4. Copy/Paste `Settings.walk` into `fix_auth/*.rb` **<< THIS PR**
5. Have `fix_auth` load the environment, but only after generating a key and/or fixing the `database.yml`.