### PR TITLE
Automate Domain with editable properties and editable contents

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1935,7 +1935,7 @@ class MiqAeClassController < ApplicationController
         item = items.split('-')
         domain = MiqAeDomain.find_by_id(from_cid(item[1]))
         next unless domain
-        if domain.editable?
+        if domain.editable_properties?
           aedomains.push(domain.id)
         else
           add_flash(_("Read Only %{model} \"%{name}\" cannot be deleted") %
@@ -1980,7 +1980,7 @@ class MiqAeClassController < ApplicationController
       item = items.split('-')
       if item[0] == "aen"
         record = MiqAeNamespace.find_by_id(from_cid(item[1]))
-        if record.editable?
+        if (record.domain? && record.editable_properties?) || record.editable?
           ns_list.push(from_cid(item[1]))
         else
           add_flash(_("\"%{field}\" %{model} cannot be deleted") %
@@ -2408,7 +2408,7 @@ class MiqAeClassController < ApplicationController
     obj = [x_node] if obj.nil? && params[:id]
     typ = params[:pressed] == "miq_ae_domain_edit" ? MiqAeDomain : MiqAeNamespace
     @ae_ns = typ.find(from_cid(obj[0].split('-')[1]))
-    if @ae_ns.domain? && !@ae_ns.editable?
+    if @ae_ns.domain? && !@ae_ns.editable_properties?
       add_flash(_("Read Only %{model} \"%{name}\" cannot be edited") %
                   {:model => ui_lookup(:model => "MiqAeDomain"), :name  => @ae_ns.name},
                 :error)
@@ -2469,7 +2469,7 @@ class MiqAeClassController < ApplicationController
   end
 
   def ordered_domains_for_priority_edit_screen
-    User.current_tenant.editable_domains.collect { |d| d.name }
+    User.current_tenant.sequenceable_domains.collect(&:name)
   end
 
   def priority_edit_screen

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -704,9 +704,11 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.lockable?
       when "miq_ae_domain_unlock"
         return true unless @record.unlockable?
-      when "miq_ae_domain_edit"
-        return false unless @record.editable_properties?
-      when "miq_ae_namespace_edit", "miq_ae_instance_copy", "miq_ae_method_copy"
+      when "miq_ae_domain_delete", "miq_ae_domain_edit"
+        return true unless @record.editable_properties?
+      when "miq_ae_namespace_edit"
+        return true unless @record.editable_contents?
+      when "miq_ae_instance_copy", "miq_ae_method_copy"
         return false unless editable_domain?(@record)
       else
         return true unless editable_domain?(@record)
@@ -1088,8 +1090,8 @@ class ApplicationHelper::ToolbarBuilder
         return N_("Default actions can not be deleted.") if @record.action_type == "default"
         return N_("Actions assigned to Policies can not be deleted") unless @record.miq_policies.empty?
       end
-    when "MiqAeDomain", "MiqAeNamespace"
-      editable_domain = editable_domain?(@record)
+    when "MiqAeDomain"
+      editable_domain = @record.editable_properties?
       case id
       when "miq_ae_domain_delete"
         return N_("Read Only Domain cannot be deleted.") unless editable_domain

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -232,11 +232,15 @@ class Tenant < ApplicationRecord
   end
 
   def editable_domains
-    ae_domains.where(:system => false).order('priority DESC')
+    ae_domains.where(:source => MiqAeDomain::USER_SOURCE).order('priority DESC')
+  end
+
+  def sequenceable_domains
+    ae_domains.where.not(:source => MiqAeDomain::SYSTEM_SOURCE).order('priority DESC')
   end
 
   def any_editable_domains?
-    ae_domains.where(:system => false).count > 0
+    ae_domains.where(:source => MiqAeDomain::USER_SOURCE).count > 0
   end
 
   def reset_domain_priority_by_ordered_ids(ids)

--- a/db/migrate/20160729182517_remove_system_add_source_to_miq_ae_namespace.rb
+++ b/db/migrate/20160729182517_remove_system_add_source_to_miq_ae_namespace.rb
@@ -1,0 +1,31 @@
+class RemoveSystemAddSourceToMiqAeNamespace < ActiveRecord::Migration[5.0]
+  class MiqAeNamespace < ActiveRecord::Base; end
+
+  def up
+    say_with_time('Migrating System attribute to Source in MiqAeNamespace') do
+      add_column :miq_ae_namespaces, :source, :string
+
+      MiqAeNamespace.where('parent_id IS NULL').each do |obj|
+        source = if obj.name == 'ManageIQ'
+                   'system'
+                 else
+                   obj.system ? 'user_locked' : 'user'
+                 end
+        obj.update_attributes!(:source => source)
+      end
+
+      remove_column :miq_ae_namespaces, :system
+    end
+  end
+
+  def down
+    say_with_time('Migrating Source attribute to System in MiqAeNamespace') do
+      add_column :miq_ae_namespaces, :system, :boolean
+      MiqAeNamespace.where('parent_id IS NULL').each do |obj|
+        system = (obj.source == 'system' || obj.source == 'user_locked') ? true : false
+        obj.update_attributes!(:system => system)
+      end
+      remove_column :miq_ae_namespaces, :source
+    end
+  end
+end

--- a/db/migrate/20160729182517_remove_system_add_source_to_miq_ae_namespace.rb
+++ b/db/migrate/20160729182517_remove_system_add_source_to_miq_ae_namespace.rb
@@ -5,11 +5,13 @@ class RemoveSystemAddSourceToMiqAeNamespace < ActiveRecord::Migration[5.0]
     say_with_time('Migrating System attribute to Source in MiqAeNamespace') do
       add_column :miq_ae_namespaces, :source, :string
 
-      MiqAeNamespace.where('parent_id IS NULL').each do |obj|
+      MiqAeNamespace.where(:parent_id => nil).each do |obj|
         source = if obj.name == 'ManageIQ'
                    'system'
+                 elsif obj.system
+                   'user_locked'
                  else
-                   obj.system ? 'user_locked' : 'user'
+                   'user'
                  end
         obj.update_attributes!(:source => source)
       end
@@ -21,8 +23,8 @@ class RemoveSystemAddSourceToMiqAeNamespace < ActiveRecord::Migration[5.0]
   def down
     say_with_time('Migrating Source attribute to System in MiqAeNamespace') do
       add_column :miq_ae_namespaces, :system, :boolean
-      MiqAeNamespace.where('parent_id IS NULL').each do |obj|
-        system = (obj.source == 'system' || obj.source == 'user_locked') ? true : false
+      MiqAeNamespace.where(:parent_id => nil).each do |obj|
+        system = (obj.source == 'system' || obj.source == 'user_locked')
         obj.update_attributes!(:system => system)
       end
       remove_column :miq_ae_namespaces, :source

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4551,7 +4551,6 @@ miq_ae_namespaces:
 - display_name
 - updated_by
 - updated_by_user_id
-- system
 - priority
 - enabled
 - tenant_id
@@ -4562,6 +4561,7 @@ miq_ae_namespaces:
 - ref
 - ref_type
 - last_import_on
+- source
 miq_ae_values:
 - id
 - instance_id

--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -36,6 +36,8 @@ module MiqAeException
   class DirectoryExists < MiqAeDatastoreError; end
   class FileExists < MiqAeDatastoreError; end
   class DomainNotAccessible < MiqAeDatastoreError; end
+  class CannotLock < MiqAeDatastoreError; end
+  class CannotUnlock < MiqAeDatastoreError; end
 end
 
 module MiqException

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -8,7 +8,7 @@ module MiqAeDatastore
   DEFAULT_OBJECT_NAMESPACE = "$"
   TEMP_DOMAIN_PREFIX = "TEMP_DOMAIN"
   ALL_DOMAINS = "*"
-  PRESERVED_ATTRS = [:priority, :enabled, :system]
+  PRESERVED_ATTRS = [:priority, :enabled, :source].freeze
 
   # deprecated module
   module Import
@@ -137,7 +137,8 @@ module MiqAeDatastore
     import_yaml_dir(datastore_dir, domain_name, tenant)
     if domain_name.downcase == MANAGEIQ_DOMAIN.downcase
       ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
-      ns.update_attributes!(:system => true, :enabled => true, :priority => MANAGEIQ_PRIORITY) if ns
+      ns.update_attributes!(:source   => MiqAeDomain::SYSTEM_SOURCE, :enabled => true,
+                            :priority => MANAGEIQ_PRIORITY) if ns
     end
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -3,7 +3,7 @@ class MiqAeDomain < MiqAeNamespace
   REMOTE_SOURCE = "remote".freeze
   USER_SOURCE   = "user".freeze
   USER_LOCKED_SOURCE = "user_locked".freeze
-  VALID_SOURCES = [SYSTEM_SOURCE, REMOTE_SOURCE, USER_SOURCE, USER_LOCKED_SOURCE].freeze
+  VALID_SOURCES  = [SYSTEM_SOURCE, REMOTE_SOURCE, USER_SOURCE, USER_LOCKED_SOURCE].freeze
   LOCKED_SOURCES = [SYSTEM_SOURCE, REMOTE_SOURCE, USER_LOCKED_SOURCE].freeze
 
   default_scope { where(:parent_id => nil).where(arel_table[:name].not_eq("$")) }
@@ -148,11 +148,11 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def self.any_unlocked?
-    MiqAeDomain.where('source = ?', USER_SOURCE).count > 0
+    MiqAeDomain.where(:source => USER_SOURCE).count > 0
   end
 
   def self.all_unlocked
-    MiqAeDomain.where('source = ?', USER_SOURCE).order('priority DESC')
+    MiqAeDomain.where(:source => USER_SOURCE).order('priority DESC')
   end
 
   def about_class

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -82,7 +82,7 @@ class MiqAeNamespace < ApplicationRecord
   def editable?(user = User.current_user)
     raise ArgumentError, "User not provided to editable?" unless user
     return false if domain? && user.current_tenant.id != tenant_id
-    return !system? if domain?
+    return source == MiqAeDomain::USER_SOURCE if domain?
     ancestors.all? { |a| a.editable?(user) }
   end
 

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -41,7 +41,7 @@ describe MiqAeClassController do
       allow(controller).to receive(:replace_right_cell)
       controller.send(:domain_lock)
       ns.reload
-      expect(ns.system).to eq(true)
+      expect(ns.contents_locked?).to eq(true)
     end
   end
 
@@ -53,7 +53,7 @@ describe MiqAeClassController do
       allow(controller).to receive(:replace_right_cell)
       controller.send(:domain_unlock)
       ns.reload
-      expect(ns.system).to eq(false)
+      expect(ns.contents_locked?).to eq(false)
     end
   end
 

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -9,16 +9,16 @@ FactoryGirl.define do
 
   factory :miq_ae_system_domain, :parent => :miq_ae_domain do
     enabled false
-    source  { 'system' }
+    source { MiqAeDomain::SYSTEM_SOURCE }
   end
 
   factory :miq_ae_system_domain_enabled, :parent => :miq_ae_domain do
-    source  { 'system' }
+    source { MiqAeDomain::SYSTEM_SOURCE }
     enabled true
   end
 
   factory :miq_ae_git_domain, :parent => :miq_ae_domain do
-    source  { 'remote' }
+    source { MiqAeDomain::REMOTE_SOURCE }
     git_repository { FactoryGirl.create(:git_repository, :url => 'https://www.example.com/abc') }
   end
 
@@ -26,7 +26,7 @@ FactoryGirl.define do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
     tenant { Tenant.seed }
     enabled true
-    source { 'user' }
+    source { MiqAeDomain::USER_SOURCE }
     trait :with_methods do
       transient do
         ae_methods do

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -9,16 +9,16 @@ FactoryGirl.define do
 
   factory :miq_ae_system_domain, :parent => :miq_ae_domain do
     enabled false
-    system true
+    source  { 'system' }
   end
 
   factory :miq_ae_system_domain_enabled, :parent => :miq_ae_domain do
-    system true
+    source  { 'system' }
     enabled true
   end
 
   factory :miq_ae_git_domain, :parent => :miq_ae_domain do
-    system true
+    source  { 'remote' }
     git_repository { FactoryGirl.create(:git_repository, :url => 'https://www.example.com/abc') }
   end
 
@@ -26,6 +26,7 @@ FactoryGirl.define do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
     tenant { Tenant.seed }
     enabled true
+    source { 'user' }
     trait :with_methods do
       transient do
         ae_methods do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2468,7 +2468,7 @@ describe ApplicationHelper do
       let(:tooltip) { "At least one domain should be enabled & unlocked" }
 
       it 'disables the configure button for MiqAeNamespace' do
-        @record = FactoryGirl.build(:miq_ae_namespace)
+        @record = FactoryGirl.build(:miq_ae_system_domain)
         result = builder.send(:build_toolbar_disable_button, 'miq_ae_namespace_edit')
 
         expect(result).to include("Domain is Locked.")

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -260,7 +260,7 @@ describe MiqAeDatastore do
       check_counts('dom'  => 1, 'ns'    => 3,  'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
       dom = MiqAeDomain.find_by_fqname(@manageiq_domain.name, false)
-      expect(dom.source).to eql(MiqAeDomain::SYSTEM_SOURCE)
+      expect(dom.source).to eq(MiqAeDomain::SYSTEM_SOURCE)
       expect(dom).to be_enabled
     end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -260,7 +260,7 @@ describe MiqAeDatastore do
       check_counts('dom'  => 1, 'ns'    => 3,  'class' => 4, 'inst'  => 10,
                    'meth' => 3, 'field' => 12, 'value' => 8)
       dom = MiqAeDomain.find_by_fqname(@manageiq_domain.name, false)
-      expect(dom).to be_system
+      expect(dom.source).to eql(MiqAeDomain::SYSTEM_SOURCE)
       expect(dom).to be_enabled
     end
 

--- a/spec/migrations/20160729182517_remove_system_add_source_to_miq_ae_namespace_spec.rb
+++ b/spec/migrations/20160729182517_remove_system_add_source_to_miq_ae_namespace_spec.rb
@@ -1,0 +1,37 @@
+require_migration
+
+describe RemoveSystemAddSourceToMiqAeNamespace do
+  let(:miq_ae_namespace_stub) { migration_stub(:MiqAeNamespace) }
+
+  migration_context :up do
+    it "migrates system to source" do
+      miq_ae_namespace_stub.create!(:name => 'ManageIQ', :system => true, :parent_id => nil)
+      miq_ae_namespace_stub.create!(:name => 'Customer', :system => true, :parent_id => nil)
+      miq_ae_namespace_stub.create!(:name => 'Temp', :system => false, :parent_id => nil)
+
+      expect(miq_ae_namespace_stub.count).to eq 3
+
+      migrate
+
+      expect(miq_ae_namespace_stub.find_by_name('ManageIQ').source).to eql("system")
+      expect(miq_ae_namespace_stub.find_by_name('Customer').source).to eql("user_locked")
+      expect(miq_ae_namespace_stub.find_by_name('Temp').source).to eql("user")
+    end
+  end
+
+  migration_context :down do
+    it "migrates source to system" do
+      miq_ae_namespace_stub.create!(:name => 'ManageIQ', :source => "system", :parent_id => nil)
+      miq_ae_namespace_stub.create!(:name => 'Customer', :source => "user_locked", :parent_id => nil)
+      miq_ae_namespace_stub.create!(:name => 'Temp', :source => "user", :parent_id => nil)
+
+      expect(miq_ae_namespace_stub.count).to eq 3
+
+      migrate
+
+      expect(miq_ae_namespace_stub.find_by_name('ManageIQ').system).to be_truthy
+      expect(miq_ae_namespace_stub.find_by_name('Customer').system).to be_truthy
+      expect(miq_ae_namespace_stub.find_by_name('Temp').system).to be_falsey
+    end
+  end
+end

--- a/spec/migrations/20160729182517_remove_system_add_source_to_miq_ae_namespace_spec.rb
+++ b/spec/migrations/20160729182517_remove_system_add_source_to_miq_ae_namespace_spec.rb
@@ -9,10 +9,9 @@ describe RemoveSystemAddSourceToMiqAeNamespace do
       miq_ae_namespace_stub.create!(:name => 'Customer', :system => true, :parent_id => nil)
       miq_ae_namespace_stub.create!(:name => 'Temp', :system => false, :parent_id => nil)
 
-      expect(miq_ae_namespace_stub.count).to eq 3
-
       migrate
 
+      expect(miq_ae_namespace_stub.count).to eq 3
       expect(miq_ae_namespace_stub.find_by_name('ManageIQ').source).to eql("system")
       expect(miq_ae_namespace_stub.find_by_name('Customer').source).to eql("user_locked")
       expect(miq_ae_namespace_stub.find_by_name('Temp').source).to eql("user")
@@ -25,10 +24,9 @@ describe RemoveSystemAddSourceToMiqAeNamespace do
       miq_ae_namespace_stub.create!(:name => 'Customer', :source => "user_locked", :parent_id => nil)
       miq_ae_namespace_stub.create!(:name => 'Temp', :source => "user", :parent_id => nil)
 
-      expect(miq_ae_namespace_stub.count).to eq 3
-
       migrate
 
+      expect(miq_ae_namespace_stub.count).to eq 3
       expect(miq_ae_namespace_stub.find_by_name('ManageIQ').system).to be_truthy
       expect(miq_ae_namespace_stub.find_by_name('Customer').system).to be_truthy
       expect(miq_ae_namespace_stub.find_by_name('Temp').system).to be_falsey

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -457,6 +457,18 @@ describe Tenant do
       end
     end
 
+    context "sequencing" do
+      it '#sequenceable' do
+        t1_1
+        FactoryGirl.create(:miq_ae_domain, :name => 'DOM15', :priority => 15,
+                           :tenant_id => t1_1.id)
+        FactoryGirl.create(:miq_ae_system_domain, :name => 'DOM10', :priority => 10,
+                           :tenant_id => root_tenant.id, :enabled => false)
+
+        expect(t1_1.sequenceable_domains.collect(&:name)).to eq(%w(DOM15))
+      end
+    end
+
     context "visibility" do
       before do
         dom1

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -457,16 +457,14 @@ describe Tenant do
       end
     end
 
-    context "sequencing" do
-      it '#sequenceable' do
-        t1_1
-        FactoryGirl.create(:miq_ae_domain, :name => 'DOM15', :priority => 15,
-                           :tenant_id => t1_1.id)
-        FactoryGirl.create(:miq_ae_system_domain, :name => 'DOM10', :priority => 10,
-                           :tenant_id => root_tenant.id, :enabled => false)
+    it '#sequenceable_domains' do
+      t1_1
+      FactoryGirl.create(:miq_ae_domain, :name => 'DOM15', :priority => 15,
+                         :tenant_id => t1_1.id)
+      FactoryGirl.create(:miq_ae_system_domain, :name => 'DOM10', :priority => 10,
+                         :tenant_id => root_tenant.id, :enabled => false)
 
-        expect(t1_1.sequenceable_domains.collect(&:name)).to eq(%w(DOM15))
-      end
+      expect(t1_1.sequenceable_domains.collect(&:name)).to eq(%w(DOM15))
     end
 
     context "visibility" do


### PR DESCRIPTION
Purpose or Intent
-----------------
> With the Git based domains we need the ability to allow for the user to change the Domains properties like 
* enabled/disabled
* priority
* git url
* select a specific branch or tag
but at the same time lock the contents from being updated.

The system column with a boolean value wasn't sufficient for this task so we added a new column called source that would replace the current system column.

The source can have 4 valid values
* system           The properties as well as the contents are not editable
* remote           The properties are editable but the contents are not editable (Git backed domains)
* user                The properties as well as the contents are editable
* user_locked   The properties are editable but the contents are not editable



