### PR TITLE
Filter a single object by rbac

### DIFF
--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -178,7 +178,7 @@ class ApiController
 
     def resource_search(id, type, klass)
       target = respond_to?("find_#{type}") ? public_send("find_#{type}", id) : klass.find(id)
-      res = Rbac.filtered([target], :user => @auth_user_obj, :class => klass).first
+      res = Rbac.filtered_object(target, :user => @auth_user_obj, :class => klass)
       raise Forbidden, "Access to the resource #{type}/#{id} is forbidden" unless res
       res
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2217,12 +2217,13 @@ class ApplicationController < ActionController::Base
   def find_by_id_filtered(db, id)
     raise _("Invalid input") unless is_integer?(id)
 
-    unless db.where(:id => from_cid(id)).exists?
+    db_obj = db.find_by(:id => from_cid(id))
+    if db_obj.nil?
       msg = _("Selected %{model_name} no longer exists") % {:model_name => ui_lookup(:model => db.to_s)}
       raise msg
     end
 
-    Rbac.filtered(db, :conditions => ["#{db.table_name}.id = ?", id], :user => current_user).first ||
+    Rbac.filtered_object(db_obj, :user => current_user) ||
       raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
               {:user_id   => current_userid,
                :record_id => id,

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -55,7 +55,8 @@ class TreeBuilderUtilization < TreeBuilderRegion
         objects += rbac_filtered_sorted_objects(f.vms_and_templates, "name")
       elsif f.name == "host"            # Don't count host folder children
       else                              # add in other folders
-        objects += Rbac.filtered([f], :match_via_descendants => VmOrTemplate)
+        f = Rbac.filtered_object(f, :match_via_descendants => VmOrTemplate)
+        objects << f if f
       end
     end
   end
@@ -69,7 +70,8 @@ class TreeBuilderUtilization < TreeBuilderRegion
         objects += rbac_filtered_sorted_objects(f.clusters, "name")
         objects += rbac_filtered_sorted_objects(f.hosts, "name")
       else                              # add in other folders
-        objects += Rbac.filtered([f])
+        f = Rbac.filtered_object(f)
+        objects << f if f
       end
     end
   end

--- a/lib/rbac.rb
+++ b/lib/rbac.rb
@@ -5,6 +5,10 @@ module Rbac
     Filterer.search(*args)
   end
 
+  def self.filtered_object(*args)
+    Filterer.filtered_object(*args)
+  end
+
   def self.filtered(*args)
     Filterer.filtered(*args)
   end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -90,6 +90,10 @@ module Rbac
       new.filtered(*args)
     end
 
+    def self.filtered_object(*args)
+      new.filtered_object(*args)
+    end
+
     def self.accessible_tenant_ids_strategy(klass)
       TENANT_ACCESS_STRATEGY[klass.base_model.to_s]
     end
@@ -226,6 +230,10 @@ module Rbac
 
     def filtered(objects, options = {})
       Rbac.search(options.reverse_merge(:targets => objects)).first
+    end
+
+    def filtered_object(object, options = {})
+      filtered([object], options).first
     end
 
     private

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -971,7 +971,7 @@ describe Rbac::Filterer do
     end
   end
 
-  describe ".filter" do
+  describe ".filtered" do
     let(:vm_location_filter) do
       MiqExpression.new("=" => {"field" => "Vm-location", "value" => "good"})
     end
@@ -1013,6 +1013,18 @@ describe Rbac::Filterer do
     it "runs rbac on array target" do
       all_vms
       expect(described_class.filtered(all_vms, :class => Vm)).to match_array(all_vms)
+    end
+  end
+
+  describe ".filtered_object" do
+    it "with :user keeps vm" do
+      result = described_class.filtered_object(owned_vm, :user => owner_user)
+      expect(result).to eq(owned_vm)
+    end
+
+    it "with :user filters out vm" do
+      result = described_class.filtered_object(other_vm, :user => owner_user)
+      expect(result).to be_nil
     end
   end
 


### PR DESCRIPTION
I noticed that we are using `rbac.filtered` to see if a single object is visible.
This is very inefficient.

Added the functionality to the API with an implementation that is no worse than the existing implementation.

Hoping that @chrisarcand or @jrafanie will optimize it before I circle back. ;)
