### PR TITLE
Remove support for relative datetimes for <, >, <=, >= in MiqExpression#to_sql

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1602,50 +1602,34 @@ class MiqExpression
     when "equal", "="
       field = Field.parse(exp[operator]["field"])
       field.eq(exp[operator]["value"])
-    when ">", "after"
+    when ">"
       field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
+      field.gt(exp[operator]["value"])
+    when "after"
+      field = Field.parse(exp[operator]["field"])
+      value = if field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").to_date
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").utc
               else
-                exp[operator]["value"]
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").utc
               end
       field.gt(value)
     when ">="
       field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").to_date
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").utc
-              else
-                exp[operator]["value"]
-              end
-      field.gteq(value)
-    when "<", "before"
+      field.gteq(exp[operator]["value"])
+    when "<"
       field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
+      field.lt(exp[operator]["value"])
+    when "before"
+      field = Field.parse(exp[operator]["field"])
+      value = if field.date?
                 RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").to_date
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").utc
               else
-                exp[operator]["value"]
+                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").utc
               end
       field.lt(value)
     when "<="
       field = Field.parse(exp[operator]["field"])
-      value = case
-              when field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").to_date
-              when field.datetime?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").utc
-              else
-                exp[operator]["value"]
-              end
-      field.lteq(value)
+      field.lteq(exp[operator]["value"])
     when "!="
       field = Field.parse(exp[operator]["field"])
       field.not_eq(exp[operator]["value"])

--- a/product/reports/110_Configuration Management - Hosts/020_Date Brought under Management.yaml
+++ b/product/reports/110_Configuration Management - Hosts/020_Date Brought under Management.yaml
@@ -4,9 +4,9 @@ created_on: 2008-08-11 16:25:13.490154 Z
 title: "Hosts: Date brought under Management for Last Week"
 conditions: !ruby/object:MiqExpression
   exp:
-    ">=":
+    "IS":
       field: Host-created_on
-      value: 7 Days Ago
+      value: Last Week
 updated_on: 2008-08-13 21:07:38.833909 Z
 order: Ascending
 graph: 

--- a/product/reports/500_Events - Operations/110_vm_operational_vm_power.yaml
+++ b/product/reports/500_Events - Operations/110_vm_operational_vm_power.yaml
@@ -73,9 +73,9 @@ conditions: !ruby/object:MiqExpression
     - "ENDS WITH": 
         field: EmsEvent-event_type
         value: Event
-    - ">=":
+    - "IS":
         field: EmsEvent-timestamp
-        value: 7 Days Ago
+        value: Last Week
 
 # Order string for the SQL query
 order: Descending

--- a/product/reports/520_Events - Policy/110_Policy Events.yaml
+++ b/product/reports/520_Events - Policy/110_Policy Events.yaml
@@ -6,9 +6,9 @@ reserved:
 title: Policy Events for Last Week - Sample 1
 conditions: !ruby/object:MiqExpression
   exp:
-    ">=":
+    "IS":
       field: PolicyEvent-timestamp
-      value: 7 Days Ago
+      value: Last Week
 updated_on: 2009-04-06 20:19:27 Z
 order: Ascending
 graph: 

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -198,54 +198,14 @@ describe MiqExpression do
         expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10'")
       end
 
-      it "generates the SQL for a > expression" do
-        exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10'")
-      end
-
       it "generates the SQL for a BEFORE expression" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
         expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10'")
       end
 
-      it "generates the SQL for a < expression" do
-        exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10'")
-      end
-
-      it "generates the SQL for a >= expression with a date field" do
-        exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" >= '2011-01-10'")
-      end
-
-      it "generates the SQL for a >= expression with a datetime field" do
-        sql, * = described_class.new(">=" => {"field" => "Vm-last_scan_on", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq(%q("vms"."last_scan_on" >= '2016-01-01 00:00:00'))
-      end
-
-      it "generates the SQL for a <= expression with a date field" do
-        exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-        sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" <= '2011-01-10'")
-      end
-
-      it "generates the SQL for a <= expression with a datetime field" do
-        sql, * = described_class.new("<=" => {"field" => "Vm-last_scan_on", "value" => "2016-01-01"}).to_sql
-        expect(sql).to eq(%q("vms"."last_scan_on" <= '2016-01-01 23:59:59.999999'))
-      end
-
       it "generates the SQL for an AFTER expression with date/time" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-        sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"last_scan_on\" > '2011-01-10 09:00:00'")
-      end
-
-      it "generates the SQL for a > expression with date/time" do
-        exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
         sql, * = exp.to_sql
         expect(sql).to eq("\"vms\".\"last_scan_on\" > '2011-01-10 09:00:00'")
       end
@@ -294,28 +254,16 @@ describe MiqExpression do
       around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
 
       context "given a non-UTC timezone" do
-        it "generates the SQL for a > expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new(">" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+        it "generates the SQL for a AFTER expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("AFTER" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
           expect(sql).to eq(%q("vms"."retires_on" > '2011-01-11'))
         end
 
-        it "generates the SQL for a >= expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new(">=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
-          sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" >= '2011-01-11'))
-        end
-
-        it "generates the SQL for a < expression with a value of 'Yesterday' for a date field" do
-          exp =  described_class.new("<" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+        it "generates the SQL for a BEFORE expression with a value of 'Yesterday' for a date field" do
+          exp =  described_class.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
           expect(sql).to eq(%q("vms"."retires_on" < '2011-01-11'))
-        end
-
-        it "generates the SQL for a <= expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new("<=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
-          sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" <= '2011-01-11'))
         end
 
         it "generates the SQL for an IS expression with a value of 'Yesterday' for a date field" do
@@ -404,14 +352,6 @@ describe MiqExpression do
           _vm1 = FactoryGirl.create(:vm_vmware, :last_scan_on => "2011-01-11 9:00")
           vm2 = FactoryGirl.create(:vm_vmware, :last_scan_on => "2011-01-11 9:00:00.000001")
           filter = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-11 9:00"})
-          result = Vm.where(filter.to_sql.first)
-          expect(result).to eq([vm2])
-        end
-
-        it "finds the correct instances for a > expression with a datetime field" do
-          _vm1 = FactoryGirl.create(:vm_vmware, :last_scan_on => "2011-01-11 9:00")
-          vm2 = FactoryGirl.create(:vm_vmware, :last_scan_on => "2011-01-11 9:00:00.000001")
-          filter = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-11 9:00"})
           result = Vm.where(filter.to_sql.first)
           expect(result).to eq([vm2])
         end


### PR DESCRIPTION
Purpose or Intent
-----------------

The UI doesn't support these operators for date/datetime fields, so
support in MiqExpression can be removed

@miq-bot add-label core, technical debt
@miq-bot assign @gtanzillo 