### PR TITLE
Expose Vmware Cloud orchestration stacks to automation engine

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudManager
+  require_nested :OrchestrationStack
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager-orchestration_stack.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Vmware_CloudManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_CloudManager_OrchestrationStack
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
This patch fixes this [PR](https://github.com/ManageIQ/manageiq/pull/10062) where OrchestrationStack module was not registered in automation system.