### PR TITLE
Container dashboard does not show graphs unless appliance timezone is UTC

### DIFF
--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -259,7 +259,10 @@ class ContainerDashboardService
   end
 
   def daily_provider_metrics
-    @daily_metrics ||= Metric::Helper.find_for_interval_name('daily', @controller.current_user.get_timezone)
+    current_user = @controller.current_user
+    tp = TimeProfile.profile_for_user_tz(current_user.id, current_user.get_timezone) || TimeProfile.default_time_profile
+
+    @daily_metrics ||= Metric::Helper.find_for_interval_name('daily', tp)
                                      .where(:resource => (@ems || ManageIQ::Providers::ContainerManager.all))
                                      .where('timestamp > ?', 30.days.ago.utc).order('timestamp')
   end


### PR DESCRIPTION
**Descrition**
current_user.get_timezone may return `nil` if no `time_profile` matching this time-zone exist in the system.
We must check for `time_profile == nil` before using this time-zone , and fall-back to `TimeProfile.default_time_profile` if no matching time-profile found.

**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1362331
https://bugzilla.redhat.com/show_bug.cgi?id=1364061