### PR TITLE
Toolbar buttons for Service Orchestration moved to separate class

### DIFF
--- a/app/helpers/application_helper/button/service_reconfigure.rb
+++ b/app/helpers/application_helper/button/service_reconfigure.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::ServiceReconfigure < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.validate_reconfigure
+  end
+end

--- a/app/helpers/application_helper/toolbar/service_center.rb
+++ b/app/helpers/application_helper/toolbar/service_center.rb
@@ -30,7 +30,8 @@ class ApplicationHelper::Toolbar::ServiceCenter < ApplicationHelper::Toolbar::Ba
           :service_reconfigure,
           'pficon pficon-edit fa-lg',
           N_('Reconfigure the options of this Service'),
-          N_('Reconfigure this Service')),
+          N_('Reconfigure this Service'),
+          :klass => ApplicationHelper::Button::ServiceReconfigure),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -482,14 +482,6 @@ class ApplicationHelper::ToolbarBuilder
     end
   end
 
-  def build_toolbar_hide_button_service(id)
-    case id
-    when "service_reconfigure"
-      return true unless @record.validate_reconfigure
-    end
-    false
-  end
-
   # Determine if a button should be hidden
   def build_toolbar_hide_button(id)
     return false if id.start_with?('history_')
@@ -815,8 +807,6 @@ class ApplicationHelper::ToolbarBuilder
       when "server_delete", "role_start", "role_suspend", "promote_server", "demote_server"
         return true
       end
-    when "Service", "ServiceOrchestration"
-      return build_toolbar_hide_button_service(id)
     when "ServiceTemplate"
       case id
       when "ab_group_new", "ab_button_new"

--- a/spec/helpers/application_helper/buttons/service_reconfigure_spec.rb
+++ b/spec/helpers/application_helper/buttons/service_reconfigure_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe ApplicationHelper::Button::ServiceReconfigure do
+  describe '#skip?' do
+    context "when record is reconfigurable" do
+      before do
+        @record = FactoryGirl.create(:service)
+        allow(@record).to receive(:validate_reconfigure).and_return(true)
+      end
+
+      it "will be not skipped" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.skip?).to be_falsey
+      end
+    end
+
+    context "when record is not reconfigurable" do
+      before do
+        @record = FactoryGirl.create(:service)
+        allow(@record).to receive(:validate_reconfigure).and_return(false)
+      end
+
+      it "will be skipped" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.skip?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------

Purpose is to move toolbar buttons from helper (`app/helpers/application_helper/toolbar_builder.rb`) to separate classes.

*In this PR is converted a `Reconfigure this Service` button for for Services.*

**Classes for one button**
- class `ServiceReconfigure` contains logic for `service_reconfigure` button in Service detail page


**Toolbar screenshots**

- service_center.rb
![screencapture-localhost-3000-service-explorer-1470149302107](https://cloud.githubusercontent.com/assets/1187051/17333569/3973e28e-58d3-11e6-8347-97a6a67ff423.png)


@martinpovolny @PanSpagetka can you review?

Links
-----
Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/127545673