### PR TITLE
Fix for API Log Requests

### DIFF
--- a/app/controllers/api_controller/logger.rb
+++ b/app/controllers/api_controller/logger.rb
@@ -2,6 +2,7 @@ class ApiController
   module Logger
     def log_request_initiated
       @requested_at = Time.now.utc
+      return unless api_log_info?
       api_log_info(" ")
       log_request("API Request", :requested_at => @requested_at.to_s,
                                  :method       => request.request_method,
@@ -9,6 +10,7 @@ class ApiController
     end
 
     def log_api_auth
+      return unless api_log_info?
       log_request("Authentication", :type        => @auth_token.blank? ? "basic" : "token",
                                     :token       => @auth_token,
                                     :x_miq_group => request.headers['X-MIQ-Group'],
@@ -24,6 +26,7 @@ class ApiController
 
     def log_api_request
       @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
+      return unless api_log_info?
       log_request("Request", @req.to_hash)
       log_request("Parameters", @parameter_filter.filter(params))
       log_request_body
@@ -31,6 +34,7 @@ class ApiController
 
     def log_api_response
       @completed_at = Time.now.utc
+      return unless api_log_info?
       log_request("Response", :completed_at => @completed_at.to_s,
                               :size         => '%.3f KBytes' % (response.body.size / 1000.0),
                               :time_taken   => '%.3f Seconds' % (@completed_at - @requested_at),
@@ -39,6 +43,10 @@ class ApiController
 
     def api_log_debug?
       $api_log.debug?
+    end
+
+    def api_log_info?
+      $api_log.info?
     end
 
     def api_get_method_name(call_stack, method)

--- a/app/controllers/api_controller/logger.rb
+++ b/app/controllers/api_controller/logger.rb
@@ -24,7 +24,7 @@ class ApiController
 
     def log_api_request
       @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
-      log_request("Request", @req)
+      log_request("Request", @req.to_hash)
       log_request("Parameters", @parameter_filter.filter(params))
       log_request_body
     end

--- a/app/controllers/api_controller/parser/request_adapter.rb
+++ b/app/controllers/api_controller/parser/request_adapter.rb
@@ -6,9 +6,21 @@ class ApiController
         @params = params
       end
 
+      def to_hash
+        [:method, :action, :fullpath, :url, :base,
+         :path, :prefix, :version, :api_prefix,
+         :collection, :c_suffix, :c_id, :subcollection, :s_id]
+          .each_with_object({}) { |attr, hash| hash[attr] = send(attr) }
+      end
+
       def action
         # for basic HTTP POST, default action is "create" with data being the POST body
-        @action ||= method == :put ? 'edit' : (json_body['action'] || 'create')
+        @action ||= case method
+                    when :get then 'read'
+                    when :put, :patch then 'edit'
+                    when :delete then 'delete'
+                    else json_body['action'] || 'create'
+                    end
       end
 
       def api_prefix
@@ -35,7 +47,7 @@ class ApiController
       end
 
       def c_suffix
-        @params[:c_suffix] || c_path_parts[1..-1].join('/')
+        @params[:c_suffix] || Array(c_path_parts[1..-1]).join('/')
       end
 
       def c_id

--- a/app/controllers/api_controller/parser/request_adapter.rb
+++ b/app/controllers/api_controller/parser/request_adapter.rb
@@ -7,7 +7,7 @@ class ApiController
       end
 
       def to_hash
-        [:method, :action, :fullpath, :url, :base,
+        [:method, :fullpath, :url, :base,
          :path, :prefix, :version, :api_prefix,
          :collection, :c_suffix, :c_id, :subcollection, :s_id]
           .each_with_object({}) { |attr, hash| hash[attr] = send(attr) }
@@ -15,12 +15,7 @@ class ApiController
 
       def action
         # for basic HTTP POST, default action is "create" with data being the POST body
-        @action ||= case method
-                    when :get then 'read'
-                    when :put, :patch then 'edit'
-                    when :delete then 'delete'
-                    else json_body['action'] || 'create'
-                    end
+        @action ||= method == :put ? 'edit' : (json_body['action'] || 'create')
       end
 
       def api_prefix

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -1,0 +1,51 @@
+#
+# REST API Logging Tests
+#
+describe ApiController do
+  describe "Successful Requests logging" do
+    EXPECTED_LOGGED_PARAMETERS = {
+      "API Request"    => nil,
+      "Authentication" => nil,
+      "Authorization"  => nil,
+      "Request"        => nil,
+      "Parameters"     => nil,
+      "Response"       => nil
+    }.freeze
+
+    def expect_log_requests(expectations)
+      expectations.each do |category, expectation|
+        expect_any_instance_of(ApiController).to receive(:log_request)
+          .with(category, expectation ? expectation : kind_of(Hash))
+      end
+    end
+
+    it "logs hashed details about the request" do
+      api_basic_authorize collection_action_identifier(:users, :read, :get)
+
+      log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
+        "Request" => a_hash_including(:path          => "/api/users",
+                                      :collection    => "users",
+                                      :c_id          => nil,
+                                      :subcollection => nil,
+                                      :s_id          => nil)
+      )
+
+      expect_log_requests(log_request_expectations)
+
+      run_get users_url
+    end
+
+    it "logs all hash entries about the request" do
+      api_basic_authorize
+
+      log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
+        "Request" => a_hash_including(:method, :fullpath, :url, :base, :path, :prefix, :version, :api_prefix,
+                                      :collection, :c_suffix, :c_id, :subcollection, :s_id)
+      )
+
+      expect_log_requests(log_request_expectations)
+
+      run_get entrypoint_url
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------


- With the introduction of the RequestAdapter we lost the related
  logging from api.log
- c_suffix fails with plain entrypoint, needs to work for all requests
- updated RequestAdapter action to work for all methods