### PR TITLE
Rename `clazz` to `klass`

### DIFF
--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -151,11 +151,11 @@ module ContainersCommonMixin
     session["#{prefix}_display".to_sym]    = @display unless @display.nil?
   end
 
-  def show_container_display(record, display, clazz, alt_controller_name = nil)
+  def show_container_display(record, display, klass, alt_controller_name = nil)
     title = ui_lookup(:tables => display)
     drop_breadcrumb(:name => _("%{name} (All %{title})") % {:name => record.name, :title => title},
                     :url  => "/#{alt_controller_name || controller_name}/show/#{record.id}?display=#{@display}")
-    @view, @pages = get_view(clazz, :parent => record)  # Get the records (into a view) and the paginator
+    @view, @pages = get_view(klass, :parent => record)  # Get the records (into a view) and the paginator
     @showtype = @display
   end
 

--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -386,8 +386,8 @@ describe ApplianceConsole::DatabaseConfiguration do
     end
   end
 
-  def stubbed_say(clazz)
-    Class.new(clazz) do
+  def stubbed_say(klass)
+    Class.new(klass) do
       include ApplianceConsole::Prompts
       # don't display the messages prompted to the end user
       def say(*_args)


### PR DESCRIPTION
The canonical Ruby way to spell this is `klass`, we're using `klass` 1495 times, and `clazz` 4 times.. unifying :)

(Sorry @kbrock ;))

EDIT: we also have `kls` 136 times, but that's a fight for another day :)