### PR TITLE
Add multiselect option to dropdowns

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -51,10 +51,8 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     MiqAeEngine.create_automation_attribute_array_value(automate_values)
   end
 
-  private
-
-  def load_values_on_init?
-    return true unless show_refresh_button
-    load_values_on_init
+  def automate_key_name
+    return super unless force_multi_value
+    MiqAeEngine.create_automation_attribute_array_key(super)
   end
 end

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -14,4 +14,30 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def initial_values
     [[nil, "<None>"]]
   end
+
+  def refresh_json_value(checked_value)
+    @raw_values = @default_value = nil
+
+    refreshed_values = values
+
+    if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
+      @value = checked_value
+    else
+      @value = @default_value
+    end
+
+    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?, :visible => visible?}
+  end
+
+  def automate_output_value
+    return nil if @value.blank?
+    MiqAeEngine.create_automation_attribute_array_value(@value.split.map(&:to_i))
+  end
+
+  private
+
+  def load_values_on_init?
+    return true unless show_refresh_button
+    load_values_on_init
+  end
 end

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -3,7 +3,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     !!show_refresh_button
   end
 
-  def multi_value?
+  def force_multi_value
     return true if options[:force_multi_value].present? &&
                    options[:force_multi_value] != "null" &&
                    options[:force_multi_value]
@@ -39,7 +39,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   end
 
   def automate_output_value
-    return super unless multi_value?
+    return super unless force_multi_value
     a = if @value.kind_of?(Integer)
           [@value]
         elsif @value.kind_of?(Array)

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -3,6 +3,14 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     !!show_refresh_button
   end
 
+  def multi_value?
+    return true if options[:force_multi_value].present? && options[:force_multi_value] != "null"
+  end
+
+  def force_multi_value=(setting)
+    options[:force_multi_value] = setting
+  end
+
   def initial_values
     [[nil, "<None>"]]
   end

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -210,11 +210,11 @@ describe DialogFieldDropDownList do
           @df = FactoryGirl.create(:dialog_field_drop_down_list, :name => 'test drop down')
         end
 
-        describe "#multi_value?" do
+        describe "#force_multi_value" do
           context "when force_multi_value is present" do
             context "when force_multi_value is null" do
               it "multivalue false" do
-                expect(@df.multi_value?).to be_falsey
+                expect(@df.force_multi_value).to be_falsey
               end
             end
 
@@ -222,13 +222,13 @@ describe DialogFieldDropDownList do
               context "when force_multi_value is truthy" do
                 it "multivalue true" do
                   @df.force_multi_value = true
-                  expect(@df.multi_value?).to be_truthy
+                  expect(@df.force_multi_value).to be_truthy
                 end
               end
 
               context "when force_multi_value is falsy" do
                 it "multivalue false" do
-                  expect(@df.multi_value?).to be_falsey
+                  expect(@df.force_multi_value).to be_falsey
                 end
               end
             end
@@ -236,7 +236,7 @@ describe DialogFieldDropDownList do
 
           context "when force_multi_value is not present" do
             it "multivalue false" do
-              expect(@df.multi_value?).to be_falsey
+              expect(@df.force_multi_value).to be_falsey
             end
           end
         end
@@ -249,8 +249,8 @@ describe DialogFieldDropDownList do
                                    :options => {:force_multi_value => true})
         end
 
-        it "#multi_value?" do
-          expect(@df.multi_value?).to be_truthy
+        it "#force_multi_value" do
+          expect(@df.force_multi_value).to be_truthy
         end
       end
 

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -92,51 +92,75 @@ describe DialogFieldDropDownList do
   describe "#refresh_json_value" do
     let(:dialog_field) { described_class.new(:dynamic => dynamic, :read_only => true) }
 
-    context "when the dialog_field is dynamic" do
+    context "dynamic" do
       let(:dynamic) { true }
-
-      before do
-        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
-          [["123", 456], ["789", 101]]
-        )
-        dialog_field.value = "123"
+      context "array" do
+        context "included" do
+          # TODO
+        end
+        context "not-included" do
+          # TODO
+        end
       end
 
-      it "sets the value" do
-        dialog_field.refresh_json_value("789")
-        expect(dialog_field.value).to eq("789")
-      end
+      context "not-array" do
+        before do
+          allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
+            [["123", 456], ["789", 101]]
+          )
+          dialog_field.value = "123"
+        end
 
-      it "returns the values from automate" do
-        expect(dialog_field.refresh_json_value("789")).to eq(
-          :refreshed_values => [["789", 101], ["123", 456]],
-          :checked_value    => "789",
-          :read_only        => true,
-          :visible          => true
-        )
+        it "sets the value" do
+          dialog_field.refresh_json_value("789")
+          expect(dialog_field.value).to eq("789")
+        end
+
+        it "returns the values from automate" do
+          expect(dialog_field.refresh_json_value("789")).to eq(
+            :refreshed_values => [["789", 101], ["123", 456]],
+            :checked_value    => "789",
+            :read_only        => true,
+            :visible          => true
+          )
+        end
       end
     end
 
-    context "when the dialog_field is not dynamic" do
+    context "non-dynamic" do
       let(:dynamic) { false }
-
-      before do
-        dialog_field.values = [["123", 456], ["789", 101]]
-        dialog_field.value = "123"
+      context "array" do
+        context "included" do
+          # TODO
+        end
+        context "not-included" do
+          # TODO
+        end
       end
 
-      it "sets the value" do
-        dialog_field.refresh_json_value("789")
-        expect(dialog_field.value).to eq("789")
-      end
+      context "not-array" do
+        context "when the dialog_field is not dynamic" do
+          let(:dynamic) { false }
 
-      it "returns the values" do
-        expect(dialog_field.refresh_json_value("789")).to eq(
-          :refreshed_values => [["789", 101], ["123", 456]],
-          :checked_value    => "789",
-          :read_only        => true,
-          :visible          => true
-        )
+          before do
+            dialog_field.values = [["123", 456], ["789", 101]]
+            dialog_field.value = "123"
+          end
+
+          it "sets the value" do
+            dialog_field.refresh_json_value("789")
+            expect(dialog_field.value).to eq("789")
+          end
+
+          it "returns the values" do
+            expect(dialog_field.refresh_json_value("789")).to eq(
+              :refreshed_values => [["789", 101], ["123", 456]],
+              :checked_value    => "789",
+              :read_only        => true,
+              :visible          => true
+            )
+          end
+        end
       end
     end
   end
@@ -186,11 +210,35 @@ describe DialogFieldDropDownList do
           @df = FactoryGirl.create(:dialog_field_drop_down_list, :name => 'test drop down')
         end
 
-        it "#multi_value?" do
-          expect(@df.multi_value?).to be_falsey
+        describe "#multi_value?" do
+          context "when force_multi_value is present" do
+            context "when force_multi_value is null" do
+              it "multivalue false" do
+                expect(@df.multi_value?).to be_falsey
+              end
+            end
 
-          @df.force_multi_value = true
-          expect(@df.multi_value?).to be_truthy
+            context "when force_multi_value is not null" do
+              context "when force_multi_value is truthy" do
+                it "multivalue true" do
+                  @df.force_multi_value = true
+                  expect(@df.multi_value?).to be_truthy
+                end
+              end
+
+              context "when force_multi_value is falsy" do
+                it "multivalue false" do
+                  expect(@df.multi_value?).to be_falsey
+                end
+              end
+            end
+          end
+
+          context "when force_multi_value is not present" do
+            it "multivalue false" do
+              expect(@df.multi_value?).to be_falsey
+            end
+          end
         end
 
         it "#automate_key_name" do

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -240,10 +240,6 @@ describe DialogFieldDropDownList do
             end
           end
         end
-
-        it "#automate_key_name" do
-          expect(@df.automate_key_name).to eq("dialog_#{@df.name}")
-        end
       end
 
       context "dialog field dropdown with options hash" do

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -181,6 +181,35 @@ describe DialogFieldDropDownList do
         end
       end
 
+      context "dialog field dropdown without options hash" do
+        before do
+          @df = FactoryGirl.create(:dialog_field_drop_down_list, :name => 'test drop down')
+        end
+
+        it "#multi_value?" do
+          expect(@df.multi_value?).to be_falsey
+
+          @df.force_multi_value = true
+          expect(@df.multi_value?).to be_truthy
+        end
+
+        it "#automate_key_name" do
+          expect(@df.automate_key_name).to eq("dialog_#{@df.name}")
+        end
+      end
+
+      context "dialog field dropdown with options hash" do
+        before do
+          @df = FactoryGirl.create(:dialog_field_drop_down_list,
+                                   :name    => 'test drop down',
+                                   :options => {:force_multi_value => true})
+        end
+
+        it "#multi_value?" do
+          expect(@df.multi_value?).to be_truthy
+        end
+      end
+
       context "when the raw values are not already set" do
         before do
           dialog_field.values = %w(original values)


### PR DESCRIPTION
Adds multiselect flag to dropdowns much like the existing single option for tag controls. 

@miq-bot add_label ui
@miq-bot assign @gmcculloug 
@miq-bot add_label wip
