### PR TITLE
Expose manager's auth token to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
@@ -13,6 +13,7 @@ module MiqAeMethodService
     expose :to_s
     expose :authentication_userid
     expose :authentication_password
+    expose :authentication_token
     expose :authentication_password_encrypted
     expose :refresh, :method => :refresh_ems
     expose :provider, :association => true


### PR DESCRIPTION
## Purpose or Intent

Expose auth token the same way as password, so we can use it to auth to external clients for example. Auth can be either using password or token.
## Steps for Testing/QA

authentication_token can be used in automate script
