### PR TITLE
UI for Nuage subnets

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -10,6 +10,6 @@ class CloudSubnetController < ApplicationController
   include Mixins::GenericShowMixin
 
   def self.display_methods
-    %w(instances)
+    %w(instances cloud_subnets)
   end
 end

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module CloudSubnetHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(parent_ems_cloud ems_network cloud_tenant availability_zone instances cloud_network network_router)
+    %i(parent_ems_cloud ems_network cloud_tenant availability_zone instances cloud_network network_router parent_subnet managed_subnets)
   end
 
   #
@@ -74,6 +74,21 @@ module CloudSubnetHelper::TextualSummary
 
   def textual_network_router
     @record.network_router
+  end
+
+  def textual_parent_subnet
+    @record.parent_cloud_subnet
+  end
+
+  def textual_managed_subnets
+    label = _("Managed Subnets")
+    num   = @record.number_of(:cloud_subnets)
+    h     = {:label => label, :image => "cloud_subnet", :value => num}
+    if num > 0 && role_allows(:feature => "cloud_subnet_show_list")
+      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'cloud_subnets')
+      h[:title] = _("Show all %{label}") % {:label => label}
+    end
+    h
   end
 
   def textual_availability_zone

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -56,15 +56,15 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.parent_manager)
+    @record.try(:parent_manager)
   end
 
   def textual_availability_zones
-    @record.availability_zones
+    @record.try(:availability_zones)
   end
 
   def textual_cloud_tenants
-    @record.cloud_tenants
+    @record.try(:cloud_tenants)
   end
 
   def textual_security_groups

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -12,7 +12,7 @@ class CloudSubnet < ApplicationRecord
   belongs_to :availability_zone
   belongs_to :network_group
   belongs_to :network_router
-  belongs_to :parent_cloud_subnet
+  belongs_to :parent_cloud_subnet, :class_name => "::CloudSubnet"
 
   has_many :cloud_subnet_network_ports, :dependent => :destroy
   has_many :network_ports, :through => :cloud_subnet_network_ports, :dependent => :destroy

--- a/app/models/manageiq/providers/nuage/network_manager.rb
+++ b/app/models/manageiq/providers/nuage/network_manager.rb
@@ -33,6 +33,6 @@ class ManageIQ::Providers::Nuage::NetworkManager < ManageIQ::Providers::NetworkM
 
   def auth_url(protocol, server, port, version)
     scheme = protocol == "no_ssl" ? "http" : "https"
-    scheme + '://' + server + ':' + port.to_s + '/' + 'nuage/api/' + version
+    "#{scheme}://#{server}:#{port}/nuage/api/#{version}"
   end
 end

--- a/app/models/manageiq/providers/nuage/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/cloud_network.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Nuage::NetworkManager::CloudNetwork < ::CloudNetwork
-end

--- a/app/models/manageiq/providers/nuage/network_manager/network_group.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/network_group.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Nuage::NetworkManager::NetworkGroup < ::NetworkGroup
+end

--- a/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/vsd_client.rb
@@ -89,37 +89,5 @@ module ManageIQ::Providers
       end
       _log.error('Error in connection ' + response.code.to_s)
     end
-
-    def install_license(license_str)
-      license_dict = {}
-      license_dict['license'] = license_str
-      response = @rest_call.post(@server + '/licenses', JSON.dump(license_dict))
-      if response.code != 201
-        if response.body == 'The license already exists'
-          _log.error('license install failed')
-        end
-      end
-    end
-
-    def add_csproot_to_cms_group
-      response = @rest_call.get(@server + "/enterprises/#{@enterprise_id}/groups")
-      groups = JSON.parse(response.body)
-      @cms_group_id = nil
-
-      @cms_group_id = groups.detect { ['name'] == 'CMS Group' }.try(:[], 'ID')
-      _log.info("groups::#{groups}")
-
-      response = @rest_call.get(@server + "/enterprises/#{@enterprise_id}/users")
-      users = JSON.parse(response.body)
-      csproot_user_id = users.detect { ['userName'] == 'csproot' }.try(:[], 'ID')
-      _log.info("user::#{users}")
-
-      response = @rest_call.get(@server + "/enterprises/#{@cms_group_id}/users")
-      _log.info(response.body)
-      userlist = ["{#{csproot_user_id}}"]
-      @rest_call.put(@server + "/groups/#{@cms_group_id}/users", JSON.dump(userlist))
-      response = @rest_call.get(@server + "/groups/#{@cms_group_id}/users")
-      _log.info(response.body)
-    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-nuage-network_manager-cloud_network.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-nuage-network_manager-cloud_network.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Nuage_NetworkManager_CloudNetwork < MiqAeServiceCloudNetwork
-  end
-end


### PR DESCRIPTION
Adding UI elements to display the text for Nuage subnets under Nuage provider.
Also subnets are now mapped to network groups to be saved as part of the ManageIQ database

Under Networks -> Providers we get to see Nuage . However since runners for refresh parser aren't completed as yet, for now the Nuage Network Provider is added through the rails console and a manual EmsRefresh is done.the subsequent screenshots are for traversing withing the Nuage Provider till we reach the summary of the cloud subnets page. 
![screenshot from 2016-08-02 12 10 54](https://cloud.githubusercontent.com/assets/18197629/17336100/a8a606ba-58aa-11e6-9f2e-6d37a658c471.png)
![screenshot from 2016-08-02 12 11 09](https://cloud.githubusercontent.com/assets/18197629/17336102/a8ad0604-58aa-11e6-923f-59682b7ab230.png)
![screenshot from 2016-08-02 12 11 23](https://cloud.githubusercontent.com/assets/18197629/17336099/a89a9410-58aa-11e6-8be0-f4efde628464.png)
![screenshot from 2016-08-02 12 11 34](https://cloud.githubusercontent.com/assets/18197629/17336101/a8ac2f2c-58aa-11e6-973b-fca7a9180caa.png)
![screenshot from 2016-08-02 12 11 46](https://cloud.githubusercontent.com/assets/18197629/17336098/a8902020-58aa-11e6-9eb5-188c2a0aee8b.png)








