### PR TITLE
Clean up removal options and warning messages

### DIFF
--- a/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudCenter < ApplicationHelper::To
           t = N_('Remove this Key Pair'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: The selected Key Pair and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Key Pair")),
+          :confirm   => N_("Warning: The selected Key Pair and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
@@ -38,7 +38,7 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
           t = N_('Remove selected Key Pairs'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Key Pairs and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Key Pairs"),
+          :confirm   => N_("Warning: The selected Key Pairs and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/chargeback_center.rb
+++ b/app/helpers/application_helper/toolbar/chargeback_center.rb
@@ -64,7 +64,7 @@ class ApplicationHelper::Toolbar::ChargebackCenter < ApplicationHelper::Toolbar:
           N_('Remove this Chargeback Rate from the VMDB'),
           N_('Remove from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Chargeback Rate will be permanently removed from the Virtual Management Database. Are you sure you want to remove this Chargeback Rate?"),
+          :confirm   => N_("Warning: This Chargeback Rate will be permanently removed!"),
           :klass     => ApplicationHelper::Button::ChargebackRateRemove),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/chargebacks_center.rb
+++ b/app/helpers/application_helper/toolbar/chargebacks_center.rb
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           t = N_('Remove selected Chargeback Rates from the VMDB'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Chargeback Rate will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Chargeback Rates?"),
+          :confirm   => N_("Warning: The selected Chargeback Rate will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/cloud_volume_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volume_center.rb
@@ -35,7 +35,7 @@ class ApplicationHelper::Toolbar::CloudVolumeCenter < ApplicationHelper::Toolbar
                        t = N_('Delete this Cloud Volume'),
                        t,
                        :url_parms => 'main_div',
-                       :confirm   => N_('Warning: This Cloud Volume and ALL of its components will be removed. Are you sure you want to remove this Cloud Volume?')
+                       :confirm   => N_('Warning: This Cloud Volume and ALL of its components will be removed!')
                      ),
                    ]
                  )

--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -46,7 +46,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        t = N_('Delete selected Cloud Volumes'),
                        t,
                        :url_parms => 'main_div',
-                       :confirm   => N_('Warning: The selected Cloud Volume and ALL of their components will be removed. Are you sure you want to remove these Cloud Volumes?'),
+                       :confirm   => N_('Warning: The selected Cloud Volume and ALL of their components will be removed!'),
                        :enabled   => false,
                        :onwhen    => '1+'
                      ),

--- a/app/helpers/application_helper/toolbar/configuration_job_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_job_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::ConfigurationJobCenter < ApplicationHelper::To
         button(
           :configuration_job_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Job from the VMDB'),
+          t = N_('Remove this Job'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Job and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Job?")),
+          :confirm   => N_("Warning: This Job and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/configuration_jobs_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_jobs_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::ConfigurationJobsCenter < ApplicationHelper::T
         button(
           :configuration_job_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Jobs from the VMDB'),
-          N_('Remove Jobs from the VMDB'),
+          N_('Remove selected Jobs'),
+          N_('Remove Jobs'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Jobs and ALL of their components will be permanently removed from the Virtual Management Database. Are you sure you want to remove the selected Jobs?"),
+          :confirm   => N_("Warning: The selected Jobs and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb
@@ -24,10 +24,10 @@ class ApplicationHelper::Toolbar::ConfigurationProfileForemanCenter < Applicatio
         button(
           :provider_foreman_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Provider from the VMDB'),
+          t = N_('Remove this Provider'),
           t,
           :url     => "delete",
-          :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Provider?")),
+          :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_center.rb
+++ b/app/helpers/application_helper/toolbar/container_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerCenter < ApplicationHelper::Toolbar::
           t = N_('Remove this Container from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Container and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Container?")),
+          :confirm   => N_("Warning: This Container and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_group_center.rb
+++ b/app/helpers/application_helper/toolbar/container_group_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerGroupCenter < ApplicationHelper::Tool
           t = N_('Remove this Pod from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Pod and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Pod?")),
+          :confirm   => N_("Warning: This Pod and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/container_groups_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ContainerGroupsCenter < ApplicationHelper::Too
           N_('Remove selected Pods from the VMDB'),
           N_('Remove Pods from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Pods and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Pods?"),
+          :confirm   => N_("Warning: The selected Pods and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_image_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_registries_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ContainerImageRegistriesCenter < ApplicationHe
           N_('Remove selected Image Registries from the VMDB'),
           N_('Remove Image Registries from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Image Registries and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Image Registries?"),
+          :confirm   => N_("Warning: The selected Image Registries and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_image_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_registry_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerImageRegistryCenter < ApplicationHelp
           t = N_('Remove this Image Registry from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Image Registry and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Image Registry")),
+          :confirm   => N_("Warning: This Image Registry and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
           t = N_('Remove this Node from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Node and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Node?")),
+          :confirm   => N_("Warning: This Node and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_nodes_center.rb
+++ b/app/helpers/application_helper/toolbar/container_nodes_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ContainerNodesCenter < ApplicationHelper::Tool
           N_('Remove selected Nodes from the VMDB'),
           N_('Remove Nodes from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Nodes and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Nodes?"),
+          :confirm   => N_("Warning: The selected Nodes and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_project_center.rb
+++ b/app/helpers/application_helper/toolbar/container_project_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerProjectCenter < ApplicationHelper::To
           t = N_('Remove this Project from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Project and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Project?")),
+          :confirm   => N_("Warning: This Project and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_projects_center.rb
+++ b/app/helpers/application_helper/toolbar/container_projects_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ContainerProjectsCenter < ApplicationHelper::T
           N_('Remove selected Services from the VMDB'),
           N_('Remove Services from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Services?"),
+          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_replicator_center.rb
+++ b/app/helpers/application_helper/toolbar/container_replicator_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerReplicatorCenter < ApplicationHelper:
           t = N_('Remove this Replicator from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Replicator and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Replicator?")),
+          :confirm   => N_("Warning: This Replicator and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_replicators_center.rb
+++ b/app/helpers/application_helper/toolbar/container_replicators_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ContainerReplicatorsCenter < ApplicationHelper
           N_('Remove selected Replicators from the VMDB'),
           N_('Remove Replicators from the VMDB'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Replicators and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Replicators?"),
+          :confirm   => N_("Warning: The selected Replicators and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_route_center.rb
+++ b/app/helpers/application_helper/toolbar/container_route_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::ContainerRouteCenter < ApplicationHelper::Tool
           t = N_('Remove this Route from the VMDB'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Route and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Route?")),
+          :confirm   => N_("Warning: This Route and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_routes_center.rb
+++ b/app/helpers/application_helper/toolbar/container_routes_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::ContainerRoutesCenter < ApplicationHelper::Too
         button(
           :container_service_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Projects from the VMDB'),
-          N_('Remove Projects from the VMDB'),
+          N_('Remove selected Projects'),
+          N_('Remove Projects'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Projects and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Projects?"),
+          :confirm   => N_("Warning: The selected Projects and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/container_service_center.rb
+++ b/app/helpers/application_helper/toolbar/container_service_center.rb
@@ -15,10 +15,10 @@ class ApplicationHelper::Toolbar::ContainerServiceCenter < ApplicationHelper::To
         button(
           :container_service_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Service from the VMDB'),
+          t = N_('Remove this Service'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Service and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Service?")),
+          :confirm   => N_("Warning: This Service and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/container_services_center.rb
+++ b/app/helpers/application_helper/toolbar/container_services_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::ContainerServicesCenter < ApplicationHelper::T
         button(
           :container_service_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Services from the VMDB'),
-          N_('Remove Services from the VMDB'),
+          N_('Remove selected Services'),
+          N_('Remove Services'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Services?"),
+          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/containers_center.rb
+++ b/app/helpers/application_helper/toolbar/containers_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::ContainersCenter < ApplicationHelper::Toolbar:
         button(
           :container_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Containers from the VMDB'),
-          N_('Remove Containers from the VMDB'),
+          N_('Remove selected Containers'),
+          N_('Remove Containers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Containers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Containers?"),
+          :confirm   => N_("Warning: The selected Containers and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/custom_button_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_button_center.rb
@@ -18,7 +18,7 @@ class ApplicationHelper::Toolbar::CustomButtonCenter < ApplicationHelper::Toolba
           t = N_('Remove this Button'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Button will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Button?")),
+          :confirm   => N_("Warning: This Button will be permanently removed from the Virtual Management Database!")),
         separator,
         button(
           :ab_button_simulate,

--- a/app/helpers/application_helper/toolbar/custom_buttons_center.rb
+++ b/app/helpers/application_helper/toolbar/custom_buttons_center.rb
@@ -23,7 +23,7 @@ class ApplicationHelper::Toolbar::CustomButtonsCenter < ApplicationHelper::Toolb
           t = N_('Remove this Button Group'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Button Group will be permanently removed.  Are you sure you want to remove the selected Button Group?")),
+          :confirm   => N_("Warning: The selected Button Group will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/customization_template_center.rb
+++ b/app/helpers/application_helper/toolbar/customization_template_center.rb
@@ -19,10 +19,10 @@ class ApplicationHelper::Toolbar::CustomizationTemplateCenter < ApplicationHelpe
         button(
           :customization_template_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Customization Template from the VMDB'),
+          t = N_('Remove this Customization Template'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Customization Template will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Customization Template?")),
+          :confirm   => N_("Warning: This Customization Template will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/customization_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/customization_templates_center.rb
@@ -30,10 +30,10 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
         button(
           :customization_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Customization Templates from the VMDB'),
-          N_('Remove Customization Templates from the VMDB'),
+          N_('Remove selected Customization Templates'),
+          N_('Remove Customization Templates'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Customization Templates will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Customization Templates?"),
+          :confirm   => N_("Warning: The selected Customization Templates will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/dialog_center.rb
+++ b/app/helpers/application_helper/toolbar/dialog_center.rb
@@ -21,10 +21,10 @@ class ApplicationHelper::Toolbar::DialogCenter < ApplicationHelper::Toolbar::Bas
         button(
           :dialog_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Dialog from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Dialog'),
+          N_('Remove Dialog'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Dialog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Dialog?")),
+          :confirm   => N_("Warning: This Dialog will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/dialogs_center.rb
+++ b/app/helpers/application_helper/toolbar/dialogs_center.rb
@@ -30,10 +30,10 @@ class ApplicationHelper::Toolbar::DialogsCenter < ApplicationHelper::Toolbar::Ba
         button(
           :dialog_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Dialogs from the VMDB'),
+          t = N_('Remove selected Dialogs'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Dialog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Dialogs?"),
+          :confirm   => N_("Warning: The selected Dialog will be permanently removed from the Virtual Management Database!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/ems_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cloud_center.rb
@@ -27,10 +27,10 @@ class ApplicationHelper::Toolbar::EmsCloudCenter < ApplicationHelper::Toolbar::B
         button(
           :ems_cloud_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Cloud Provider from the VMDB'),
+          t = N_('Remove this Cloud Provider'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Cloud Provider and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Cloud Provider?")),
+          :confirm   => N_("Warning: This Cloud Provider and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -40,10 +40,10 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
         button(
           :ems_cloud_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Cloud Providers from the VMDB'),
-          N_('Remove Cloud Providers from the VMDB'),
+          N_('Remove selected Cloud Providers'),
+          N_('Remove Cloud Providers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Cloud Providers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Cloud Providers?"),
+          :confirm   => N_("Warning: The selected Cloud Providers and ALL related components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/ems_cluster_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_cluster_center.rb
@@ -15,10 +15,10 @@ class ApplicationHelper::Toolbar::EmsClusterCenter < ApplicationHelper::Toolbar:
         button(
           :ems_cluster_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this item from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this item'),
+          N_('Remove item'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This item and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this item?")),
+          :confirm   => N_("Warning: This item and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_clusters_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clusters_center.rb
@@ -29,10 +29,10 @@ class ApplicationHelper::Toolbar::EmsClustersCenter < ApplicationHelper::Toolbar
         button(
           :ems_cluster_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items from the VMDB'),
+          t = N_('Remove selected items'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!?"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/ems_container_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_container_center.rb
@@ -26,10 +26,10 @@ class ApplicationHelper::Toolbar::EmsContainerCenter < ApplicationHelper::Toolba
         button(
           :ems_container_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Containers Provider from the VMDB'),
+          t = N_('Remove this Containers Provider'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Containers Provider and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Containers Provider?")),
+          :confirm   => N_("Warning: This Containers Provider and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -33,10 +33,10 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
         button(
           :ems_container_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Containers Providers from the VMDB'),
-          N_('Remove Containers Providers from the VMDB'),
+          N_('Remove selected Containers Providers'),
+          N_('Remove Containers Providers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Containers Providers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Containers Providers?"),
+          :confirm   => N_("Warning: The selected Containers Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/ems_infra_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infra_center.rb
@@ -38,10 +38,10 @@ class ApplicationHelper::Toolbar::EmsInfraCenter < ApplicationHelper::Toolbar::B
         button(
           :ems_infra_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Infrastructure Provider from the VMDB'),
+          t = N_('Remove this Infrastructure Provider'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Infrastructure Provider and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Infrastructure Provider?")),
+          :confirm   => N_("Warning: This Infrastructure Provider and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infras_center.rb
@@ -40,10 +40,10 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
         button(
           :ems_infra_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Infrastructure Providers from the VMDB'),
-          N_('Remove Infrastructure Providers from the VMDB'),
+          N_('Remove selected Infrastructure Providers'),
+          N_('Remove Infrastructure Providers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Infrastructure Providers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Infrastructure Providers?"),
+          :confirm   => N_("Warning: The selected Infrastructure Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
         button(
           :ems_middleware_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Middleware Provider from the VMDB'),
+          t = N_('Remove this Middleware Provider'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Middleware Provider and ALL of its components will be permanently removed from the Virtual Management Database. Are you sure you want to remove this Middleware Provider?")),
+          :confirm   => N_("Warning: This Middleware Provider and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middlewares_center.rb
@@ -23,10 +23,10 @@ class ApplicationHelper::Toolbar::EmsMiddlewaresCenter < ApplicationHelper::Tool
         button(
           :ems_middleware_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Middleware Providers from the VMDB'),
-          N_('Remove Middleware Providers from the VMDB'),
+          N_('Remove selected Middleware Providers'),
+          N_('Remove Middleware Providers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Middleware Providers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Middleware Providers?"),
+          :confirm   => N_("Warning: The selected Middleware Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/ems_network_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_network_center.rb
@@ -21,10 +21,10 @@ class ApplicationHelper::Toolbar::EmsNetworkCenter < ApplicationHelper::Toolbar:
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Network Provider from the VMDB'),
+          t = N_('Remove this Network Provider'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Network Provider and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Network Provider?")),
+          :confirm   => N_("Warning: This Network Provider and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/ems_networks_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_networks_center.rb
@@ -19,10 +19,10 @@ class ApplicationHelper::Toolbar::EmsNetworksCenter < ApplicationHelper::Toolbar
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Network Providers from the VMDB'),
-          N_('Remove Network Providers from the VMDB'),
+          N_('Remove selected Network Providers'),
+          N_('Remove Network Providers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Network Providers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Network Providers?"),
+          :confirm   => N_("Warning: The selected Network Providers and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/host_center.rb
+++ b/app/helpers/application_helper/toolbar/host_center.rb
@@ -35,10 +35,10 @@ class ApplicationHelper::Toolbar::HostCenter < ApplicationHelper::Toolbar::Basic
         button(
           :host_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this item from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this item'),
+          N_('Remove item'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This item and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this item?")),
+          :confirm   => N_("Warning: This item and ALL of its components will be permanently removed!?")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/hosts_center.rb
+++ b/app/helpers/application_helper/toolbar/hosts_center.rb
@@ -57,10 +57,10 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
         button(
           :host_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove Selected items from the VMDB'),
-          N_('Remove items from the VMDB'),
+          N_('Remove Selected items'),
+          N_('Remove items'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!?"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/inventory_group_center.rb
+++ b/app/helpers/application_helper/toolbar/inventory_group_center.rb
@@ -24,10 +24,10 @@ class ApplicationHelper::Toolbar::InventoryGroupCenter < ApplicationHelper::Tool
         button(
           :provider_foreman_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Provider from the VMDB'),
+          t = N_('Remove this Provider'),
           t,
           :url     => "delete",
-          :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Provider?")),
+          :confirm => N_("Warning: The selected Provider and ALL of their components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/iso_datastore_center.rb
+++ b/app/helpers/application_helper/toolbar/iso_datastore_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::IsoDatastoreCenter < ApplicationHelper::Toolba
         button(
           :iso_datastore_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this ISO Datastore from the VMDB'),
+          t = N_('Remove this ISO Datastore'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This ISO Datastore and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this ISO Datastore?")),
+          :confirm   => N_("Warning: This ISO Datastore and ALL of its components will be permanently removed!")),
         separator,
         button(
           :iso_datastore_refresh,

--- a/app/helpers/application_helper/toolbar/iso_datastores_center.rb
+++ b/app/helpers/application_helper/toolbar/iso_datastores_center.rb
@@ -14,10 +14,10 @@ class ApplicationHelper::Toolbar::IsoDatastoresCenter < ApplicationHelper::Toolb
         button(
           :iso_datastore_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected ISO Datastores from the VMDB'),
-          N_('Remove ISO Datastores from the VMDB'),
+          N_('Remove selected ISO Datastores'),
+          N_('Remove ISO Datastores'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected ISO Datastores and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected ISO Datastores?"),
+          :confirm   => N_("Warning: The selected ISO Datastores and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/miq_dialog_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_dialog_center.rb
@@ -21,10 +21,10 @@ class ApplicationHelper::Toolbar::MiqDialogCenter < ApplicationHelper::Toolbar::
         button(
           :old_dialogs_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Dialog from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Dialog'),
+          N_('Remove Dialog'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Dialog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Dialog?"),
+          :confirm   => N_("Warning: This Dialog will be permanently removed from the Virtual Management Database!"),
           :klass     => ApplicationHelper::Button::OldDialogsEditDelete),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/miq_dialogs_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_dialogs_center.rb
@@ -31,11 +31,11 @@ class ApplicationHelper::Toolbar::MiqDialogsCenter < ApplicationHelper::Toolbar:
         button(
           :old_dialogs_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected Dialogs from the VMDB'),
+          t = N_('Remove selected Dialogs'),
           t,
           :klass     => ApplicationHelper::Button::OldDialogsEditDelete,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Dialog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Dialogs?"),
+          :confirm   => N_("Warning: The selected Dialog will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/miq_report_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_center.rb
@@ -36,14 +36,14 @@ class ApplicationHelper::Toolbar::MiqReportCenter < ApplicationHelper::Toolbar::
           :url_parms => "main_div",
           :enabled   => false,
           :onwhen    => "1+",
-          :confirm   => N_("The selected Saved Reports will be permanently removed from the database. Are you sure you want to delete this saved Report?")),
+          :confirm   => N_("Warning: The selected Saved Reports will be permanently removed from the database!")),
         button(
           :miq_report_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Delete this Report from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("The selected Reports will be permanently removed from the database. Are you sure you want to delete this Report?")),
+          :confirm   => N_("Warning: The selected Reports will be permanently removed from the database!")),
         button(
           :miq_report_schedule_add,
           'fa fa-clock-o fa-lg',

--- a/app/helpers/application_helper/toolbar/miq_report_schedule_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_schedule_center.rb
@@ -14,10 +14,10 @@ class ApplicationHelper::Toolbar::MiqReportScheduleCenter < ApplicationHelper::T
         button(
           :miq_report_schedule_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Delete this Schedule from the VMDB'),
+          t = N_('Delete this Schedule'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Schedule and ALL of its components will be permanently removed from the VMDB.  Are you sure you want to delete this Schedule?")),
+          :confirm   => N_("Warning: This Schedule and ALL of its components will be permanently removed!")),
         separator,
         button(
           :miq_report_schedule_run_now,

--- a/app/helpers/application_helper/toolbar/miq_report_schedules_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_report_schedules_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::MiqReportSchedulesCenter < ApplicationHelper::
         button(
           :miq_report_schedule_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Delete the selected Schedules from the VMDB'),
+          t = N_('Delete the selected Schedules'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Schedules and ALL of their components will be permanently removed from the VMDB.  Are you sure you want to delete the selected Schedules?"),
+          :confirm   => N_("Warning: The selected Schedules and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         button(

--- a/app/helpers/application_helper/toolbar/miq_schedule_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_schedule_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::MiqScheduleCenter < ApplicationHelper::Toolbar
           t = N_('Delete this Schedule from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Schedule and ALL of its components will be permanently removed from the VMDB.  Are you sure you want to delete this Schedule?")),
+          :confirm   => N_("Warning: This Schedule and ALL of its components will be permanently removed!")),
         separator,
         button(
           :schedule_run_now,

--- a/app/helpers/application_helper/toolbar/miq_schedules_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_schedules_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::MiqSchedulesCenter < ApplicationHelper::Toolba
         button(
           :schedule_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Delete the selected Schedules from the VMDB'),
+          t = N_('Delete the selected Schedules'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Schedules and ALL of their components will be permanently removed from the VMDB.  Are you sure you want to delete the selected Schedules?"),
+          :confirm   => N_("Warning: The selected Schedules and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         button(

--- a/app/helpers/application_helper/toolbar/miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_template_center.rb
@@ -33,10 +33,10 @@ class ApplicationHelper::Toolbar::MiqTemplateCenter < ApplicationHelper::Toolbar
         button(
           :miq_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Template from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Template'),
+          N_('Remove Template'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Template and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Template?")),
+          :confirm   => N_("Warning: This Template and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/miq_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_templates_center.rb
@@ -45,10 +45,10 @@ class ApplicationHelper::Toolbar::MiqTemplatesCenter < ApplicationHelper::Toolba
         button(
           :miq_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Templates from the VMDB'),
-          N_('Remove Templates from the VMDB'),
+          N_('Remove selected Templates'),
+          N_('Remove Templates'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Templates?"),
+          :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/miq_widget_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widget_center.rb
@@ -22,7 +22,7 @@ class ApplicationHelper::Toolbar::MiqWidgetCenter < ApplicationHelper::Toolbar::
           t = N_('Delete this Widget from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Widget and ALL of its components will be permanently removed from the VMDB.  Are you sure you want to delete this Widget?")),
+          :confirm   => N_("Warning: This Widget and ALL of its components will be permanently removed!")),
         separator,
         button(
           :widget_generate_content,

--- a/app/helpers/application_helper/toolbar/miq_widget_set_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_widget_set_center.rb
@@ -17,7 +17,7 @@ class ApplicationHelper::Toolbar::MiqWidgetSetCenter < ApplicationHelper::Toolba
           t = N_('Delete this Dashboard from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Dashboard and ALL of its components will be permanently removed from the VMDB.  Are you sure you want to delete this Dashboard?")),
+          :confirm   => N_("Warning: This Dashboard and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/openstack_vm_cloud_center.rb
@@ -33,10 +33,10 @@ class ApplicationHelper::Toolbar::OpenstackVmCloudCenter < ApplicationHelper::To
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Instance from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Instance'),
+          N_('Remove Instance'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Instance and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Instance?")),
+          :confirm   => N_("Warning: This Instance and ALL of its components will be permanently removed!")),
         button(
           :instance_evm_relationship,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/orchestration_stack_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stack_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::OrchestrationStackCenter < ApplicationHelper::
         button(
           :orchestration_stack_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Orchestration Stack from the VMDB'),
+          t = N_('Remove this Orchestration Stack'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Orchestration Stack and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Orchestration Stack?")),
+          :confirm   => N_("Warning: This Orchestration Stack and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
+++ b/app/helpers/application_helper/toolbar/orchestration_stacks_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::OrchestrationStacksCenter < ApplicationHelper:
         button(
           :orchestration_stack_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Orchestration Stacks from the VMDB'),
-          N_('Remove Orchestration Stacks from the VMDB'),
+          N_('Remove selected Orchestration Stacks'),
+          N_('Remove Orchestration Stacks'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Orchestration Stacks and ALL of their components will be permanently removed from the Virtual Management Database. Are you sure you want to remove the selected Orchestration Stacks?"),
+          :confirm   => N_("Warning: The selected Orchestration Stacks and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/persistent_volume_center.rb
+++ b/app/helpers/application_helper/toolbar/persistent_volume_center.rb
@@ -17,11 +17,11 @@ class ApplicationHelper::Toolbar::PersistentVolumeCenter < ApplicationHelper::To
         button(
           :persistent_volume_delete,
           nil,
-          t = N_('Remove this Volume from the VMDB'),
+          t = N_('Remove this Volume'),
           t,
           :image     => "delete",
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Volume and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Volume?")),
+          :confirm   => N_("Warning: This Volume and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/persistent_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/persistent_volumes_center.rb
@@ -25,11 +25,11 @@ class ApplicationHelper::Toolbar::PersistentVolumesCenter < ApplicationHelper::T
         button(
           :persistent_volume_delete,
           nil,
-          N_('Remove selected Volumes from the VMDB'),
-          N_('Remove Volumes from the VMDB'),
+          N_('Remove selected Volumes'),
+          N_('Remove Volumes'),
           :image     => "remove",
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Volumes and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Volumes?"),
+          :confirm   => N_("Warning: The selected Volumes and ALL of their components will be permanently removed!"),
           :onwhen    => "1+"),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/provider_foreman_center.rb
+++ b/app/helpers/application_helper/toolbar/provider_foreman_center.rb
@@ -37,11 +37,11 @@ class ApplicationHelper::Toolbar::ProviderForemanCenter < ApplicationHelper::Too
         button(
           :provider_foreman_delete_provider,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items from the VMDB'),
+          t = N_('Remove selected items'),
           t,
           :url       => "delete",
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/pxe_image_type_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_image_type_center.rb
@@ -14,10 +14,10 @@ class ApplicationHelper::Toolbar::PxeImageTypeCenter < ApplicationHelper::Toolba
         button(
           :pxe_image_type_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this System Image Type from the VMDB'),
+          t = N_('Remove this System Image Type'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This System Image Type will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this System Image Type?")),
+          :confirm   => N_("Warning: This System Image Type will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/pxe_image_types_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_image_types_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::PxeImageTypesCenter < ApplicationHelper::Toolb
         button(
           :pxe_image_type_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected System Image Types from the VMDB'),
-          N_('Remove System Image Types from the VMDB'),
+          N_('Remove selected System Image Types'),
+          N_('Remove System Image Types'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected System Image Types will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected System Image Types?"),
+          :confirm   => N_("Warning: The selected System Image Types will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/pxe_server_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_server_center.rb
@@ -14,10 +14,10 @@ class ApplicationHelper::Toolbar::PxeServerCenter < ApplicationHelper::Toolbar::
         button(
           :pxe_server_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this PXE Server from the VMDB'),
+          t = N_('Remove this PXE Server'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This PXE Server and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this PXE Server?")),
+          :confirm   => N_("Warning: This PXE Server and ALL of its components will be permanently removed!")),
         separator,
         button(
           :pxe_server_refresh,

--- a/app/helpers/application_helper/toolbar/pxe_servers_center.rb
+++ b/app/helpers/application_helper/toolbar/pxe_servers_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::PxeServersCenter < ApplicationHelper::Toolbar:
         button(
           :pxe_server_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected PXE Servers from the VMDB'),
-          N_('Remove PXE Servers from the VMDB'),
+          N_('Remove selected PXE Servers'),
+          N_('Remove PXE Servers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected PXE Servers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected PXE Servers?"),
+          :confirm   => N_("Warning: The selected PXE Servers and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/resource_pool_center.rb
+++ b/app/helpers/application_helper/toolbar/resource_pool_center.rb
@@ -9,10 +9,10 @@ class ApplicationHelper::Toolbar::ResourcePoolCenter < ApplicationHelper::Toolba
         button(
           :resource_pool_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Resource Pool from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Resource Pool'),
+          N_('Remove Resource Pool'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Resource Pool and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Resource Pool?")),
+          :confirm   => N_("Warning: This Resource Pool and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/resource_pools_center.rb
+++ b/app/helpers/application_helper/toolbar/resource_pools_center.rb
@@ -11,10 +11,10 @@ class ApplicationHelper::Toolbar::ResourcePoolsCenter < ApplicationHelper::Toolb
         button(
           :resource_pool_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Resource Pools from the VMDB'),
-          N_('Remove Resource Pools from the VMDB'),
+          N_('Remove selected Resource Pools'),
+          N_('Remove Resource Pools'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Resource Pools and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Resource Pools?"),
+          :confirm   => N_("Warning: The selected Resource Pools and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/saved_report_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_report_center.rb
@@ -20,7 +20,7 @@ class ApplicationHelper::Toolbar::SavedReportCenter < ApplicationHelper::Toolbar
           t = N_('Delete this Saved Report from the Database'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Saved Report and ALL of its components will be permanently removed from the VMDB.  Are you sure you want to delete this Saved Report?")),
+          :confirm   => N_("Warning: This Saved Report and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/saved_reports_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_reports_center.rb
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::SavedReportsCenter < ApplicationHelper::Toolba
           t = N_('Delete selected Saved Reports'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("The selected Saved Reports will be permanently removed from the database. Are you sure you want to delete the selected Saved Reports?"),
+          :confirm   => N_("Warning: The selected Saved Reports will be permanently removed from the database!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/scan_profile_center.rb
+++ b/app/helpers/application_helper/toolbar/scan_profile_center.rb
@@ -20,10 +20,10 @@ class ApplicationHelper::Toolbar::ScanProfileCenter < ApplicationHelper::Toolbar
         button(
           :ap_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Delete this Analysis Profile from the VMDB'),
+          t = N_('Delete this Analysis Profile'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Analysis Profile and ALL of its components will be permanently removed from the VMDB.  Are you sure you want to delete this Analysis Profile?")),
+          :confirm   => N_("Warning: This Analysis Profile and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/scan_profiles_center.rb
+++ b/app/helpers/application_helper/toolbar/scan_profiles_center.rb
@@ -35,10 +35,10 @@ class ApplicationHelper::Toolbar::ScanProfilesCenter < ApplicationHelper::Toolba
         button(
           :ap_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Delete the selected Analysis Profiles from the VMDB'),
+          t = N_('Delete the selected Analysis Profiles'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Analysis Profiles and ALL of their components will be permanently removed from the VMDB.  Are you sure you want to delete the selected Analysis Profiles?"),
+          :confirm   => N_("Warning: The selected Analysis Profiles and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/service_center.rb
+++ b/app/helpers/application_helper/toolbar/service_center.rb
@@ -15,10 +15,10 @@ class ApplicationHelper::Toolbar::ServiceCenter < ApplicationHelper::Toolbar::Ba
         button(
           :service_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Service from the VMDB'),
-          N_('Remove Service from the VMDB'),
+          N_('Remove this Service'),
+          N_('Remove Service'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Service and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Service?")),
+          :confirm   => N_("Warning: This Service and ALL of their components will be permanently removed!")),
         separator,
         button(
           :service_ownership,

--- a/app/helpers/application_helper/toolbar/services_center.rb
+++ b/app/helpers/application_helper/toolbar/services_center.rb
@@ -19,10 +19,10 @@ class ApplicationHelper::Toolbar::ServicesCenter < ApplicationHelper::Toolbar::B
         button(
           :service_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Services from the VMDB'),
-          N_('Remove Services from the VMDB'),
+          N_('Remove selected Services'),
+          N_('Remove Services'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Services?"),
+          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -29,7 +29,7 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
           N_('Remove this Catalog Item'),
           N_('Remove Catalog Item'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Catalog Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog Item?")),
+          :confirm   => N_("Warning: This Catalog Items and ALL of their components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb
@@ -19,7 +19,7 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogCenter < ApplicationHelp
           N_('Remove this Catalog'),
           N_('Remove Catalog'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: This Catalog will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Catalog?")),
+          :confirm   => N_("Warning: This Catalog will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
@@ -25,7 +25,7 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogsCenter < ApplicationHel
           N_('Remove selected Catalog Items'),
           N_('Remove Catalog Items'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Items will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
+          :confirm   => N_("Warning: The selected Items will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/servicetemplates_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplates_center.rb
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::ServicetemplatesCenter < ApplicationHelper::To
           N_('Remove selected Catalog Items'),
           N_('Remove Catalog Items'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Items?"),
+          :confirm   => N_("Warning: The selected Items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/storage_center.rb
+++ b/app/helpers/application_helper/toolbar/storage_center.rb
@@ -16,10 +16,10 @@ class ApplicationHelper::Toolbar::StorageCenter < ApplicationHelper::Toolbar::Ba
         button(
           :storage_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Datastore from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Datastore'),
+          N_('Remove Datastore'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Datastore and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Datastore?")),
+          :confirm   => N_("Warning: This Datastore and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/storage_manager_center.rb
+++ b/app/helpers/application_helper/toolbar/storage_manager_center.rb
@@ -28,10 +28,10 @@ class ApplicationHelper::Toolbar::StorageManagerCenter < ApplicationHelper::Tool
         button(
           :storage_manager_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove this Storage Manager from the VMDB'),
+          t = N_('Remove this Storage Manager'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Storage Manager and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Storage Manager?")),
+          :confirm   => N_("Warning: This Storage Manager and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/storage_managers_center.rb
+++ b/app/helpers/application_helper/toolbar/storage_managers_center.rb
@@ -42,10 +42,10 @@ class ApplicationHelper::Toolbar::StorageManagersCenter < ApplicationHelper::Too
         button(
           :storage_manager_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Storage Managers from the VMDB'),
-          N_('Remove Storage Managers from the VMDB'),
+          N_('Remove selected Storage Managers'),
+          N_('Remove Storage Managers'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Storage Managers and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Storage Managers?"),
+          :confirm   => N_("Warning: The selected Storage Managers and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/storages_center.rb
+++ b/app/helpers/application_helper/toolbar/storages_center.rb
@@ -20,10 +20,10 @@ class ApplicationHelper::Toolbar::StoragesCenter < ApplicationHelper::Toolbar::B
         button(
           :storage_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Datastores from the VMDB'),
-          N_('Remove Datastores from the VMDB'),
+          N_('Remove selected Datastores'),
+          N_('Remove Datastores'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Datastores and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Datastores?"),
+          :confirm   => N_("Warning: The selected Datastores and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/tasks_center.rb
+++ b/app/helpers/application_helper/toolbar/tasks_center.rb
@@ -18,10 +18,10 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
         button(
           :miq_task_delete,
           'pficon pficon-delete fa-lg',
-          N_('Delete selected tasks from the VMDB'),
+          N_('Delete selected tasks'),
           N_('Delete'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected tasks will be permanently removed from the database. Are you sure you want to delete the selected tasks?"),
+          :confirm   => N_("Warning: The selected tasks will be permanently removed from the database!"),
           :enabled   => false,
           :onwhen    => "1+"),
         button(
@@ -30,7 +30,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete tasks older than the selected task'),
           N_('Delete Older'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: Tasks that are older than selected task will be permanently removed from the database. Are you sure you want to delete older tasks?"),
+          :confirm   => N_("Warning: Tasks that are older than selected task will be permanently removed from the database!"),
           :enabled   => false,
           :onwhen    => "1"),
         button(
@@ -39,7 +39,7 @@ class ApplicationHelper::Toolbar::TasksCenter < ApplicationHelper::Toolbar::Basi
           N_('Delete all finished tasks'),
           N_('Delete All'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: Finished tasks will be permanently removed from the database. Are you sure you want to delete all finished tasks?"),
+          :confirm   => N_("Warning: Finished tasks will be permanently removed from the database!"),
           :enabled   => true),
       ]
     ),

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -54,10 +54,10 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
         button(
           :image_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items from the VMDB'),
+          t = N_('Remove selected items'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -54,10 +54,10 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
         button(
           :miq_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Templates from the VMDB'),
-          N_('Remove Templates from the VMDB'),
+          N_('Remove selected Templates'),
+          N_('Remove Templates'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected Templates?"),
+          :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/time_profiles_center.rb
+++ b/app/helpers/application_helper/toolbar/time_profiles_center.rb
@@ -34,7 +34,7 @@ class ApplicationHelper::Toolbar::TimeProfilesCenter < ApplicationHelper::Toolba
           t = N_('Delete selected Time Profiles'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Time Profiles will be permanently removed from the VMDB. Are you sure you want to delete the selected Time Profiles?"),
+          :confirm   => N_("Warning: The selected Time Profiles will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -56,10 +56,10 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items from the VMDB'),
+          t = N_('Remove selected items'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -64,10 +64,10 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
         button(
           :vm_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items from the VMDB'),
+          t = N_('Remove selected items'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/vms_center.rb
+++ b/app/helpers/application_helper/toolbar/vms_center.rb
@@ -45,10 +45,10 @@ class ApplicationHelper::Toolbar::VmsCenter < ApplicationHelper::Toolbar::Basic
         button(
           :vm_delete,
           'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items from the VMDB'),
+          t = N_('Remove selected items'),
           t,
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected items?"),
+          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
         separator,

--- a/app/helpers/application_helper/toolbar/x_miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/x_miq_template_center.rb
@@ -32,10 +32,10 @@ class ApplicationHelper::Toolbar::XMiqTemplateCenter < ApplicationHelper::Toolba
         button(
           :miq_template_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Template from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Template'),
+          N_('Remove Template'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Template and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Template?")),
+          :confirm   => N_("Warning: This Template and ALL of its components will be permanently removed!")),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -32,10 +32,10 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
         button(
           :image_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Image from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Image'),
+          N_('Remove Image'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Image and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Image?")),
+          :confirm   => N_("Warning: This Image and ALL of its components will be permanently removed!")),
         separator,
         button(
           :image_right_size,

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -40,10 +40,10 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
         button(
           :vm_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this VM from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Virtual machine'),
+          N_('Remove Virtual Machine'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This VM and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this VM?")),
+          :confirm   => N_("Warning: This Virtual Machine and ALL of its components will be permanently removed!")),
         button(
           :vm_evm_relationship,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -34,10 +34,10 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
         button(
           :instance_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove this Instance from the VMDB'),
-          N_('Remove from the VMDB'),
+          N_('Remove this Instance'),
+          N_('Remove Instance'),
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Instance and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this Instance?")),
+          :confirm   => N_("Warning: This Instance and ALL of its components will be permanently removed!")),
         button(
           :instance_evm_relationship,
           'pficon pficon-edit fa-lg',

--- a/config/yaml_strings.rb
+++ b/config/yaml_strings.rb
@@ -156,7 +156,7 @@ _("Modify Catalog Items")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Remove Catalog Item")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Catalog Items from the VMDB")
+_("Remove Catalog Items")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit Composite Catalog Item")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -199,7 +199,7 @@ _("Modify Catalog")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Remove Catalog")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Catalog from the VMDB")
+_("Remove Catalog")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit Catalog")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -254,7 +254,7 @@ _("Edit Services")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Remove Services")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Services from the VMDB")
+_("Remove Services")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Set Ownership")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -313,7 +313,7 @@ _("Modify Cloud Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Remove")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Cloud Providers from the VMDB")
+_("Remove Cloud Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Cloud Provider")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -413,7 +413,7 @@ _("Detach")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Detach a Volume")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Volumes from the VMDB")
+_("Remove Volumes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Auth Key Pairs")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -491,7 +491,7 @@ _("Re-check Authentication Status of Infrastructure Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Infrastructure Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Infrastructure Providers from the VMDB")
+_("Remove Infrastructure Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit an Infrastructure Provider")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -552,7 +552,7 @@ _("Edit Tags for Clusters / Deployment Roles")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Clusters / Deployment Roles")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Clusters / Deployment Roles from the VMDB")
+_("Remove Clusters / Deployment Roles")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Hosts / Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -632,7 +632,7 @@ _("Modify Hosts / Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Add a Host / Node")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Hosts / Nodes from the VMDB")
+_("Remove Hosts / Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Host / Node")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -657,7 +657,7 @@ _("Manage Policies of Resource Pools")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Resource Pools")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Resource Pools from the VMDB")
+_("Remove Resource Pools")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 # TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
 # TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
@@ -686,7 +686,7 @@ _("Edit Datastore Tags")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Datastores")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Datastores from the VMDB")
+_("Remove Datastores")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Datastore Clusters")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -704,7 +704,7 @@ _("Edit Datastore Cluster Tags")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Datastore Clusters")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Datastore Clusters from the VMDB")
+_("Remove Datastore Clusters")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Dashboard")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1581,7 +1581,7 @@ _("Modify Storage Managers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Add an Storage Manager")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Storage Managers from the VMDB")
+_("Remove Storage Managers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit an Storage Manager")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1604,7 +1604,7 @@ _("Modify PXE Servers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Add an PXE Server")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove PXE Servers from the VMDB")
+_("Remove PXE Servers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit an PXE Server")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1627,7 +1627,7 @@ _("Modify Customization Templates")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Add an Customization Template")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Customization Templates from the VMDB")
+_("Remove Customization Templates")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit Customization Template")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1644,7 +1644,7 @@ _("Modify System Image Types")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Add System Image Types")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove System Image Types from the VMDB")
+_("Remove System Image Types")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit System Image Type")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1663,7 +1663,7 @@ _("Modify ISO Datastores")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Add an ISO Datastore")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove ISO Datastores from the VMDB")
+_("Remove ISO Datastores")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit ISO Images")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1689,7 +1689,7 @@ _("Display Individual Orchestration Stacks")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Orchestration Stacks")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Orchestration Stacks from the VMDB")
+_("Remove Orchestration Stacks")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit Orchestration Stack")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1735,7 +1735,7 @@ _("Container Deployment Create")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Containers Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Containers Providers from the VMDB")
+_("Remove Containers Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Containers Provider")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1763,7 +1763,7 @@ _("Edit Tags of Middleware Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Middleware Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Middleware Providers from the VMDB")
+_("Remove Middleware Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Middleware Provider")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1829,7 +1829,7 @@ _("Display Individual Middleware Deployments")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Middleware Deployments")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Middleware Deployments from the VMDB")
+_("Remove Middleware Deployments")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Middleware Deployment")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1861,7 +1861,7 @@ _("Show Capacity & Utilization data of Middleware DataSources")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Middleware Datasources")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Middleware Datasource from the VMDB")
+_("Remove Middleware Datasource")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Middleware Datasource")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -1896,7 +1896,7 @@ _("Refresh Network Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Network Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Network Providers from the VMDB")
+_("Remove Network Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Network Provider")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2012,7 +2012,7 @@ _("Show Capacity & Utilization data of Pods")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Pods")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Pods from the VMDB")
+_("Remove Pods")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Pod")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2038,7 +2038,7 @@ _("Display Timelines for Container Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Container Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Container Nodes from the VMDB")
+_("Remove Container Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Container Nodes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2063,7 +2063,7 @@ _("Show Capacity & Utilization data of Replicators")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Display Timelines for container Replicators")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Container Replicators from the VMDB")
+_("Remove Container Replicators")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Container Replicator")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2103,7 +2103,7 @@ _("Display Individual Container Image Registries")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Container Image Registries")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Container Image Registries from the VMDB")
+_("Remove Container Image Registries")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Container Image Registry")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2125,7 +2125,7 @@ _("Display Individual Persistent Volume")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Persistent Volumes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Persistent Volumes from the VMDB")
+_("Remove Persistent Volumes")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Persistent Volume")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2147,7 +2147,7 @@ _("Display Individual Container Build")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Container Build")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Container Build from the VMDB")
+_("Remove Container Build")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Container Build")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2175,7 +2175,7 @@ _("Show Capacity & Utilization data of Service")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Container Services")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Container Services from the VMDB")
+_("Remove Container Services")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Container Services")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2235,7 +2235,7 @@ _("Modify Containers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Remove Container")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Containers from the VMDB")
+_("Remove Containers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit Container")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2281,7 +2281,7 @@ _("Modify Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Remove Providers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Proviers from the VMDB")
+_("Remove Proviers")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit Provider")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2404,7 +2404,7 @@ _("Provision Instances")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Request to Provision Instances")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Instances from the VMDB")
+_("Remove Instances")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Instance")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
@@ -2444,7 +2444,7 @@ _("Edit Image Tags")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Modify Images")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
-_("Remove Images from the VMDB")
+_("Remove Images")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml
 _("Edit a Image")
 # TRANSLATORS: file: db/fixtures/miq_product_features.yml

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -149,7 +149,7 @@
       :identifier: catalogitem_admin
       :children:
       - :name: Remove Catalog Item
-        :description: Remove Catalog Items from the VMDB
+        :description: Remove Catalog Items
         :feature_type: admin
         :identifier: catalogitem_delete
       - :name: Edit Composite Catalog Item
@@ -206,7 +206,7 @@
       :identifier: st_catalog_admin
       :children:
       - :name: Remove Catalog
-        :description: Remove Catalog from the VMDB
+        :description: Remove Catalog
         :feature_type: admin
         :identifier: st_catalog_delete
       - :name: Edit Catalog
@@ -291,7 +291,7 @@
         :feature_type: admin
         :identifier: service_edit
       - :name: Remove Services
-        :description: Remove Services from the VMDB
+        :description: Remove Services
         :feature_type: admin
         :identifier: service_delete
       - :name: Set Ownership
@@ -374,7 +374,7 @@
     :identifier: ems_cloud_admin
     :children:
     - :name: Remove
-      :description: Remove Cloud Providers from the VMDB
+      :description: Remove Cloud Providers
       :feature_type: admin
       :identifier: ems_cloud_delete
     - :name: Edit
@@ -568,7 +568,7 @@
       :feature_type: admin
       :identifier: cloud_volume_detach
     - :name: Remove
-      :description: Remove Volumes from the VMDB
+      :description: Remove Volumes
       :feature_type: admin
       :identifier: cloud_volume_delete
 
@@ -726,7 +726,7 @@
     :identifier: ems_infra_admin
     :children:
     - :name: Remove
-      :description: Remove Infrastructure Providers from the VMDB
+      :description: Remove Infrastructure Providers
       :feature_type: admin
       :identifier: ems_infra_delete
     - :name: Edit
@@ -824,7 +824,7 @@
     :identifier: ems_cluster_admin
     :children:
     - :name: Remove
-      :description: Remove Clusters / Deployment Roles from the VMDB
+      :description: Remove Clusters / Deployment Roles
       :feature_type: admin
       :identifier: ems_cluster_delete
 
@@ -945,7 +945,7 @@
       :feature_type: admin
       :identifier: host_new
     - :name: Remove
-      :description: Remove Hosts / Nodes from the VMDB
+      :description: Remove Hosts / Nodes
       :feature_type: admin
       :identifier: host_delete
     - :name: Edit
@@ -995,7 +995,7 @@
     :identifier: resource_pool_admin
     :children:
     - :name: Remove
-      :description: Remove Resource Pools from the VMDB
+      :description: Remove Resource Pools
       :feature_type: admin
       :identifier: resource_pool_delete
 
@@ -1041,7 +1041,7 @@
     :identifier: storage_admin
     :children:
     - :name: Remove
-      :description: Remove Datastores from the VMDB
+      :description: Remove Datastores
       :feature_type: admin
       :identifier: storage_delete
 
@@ -1079,7 +1079,7 @@
     :identifier: storage_pod_admin
     :children:
     - :name: Remove
-      :description: Remove Datastore Clusters from the VMDB
+      :description: Remove Datastore Clusters
       :feature_type: admin
       :identifier: storage_pod_delete
 
@@ -2960,7 +2960,7 @@
       :feature_type: admin
       :identifier: storage_manager_new
     - :name: Remove
-      :description: Remove Storage Managers from the VMDB
+      :description: Remove Storage Managers
       :feature_type: admin
       :identifier: storage_manager_delete
     - :name: Edit
@@ -3003,7 +3003,7 @@
         :feature_type: admin
         :identifier: pxe_server_new
       - :name: Remove
-        :description: Remove PXE Servers from the VMDB
+        :description: Remove PXE Servers
         :feature_type: admin
         :identifier: pxe_server_delete
       - :name: Edit
@@ -3038,7 +3038,7 @@
         :feature_type: admin
         :identifier: customization_template_new
       - :name: Remove
-        :description: Remove Customization Templates from the VMDB
+        :description: Remove Customization Templates
         :feature_type: admin
         :identifier: customization_template_delete
       - :name: Edit
@@ -3069,7 +3069,7 @@
         :feature_type: admin
         :identifier: pxe_image_type_new
       - :name: Remove
-        :description: Remove System Image Types from the VMDB
+        :description: Remove System Image Types
         :feature_type: admin
         :identifier: pxe_image_type_delete
       - :name: Edit
@@ -3105,7 +3105,7 @@
         :feature_type: admin
         :identifier: iso_datastore_new
       - :name: Remove
-        :description: Remove ISO Datastores from the VMDB
+        :description: Remove ISO Datastores
         :feature_type: admin
         :identifier: iso_datastore_delete
       - :name: Edit ISO Images
@@ -3161,7 +3161,7 @@
     :identifier: orchestration_stack_admin
     :children:
     - :name: Remove
-      :description: Remove Orchestration Stacks from the VMDB
+      :description: Remove Orchestration Stack
       :feature_type: admin
       :identifier: orchestration_stack_delete
     - :name: Edit
@@ -3264,7 +3264,7 @@
     :identifier: ems_container_admin
     :children:
     - :name: Remove
-      :description: Remove Containers Providers from the VMDB
+      :description: Remove Containers Provider
       :feature_type: admin
       :identifier: ems_container_delete
     - :name: Edit
@@ -3322,7 +3322,8 @@
     :identifier: ems_middleware_admin
     :children:
     - :name: Remove
-      :description: Remove Middleware Providers from the VMDB
+      :description: Remove Middleware Provider720709
+      
       :feature_type: admin
       :identifier: ems_middleware_delete
     - :name: Edit
@@ -3435,7 +3436,7 @@
     :identifier: middleware_deployment_admin
     :children:
     - :name: Remove
-      :description: Remove Middleware Deployments from the VMDB
+      :description: Remove Middleware Deployment
       :feature_type: admin
       :identifier: middleware_deployment_delete
     - :name: Edit
@@ -3501,7 +3502,7 @@
     :identifier: middleware_datasource_admin
     :children:
     - :name: Remove
-      :description: Remove Middleware Datasource from the VMDB
+      :description: Remove Middleware Datasource
       :feature_type: admin
       :identifier: middleware_datasource_remove
     - :name: Edit
@@ -3572,7 +3573,7 @@
     :identifier: ems_network_admin
     :children:
     - :name: Remove
-      :description: Remove Network Providers from the VMDB
+      :description: Remove Network Provider
       :feature_type: admin
       :identifier: ems_network_delete
     - :name: Edit
@@ -3802,7 +3803,7 @@
     :identifier: container_group_admin
     :children:
     - :name: Remove
-      :description: Remove Pods from the VMDB
+      :description: Remove Pod
       :feature_type: admin
       :identifier: container_group_delete
     - :name: Edit
@@ -3864,7 +3865,7 @@
     :identifier: container_node_admin
     :children:
     - :name: Remove
-      :description: Remove Container Nodes from the VMDB
+      :description: Remove Container Nodes
       :feature_type: admin
       :identifier: container_node_delete
     - :name: Edit
@@ -3926,7 +3927,7 @@
     :identifier: container_replicator_admin
     :children:
     - :name: Remove
-      :description: Remove Container Replicators from the VMDB
+      :description: Remove Container Replicator
       :feature_type: admin
       :identifier: container_replicator_delete
     - :name: Edit
@@ -4022,7 +4023,7 @@
     :identifier: container_image_registry_admin
     :children:
     - :name: Remove
-      :description: Remove Container Image Registries from the VMDB
+      :description: Remove Container Image Registry
       :feature_type: admin
       :identifier: container_image_registry_delete
     - :name: Edit
@@ -4068,7 +4069,7 @@
     :identifier: persistent_volume_admin
     :children:
     - :name: Remove
-      :description: Remove Persistent Volumes from the VMDB
+      :description: Remove Persistent Volume
       :feature_type: admin
       :identifier: persistent_volume_delete
     - :name: Edit
@@ -4114,7 +4115,7 @@
     :identifier: container_build_admin
     :children:
     - :name: Remove
-      :description: Remove Container Build from the VMDB
+      :description: Remove Container Build
       :feature_type: admin
       :identifier: container_build_delete
     - :name: Edit
@@ -4164,7 +4165,7 @@
     :identifier: container_service_admin
     :children:
     - :name: Remove
-      :description: Remove Container Services from the VMDB
+      :description: Remove Container Services
       :feature_type: admin
       :identifier: container_service_delete
     - :name: Edit
@@ -4290,7 +4291,7 @@
       :identifier: container_admin
       :children:
       - :name: Remove Container
-        :description: Remove Containers from the VMDB
+        :description: Remove Container
         :feature_type: admin
         :identifier: container_delete
       - :name: Edit Container
@@ -4375,7 +4376,7 @@
       :identifier: provider_admin
       :children:
         - :name: Remove Providers
-          :description: Remove Proviers from the VMDB
+          :description: Remove Provier
           :feature_type: admin
           :identifier: provider_foreman_delete_provider
         - :name: Edit Provider
@@ -4455,7 +4456,7 @@
     :identifier: configuration_job_admin
     :children:
     - :name: Remove
-      :description: Remove Configuration Jobs from the VMDB
+      :description: Remove Configuration Job
       :feature_type: admin
       :identifier: configuration_job_delete
     - :name: Edit
@@ -4623,7 +4624,7 @@
         :feature_type: admin
         :identifier: instance_miq_request_new
       - :name: Remove
-        :description: Remove Instances from the VMDB
+        :description: Remove Instance
         :feature_type: admin
         :identifier: instance_delete
       - :name: Edit
@@ -4709,7 +4710,7 @@
       :identifier: image_admin
       :children:
       - :name: Remove
-        :description: Remove Images from the VMDB
+        :description: Remove Image
         :feature_type: admin
         :identifier: image_delete
       - :name: Edit
@@ -4868,7 +4869,7 @@
         :feature_type: admin
         :identifier: vm_migrate
       - :name: Remove
-        :description: Remove VMs from the VMDB
+        :description: Remove VM
         :feature_type: admin
         :identifier: vm_delete
       - :name: Edit


### PR DESCRIPTION
This pull request removes the variations of "from the VMDB" from different items and removal messages.  With this change it matches the format of the create and modify actions.

There is no advantage of using the term "VMDB" as is not something that the user would necessarily know about and does not convey any additional information. 

In addition it shortens the dialog warning message and should fix about 80 rubocop warnings.

https://bugzilla.redhat.com/show_bug.cgi?id=1354044