### PR TITLE
Fix possible nil error in Resource Pool show view

### DIFF
--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -154,8 +154,11 @@ class ResourcePool < ApplicationRecord
 
   # Overridden from AggregationMixin to provide hosts related to this RP
   def all_hosts
-    p = parent_cluster_or_host
-    p.kind_of?(Host) ? [p] : p.all_hosts
+    if p = parent_cluster_or_host
+      p.kind_of?(Host) ? [p] : p.all_hosts
+    else
+      []
+    end
   end
 
   def all_host_ids

--- a/app/views/layouts/listnav/_resource_pool.html.haml
+++ b/app/views/layouts/listnav/_resource_pool.html.haml
@@ -16,9 +16,9 @@
         - if role_allows(:feature => "ems_cluster_show")
           = li_link(:if => !@record.parent_cluster.nil?,
             :text       => _("Parent %{title}: %{name}") % {:title => title_for_cluster,
-              :name       => @record.parent_cluster.name},
+              :name       => @record.parent_cluster.try(:name)},
             :controller => 'ems_cluster',
-            :record_id  => @record.parent_cluster.id,
+            :record_id  => @record.parent_cluster.try(:id),
             :title      => _('Show VMs'))
 
         - if role_allows(:feature => "host_show")


### PR DESCRIPTION
Purpose or Intent
-----------------
It's possible to have a Resource Pool without a parent host or cluster. If you attempt to visit the show screen for such a pool the page will error. First reported in issue #1213 .

**Before**
![screen shot 2016-08-01 at 4 52 39 pm](https://cloud.githubusercontent.com/assets/39493/17312577/7e6a3526-5808-11e6-8037-15f8632bc7d4.png)

-------

**After**
![screen shot 2016-08-01 at 4 53 21 pm](https://cloud.githubusercontent.com/assets/39493/17312580/844488e8-5808-11e6-945c-97319d40a85f.png)

/cc @Fryguy @dclarizio 

fixes #1213