### PR TITLE
Consolidate deployment types in container deployment service 

### DIFF
--- a/app/models/container_deployment.rb
+++ b/app/models/container_deployment.rb
@@ -7,4 +7,6 @@ class ContainerDeployment < ApplicationRecord
   has_many :custom_attributes, :as => :resource, :dependent => :destroy
   has_many :authentications, :as => :resource, :dependent => :destroy
   serialize :customize, Hash
+
+  DEPLOYMENT_TYPES = %w(origin openshift-enterprise).freeze
 end

--- a/app/services/container_deployment_service.rb
+++ b/app/services/container_deployment_service.rb
@@ -54,6 +54,6 @@ class ContainerDeploymentService
   end
 
   def optional_deployment_types
-    %w(openshiftOrigin, openshiftEnterprise)
+    ContainerDeployment::DEPLOYMENT_TYPES
   end
 end


### PR DESCRIPTION
This change started as a fix to the strings array returned from the container deployment service.
Eventually, we decided to consolidate the deployment types in the model itself and maintain consistency with the way the types are written in the openshift-ansible config yaml/inventory.