### PR TITLE
Fix live metrics names from Hawkular Services

### DIFF
--- a/product/live_metrics/middleware_datasource.yaml
+++ b/product/live_metrics/middleware_datasource.yaml
@@ -9,9 +9,9 @@
 #   - Provider native metric id: MiQ metric id
 #
 supported_metrics:
-  - Datasource Pool Metrics~Available Count: mw_ds_available_count
-  - Datasource Pool Metrics~In Use Count: mw_ds_in_use_count
-  - Datasource Pool Metrics~Timed Out: mw_ds_timed_out
-  - Datasource Pool Metrics~Average Get Time: mw_ds_average_get_time
-  - Datasource Pool Metrics~Average Creation Time: mw_ds_average_creation_time
-  - Datasource Pool Metrics~Max Wait Time: mw_ds_max_wait_time
+  - Available Count: mw_ds_available_count
+  - In Use Count: mw_ds_in_use_count
+  - Timed Out: mw_ds_timed_out
+  - Average Get Time: mw_ds_average_get_time
+  - Average Creation Time: mw_ds_average_creation_time
+  - Max Wait Time: mw_ds_max_wait_time

--- a/product/live_metrics/middleware_server.yaml
+++ b/product/live_metrics/middleware_server.yaml
@@ -12,27 +12,27 @@ included_children:
   - Transaction Manager
 
 supported_metrics:
-  - WildFly Memory Metrics~Heap Used: mw_heap_used
-  - WildFly Memory Metrics~Heap Max: mw_heap_max
-  - WildFly Memory Metrics~Heap Committed: mw_heap_committed
-  - WildFly Memory Metrics~NonHeap Used: mw_non_heap_used
-  - WildFly Memory Metrics~NonHeap Committed: mw_non_heap_committed
-  - WildFly Memory Metrics~Accumulated GC Duration: mw_accumulated_gc_duration
-  - WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_agregated_servlet_time
-  - WildFly Aggregated Web Metrics~Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
-  - WildFly Aggregated Web Metrics~Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
-  - WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
-  - WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
-  - WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
-  - WildFly Threading Metrics~Thread Count: mw_thread_count
-  - Server Availability~App Server: mw_availability_app_server
-  - Transactions Metrics~Number of Aborted Transactions: mw_tx_aborted
-  - Transactions Metrics~Number of In-Flight Transactions: mw_tx_inflight
-  - Transactions Metrics~Number of Committed Transactions: mw_tx_committed
-  - Transactions Metrics~Number of Transactions: mw_tx_total
-  - Transactions Metrics~Number of Application Rollbacks: mw_tx_application_rollbacks
-  - Transactions Metrics~Number of Resource Rollbacks: mw_tx_resource_rollbacks
-  - Transactions Metrics~Number of Timed Out Transactions: mw_tx_timeout
-  - Transactions Metrics~Number of Nested Transactions: mw_tx_nested
-  - Transactions Metrics~Number of Heuristics: mw_tx_heuristics
+  - Heap Used: mw_heap_used
+  - Heap Max: mw_heap_max
+  - Heap Committed: mw_heap_committed
+  - NonHeap Used: mw_non_heap_used
+  - NonHeap Committed: mw_non_heap_committed
+  - Accumulated GC Duration: mw_accumulated_gc_duration
+  - Aggregated Servlet Request Time: mw_agregated_servlet_time
+  - Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
+  - Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
+  - Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
+  - Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
+  - Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
+  - Thread Count: mw_thread_count
+  - Server Availability: mw_availability_app_server
+  - Number of Aborted Transactions: mw_tx_aborted
+  - Number of In-Flight Transactions: mw_tx_inflight
+  - Number of Committed Transactions: mw_tx_committed
+  - Number of Transactions: mw_tx_total
+  - Number of Application Rollbacks: mw_tx_application_rollbacks
+  - Number of Resource Rollbacks: mw_tx_resource_rollbacks
+  - Number of Timed Out Transactions: mw_tx_timeout
+  - Number of Nested Transactions: mw_tx_nested
+  - Number of Heuristics: mw_tx_heuristics
 

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/hawkular_helper.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/hawkular_helper.rb
@@ -1,4 +1,28 @@
 # Feed id to be used for all spec
 def the_feed_id
-  '3a06ba83-355b-4ae7-86ea-d0692ba6b347'.freeze
+  '71daaa4b-da76-4373-8753-68279f33a884'.freeze
+end
+
+def test_start_time
+  Time.new(2016, 8, 3, 9, 0, 0, "+02:00").freeze
+end
+
+def test_end_time
+  Time.new(2016, 8, 3, 13, 0, 0, "+02:00").freeze
+end
+
+def test_hostname
+  'hservices.torii.gva.redhat.com'.freeze
+end
+
+def test_port
+  80
+end
+
+def test_userid
+  'jdoe'.freeze
+end
+
+def test_password
+  'password'.freeze
 end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
@@ -1,13 +1,18 @@
 require_relative 'hawkular_helper'
 
+# VCR Cassettes: Hawkular Services 0.0.8.Final-SNAPSHOT (commit 0b50b06025641fa83128bb13de3a3eff8d37bb8b)
+
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource do
 
   let(:ems_hawkular) do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "jdoe", :password => "password")
+    auth = AuthToken.new(:name     => "test",
+                         :auth_key => "valid-token",
+                         :userid   => test_userid,
+                         :password => test_password)
     FactoryGirl.create(:ems_hawkular,
-                       :hostname        => 'localhost',
-                       :port            => 8080,
+                       :hostname        => test_hostname,
+                       :port            => test_port,
                        :authentications => [auth],
                        :zone            => zone)
   end
@@ -25,7 +30,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
 
   let(:ds) do
     FactoryGirl.create(:hawkular_middleware_datasource,
-                       :name                  => 'KeycloakDS',
+                       :name                  => 'ExampleDS',
                        :ems_ref               => '/t;hawkular'\
                                                  "/f;#{the_feed_id}/r;Local~~"\
                                                  '/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS',
@@ -40,8 +45,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
   end
 
   it "#collect_live_metrics for all metrics available" do
-    start_time = Time.new(2016, 7, 17, 10, 0, 0, "+02:00")
-    end_time = Time.new(2016, 7, 17, 11, 0, 0, "+02:00")
+    start_time = test_start_time
+    end_time = test_end_time
     interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
@@ -54,8 +59,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
   end
 
   it "#collect_live_metrics for three metrics" do
-    start_time = Time.new(2016, 7, 17, 10, 0, 0, "+02:00")
-    end_time = Time.new(2016, 7, 17, 11, 0, 0, "+02:00")
+    start_time = test_start_time
+    end_time = test_end_time
     interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
@@ -83,12 +88,12 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
 
   it "#supported_metrics" do
     expected_metrics = {
-      "Datasource Pool Metrics~Available Count"       => "mw_ds_available_count",
-      "Datasource Pool Metrics~In Use Count"          => "mw_ds_in_use_count",
-      "Datasource Pool Metrics~Timed Out"             => "mw_ds_timed_out",
-      "Datasource Pool Metrics~Average Get Time"      => "mw_ds_average_get_time",
-      "Datasource Pool Metrics~Average Creation Time" => "mw_ds_average_creation_time",
-      "Datasource Pool Metrics~Max Wait Time"         => "mw_ds_max_wait_time"
+      "Available Count"       => "mw_ds_available_count",
+      "In Use Count"          => "mw_ds_in_use_count",
+      "Timed Out"             => "mw_ds_timed_out",
+      "Average Get Time"      => "mw_ds_average_get_time",
+      "Average Creation Time" => "mw_ds_average_creation_time",
+      "Max Wait Time"         => "mw_ds_max_wait_time"
     }.freeze
     supported_metrics = MiddlewareDatasource.supported_metrics
     expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -1,14 +1,19 @@
 require_relative 'hawkular_helper'
 
+# VCR Cassettes: Hawkular Services 0.0.8.Final-SNAPSHOT (commit 0b50b06025641fa83128bb13de3a3eff8d37bb8b)
+
 describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
 
   let(:ems_hawkular) do
     # allow(MiqServer).to receive(:my_zone).and_return("default")
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    auth = AuthToken.new(:name => "test", :auth_key => "valid-token", :userid => "jdoe", :password => "password")
+    auth = AuthToken.new(:name     => "test",
+                         :auth_key => "valid-token",
+                         :userid   => test_userid,
+                         :password => test_password)
     FactoryGirl.create(:ems_hawkular,
-                       :hostname        => 'localhost',
-                       :port            => 8080,
+                       :hostname        => test_hostname,
+                       :port            => test_port,
                        :authentications => [auth],
                        :zone            => zone)
   end
@@ -25,39 +30,39 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
 
   let(:expected_metrics) do
     {
-      "WildFly Memory Metrics~Heap Used"                                  => "mw_heap_used",
-      "WildFly Memory Metrics~Heap Max"                                   => "mw_heap_max",
-      "WildFly Memory Metrics~Heap Committed"                             => "mw_heap_committed",
-      "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
-      "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
-      "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
-      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
-      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
-      "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
-      "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
-      "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
-      "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
-      "WildFly Threading Metrics~Thread Count"                            => "mw_thread_count",
-      "Server Availability~App Server"                                    => "mw_availability_app_server",
-      "Transactions Metrics~Number of Aborted Transactions"               => "mw_tx_aborted",
-      "Transactions Metrics~Number of In-Flight Transactions"             => "mw_tx_inflight",
-      "Transactions Metrics~Number of Committed Transactions"             => "mw_tx_committed",
-      "Transactions Metrics~Number of Transactions"                       => "mw_tx_total",
-      "Transactions Metrics~Number of Application Rollbacks"              => "mw_tx_application_rollbacks",
-      "Transactions Metrics~Number of Resource Rollbacks"                 => "mw_tx_resource_rollbacks",
-      "Transactions Metrics~Number of Timed Out Transactions"             => "mw_tx_timeout",
-      "Transactions Metrics~Number of Nested Transactions"                => "mw_tx_nested",
-      "Transactions Metrics~Number of Heuristics"                         => "mw_tx_heuristics"
+      "Heap Used"                          => "mw_heap_used",
+      "Heap Max"                           => "mw_heap_max",
+      "Heap Committed"                     => "mw_heap_committed",
+      "NonHeap Used"                       => "mw_non_heap_used",
+      "NonHeap Committed"                  => "mw_non_heap_committed",
+      "Accumulated GC Duration"            => "mw_accumulated_gc_duration",
+      "Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
+      "Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
+      "Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
+      "Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
+      "Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
+      "Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
+      "Thread Count"                       => "mw_thread_count",
+      "Server Availability"                => "mw_availability_app_server",
+      "Number of Aborted Transactions"     => "mw_tx_aborted",
+      "Number of In-Flight Transactions"   => "mw_tx_inflight",
+      "Number of Committed Transactions"   => "mw_tx_committed",
+      "Number of Transactions"             => "mw_tx_total",
+      "Number of Application Rollbacks"    => "mw_tx_application_rollbacks",
+      "Number of Resource Rollbacks"       => "mw_tx_resource_rollbacks",
+      "Number of Timed Out Transactions"   => "mw_tx_timeout",
+      "Number of Nested Transactions"      => "mw_tx_nested",
+      "Number of Heuristics"               => "mw_tx_heuristics"
     }.freeze
   end
 
   it "#collect_live_metrics for all metrics available" do
-    start_time = Time.new(2016, 7, 05, 17, 0, 0, "+02:00")
-    end_time = Time.new(2016, 7, 05, 18, 0, 0, "+02:00")
+    start_time = test_start_time
+    end_time = test_end_time
     interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,
-                     :decode_compressed_response     => true, :record => :new_episodes) do
+                     :decode_compressed_response     => true) do # , :record => :new_episodes) do
       metrics_available = eap.metrics_available
       metrics_data = eap.collect_live_metrics(metrics_available, start_time, end_time, interval)
       keys = metrics_data.keys
@@ -66,8 +71,8 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   end
 
   it "#collect_live_metrics for three metrics" do
-    start_time = Time.new(2016, 7, 05, 17, 0, 0, "+02:00")
-    end_time = Time.new(2016, 7, 05, 18, 0, 0, "+02:00")
+    start_time = test_start_time
+    end_time = test_end_time
     interval = 3600
     VCR.use_cassette(described_class.name.underscore.to_s,
                      :allow_unused_http_interactions => true,

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_datasource.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_datasource.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/status
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -22,32 +22,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Connection:
-      - keep-alive
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:05 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '234'
-      Date:
-      - Wed, 27 Jul 2016 15:59:02 GMT
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "Implementation-Version" : "0.17.2.Final",
-          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
+          "Implementation-Version" : "0.17.3.Final",
+          "Built-From-Git-SHA1" : "144a571ea8f3a819737c2937ccc0492d8a116bb4",
           "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
           "Initialized" : "true"
         }
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 15:59:02 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:05 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/status
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/status
     body:
       encoding: US-ASCII
       string: ''
@@ -57,7 +57,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -67,26 +67,26 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Connection:
-      - keep-alive
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:05 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '133'
-      Date:
-      - Wed, 27 Jul 2016 15:59:02 GMT
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
     body:
       encoding: UTF-8
-      string: '{"MetricsService":"STARTED","Implementation-Version":"0.17.0.Final","Built-From-Git-SHA1":"c439d3797397425d340eac7c549e330d51fc2cac"}'
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.18.0.Final","Built-From-Git-SHA1":"d5281e70603719809bdada72249b9330b22ebf96"}'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 15:59:02 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:05 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/rl;incorporates/type=m?sort=id
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/rl;incorporates/type=m?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -96,7 +96,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -106,530 +106,350 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 15:59:02 GMT
-      X-Total-Count:
-      - "-1"
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:06 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;70c798a0-6985-4f8a-a525-012d8d28e8a3/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/rl;incorporates/type=m?sort=id>;
-        rel="current"
-    body:
-      encoding: ASCII-8BIT
-      string: "[ ]"
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 15:59:02 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/rl;incorporates/type=m?sort=id
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
+      - '19130'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
       X-Total-Count:
       - '26'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '25935'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/rl;incorporates/type=m?sort=id>;
+      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/rl;incorporates/type=m?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
-          "properties" : {
-            "__identityHash" : "21ba17d5f8a9dba88864b267c18654455651024"
-          },
-          "name" : "Datasource JDBC Metrics~Prepared Statement Cache Access Count",
-          "identityHash" : "21ba17d5f8a9dba88864b267c18654455651024",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
+          "name" : "Prepared Statement Cache Access Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
-            "name" : "Datasource JDBC Metrics~Prepared Statement Cache Access Count",
-            "identityHash" : "23ebe568db6f52b17846c444f15932c79f78511",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Access%20Count",
+            "name" : "Prepared Statement Cache Access Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Access Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Access Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Access Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
-          "properties" : {
-            "__identityHash" : "9b972bc8b6706bf417d85bd518102724b315af1"
-          },
-          "name" : "Datasource JDBC Metrics~Prepared Statement Cache Add Count",
-          "identityHash" : "9b972bc8b6706bf417d85bd518102724b315af1",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
+          "name" : "Prepared Statement Cache Add Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
-            "name" : "Datasource JDBC Metrics~Prepared Statement Cache Add Count",
-            "identityHash" : "4968d388605964fae5a92c72e4372174b51365c",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Add%20Count",
+            "name" : "Prepared Statement Cache Add Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Add Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Add Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Add Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
-          "properties" : {
-            "__identityHash" : "48e55133415f5f918ab67af7eecc798da35a3cd9"
-          },
-          "name" : "Datasource JDBC Metrics~Prepared Statement Cache Current Size",
-          "identityHash" : "48e55133415f5f918ab67af7eecc798da35a3cd9",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
+          "name" : "Prepared Statement Cache Current Size",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
-            "name" : "Datasource JDBC Metrics~Prepared Statement Cache Current Size",
-            "identityHash" : "f74f115f7e11da9dad9987d7a616bee1339bc1f",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Current%20Size",
+            "name" : "Prepared Statement Cache Current Size",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Current Size"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Current Size"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Current Size"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
-          "properties" : {
-            "__identityHash" : "605a9cb089cbeda9bf935d2c95c331c412415c2"
-          },
-          "name" : "Datasource JDBC Metrics~Prepared Statement Cache Delete Count",
-          "identityHash" : "605a9cb089cbeda9bf935d2c95c331c412415c2",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
+          "name" : "Prepared Statement Cache Delete Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
-            "name" : "Datasource JDBC Metrics~Prepared Statement Cache Delete Count",
-            "identityHash" : "6cca794bea731a28ef21f4162b934f89f594a59c",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Delete%20Count",
+            "name" : "Prepared Statement Cache Delete Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Delete Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Delete Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Delete Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
-          "properties" : {
-            "__identityHash" : "44c5f05a5acbc15edb5d52b509bf08187b2b7"
-          },
-          "name" : "Datasource JDBC Metrics~Prepared Statement Cache Hit Count",
-          "identityHash" : "44c5f05a5acbc15edb5d52b509bf08187b2b7",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
+          "name" : "Prepared Statement Cache Hit Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
-            "name" : "Datasource JDBC Metrics~Prepared Statement Cache Hit Count",
-            "identityHash" : "bbfe3a3a6f0c857dd20105c21a3583215bb1ff6",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Hit%20Count",
+            "name" : "Prepared Statement Cache Hit Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Hit Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Hit Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Hit Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
-          "properties" : {
-            "__identityHash" : "b9bd199f2e2f49a8cb639a32b415ba428eb5748"
-          },
-          "name" : "Datasource JDBC Metrics~Prepared Statement Cache Miss Count",
-          "identityHash" : "b9bd199f2e2f49a8cb639a32b415ba428eb5748",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
+          "name" : "Prepared Statement Cache Miss Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
-            "name" : "Datasource JDBC Metrics~Prepared Statement Cache Miss Count",
-            "identityHash" : "b8a0f5782c83e8e4621cde1a9708b1cef9f8041",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20JDBC%20Metrics~Prepared%20Statement%20Cache%20Miss%20Count",
+            "name" : "Prepared Statement Cache Miss Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource JDBC Metrics~Prepared Statement Cache Miss Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Miss Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource JDBC Metrics~Prepared Statement Cache Miss Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Active%20Count",
-          "properties" : {
-            "__identityHash" : "b0727b1e098daece876cc47111eafbfa722bf"
-          },
-          "name" : "Datasource Pool Metrics~Active Count",
-          "identityHash" : "b0727b1e098daece876cc47111eafbfa722bf",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Active%20Count",
+          "name" : "Active Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Active%20Count",
-            "name" : "Datasource Pool Metrics~Active Count",
-            "identityHash" : "618466f7c5ba51b3a4cfbebd181983739b287b",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Active%20Count",
+            "name" : "Active Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Active Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Active Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Active Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count",
-          "properties" : {
-            "__identityHash" : "3e22da9f555a759eb16465965b805e13d2481452"
-          },
-          "name" : "Datasource Pool Metrics~Available Count",
-          "identityHash" : "3e22da9f555a759eb16465965b805e13d2481452",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count",
+          "name" : "Available Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Available%20Count",
-            "name" : "Datasource Pool Metrics~Available Count",
-            "identityHash" : "8cde6c3fac5b49da59c13b1f75fdc64488f90f7",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Available%20Count",
+            "name" : "Available Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Available Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Available Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Available Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
-          "properties" : {
-            "__identityHash" : "61973e7b1d8ba3602f4f017197527dfbedb60"
-          },
-          "name" : "Datasource Pool Metrics~Average Blocking Time",
-          "identityHash" : "61973e7b1d8ba3602f4f017197527dfbedb60",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
+          "name" : "Average Blocking Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
-            "name" : "Datasource Pool Metrics~Average Blocking Time",
-            "identityHash" : "1cf4767a72f5a12d3726ed37d8a3b3a5028d70",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Average%20Blocking%20Time",
+            "name" : "Average Blocking Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Average Blocking Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Blocking Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Blocking Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time",
-          "properties" : {
-            "__identityHash" : "7121e286e9a524dbf92f5d516417abec252e8"
-          },
-          "name" : "Datasource Pool Metrics~Average Creation Time",
-          "identityHash" : "7121e286e9a524dbf92f5d516417abec252e8",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time",
+          "name" : "Average Creation Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Average%20Creation%20Time",
-            "name" : "Datasource Pool Metrics~Average Creation Time",
-            "identityHash" : "d37beaba7174897dcf392ee284567fcd21b092",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Average%20Creation%20Time",
+            "name" : "Average Creation Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Average Creation Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Creation Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Creation Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time",
-          "properties" : {
-            "__identityHash" : "586315de06febc5a295dcbb6a3d938ede6cab6"
-          },
-          "name" : "Datasource Pool Metrics~Average Get Time",
-          "identityHash" : "586315de06febc5a295dcbb6a3d938ede6cab6",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time",
+          "name" : "Average Get Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Average%20Get%20Time",
-            "name" : "Datasource Pool Metrics~Average Get Time",
-            "identityHash" : "20c7902c49b19bc97162e8ca17ebe62dad4d1ff",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Average%20Get%20Time",
+            "name" : "Average Get Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Average Get Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Get Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Average Get Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
-          "properties" : {
-            "__identityHash" : "db3e95ee3d59f325086c9501922a44c166e8e23"
-          },
-          "name" : "Datasource Pool Metrics~Blocking Failure Count",
-          "identityHash" : "db3e95ee3d59f325086c9501922a44c166e8e23",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
+          "name" : "Blocking Failure Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
-            "name" : "Datasource Pool Metrics~Blocking Failure Count",
-            "identityHash" : "74be1a84128a299d7a09b938287d51c75ec12",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Blocking%20Failure%20Count",
+            "name" : "Blocking Failure Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Blocking Failure Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Blocking Failure Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Blocking Failure Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Created%20Count",
-          "properties" : {
-            "__identityHash" : "efefab9fd5ade490094c731096b860a57d9e25"
-          },
-          "name" : "Datasource Pool Metrics~Created Count",
-          "identityHash" : "efefab9fd5ade490094c731096b860a57d9e25",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Created%20Count",
+          "name" : "Created Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Created%20Count",
-            "name" : "Datasource Pool Metrics~Created Count",
-            "identityHash" : "324f82c7bede83c8f9ac5e0c4db1637259ff73",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Created%20Count",
+            "name" : "Created Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Created Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Created Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Created Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Destroyed%20Count",
-          "properties" : {
-            "__identityHash" : "c2c75760c88961d3f3f75095214c47a5ae34bc3"
-          },
-          "name" : "Datasource Pool Metrics~Destroyed Count",
-          "identityHash" : "c2c75760c88961d3f3f75095214c47a5ae34bc3",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Destroyed%20Count",
+          "name" : "Destroyed Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Destroyed%20Count",
-            "name" : "Datasource Pool Metrics~Destroyed Count",
-            "identityHash" : "87f3c2434743e715935d382af6266e5e6d66d469",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Destroyed%20Count",
+            "name" : "Destroyed Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Destroyed Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Destroyed Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Destroyed Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Idle%20Count",
-          "properties" : {
-            "__identityHash" : "45ae55b77b0578094c12a7b25592cef592e0c1"
-          },
-          "name" : "Datasource Pool Metrics~Idle Count",
-          "identityHash" : "45ae55b77b0578094c12a7b25592cef592e0c1",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Idle%20Count",
+          "name" : "Idle Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Idle%20Count",
-            "name" : "Datasource Pool Metrics~Idle Count",
-            "identityHash" : "6ba232119aae831f0fc9559fd753ce7fce69f21",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Idle%20Count",
+            "name" : "Idle Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Idle Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Idle Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Idle Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count",
-          "properties" : {
-            "__identityHash" : "1ebaf2fcf587faf22f7ca1cb74014c4f3168ce"
-          },
-          "name" : "Datasource Pool Metrics~In Use Count",
-          "identityHash" : "1ebaf2fcf587faf22f7ca1cb74014c4f3168ce",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count",
+          "name" : "In Use Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~In%20Use%20Count",
-            "name" : "Datasource Pool Metrics~In Use Count",
-            "identityHash" : "8314efb84866539834be4fdedd8cba86dffcdf",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~In%20Use%20Count",
+            "name" : "In Use Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~In Use Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~In Use Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~In Use Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Creation%20Time",
-          "properties" : {
-            "__identityHash" : "a4a9d5f35050cffba185bb4c492ab58d19b513"
-          },
-          "name" : "Datasource Pool Metrics~Max Creation Time",
-          "identityHash" : "a4a9d5f35050cffba185bb4c492ab58d19b513",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Creation%20Time",
+          "name" : "Max Creation Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Max%20Creation%20Time",
-            "name" : "Datasource Pool Metrics~Max Creation Time",
-            "identityHash" : "d64864108b263182f32a5f64cda7637ae288b24",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Max%20Creation%20Time",
+            "name" : "Max Creation Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Creation Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Creation Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Creation Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Get%20Time",
-          "properties" : {
-            "__identityHash" : "7af8d7b9861047931e92d21717ca21f64dcd1df8"
-          },
-          "name" : "Datasource Pool Metrics~Max Get Time",
-          "identityHash" : "7af8d7b9861047931e92d21717ca21f64dcd1df8",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Get%20Time",
+          "name" : "Max Get Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Max%20Get%20Time",
-            "name" : "Datasource Pool Metrics~Max Get Time",
-            "identityHash" : "ac18a27bd1f463fce93157b990169aa0f896366",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Max%20Get%20Time",
+            "name" : "Max Get Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Get Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Get Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Get Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Used%20Count",
-          "properties" : {
-            "__identityHash" : "ad4051a16aebd22f24293c7f4167b22ff021996"
-          },
-          "name" : "Datasource Pool Metrics~Max Used Count",
-          "identityHash" : "ad4051a16aebd22f24293c7f4167b22ff021996",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Used%20Count",
+          "name" : "Max Used Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Max%20Used%20Count",
-            "name" : "Datasource Pool Metrics~Max Used Count",
-            "identityHash" : "48b4fd8514a162ee442d04faa1329794cfa14d",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Max%20Used%20Count",
+            "name" : "Max Used Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Used Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Used Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Used Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Count",
-          "properties" : {
-            "__identityHash" : "6f4579cda155d394e84368424b197c67f622091"
-          },
-          "name" : "Datasource Pool Metrics~Max Wait Count",
-          "identityHash" : "6f4579cda155d394e84368424b197c67f622091",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Count",
+          "name" : "Max Wait Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Count",
-            "name" : "Datasource Pool Metrics~Max Wait Count",
-            "identityHash" : "95f46d183b573db9571950bb1a5fd7427615a",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Count",
+            "name" : "Max Wait Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Wait Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time",
-          "properties" : {
-            "__identityHash" : "afec6eb820466de87d1ae2cd794a92f30397114"
-          },
-          "name" : "Datasource Pool Metrics~Max Wait Time",
-          "identityHash" : "afec6eb820466de87d1ae2cd794a92f30397114",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time",
+          "name" : "Max Wait Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Time",
-            "name" : "Datasource Pool Metrics~Max Wait Time",
-            "identityHash" : "f36e0dffc4255a7863606fe88907d839d9edc",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Max%20Wait%20Time",
+            "name" : "Max Wait Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Max Wait Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Max Wait Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out",
-          "properties" : {
-            "__identityHash" : "3232c1d981c1538c705cde263d091f968d54ffb"
-          },
-          "name" : "Datasource Pool Metrics~Timed Out",
-          "identityHash" : "3232c1d981c1538c705cde263d091f968d54ffb",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out",
+          "name" : "Timed Out",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Timed%20Out",
-            "name" : "Datasource Pool Metrics~Timed Out",
-            "identityHash" : "ad28789d5c06a73cd50455f1c20aaaa7a82259",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Timed%20Out",
+            "name" : "Timed Out",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Datasource Pool Metrics~Timed Out"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Timed Out"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Timed Out"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
-          "properties" : {
-            "__identityHash" : "f2e8eb5673b65fd9aa6c9196ace8b4caaaa57ed"
-          },
-          "name" : "Datasource Pool Metrics~Total Blocking Time",
-          "identityHash" : "f2e8eb5673b65fd9aa6c9196ace8b4caaaa57ed",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
+          "name" : "Total Blocking Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
-            "name" : "Datasource Pool Metrics~Total Blocking Time",
-            "identityHash" : "a817d8533639bd1f71a70c9aefad040aacdd7cb",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Total%20Blocking%20Time",
+            "name" : "Total Blocking Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Total Blocking Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Blocking Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Blocking Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Creation%20Time",
-          "properties" : {
-            "__identityHash" : "222dce1613722647b45c8371f6529fe4d8a22cbb"
-          },
-          "name" : "Datasource Pool Metrics~Total Creation Time",
-          "identityHash" : "222dce1613722647b45c8371f6529fe4d8a22cbb",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Creation%20Time",
+          "name" : "Total Creation Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Total%20Creation%20Time",
-            "name" : "Datasource Pool Metrics~Total Creation Time",
-            "identityHash" : "47a62ab81c57f6b0b3cb81813acafba042615570",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Total%20Creation%20Time",
+            "name" : "Total Creation Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Total Creation Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Creation Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Creation Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Get%20Time",
-          "properties" : {
-            "__identityHash" : "6e344995c3f801bcd40ada73f14778ddc6de6"
-          },
-          "name" : "Datasource Pool Metrics~Total Get Time",
-          "identityHash" : "6e344995c3f801bcd40ada73f14778ddc6de6",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Total%20Get%20Time",
+          "name" : "Total Get Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Total%20Get%20Time",
-            "name" : "Datasource Pool Metrics~Total Get Time",
-            "identityHash" : "cb116e6bfac01b7c478b9cb5729b63c052bdf498",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Total%20Get%20Time",
+            "name" : "Total Get Time",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Total Get Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Get Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Total Get Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Wait%20Count",
-          "properties" : {
-            "__identityHash" : "9c379577d287c41acba984b687c46dc8afb227"
-          },
-          "name" : "Datasource Pool Metrics~Wait Count",
-          "identityHash" : "9c379577d287c41acba984b687c46dc8afb227",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS%5D~MT~Datasource%20Pool%20Metrics~Wait%20Count",
+          "name" : "Wait Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Datasource%20Pool%20Metrics~Wait%20Count",
-            "name" : "Datasource Pool Metrics~Wait Count",
-            "identityHash" : "9cd2d0e9e1657b87fcc5fb85481a93f8ebbd63c",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Datasource%20Pool%20Metrics~Wait%20Count",
+            "name" : "Wait Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 600,
             "id" : "Datasource Pool Metrics~Wait Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Wait Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=datasources/data-source=ExampleDS]~MT~Datasource Pool Metrics~Wait Count"
         } ]
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:06 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
     body:
       encoding: US-ASCII
       string: ''
@@ -639,7 +459,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -649,32 +469,167 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:52:06 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
+      - Wed, 03 Aug 2016 15:52:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
       Connection:
       - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:52:06 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:52:06 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529010,"value":0.0}]'
+      string: '[{"timestamp":1470233678131,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:07 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -684,7 +639,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -694,32 +649,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635274001,"value":0.0}]'
+      string: '[{"timestamp":1470239512015,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:07 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -729,7 +684,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -739,32 +694,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529011,"value":0.0}]'
+      string: '[{"timestamp":1470233678212,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:07 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -774,7 +729,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -784,32 +739,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635247006,"value":0.0}]'
+      string: '[{"timestamp":1470239512003,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:07 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -819,7 +774,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -829,32 +784,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:07 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529007,"value":0.0}]'
+      string: '[{"timestamp":1470233678241,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:07 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -864,7 +819,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -874,32 +829,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635247003,"value":0.0}]'
+      string: '[{"timestamp":1470239512005,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:08 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -909,7 +864,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -919,32 +874,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529009,"value":0.0}]'
+      string: '[{"timestamp":1470233678212,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:08 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -954,7 +909,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -964,32 +919,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635247004,"value":0.0}]'
+      string: '[{"timestamp":1470239512015,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:08 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -999,7 +954,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1009,32 +964,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:08 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469634099010,"value":0.0}]'
+      string: '[{"timestamp":1470234248030,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:08 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1044,7 +999,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1054,32 +1009,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469634699000,"value":0.0}]'
+      string: '[{"timestamp":1470239463001,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:09 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1089,7 +1044,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1099,32 +1054,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529005,"value":0.0}]'
+      string: '[{"timestamp":1470233678215,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:09 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -1134,7 +1089,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1144,32 +1099,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:52:09 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635247001,"value":0.0}]'
+      string: '[{"timestamp":1470239512006,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:09 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Available%20Count/stats/?bucketDuration=3600s&end=1468746000001&start=1468738800000
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
     body:
       encoding: US-ASCII
       string: ''
@@ -1179,7 +1134,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1189,32 +1144,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
     body:
       encoding: UTF-8
-      string: '[{"start":1468738800000,"end":1468742400000,"empty":true},{"start":1468742400000,"end":1468746000000,"empty":true},{"start":1468746000000,"end":1468749600000,"empty":true}]'
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:09 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Creation%20Time/stats/?bucketDuration=3600s&end=1468746000001&start=1468738800000
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
     body:
       encoding: US-ASCII
       string: ''
@@ -1224,7 +1179,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1234,32 +1189,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
     body:
       encoding: UTF-8
-      string: '[{"start":1468738800000,"end":1468742400000,"empty":true},{"start":1468742400000,"end":1468746000000,"empty":true},{"start":1468746000000,"end":1468749600000,"empty":true}]'
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:09 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Average%20Get%20Time/stats/?bucketDuration=3600s&end=1468746000001&start=1468738800000
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
     body:
       encoding: US-ASCII
       string: ''
@@ -1269,7 +1224,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -1279,162 +1234,27 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:52:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
     body:
       encoding: UTF-8
-      string: '[{"start":1468738800000,"end":1468742400000,"empty":true},{"start":1468742400000,"end":1468746000000,"empty":true},{"start":1468746000000,"end":1468749600000,"empty":true}]'
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~In%20Use%20Count/stats/?bucketDuration=3600s&end=1468746000001&start=1468738800000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1468738800000,"end":1468742400000,"empty":true},{"start":1468742400000,"end":1468746000000,"empty":true},{"start":1468746000000,"end":1468749600000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Max%20Wait%20Time/stats/?bucketDuration=3600s&end=1468746000001&start=1468738800000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1468738800000,"end":1468742400000,"empty":true},{"start":1468742400000,"end":1468746000000,"empty":true},{"start":1468746000000,"end":1468749600000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=datasources%2Fdata-source=ExampleDS%5D~MT~Datasource%20Pool%20Metrics~Timed%20Out/stats/?bucketDuration=3600s&end=1468746000001&start=1468738800000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:01:14 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1468738800000,"end":1468742400000,"empty":true},{"start":1468742400000,"end":1468746000000,"empty":true},{"start":1468746000000,"end":1468749600000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:01:14 GMT
+  recorded_at: Wed, 03 Aug 2016 15:52:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_server.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/middleware_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/status
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -22,71 +22,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Connection:
-      - keep-alive
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:39 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '234'
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "Implementation-Version" : "0.17.2.Final",
-          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
-          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
-          "Initialized" : "true"
-        }
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
       Connection:
       - keep-alive
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '133'
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
     body:
-      encoding: UTF-8
-      string: '{"MetricsService":"STARTED","Implementation-Version":"0.17.0.Final","Built-From-Git-SHA1":"c439d3797397425d340eac7c549e330d51fc2cac"}'
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "Implementation-Version" : "0.17.3.Final",
+          "Built-From-Git-SHA1" : "144a571ea8f3a819737c2937ccc0492d8a116bb4",
+          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
+          "Initialized" : "true"
+        }
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/rl;incorporates/type=m?sort=id
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/status
     body:
       encoding: US-ASCII
       string: ''
@@ -96,7 +57,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -106,276 +67,245 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+    body:
+      encoding: UTF-8
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.18.0.Final","Built-From-Git-SHA1":"d5281e70603719809bdada72249b9330b22ebf96"}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:39 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/rl;incorporates/type=m?sort=id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '9321'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
       X-Total-Count:
       - '14'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '13066'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/rl;incorporates/type=m?sort=id>;
+      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/rl;incorporates/type=m?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;AI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
-          "properties" : {
-            "__identityHash" : "fa194dbc2719bcccbda7a8546db986adeff870df"
-          },
-          "name" : "Server Availability~Server Availability",
-          "identityHash" : "fa194dbc2719bcccbda7a8546db986adeff870df",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;AI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
+          "name" : "Server Availability",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Server%20Availability~Server%20Availability",
-            "name" : "Server Availability~Server Availability",
-            "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Server%20Availability~Server%20Availability",
+            "name" : "Server Availability",
             "unit" : "NONE",
             "type" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
-          "id" : "AI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~AT~Server Availability~Server Availability"
+          "id" : "AI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~AT~Server Availability~Server Availability"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
-          "properties" : {
-            "__identityHash" : "c11de2a3ed6574d936bb7b45b455aba4b95b6ab0"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
-          "identityHash" : "c11de2a3ed6574d936bb7b45b455aba4b95b6ab0",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+          "name" : "Aggregated Active Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
-            "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
+            "name" : "Aggregated Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-          "properties" : {
-            "__identityHash" : "e87b91421e2613ebe20d45dcd33d7c7db8b36da"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-          "identityHash" : "e87b91421e2613ebe20d45dcd33d7c7db8b36da",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+          "name" : "Aggregated Expired Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-            "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "name" : "Aggregated Expired Web Sessions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-          "properties" : {
-            "__identityHash" : "8493d2702f13bdd451894c3995cd335532d68bb"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-          "identityHash" : "8493d2702f13bdd451894c3995cd335532d68bb",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "name" : "Aggregated Max Active Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-            "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "name" : "Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-          "properties" : {
-            "__identityHash" : "40b9651bae1a7df76b31a245cbfbc47b40f751e6"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-          "identityHash" : "40b9651bae1a7df76b31a245cbfbc47b40f751e6",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "name" : "Aggregated Rejected Web Sessions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-            "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "name" : "Aggregated Rejected Web Sessions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-          "properties" : {
-            "__identityHash" : "6a4c28e760737a5d84bf9fb391461274ebf9190"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-          "identityHash" : "6a4c28e760737a5d84bf9fb391461274ebf9190",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "name" : "Aggregated Servlet Request Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-            "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "name" : "Aggregated Servlet Request Count",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-          "properties" : {
-            "__identityHash" : "373ea17a6d40f8ad5dd1f184afcd527701af4eb"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-          "identityHash" : "373ea17a6d40f8ad5dd1f184afcd527701af4eb",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "name" : "Aggregated Servlet Request Time",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-            "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "name" : "Aggregated Servlet Request Time",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-          "properties" : {
-            "__identityHash" : "1190ab3bbf49b3da5c1ba3662f3bbf93cbb3e2c"
-          },
-          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-          "identityHash" : "1190ab3bbf49b3da5c1ba3662f3bbf93cbb3e2c",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "name" : "Accumulated GC Duration",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-            "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "name" : "Accumulated GC Duration",
             "unit" : "MILLISECONDS",
             "type" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
-          "properties" : {
-            "__identityHash" : "ebaca2a6da101227f8692387d0223aa0a13413a9"
-          },
-          "name" : "WildFly Memory Metrics~Heap Committed",
-          "identityHash" : "ebaca2a6da101227f8692387d0223aa0a13413a9",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
+          "name" : "Heap Committed",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Memory%20Metrics~Heap%20Committed",
-            "name" : "WildFly Memory Metrics~Heap Committed",
-            "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Memory%20Metrics~Heap%20Committed",
+            "name" : "Heap Committed",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Memory Metrics~Heap Committed"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Memory Metrics~Heap Committed"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max",
-          "properties" : {
-            "__identityHash" : "883a8b23554b135927922c5c08bbfc67d6b401f"
-          },
-          "name" : "WildFly Memory Metrics~Heap Max",
-          "identityHash" : "883a8b23554b135927922c5c08bbfc67d6b401f",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max",
+          "name" : "Heap Max",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Memory%20Metrics~Heap%20Max",
-            "name" : "WildFly Memory Metrics~Heap Max",
-            "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Memory%20Metrics~Heap%20Max",
+            "name" : "Heap Max",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Memory Metrics~Heap Max"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
-          "properties" : {
-            "__identityHash" : "2e8c58b14447cfeca6b1d7ca43641195217e7fb"
-          },
-          "name" : "WildFly Memory Metrics~Heap Used",
-          "identityHash" : "2e8c58b14447cfeca6b1d7ca43641195217e7fb",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
+          "name" : "Heap Used",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Memory%20Metrics~Heap%20Used",
-            "name" : "WildFly Memory Metrics~Heap Used",
-            "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Memory%20Metrics~Heap%20Used",
+            "name" : "Heap Used",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Memory Metrics~Heap Used"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
-          "properties" : {
-            "__identityHash" : "faff6c6fb6855aa939615c90b545f71ce55e"
-          },
-          "name" : "WildFly Memory Metrics~NonHeap Committed",
-          "identityHash" : "faff6c6fb6855aa939615c90b545f71ce55e",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "name" : "NonHeap Committed",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
-            "name" : "WildFly Memory Metrics~NonHeap Committed",
-            "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "name" : "NonHeap Committed",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
-          "properties" : {
-            "__identityHash" : "47c12c4c7c9910b2ab63f29c3ed4b614f9a3bf31"
-          },
-          "name" : "WildFly Memory Metrics~NonHeap Used",
-          "identityHash" : "47c12c4c7c9910b2ab63f29c3ed4b614f9a3bf31",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "name" : "NonHeap Used",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
-            "name" : "WildFly Memory Metrics~NonHeap Used",
-            "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "name" : "NonHeap Used",
             "unit" : "BYTES",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
-          "properties" : {
-            "__identityHash" : "321738e280b87f4ad4c2c0d8dab7520f4af9843"
-          },
-          "name" : "WildFly Threading Metrics~Thread Count",
-          "identityHash" : "321738e280b87f4ad4c2c0d8dab7520f4af9843",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "name" : "Thread Count",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;WildFly%20Threading%20Metrics~Thread%20Count",
-            "name" : "WildFly Threading Metrics~Thread Count",
-            "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "name" : "Thread Count",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~~]~MT~WildFly Threading Metrics~Thread Count"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/type=r
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/type=r
     body:
       encoding: US-ASCII
       string: ''
@@ -385,7 +315,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -395,248 +325,244 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '8831'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
       X-Total-Count:
       - '15'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '9157'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/type=r>;
+      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/type=r>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
           "properties" : {
             "__identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4"
           },
           "name" : "Datasource [ExampleDS]",
           "identityHash" : "e5bba7c6c22ec4591bff4532ca14e989d1498c4",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Datasource",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Datasource",
             "name" : "Datasource",
             "identityHash" : "b3291af08b396960f425871b493b6d9ee97e339f",
             "id" : "Datasource"
           },
           "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2",
           "properties" : {
             "__identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d"
           },
           "name" : "JDBC Driver [h2]",
           "identityHash" : "8552bea1e08fc66573fff8b1a3645fb845a107d",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;JDBC%20Driver",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;JDBC%20Driver",
             "name" : "JDBC Driver",
-            "identityHash" : "f9eaf22c8dff1416a34eb4d26a4bc6a99c46af2",
             "id" : "JDBC Driver"
           },
           "id" : "Local~/subsystem=datasources/jdbc-driver=h2"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war",
           "properties" : {
             "__identityHash" : "145efc8c7d6ce8c93167dd4956a3c1cbc6d0d1a"
           },
           "name" : "Deployment [hawkular-command-gateway-war.war]",
           "identityHash" : "145efc8c7d6ce8c93167dd4956a3c1cbc6d0d1a",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
             "name" : "Deployment",
             "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-command-gateway-war.war"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war",
           "properties" : {
             "__identityHash" : "eff2441b1d32b22a2428bec8fe59452ef5711e"
           },
           "name" : "Deployment [hawkular-metrics-component.war]",
           "identityHash" : "eff2441b1d32b22a2428bec8fe59452ef5711e",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
             "name" : "Deployment",
             "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-metrics-component.war"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-war.war",
-          "properties" : {
-            "__identityHash" : "8818ce75b624f951c6d2f406045d0349328fc4"
-          },
-          "name" : "Deployment [hawkular-commons-embedded-cassandra-war.war]",
-          "identityHash" : "8818ce75b624f951c6d2f406045d0349328fc4",
-          "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-commons-embedded-cassandra-war.war"
-        }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war",
           "properties" : {
             "__identityHash" : "f07118ef62f45788dba5d01a38b13fe33115785e"
           },
           "name" : "Deployment [hawkular-alerts-actions-email.war]",
           "identityHash" : "f07118ef62f45788dba5d01a38b13fe33115785e",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
             "name" : "Deployment",
             "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-alerts-actions-email.war"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war",
           "properties" : {
             "__identityHash" : "10181e9ef78b953ed93eb67f0d270de8dd5cce4"
           },
           "name" : "Deployment [hawkular-wildfly-agent-download.war]",
           "identityHash" : "10181e9ef78b953ed93eb67f0d270de8dd5cce4",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
             "name" : "Deployment",
             "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-wildfly-agent-download.war"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
-          "properties" : {
-            "__identityHash" : "fe13b87cf8edfcd191a6d5169c3f376ac6b5d6"
-          },
-          "name" : "Deployment [hawkular-inventory-dist.war]",
-          "identityHash" : "fe13b87cf8edfcd191a6d5169c3f376ac6b5d6",
-          "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
-            "name" : "Deployment",
-            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
-            "id" : "Deployment"
-          },
-          "id" : "Local~/deployment=hawkular-inventory-dist.war"
-        }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war",
           "properties" : {
             "__identityHash" : "3fbe2fcdf21d9886257438b2aeb957825d6ffe"
           },
           "name" : "Deployment [hawkular-alerts-rest.war]",
           "identityHash" : "3fbe2fcdf21d9886257438b2aeb957825d6ffe",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
             "name" : "Deployment",
             "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-alerts-rest.war"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war",
           "properties" : {
-            "__identityHash" : "d99ddc62fe9a955b3bc7a309f761f763f527516"
+            "__identityHash" : "fe13b87cf8edfcd191a6d5169c3f376ac6b5d6"
+          },
+          "name" : "Deployment [hawkular-inventory-dist.war]",
+          "identityHash" : "fe13b87cf8edfcd191a6d5169c3f376ac6b5d6",
+          "type" : {
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-inventory-dist.war"
+        }, {
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-status.war",
+          "properties" : {
+            "__identityHash" : "1f10909debc744e659b8d4469384c361beae915b"
+          },
+          "name" : "Deployment [hawkular-status.war]",
+          "identityHash" : "1f10909debc744e659b8d4469384c361beae915b",
+          "type" : {
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
+            "name" : "Deployment",
+            "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
+            "id" : "Deployment"
+          },
+          "id" : "Local~/deployment=hawkular-status.war"
+        }, {
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war",
+          "properties" : {
+            "__identityHash" : "5e7b52b93528c8c79c67eacd73723464c9755b9b"
           },
           "name" : "Deployment [hawkular-rest-api.war]",
-          "identityHash" : "d99ddc62fe9a955b3bc7a309f761f763f527516",
+          "identityHash" : "5e7b52b93528c8c79c67eacd73723464c9755b9b",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Deployment",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Deployment",
             "name" : "Deployment",
             "identityHash" : "183e79e0462c1f2fc866ba71f5db64c477b5dc",
             "id" : "Deployment"
           },
           "id" : "Local~/deployment=hawkular-rest-api.war"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions",
           "properties" : {
             "__identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622"
           },
           "name" : "Transaction Manager",
           "identityHash" : "a3c9e6acf121df96fea6e5fcca9e846d8c9622",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Transaction%20Manager",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Transaction%20Manager",
             "name" : "Transaction Manager",
-            "identityHash" : "2c82df7330b7ae48c43ae5413f9b8857f24a85f",
             "id" : "Transaction Manager"
           },
           "id" : "Local~/subsystem=transactions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault",
           "properties" : {
-            "__identityHash" : "974ff756ed785e2264577211c2bb843e27c991f"
+            "__identityHash" : "233999a3ffee0102f2acf833534625a196f74"
           },
           "name" : "Messaging Server [default]",
-          "identityHash" : "974ff756ed785e2264577211c2bb843e27c991f",
+          "identityHash" : "233999a3ffee0102f2acf833534625a196f74",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Messaging%20Server",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Messaging%20Server",
             "name" : "Messaging Server",
-            "identityHash" : "c21e2c4be8b952d760ef3929652e304bd951ac4e",
             "id" : "Messaging Server"
           },
           "id" : "Local~/subsystem=messaging-activemq/server=default"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent",
           "properties" : {
             "__identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac"
           },
           "name" : "Hawkular WildFly Agent",
           "identityHash" : "d9c07665258f43c5b0204259d342c8cb16f3ac",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Hawkular%20WildFly%20Agent",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Hawkular%20WildFly%20Agent",
             "name" : "Hawkular WildFly Agent",
             "identityHash" : "1d7fbc312f708afc4643812f2772e7aabf283328",
             "id" : "Hawkular WildFly Agent"
           },
           "id" : "Local~/subsystem=hawkular-wildfly-agent"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsocket-binding-group%3Dstandard-sockets",
           "properties" : {
-            "__identityHash" : "46dd1eae29f56639b947a9a85ef7c5833ec324"
+            "__identityHash" : "46b11f1b4da1bc4144e436565576d64353a8f7"
           },
           "name" : "Socket Binding Group [standard-sockets]",
-          "identityHash" : "46dd1eae29f56639b947a9a85ef7c5833ec324",
+          "identityHash" : "46b11f1b4da1bc4144e436565576d64353a8f7",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Socket%20Binding%20Group",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Socket%20Binding%20Group",
             "name" : "Socket Binding Group",
             "identityHash" : "689259496c606a774ff8d4288893cf656230642d",
             "id" : "Socket Binding Group"
           },
           "id" : "Local~/socket-binding-group=standard-sockets"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dinfinispan",
           "properties" : {
             "__identityHash" : "693fc87bc7a8fba877b299f333f86b67ff644a3c"
           },
           "name" : "Infinispan",
           "identityHash" : "693fc87bc7a8fba877b299f333f86b67ff644a3c",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/rt;Infinispan",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/rt;Infinispan",
             "name" : "Infinispan",
-            "identityHash" : "a02a9a0121b9fe564ef869e72765e7f1c56b2a",
             "id" : "Infinispan"
           },
           "id" : "Local~/subsystem=infinispan"
         } ]
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:39 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem=transactions/rl;incorporates/type=m?sort=id
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem=transactions/rl;incorporates/type=m?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -646,7 +572,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -656,191 +582,146 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6572'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
       X-Total-Count:
       - '9'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '8885'
       Link:
-      - <http://localhost:8080/hawkular/inventory/traversal/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions/rl;incorporates/type=m?sort=id>;
+      - <http://hservices.torii.gva.redhat.com/hawkular/inventory/traversal/f;71daaa4b-da76-4373-8753-68279f33a884/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions/rl;incorporates/type=m?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
-          "properties" : {
-            "__identityHash" : "178c9a43f84edb12975911bf4836611b981fac67"
-          },
-          "name" : "Transactions Metrics~Number of Aborted Transactions",
-          "identityHash" : "178c9a43f84edb12975911bf4836611b981fac67",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+          "name" : "Number of Aborted Transactions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
-            "name" : "Transactions Metrics~Number of Aborted Transactions",
-            "identityHash" : "25b4b8fa5058306e80e0295168425d6fb75f6a3",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Aborted%20Transactions",
+            "name" : "Number of Aborted Transactions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Aborted Transactions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Aborted Transactions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Aborted Transactions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
-          "properties" : {
-            "__identityHash" : "808416abb8bef7c9d54a4c6f34b39973436ce4a"
-          },
-          "name" : "Transactions Metrics~Number of Application Rollbacks",
-          "identityHash" : "808416abb8bef7c9d54a4c6f34b39973436ce4a",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+          "name" : "Number of Application Rollbacks",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
-            "name" : "Transactions Metrics~Number of Application Rollbacks",
-            "identityHash" : "fc99f879312f15bc555d30d12ddd4cf3b81b2285",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Application%20Rollbacks",
+            "name" : "Number of Application Rollbacks",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Application Rollbacks"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Application Rollbacks"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Application Rollbacks"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions",
-          "properties" : {
-            "__identityHash" : "e7a7137cd3265af61e26fa2151b2466d771386ed"
-          },
-          "name" : "Transactions Metrics~Number of Committed Transactions",
-          "identityHash" : "e7a7137cd3265af61e26fa2151b2466d771386ed",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+          "name" : "Number of Committed Transactions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Committed%20Transactions",
-            "name" : "Transactions Metrics~Number of Committed Transactions",
-            "identityHash" : "fe60974feaf3aa227d639192b114f116274ae4b2",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Committed%20Transactions",
+            "name" : "Number of Committed Transactions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Committed Transactions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Committed Transactions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Committed Transactions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics",
-          "properties" : {
-            "__identityHash" : "13de9fd82448e75c2613af6c6d64519ca13347e8"
-          },
-          "name" : "Transactions Metrics~Number of Heuristics",
-          "identityHash" : "13de9fd82448e75c2613af6c6d64519ca13347e8",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics",
+          "name" : "Number of Heuristics",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Heuristics",
-            "name" : "Transactions Metrics~Number of Heuristics",
-            "identityHash" : "e9dc6c8454d533e67b609a8a411ce24c7a4a2b69",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Heuristics",
+            "name" : "Number of Heuristics",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Heuristics"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Heuristics"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Heuristics"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
-          "properties" : {
-            "__identityHash" : "f689d2351e5f3ba8c4b21a89b2dd6bcf6e729"
-          },
-          "name" : "Transactions Metrics~Number of In-Flight Transactions",
-          "identityHash" : "f689d2351e5f3ba8c4b21a89b2dd6bcf6e729",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+          "name" : "Number of In-Flight Transactions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
-            "name" : "Transactions Metrics~Number of In-Flight Transactions",
-            "identityHash" : "deb940deaf6f7c6db1bd23c1673ca4f19394b4d",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20In-Flight%20Transactions",
+            "name" : "Number of In-Flight Transactions",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of In-Flight Transactions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of In-Flight Transactions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of In-Flight Transactions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions",
-          "properties" : {
-            "__identityHash" : "c3992989c1312969e9425f39ab3a9d655135a57"
-          },
-          "name" : "Transactions Metrics~Number of Nested Transactions",
-          "identityHash" : "c3992989c1312969e9425f39ab3a9d655135a57",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+          "name" : "Number of Nested Transactions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Nested%20Transactions",
-            "name" : "Transactions Metrics~Number of Nested Transactions",
-            "identityHash" : "6a43c18b6984c4a5b6642f6e38d25d9ce66e2",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Nested%20Transactions",
+            "name" : "Number of Nested Transactions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Nested Transactions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Nested Transactions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Nested Transactions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
-          "properties" : {
-            "__identityHash" : "f6e8fef2f67539af85b26a74f91c26fe452df0"
-          },
-          "name" : "Transactions Metrics~Number of Resource Rollbacks",
-          "identityHash" : "f6e8fef2f67539af85b26a74f91c26fe452df0",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+          "name" : "Number of Resource Rollbacks",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
-            "name" : "Transactions Metrics~Number of Resource Rollbacks",
-            "identityHash" : "2a1e4fb6d47babebfd5e92b377d5b15e8bcce54",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Resource%20Rollbacks",
+            "name" : "Number of Resource Rollbacks",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Resource Rollbacks"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Resource Rollbacks"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Resource Rollbacks"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
-          "properties" : {
-            "__identityHash" : "71ea3361e63978a1cef24a9bae68d991115fe24"
-          },
-          "name" : "Transactions Metrics~Number of Timed Out Transactions",
-          "identityHash" : "71ea3361e63978a1cef24a9bae68d991115fe24",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+          "name" : "Number of Timed Out Transactions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
-            "name" : "Transactions Metrics~Number of Timed Out Transactions",
-            "identityHash" : "489a7f12f69723b83099d4111f8fea767a0",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions",
+            "name" : "Number of Timed Out Transactions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Timed Out Transactions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Timed Out Transactions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Timed Out Transactions"
         }, {
-          "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/m;MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions",
-          "properties" : {
-            "__identityHash" : "cf973b9ccc86127bbd495aa8c1c49d7218b01861"
-          },
-          "name" : "Transactions Metrics~Number of Transactions",
-          "identityHash" : "cf973b9ccc86127bbd495aa8c1c49d7218b01861",
+          "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/m;MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem%3Dtransactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions",
+          "name" : "Number of Transactions",
           "type" : {
-            "path" : "/t;hawkular/f;3a06ba83-355b-4ae7-86ea-d0692ba6b347/mt;Transactions%20Metrics~Number%20of%20Transactions",
-            "name" : "Transactions Metrics~Number of Transactions",
-            "identityHash" : "affa229994b569b825e763d3b4194a613520dbb3",
+            "path" : "/t;hawkular/f;71daaa4b-da76-4373-8753-68279f33a884/mt;Transactions%20Metrics~Number%20of%20Transactions",
+            "name" : "Number of Transactions",
             "unit" : "NONE",
             "type" : "COUNTER",
             "collectionInterval" : 30,
             "id" : "Transactions Metrics~Number of Transactions"
           },
-          "id" : "MI~R~[3a06ba83-355b-4ae7-86ea-d0692ba6b347/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Transactions"
+          "id" : "MI~R~[71daaa4b-da76-4373-8753-68279f33a884/Local~/subsystem=transactions]~MT~Transactions Metrics~Number of Transactions"
         } ]
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/availability/AI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -850,7 +731,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -860,1202 +741,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/stats/?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/rate/stats?bucketDuration=3600s&end=1467734400001&start=1467727200000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: '[{"start":1467727200000,"end":1467730800000,"empty":true},{"start":1467730800000,"end":1467734400000,"empty":true},{"start":1467734400000,"end":1467738000000,"empty":true}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '41'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559004,"value":0.0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '41'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635301003,"value":0.0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559011,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635307003,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:42:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '42'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633559016,"value":-8.0}]'
+      string: '[{"timestamp":1470233678006,"value":"up"}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/availability/AI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2065,7 +776,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2075,32 +786,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:42:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '42'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635307010,"value":-8.0}]'
+      string: '[{"timestamp":1470238960002,"value":"up"}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -2110,7 +821,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -2120,1292 +831,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559008,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635307009,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559019,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635307005,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559021,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635307012,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559001,"value":4408}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635307006,"value":5064}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559002,"value":5.04365056E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635308000,"value":5.12229376E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559011,"value":5.04365056E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635308000,"value":5.12229376E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633529009,"value":3.38701336E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635342001,"value":3.83084096E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633559002,"value":3.34168064E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '47'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635308000,"value":3.60448E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633529022,"value":3.15346568E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '50'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635342004,"value":3.42707464E8}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '44'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633619024,"value":1446.0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '44'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635301001,"value":1463.0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633529029,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635342005,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633529048,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635342003,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633529026,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635342004,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469633529026,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/raw/?limit=1&order=DESC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
-    body:
-      encoding: UTF-8
-      string: '[{"timestamp":1469635342004,"value":0}]'
-    http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/raw/?limit=1&order=ASC&start=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Hawkular-Tenant:
-      - hawkular
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:42:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529038,"value":0.0}]'
+      string: '[{"timestamp":1470233708186,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3415,7 +866,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3425,32 +876,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
       Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:42:40 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635342002,"value":0.0}]'
+      string: '[{"timestamp":1470238928028,"value":0.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:40 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3460,7 +911,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3470,32 +921,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529026,"value":0}]'
+      string: '[{"timestamp":1470233708037,"value":0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3505,7 +956,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3515,32 +966,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635342005,"value":0}]'
+      string: '[{"timestamp":1470238928005,"value":0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3550,7 +1001,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3560,32 +1011,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529051,"value":0}]'
+      string: '[{"timestamp":1470233708141,"value":-8.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:27 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3595,7 +1046,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3605,32 +1056,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:27 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635342004,"value":0}]'
+      string: '[{"timestamp":1470238928017,"value":-8.0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:28 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3640,7 +1091,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3650,32 +1101,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:28 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529011,"value":0}]'
+      string: '[{"timestamp":1470233708089,"value":0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:28 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3685,7 +1136,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3695,32 +1146,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:28 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635342003,"value":0}]'
+      string: '[{"timestamp":1470238928014,"value":0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:28 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/raw/?limit=1&order=ASC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/raw/?limit=1&order=ASC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3730,7 +1181,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3740,32 +1191,32 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
-      Date:
-      - Wed, 27 Jul 2016 16:02:28 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '39'
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469633529010,"value":0}]'
+      string: '[{"timestamp":1470233708082,"value":0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:28 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/MI~R~%5B3a06ba83-355b-4ae7-86ea-d0692ba6b347%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/raw/?limit=1&order=DESC&start=0
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/raw/?limit=1&order=DESC&start=0
     body:
       encoding: US-ASCII
       string: ''
@@ -3775,7 +1226,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
       Hawkular-Tenant:
       - hawkular
       Content-Type:
@@ -3785,27 +1236,2592 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
       Expires:
       - '0'
       Cache-Control:
       - no-cache, no-store, must-revalidate
       X-Powered-By:
       - Undertow/1
-      Server:
-      - WildFly/10
       Pragma:
       - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238928011,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:42 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
       Date:
-      - Wed, 27 Jul 2016 16:02:28 GMT
-      Connection:
-      - keep-alive
+      - Wed, 03 Aug 2016 15:42:42 GMT
       Content-Type:
       - application/json
       Content-Length:
       - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
     body:
       encoding: UTF-8
-      string: '[{"timestamp":1469635342003,"value":0}]'
+      string: '[{"timestamp":1470233708145,"value":0}]'
     http_version: 
-  recorded_at: Wed, 27 Jul 2016 16:02:28 GMT
+  recorded_at: Wed, 03 Aug 2016 15:42:42 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238928025,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:43 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233708059,"value":9967}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:43 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238928006,"value":10277}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:43 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233708090,"value":4.32013312E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:43 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238928014,"value":4.29391872E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:43 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233708003,"value":4.77626368E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238928001,"value":4.77626368E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678240,"value":2.47408216E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939002,"value":3.1214516E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233708004,"value":2.75644416E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238928001,"value":2.91766272E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678238,"value":2.58525288E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939001,"value":2.74561392E8}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233768018,"value":745.0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238864021,"value":723.0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678214,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939003,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678214,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939002,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678215,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939003,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678018,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939003,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678242,"value":0.0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939005,"value":0.0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:48 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678260,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:48 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939004,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:48 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678240,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:48 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939002,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:49 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678258,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:49 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939004,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:49 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/raw/?limit=1&order=ASC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470233678236,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:49 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/raw/?limit=1&order=DESC&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1470238939002,"value":0}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:49 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/availability/AI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:50 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:50 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:50 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:51 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:51 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:51 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:51 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:51 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:52 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:52 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:52 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:52 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:52 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:53 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Aborted%20Transactions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:53 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Application%20Rollbacks/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:53 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Committed%20Transactions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:53 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Heuristics/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:53 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/gauges/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20In-Flight%20Transactions/stats/?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:54 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Nested%20Transactions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:54 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Resource%20Rollbacks/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:54 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Timed%20Out%20Transactions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:54 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@hservices.torii.gva.redhat.com/hawkular/metrics/counters/MI~R~%5B71daaa4b-da76-4373-8753-68279f33a884%2FLocal~%2Fsubsystem=transactions%5D~MT~Transactions%20Metrics~Number%20of%20Transactions/rate/stats?bucketDuration=3600s&end=1470222000001&start=1470204000000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.6.3
+      Date:
+      - Wed, 03 Aug 2016 15:42:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '343'
+      Connection:
+      - keep-alive
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: '[{"start":1470204000000,"end":1470207600000,"empty":true},{"start":1470207600000,"end":1470211200000,"empty":true},{"start":1470211200000,"end":1470214800000,"empty":true},{"start":1470214800000,"end":1470218400000,"empty":true},{"start":1470218400000,"end":1470222000000,"empty":true},{"start":1470222000000,"end":1470225600000,"empty":true}]'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 15:42:55 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
New version of Hawkular Services modified the native metrics names used in ManageIQ.
This PR updates the configuration files with the mapping between new native metrics names from Hawkular and virtual column names used in live metrics context.
Fixes #10185
