### PR TITLE
Fix value of dynamic dropdown list in prov. request details screen

### DIFF
--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -7,7 +7,7 @@
     dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}', '#{field.id}', '#{selected}', '#{url}');
 
 - else
-  = h(field.values.detect { |k, _v| k == wf.value(field.name) }.try(:last) || wf.value(field.name))
+  = h(field.values.detect { |k, _v| [k, k.to_s].include?(wf.value(field.name)) }.try(:last) || wf.value(field.name))
 
 - if field.dynamic
   - if field.auto_refresh


### PR DESCRIPTION
Steps to reproduce:

* create automation method for a dynamic dropdown list, for example:
```ruby
dialog_hash = {}
dialog_hash[:first] = "First #{Time.now}"
dialog_hash[:second] = "Second #{Time.now}"
dialog_hash[:third] = "Third #{Time.now}" 
$evm.object['required'] = true
$evm.object['protected'] = false
$evm.object['read_only'] = false
$evm.object['values'] = dialog_hash 
```
* create a service dialog using dynamic dropdown list & the above automation method
* create a service using the above created service dialog
* order the service and navigate to the request details screen
* See that the value which was used to submit the request wasn't rendered.

https://bugzilla.redhat.com/show_bug.cgi?id=1336015