### PR TITLE
[DARGA] Fix Relationship links for a Middleware Provider

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,9 +84,18 @@ module ApplicationHelper
         end
       else
         out = content_tag(:li) do
-          link_to("#{plural} (#{count})",
-                  polymorphic_path(@record, :display => table_name.to_s.pluralize),
-                  :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+          if restful_routed?(record)
+            link_to("#{plural} (#{count})",
+                    polymorphic_path(record, :display => table_name.to_s.pluralize),
+                    :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+          else
+            link_to("#{plural} (#{count})",
+                    {:controller => controller_name,
+                     :action     => 'show',
+                     :id         => record.id,
+                     :display    => table_name.to_s.pluralize},
+                    :title => _("Show %{plural_linked_name}") % {:plural_linked_name => plural})
+          end
         end
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1701,4 +1701,14 @@ describe ApplicationHelper do
       ).to eq('host_services')
     end
   end
+
+  describe "#multiple_relationship_link" do
+    context "When record is a Container Provider" do
+      it "Uses polymorphic_path for the show action" do
+        ems = FactoryGirl.create(:ems_kubernetes)
+        ContainerProject.create(:ext_management_system => ems, :name => "Test Project")
+        expect(helper.multiple_relationship_link(ems, "container_project")).to eq("<li><a title=\"Show Projects\" href=\"/ems_container/#{ems.id}?display=container_projects\">Projects (1)</a></li>")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The Middleware Provider controller (ems_middleware) does not support RESTful routing yet, therefore the Relationship links should be routed using :controller, :action and :id
cherry-picking changes from https://github.com/ManageIQ/manageiq/pull/8866

Fixes #8803
https://bugzilla.redhat.com/show_bug.cgi?id=1361844

@dclarizio @chessbyte removed failing spec tests that were referencing to MiddlewareDatasource that does not exist on Darga. 