### PR TITLE
No longer default a datacenter at the root folder of a host.

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -65,12 +65,12 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     host_dc = dest_host.parent_datacenter || dest_host.ems_cluster.parent_datacenter
 
     # Pick 'Discovered virtual machine' or its parent folder in the destination datacenter
-    vm_folder = "Datacenters/#{host_dc.name}/vm"
+    vm_folder = "#{host_dc.folder_path}/vm"
     find_folder("#{vm_folder}/Discovered virtual machine", host_dc) || find_folder(vm_folder, host_dc)
   end
 
   def find_folder(folder_path, datacenter)
-    EmsFolder.where(:name => File.basename(folder_path)).detect do |f|
+    EmsFolder.where(:name => File.basename(folder_path), :ems_id => source.ems_id).detect do |f|
       f.folder_path == folder_path && f.parent_datacenter == datacenter
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
> If a datacenter was nested logically under various folders
we were unable to find the placement id during an autoplacement 
vmware provision request.

>This fix always does a lookup of the folder path from the
host datacenter instead of statically setting a possible wrong
default value.






Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1358474
> * [PT #127205001](https://www.pivotaltracker.com/story/show/127205001)


Steps for Testing/QA
--------------------
> Set up an environment as below: (Make sure there is only 1 datacenter for autoplacement to find)

<img width="471" alt="screen shot 2016-08-04 at 12 47 40 pm" src="https://cloud.githubusercontent.com/assets/697347/17410448/ba4866ae-5a41-11e6-9caf-55c073ab6ddf.png">

Provision a VM to the nested datacenter using the autoplacement option.