### PR TITLE
Virtual Template updates

### DIFF
--- a/app/models/arbitration_profile.rb
+++ b/app/models/arbitration_profile.rb
@@ -1,4 +1,6 @@
 class ArbitrationProfile < ApplicationRecord
+  default_scope { where(:profile => true) }
+
   validates :ext_management_system, :presence => true
   validates :name, :presence => true
   validate :falsify_all_others, :if => :default_profile_changed?

--- a/app/models/arbitration_profile.rb
+++ b/app/models/arbitration_profile.rb
@@ -4,6 +4,9 @@ class ArbitrationProfile < ApplicationRecord
   validate :falsify_all_others, :if => :default_profile_changed?
 
   default_value_for :default_profile, false
+  default_value_for :profile, true
+
+  alias_attribute :ems_ref, :uid_ems
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
   belongs_to :cloud_subnet

--- a/app/models/arbitration_profile.rb
+++ b/app/models/arbitration_profile.rb
@@ -1,4 +1,4 @@
-class ArbitrationProfile < ApplicationRecord
+class ArbitrationProfile < ArbitrationRecord
   default_scope { where(:profile => true) }
 
   validates :ext_management_system, :presence => true
@@ -7,16 +7,6 @@ class ArbitrationProfile < ApplicationRecord
 
   default_value_for :default_profile, false
   default_value_for :profile, true
-
-  alias_attribute :ems_ref, :uid_ems
-
-  belongs_to :ext_management_system, :foreign_key => :ems_id
-  belongs_to :cloud_subnet
-  belongs_to :cloud_network
-  belongs_to :authentication
-  belongs_to :flavor
-  belongs_to :availability_zone
-  belongs_to :security_group
 
   # If a record is updated as the default, falsify others
   def falsify_all_others

--- a/app/models/arbitration_record.rb
+++ b/app/models/arbitration_record.rb
@@ -1,0 +1,13 @@
+class ArbitrationRecord < ApplicationRecord
+  self.table_name = 'arbitration_profiles'
+
+  alias_attribute :ems_ref, :uid_ems
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+  belongs_to :cloud_subnet
+  belongs_to :cloud_network
+  belongs_to :authentication
+  belongs_to :flavor
+  belongs_to :availability_zone
+  belongs_to :security_group
+end

--- a/app/models/manageiq/providers/cloud_manager/virtual_template.rb
+++ b/app/models/manageiq/providers/cloud_manager/virtual_template.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::CloudManager::VirtualTemplate < ArbitrationProfile
+class ManageIQ::Providers::CloudManager::VirtualTemplate < ArbitrationRecord
   default_scope { where(:profile => false) }
 
   validates :ext_management_system, :presence => true

--- a/app/models/manageiq/providers/cloud_manager/virtual_template.rb
+++ b/app/models/manageiq/providers/cloud_manager/virtual_template.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::CloudManager::VirtualTemplate < ArbitrationProfile
+  default_scope { where(:profile => false) }
+
   validates :ext_management_system, :presence => true
 
   default_value_for :profile, false

--- a/app/models/manageiq/providers/cloud_manager/virtual_template.rb
+++ b/app/models/manageiq/providers/cloud_manager/virtual_template.rb
@@ -1,14 +1,5 @@
-class ManageIQ::Providers::CloudManager::VirtualTemplate < ::MiqTemplate
-  validate :validate_single_template, :on => :create
+class ManageIQ::Providers::CloudManager::VirtualTemplate < ArbitrationProfile
   validates :ext_management_system, :presence => true
 
-  default_value_for :cloud, true
-
-  def single_template?
-    type.constantize.where(:type => type).empty?
-  end
-
-  def validate_single_template
-    errors.add(:virtual_template, _('may only have one per type')) unless single_template?
-  end
+  default_value_for :profile, false
 end

--- a/db/migrate/20160801170547_add_type_to_arbitration_profile.rb
+++ b/db/migrate/20160801170547_add_type_to_arbitration_profile.rb
@@ -1,0 +1,6 @@
+class AddTypeToArbitrationProfile < ActiveRecord::Migration[5.0]
+  def change
+    add_column :arbitration_profiles, :type, :string
+    add_column :arbitration_profiles, :profile, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -46,6 +46,8 @@ arbitration_profiles:
 - name
 - description
 - default_profile
+- type
+- profile
 arbitration_rules:
 - id
 - name

--- a/lib/miq_automation_engine/service_models/miq_ae_service_arbitration_profile.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_arbitration_profile.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceArbitrationProfile < MiqAeServiceModelBase
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_arbitration_record.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_arbitration_record.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceArbitrationRecord < MiqAeServiceModelBase
+  end
+end

--- a/spec/factories/arbitration_profile.rb
+++ b/spec/factories/arbitration_profile.rb
@@ -1,8 +1,9 @@
 FactoryGirl.define do
   factory :arbitration_profile do
-    name 'profile'
-    description 'an arbitration profile'
-    default_profile false
+    name                   'profile'
+    description            'an arbitration profile'
+    default_profile        false
+    ext_management_system  { FactoryGirl.create(:ems_cloud) }
 
     trait :default do
       default_profile true

--- a/spec/factories/virtual_template.rb
+++ b/spec/factories/virtual_template.rb
@@ -1,22 +1,19 @@
 FactoryGirl.define do
   factory :virtual_template, :class => 'ManageIQ::Providers::CloudManager::VirtualTemplate' do
-    vendor                  'amazon'
-    name                    'vt'
-    location                'us-west-1'
-    ems_ref                 'i-12345'
+    name                    'a virtual template'
+    description             'stores all arbitration decisions'
+    ext_management_system   { FactoryGirl.create(:ems_cloud) }
   end
 
   factory :virtual_template_amazon, :class => 'ManageIQ::Providers::Amazon::CloudManager::VirtualTemplate' do
-    vendor                  'amazon'
     name                    'virtual template amazon'
-    location                'us-west-1'
-    ems_ref                 'i-12345'
+    description             'a virtual template for amazon'
+    ext_management_system   { FactoryGirl.create(:ems_amazon) }
   end
 
   factory :virtual_template_google, :class => 'ManageIQ::Providers::Google::CloudManager::VirtualTemplate' do
-    vendor                  'google'
     name                    'virtual template google'
-    location                'us-west-1'
-    ems_ref                 'i-12345'
+    description             'a virtual template for google'
+    ext_management_system   { FactoryGirl.create(:ems_google) }
   end
 end

--- a/spec/factories/virtual_template.rb
+++ b/spec/factories/virtual_template.rb
@@ -9,11 +9,19 @@ FactoryGirl.define do
     name                    'virtual template amazon'
     description             'a virtual template for amazon'
     ext_management_system   { FactoryGirl.create(:ems_amazon) }
+    cloud_network           { FactoryGirl.create(:cloud_network_amazon) }
+    availability_zone       { FactoryGirl.create(:availability_zone_amazon) }
+    flavor                  { FactoryGirl.create(:flavor_amazon) }
+    ems_ref                 'ami-1234'
   end
 
   factory :virtual_template_google, :class => 'ManageIQ::Providers::Google::CloudManager::VirtualTemplate' do
     name                    'virtual template google'
     description             'a virtual template for google'
     ext_management_system   { FactoryGirl.create(:ems_google) }
+    cloud_network           { FactoryGirl.create(:cloud_network_google) }
+    availability_zone       { FactoryGirl.create(:availability_zone_google) }
+    flavor                  { FactoryGirl.create(:flavor_google) }
+    ems_ref                 'ami-1244'
   end
 end

--- a/spec/models/arbitration_profile_spec.rb
+++ b/spec/models/arbitration_profile_spec.rb
@@ -1,24 +1,22 @@
 describe ArbitrationProfile do
-  let(:ems) { FactoryGirl.create(:ext_management_system) }
-
   describe '#ems_id' do
     it 'validates existence of ext management system' do
-      expect { FactoryGirl.create(:arbitration_profile) }
+      expect { FactoryGirl.create(:arbitration_profile, :ems_id => nil) }
         .to raise_error(ActiveRecord::RecordInvalid, /Ext management system can't be blank/)
     end
   end
 
   describe '#name' do
     it 'requires a name' do
-      expect { FactoryGirl.create(:arbitration_profile, :ems_id => ems.id, :name => nil) }
+      expect { FactoryGirl.create(:arbitration_profile, :name => nil) }
         .to raise_error(ActiveRecord::RecordInvalid, /Name can't be blank/)
     end
   end
 
   describe '#default_profile' do
     it 'will falsify all other records when new default is set' do
-      original_default = FactoryGirl.create(:arbitration_profile, :default, :ems_id => ems.id)
-      original_non_default = FactoryGirl.create(:arbitration_profile, :ems_id => ems.id)
+      original_default = FactoryGirl.create(:arbitration_profile, :default)
+      original_non_default = FactoryGirl.create(:arbitration_profile)
 
       expect(original_default.default_profile).to be_truthy
       expect(original_non_default.default_profile).to be_falsey
@@ -32,11 +30,11 @@ describe ArbitrationProfile do
     end
 
     it 'will falsify all other records when new default is created' do
-      original_default = FactoryGirl.create(:arbitration_profile, :default, :ems_id => ems.id)
+      original_default = FactoryGirl.create(:arbitration_profile, :default)
 
       expect(original_default.default_profile).to be_truthy
 
-      new_default = FactoryGirl.create(:arbitration_profile, :default, :ems_id => ems.id)
+      new_default = FactoryGirl.create(:arbitration_profile, :default)
 
       expect(original_default.reload.default_profile).to be_falsey
       expect(new_default.default_profile).to be_truthy

--- a/spec/models/manageiq/providers/cloud_manager/virtual_template_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/virtual_template_spec.rb
@@ -1,27 +1,9 @@
 describe ManageIQ::Providers::CloudManager::VirtualTemplate do
-  let(:ext_management_system) { FactoryGirl.create(:ext_management_system) }
-  let(:vt_properties) do
-    {
-      :vendor   => 'amazon',
-      :name     => 'virtualtemplate',
-      :location => 'here',
-      :ems_id   => ext_management_system.id
-    }
-  end
+  describe '#profile' do
+    it 'has a default value of false' do
+      vt = FactoryGirl.create(:virtual_template)
 
-  describe '#type' do
-    it 'may only have one per type' do
-      FactoryGirl.create(:virtual_template, vt_properties)
-      expect { FactoryGirl.create(:virtual_template, vt_properties) }
-        .to raise_error(ActiveRecord::RecordInvalid, /Virtual template may only have one per type/)
-    end
-  end
-
-  describe '#cloud' do
-    it 'has a default value of true' do
-      vt = FactoryGirl.create(:virtual_template, vt_properties)
-
-      expect(vt.cloud).to be_truthy
+      expect(vt.profile).to be_falsey
     end
   end
 end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -229,12 +229,6 @@ describe ApiController do
       test_collection_query(:vms, vms_url, Vm, :guid)
     end
 
-    it 'query Virtual Templates' do
-      FactoryGirl.create(:virtual_template, :ems_id => ems.id)
-      test_collection_query(:virtual_templates,
-                            virtual_templates_url, ManageIQ::Providers::CloudManager::VirtualTemplate)
-    end
-
     it "query Zones" do
       FactoryGirl.create(:zone, :name => "api zone")
       test_collection_query(:zones, zones_url, Zone)


### PR DESCRIPTION
Purpose or Intent
-----------------
> The structure of the Service Broker has changed and has altered the purpose of a Virtual Template. This PR updates them - below is some context to these changes.
> 
Service Broker
-----------------
> The service broker is a system that will make decisions about provisioning based off of `ArbitrationRules`. These `ArbitrationRules` will be associated with an `ArbitrationProfile` which store the different attributes (Network, Flavor, etc) that will be applied to whatever is being provisioned
Virtual Templates
-----------------
Where do Virtual Templates come in? Virtual Templates will store the decisions made by the Arbitration Rules. They no longer need an API as they will not be user-created, but created based off of the rules that are being applied. Will be using single table inheritance with ArbitrationProfiles because they share the same attributes.

Links
-----
> * [Pivotal tracker ticket](https://www.pivotaltracker.com/story/show/126393227)

@miq-bot add_label service broker, darga/no