### PR TITLE
Utilization tree remembers selected node

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -24,7 +24,7 @@ class MiqCapacityController < ApplicationController
     @explorer = true
     @collapse_c_cell = true
     @sb[:active_tab] = "summary"
-    self.x_node = ""
+    self.x_node ||= ""
     @sb[:util] = {}            # reset existing values
     @sb[:util][:options] = {}  # reset existing values
     get_time_profiles # Get time profiles list (global and user specific)


### PR DESCRIPTION
Optimize -> Utilization

The tree on the left side had selected node but didn't show its info on the right side. Now it does. 

@miq-bot add_label ui, bug

