### PR TITLE
Convert Utilization and Bottleneck trees to use TreeBuilder

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -761,13 +761,14 @@ class MiqCapacityController < ApplicationController
   end
 
   def util_build_tree(type, name)
-    utilization = TreeBuilderUtilization.new(name, type, @sb)
-    @right_cell_text = if type == :bottlenecks
-                         _("Bottlenecks Summary")
-                       else
-                         _("Utilization Summary")
-                       end
-    instance_variable_set :"@#{name}", utilization.tree_nodes
+    selected_node = x_node(name)
+    if type == :bottlenecks
+      @right_cell_text = _("Bottlenecks Summary")
+      @bottlenecks_tree = TreeBuilderUtilization.new(name, type, @sb, true, selected_node)
+    else
+      @right_cell_text = _("Utilization Summary")
+      @utilization_tree = TreeBuilderUtilization.new(name, type, @sb, true, selected_node)
+    end
   end
 
   # Create an array of hashes from the Utilization summary report tab information

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -4,7 +4,21 @@ class TreeBuilderUtilization < TreeBuilderRegion
   has_kids_for EmsFolder, [:x_get_tree_folder_kids, :type]
   has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
 
+  def initialize(name, type, sandbox, build = true, selected_node)
+    @selected_node = selected_node
+    super(name, type, sandbox, build)
+  end
+
   private
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:id_prefix                   => @name == :utilization_tree ? 'utilization_' : 'bottlenecks_',
+                  :onclick                     => "miqOnClickSelectOptimizeTreeNode",
+                  :select_node                 => @selected_node.to_s,
+                  :open_close_all_on_dbl_click => true,
+                  :tree_state                  => true)
+  end
 
   def root_options
     if MiqEnterprise.my_enterprise.is_enterprise?

--- a/app/views/miq_capacity/_bottlenecks_tree.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_tree.html.haml
@@ -1,15 +1,2 @@
 -# Div to hold the actual tree
-#bottlenecks_tree_div{:style => "width: 100%; height: 100%"}
-  #bottlenecks_treebox{:style => "width: 100%; height: 100%; color: #000; overflow: hidden;"}
-  = render(:partial => "layouts/dynatree",
-    :locals         => {:tree_id => "bottlenecks_treebox",
-      :tree_name                 => "bottlenecks_tree",
-      :json_tree                 => @bottlenecks_tree,
-      :onclick                   => "miqOnClickSelectOptimizeTreeNode",
-      :select_node               => "#{x_node(:bottlenecks_tree)}",
-      :exp_tree                  => false,
-      :highlighting              => true,
-      :no_tree_lines             => false,
-      :tree_state                => true,
-      :autoload                  => true,
-      :multi_lines               => true})
+= render(:partial => 'shared/tree', :locals => {:tree => @bottlenecks_tree, :name => @bottlenecks_tree.name})

--- a/app/views/miq_capacity/_utilization_tree.html.haml
+++ b/app/views/miq_capacity/_utilization_tree.html.haml
@@ -1,16 +1,2 @@
 -# Div to hold the actual tree
-#utilization_tree_div{:style => "width: 100%; height: 100%;"}
-  #utilization_treebox{:style => "width: 100%; height: 100%; color: #000; overflow: hidden;"}
-  = render(:partial => "layouts/dynatree",
-    :locals         => {:tree_id => "utilization_treebox",
-    :tree_name                   => "utilization_tree",
-    :json_tree                   => @utilization_tree,
-    :onclick                     => "miqOnClickSelectOptimizeTreeNode",
-    :select_node                 => x_node(:utilization_tree).to_s,
-    :no_base_exp                 => true,
-    :exp_tree                    => false,
-    :highlighting                => true,
-    :no_tree_lines               => false,
-    :tree_state                  => true,
-    :autoload                    => true,
-    :multi_lines                 => true})
+= render(:partial => 'shared/tree', :locals => {:tree => @utilization_tree, :name => @utilization_tree.name})


### PR DESCRIPTION
Optimize -> Bottlenecks
Optimize -> Utilization

Convert utilization_tree to use `shared/tree` view.

@miq-bot add_label wip, technical debt, ui

@miq-bot  remove_label wip