### PR TITLE
Don't use the schema name when querying repmgr for failover databases

### DIFF
--- a/gems/pending/postgres_ha_admin/failover_databases.rb
+++ b/gems/pending/postgres_ha_admin/failover_databases.rb
@@ -4,6 +4,8 @@ require 'pg/dsn_parser'
 
 module PostgresHaAdmin
   class FailoverDatabases
+    TABLE_NAME = "repl_nodes".freeze
+
     attr_reader :yml_file, :connection_hash, :logger, :log_file
 
     def initialize(config_dir, log_dir, connection_params_hash)
@@ -49,8 +51,8 @@ module PostgresHaAdmin
       end
 
       result = []
-      if miq_repllication_exists?(connection)
-        db_result = connection.exec("SELECT type, conninfo, active FROM repmgr_miq.repl_nodes")
+      if miq_replication_exists?(connection)
+        db_result = connection.exec("SELECT type, conninfo, active FROM #{TABLE_NAME}")
         db_result.map_types!(PG::BasicTypeMapForResults.new(connection)).each do |record|
           dsn = PG::DSNParser.parse(record.delete("conninfo"))
           result << record.symbolize_keys.merge(dsn)
@@ -71,8 +73,8 @@ module PostgresHaAdmin
       raise
     end
 
-    def miq_repllication_exists?(connection)
-      connection.exec("SELECT to_regclass('repmgr_miq.repl_nodes')")
+    def miq_replication_exists?(connection)
+      connection.exec("SELECT to_regclass('#{TABLE_NAME}')")
     end
   end
 end

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -21,10 +21,9 @@ describe PostgresHaAdmin::FailoverDatabases do
   around(:each) do |example|
     begin
       connection.exec("START TRANSACTION")
-      connection.exec("CREATE SCHEMA repmgr_miq")
 
       connection.exec(<<-SQL)
-        CREATE TABLE repmgr_miq.repl_nodes (
+        CREATE TABLE #{described_class::TABLE_NAME} (
           type text NOT NULL,
           conninfo text NOT NULL,
           active boolean DEFAULT true NOT NULL
@@ -33,7 +32,7 @@ describe PostgresHaAdmin::FailoverDatabases do
 
       connection.exec(<<-SQL)
         INSERT INTO
-          repmgr_miq.repl_nodes(type, conninfo, active)
+          #{described_class::TABLE_NAME}(type, conninfo, active)
         VALUES
           ('master', 'host=1.1.1.1 user=root dbname=vmdb_test', 'true'),
           ('standby', 'host=2.2.2.2 user=root dbname=vmdb_test', 'true'),
@@ -116,7 +115,7 @@ describe PostgresHaAdmin::FailoverDatabases do
   def add_new_record
     connection.exec(<<-SQL)
       INSERT INTO
-        repmgr_miq.repl_nodes(type, conninfo, active)
+        #{described_class::TABLE_NAME}(type, conninfo, active)
       VALUES
         ('standby', 'host=4.4.4.4 user=root dbname=some_db', 'true')
     SQL


### PR DESCRIPTION
The schema name is dependent on the repmgr cluster name which we are planning on basing on the region number of the primary database.

When registering the primary node we will add the new schema to the root user's search_path so that the repmgr tables can be queried without specifying the schema explicitly.

@yrudman @Fryguy please review