### PR TITLE
ActsAsArModel supports more report and rbac use cases

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -177,11 +177,8 @@ module Rbac
         scope = apply_scope(klass, scope)
 
         ids_clause = ["#{klass.table_name}.id IN (?)", target_ids] if klass.respond_to?(:table_name)
-      else # targets is a scope, class, or AASM class (VimPerformanceDaily in particular)
-        targets = to_class(targets)
-        # could just call all on everything, but that will display deprecation warnings
-        targets = targets.all if targets < ActiveRecord::Base || targets.kind_of?(ActsAsArModel)
-
+      else # targets is a class_name, scope, class, or AASM class (VimPerformanceDaily in particular)
+        targets = to_class(targets).all
         scope = apply_scope(targets, scope)
 
         unless klass.respond_to?(:find)
@@ -450,6 +447,7 @@ module Rbac
     end
 
     def apply_scope(klass, scope)
+      klass = klass.all
       scope_name = Array.wrap(scope).first
       if scope_name.nil?
         klass

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1008,6 +1008,11 @@ describe Rbac::Filterer do
       expect(described_class.filtered(Vm.where(:location => "good"))).to match_array(matched_vms)
     end
 
+    it "support aaarm object" do
+      expect(LiveMetric).to receive(:find).with(:all, :include => {:a => {}}).and_return([:good])
+      expect(described_class.filtered(LiveMetric, :include_for_find => {:a => {}}).to_a).to match_array([:good])
+    end
+
     # it returns objects too
     # TODO: cap number of queries here
     it "runs rbac on array target" do


### PR DESCRIPTION
~~BLOCKED ON: #10273~~

Screens that display `ActsAsArModel` are broken. There are a few steps to merge:

- [x] #10264 remove references to `apply_legacy_finder_options`
- [x] #10175 remove `apply_legacy_finder_options` (calling on query blew things up)
- [x] #10273 Fix includes for reports
- This PR (1 commit) - add a test to ensure `ActsAsArModel` works for basic cases

Fixes #10087

Details:
-----

1. Support `includes(:table => {})` (an similar references / order). It is not smart enought to properly the second level of hashes. but `:includes` is not really supported by our `ActsAsArModel` implementations.
2. Support `references(:table => {})`. Though we do not use `:references` in any of our implementations, it was blowing up before. it was free with the `includes()` implementation
3. Support `order(Hash)`. It was free. We may need to support other syntaxes for this as well.
4. Support `length` attribute, which is essentially the same as `size`
5. Support `where(nil)` which is getting called more often now that we are sql munging less.

/cc @lucasponce 