### PR TITLE
Fixed issue with reset button on instance pages

### DIFF
--- a/app/helpers/application_helper/button/instance_reset.rb
+++ b/app/helpers/application_helper/button/instance_reset.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::InstanceReset < ApplicationHelper::Button::Basi
   needs_record
 
   def skip?
-    return false if @record.kind_of?(OrchestrationStack) && @display == "instances"
+    return false if @display == "instances"
     !@record.is_available?(:reset)
   end
 end


### PR DESCRIPTION
The fixup for the [bug](https://gitter.im/ManageIQ/manageiq?at=57a1f6011c2bf6621bb87c37) is the same as in #9973. I did the same mistake again in the PR #9941, causing error:

```
/home/rblanco/devel/manageiq/app/models/mixins/availability_mixin.rb:24:in `is_available?'
/home/rblanco/devel/manageiq/app/helpers/application_helper/button/instance_reset.rb:7:in `skip?'
/home/rblanco/devel/manageiq/app/helpers/application_helper/button/basic.rb:32:in `skipped?'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:81:in `block in build_select_button'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:65:in `each'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:65:in `each_with_index'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:65:in `build_select_button'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:185:in `build_button'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:221:in `block (2 levels) in build'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:220:in `each'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:220:in `block in build'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:212:in `each'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:212:in `each_with_index'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:212:in `build'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:43:in `build_toolbar'
/home/rblanco/devel/manageiq/app/helpers/application_helper/toolbar_builder.rb:6:in `call'
/home/rblanco/devel/manageiq/app/helpers/application_helper.rb:374:in `build_toolbar'
/home/rblanco/devel/manageiq/app/helpers/toolbar_helper.rb:39:in `block (2 levels) in render_toolbars'
```

**Steps to reproduce the bug;**
Azure provider -> [select instance] -> Coud subnets -> instances

@bronaghs @martinpovolny