### PR TITLE
Don't add extraneous time to received retire_date

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -271,7 +271,7 @@ module ApplicationController::CiProcessing
             flash = _("Retirement dates removed")
           end
         else
-          t = "#{params[:retire_date]} 00:00:00 Z"
+          t = params[:retire_date]
           w = params[:retire_warn].to_i
           if session[:retire_items].length == 1
             flash = _("Retirement date set to %{date}") % {:date => params[:retire_date]}


### PR DESCRIPTION
The date that comes from the angular controller already contains time information
(the controller works with `Date` objects), so there's no need to add additional time information.

The whole retirement process would work even without this change correctly, since we don't
take the time information into account at all (date is all what matters), though the added time
is extraneous and confusing.