### PR TITLE
[WIP] Use angular-rails-templates to cache angular templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "lodash-rails",                 "~>3.10.0"
   gem "sass-rails"
   gem "sprockets-es6",                "~>0.9.0",  :require => "sprockets/es6"
+  gem "angular-rails-templates",      "~>1.0.0"
 
   # Modified gems (forked on Github)
   gem "jquery-rjs",                   "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require angular-ui-bootstrap
 //= require angular-ui-bootstrap-tpls
 //= require angular-sanitize
+//= require angular-rails-templates
 //= require moment
 //= require moment-strftime/build/moment-strftime.min
 //= require moment-timezone
@@ -23,6 +24,7 @@
 //= require_tree ./directives/
 //= require_tree ./services/
 //= require_tree ./controllers/
+//= require_tree ../../views/static/
 //= require d3
 //= require c3
 //= require lodash

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -2,6 +2,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'ui.bootstrap',
   'patternfly',
   'frapontillo.bootstrap-switch',
+  'miq.templates',
 ]);
 miqHttpInject(ManageIQ.angular.app);
 

--- a/config/initializers/angular-rails-templates.rb
+++ b/config/initializers/angular-rails-templates.rb
@@ -1,0 +1,9 @@
+module Vmdb
+  class Application < Rails::Application
+    config.angular_templates.module_name    = 'miq.templates'
+    config.angular_templates.ignore_prefix  = []
+    config.angular_templates.inside_paths   = ['app/views/static']
+    config.angular_templates.markups        = %w(haml)
+    config.angular_templates.extension      = 'html'
+  end
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,5 @@
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'bower_components')
+Rails.application.config.assets.paths << Rails.root.join('app', 'views', 'static')
 
 Rails.application.config.assets.precompile += %w(
   jquery-1.8/jquery.js jquery_overrides.js jquery vmrc.css


### PR DESCRIPTION
This builds on #4455 to provide angular templates in `app/views/static` to angular applications without that extra round-trip.

The only difference should be that before, `templateUrl: "/static/foo.html"` would trigger a GET request for that file, wheras with this, the angular code will already have that template in the cache and won't need that extra request.

(Extraced from @AparnaKarve's #9529, with some changes in the template location (to reuse /static), and calling the module `miq.templates`))

..still WIP - it strips the leading `/static` from `angular_template_name`
.. aah, because we'd have to add the whole `views` directory to asset paths, not only static, for it to do what we want.. which is *not good* :) .. will probably need to move to a different directory => will wait for the 3 currently open PRs which introduce new files to /static before that..