### PR TITLE
Remove references to unsupported MiqExpression ruby operator

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1363,7 +1363,7 @@ class MiqExpression
     return model, parts, col
   end
 
-  NUM_OPERATORS     = ["=", "!=", "<", "<=", ">=", ">"]
+  NUM_OPERATORS     = ["=", "!=", "<", "<=", ">=", ">"].freeze
   STRING_OPERATORS  = ["=",
                        "STARTS WITH",
                        "ENDS WITH",
@@ -1409,7 +1409,7 @@ class MiqExpression
     end
   end
 
-  STYLE_OPERATORS_EXCLUDES = ["REGULAR EXPRESSION MATCHES", "REGULAR EXPRESSION DOES NOT MATCH", "FROM"]
+  STYLE_OPERATORS_EXCLUDES = ["REGULAR EXPRESSION MATCHES", "REGULAR EXPRESSION DOES NOT MATCH", "FROM"].freeze
   def self.get_col_style_operators(field)
     result = get_col_operators(field) - STYLE_OPERATORS_EXCLUDES
   end

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -497,8 +497,6 @@ class MiqExpression
       clause = operands2rubyvalue(operator, exp[operator], context_type)
     when "value exists"
       clause = operands2rubyvalue(operator, exp[operator], context_type)
-    when "ruby"
-      raise _("Ruby scripts in expressions are no longer supported. Please use the regular expression feature of conditions instead.")
     when "is"
       col_name = exp[operator]["field"]
       col_ruby, dummy = operands2rubyvalue(operator, {"field" => col_name}, context_type)

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1396,9 +1396,7 @@ class MiqExpression
     case col_type.to_s.downcase.to_sym
     when :string
       return STRING_OPERATORS
-    when :integer, :float, :fixnum
-      return NUM_OPERATORS
-    when :count
+    when :integer, :float, :fixnum, :count
       return NUM_OPERATORS
     when :numeric_set, :string_set
       return SET_OPERATORS

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -2001,12 +2001,12 @@ describe MiqExpression do
 
     it "returns list of available operations for field type 'integer'" do
       @field = "ManageIQ::Providers::InfraManager::Vm-cpu_limit"
-      expect(subject).to contain_exactly("=", "!=", "<", "<=", ">=", ">", "RUBY")
+      expect(subject).to contain_exactly("=", "!=", "<", "<=", ">=", ">")
     end
 
     it "returns list of available operations for field type 'float'" do
       @field = "Storage-v_provisioned_percent_of_total"
-      expect(subject).to contain_exactly("=", "!=", "<", "<=", ">=", ">", "RUBY")
+      expect(subject).to contain_exactly("=", "!=", "<", "<=", ">=", ">")
     end
 
 =begin

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -685,7 +685,7 @@ describe MiqExpression do
 
     it "raises error if expression contains ruby script" do
       exp = MiqExpression.new("RUBY" => {"field" => "Host-name", "value" => "puts 'Hello world!'"})
-      expect { exp.to_ruby }.to raise_error(/Ruby scripts in expressions are no longer supported/)
+      expect { exp.to_ruby }.to raise_error(/operator 'RUBY' is not supported/)
     end
 
     it "tests numeric set expressions" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Support for the ruby operator was removed in 9e5ba7dcf4443eab7f028a699a2f43cee9e18175. This revision removes all references to it. Continued use of the ruby operator will now default to raising an error as with any unsupported operator.

@miq-bot add-label core, technical debt
@miq-bot assign @gtanzillo 
:scissors: :fire: :scissors: 