### PR TITLE
Refactored FailoverDatabases and corresponding rspec

### DIFF
--- a/gems/pending/postgres_ha_admin/postgres_ha_admin.rb
+++ b/gems/pending/postgres_ha_admin/postgres_ha_admin.rb
@@ -1,4 +1,0 @@
-module PostgresHaAdmin
-  DB_YML_FILE = 'failover_databases.yml'.freeze
-  LOG_FILE_NAME = "ha_admin.log".freeze
-end

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -1,132 +1,95 @@
 require 'postgres_ha_admin/failover_databases'
-require 'postgres_ha_admin/postgres_ha_admin'
-require 'spec/support/test_env_helper'
 require 'pg'
 
 describe PostgresHaAdmin::FailoverDatabases do
-  subject do
-    described_class.new(TestEnvHelper::CONFIG_DIR, TestEnvHelper::CONFIG_DIR, :dbname => 'travis', :user => 'travis')
-    # described_class.new(TestEnvHelper::CONFIG_DIR, TestEnvHelper::CONFIG_DIR, :dbname => 'vmdb_test')
+  let(:logger) { Logger.new(@logger_file) }
+  let(:failover_databases) { described_class.new(@yml_file, logger) }
+
+  before do
+    @yml_file = Tempfile.new('failover_databases.yml')
+    @logger_file = Tempfile.new('ha_admin.log')
   end
 
-  # let(:connection) { PG::Connection.open(:dbname => 'vmdb_test') }
-  let(:connection) do
-    begin
-      PG::Connection.open(:dbname => 'travis', :user => 'travis')
-    rescue PG::ConnectionBad => _err
-      skip "travis database does not exist"
+  after do
+    @yml_file.close(true)
+    @logger_file.close(true)
+  end
+
+  describe "#active_databases" do
+    it "return list of active databases saved in 'config/failover_databases.yml'" do
+      File.write(@yml_file, initial_db_list.to_yaml)
+      expect(failover_databases.active_databases).to contain_exactly(
+        {:type => 'master', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'},
+        {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'})
     end
   end
 
-  around(:each) do |example|
-    begin
-      connection.exec("START TRANSACTION")
+  describe "#update_failover_yml" do
+    after do
+      @connection.exec("ROLLBACK")
+      @connection.finish
+    end
 
-      connection.exec(<<-SQL)
-        CREATE TABLE #{described_class::TABLE_NAME} (
+    before do
+      # @connection = PG::Connection.open(:dbname => 'vmdb_test')
+      begin
+        @connection = PG::Connection.open(:dbname => 'travis', :user => 'travis')
+      rescue PG::ConnectionBad
+        skip "travis database does not exist"
+      end
+
+      @connection.exec("START TRANSACTION")
+      @connection.exec(<<-SQL)
+        CREATE TABLE #{described_class::TABLE_NAME}  (
           type text NOT NULL,
           conninfo text NOT NULL,
           active boolean DEFAULT true NOT NULL
         )
       SQL
 
-      connection.exec(<<-SQL)
+      @connection.exec(<<-SQL)
         INSERT INTO
           #{described_class::TABLE_NAME}(type, conninfo, active)
         VALUES
-          ('master', 'host=1.1.1.1 user=root dbname=vmdb_test', 'true'),
-          ('standby', 'host=2.2.2.2 user=root dbname=vmdb_test', 'true'),
-          ('standby', 'host=3.3.3.3 user=root dbname=vmdb_test', 'false')
+          ('master', 'host=203.0.113.1 user=root dbname=vmdb_test', 'true'),
+          ('standby', 'host=203.0.113.2 user=root dbname=vmdb_test', 'true'),
+          ('standby', 'host=203.0.113.3 user=root dbname=vmdb_test', 'false')
       SQL
-
-      example.run
-    ensure
-      connection.exec("ROLLBACK")
-      connection.finish
-      remove_file
-    end
-  end
-
-  describe "#all_databases" do
-    it "returns list of all available databases saved in yaml file" do
-      list = subject.all_databases(connection)
-
-      expect(list.size).to be 3
-      expect(list).to include({:type => "master", :host => "1.1.1.1", :dbname => "vmdb_test",
-                               :user => "root", :active => true},
-                              {:type => "standby", :host => "2.2.2.2", :dbname => "vmdb_test",
-                               :user => "root", :active => true},
-                              {:type => "standby", :host => "3.3.3.3", :dbname => "vmdb_test",
-                               :user => "root", :active => false})
     end
 
-    it "create yaml file with list of available databases if file did not exist" do
-      expect(File.exist?(subject.yml_file)).to be false
+    it "updates 'failover_databases.yml'" do
+      failover_databases.update_failover_yml(@connection)
 
-      subject.all_databases(connection)
-      expect(File.exist?(subject.yml_file)).to be true
-    end
-
-    it "if yaml file exists, it loads list of databases from existing file" do
-      list = subject.all_databases(connection)
-      expect(list.size).to be 3
+      yml_hash = YAML.load_file(@yml_file)
+      expect(yml_hash).to eq initial_db_list
 
       add_new_record
 
-      subject.all_databases(connection)
-      expect(list.size).to be 3
-      expect(list).to include({:type => "master", :host => "1.1.1.1", :dbname => "vmdb_test",
-                              :user => "root", :active => true},
-                              {:type => "standby", :host => "2.2.2.2", :dbname => "vmdb_test",
-                               :user => "root", :active => true},
-                              {:type => "standby", :host => "3.3.3.3", :dbname => "vmdb_test",
-                               :user => "root", :active => false})
+      failover_databases.update_failover_yml(@connection)
+      yml_hash = YAML.load_file(@yml_file)
+      expect(yml_hash).to eq new_db_list
     end
   end
 
-  describe "#refresh_databases_list" do
-    it "override existing yaml file and returns updated list of databases" do
-      list = subject.all_databases(connection)
-      expect(list.size).to be 3
-
-      add_new_record
-
-      list = subject.refresh_databases_list(connection)
-      expect(list.size).to be 4
-      expect(list).to include(:type => "standby", :host => "4.4.4.4", :dbname => "some_db",
-                              :user => "root", :active => true)
-    end
+  def initial_db_list
+    arr = []
+    arr << {:type => 'master', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'standby', :active => false, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
+    arr
   end
 
-  describe "#standby_databases" do
-    it "returns list of databases in standby mode" do
-      list = subject.standby_databases(connection)
-      expect(list.size).to eq 2
-    end
-  end
-
-  describe "#active_standby_databases" do
-    it "returns list of active databases in standby mode" do
-      list = subject.active_standby_databases(connection)
-      expect(list.size).to eq 1
-    end
+  def new_db_list
+    initial_db_list << {:type => 'standby', :active => true, :host => '203.0.113.4',
+                        :user => 'root', :dbname => 'some_db'}
   end
 
   def add_new_record
-    connection.exec(<<-SQL)
+    @connection.exec(<<-SQL)
       INSERT INTO
         #{described_class::TABLE_NAME}(type, conninfo, active)
       VALUES
-        ('standby', 'host=4.4.4.4 user=root dbname=some_db', 'true')
+        ('standby', 'host=203.0.113.4 user=root dbname=some_db', 'true')
     SQL
-  end
-
-  def remove_file
-    if File.exist?(subject.yml_file)
-      File.delete(subject.yml_file)
-    end
-    if File.exist?(subject.log_file)
-      File.delete(subject.log_file)
-    end
   end
 end

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -3,7 +3,7 @@ require 'pg'
 
 describe PostgresHaAdmin::FailoverDatabases do
   let(:logger) { Logger.new(@logger_file) }
-  let(:failover_databases) { described_class.new(@yml_file, logger) }
+  let(:failover_databases) { described_class.new(@yml_file.path, logger) }
 
   before do
     @yml_file = Tempfile.new('failover_databases.yml')


### PR DESCRIPTION
Refactoring FailoverDatabases class making code cleaner and allowing to use```Tempfile``` in rspec instead of 'real' files.

This PR is follow-up for: https://github.com/ManageIQ/manageiq/pull/10103

/cc @carbonin 
