### PR TITLE
Enhance ActsAsArQuery for reports

### DIFF
--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -38,11 +38,11 @@ class ActsAsArQuery
   end
 
   def where(*val)
-    val = val.flatten
+    val = val.flatten.compact
     val = val.first if val.size == 1 && val.first.kind_of?(Hash)
     dup.tap do |r|
       old_where = r.options[:where]
-      if val.empty?
+      if val.blank?
         # nop
       elsif old_where.blank?
         r.options[:where] = val
@@ -90,7 +90,7 @@ class ActsAsArQuery
   end
 
   def reorder(*val)
-    val = val.flatten
+    val = val.flatten.compact
     if val.first.kind_of?(Hash)
       raise ArgumentError, "Need to support #{__callee__}(#{val.class.name})"
     end
@@ -102,7 +102,7 @@ class ActsAsArQuery
 
   def except(*val)
     dup.tap do |r|
-      val.flatten.each do |key|
+      val.flatten.compact.each do |key|
         r.options.delete(key)
       end
     end
@@ -111,7 +111,7 @@ class ActsAsArQuery
   # similar to except. difference being this persists across merges
   def unscope(*val)
     dup.tap do |r|
-      val.flatten.each do |key|
+      val.flatten.compact.each do |key|
         r.options[key] = nil
       end
     end
@@ -185,7 +185,7 @@ class ActsAsArQuery
   end
 
   def append_hash_arg(symbol, *val)
-    val = val.flatten
+    val = val.flatten.compact
     if val.first.kind_of?(Hash)
       raise ArgumentError, "Need to support #{symbol}(#{val.class.name})"
     end
@@ -195,7 +195,7 @@ class ActsAsArQuery
   end
 
   def append_hash_array_arg(symbol, default, *val)
-    val = val.flatten
+    val = val.flatten.compact
     val = val.first if val.size == 1 && val.first.kind_of?(Hash)
     dup.tap do |r|
       r.options[symbol] = merge_hash_or_array(r.options[symbol], val, default)
@@ -208,7 +208,7 @@ class ActsAsArQuery
   def merge_hash_or_array(a, b, default = {})
     if a.blank?
       b
-    elsif b.empty?
+    elsif b.blank?
       a
     elsif a.kind_of?(Array) && b.kind_of?(Array)
       a + b

--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -148,7 +148,7 @@ class ActsAsArQuery
     to_a.size
   end
 
-  def_delegators :to_a, :size, :take, :each, :empty?, :presence
+  def_delegators :to_a, :size, :length, :take, :each, :empty?, :presence
 
   # TODO: support arguments
   def first

--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -219,8 +219,21 @@ class ActsAsArQuery
     end
   end
 
-  def array_to_hash(arr, default = {})
-    arr.each_with_object({}) { |k, h| h[k] = default.dup }
+  # This takes the array form and converts into the equivalent hash form
+  #
+  # @example converting an order parameter
+  #   # Vm.order(:name, :ip)
+  #   array_to_hash([:name, :ip], "ASC") #=> {:name => "ASC", :ip => "ASC"}
+  #
+  # @example converting an includes parameter
+  #   # Vm.includes([:ext_management_system, :host])
+  #   array_to_hash([:ext_management_system, :host], {}) #=> {:ext_management_system => {}, :host =>{}}
+  #
+  # @param array [Array<Symbol>] array of names
+  # @param default value to be associated with each object (i.e.: "ASC", {})
+  # @return [Hash{Symbol => String, Hash}] Hash equivalent of the input array
+  def array_to_hash(array, default = {})
+    array.each_with_object({}) { |k, h| h[k] = default.dup }
   end
 
   def assign_arg(symbol, val)

--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -66,7 +66,7 @@ class ActsAsArQuery
   end
 
   def references(*args)
-    append_hash_arg :references, *args
+    append_hash_array_arg :references, {}, *args
   end
 
   def limit(val)

--- a/lib/acts_as_ar_query.rb
+++ b/lib/acts_as_ar_query.rb
@@ -78,7 +78,7 @@ class ActsAsArQuery
   end
 
   def order(*args)
-    append_hash_arg :order, *args
+    append_hash_array_arg :order, "ASC", *args
   end
 
   def order_values

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -109,7 +109,15 @@ describe ActsAsArQuery do
     it { expect(query.order(:a).order(:b).order_values).to eq([:a, :b]) }
   end
 
-  # - [X] references (partial) - currently ignored
+  # this is a copy of includes, so just ensuring that the "hardest" thing works
+  # our finders do not use this, so it is just skipped
+  # we're just making sure stuff does not blow up
+  describe "#references" do
+    it "chains array hash" do
+      expect(model).to receive(:find).with(:all, {})
+      query.references(:a).references(:b => {}).to_a
+    end
+  end
 
   describe "#reorder" do
     it "reorders" do

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -40,6 +40,11 @@ describe ActsAsArQuery do
       query.includes(:a => {}).includes(:b).to_a
     end
 
+    it "ignores nils" do
+      expect(model).to receive(:find).with(:all, :include => {:a => 5})
+      query.includes(nil).includes(:a => 5).includes(nil).to_a
+    end
+
     it "chains array hash" do
       expect(model).to receive(:find).with(:all, :include => {:a => {}, :b => {}})
       query.includes(:a).includes(:b => {}).to_a
@@ -50,6 +55,11 @@ describe ActsAsArQuery do
     it "limits" do
       expect(model).to receive(:find).with(:all, :limit => 5)
       query.limit(5).to_a
+    end
+
+    it "supports nils" do
+      expect(model).to receive(:find).with(:all, {})
+      query.limit(5).limit(nil).to_a
     end
   end
 
@@ -64,6 +74,11 @@ describe ActsAsArQuery do
     it "offsets" do
       expect(model).to receive(:find).with(:all, :offset => 5)
       query.offset(5).to_a
+    end
+
+    it "supports nils" do
+      expect(model).to receive(:find).with(:all, {})
+      query.offset(5).offset(nil).to_a
     end
   end
 
@@ -135,9 +150,14 @@ describe ActsAsArQuery do
       query.reorder(:c, :d).reorder(:a, :b).to_a
     end
 
-    it "order" do
+    it "overrides order" do
       expect(model).to receive(:find).with(:all, :order => [:a, :b])
       query.order(:c).order(:d).reorder(:a, :b).to_a
+    end
+
+    it "replaces order with nil" do
+      expect(model).to receive(:find).with(:all, {})
+      query.order(:c).reorder(nil).to_a
     end
   end
 
@@ -155,6 +175,11 @@ describe ActsAsArQuery do
     it "chains fields" do
       expect(model).to receive(:find).with(:all, :select => [:c, :d, :a, :b])
       query.select(:c, :d).select(:a, :b).to_a
+    end
+
+    it "ignores nils" do
+      expect(model).to receive(:find).with(:all, :select => [:a, :b])
+      query.select(nil).select(:a, :b).select(nil).to_a
     end
 
     it "doesn't support hashes" do # TODO
@@ -188,6 +213,11 @@ describe ActsAsArQuery do
     it "merges hashes" do
       expect(model).to receive(:find).with(:all, :conditions => {:a => [5, 55], :b => [6, 66]})
       query.where(:a => 5, :b => 6).where(:a => 55, :b => 66).to_a
+    end
+
+    it "ignores nils" do
+      expect(model).to receive(:find).with(:all, :conditions => {:a => 5})
+      query.where(nil).where(:a => 5).where(nil).to_a
     end
 
     it "supports string queries" do

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -83,9 +83,24 @@ describe ActsAsArQuery do
       query.order(:a, :b).to_a
     end
 
-    it "chains" do
+    it "chains singles" do
       expect(model).to receive(:find).with(:all, :order => [:a, :b])
       query.order(:a).order(:b).to_a
+    end
+
+    it "chains arrays" do
+      expect(model).to receive(:find).with(:all, :order => [:a, :b, :c, :d])
+      query.order(:a, :b).order(:c, :d).to_a
+    end
+
+    it "chains hash array" do
+      expect(model).to receive(:find).with(:all, :order => {:a => "DESC", :b => "ASC"})
+      query.order(:a => "DESC").order(:b).to_a
+    end
+
+    it "chains hash array" do
+      expect(model).to receive(:find).with(:all, :order => {:a => "ASC", :b => "DESC"})
+      query.order(:a).order(:b => "DESC").to_a
     end
   end
 

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -20,9 +20,29 @@ describe ActsAsArQuery do
       query.includes(:a, :b).to_a
     end
 
-    it "chains" do
+    it "accepts a hash argument" do
+      expect(model).to receive(:find).with(:all, :include => {:a => {}})
+      query.includes(:a => {}).to_a
+    end
+
+    it "chains singles" do
       expect(model).to receive(:find).with(:all, :include => [:a, :b])
       query.includes(:a).includes(:b).to_a
+    end
+
+    it "chains arrays" do
+      expect(model).to receive(:find).with(:all, :include => [:a, :b, :c, :d])
+      query.includes(:a, :b).includes(:c, :d).to_a
+    end
+
+    it "chains hash array" do
+      expect(model).to receive(:find).with(:all, :include => {:a => {}, :b => {}})
+      query.includes(:a => {}).includes(:b).to_a
+    end
+
+    it "chains array hash" do
+      expect(model).to receive(:find).with(:all, :include => {:a => {}, :b => {}})
+      query.includes(:a).includes(:b => {}).to_a
     end
   end
 

--- a/spec/lib/acts_as_ar_query_spec.rb
+++ b/spec/lib/acts_as_ar_query_spec.rb
@@ -269,6 +269,13 @@ describe ActsAsArQuery do
     end
   end
 
+  describe "#length" do
+    it "accepts a single table" do
+      expect(model).to receive(:find).with(:all, :include => [:a]).and_return([1, 2, 3, 4, 5])
+      expect(query.includes(:a).length).to eq(5)
+    end
+  end
+
   describe "#size" do
     it "accepts a single table" do
       expect(model).to receive(:find).with(:all, :include => [:a]).and_return([1, 2, 3, 4, 5])


### PR DESCRIPTION
ActsAsArQuery gives us chainable query interface for ActsAsArModel.

Reporting uses a few features in building queries that are currently not supported by `ActsAsArQuery`

The final goal of this PR is to get LiveMetric working again.

1. support `includes(:table => {})`
2. support `requires(:table => {})`
3. support `length`
4. support `where(nil)`, `includes(nil)`, ...  (which is used more now that we are munging less)
