### PR TITLE
miq_dynatree - make checkboxes work even when cfme_no_click

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -599,7 +599,6 @@ function miqTreeEventSafeEval(func) {
 }
 
 function miqInitDynatree(options, tree) {
-
   if (options.check_url) {
     ManageIQ.dynatree.checkUrl = options.check_url;
   }
@@ -637,10 +636,6 @@ function miqInitDynatree(options, tree) {
     onClick: function(node, event) {
       var event_type = node.getEventTargetType(event);
 
-      if (options.no_click && event_type != 'expander') {
-        return false;
-      }
-
       if (options.onclick || options.disable_checks || options.oncheck) {
         if (event_type != 'expander' && node.data.cfmeNoClick) return false;
         if (options.onclick) {
@@ -671,6 +666,8 @@ function miqInitDynatree(options, tree) {
 
           if (event_type != 'expander') return false;
         }
+      } else if (options.no_click && event_type != 'expander') {
+        return false;
       }
     },
     onSelect: function(flag, node) {


### PR DESCRIPTION
This fixes a bug introduced in #9943, where a tree with cfme_no_click would never do anything on click.

Probably the only tree affected is `protect_tree` (`Policy > Manage Policies` on a VM), without this, it's impossible to check a checkbox there.

In the original code, `onClick: function...` was created twice and this case is the one where both were created, so the [second one](https://github.com/ManageIQ/manageiq/pull/9943/files#diff-68c04f575f602a2ea2b246518f9b0acdL78) would override [the first](https://github.com/ManageIQ/manageiq/pull/9943/files#diff-68c04f575f602a2ea2b246518f9b0acdL55). Changing the logic to fit that behaviour.

@skateman, @ZitaNemeckova FYI

@martinpovolny could you please..? :)