### PR TITLE
Delete MiqExpression#field_is_virtual_column?

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -670,10 +670,6 @@ class MiqExpression
     col_details[field][:sql_support]
   end
 
-  def field_is_virtual_column?(field)
-    col_details[field][:virtual_column]
-  end
-
   def field_excluded_by_preprocess_options?(field)
     col_details[field][:excluded_by_preprocess_options]
   end


### PR DESCRIPTION
Purpose or Intent
-----------------

The last reference to this method was deleted in 8e05efd69c4027281bff21de3880485ae5b43b3a

@miq-bot add-label core, techinical debt
@miq-bot assign @gtanzillo 