### PR TITLE
Reduce the number of conditionals and include(:tag) in MiqRequestWorkflow#allowed_tags

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -27,6 +27,10 @@ class Classification < ApplicationRecord
   validates :syntax, :inclusion => {:in      => %w( string integer boolean ),
                                     :message => "should be one of 'string', 'integer' or 'boolean'"}
 
+  scope :visible,    -> { where :show => true }
+  scope :read_only,  -> { where :read_only => true }
+  scope :writeable,  -> { where :read_only => false }
+
   DEFAULT_NAMESPACE = "/managed"
 
   default_value_for :read_only,    false
@@ -48,6 +52,23 @@ class Classification < ApplicationRecord
     end
 
     ret
+  end
+
+  def self.parent_ids(parent_ids)
+    where :parent_id => parent_ids
+  end
+
+  def self.tags_arel
+    Tag.arel_table
+  end
+
+  def self.with_tag_name
+    select(arel_table[Arel.star], tags_arel[:name].as('tag_name'))
+      .joins(:tag)
+  end
+
+  def self.managed
+    with_tag_name.where(tags_arel[:name].matches_regexp("/managed/[^\\/]+$"))
   end
 
   attr_writer :ns
@@ -292,8 +313,12 @@ class Classification < ApplicationRecord
     parent.try(:name)
   end
 
+  def tag_name
+    attribute(:tag_name)
+  end
+
   def name
-    @name ||= tag2name(tag.name)
+    @name ||= tag2name(tag_name || tag.name)
   end
 
   attr_writer :name

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -205,6 +205,29 @@ describe MiqRequestWorkflow do
     end
   end
 
+  context "#allowed_tags" do
+    let!(:managed_classification)   { FactoryGirl.create(:classification) }
+    let!(:no_child_classification)  { FactoryGirl.create(:classification) }
+    let!(:read_only_classification) { FactoryGirl.create(:classification, :read_only => true) }
+    let!(:hidden_classification)    { FactoryGirl.create(:classification, :show => false) }
+    let!(:unmanaged_classification) { FactoryGirl.create(:classification, :ns => "/unmanaged") }
+    let!(:child_classification_1)   { FactoryGirl.create(:classification, :parent => managed_classification) }
+    let!(:child_classification_2)   { FactoryGirl.create(:classification, :parent => unmanaged_classification) }
+
+    it "includes all managed tags" do
+      allowed_tag_ids = workflow.allowed_tags.map { |c| c[:id] }
+      expect(allowed_tag_ids).to match_array([managed_classification.id])
+    end
+
+    it "includes all managed children" do
+      allowed_tags_children = workflow.allowed_tags
+                                      .map { |c| c[:children].map(&:first) }
+                                      .flatten
+
+      expect(allowed_tags_children).to match_array([child_classification_1.id])
+    end
+  end
+
   context "'allowed_*' methods" do
     let(:cluster)       { FactoryGirl.create(:ems_cluster, :ems_id => ems.id) }
     let(:ems)           { FactoryGirl.create(:ext_management_system) }


### PR DESCRIPTION
Purpose or Intent
-----------------
Much of what is done in this method can be done with sql to prevent instantiating extra objects, extra loop iterations, and conditionals.

### Changes:

* Removes the `class_tags` variable and query (avoids reject over all the return `Classification` records)
  - Changed to using the `writeable` query on Classification to replace `reject!` functionality.
  - Not sure why the comment said it was a string, because it is [definitely a boolean column](https://github.com/ManageIQ/manageiq/blob/master/db/migrate/20130923182042_collapsed_initial_migration.rb#L163).
* Remove `.includes(:tag)` on all queries
  - `managed` and `with_tag_names` scope are now used to avoid needing the "tag" for just the "name" field and alias a column in the returned result set called `tag_name`.  Now when `t.name` is called, it will use `tag_name` under the hood instead of needing to fetch (or have already fetched) the associated tag.
  - This also prevents instanciating the `ActiveRecord` for the tag columns (which are then thrown out shortly after building up a hash).
* `managed` is used instead of `if t.tag2ns(t.tag.name) == "/managed"`
  - The `tag2ns` method determines the namespace of the tag name, which is just "one level up" for the tag (so with "/foo/bar/baz/qux", it would have a namespace of "/foo/bar/baz").  The `managed` scope just does a regexp that looks for tags with only one level below `/managed`, so a regexp of `\/managed/[^\/]+$` - This removes a if statement for each element and does it in sql.
* Splits up "cats" and "ents" into two separate queries
  - Makes two queries instead of one, but we only query the ones we need in the `ents` instead of throwing out the ones in ruby with a conditional that don't have a parent in `cats` (was `if @tags.key?(t.parent_id)`)
  - This also allows us to remove the `class_tags.partition`, which was another iteration of the entire result set before they were processed.


Metrics
-------
With around 15k tags, about 13k that are used in this request, 342 of which are the "parent" (cat) tags:

### Before

```
Started GET "/miq_request/show/:id"...
Completed 200 OK in 3622ms (Views: 1068.5ms | ActiveRecord: 0.0ms)
```

|      ms |   bytes |   objects | queries | query (ms) |   rows |
|    ---: |    ---: |      ---: |    ---: |       ---: |   ---: |
| 2,003.2 |     N/A | 1,959,299 |      78 |      889.2 | 33,593 |

```
# from the log/evm.log
[----] I, [2016-08-02T15:39:11.729852 #58626:3fe2056fcae4]  INFO -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_tags) allowed_tags returned [342] objects in [1.644017] seconds
```


### After

```
Started GET "/miq_request/show/:id"...
Completed 200 OK in 2461ms (Views: 1041.0ms | ActiveRecord: 0.0ms)
```

|      ms |   bytes |   objects | queries | query (ms) |   rows |
|    ---: |    ---: |      ---: |    ---: |       ---: |   ---: |
| 1,008.4 |     N/A | 1,181,966 |      80 |      677.9 | 16,815 |

```
# from the log/evm.log
[----] I, [2016-08-02T15:24:04.767645 #56049:3fe7b12f5b24]  INFO -- : MIQ(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow#allowed_tags) allowed_tags returned [342] objects in [0.621536] seconds
```


Links
-----
* This is an extension of the improvements made in https://github.com/ManageIQ/manageiq/pull/10181