### PR TITLE
New #stub_user controller macro

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ GlobalVars:
 # Special Exclusions
 #
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
     - db/schema.rb

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -1,7 +1,7 @@
 describe MiqAeCustomizationController, "ApplicationController::Automate" do
   context "#resolve" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       @custom_button = FactoryGirl.create(:custom_button, :applies_to_class => "Host")
       target_classes = {}
       CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
@@ -32,7 +32,7 @@ describe MiqAeToolsController, "ApplicationController::Automate" do
     let(:custom_button) { FactoryGirl.create(:custom_button, :applies_to_class => "Host") }
     let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
     end
 
     def resolve_hash(button)

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -243,7 +243,7 @@ end
 describe HostController do
   context "#show_association" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       @host = FactoryGirl.create(:host)
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -108,7 +108,7 @@ describe ApplicationController do
     it "sets Processors details successfully" do
       host_hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
       host = FactoryGirl.create(:host, :hardware => host_hardware)
-      set_user_privileges
+      stub_user(:features => :all)
 
       controller.send(:set_config, host)
       expect(response.status).to eq(200)
@@ -119,7 +119,7 @@ describe ApplicationController do
       disk = FactoryGirl.create(:disk, :filename => nil, :controller_type => nil, :device_type => 'disk', :mode => "foo")
       host_hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8, :disks => [disk])
       host = FactoryGirl.create(:host, :hardware => host_hardware)
-      set_user_privileges
+      stub_user(:features => :all)
 
       controller.send(:set_config, host)
       expect(response.status).to eq(200)
@@ -130,7 +130,7 @@ describe ApplicationController do
       disk = FactoryGirl.create(:disk, :controller_type => nil)
       host_hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8, :disks => [disk])
       host = FactoryGirl.create(:host, :hardware => host_hardware)
-      set_user_privileges
+      stub_user(:features => :all)
 
       controller.send(:set_config, host)
       expect(response.status).to eq(200)

--- a/spec/controllers/auth_key_pair_cloud_controller_spec.rb
+++ b/spec/controllers/auth_key_pair_cloud_controller_spec.rb
@@ -1,17 +1,16 @@
 describe AuthKeyPairCloudController do
   context "#button" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
     end
   end
 
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @kp = FactoryGirl.create(:auth_key_pair_cloud, :name => "auth-key-pair-cloud-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@kp).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -13,7 +13,7 @@ describe CatalogController do
   end
 
   before(:each) do
-    set_user_privileges user
+    stub_user(:features => :all)
     controller.instance_variable_set(:@settings, {})
     allow_any_instance_of(ApplicationController).to receive(:fetch_path)
   end

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -1,5 +1,5 @@
 describe ChargebackController do
-  before { set_user_privileges }
+  before { stub_user(:features => :all) }
 
   context "returns current rate assignments or set them to blank if category/tag is deleted" do
     let(:category) { FactoryGirl.create(:classification) }

--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe CloudNetworkController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/cloud_object_store_container_spec.rb
+++ b/spec/controllers/cloud_object_store_container_spec.rb
@@ -1,10 +1,9 @@
 describe CloudObjectStoreContainerController do
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @container = FactoryGirl.create(:cloud_object_store_container, :name => "cloud-object-store-container-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@container).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/cloud_object_store_object_spec.rb
+++ b/spec/controllers/cloud_object_store_object_spec.rb
@@ -1,10 +1,9 @@
 describe CloudObjectStoreObjectController do
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @object = FactoryGirl.create(:cloud_object_store_object, :name => "cloud-object-store-container-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@object).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe CloudSubnetController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -1,7 +1,7 @@
 describe CloudTenantController do
   context "#button" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
 
       ApplicationController.handle_exceptions = true
@@ -21,11 +21,10 @@ describe CloudTenantController do
   end
 
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @ct = FactoryGirl.create(:cloud_tenant, :name => "cloud-tenant-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/cloud_volume_snapshot_controller_spec.rb
+++ b/spec/controllers/cloud_volume_snapshot_controller_spec.rb
@@ -1,10 +1,9 @@
 describe CloudVolumeSnapshotController do
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @snapshot = FactoryGirl.create(:cloud_volume_snapshot, :name => "cloud-volume-snapshot-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@snapshot).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -1,10 +1,9 @@
 include CompressedIds
 
 describe ConfigurationJobController do
-  let(:user) { FactoryGirl.create(:user_with_group) }
+  let!(:user) { stub_user(:features => :all) }
 
   before(:each) do
-    set_user_privileges user
     EvmSpecHelper.create_guid_miq_server_zone
   end
 
@@ -28,11 +27,10 @@ describe ConfigurationJobController do
   end
 
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @cj = FactoryGirl.create(:ansible_tower_job, :name => "testJob")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@cj).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/container_build_controller_spec.rb
+++ b/spec/controllers/container_build_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe ContainerBuildController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_controller_spec.rb
+++ b/spec/controllers/container_controller_spec.rb
@@ -3,17 +3,16 @@ describe ContainerController do
     server = EvmSpecHelper.local_miq_server
     allow(MiqServer).to receive(:my_server).and_return(server)
     allow(MiqServer).to receive(:my_zone).and_return("default")
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   render_views
 
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @ct = FactoryGirl.create(:container, :name => "container-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
 

--- a/spec/controllers/container_dashboard_controller_spec.rb
+++ b/spec/controllers/container_dashboard_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerDashboardController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_group_controller_spec.rb
+++ b/spec/controllers/container_group_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerGroupController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerImageController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "when Smart Analysis is pressed" do

--- a/spec/controllers/container_image_registry_controller_spec.rb
+++ b/spec/controllers/container_image_registry_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerImageRegistryController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_node_controller_spec.rb
+++ b/spec/controllers/container_node_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerNodeController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_project_controller_spec.rb
+++ b/spec/controllers/container_project_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerProjectController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_replicator_controller_spec.rb
+++ b/spec/controllers/container_replicator_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerReplicatorController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_route_controller_spec.rb
+++ b/spec/controllers/container_route_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerRouteController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_service_controller_spec.rb
+++ b/spec/controllers/container_service_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerServiceController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/container_topology_controller_spec.rb
+++ b/spec/controllers/container_topology_controller_spec.rb
@@ -1,7 +1,7 @@
 describe ContainerTopologyController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -34,7 +34,7 @@ describe EmsCloudController do
 
     context "#new" do
       before do
-        set_user_privileges
+        stub_user(:features => :all)
         allow(controller).to receive(:drop_breadcrumb)
       end
 
@@ -53,7 +53,7 @@ describe EmsCloudController do
 
     context "#form_field_changed" do
       before :each do
-        set_user_privileges
+        stub_user(:features => :all)
       end
 
       it "form_div should be updated when server type is sent up" do
@@ -74,7 +74,7 @@ describe EmsCloudController do
     context "#set_record_vars" do
       context "strip leading/trailing whitespace from hostname/ipaddress" do
         after :each do
-          set_user_privileges
+          stub_user(:features => :all)
           controller.instance_variable_set(:@edit, :new => {:name     => 'EMS 1',
                                                             :emstype  => @type,
                                                             :hostname => '  10.10.10.10  ',
@@ -127,7 +127,7 @@ describe EmsCloudController do
 
     context "#button" do
       before(:each) do
-        set_user_privileges
+        stub_user(:features => :all)
         EvmSpecHelper.create_guid_miq_server_zone
       end
 
@@ -152,7 +152,7 @@ describe EmsCloudController do
 
     context "download pdf file" do
       before :each do
-        set_user_privileges
+        stub_user(:features => :all)
         allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
         get :show, :id => ems_openstack.id, :display => "download_pdf"
       end
@@ -180,7 +180,7 @@ describe EmsContainerController do
     context "#update" do
       context "updates provider with new token" do
         after :each do
-          set_user_privileges
+          stub_user(:features => :all)
           controller.instance_variable_set(:@_params, :name              => 'EMS 2',
                                                       :default_hostname  => '10.10.10.11',
                                                       :default_api_port  => '5000',
@@ -212,7 +212,7 @@ describe EmsContainerController do
 
     context "#button" do
       before(:each) do
-        set_user_privileges
+        stub_user(:features => :all)
         EvmSpecHelper.create_guid_miq_server_zone
       end
 
@@ -248,7 +248,7 @@ describe EmsContainerController do
 
       context "download pdf file" do
         before :each do
-          set_user_privileges
+          stub_user(:features => :all)
           allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
           get :show, :id => ems_kubernetes_container.id, :display => "download_pdf"
         end
@@ -297,7 +297,7 @@ describe EmsInfraController do
 
     context "download pdf file" do
       before :each do
-        set_user_privileges
+        stub_user(:features => :all)
         allow(PdfGenerator).to receive(:pdf_from_string).with('', 'pdf_summary').and_return("")
         get :show, :id => ems_openstack_infra.id, :display => "download_pdf"
       end

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -1,6 +1,6 @@
 describe EmsContainerController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "#new" do

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -5,7 +5,7 @@ describe EmsInfraController do
   let(:zone) { FactoryGirl.build(:zone) }
   context "#button" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
 
       ApplicationController.handle_exceptions = true
@@ -97,7 +97,7 @@ describe EmsInfraController do
 
   describe "#scaling" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       @ems = FactoryGirl.create(:ems_openstack_infra_with_stack)
       @orchestration_stack_parameter_compute = FactoryGirl.create(:orchestration_stack_parameter_openstack_infra_compute)
 
@@ -167,7 +167,7 @@ describe EmsInfraController do
 
   describe "#scaledown" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       @ems = FactoryGirl.create(:ems_openstack_infra_with_stack_and_compute_nodes)
 
       allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack)
@@ -274,7 +274,7 @@ describe EmsInfraController do
     end
 
     it " can tag associated datastores" do
-      set_user_privileges
+      stub_user(:features => :all)
       datastore = FactoryGirl.create(:storage, :name => 'storage_name')
       datastore.parent = @ems
       controller.instance_variable_set(:@_orig_action, "x_history")
@@ -292,7 +292,7 @@ describe EmsInfraController do
 
   describe "#show_list" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       FactoryGirl.create(:ems_vmware)
       get :show_list
     end
@@ -304,7 +304,7 @@ describe EmsInfraController do
     render_views
     context "#form_field_changed" do
       before do
-        set_user_privileges
+        stub_user(:features => :all)
         EvmSpecHelper.create_guid_miq_server_zone
       end
 
@@ -329,7 +329,7 @@ describe EmsInfraController do
 
   describe "breadcrumbs path on a 'show' page of an Infrastructure Provider accessed from Dashboard maintab" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
     end
     context "when previous breadcrumbs path contained 'Cloud Providers'" do

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -1,6 +1,6 @@
 describe EmsMiddlewareController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "#new" do

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe EmsNetworkController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe FloatingIpController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -3,7 +3,7 @@ describe HostController do
     render_views
 
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
 
       ApplicationController.handle_exceptions = true
@@ -85,7 +85,7 @@ describe HostController do
 
   context "#create" do
     it "can create a host with custom id and no host name" do
-      set_user_privileges
+      stub_user(:features => :all)
       controller.instance_variable_set(:@breadcrumbs, [])
 
       controller.instance_variable_set(:@_params,
@@ -103,7 +103,7 @@ describe HostController do
     end
 
     it "doesn't crash when trying to validate a new host" do
-      set_user_privileges
+      stub_user(:features => :all)
       controller.instance_variable_set(:@breadcrumbs, [])
       controller.new
 
@@ -126,7 +126,7 @@ describe HostController do
 
   context "#set_record_vars" do
     it "strips leading/trailing whitespace from hostname/ipaddress when adding infra host" do
-      set_user_privileges
+      stub_user(:features => :all)
       controller.instance_variable_set(:@_params,
                                        :name     => 'EMS 2',
                                        :emstype  => 'rhevm',
@@ -140,7 +140,7 @@ describe HostController do
 
   context "#show_association" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       @host = FactoryGirl.create(:host, :name =>'hostname1')
       @guest_application = FactoryGirl.create(:guest_application, :name => "foo", :host_id => @host.id)
       @datastore = FactoryGirl.create(:storage, :name => 'storage_name')
@@ -265,7 +265,7 @@ describe HostController do
   context "#render pages" do
     render_views
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
     end
     it "renders a new page with ng-required condition set to false for password" do

--- a/spec/controllers/middleware_datasource_controller_spec.rb
+++ b/spec/controllers/middleware_datasource_controller_spec.rb
@@ -1,7 +1,7 @@
 describe MiddlewareDatasourceController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it 'renders index' do

--- a/spec/controllers/middleware_topology_controller_spec.rb
+++ b/spec/controllers/middleware_topology_controller_spec.rb
@@ -1,7 +1,7 @@
 describe MiddlewareTopologyController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -35,7 +35,7 @@ describe MiqAeClassController do
 
   context "#domain_lock" do
     it "Marks domain as locked/readonly" do
-      set_user_privileges
+      stub_user(:features => :all)
       ns = FactoryGirl.create(:miq_ae_domain_enabled)
       controller.instance_variable_set(:@_params, :id => ns.id)
       allow(controller).to receive(:replace_right_cell)
@@ -47,7 +47,7 @@ describe MiqAeClassController do
 
   context "#domain_unlock" do
     it "Marks domain as unlocked/editable" do
-      set_user_privileges
+      stub_user(:features => :all)
       ns = FactoryGirl.create(:miq_ae_domain_disabled)
       controller.instance_variable_set(:@_params, :id => ns.id)
       allow(controller).to receive(:replace_right_cell)
@@ -59,7 +59,7 @@ describe MiqAeClassController do
 
   context "#domains_priority_edit" do
     it "sets priority of domains" do
-      set_user_privileges
+      stub_user(:features => :all)
       FactoryGirl.create(:miq_ae_domain, :name => "test1", :parent => nil, :priority => 1)
       FactoryGirl.create(:miq_ae_domain, :name => "test2", :parent => nil, :priority => 2)
       FactoryGirl.create(:miq_ae_domain, :name => "test3", :parent => nil, :priority => 3)
@@ -84,7 +84,7 @@ describe MiqAeClassController do
 
   context "#copy_objects" do
     it "do not replace left side explorer tree when copy form is loaded initially" do
-      set_user_privileges
+      stub_user(:features => :all)
       d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
@@ -103,7 +103,7 @@ describe MiqAeClassController do
     end
 
     it "copies class under specified namespace" do
-      set_user_privileges
+      stub_user(:features => :all)
       d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
@@ -133,7 +133,7 @@ describe MiqAeClassController do
     end
 
     it "copy class under same namespace returns error when class exists" do
-      set_user_privileges
+      stub_user(:features => :all)
       d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
@@ -160,7 +160,7 @@ describe MiqAeClassController do
     end
 
     it "overwrite class under same namespace when class exists" do
-      set_user_privileges
+      stub_user(:features => :all)
       d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
@@ -189,7 +189,7 @@ describe MiqAeClassController do
     end
 
     it "copies a class with new name under same domain" do
-      set_user_privileges
+      stub_user(:features => :all)
       d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
       ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
       cls1 = FactoryGirl.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
@@ -286,7 +286,7 @@ describe MiqAeClassController do
 
     context "#node_info" do
       it "collect namespace info" do
-        set_user_privileges
+        stub_user(:features => :all)
         d1 = FactoryGirl.create(:miq_ae_domain, :name => "domain1")
         ns1 = FactoryGirl.create(:miq_ae_namespace, :name => "ns1", :parent_id => d1.id)
         FactoryGirl.create(:miq_ae_namespace, :name => "ns2", :parent_id => ns1.id)
@@ -401,7 +401,7 @@ describe MiqAeClassController do
 
   context "#delete_domain" do
     it "Should only delete editable domains" do
-      set_user_privileges
+      stub_user(:features => :all)
       domain1 = FactoryGirl.create(:miq_ae_system_domain_enabled)
 
       domain2 = FactoryGirl.create(:miq_ae_domain_enabled)
@@ -420,7 +420,7 @@ describe MiqAeClassController do
 
   context "#ae_class_validation" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       ns = FactoryGirl.create(:miq_ae_namespace)
       @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
       @cls.ae_fields << FactoryGirl.create(:miq_ae_field, :name => 'fred',
@@ -499,7 +499,7 @@ describe MiqAeClassController do
 
   context "save class/method" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       ns = FactoryGirl.create(:miq_ae_namespace)
       @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
       @cls.ae_fields << FactoryGirl.create(:miq_ae_field, :name => 'fred',
@@ -570,7 +570,7 @@ describe MiqAeClassController do
 
   context "#delete_domain_or_namespaces" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       domain = FactoryGirl.create(:miq_ae_domain, :tenant => Tenant.seed)
       @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "foo_namespace", :parent => domain)
       @ae_class = FactoryGirl.create(:miq_ae_class, :name => "foo_class", :namespace_id => 1)

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -1,6 +1,6 @@
 describe MiqAeCustomizationController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
   context "::CustomButtons" do
     context "#ab_get_node_info" do

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -1,6 +1,6 @@
 describe MiqAeCustomizationController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   context "#get_node_info" do
@@ -120,9 +120,6 @@ describe MiqAeCustomizationController do
 
   describe 'x_button' do
     before(:each) do
-      allow_any_instance_of(described_class).to receive(:set_user_time_zone)
-      allow(controller).to receive(:check_privileges).and_return(true)
-
       ApplicationController.handle_exceptions = true
     end
 
@@ -240,6 +237,10 @@ describe MiqAeCustomizationController do
       before do
         FactoryGirl.create(:miq_server, :guid => MiqServer.my_guid)
         MiqServer.my_server_clear_cache
+
+        # It looks like edit state causes some of the features to be denied
+        # Why?
+        stub_user(:features => :none)
       end
 
       it "still renders the main_div" do
@@ -517,7 +518,6 @@ describe MiqAeCustomizationController do
   context "#x_button" do
     before :each do
       controller.instance_variable_set(:@sb, :applies_to_class => "EmsCluster")
-      allow(controller).to receive(:role_allows).and_return(true)
       session[:sandboxes] = {
         "miq_ae_customization" => {
           :applies_to_class => "EmsCluster",

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -1,6 +1,6 @@
 describe MiqAeToolsController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   context "#form_field_changed" do

--- a/spec/controllers/miq_capacity_controller_spec.rb
+++ b/spec/controllers/miq_capacity_controller_spec.rb
@@ -46,7 +46,7 @@ describe MiqCapacityController do
   context "#find_filtered" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      set_user_privileges
+      stub_user(:features => :all)
 
       @host1 = FactoryGirl.create(:host, :name => 'Host1')
       @host2 = FactoryGirl.create(:host, :name => 'Host2')
@@ -97,7 +97,7 @@ describe MiqCapacityController do
   context '#bottlenecks' do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      set_user_privileges
+      stub_user(:features => :all)
       FactoryGirl.create(:miq_enterprise)
       FactoryGirl.create(:miq_region, :description => "My Region")
     end
@@ -113,7 +113,7 @@ describe MiqCapacityController do
   describe "#reload" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone
-      set_user_privileges
+      stub_user(:features => :all)
       FactoryGirl.create(:miq_enterprise)
     end
     it 'reloads tree with active node' do

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -1,6 +1,6 @@
 describe MiqPolicyController do
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
   end
   context "::Policies" do
     context "#policy_edit" do

--- a/spec/controllers/miq_policy_controller/rsop_spec.rb
+++ b/spec/controllers/miq_policy_controller/rsop_spec.rb
@@ -2,7 +2,7 @@ describe MiqPolicyController do
   render_views
   before :each do
     EvmSpecHelper.local_miq_server
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   context "#rsop" do

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -1,6 +1,6 @@
 describe MiqPolicyController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   describe "#import" do

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -1,9 +1,9 @@
 describe ReportController do
   context "::Reports::Editor" do
     context "#set_form_vars" do
+      let(:user) { stub_user(:features => :all) }
+
       it "check existence of cb_owner_id key" do
-        user = FactoryGirl.create(:user)
-        login_as user
         rep = FactoryGirl.create(
           :miq_report,
           :db         => "ChargebackVm",
@@ -21,8 +21,6 @@ describe ReportController do
       it "should save the selected time zone with a chargeback report" do
         ApplicationController.handle_exceptions = true
 
-        user = FactoryGirl.create(:user)
-        login_as user
         rep = FactoryGirl.create(
           :miq_report,
           :db         => "ChargebackVm",
@@ -50,9 +48,6 @@ describe ReportController do
 
         allow(User).to receive(:server_timezone).and_return("UTC")
 
-        login_as user
-        allow_any_instance_of(User).to receive(:role_allows?).and_return(true)
-
         allow(controller).to receive(:check_privileges).and_return(true)
         allow(controller).to receive(:load_edit).and_return(true)
         allow(controller).to receive(:valid_report?).and_return(true)
@@ -79,11 +74,11 @@ describe ReportController do
     end
 
     context "#miq_report_edit" do
+      before { stub_user(:features => :all) }
+
       it "should build tabs with correct tab id after reset button is pressed to prevent error when changing tabs" do
         ApplicationController.handle_exceptions = true
 
-        user = FactoryGirl.create(:user)
-        login_as user
         rep = FactoryGirl.create(
           :miq_report,
           :rpt_type   => "Custom",
@@ -111,12 +106,6 @@ describe ReportController do
         controller.instance_variable_set(:@edit, edit)
         session[:edit] = assigns(:edit)
 
-        allow(User).to receive(:server_timezone).and_return("UTC")
-
-        login_as user
-        allow_any_instance_of(User).to receive(:role_allows?).and_return(true)
-
-        allow(controller).to receive(:check_privileges).and_return(true)
         allow(controller).to receive(:load_edit).and_return(true)
 
         allow(controller).to receive(:replace_right_cell)

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -1,7 +1,7 @@
 describe ReportController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(features: :all)
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -1,7 +1,7 @@
 describe ReportController do
   render_views
   before :each do
-    stub_user(features: :all)
+    login_as FactoryGirl.create(:user_with_group)
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/miq_report_controller/widgets_spec.rb
+++ b/spec/controllers/miq_report_controller/widgets_spec.rb
@@ -1,7 +1,7 @@
 describe ReportController do
   before(:each) do
     EvmSpecHelper.create_guid_miq_server_zone
-    set_user_privileges
+    stub_user(:features => :all)
   end
   describe "#widget_edit" do
     let(:miq_schedule) { FactoryGirl.build(:miq_schedule, :run_at => {}, :sched_action => {}) }

--- a/spec/controllers/miq_request_controller_spec.rb
+++ b/spec/controllers/miq_request_controller_spec.rb
@@ -150,7 +150,7 @@ describe MiqRequestController do
 
   context "#button" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       @miq_request = MiqProvisionConfiguredSystemRequest.create(:description    => "Foreman provision",
                                                                 :approval_state => "pending_approval",
@@ -172,7 +172,7 @@ describe MiqRequestController do
   render_views
   context "#edit_button" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       @miq_request = MiqProvisionConfiguredSystemRequest.create(:description    => "Foreman provision",
                                                                 :approval_state => "pending_approval",
@@ -188,7 +188,7 @@ describe MiqRequestController do
 
   context "#layout_from_tab_name" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       session[:settings] = {:display   => {:quad_truncate => 'f'},
                             :views     => {:miq_request => 'grid'}}

--- a/spec/controllers/network_port_controller_spec.rb
+++ b/spec/controllers/network_port_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe NetworkPortController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe NetworkRouterController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/network_topology_controller_spec.rb
+++ b/spec/controllers/network_topology_controller_spec.rb
@@ -1,7 +1,7 @@
 describe NetworkTopologyController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/ontap_file_share_controller_spec.rb
+++ b/spec/controllers/ontap_file_share_controller_spec.rb
@@ -1,7 +1,7 @@
 describe OntapFileShareController do
   context "#process_button" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
 
       ApplicationController.handle_exceptions = true

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -59,7 +59,7 @@ describe OpsController do
   render_views
   context "#tree_select" do
     it "renders zone list for diagnostics_tree root node" do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       MiqRegion.seed
 
@@ -73,7 +73,7 @@ describe OpsController do
 
   context "#log_collection_form_fields" do
     it "renders log_collection_form_fields" do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       MiqRegion.seed
 
@@ -92,7 +92,7 @@ describe OpsController do
 
   context "#set_credentials" do
     it "uses params[:log_password] to set the creds hash if it exists" do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       MiqRegion.seed
 
@@ -106,7 +106,7 @@ describe OpsController do
     end
 
     it "uses stored password to set the creds hash" do
-      set_user_privileges
+      stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
       MiqRegion.seed
 
@@ -123,9 +123,8 @@ describe OpsController do
   end
 
   context "::Diagnostics" do
-    let(:user) { FactoryGirl.create(:user) }
+    let!(:user) { stub_user(:features => :all) }
     before do
-      set_user_privileges user
       EvmSpecHelper.local_miq_server
       MiqRegion.seed
       _guid, @miq_server, @zone = EvmSpecHelper.remote_guid_miq_server_zone

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -5,7 +5,7 @@ describe OpsController do
     before do
       Tenant.seed
       MiqRegion.seed
-      set_user_privileges
+      stub_user(:features => :all)
     end
 
     context "#tree_select" do
@@ -306,9 +306,8 @@ describe OpsController do
     end
 
     describe "#tags_edit" do
+      let!(:user) { stub_user(:features => :all) }
       before(:each) do
-        user = FactoryGirl.create(:user)
-        set_user_privileges user
         @tenant = FactoryGirl.create(:tenant,
                                      :name      => "OneTenant",
                                      :parent    => Tenant.root_tenant,
@@ -381,7 +380,7 @@ describe OpsController do
       MiqUserRole.seed
       MiqGroup.seed
       MiqRegion.seed
-      set_user_privileges
+      stub_user(:features => :all)
     end
 
     it "does not display tenant default groups in Edit Sequence" do

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -2,7 +2,7 @@ describe OpsController do
   before(:each) do
     EvmSpecHelper.create_guid_miq_server_zone
     MiqRegion.seed
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   describe 'x_button' do

--- a/spec/controllers/orchestration_stack_controller_spec.rb
+++ b/spec/controllers/orchestration_stack_controller_spec.rb
@@ -1,8 +1,7 @@
 describe OrchestrationStackController do
-  let(:user) { FactoryGirl.create(:user_with_group) }
+  let!(:user) { stub_user(:features => :all) }
 
   before(:each) do
-    set_user_privileges user
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/persistent_volume_controller_spec.rb
+++ b/spec/controllers/persistent_volume_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe PersistentVolumeController do
   render_views
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/picture_controller_spec.rb
+++ b/spec/controllers/picture_controller_spec.rb
@@ -3,7 +3,7 @@ describe PictureController do
   let(:picture) { FactoryGirl.create(:picture, :id => 10_000_000_000_005, :extension => "jpg") }
 
   before do
-    set_user_privileges
+    stub_user(:features => :all)
 
     EvmSpecHelper.create_guid_miq_server_zone
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -64,14 +64,14 @@ describe ProviderForemanController do
   end
 
   it "renders index" do
-    set_user_privileges
+    stub_user(:features => :all)
     get :index
     expect(response.status).to eq(302)
     expect(response).to redirect_to(:action => 'explorer')
   end
 
   it "renders explorer" do
-    set_user_privileges user_with_feature %w(providers_accord configured_systems_filter_accord configuration_scripts_accord)
+    login_as user_with_feature(%w(providers_accord configured_systems_filter_accord configuration_scripts_accord))
 
     get :explorer
     accords = controller.instance_variable_get(:@accords)
@@ -84,7 +84,7 @@ describe ProviderForemanController do
 
   context "renders explorer based on RBAC" do
     it "renders explorer based on RBAC access to feature 'configured_system_tag'" do
-      set_user_privileges user_with_feature %w(configured_system_tag)
+      login_as user_with_feature %w(configured_system_tag)
 
       get :explorer
       accords = controller.instance_variable_get(:@accords)
@@ -95,7 +95,7 @@ describe ProviderForemanController do
     end
 
     it "renders explorer based on RBAC access to feature 'provider_foreman_add_provider'" do
-      set_user_privileges user_with_feature %w(provider_foreman_add_provider)
+      login_as user_with_feature %w(provider_foreman_add_provider)
 
       get :explorer
       accords = controller.instance_variable_get(:@accords)
@@ -122,7 +122,7 @@ describe ProviderForemanController do
   end
 
   it "renders show_list" do
-    set_user_privileges
+    stub_user(:features => :all)
     get :show_list
     expect(response.status).to eq(302)
     expect(response.body).to_not be_empty
@@ -172,7 +172,7 @@ describe ProviderForemanController do
 
   context "#edit" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
     end
 
     it "renders the edit page when the configuration manager id is supplied" do
@@ -216,7 +216,7 @@ describe ProviderForemanController do
 
   context "#refresh" do
     before do
-      set_user_privileges
+      stub_user(:features => :all)
       allow(controller).to receive(:x_node).and_return("root")
       allow(controller).to receive(:rebuild_toolbars).and_return("true")
     end
@@ -237,7 +237,7 @@ describe ProviderForemanController do
   context "renders right cell text" do
     before do
       right_cell_text = nil
-      set_user_privileges user_with_feature %w(providers_accord configured_systems_filter_accord configuration_scripts_accord)
+      login_as user_with_feature(%w(providers_accord configured_systems_filter_accord configuration_scripts_accord))
       controller.instance_variable_set(:@right_cell_text, right_cell_text)
       allow(controller).to receive(:get_view_calculate_gtl_type)
       allow(controller).to receive(:get_view_pages)
@@ -315,7 +315,7 @@ describe ProviderForemanController do
   end
 
   it "constructs the ansible tower job templates tree node" do
-    set_user_privileges user_with_feature %w(providers_accord configured_systems_filter_accord configuration_scripts_accord)
+    login_as user_with_feature(%w(providers_accord configured_systems_filter_accord configuration_scripts_accord))
     controller.send(:build_configuration_manager_tree, :configuration_scripts, :configuration_scripts_tree)
     tree_builder = TreeBuilderConfigurationManagerConfigurationScripts.new("root", "", {})
     objects = tree_builder.send(:x_get_tree_roots, false, {})
@@ -328,7 +328,7 @@ describe ProviderForemanController do
     before do
       get :explorer
       right_cell_text = nil
-      set_user_privileges user_with_feature %w(providers_accord configured_systems_filter_accord configuration_scripts_accord)
+      login_as user_with_feature(%w(providers_accord configured_systems_filter_accord configuration_scripts_accord))
       controller.instance_variable_set(:@right_cell_text, right_cell_text)
       allow(controller).to receive(:get_view_calculate_gtl_type)
       allow(controller).to receive(:get_view_pages)
@@ -494,7 +494,7 @@ describe ProviderForemanController do
     allow(controller).to receive(:replace_search_box)
     allow(controller).to receive(:update_partials)
 
-    set_user_privileges
+    stub_user(:features => :all)
 
     key = ems_key_for_provider(@provider)
     post :tree_select, :params => { :id => key, :format => :js }
@@ -525,7 +525,7 @@ describe ProviderForemanController do
 
   context "fetches the list setting:Grid/Tile/List from settings" do
     before do
-      set_user_privileges user_with_feature %w(providers_accord configured_systems_filter_accord)
+      login_as user_with_feature(%w(providers_accord configured_systems_filter_accord))
       allow(controller).to receive(:items_per_page).and_return(20)
       allow(controller).to receive(:current_page).and_return(1)
       allow(controller).to receive(:get_view_pages)
@@ -607,7 +607,7 @@ describe ProviderForemanController do
 
   context "#configscript_service_dialog" do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       @cs = FactoryGirl.create(:ansible_configuration_script)
       @dialog_label = "New Dialog 01"
       session[:edit] = {

--- a/spec/controllers/pxe_controller/iso_datastores_spec.rb
+++ b/spec/controllers/pxe_controller/iso_datastores_spec.rb
@@ -1,6 +1,6 @@
 describe PxeController do
   before do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   describe "#iso_datastore_set_form_vars" do

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -1,6 +1,6 @@
 describe PxeController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   describe 'x_button' do

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -845,7 +845,7 @@ describe ReportController do
 
   describe 'x_button' do
     before(:each) do
-      set_user_privileges
+      stub_user(:features => :all)
       ApplicationController.handle_exceptions = true
     end
 

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -3,7 +3,7 @@ include CompressedIds
 describe SecurityGroupController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     setup_zone
   end
 

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -1,6 +1,6 @@
 describe ServiceController do
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   context "#service_delete" do

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -4,7 +4,7 @@ describe StorageController do
 
   let(:storage) { FactoryGirl.create(:storage, :name => 'test_storage1') }
   let(:storage_cluster) { FactoryGirl.create(:storage_cluster, :name => 'test_storage_cluster1') }
-  before { set_user_privileges }
+  before { stub_user(:features => :all) }
 
   context "#button" do
     it "when VM Right Size Recommendations is pressed" do
@@ -229,11 +229,10 @@ describe StorageController do
   end
 
   context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
       @ds = FactoryGirl.create(:storage, :name => "Datastore-01")
-      user = FactoryGirl.create(:user, :userid => 'testuser')
-      set_user_privileges user
       allow(@ds).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
       classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
       @tag1 = FactoryGirl.create(:classification_tag,

--- a/spec/controllers/storage_manager_controller_spec.rb
+++ b/spec/controllers/storage_manager_controller_spec.rb
@@ -2,7 +2,7 @@ describe StorageManagerController do
   render_views
   before(:each) do
     @zone = EvmSpecHelper.local_miq_server.zone
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   it "renders index" do

--- a/spec/controllers/support_controller_spec.rb
+++ b/spec/controllers/support_controller_spec.rb
@@ -3,7 +3,7 @@ describe SupportController do
 
   before do
     EvmSpecHelper.create_guid_miq_server_zone
-    set_user_privileges
+    stub_user(:features => :all)
   end
 
   context "#index" do

--- a/spec/controllers/vm_cloud_controller/trees_spec.rb
+++ b/spec/controllers/vm_cloud_controller/trees_spec.rb
@@ -1,7 +1,7 @@
 describe VmCloudController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -6,7 +6,7 @@ describe VmCloudController do
                        :ext_management_system => FactoryGirl.create(:ems_openstack))
   end
   before(:each) do
-    set_user_privileges
+    stub_user(:features => :all)
     session[:settings] = {:views => {:treesize => 20}}
     EvmSpecHelper.create_guid_miq_server_zone
   end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -1,8 +1,7 @@
 describe VmOrTemplateController do
   context "#snap_pressed" do
     before :each do
-      set_user_privileges
-      allow(controller).to receive(:role_allows).and_return(true)
+      stub_user(:features => :all)
       vm = FactoryGirl.create(:vm_vmware)
       @snapshot = FactoryGirl.create(:snapshot, :vm_or_template_id => vm.id,
                                                 :name              => 'EvmSnapshot',
@@ -75,7 +74,7 @@ describe VmOrTemplateController do
     end
 
     it "Redirects user with privileges to vm_infra/explorer" do
-      set_user_privileges
+      stub_user(:features => :all)
       get :show, :params => {:id => @vm.id}
       expect(response.status).to eq(302)
       expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')

--- a/spec/controllers/vm_infra_controller/trees_spec.rb
+++ b/spec/controllers/vm_infra_controller/trees_spec.rb
@@ -1,7 +1,7 @@
 describe VmInfraController do
   render_views
   before :each do
-    set_user_privileges
+    stub_user(:features => :all)
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -5,7 +5,7 @@ describe VmInfraController do
   let(:host_2x2)  { FactoryGirl.create(:host_vmware_esx, :hardware => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB)) }
   let(:vm_vmware) { FactoryGirl.create(:vm_vmware) }
   before do
-    set_user_privileges
+    stub_user(:features => :all)
 
     session[:settings] = {:views => {:treesize => 20}}
 

--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -1,7 +1,7 @@
 describe VmOrTemplateController do
   let(:template_vmware) { FactoryGirl.create(:template_vmware, :name => 'template_vmware Name') }
   let(:vm_vmware)       { FactoryGirl.create(:vm_vmware, :name => "vm_vmware Name") }
-  before { set_user_privileges }
+  before { stub_user(:features => :all) }
 
   # All of the x_button is a suplement for Rails routes that is written in
   # controller.

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -36,7 +36,7 @@ FactoryGirl.define do
       tenant { Tenant.seed }
     end
 
-    miq_groups { FactoryGirl.create_list(:miq_group, 1, :tenant => tenant) }
+    miq_groups { FactoryGirl.build_list(:miq_group, 1, :tenant => tenant) }
   end
 
   factory :user_admin, :parent => :user do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -316,7 +316,7 @@ describe ApplicationHelper do
       end
 
       it "and miq_request_approval feature is allowed" do
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         expect(subject).to be_falsey
       end
     end
@@ -328,7 +328,7 @@ describe ApplicationHelper do
       end
 
       it "and miq_request_approval feature is allowed" do
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         expect(subject).to be_falsey
       end
     end
@@ -341,14 +341,14 @@ describe ApplicationHelper do
     it "when with miq_request_approve and allowed by the role" do
       @id = "miq_request_approve"
       # when the role allows the feature
-      allow(user).to receive(:role_allows?).and_return(true)
+      stub_user(:features => :all)
       expect(subject).to be_falsey
     end
 
     it "when with miq_request_deny and allowed by the role" do
       @id = "miq_request_deny"
       # when the role allows the feature
-      allow(user).to receive(:role_allows?).and_return(true)
+      stub_user(:features => :all)
       expect(subject).to be_falsey
     end
 
@@ -379,7 +379,7 @@ describe ApplicationHelper do
      "vm_snapshot_revert"].each do |id|
       it "when with #{id}" do
         @id = id
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         expect(subject).to be_falsey
       end
     end
@@ -576,7 +576,7 @@ describe ApplicationHelper do
     %w(host_miq_request_new vm_miq_request_new vm_pre_prov).each do |id|
       it "when with #{id}" do
         @id = id
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         expect(subject).to be_falsey
       end
     end
@@ -584,7 +584,7 @@ describe ApplicationHelper do
     context "when with miq_task_canceljob" do
       before do
         @id = 'miq_task_canceljob'
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       it "and @layout != all_tasks" do
@@ -611,7 +611,7 @@ describe ApplicationHelper do
     context "when with vm_console" do
       before do
         @id = "vm_console"
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         allow(@record).to receive_messages(:console_supported? => false)
       end
 
@@ -639,7 +639,7 @@ describe ApplicationHelper do
     context "when with vm_vnc_console" do
       before do
         @id = "vm_vnc_console"
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         allow(@record).to receive_messages(:console_supported? => false)
       end
 
@@ -667,7 +667,7 @@ describe ApplicationHelper do
     context "when with vm_vmrc_console" do
       before do
         @id = "vm_vmrc_console"
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         allow(@record).to receive_messages(:console_supported? => false)
       end
 
@@ -696,7 +696,7 @@ describe ApplicationHelper do
       context "when with #{id}" do
         before do
           @id = id
-          allow(user).to receive(:role_allows?).and_return(true)
+          stub_user(:features => :all)
         end
 
         it "and @vmdb_config[:product][:smis] != true " do
@@ -714,7 +714,7 @@ describe ApplicationHelper do
     context "when with AssignedServerRole" do
       before do
         @record = AssignedServerRole.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       it "and id = delete_server" do
@@ -745,7 +745,7 @@ describe ApplicationHelper do
     context "when with EmsCluster" do
       before do
         @record = EmsCluster.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       context "and id = common_drift" do
@@ -768,7 +768,7 @@ describe ApplicationHelper do
     context "when with Host" do
       before do
         @record = Host.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       context "and id = common_drift" do
@@ -869,7 +869,7 @@ describe ApplicationHelper do
       context "when with #{cls}" do
         before do
           @record = cls.constantize.new
-          allow(user).to receive(:role_allows?).and_return(true)
+          stub_user(:features => :all)
         end
 
         context "and id = miq_request_approve" do
@@ -1050,13 +1050,13 @@ describe ApplicationHelper do
       end
 
       it "alert_copy don't hide if RBAC allows" do
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
         @id = "alert_copy"
         expect(subject).to be_falsey
       end
 
       it "alert_copy hide if RBAC denies" do
-        allow(user).to receive(:role_allows?).and_return(false)
+        stub_user(:features => :none)
         @id = "alert_copy"
         expect(subject).to be_truthy
       end
@@ -1065,7 +1065,7 @@ describe ApplicationHelper do
     context "when with MiqServer" do
       before do
         @record = MiqServer.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       ["role_start", "role_suspend", "promote_server", "demote_server",
@@ -1085,7 +1085,7 @@ describe ApplicationHelper do
     context "when with ScanItemSet" do
       before do
         @record = ScanItemSet.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       ["scan_delete", "scan_edit"].each do |id|
@@ -1110,7 +1110,7 @@ describe ApplicationHelper do
     context "when with ServerRole" do
       before do
         @record = ServerRole.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       ["server_delete", "role_start", "role_suspend", "promote_server", "demote_server"].each do |id|
@@ -1143,7 +1143,7 @@ describe ApplicationHelper do
     context "when with Vm" do
       before do
         @record = Vm.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       context "and id = vm_reconfigure" do
@@ -1340,7 +1340,7 @@ describe ApplicationHelper do
     context "when with MiqTemplate" do
       before do
         @record = MiqTemplate.new
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       context "and id = miq_template_clone" do
@@ -1450,7 +1450,7 @@ describe ApplicationHelper do
     context "when with record = nil" do
       before do
         @record = nil
-        allow(user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       ["log_download", "log_reload"].each do |id|
@@ -1564,18 +1564,18 @@ describe ApplicationHelper do
         end
 
         it "user allowed" do
-          allow(user).to receive(:role_allows?).and_return(true)
+          stub_user(:features => :all)
           expect(subject).to be_falsey
         end
 
         it "user not allowed" do
-          allow(user).to receive(:role_allows?).and_return(false)
+          stub_user(:features => :none)
           expect(subject).to be_truthy
         end
 
         it "button hidden if provider has no stacks" do
           @record = FactoryGirl.create(:ems_openstack_infra)
-          allow(user).to receive(:role_allows?).and_return(true)
+          stub_user(:features => :all)
           expect(subject).to be_truthy
         end
       end
@@ -1586,12 +1586,12 @@ describe ApplicationHelper do
         end
 
         it "user allowed but hide button because wrong provider" do
-          allow(user).to receive(:role_allows?).and_return(true)
+          stub_user(:features => :all)
           expect(subject).to be_truthy
         end
 
         it "user not allowed" do
-          allow(user).to receive(:role_allows?).and_return(false)
+          stub_user(:features => :all)
           expect(subject).to be_truthy
         end
       end
@@ -1601,7 +1601,7 @@ describe ApplicationHelper do
       before(:each) do
         @record = FactoryGirl.create(:miq_event_definition)
         @layout = "miq_policy"
-        allow(User.current_user).to receive(:role_allows?).and_return(true)
+        stub_user(:features => :all)
       end
 
       it "hides toolbar in policy event tree" do
@@ -2917,7 +2917,7 @@ describe ApplicationHelper do
                      :url_parms => "?download_type=pdf",
                      :data      => nil}
       @layout = "catalogs"
-      allow(helper).to receive(:role_allows).and_return(true)
+      stub_user(:features => :all)
       allow(helper).to receive(:x_active_tree).and_return(:ot_tree)
     end
 

--- a/spec/helpers/container_summary_helper.rb
+++ b/spec/helpers/container_summary_helper.rb
@@ -7,23 +7,19 @@ describe ContainerSummaryHelper do
     self.class.send(:include, ApplicationHelper)
 
     @record = FactoryGirl.build(:container_group, :container_project => container_project)
-
-    login_as @user = FactoryGirl.create(:user)
   end
 
   context ".textual_container_project" do
     subject { textual_container_project }
 
     it 'show link when role allows' do
-      allow(@user).to receive(:role_allows?).and_return(true)
-
+      stub_user(:features => :all)
       expect(subject.keys).to eq(REL_HASH_WITH_LINK)
       expect(subject[:value]).to eq(container_project.name)
     end
 
     it 'hide link when role does not allow' do
-      allow(@user).to receive(:role_allows?).and_return(false)
-
+      stub_user(:features => :none)
       expect(subject.keys).to eq(REL_HASH_WITHOUT_LINK)
       expect(subject[:value]).to eq(container_project.name)
     end
@@ -34,15 +30,13 @@ describe ContainerSummaryHelper do
     subject { textual_containers }
 
     it 'show link when role allows' do
-      allow(@user).to receive(:role_allows?).and_return(true)
-
+      stub_user(:features => :all)
       expect(subject.keys).to eq(REL_HASH_WITH_LINK)
       expect(subject[:value]).to eq("2")
     end
 
     it 'hide link when role does not allow' do
-      allow(@user).to receive(:role_allows?).and_return(false)
-
+      stub_user(:features => :none)
       expect(subject.keys).to eq(REL_HASH_WITHOUT_LINK)
       expect(subject[:value]).to eq("2")
     end

--- a/spec/helpers/textual_summary_helper_spec.rb
+++ b/spec/helpers/textual_summary_helper_spec.rb
@@ -1,7 +1,6 @@
 describe TextualSummaryHelper do
   before do
-    login_as @user = FactoryGirl.create(:user)
-    allow(@user).to receive(:role_allows?).and_return(true)
+    stub_user(:features => :all)
   end
 
   context "textual_link" do

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -12,7 +12,9 @@ module AuthHelper
 
   # TODO: Stub specific features, document use
   def stub_user(features:)
-    user = FactoryGirl.create(:user_with_group) # TODO stub instead
+    user = FactoryGirl.build(:user_with_group)
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(User).to receive(:current_user).and_return(user)
     allow(User).to receive(:server_timezone).and_return("UTC")
     allow_any_instance_of(described_class).to receive(:set_user_time_zone)
 

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -9,6 +9,30 @@ module AuthHelper
     session[:group]   = user.current_group_id
     user
   end
+
+  # TODO: Stub specific features, document use
+  def stub_user(features:)
+    user = FactoryGirl.create(:user_with_group) # TODO stub instead
+    allow(User).to receive(:server_timezone).and_return("UTC")
+    allow_any_instance_of(described_class).to receive(:set_user_time_zone)
+
+    stub_bool = case features
+                when :all  then true
+                when :none then false
+                else
+                  raise ArgumentError, <<-EOS
+  Unknown features option. You must pass :all or :none to #stub_user.
+  If you need specific features, use #login_as with an actual User model instead.
+                  EOS
+                end
+    allow(controller).to receive(:check_privileges).and_return(stub_bool)
+    allow(controller).to receive(:role_allows).and_return(stub_bool)
+    allow_any_instance_of(User).to receive(:role_allows?).and_return(stub_bool)
+    allow_any_instance_of(User).to receive(:role_allows_any?).and_return(stub_bool)
+
+    login_as user
+    user
+  end
 end
 
 module AuthRequestHelper

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -7,16 +7,6 @@ module ControllerSpecHelper
     end
   end
 
-  def set_user_privileges(user = FactoryGirl.create(:user_with_group))
-    allow(User).to receive(:server_timezone).and_return("UTC")
-    allow_any_instance_of(described_class).to receive(:set_user_time_zone)
-
-    # TODO: remove these stubs
-    allow(controller).to receive(:check_privileges).and_return(true)
-    login_as user
-    allow_any_instance_of(User).to receive(:role_allows?).and_return(true)
-  end
-
   def setup_zone
     EvmSpecHelper.create_guid_miq_server_zone
   end


### PR DESCRIPTION
This replaces the old #set_user_privileges method.

Besides being awesome that you don't need to remember how to spell 'privileges', this replacement method is much more flexible and correct than the previous one.

It is the groundwork for forthcoming role checking changes and reduces the diff substantially.

@miq-bot add_labels tenancy, core, darga/no
@miq-bot assign @Fryguy
cc/ @gtanzillo @dclarizio