### PR TITLE
Adding taggable method to miq_ae_service_model_base

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -230,15 +230,18 @@ module MiqAeMethodService
     end
 
     def tagged_with?(category, name)
+      verify_taggable_model
       object_send(:is_tagged_with?, name.to_s, :ns => "/managed/#{category}")
     end
 
     def tags(category = nil)
+      verify_taggable_model
       ns = category.nil? ? "/managed" : "/managed/#{category}"
       object_send(:tag_list, :ns => ns).split
     end
 
     def tag_assign(tag)
+      verify_taggable_model
       ar_method do
         Classification.classify_by_tag(@object, "/managed/#{tag}")
         true
@@ -246,11 +249,25 @@ module MiqAeMethodService
     end
 
     def tag_unassign(tag)
+      verify_taggable_model
       ar_method do
         Classification.unclassify_by_tag(@object, "/managed/#{tag}")
         true
       end
     end
+
+    def taggable?
+      self.class.taggable?
+    end
+
+    def self.taggable?
+      model.respond_to?(:tags)
+    end
+
+    def verify_taggable_model
+      raise MiqAeException::UntaggableModel, "Model #{self.class} doesn't support tagging" unless taggable?
+    end
+    private :verify_taggable_model
 
     def reload
       object_send(:reload)

--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -22,6 +22,7 @@ module MiqAeException
   class MethodParmMissing < MiqAeEngineError; end
   class WorkspaceNotFound < MiqAeEngineError; end
   class AttributeNotFound < MiqAeEngineError; end
+  class UntaggableModel < MiqAeEngineError; end
 
   class MiqAeDatastoreError < Error; end
   class DomainNotFound < MiqAeDatastoreError; end

--- a/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_model_spec.rb
@@ -48,6 +48,14 @@ module MiqAeServiceModelSpec
         expect(@ae_vm.tag_assign("#{category.name}/non_exisiting_tag")).to be_truthy
         expect(@ae_vm.tagged_with?(category.name, 'non_exisiting_tag')).to be_falsey
       end
+
+      it "getting UntaggableModel exception while tagging lan model" do
+        lan = FactoryGirl.create(:lan)
+        lan_provider = MiqAeMethodService::MiqAeServiceLan.new(lan.id)
+        expect do
+          lan_provider.tag_assign("#{category.name}/#{tag.name}")
+        end.to raise_error(MiqAeException::UntaggableModel)
+      end
     end
 
     describe "#tag_unassign" do
@@ -75,6 +83,18 @@ module MiqAeServiceModelSpec
 
       it "does not raise an error when attempts to unassign a non-existing tag" do
         expect(@ae_vm.tag_unassign("#{category.name}/non_exisiting_tag")).to be_truthy
+      end
+    end
+
+    describe "#taggable" do
+      it "Vm model is taggable" do
+        expect(@ae_vm.taggable?).to be_truthy
+      end
+
+      it "Lan model is not taggable" do
+        lan = FactoryGirl.create(:lan)
+        lan_provider = MiqAeMethodService::MiqAeServiceLan.new(lan.id)
+        expect(lan_provider.taggable?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Adding 'taggable?' method for detecting if the miq_ae_service_model is taggable or not. I also made new UntaggableModel exception and tagged_with?, tags, tag_assign and tag_unassign methods now check taggable on their classes.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1360186


