### PR TITLE
Fix Advanced Search in Workloads

### DIFF
--- a/app/views/layouts/exp_atom/_edit_regkey.html.haml
+++ b/app/views/layouts/exp_atom/_edit_regkey.html.haml
@@ -22,4 +22,4 @@
 
 :javascript
   miqInitSelectPicker();
-  miqSelectPickerEvent('chosen_key, '#{url}');
+  miqSelectPickerEvent('chosen_key', '#{url}');


### PR DESCRIPTION
The options dropdown in the advanced search modal disappeared when "Registry" was selected due to a missing quote.

https://bugzilla.redhat.com/show_bug.cgi?id=1344338

Old
<img width="782" alt="screen shot 2016-08-02 at 4 05 29 pm" src="https://cloud.githubusercontent.com/assets/1287144/17343404/7a388e1c-58cb-11e6-8714-9e7182c7f659.png">

New
<img width="784" alt="screen shot 2016-08-02 at 4 05 04 pm" src="https://cloud.githubusercontent.com/assets/1287144/17343405/7a479632-58cb-11e6-9201-186f155d96df.png">
