### PR TITLE
Backend supports for service types that are generic of a certain type.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -150,6 +150,17 @@ class CatalogController < ApplicationController
     }
   end
 
+  def generic_item_subtypes
+    {
+      "custom"          => _("Custom"),
+      "vm"              => _("VM"),
+      "playbook"        => _("Playbook"),
+      "hosted_database" => _("Hosted Database"),
+      "load_balancer"   => _("Load Balancer"),
+      "storage"         => _("Storage")
+    }
+  end
+
   def atomic_form_field_changed
     # need to check req_id in session since we are using common code for prov requests and atomic ST screens
     id = session[:edit][:req_id] || "new"

--- a/db/migrate/20160801214912_add_generic_subtype_to_service_template.rb
+++ b/db/migrate/20160801214912_add_generic_subtype_to_service_template.rb
@@ -1,0 +1,6 @@
+class AddGenericSubtypeToServiceTemplate < ActiveRecord::Migration[5.0]
+  def change
+    add_column :service_templates, :generic_subtype, :string
+    add_index  :service_templates, :generic_subtype
+  end
+end

--- a/db/migrate/20160802145938_set_generic_subtype_on_service_template.rb
+++ b/db/migrate/20160802145938_set_generic_subtype_on_service_template.rb
@@ -1,0 +1,15 @@
+class SetGenericSubtypeOnServiceTemplate < ActiveRecord::Migration[5.0]
+  class ServiceTemplate < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time('Set generic_subtype to custom on ServiceTemplate') do
+      ServiceTemplate.where(:prov_type => "generic").update_all(:generic_subtype => "custom")
+    end
+  end
+
+  def down
+    ServiceTemplate.where(:prov_type => "generic").update_all(:generic_subtype => nil)
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6087,6 +6087,7 @@ service_templates:
 - long_description
 - tenant_id
 - blueprint_id
+- generic_subtype
 services:
 - id
 - name

--- a/spec/migrations/20160802145938_set_generic_subtype_on_service_template_spec.rb
+++ b/spec/migrations/20160802145938_set_generic_subtype_on_service_template_spec.rb
@@ -1,0 +1,41 @@
+require_migration
+
+describe SetGenericSubtypeOnServiceTemplate do
+  let(:service_template_stub) { migration_stub(:ServiceTemplate) }
+
+  migration_context :up do
+    it 'sets generic_subtype to custom on generic Service Templates' do
+      st = service_template_stub.create!(:prov_type => 'generic')
+
+      migrate
+
+      expect(st.reload.generic_subtype).to eq('custom')
+    end
+
+    it 'skips non-generic Service Templates' do
+      st = service_template_stub.create!(:prov_type => 'vmware')
+
+      migrate
+
+      expect(st.reload.generic_subtype).to be_nil
+    end
+  end
+
+  migration_context :down do
+    it 'sets generic_subtype to nil on generic Service Templates' do
+      st = service_template_stub.create!(:prov_type => 'generic', :generic_subtype => 'custom')
+
+      migrate
+
+      expect(st.reload.generic_subtype).to be_nil
+    end
+
+    it 'skips non-generic Service Templates' do
+      st = service_template_stub.create!(:prov_type => 'vmware', :generic_subtype => 'something')
+
+      migrate
+
+      expect(st.reload.generic_subtype).to eq('something')
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Add generic_subtype column to ServiceTemplate.

The idea is that a blue print can be authored using only these generic types, laying out the architecture to an application, without the need to explicitly define the resources to make the application.

Links
-----
https://www.pivotaltracker.com/n/projects/1613499/stories/127494975