### PR TITLE
arbitration_rules API

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -56,6 +56,7 @@ class ApiController < ApplicationController
 
   include_concern 'Accounts'
   include_concern 'ArbitrationProfiles'
+  include_concern 'ArbitrationRules'
   include_concern 'Authentication'
   include_concern 'AutomationRequests'
   include_concern 'Blueprints'

--- a/app/controllers/api_controller/arbitration_rules.rb
+++ b/app/controllers/api_controller/arbitration_rules.rb
@@ -1,0 +1,29 @@
+class ApiController
+  module ArbitrationRules
+    def create_resource_arbitration_rules(type, _id, data)
+      attributes = validate_arbitration_rules(data)
+      arbitration_rule = collection_class(type).create(attributes)
+      if arbitration_rule.invalid?
+        raise BadRequestError,
+              "Failed to create a new virtual template - #{arbitration_rule.errors.full_messages.join(', ')}"
+      end
+      arbitration_rule
+    end
+
+    def edit_resource_arbitration_rules(type, id, data)
+      attributes = validate_arbitration_rules(data)
+      edit_resource(type, id, attributes)
+    end
+
+    private
+
+    def validate_arbitration_rules(data)
+      if data.key?('id') || data.key?('href')
+        raise BadRequestError, 'Resource id or href should not be specified'
+      end
+      attributes = data.dup
+      attributes['expression'] = MiqExpression.new(data['expression'])
+      attributes
+    end
+  end
+end

--- a/app/controllers/api_controller/arbitration_rules.rb
+++ b/app/controllers/api_controller/arbitration_rules.rb
@@ -1,7 +1,7 @@
 class ApiController
   module ArbitrationRules
     def create_resource_arbitration_rules(type, _id, data)
-      attributes = validate_arbitration_rules(data)
+      attributes = build_rule_attributes(data)
       arbitration_rule = collection_class(type).create(attributes)
       if arbitration_rule.invalid?
         raise BadRequestError,
@@ -11,16 +11,14 @@ class ApiController
     end
 
     def edit_resource_arbitration_rules(type, id, data)
-      attributes = validate_arbitration_rules(data)
+      attributes = build_rule_attributes(data)
       edit_resource(type, id, attributes)
     end
 
     private
 
-    def validate_arbitration_rules(data)
-      if data.key?('id') || data.key?('href')
-        raise BadRequestError, 'Resource id or href should not be specified'
-      end
+    def build_rule_attributes(data)
+      return data unless data.key?('expression')
       attributes = data.dup
       attributes['expression'] = MiqExpression.new(data['expression'])
       attributes

--- a/config/api.yml
+++ b/config/api.yml
@@ -1754,3 +1754,30 @@
       :delete:
       - :name: delete
         :identifier: delete_arbitration_setting
+  :arbitration_rules:
+    :description: Arbitration Rules
+    :identifier: miq_arbitration_rules
+    :options:
+    - :collection
+    :verbs: *70174834084700
+    :klass: ArbitrationRule
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: arbitration_rule_show_list
+      :post:
+      - :name: create
+        :identifier: arbitration_rule_new
+      - :name: delete
+        :identifier: arbitration_rule_delete
+      - :name: edit
+        :identifier: arbitration_rule_edit
+    :resource_actions:
+      :post:
+      - :name: edit
+        :identifier: arbitration_rule_edit
+      - :name: delete
+        :identifier: arbitration_rule_delete
+      :delete:
+      - :name: edit
+        :identifier: arbitration_rule_delete

--- a/config/api.yml
+++ b/config/api.yml
@@ -1759,7 +1759,7 @@
     :identifier: miq_arbitration_rules
     :options:
     - :collection
-    :verbs: *70174834084700
+    :verbs: *gpppd
     :klass: ArbitrationRule
     :collection_actions:
       :get:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5128,6 +5128,29 @@
     :feature_type: admin
     :identifier: delete_arbitration_setting
 
+# ArbitrationRules
+- :name: Arbitration Rules
+  :description: All functions for Arbitration Rules
+  :feature_type: admin
+  :identifier: miq_arbitration_rules
+  :children:
+  - :name: Show Arbitration List
+    :description: Show Arbitration Rule list
+    :feature_type: admin
+    :identifier: arbitration_rule_show_list
+  - :name: Create Arbitration Rule
+    :description: Create Arbitration Rule
+    :feature_type: admin
+    :identifier: arbitration_rule_new
+  - :name: Delete Arbitration Rule
+    :description: Delete Arbitration Rule
+    :feature_type: admin
+    :identifier: arbitration_rule_delete
+  - :name: Edit Arbitration Rule
+    :description: Edit Arbitration Rule
+    :feature_type: admin
+    :identifier: arbitration_rule_edit
+
 # Blueprints
 - :name: Blueprints
   :description: All Blueprint Access Rules

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -23,52 +23,41 @@ RSpec.describe 'Arbitration Rule API' do
   end
 
   context 'arbitration rules create' do
-    let(:expression) do
+    let(:request_body) do
       {
-        'EQUAL' => {
-          'field' => 'User-userid',
-          'value' => 'admin'
+        'name'       => 'admin rule',
+        'operation'  => 'inject',
+        'expression' => {
+          'EQUAL' => {
+            'field' => 'User-userid',
+            'value' => 'admin'
+          }
         }
       }
     end
-    let(:request_body) do
-      {
-        'name'      => 'admin rule',
-        'operation' => 'inject'
-      }
-    end
 
-    it 'can create an arbitration rule with an expression' do
+    it 'supports single arbitration_rule creation' do
       api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
-      body = request_body.merge('expression' => expression)
+
       expect do
-        run_post(arbitration_rules_url, gen_request(:create, body))
+        run_post(arbitration_rules_url, gen_request(:create, request_body))
       end.to change(ArbitrationRule, :count).by(1)
     end
 
     it 'supports multiple arbitration_rule creation' do
       api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
-      body = request_body.merge('expression' => expression)
 
       expect do
-        run_post(arbitration_rules_url, gen_request(:create, [body, body]))
+        run_post(arbitration_rules_url, gen_request(:create, [request_body, request_body]))
       end.to change(ArbitrationRule, :count).by(2)
-    end
-
-    it 'rejects a request with an href' do
-      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
-
-      run_post(arbitration_rules_url, request_body.merge(:href => arbitration_rules_url))
-
-      expect_bad_request(/Resource id or href should not be specified/)
     end
 
     it 'rejects a request with an id' do
       api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
 
-      run_post(arbitration_rules_url, request_body.merge(:id => 999_999))
+      run_post(arbitration_rules_url(999_999), request_body.merge(:id => 999_999))
 
-      expect_bad_request(/Resource id or href should not be specified/)
+      expect_bad_request(/Unsupported Action create for the arbitration_rules resource/)
     end
   end
 
@@ -96,6 +85,7 @@ RSpec.describe 'Arbitration Rule API' do
     it 'supports single arbitration rule delete' do
       rule = FactoryGirl.create(:arbitration_rule)
       api_basic_authorize collection_action_identifier(:arbitration_rules, :delete)
+
       expect do
         run_delete(arbitration_rules_url(rule.id))
       end.to change(ArbitrationRule, :count).by(-1)

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe 'Arbitration Rule API' do
+  context 'arbitration rules index' do
+    it 'rejects requests without an appropriate role' do
+      api_basic_authorize
+
+      run_get arbitration_rules_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can list arbitration rules' do
+      rules = FactoryGirl.create_list(:arbitration_rule, 2)
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :read, :get)
+
+      run_get arbitration_rules_url
+
+      expect_result_resources_to_include_hrefs(
+        'resources',
+        rules.map { |rule| arbitration_rules_url(rule.id) }
+      )
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'arbitration rules create' do
+    let(:expression) do
+      {
+        'EQUAL' => {
+          'field' => 'User-userid',
+          'value' => 'admin'
+        }
+      }
+    end
+    let(:request_body) do
+      {
+        'name'      => 'admin rule',
+        'operation' => 'inject'
+      }
+    end
+
+    it 'can create an arbitration rule with an expression' do
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      body = request_body.merge('expression' => expression)
+      expect do
+        run_post(arbitration_rules_url, gen_request(:create, body))
+      end.to change(ArbitrationRule, :count).by(1)
+    end
+
+    it 'supports multiple arbitration_rule creation' do
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+      body = request_body.merge('expression' => expression)
+
+      expect do
+        run_post(arbitration_rules_url, gen_request(:create, [body, body]))
+      end.to change(ArbitrationRule, :count).by(2)
+    end
+
+    it 'rejects a request with an href' do
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+
+      run_post(arbitration_rules_url, request_body.merge(:href => arbitration_rules_url))
+
+      expect_bad_request(/Resource id or href should not be specified/)
+    end
+
+    it 'rejects a request with an id' do
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :create)
+
+      run_post(arbitration_rules_url, request_body.merge(:id => 999_999))
+
+      expect_bad_request(/Resource id or href should not be specified/)
+    end
+  end
+
+  context 'arbitration rules edit' do
+    let(:rule) { FactoryGirl.create(:arbitration_rule) }
+
+    it 'rejects edit without an appropriate role' do
+      api_basic_authorize
+
+      run_post(arbitration_rules_url(rule.id), gen_request(:edit, :name => 'edited name'))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can edit a setting' do
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :edit)
+
+      expect do
+        run_post(arbitration_rules_url(rule.id), gen_request(:edit, :name => 'edited name'))
+      end.to change { rule.reload.name }.to('edited name')
+    end
+  end
+
+  context 'arbitration rules delete' do
+    it 'supports single arbitration rule delete' do
+      rule = FactoryGirl.create(:arbitration_rule)
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :delete)
+      expect do
+        run_delete(arbitration_rules_url(rule.id))
+      end.to change(ArbitrationRule, :count).by(-1)
+    end
+
+    it 'supports multiple arbitration rule delete' do
+      rules = FactoryGirl.create_list(:arbitration_rule, 2)
+      hrefs = rules.map { |rule| { 'href' => arbitration_rules_url(rule.id) } }
+      api_basic_authorize collection_action_identifier(:arbitration_rules, :delete)
+
+      expect do
+        run_post(arbitration_rules_url, gen_request(:delete, hrefs))
+      end.to change(ArbitrationRule, :count).by(-2)
+    end
+  end
+end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -260,5 +260,10 @@ describe ApiController do
       FactoryGirl.create(:arbitration_setting)
       test_collection_query(:arbitration_settings, arbitration_settings_url, ArbitrationSetting)
     end
+
+    it 'queries ArbitrationRules' do
+      FactoryGirl.create(:arbitration_rule)
+      test_collection_query(:arbitration_rules, arbitration_rules_url, ArbitrationRule)
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
> CRUD Api for Arbitration Rules
> when creating / editing an arbitration rule, it will turn the passed `expression` into an `MiqExpression`

Links
-----
> * [Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/126393041)

@miq-bot add_label service broker, darga/no, enhancement 

cc: @chriskacerguis 
