### PR TITLE
MiqExpression#to_sql: extract/simplify value

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1664,14 +1664,10 @@ class MiqExpression
       start_val = RelativeDatetime.normalize(value, tz, "beginning", field.date?)
       end_val = RelativeDatetime.normalize(value, tz, "end", field.date?)
 
-      if field.date?
-        if RelativeDatetime.relative?(value)
-          field.between(start_val..end_val)
-        else
-          field.eq(start_val)
-        end
-      else
+      if !field.date? || RelativeDatetime.relative?(value)
         field.between(start_val..end_val)
+      else
+        field.eq(start_val)
       end
     when "from"
       start_val, end_val = exp[operator]["value"]

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -450,21 +450,21 @@ class MiqExpression
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       col_name = exp[operator]["field"]
       col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
-      val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning")
+      val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning", col_type == :date)
       clause = if col_type == :date
-                 "val=#{col_ruby}; !val.nil? && val.to_date < #{quote(val.to_date, :date)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_date < #{quote(val, :date)}"
                else
-                 "val=#{col_ruby}; !val.nil? && val.to_time < #{quote(val.utc, :datetime)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_time < #{quote(val, :datetime)}"
                end
     when "after"
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       col_name = exp[operator]["field"]
       col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
-      val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end")
+      val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end", col_type == :date)
       clause = if col_type == :date
-                 "val=#{col_ruby}; !val.nil? && val.to_date > #{quote(val.to_date, :date)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_date > #{quote(val, :date)}"
                else
-                 "val=#{col_ruby}; !val.nil? && val.to_time > #{quote(val.utc, :datetime)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_time > #{quote(val, :datetime)}"
                end
     when "includes all"
       operands = operands2rubyvalue(operator, exp[operator], context_type)
@@ -525,16 +525,16 @@ class MiqExpression
       value = exp[operator]["value"]
       if col_type == :date
         if RelativeDatetime.relative?(value)
-          start_val = quote(RelativeDatetime.normalize(value, tz, "beginning").to_date, :date)
-          end_val   = quote(RelativeDatetime.normalize(value, tz, "end").to_date, :date)
+          start_val = quote(RelativeDatetime.normalize(value, tz, "beginning", col_type == :date), :date)
+          end_val   = quote(RelativeDatetime.normalize(value, tz, "end", col_type == :date), :date)
           clause    = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
         else
-          value  = quote(RelativeDatetime.normalize(value, tz, "beginning").to_date, :date)
+          value  = quote(RelativeDatetime.normalize(value, tz, "beginning", col_type == :date), :date)
           clause = "val=#{col_ruby}; !val.nil? && val.to_date == #{value}"
         end
       else
-        start_val = quote(RelativeDatetime.normalize(value, tz, "beginning").utc, :datetime)
-        end_val   = quote(RelativeDatetime.normalize(value, tz, "end").utc, :datetime)
+        start_val = quote(RelativeDatetime.normalize(value, tz, "beginning", col_type == :date), :datetime)
+        end_val   = quote(RelativeDatetime.normalize(value, tz, "end", col_type == :date), :datetime)
         clause    = "val=#{col_ruby}; !val.nil? && val.to_time >= #{start_val} && val.to_time <= #{end_val}"
       end
     when "from"
@@ -544,13 +544,13 @@ class MiqExpression
 
       start_val, end_val = exp[operator]["value"]
       if col_type == :date
-        start_val = quote(RelativeDatetime.normalize(start_val, tz, "beginning").to_date, :date)
-        end_val   = quote(RelativeDatetime.normalize(end_val, tz, "end").to_date, :date)
+        start_val = quote(RelativeDatetime.normalize(start_val, tz, "beginning", col_type == :date), :date)
+        end_val   = quote(RelativeDatetime.normalize(end_val, tz, "end", col_type == :date), :date)
 
         clause = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
       else
-        start_val = quote(RelativeDatetime.normalize(start_val, tz, "beginning").utc, :datetime)
-        end_val   = quote(RelativeDatetime.normalize(end_val, tz, "end").utc, :datetime)
+        start_val = quote(RelativeDatetime.normalize(start_val, tz, "beginning", col_type == :date), :datetime)
+        end_val   = quote(RelativeDatetime.normalize(end_val, tz, "end", col_type == :date), :datetime)
 
         clause = "val=#{col_ruby}; !val.nil? && val.to_time >= #{start_val} && val.to_time <= #{end_val}"
       end
@@ -1595,22 +1595,14 @@ class MiqExpression
     when ">"
       field.gt(exp[operator]["value"])
     when "after"
-      value = if field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").to_date
-              else
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "end").utc
-              end
+      value = RelativeDatetime.normalize(exp[operator]["value"], tz, "end", field.date?)
       field.gt(value)
     when ">="
       field.gteq(exp[operator]["value"])
     when "<"
       field.lt(exp[operator]["value"])
     when "before"
-      value = if field.date?
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").to_date
-              else
-                RelativeDatetime.normalize(exp[operator]["value"], tz, _mode = "beginning").utc
-              end
+      value = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning", field.date?)
       field.lt(value)
     when "<="
       field.lteq(exp[operator]["value"])
@@ -1667,27 +1659,22 @@ class MiqExpression
       value = exp[operator]["value"]
       if field.date?
         if RelativeDatetime.relative?(value)
-          start_val = RelativeDatetime.normalize(value, tz, "beginning").to_date
-          end_val = RelativeDatetime.normalize(value, tz, "end").to_date
+          start_val = RelativeDatetime.normalize(value, tz, "beginning", field.date?)
+          end_val = RelativeDatetime.normalize(value, tz, "end", field.date?)
           field.between(start_val..end_val)
         else
-          value = RelativeDatetime.normalize(value, tz, "beginning").to_date
+          value = RelativeDatetime.normalize(value, tz, "beginning", field.date?)
           field.eq(value)
         end
       else
-        start_val = RelativeDatetime.normalize(value, tz, "beginning").utc
-        end_val   = RelativeDatetime.normalize(value, tz, "end").utc
+        start_val = RelativeDatetime.normalize(value, tz, "beginning", field.date?)
+        end_val   = RelativeDatetime.normalize(value, tz, "end", field.date?)
         field.between(start_val..end_val)
       end
     when "from"
       start_val, end_val = exp[operator]["value"]
-      if field.date?
-        start_val = RelativeDatetime.normalize(start_val, tz, "beginning").to_date
-        end_val   = RelativeDatetime.normalize(end_val, tz, "end").to_date
-      else
-        start_val = RelativeDatetime.normalize(start_val, tz, "beginning").utc
-        end_val   = RelativeDatetime.normalize(end_val, tz, "end").utc
-      end
+      start_val = RelativeDatetime.normalize(start_val, tz, "beginning", field.date?)
+      end_val   = RelativeDatetime.normalize(end_val, tz, "end", field.date?)
       field.between(start_val..end_val)
     else
       raise _("operator '%{operator_name}' is not supported") % {:operator_name => operator}

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -452,9 +452,9 @@ class MiqExpression
       col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning", col_type == :date)
       clause = if col_type == :date
-                 "val=#{col_ruby}; !val.nil? && val.to_date < #{quote(val, :date)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_date < #{quote(val, col_type)}"
                else
-                 "val=#{col_ruby}; !val.nil? && val.to_time < #{quote(val, :datetime)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_time < #{quote(val, col_type)}"
                end
     when "after"
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
@@ -462,9 +462,9 @@ class MiqExpression
       col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end", col_type == :date)
       clause = if col_type == :date
-                 "val=#{col_ruby}; !val.nil? && val.to_date > #{quote(val, :date)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_date > #{quote(val, col_type)}"
                else
-                 "val=#{col_ruby}; !val.nil? && val.to_time > #{quote(val, :datetime)}"
+                 "val=#{col_ruby}; !val.nil? && val.to_time > #{quote(val, col_type)}"
                end
     when "includes all"
       operands = operands2rubyvalue(operator, exp[operator], context_type)
@@ -527,16 +527,16 @@ class MiqExpression
       end_val = RelativeDatetime.normalize(value, tz, "end", col_type == :date)
       if col_type == :date
         if RelativeDatetime.relative?(value)
-          start_val = quote(start_val, :date)
-          end_val   = quote(end_val, :date)
+          start_val = quote(start_val, col_type)
+          end_val   = quote(end_val, col_type)
           clause    = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
         else
-          value  = quote(start_val, :date)
+          value  = quote(start_val, col_type)
           clause = "val=#{col_ruby}; !val.nil? && val.to_date == #{value}"
         end
       else
-        start_val = quote(start_val, :datetime)
-        end_val   = quote(end_val, :datetime)
+        start_val = quote(start_val, col_type)
+        end_val   = quote(end_val, col_type)
         clause    = "val=#{col_ruby}; !val.nil? && val.to_time >= #{start_val} && val.to_time <= #{end_val}"
       end
     when "from"
@@ -548,13 +548,13 @@ class MiqExpression
       start_val = RelativeDatetime.normalize(start_val, tz, "beginning", col_type == :date)
       end_val = RelativeDatetime.normalize(end_val, tz, "end", col_type == :date)
       if col_type == :date
-        start_val = quote(start_val, :date)
-        end_val   = quote(end_val, :date)
+        start_val = quote(start_val, col_type)
+        end_val   = quote(end_val, col_type)
 
         clause = "val=#{col_ruby}; !val.nil? && val.to_date >= #{start_val} && val.to_date <= #{end_val}"
       else
-        start_val = quote(start_val, :datetime)
-        end_val   = quote(end_val, :datetime)
+        start_val = quote(start_val, col_type)
+        end_val   = quote(end_val, col_type)
 
         clause = "val=#{col_ruby}; !val.nil? && val.to_time >= #{start_val} && val.to_time <= #{end_val}"
       end


### PR DESCRIPTION
Hypothesis
----------

When `MiqExpression` does not support sql, then `Rbac` does not support sql, then screens pull back all records from the database, and then screens are slow.

If `MiqExpression` is small and without duplication, then it is easier to understand and ensure all aspects possible support sql. (And possibly can be supported in ruby without a separate `to_ruby` method.

Scenario
-------

Separate field, operator, and value in `to_sql`. This PR focuses on the **value** portion and is split up into a number of commits to show each step of extracting the dates ~~and then date ranges.~~

I was surprised/pleased by the final range outcome

/cc @imtayadeway this is what you and I were talking about

**UPDATE:** I pulled out the range code and just focused on the `normalize` method.
Added the extra parameter (we will remove soon hopefully) but this really reduced the redundancy.

Interestingly, I avoided the relative dates, but they ended up disappearing anyway.