### PR TITLE
Rbac allow limits to come from the scope

### DIFF
--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -73,8 +73,16 @@ class ActsAsArQuery
     assign_arg :limit, val
   end
 
+  def limit_value
+    options[:limit]
+  end
+
   def order(*args)
     append_hash_arg :order, *args
+  end
+
+  def order_values
+    options[:order] || []
   end
 
   def group(*args)
@@ -111,6 +119,10 @@ class ActsAsArQuery
 
   def offset(val)
     assign_arg :offset, val
+  end
+
+  def offset_value
+    options[:offset]
   end
 
   # @param val [Array<Sting,Symbol>,String, Symbol]

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -33,6 +33,11 @@ describe ActsAsArQuery do
     end
   end
 
+  describe "#limit_value" do
+    it { expect(query.limit_value).to eq(nil) }
+    it { expect(query.limit(5).limit_value).to eq(5) }
+  end
+
   # - [.] none
 
   describe "#offset" do
@@ -40,6 +45,11 @@ describe ActsAsArQuery do
       expect(model).to receive(:find).with(:all, :offset => 5)
       query.offset(5).to_a
     end
+  end
+
+  describe "#offset_value" do
+    it { expect(query.offset_value).to eq(nil) }
+    it { expect(query.offset(5).offset_value).to eq(5) }
   end
 
   describe "#order" do
@@ -57,6 +67,11 @@ describe ActsAsArQuery do
       expect(model).to receive(:find).with(:all, :order => [:a, :b])
       query.order(:a).order(:b).to_a
     end
+  end
+
+  describe "#order_values" do
+    it { expect(query.order_values).to eq([]) }
+    it { expect(query.order(:a).order(:b)order_values).to eq([:a, :b]) }
   end
 
   # - [X] references (partial) - currently ignored

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -71,7 +71,7 @@ describe ActsAsArQuery do
 
   describe "#order_values" do
     it { expect(query.order_values).to eq([]) }
-    it { expect(query.order(:a).order(:b)order_values).to eq([:a, :b]) }
+    it { expect(query.order(:a).order(:b).order_values).to eq([:a, :b]) }
   end
 
   # - [X] references (partial) - currently ignored


### PR DESCRIPTION
Theme
-------

This is part of reducing rbac's interface

before:
------

`Rbac::Filtered` uses `limit`, `order`, and `offset` from the options hash:

```ruby
Rbac.filtered(Vm.all, :limit => 20, :offset => 40)
```

after:
-----

`Rbac::Filtered` can use `limit`, `order`, and `offset` from standard rails scopes.

```ruby
Rbac.filtered(Vm.limit(20).offset(40))
```

Backwards compatibility is provided while the hashes are converted to scopes.


Notes
------

This will conflict with #10175 as both are reducing the rbac interface. Merge either and I'll fixup

/cc @chrisarcand 