### PR TITLE
Add topology link for subnet provider view

### DIFF
--- a/app/controllers/container_topology_controller.rb
+++ b/app/controllers/container_topology_controller.rb
@@ -1,30 +1,13 @@
 class ContainerTopologyController < ApplicationController
+  include TopologyMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
 
-  def show
-    # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
-    # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
-    # any other page in the application.
-    @breadcrumbs.clear if params[:id].nil?
-    drop_breadcrumb(:name => _('Topology'), :url => '')
-    @lastaction = 'show'
-    @display = @showtype = 'topology'
-  end
-
-  def index
-    redirect_to :action => 'show'
-  end
-
   private
 
   def get_session_data
     @layout = "container_topology"
-  end
-
-  def set_session_data
-    session[:layout] = @layout
   end
 end

--- a/app/controllers/middleware_topology_controller.rb
+++ b/app/controllers/middleware_topology_controller.rb
@@ -1,33 +1,14 @@
 class MiddlewareTopologyController < ApplicationController
+  include TopologyMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
 
-  def show
-    # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
-    # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
-    # any other page in the application.
-    @breadcrumbs.clear if params[:id].nil?
-    drop_breadcrumb(:name => _('Topology'), :url => '')
-  end
-
-  def index
-    redirect_to :action => 'show'
-  end
-
-  def data
-    render :json => {:data => generate_topology(params[:id])}
-  end
-
   private
 
   def get_session_data
     @layout = "middleware_topology"
-  end
-
-  def set_session_data
-    session[:layout] = @layout
   end
 
   def generate_topology(provider_id)

--- a/app/controllers/mixins/topology_mixin.rb
+++ b/app/controllers/mixins/topology_mixin.rb
@@ -5,6 +5,8 @@ module TopologyMixin
     # any other page in the application.
     @breadcrumbs.clear if params[:id].nil?
     drop_breadcrumb(:name => _('Topology'), :url => '')
+    @lastaction = 'show'
+    @display = @showtype = 'topology'
   end
 
   def index

--- a/app/controllers/mixins/topology_mixin.rb
+++ b/app/controllers/mixins/topology_mixin.rb
@@ -1,0 +1,23 @@
+module TopologyMixin
+  def show
+    # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
+    # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
+    # any other page in the application.
+    @breadcrumbs.clear if params[:id].nil?
+    drop_breadcrumb(:name => _('Topology'), :url => '')
+  end
+
+  def index
+    redirect_to :action => 'show'
+  end
+
+  def data
+    render :json => {:data => generate_topology(params[:id])}
+  end
+
+  private
+
+  def set_session_data
+    session[:layout] = @layout
+  end
+end

--- a/app/controllers/network_topology_controller.rb
+++ b/app/controllers/network_topology_controller.rb
@@ -1,33 +1,14 @@
 class NetworkTopologyController < ApplicationController
+  include TopologyMixin
   before_action :check_privileges
   before_action :get_session_data
   after_action :cleanup_action
   after_action :set_session_data
 
-  def show
-    # When navigated here without id, it means this is a general view for all providers (not for a specific provider)
-    # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
-    # any other page in the application.
-    @breadcrumbs.clear if params[:id].nil?
-    drop_breadcrumb(:name => _('Topology'), :url => '')
-  end
-
-  def index
-    redirect_to :action => 'show'
-  end
-
-  def data
-    render :json => {:data => generate_topology(params[:id])}
-  end
-
   private
 
   def get_session_data
     @layout = "network_topology"
-  end
-
-  def set_session_data
-    session[:layout] = @layout
   end
 
   def generate_topology(provider_id)

--- a/app/controllers/subnet_topology_controller.rb
+++ b/app/controllers/subnet_topology_controller.rb
@@ -1,0 +1,18 @@
+class SubnetTopologyController < ApplicationController
+  include TopologyMixin
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  private
+
+  def get_session_data
+    @layout = "subnet_topology"
+  end
+
+  def generate_topology(provider_id)
+    SubnetTopologyService.new(provider_id).build_topology
+  end
+end

--- a/app/helpers/cloud_subnet_helper/textual_summary.rb
+++ b/app/helpers/cloud_subnet_helper/textual_summary.rb
@@ -14,6 +14,11 @@ module CloudSubnetHelper::TextualSummary
     %i(parent_ems_cloud ems_network cloud_tenant availability_zone instances cloud_network network_router)
   end
 
+  def textual_group_topology
+    items = %w(topology)
+    items.collect { |m| send("textual_#{m}") }.flatten.compact
+  end
+
   #
   # Items
   #
@@ -78,5 +83,12 @@ module CloudSubnetHelper::TextualSummary
 
   def textual_availability_zone
     @record.availability_zone
+  end
+
+  def textual_topology
+    {:label => _('Topology'),
+     :image => 'topology',
+     :link => url_for(:controller => 'subnet_topology', :action => 'show', :id => @record.id),
+     :title => _('Show topology')}
   end
 end

--- a/app/views/cloud_subnet/_main.html.haml
+++ b/app/views/cloud_subnet/_main.html.haml
@@ -4,6 +4,8 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
+
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Overview"), :items => textual_group_topology}
 .row
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_tags}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -840,6 +840,14 @@ Vmdb::Application.routes.draw do
         data
       )
     },
+
+    :subnet_topology         => {
+      :get => %w(
+        show
+        data
+      )
+    },
+
     :container_dashboard      => {
       :get => %w(
         show


### PR DESCRIPTION
Added to Subnet provider the same topology as seen in the Network provider.![topology](https://cloud.githubusercontent.com/assets/8054645/17322708/15153c50-589f-11e6-8c1d-984b770e3aae.jpg)
