### PR TITLE
Add relationship between container project\pod\node and container images

### DIFF
--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module ContainerGroupHelper::TextualSummary
 
   def textual_group_relationships
     # Order of items should be from parent to child
-    %i(ems container_project container_services container_replicator containers container_node lives_on)
+    %i(ems container_project container_services container_replicator containers container_node lives_on container_images)
   end
 
   def textual_group_conditions

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -10,7 +10,7 @@ module ContainerNodeHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(ems container_routes container_services container_replicators container_groups containers lives_on)
+    %i(ems container_routes container_services container_replicators container_groups containers lives_on container_images)
   end
 
   def textual_group_conditions

--- a/app/helpers/container_project_helper/textual_summary.rb
+++ b/app/helpers/container_project_helper/textual_summary.rb
@@ -8,7 +8,7 @@ module ContainerProjectHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(ems container_routes container_services container_replicators container_groups container_nodes)
+    %i(ems container_routes container_services container_replicators container_groups container_nodes container_images)
   end
 
   def textual_group_smart_management

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -6,7 +6,7 @@ class ContainerDefinition < ApplicationRecord
   has_many :container_env_vars,     :dependent => :destroy
   has_one :container,               :dependent => :destroy
   has_one :security_context,        :as => :resource, :dependent => :destroy
-  has_and_belongs_to_many           :container_images, :join_table => :containers
+  has_one :container_image,         :through => :container
 
   def disconnect_inv
     _log.info "Disconnecting Container definition [#{name}] id [#{id}]"

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -6,6 +6,7 @@ class ContainerDefinition < ApplicationRecord
   has_many :container_env_vars,     :dependent => :destroy
   has_one :container,               :dependent => :destroy
   has_one :security_context,        :as => :resource, :dependent => :destroy
+  has_and_belongs_to_many           :container_images, :join_table => :containers
 
   def disconnect_inv
     _log.info "Disconnecting Container definition [#{name}] id [#{id}]"

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -11,6 +11,7 @@ class ContainerGroup < ApplicationRecord
   has_many :containers,
            :through => :container_definitions
   has_many :container_definitions, :dependent => :destroy
+  has_many :container_images, :through => :container_definitions
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
   has_many :node_selector_parts, -> { where(:section => "node_selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -11,7 +11,7 @@ class ContainerGroup < ApplicationRecord
   has_many :containers,
            :through => :container_definitions
   has_many :container_definitions, :dependent => :destroy
-  has_many :container_images, :through => :container_definitions
+  has_many :container_images, -> { distinct }, :through => :container_definitions
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
   has_many :node_selector_parts, -> { where(:section => "node_selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -9,7 +9,7 @@ class ContainerNode < ApplicationRecord
   has_many   :container_groups
   has_many   :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
   has_many   :containers, :through => :container_groups
-  has_many   :container_images, :through => :container_groups
+  has_many   :container_images, -> { distinct }, :through => :container_groups
   has_many   :container_services, -> { distinct }, :through => :container_groups
   has_many   :container_routes, -> { distinct }, :through => :container_services
   has_many   :container_replicators, -> { distinct }, :through => :container_groups

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -9,6 +9,7 @@ class ContainerNode < ApplicationRecord
   has_many   :container_groups
   has_many   :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
   has_many   :containers, :through => :container_groups
+  has_many   :container_images, :through => :container_groups
   has_many   :container_services, -> { distinct }, :through => :container_groups
   has_many   :container_routes, -> { distinct }, :through => :container_services
   has_many   :container_replicators, -> { distinct }, :through => :container_groups

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -7,7 +7,7 @@ class ContainerProject < ApplicationRecord
   has_many :container_services
   has_many :containers, :through => :container_groups
   has_many :container_definitions, :through => :container_groups
-  has_many :container_images, :through => :container_groups
+  has_many :container_images, -> { distinct }, :through => :container_groups
   has_many :container_nodes, -> { distinct }, :through => :container_groups
   has_many :container_quotas
   has_many :container_quota_items, :through => :container_quotas

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -5,7 +5,9 @@ class ContainerProject < ApplicationRecord
   has_many :container_routes
   has_many :container_replicators
   has_many :container_services
+  has_many :containers, :through => :container_groups
   has_many :container_definitions, :through => :container_groups
+  has_many :container_images, :through => :container_groups
   has_many :container_nodes, -> { distinct }, :through => :container_groups
   has_many :container_quotas
   has_many :container_quota_items, :through => :container_quotas
@@ -26,6 +28,7 @@ class ContainerProject < ApplicationRecord
   virtual_column :routes_count,      :type => :integer
   virtual_column :replicators_count, :type => :integer
   virtual_column :containers_count,  :type => :integer
+  virtual_column :images_count,      :type => :integer
 
   def groups_count
     container_groups.size
@@ -45,6 +48,10 @@ class ContainerProject < ApplicationRecord
 
   def containers_count
     container_definitions.size
+  end
+
+  def images_count
+    container_images.size
   end
 
   include EventMixin

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(containers container_services).include?(@display)
+- if %w(containers container_services container_images).include?(@display)
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - else
     - case @showtype

--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -1,5 +1,4 @@
-- if %w(container_routes container_services container_replicators container_groups containers).include?(@display)
-  && @showtype != "compare"
+- if %w(container_routes container_services container_replicators container_groups containers container_images).include?(@display) && @showtype != "compare"
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
   = render(:partial => "layouts/tl_show")

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -1,4 +1,4 @@
-- if %w(container_routes container_services container_replicators container_groups container_nodes).include?(@display)
+- if %w(container_routes container_services container_replicators container_groups container_nodes container_images).include?(@display)
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
 - elsif @showtype == "timeline"
   = render(:partial => "layouts/tl_show")

--- a/app/views/layouts/listnav/_container_group.html.haml
+++ b/app/views/layouts/listnav/_container_group.html.haml
@@ -34,4 +34,5 @@
         = multiple_relationship_link(@record, :container_service)
         = single_relationship_link(@record, :container_replicator)
         = multiple_relationship_link(@record, :container)
+        = multiple_relationship_link(@record, :container_image)
         = single_relationship_link(@record, :container_node)

--- a/app/views/layouts/listnav/_container_node.html.haml
+++ b/app/views/layouts/listnav/_container_node.html.haml
@@ -30,5 +30,5 @@
     = miq_accordion_panel(_("Relationships"), false, "container_node_rel") do
       %ul.nav.nav-pills.nav-stacked
         = single_relationship_link(@record, :ems_container, "ext_management_system")
-        - %i(container_route container_service container_replicator container_group container).each do |ent|
+        - %i(container_route container_service container_replicator container_group container container_image).each do |ent|
           = multiple_relationship_link(@record, ent)

--- a/app/views/layouts/listnav/_container_project.html.haml
+++ b/app/views/layouts/listnav/_container_project.html.haml
@@ -29,5 +29,5 @@
     = miq_accordion_panel(_("Relationships"), false, "container_project_rel") do
       %ul.nav.nav-pills.nav-stacked
         = single_relationship_link(@record, :ems_container, "ext_management_system")
-        - %i(container_route container_service container_replicator container_group container_node).each do |ent|
+        - %i(container_route container_service container_replicator container_group container_node container_image).each do |ent|
           = multiple_relationship_link(@record, ent)

--- a/product/views/ContainerProject.yaml
+++ b/product/views/ContainerProject.yaml
@@ -26,6 +26,7 @@ cols:
 - replicators_count
 - groups_count
 - containers_count
+- images_count
 
 # Included tables (joined, has_one, has_many) and columns
 include:
@@ -46,6 +47,7 @@ col_order:
 - replicators_count
 - groups_count
 - containers_count
+- images_count
 
 # Column titles, in order
 headers:
@@ -57,6 +59,7 @@ headers:
 - Container Replicators
 - Pods
 - Containers
+- Images
 
 # Condition(s) string for the SQL query
 conditions: 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_group_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_group_spec.rb
@@ -1,0 +1,14 @@
+describe ContainerNode do
+  it "has distinct images" do
+    group = FactoryGirl.create(
+      :container_group,
+      :name => "group",
+    )
+    FactoryGirl.create(
+      :container_image,
+      :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
+                      FactoryGirl.create(:container, :name => "container_b", :container_group => group)]
+    )
+    expect(group.container_images.count).to eq(1)
+  end
+end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_node_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_node_spec.rb
@@ -12,4 +12,24 @@ describe ContainerNode do
                           FactoryGirl.create(:container_group, :name => "g2", :container_services => [service])]
     ).container_routes.count).to eq(1)
   end
+
+  it "has distinct images" do
+    node = FactoryGirl.create(:container_node, :name => "n")
+    group = FactoryGirl.create(
+      :container_group,
+      :name           => "group",
+      :container_node => node
+    )
+    group2 = FactoryGirl.create(
+      :container_group,
+      :name           => "group2",
+      :container_node => node
+    )
+    FactoryGirl.create(
+      :container_image,
+      :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
+                      FactoryGirl.create(:container, :name => "container_b", :container_group => group2)]
+    )
+    expect(node.container_images.count).to eq(1)
+  end
 end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/container_project_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/container_project_spec.rb
@@ -7,4 +7,25 @@ describe ContainerProject do
                           FactoryGirl.create(:container_group, :name => "g2", :container_node => node)]
     ).container_nodes.count).to eq(1)
   end
+
+  it "has distinct images" do
+    # Create a project with 2 containers from different pods that run the same image
+    node = FactoryGirl.create(:container_node, :name => "n")
+    group = FactoryGirl.create(
+      :container_group,
+      :name           => "group",
+      :container_node => node
+    )
+    group2 = FactoryGirl.create(
+      :container_group,
+      :name           => "group2",
+      :container_node => node
+    )
+    FactoryGirl.create(
+      :container_image,
+      :containers => [FactoryGirl.create(:container, :name => "container_a", :container_group => group),
+                      FactoryGirl.create(:container, :name => "container_b", :container_group => group2)]
+    )
+    expect(FactoryGirl.create(:container_project, :container_groups => [group]).container_images.count).to eq(1)
+  end
 end


### PR DESCRIPTION
This change enables us to:
* be able to list which container images are in use by a pod
* be able to list which container images are in use by a project (which is useful information apparently)
* be able to list which container images are in use by a Node
* use this relationship in reports 
* be able to get pod\image trends in Metrics

Side effects:
* 'image creation trend' in metrics would be misleading here since it wasnt necessarily this project that caused the creation of each image it uses. 
* Awful, just terrible performance since were going through 5 tables:
```Ruby
2.2.3 :097 > ContainerProject.find(20).container_images
  ContainerProject Load (0.2ms)  SELECT  "container_projects".* FROM "container_projects" WHERE "container_projects"."id" = $1 LIMIT $2  [["id", 20], ["LIMIT", 1]]
  ContainerProject Inst Including Associations (0.1ms - 1rows)
  ContainerImage Load (0.5ms)  SELECT "container_images".* FROM "container_images" INNER JOIN "containers" ON "container_images"."id" = "containers"."container_image_id" INNER JOIN "container_definitions" ON "containers"."container_definition_id" = "container_definitions"."id" INNER JOIN "container_groups" ON "container_definitions"."container_group_id" = "container_groups"."id" WHERE "container_groups"."container_project_id" = $1  [["container_project_id", 20]]
  ContainerImage Inst Including Associations (0.1ms - 3rows)
 => #<ActiveRecord::Associations::CollectionProxy [#<ContainerImage id: 20, tag: "v1.0.8", name: "openshift/origin-docker-registry"...]> 
```
    

Screenshots:
Pod:
![screencapture-localhost-3000-container_group-show-40-1470141667178](https://cloud.githubusercontent.com/assets/11256940/17328672/abac3416-58c7-11e6-9d96-2b197ebfd221.png)

Project:
![screencapture-localhost-3000-container_project-show-20-1470141644835](https://cloud.githubusercontent.com/assets/11256940/17328673/ac7a8a64-58c7-11e6-87a0-42c697672988.png)
![screencapture-localhost-3000-container_project-show_list-1470144439042](https://cloud.githubusercontent.com/assets/11256940/17330067/061217b2-58ce-11e6-826f-85b29219f5f8.png)

Node:
![screencapture-localhost-3000-container_node-show-9-1470144484082](https://cloud.githubusercontent.com/assets/11256940/17330087/1a0a1314-58ce-11e6-9d75-4fc7cc93eccb.png)


report:
![screencapture-localhost-3000-report-explorer-1470142196250](https://cloud.githubusercontent.com/assets/11256940/17328902/cb92eda0-58c8-11e6-9c95-06cc25402f42.png)


@miq-bot add_label providers/containers, ui
@simon3z @moolitayer Please review