### PR TITLE
Duplicate the VIM session cookie when initializing the PBM service

### DIFF
--- a/gems/pending/VMwareWebService/PbmService.rb
+++ b/gems/pending/VMwareWebService/PbmService.rb
@@ -7,7 +7,7 @@ class PbmService
   def initialize(vim)
     # RbVmomi::PBM#connect expects a RbVmomi::VIM object, use a struct
     # to fake it out into using our vim Handsoap connection
-    pbm_vim_conn = PbmVimConnection.new(vim.server, vim.session_cookie)
+    pbm_vim_conn = PbmVimConnection.new(vim.server.dup, vim.session_cookie.dup)
 
     @pbm = RbVmomi::PBM.connect(pbm_vim_conn, :insecure => true)
     @sic = @pbm.serviceContent


### PR DESCRIPTION
Create a copy of the needed data from VimService for PbmService while under the connection lock so that it is safe to use for subsequent API calls while not holding the lock.