### PR TITLE
Remove ng-app, use miq_bootstrap instead

### DIFF
--- a/app/views/ems_container/_show_topology.html.haml
+++ b/app/views/ems_container/_show_topology.html.haml
@@ -1,5 +1,5 @@
 - tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
-.container_topology{'data-ng-app' => "topologyApp", 'ng-controller' => "containerTopologyController"}
+.container_topology{'ng-controller' => "containerTopologyController"}
   .legend
     %label#selected
     %div{'ng-if' => "kinds"}
@@ -75,3 +75,6 @@
     %strong
       = _("Click on the legend to show/hide entities, and double click/right click the entities in the graph to navigate to their summary pages.")
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
+
+:javascript
+  miq_bootstrap('.container_topology', 'topologyApp');

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -1,5 +1,5 @@
 - tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
-.container_topology{'data-ng-app' => "mwTopologyApp", 'ng-controller' => "middlewareTopologyController"}
+.container_topology{'ng-controller' => "middlewareTopologyController"}
   .row.toolbar-pf
     .col-md-12
       = render :partial => "shared/topology_header"
@@ -38,3 +38,5 @@
       = _("Click on the legend to show/hide entities, and double click on the entities in the graph to navigate to their summary pages.")
   %kubernetes-topology-graph.middleware{:items => "items", :relations => "relations", :kinds => "kinds"}
 
+:javascript
+  miq_bootstrap('.container_topology', 'mwTopologyApp');

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -1,5 +1,5 @@
 - tooltipOptions = {"tooltip-placement" => "bottom", "tooltip" => "{{legendTooltip}}"}
-.container_topology{'data-ng-app' => "netTopologyApp", 'ng-controller' => "networkTopologyController"}
+.container_topology{'ng-controller' => "networkTopologyController"}
   .row.toolbar-pf
     .col-md-12
       = render :partial => "shared/topology_header"
@@ -78,3 +78,6 @@
     %strong
       = _("Click on the legend to show/hide entities, and double click/right click the entities in the graph to navigate to their summary pages.")
   %kubernetes-topology-graph{:items => "items", :relations => "relations", :kinds => "kinds"}
+
+:javascript
+  miq_bootstrap('.container_topology', 'netTopologyApp');

--- a/app/views/shared/views/_show_containers_dashboard.html.haml
+++ b/app/views/shared/views/_show_containers_dashboard.html.haml
@@ -1,5 +1,4 @@
-.container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view{"ng-app"        => "containerDashboard",
-                                                                            "ng-controller" => "containerDashboardController as dashboard"}
+.container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view{"ng-controller" => "containerDashboardController as dashboard"}
   .row.row-tile-pf
     .col-xs-12.col-sm-12.col-md-2
       .provider-card{"pf-card"         => "",
@@ -144,3 +143,6 @@
 
             %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': !podEntityTrendDailyConfig }"}
               = _("Last 30 Days")
+
+:javascript
+  miq_bootstrap('.containers-dashboard', 'containerDashboard');


### PR DESCRIPTION
In order to support angularified toolbars (https://github.com/ManageIQ/manageiq/pull/9753), we need to get rid of `ng-app` in our application and bootstrap each angular module using `miq_bootstrap` (which is our wrapper around `angular.bootstrap`).

This converts all these `ng-app` instances to use `miq_bootstrap` instead.

WIP - need to test properly, might be edge cases or missing strictDi..