### PR TITLE
Remove references to apply_legacy_finder_options - part 1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2230,15 +2230,15 @@ class ApplicationController < ActionController::Base
                :model     => ui_lookup(:model => db.to_s)})
   end
 
-  def find_filtered(db, options = {})
+  def find_filtered(db)
     user     = current_user
     mfilters = user ? user.get_managed_filters : []
     bfilters = user ? user.get_belongsto_filters : []
 
     if db.respond_to?(:find_tags_by_grouping) && !mfilters.empty?
-      result = db.where(options[:conditions]).find_tags_by_grouping(mfilters, :ns => "*")
+      result = db.find_tags_by_grouping(mfilters, :ns => "*")
     else
-      result = db.apply_legacy_finder_options(options)
+      result = db.all
     end
 
     result = MiqFilter.apply_belongsto_filters(result, bfilters) if db.respond_to?(:apply_belongsto_filters) && result

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -62,6 +62,8 @@ class MiqReportResult < ApplicationRecord
     miq_report_result_details.build(results)
   end
 
+  # @option options :per_page number of items per page
+  # @option options :page page number (defaults to page 1)
   def html_rows(options = {})
     per_page = options.delete(:per_page)
     page     = options.delete(:page) || 1
@@ -71,7 +73,7 @@ class MiqReportResult < ApplicationRecord
     end
     update_attribute(:last_accessed_on, Time.now.utc)
     purge_for_user
-    html_details.apply_legacy_finder_options(options.merge(:order => "id asc")).collect(&:data)
+    html_details.order("id asc").offset(options[:offset]).limit(options[:limit]).collect(&:data)
   end
 
   def save_for_user(userid)


### PR DESCRIPTION
Extracted from #10175

commentary:

No reason to call `apply_legacy_finder_options()` for only 2 options (or none)

