### PR TITLE
Changing default instance_name in custom button from "Automation" to "Request"

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -828,7 +828,7 @@ module ApplicationController::Buttons
     @edit[:new][:button_image] = @custom_button.options && @custom_button.options[:button_image] ? @custom_button.options[:button_image] : ""
     @edit[:new][:display] = @custom_button.options && @custom_button.options.key?(:display) ? @custom_button.options[:display] : true
     @edit[:new][:object_message] = @custom_button.uri_message || "create"
-    @edit[:new][:instance_name] ||= "Automation"
+    @edit[:new][:instance_name] ||= "Request"
     @edit[:current] = copy_hash(@edit[:new])
 
     @edit[:new][:button_images] = @edit[:current][:button_images] = build_button_image_options


### PR DESCRIPTION
Purpose or Intent
-----------------
Change Custom Button edit screen to default the Object Details selection from "Automation" to "Request". Similar to the change for the Simulation screen in PR https://github.com/ManageIQ/manageiq/pull/9979.
Links
-----
https://www.pivotaltracker.com/n/projects/1613499/stories/127571067

