### PR TITLE
Fix wrong error handling in rhevm infrastructure provider

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -155,14 +155,17 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def verify_credentials_for_rhevm(options = {})
-    connect(options).api
-  rescue URI::InvalidURIError
-    raise "Invalid URI specified for RHEV server."
-  rescue SocketError => err
-    raise "Error occurred attempted to connect to RHEV server.", err
-  rescue => err
-    _log.error("Error while verifying credentials #{err}")
-    raise MiqException::MiqEVMLoginError, err
+    with_provider_connection(options, &:api)
+  rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH
+    _log.warn($ERROR_INFO)
+    raise MiqException::MiqUnreachableError, $ERROR_INFO
+  rescue Ovirt::MissingResourceError, URI::InvalidURIError
+    raise MiqException::MiqUnreachableError, "Invalid URI specified for the server."
+  rescue RestClient::Unauthorized
+    raise MiqException::MiqInvalidCredentialsError, "Incorrect user name or password."
+  rescue
+    _log.error("Error while verifying credentials #{$ERROR_INFO}")
+    raise MiqException::MiqEVMLoginError, $ERROR_INFO
   end
 
   def rhevm_metrics_connect_options(options = {})


### PR DESCRIPTION
Purpose or Intent
-----------------
> When adding a new rhev provider filling in incorrect credentials/url/port the error message was not correct.
Please note this patch needs the https://github.com/ManageIQ/ovirt/pull/63/commits to be merged to function properly.

Links
-----
> * [Required patch](https://github.com/ManageIQ/ovirt/pull/63/)


