### PR TITLE
Memoize image_path helper in build_tags_tree

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -1034,6 +1034,8 @@ module ApplicationController::MiqRequestMethods
     # Build the default filters tree for the search views
     all_tags = []                          # Array to hold all CIs
     kids_checked = false
+    parent_icon = ActionController::Base.helpers.image_path("100/folder.png")
+    child_icon  = ActionController::Base.helpers.image_path("100/tag.png")
     tags.each_with_index do |t, i| # Go thru all of the Searches
       if @curr_tag.blank? || @curr_tag != t[:name]
         if @curr_tag != t[:name] && @ci_node
@@ -1049,7 +1051,7 @@ module ApplicationController::MiqRequestMethods
         @ci_node[:title] += " *" if t[:single_value]
         @ci_node[:tooltip] = t[:description]
         @ci_node[:addClass] = "cfme-no-cursor-node"      # No cursor pointer
-        @ci_node[:icon] = ActionController::Base.helpers.image_path("100/folder.png")
+        @ci_node[:icon] = parent_icon
         @ci_node[:hideCheckbox] = @ci_node[:cfmeNoClick] = true
         @ci_node[:addClass] = "cfme-bold-node"  # Show node as different
         @ci_kids = []
@@ -1062,7 +1064,7 @@ module ApplicationController::MiqRequestMethods
           temp[:cfme_parent_key] = t[:id].to_s if t[:single_value]
           temp[:title] = temp[:tooltip] = c[1][:description]
           temp[:addClass] = "cfme-no-cursor-node"
-          temp[:icon] = ActionController::Base.helpers.image_path("100/tag.png")
+          temp[:icon] = child_icon
           if edit_mode              # Don't show checkboxes/radio buttons in non-edit mode
             if vm_tags && vm_tags.include?(c[0].to_i)
               temp[:select] = true


### PR DESCRIPTION
Purpose or Intent
-----------------
Improves the load time of the `/miq_request/show/:id` route for databases with a large number of Tags (over 10k).


Overview
--------
Making the call to `ActionController::Base.helpers.image_path` is expensive and is called N times for the total number of tags (parents and children) iterated over in `build_tags_tree`.  Since this value never changes for each parent and child and in the iteration, saving these before entering the loop saves significant amount of time and resources when N grows large.


Metrics
-------

Here is an example showing a before and after with a DB that includes 15k Tags:

**Before**

Started GET "/miq_request/show/:id"...
Completed 200 OK in 13204ms (Views: 919.9ms | ActiveRecord: 0.0ms)

|       ms |   bytes |    objects | queries | query (ms) |   rows |
|     ---: |    ---: |       ---: |    ---: |       ---: |   ---: |
| 11,811.7 |     N/A | 38,383,207 |      78 |      905.3 | 33,593 |


**After**

Started GET "/miq_request/show/:id"...
Completed 200 OK in 3819ms (Views: 1380.0ms | ActiveRecord: 0.0ms)

|       ms |   bytes |    objects | queries | query (ms) |   rows |
|     ---: |    ---: |       ---: |    ---: |       ---: |   ---: |
|  1,974.4 |     N/A |  2,146,710 |      78 |      843.9 | 33,593 |