### PR TITLE
cap&u assignment: use flat_map

### DIFF
--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -116,11 +116,9 @@ module AssignmentMixin
         parents = options[:parents]
       else
         model = kind_of?(Class) ? self : model
-        parents = model::ASSIGNMENT_PARENT_ASSOCIATIONS.each_with_object([]) do |rel, arr|
-          t = rel == :my_enterprise ? MiqEnterprise : target
-          next unless t.respond_to?(rel)
-          arr << t.send(rel)
-        end.flatten.compact
+        parents = model::ASSIGNMENT_PARENT_ASSOCIATIONS.flat_map do |rel|
+          (rel == :my_enterprise ? MiqEnterprise.my_enterprise : target.try(rel)) || []
+        end
         parents << target
       end
 


### PR DESCRIPTION
use `flat_map` instead of `each_with_object([])` and `next`


I've been stepping through this code alot.
The old code is ugly.
Both function the same.

There are enough tests that when I removed the extra parenthesis, it blew up. (many tests have `my_enterprise == nil`)

