### PR TITLE
[WIP]  Add event monitoring for VMware Cloud

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -92,6 +92,10 @@ class EmsEvent < EventStream
     add(ems_id, ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, ems_id))
   end
 
+  def self.add_vmware_vcloud(ems_id, event)
+    add(ems_id, ManageIQ::Providers::Vmware::CloudManager::EventParser.event_to_hash(event, ems_id))
+  end
+
   def self.add(ems_id, event_hash)
     event_type = event_hash[:event_type]
     raise MiqException::Error, _("event_type must be set in event") if event_type.nil?

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Vmware::CloudManager::EventCatcher < ::MiqEventCatcher
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Vmware::CloudManager
+  end
+
+  def self.settings_name
+    :event_catcher_vmware_cloud
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/runner.rb
@@ -1,0 +1,4 @@
+class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Runner <
+    ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  include ManageIQ::Providers::Vmware::EventCatcherMixin
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_parser.rb
@@ -1,0 +1,20 @@
+module ManageIQ::Providers::Vmware::CloudManager::EventParser
+  def self.event_to_hash(event, ems_id)
+    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
+    _log.debug("#{log_header}event: [#{event[:event_type]}]")
+
+    event_hash = {
+      # TODO: implement rel4 policies for vmware cloud
+      :event_type => "go-to-missing",
+      # :event_type => event[:event_type],
+      :source     => "VMWARE-VCLOUD",
+      :message    => event.to_hash,
+      :timestamp  => event[:timestamp],
+      :vm_ems_ref => event[:instance_id],
+      :full_data  => event,
+      :ems_id     => ems_id,
+    }
+
+    event_hash
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager_mixin_events.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager_mixin_events.rb
@@ -1,0 +1,46 @@
+module ManageIQ::Providers::Vmware::CloudManagerMixinEvents
+  extend ActiveSupport::Concern
+
+  def event_monitor_options
+    @event_monitor_options ||= begin
+      opts = {
+        :ems          => self,
+        :virtual_host => "/",
+      }
+      amqp = connection_configuration_by_role("amqp")
+
+      if (endpoint = amqp.try(:endpoint))
+        opts[:hostname]          = endpoint.hostname
+        opts[:port]              = endpoint.port
+        opts[:security_protocol] = endpoint.security_protocol
+      end
+
+      if (authentication = amqp.try(:authentication))
+        opts[:username] = authentication.userid
+        opts[:password] = authentication.password
+      end
+
+      opts
+    end
+  end
+
+  def event_monitor_available?
+    require 'vmware/vmware_vcloud_event_monitor'
+    VmwareVcloudEventMonitor.available?(event_monitor_options)
+  rescue => e
+    _log.error("Exception trying to find Vmware vCloud event monitor for #{name}(#{hostname}). #{e.message}")
+    _log.error(e.backtrace.join("\n"))
+    false
+  end
+
+  def verify_amqp_credentials(_options = {})
+    require 'vmware/vmware_vcloud_event_monitor'
+    VmwareVcloudEventMonitor.test_amqp_connection(event_monitor_options)
+  rescue => err
+    miq_exception = translate_exception(err)
+    raise unless miq_exception
+
+    _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+    raise miq_exception
+  end
+end

--- a/app/models/manageiq/providers/vmware/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/vmware/event_catcher_mixin.rb
@@ -1,0 +1,62 @@
+module ManageIQ::Providers::Vmware::EventCatcherMixin
+  def event_monitor_handle
+    require 'vmware/vmware_vcloud_event_monitor'
+    unless @event_monitor_handle
+      options = @ems.event_monitor_options
+      options[:topics]                        = worker_settings[:topics]
+      options[:duration]                      = worker_settings[:duration]
+      options[:capacity]                      = worker_settings[:capacity]
+      options[:heartbeat]                     = worker_settings[:amqp_heartbeat]
+      options[:recovery_attempts]             = worker_settings[:amqp_recovery_attempts]
+      options[:client_ip]                     = server.ipaddress
+      options[:automatic_recovery]            = true
+      options[:recover_from_connection_close] = true
+      options[:ems]                           = @ems
+
+      @event_monitor_handle = VmwareVcloudEventMonitor.new(options)
+    end
+    @event_monitor_handle
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  # Start monitoring for events. This method blocks forever until stop_event_monitor is called.
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.each_batch do |events|
+      event_monitor_running
+      if events && !events.empty?
+        _log.debug("#{log_prefix} Received events #{events.collect(&:type)}") if _log.debug?
+        @queue.enq events
+      end
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.stop unless @event_monitor_handle.nil?
+  rescue StandardException => err
+    _log.warn("#{log_prefix} Event Monitor Stop errored because [#{err.message}]")
+    _log.warn("#{log_prefix} Error details: [#{err.details}]")
+    _log.log_backtrace(err)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def process_event(event)
+    if filtered_events.include?(event.type)
+      _log.info "#{log_prefix} Skipping caught event [#{event.type}]"
+    else
+      _log.info "#{log_prefix} Caught event [#{event.type}]"
+      add_to_worker_queue(event)
+    end
+  end
+
+  def add_to_worker_queue(event)
+    EmsEvent.add_queue('add_vmware_vcloud', @cfg[:ems_id], event.to_hash)
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -54,6 +54,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Openstack::NetworkManager::EventCatcher
     ManageIQ::Providers::Openstack::InfraManager::EventCatcher
     ManageIQ::Providers::Vmware::InfraManager::EventCatcher
+    ManageIQ::Providers::Vmware::CloudManager::EventCatcher
     MiqEventHandler
     MiqGenericWorker
     MiqNetappRefreshWorker
@@ -121,6 +122,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqWebServiceWorker
     MiqEmsRefreshCoreWorker
     MiqVimBrokerWorker
+    ManageIQ::Providers::Vmware::CloudManager::EventCatcher
     ManageIQ::Providers::Vmware::InfraManager::EventCatcher
     ManageIQ::Providers::Redhat::InfraManager::EventCatcher
     ManageIQ::Providers::Openstack::CloudManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1209,6 +1209,15 @@
       :event_catcher_vmware:
         :poll: 1.seconds
         :ems_event_max_wait: 60
+      :event_catcher_vmware_cloud:
+        :poll: 15.seconds
+        :topics:
+          :vcd.notifications20: "#"
+        :duration: 10.seconds
+        :capacity: 50
+        :amqp_port: 5672
+        :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
       :event_catcher_openstack:
         :poll: 15.seconds
         :topics:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD/__class__.yaml
@@ -1,0 +1,433 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: VMware
+    name: VMWARE-VCLOUD
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: assertion
+      name: guard
+      display_name: 
+      datatype: 
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: logical_event
+      display_name: 
+      datatype: 
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_entry
+      display_name: 
+      datatype: 
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel1
+      display_name: 
+      datatype: 
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth1
+      display_name: 
+      datatype: 
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel2
+      display_name: 
+      datatype: 
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth2
+      display_name: 
+      datatype: 
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel3
+      display_name: 
+      datatype: 
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth3
+      display_name: 
+      datatype: 
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel4
+      display_name: 
+      datatype: 
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth4
+      display_name: 
+      datatype: 
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel5
+      display_name: 
+      datatype: 
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth5
+      display_name: 
+      datatype: 
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel6
+      display_name: 
+      datatype: 
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth6
+      display_name: 
+      datatype: 
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel7
+      display_name: 
+      datatype: 
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth7
+      display_name: 
+      datatype: 
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel8
+      display_name: 
+      datatype: 
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth8
+      display_name: 
+      datatype: 
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel9
+      display_name: 
+      datatype: 
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_exit
+      display_name: 
+      datatype: 
+      priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD/_missing.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/gems/pending/spec/vmware/vmware_vcloud_event_monitor_spec.rb
+++ b/gems/pending/spec/vmware/vmware_vcloud_event_monitor_spec.rb
@@ -1,0 +1,48 @@
+require 'vmware/vmware_vcloud_event_monitor'
+
+describe VmwareVcloudEventMonitor do
+  before do
+    @original_log = $log
+    $log = double.as_null_object
+
+    @topic = "vmware_vcloud_topic"
+    @receiver_options = {:capacity => 1, :duration => 1}
+    @options = @receiver_options.merge(:topics => @topic, :client_ip => "10.11.12.13")
+
+    @rabbit_connection = double
+    allow(VmwareVcloudEventMonitor).to receive(:connect).and_return(@rabbit_connection)
+  end
+
+  after do
+    $log = @original_log
+  end
+
+  context "testing a connection" do
+    it "returns true on a successful test" do
+      expect(@rabbit_connection).to receive(:start)
+      expect(@rabbit_connection).to receive(:close)
+
+      expect(VmwareVcloudEventMonitor.test_connection(@options)).to be_truthy
+    end
+
+    it "raise exception on an unsuccessful test with bad credentials" do
+      expect(@rabbit_connection).to receive(:start).and_raise(Bunny::AuthenticationFailureError.new('test', 'test', 5))
+      expect(@rabbit_connection).to receive(:close)
+      expect { VmwareVcloudEventMonitor.test_connection(@options) }.to(
+        raise_error(MiqException::MiqInvalidCredentialsError)
+      )
+    end
+
+    it "raise exception on an unsuccessful test with unreachable hostname" do
+      expect(@rabbit_connection).to receive(:start).and_raise(Bunny::TCPConnectionFailedForAllHosts.new)
+      expect(@rabbit_connection).to receive(:close)
+      expect { VmwareVcloudEventMonitor.test_connection(@options) }.to raise_error(MiqException::MiqHostError)
+    end
+
+    it "raise exception on an unsuccessful test with unexpected exception" do
+      expect(@rabbit_connection).to receive(:start).and_raise("Cannot connect to rabbit amqp")
+      expect(@rabbit_connection).to receive(:close)
+      expect { VmwareVcloudEventMonitor.test_connection(@options) }.to raise_error("Cannot connect to rabbit amqp")
+    end
+  end
+end

--- a/gems/pending/vmware/events/vmware_vcloud_event.rb
+++ b/gems/pending/vmware/events/vmware_vcloud_event.rb
@@ -1,0 +1,42 @@
+# https://pubs.vmware.com/vca/index.jsp#com.vmware.vcloud.api.doc_56/GUID-7C1F16FF-C530-404E-8533-329670B20A19.html
+#
+# EXAMPLE PAYLOAD:
+# {
+# "eventId"           : "a1440dd8-60ae-46c7-b216-44693bc00c90",
+# "type"              : "com/vmware/vcloud/event/blockingtask/create",
+# "timestamp"         : "2011-06-18T14:33:27.787+03:00",
+# "operationSuccess"  : true,
+# "user"              : "urn:vcloud:user:44",
+# "org"               : "urn:vcloud:org:70",
+# "entity"            : "urn:vcloud:blockingTask:25"
+# "task"              : "urn:vcloud:task:34",
+# "taskOwner"         : "urn:vcloud:vapp:26"
+# }
+
+class VmwareVcloudEvent
+  attr_accessor :payload, :metadata
+
+  EVENT_ID_KEY = "eventId".freeze
+  EVENT_TYPE_KEY = "type".freeze
+
+  def initialize(payload, metadata)
+    raise "AMQP message missing raquired keys" if [EVENT_ID_KEY, EVENT_TYPE_KEY].any? { |s| !payload.key? s }
+
+    @payload = payload
+    @metadata = metadata
+  end
+
+  def type
+    @payload[EVENT_TYPE_KEY]
+  end
+
+  def to_hash
+    {
+      :event_id    => @payload[EVENT_ID_KEY],
+      :event_type  => @payload[EVENT_TYPE_KEY],
+      :timestamp   => @payload["timestamp"],
+      :user_id     => @payload["user"],
+      :instance_id => @payload["taskOwner"]
+    }
+  end
+end

--- a/gems/pending/vmware/vmware_vcloud_event_monitor.rb
+++ b/gems/pending/vmware/vmware_vcloud_event_monitor.rb
@@ -1,0 +1,141 @@
+require 'more_core_extensions/core_ext/hash'
+require 'util/extensions/miq-module'
+require 'vmware/events/vmware_vcloud_event'
+require 'bunny'
+require 'thread'
+
+# Listens to RabbitMQ events
+class VmwareVcloudEventMonitor
+  DEFAULT_AMQP_PORT = 5672
+  DEFAULT_AMQP_HEARTBEAT = 30
+
+  def self.test_connection(options = {})
+    connection = nil
+    begin
+      connection = connect(options)
+      connection.start
+      return true
+    rescue Bunny::AuthenticationFailureError => e
+      $log.info("#{log_prefix} Failed testing rabbit amqp connection: #{e.message}") if $log
+      raise MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+    rescue Bunny::TCPConnectionFailedForAllHosts => e
+      raise MiqException::MiqHostError.new "Socket error: #{e.message}"
+    rescue
+      $log.info("#{log_prefix} Failed testing rabbit amqp connection for #{options[:hostname]}. ") if $log
+      raise
+    ensure
+      connection.close if connection.respond_to? :close
+    end
+  end
+
+  def self.available?(options = {})
+    test_connection(options)
+  end
+
+  def self.test_amqp_connection(options)
+    available?(options)
+  end
+
+  def self.connect(options = {})
+    connection_options = {:host => options[:hostname]}
+    connection_options[:port]               = options[:port] || DEFAULT_AMQP_PORT
+    connection_options[:heartbeat]          = options[:heartbeat] || DEFAULT_AMQP_HEARTBEAT
+    connection_options[:automatic_recovery] = options[:automatic_recovery] if options.key? :automatic_recovery
+    connection_options[:recovery_attempts]  = options[:recovery_attempts] if options.key? :recovery_attempts
+
+    if options.key? :recover_from_connection_close
+      connection_options[:recover_from_connection_close] = options[:recover_from_connection_close]
+    end
+
+    if options.key? :username
+      connection_options[:username] = options[:username]
+      connection_options[:password] = options[:password]
+    end
+    Bunny.new(connection_options)
+  end
+
+  def self.log_prefix
+    "MIQ(#{self.class.name})"
+  end
+
+  def initialize(options = {})
+    @options          = options
+    @options[:port] ||= DEFAULT_AMQP_PORT
+    @client_ip        = @options[:client_ip]
+
+    @collecting_events = false
+    @events = []
+    # protect threaded access to the events array
+    @events_array_mutex = Mutex.new
+  end
+
+  def start
+    $log.debug("#{self.class.log_prefix} Opening amqp connection to #{@options}") if $log
+    connection.start
+    @channel = connection.create_channel
+    initialize_queues(@channel)
+  end
+
+  def stop
+    @connection.close if @connection.respond_to? :close
+    @collecting_events = false
+  end
+
+  def each_batch
+    @collecting_events = true
+    subscribe_queues
+    while @collecting_events
+      @events_array_mutex.synchronize do
+        $log.debug("#{self.class.log_prefix} Yielding #{@events.size} events to" \
+                   " event_catcher: #{@events.map { |e| e.payload["event_type"] }}") if $log
+        yield @events
+        $log.debug("#{self.class.log_prefix} Clearing events") if $log
+        @events.clear
+      end
+      sleep 5
+    end
+  end
+
+  def each
+    each_batch do |events|
+      events.each { |e| yield e }
+    end
+  end
+
+  private
+
+  def connection
+    @connection ||= self.class.connect(@options)
+  end
+
+  def initialize_queues(channel)
+    @queues = {}
+    if @options[:topics]
+      @options[:topics].each do |exchange, topic|
+        amqp_exchange = channel.topic(exchange, :durable => true)
+        queue_name = "miq-#{@client_ip}-#{exchange}"
+        @queues[exchange] = channel.queue(queue_name, :auto_delete => true, :exclusive => true)
+                                   .bind(amqp_exchange, :routing_key => topic)
+      end
+
+    end
+  end
+
+  def subscribe_queues
+    @queues.each do |exchange, queue|
+      queue.subscribe do |_, metadata, payload|
+        begin
+          event = VmwareVcloudEvent.new(JSON.parse(payload), metadata)
+          @events_array_mutex.synchronize do
+            @events << event
+            $log.debug("#{self.class.log_prefix} Received Rabbit (amqp) event"\
+                       " on #{exchange} from #{@options[:hostname]}: #{event.type}") if $log
+          end
+        rescue => e
+          $log.error("#{self.class.log_prefix} Exception receiving Rabbit (amqp)"\
+                     " event on #{exchange} from #{@options[:hostname]}: #{e}") if $log
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
This patch implements EventMonitor that connects to RabbitMQ
where VMware Cloud Director drops notifications. Furthermore,
this patch implements EventCatcher that makes use of EventMonitor.

Currently, any event triggers full refresh of provider as rel4
policies are not implemented yet.

Currently, adding event monitoring credentials is not possible
from GUI, since this relies on this  [PR](https://github.com/ManageIQ/manageiq/pull/10018).

Links
-----
[event message format](https://pubs.vmware.com/vca/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_56%2FGUID-D313E4EE-C404-41EF-B223-5723B7B4B29F.html)

Steps for Testing/QA
--------------------
Since it is difficult to write automated unit tests with
RabbitMQ broker, I've tested like this:
- setup RabbitMQ somewhere
- add rabbit credentials to Vmware::CloudManager using rails console
- run manageiq server and automation workers
- use Rabbitmq Web GUI and manually enqueue event message
- see that VMware provider performs refresh