### PR TITLE
miqTreeEventSafeEval - add missing tree onclick handlers to the whitelist

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -573,23 +573,28 @@ function miqSquashToggle(treeName) {
 }
 
 function miqTreeEventSafeEval(func) {
-  var whitelist = ['miqOnCheckProtect',
-                  'miqOnCheckHandler',
-                  'miqOnCheckProvTags',
-                  'miqOnCheckUserFilters',
-                  'miqOnClickSmartProxyAffinityCheck',
-                  'miqGetChecked',
-                  'miqOnClickSelectTreeNode',
-                  'miqOnClickHostNet',
-                  'miqOnClickSelectAETreeNode',
-                  'miqOnClickTimelineSelection',
-                  'miqOnClickSelectDlgEditTreeNode',
-                  'miqOnClickSelectOptimizeTreeNode',
-                  'miqOnClickServerRoles',
-                  'miqOnClickGenealogyTree',
-                  'miqOnCheckSections',
-                  'miqOnCheckCUFilters',
-                  'miqOnClickSnapshotTree'];
+  var whitelist = [
+    'miqGetChecked',
+    'miqMenuEditor',
+    'miqOnCheckCUFilters',
+    'miqOnCheckHandler',
+    'miqOnCheckProtect',
+    'miqOnCheckProvTags',
+    'miqOnCheckSections',
+    'miqOnCheckUserFilters',
+    'miqOnClickGenealogyTree',
+    'miqOnClickHostNet',
+    'miqOnClickProvLdapOus',
+    'miqOnClickSelectAETreeNode',
+    'miqOnClickSelectDlgEditTreeNode',
+    'miqOnClickSelectOptimizeTreeNode',
+    'miqOnClickSelectTreeNode',
+    'miqOnClickServerRoles',
+    'miqOnClickSmartProxyAffinityCheck',
+    'miqOnClickSnapshotTree',
+    'miqOnClickTagCat',
+    'miqOnClickTimelineSelection',
+  ];
 
   if (whitelist.includes(func)) {
     return window[func];


### PR DESCRIPTION
Introduced in #9943 (darga/no), we whitelist all the functions that can be used as an onclick handler from dynatree.

Found 3 more functions passed as `:onclick` to dynatree missing from the whitelist, adding..

  * miqMenuEditor - report/_role_list
  * miqOnClickProvLdapOus - miq_request/_prov_field
  * miqOnClickTagCat - miq_policy/_action_options

\+ sorted the names and fixed formatting..

Fixes #10187