### PR TITLE
Docker build is failing because libcurl-devel is needed for curb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
                    file                    \
                    gcc-c++                 \
                    git                     \
+                   libcurl-devel           \
                    libffi-devel            \
                    libtool                 \
                    libxml2-devel           \


### PR DESCRIPTION
More error details:
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: ~/.gem/ruby/2.3.1/gems/curb-0.9.3/ext
~/.rubies/ruby-2.3.1/bin/ruby -r ./siteconf20160802-10667-16kanmx.rb extconf.rb
checking for curl-config... no
checking for main() in -lcurl... no
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=~/.rubies/ruby-2.3.1/bin/$(RUBY_BASE_NAME)
	--with-curl-dir
	--without-curl-dir
	--with-curl-include
	--without-curl-include=${curl-dir}/include
	--with-curl-lib
	--without-curl-lib=${curl-dir}/lib
	--with-curllib
	--without-curllib
extconf.rb:18:in `<main>':   Can't find libcurl or curl/curl.h (RuntimeError)

  Try passing --with-curl-dir or --with-curl-lib and --with-curl-include
  options to extconf.

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  ~/.gem/ruby/2.3.1/extensions/x86_64-linux/2.3.0-static/curb-0.9.3/mkmf.log

extconf failed, exit code 1
```