### PR TITLE
[DARGA] Remove filters Type / Template/VMs from yml file

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -1115,27 +1115,6 @@
     search_type: default
     db: ManageIQ::Providers::InfraManager::Vm
 - attributes:
-    name: default_Type / Template
-    description: Type / Template
-    filter: !ruby/object:MiqExpression
-      exp:
-        "=":
-          field: VmInfra-template
-          value: "true"
-    search_type: default
-    db: ManageIQ::Providers::InfraManager::Vm
-- attributes:
-    name: default_Type / VM
-    description: Type / VM
-    filter: !ruby/object:MiqExpression
-      exp:
-        not:
-          ENDS WITH:
-            field: VmInfra-location
-            value: .vmtx
-    search_type: default
-    db: ManageIQ::Providers::InfraManager::Vm
-- attributes:
     name: default_Status / Retired
     description: Status / Retired
     filter: !ruby/object:MiqExpression


### PR DESCRIPTION
(cherry picked from commit e14faac0c19e9ec9e60b58dc3714adfd7e3adf2a)
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1351210

Filters are removed from db/fixtures/miq_searches.yml
because they are not needed in VMs filters
anymore. They were seeded in MiqSearch table.