### PR TITLE
Implement pending gem for Vmware Cloud connection to Rabbit

### DIFF
--- a/gems/pending/spec/vmware/vmware_vcloud_event_monitor_spec.rb
+++ b/gems/pending/spec/vmware/vmware_vcloud_event_monitor_spec.rb
@@ -1,0 +1,48 @@
+require 'vmware/vmware_vcloud_event_monitor'
+
+describe VmwareVcloudEventMonitor do
+  before do
+    @original_log = $log
+    $log = double.as_null_object
+
+    @topic = "vmware_vcloud_topic"
+    @receiver_options = {:capacity => 1, :duration => 1}
+    @options = @receiver_options.merge(:topics => @topic, :client_ip => "10.11.12.13")
+
+    @rabbit_connection = double
+    allow(VmwareVcloudEventMonitor).to receive(:connect).and_return(@rabbit_connection)
+  end
+
+  after do
+    $log = @original_log
+  end
+
+  context "testing a connection" do
+    it "returns true on a successful test" do
+      expect(@rabbit_connection).to receive(:start)
+      expect(@rabbit_connection).to receive(:close)
+
+      expect(VmwareVcloudEventMonitor.test_connection(@options)).to be_truthy
+    end
+
+    it "raise exception on an unsuccessful test with bad credentials" do
+      expect(@rabbit_connection).to receive(:start).and_raise(Bunny::AuthenticationFailureError.new('test', 'test', 5))
+      expect(@rabbit_connection).to receive(:close)
+      expect { VmwareVcloudEventMonitor.test_connection(@options) }.to(
+        raise_error(MiqException::MiqInvalidCredentialsError)
+      )
+    end
+
+    it "raise exception on an unsuccessful test with unreachable hostname" do
+      expect(@rabbit_connection).to receive(:start).and_raise(Bunny::TCPConnectionFailedForAllHosts.new)
+      expect(@rabbit_connection).to receive(:close)
+      expect { VmwareVcloudEventMonitor.test_connection(@options) }.to raise_error(MiqException::MiqHostError)
+    end
+
+    it "raise exception on an unsuccessful test with unexpected exception" do
+      expect(@rabbit_connection).to receive(:start).and_raise("Cannot connect to rabbit amqp")
+      expect(@rabbit_connection).to receive(:close)
+      expect { VmwareVcloudEventMonitor.test_connection(@options) }.to raise_error("Cannot connect to rabbit amqp")
+    end
+  end
+end

--- a/gems/pending/vmware/events/vmware_vcloud_event.rb
+++ b/gems/pending/vmware/events/vmware_vcloud_event.rb
@@ -1,0 +1,53 @@
+# https://pubs.vmware.com/vca/index.jsp#com.vmware.vcloud.api.doc_56/GUID-7C1F16FF-C530-404E-8533-329670B20A19.html
+
+class VmwareVcloudEvent
+  attr_accessor :payload, :metadata, :delivery_info
+
+  TYPE_KEY              = 'notification.type'.freeze
+  ORGANIZATION_UUID_KEY = 'notification.orgUUID'.freeze
+  ENTITY_TYPE_KEY       = 'notification.entityType'.freeze
+  ENTITY_UUID_KEY       = 'notification.entityUUID'.freeze
+  TIMESTAMP_KEY         = 'notification.timestamp'.freeze
+
+  def required_header_keys
+    [TYPE_KEY, ORGANIZATION_UUID_KEY, ENTITY_TYPE_KEY, ENTITY_UUID_KEY, TIMESTAMP_KEY]
+  end
+
+  def initialize(payload, metadata, delivery_info)
+    raise "AMQP message missing header" unless metadata.respond_to? :headers
+    raise "AMQP message missing required headers" if required_header_keys.any? { |s| !metadata.headers.key? s }
+
+    @payload       = payload
+    @payload_hash  = payload_hash
+    @metadata      = metadata
+    @delivery_info = delivery_info
+  end
+
+  def header(key)
+    @metadata.headers[key]
+  end
+
+  def payload_hash
+    begin
+      @payload_hash ||= { :eventId => Hash.from_xml(@payload)['Notification']['eventId'] }
+    rescue
+      raise "AMQP message invalid payload"
+    end
+    @payload_hash
+  end
+
+  def type
+    header TYPE_KEY
+  end
+
+  def to_hash
+    {
+      :id                => payload_hash[:eventId],
+      :type              => type,
+      :organization_uuid => header(ORGANIZATION_UUID_KEY),
+      :entity_type       => header(ENTITY_TYPE_KEY),
+      :entity_uuid       => header(ENTITY_UUID_KEY),
+      :timestamp         => header(TIMESTAMP_KEY),
+    }
+  end
+end

--- a/gems/pending/vmware/vmware_vcloud_event_monitor.rb
+++ b/gems/pending/vmware/vmware_vcloud_event_monitor.rb
@@ -1,0 +1,136 @@
+require 'more_core_extensions/core_ext/hash'
+require 'util/extensions/miq-module'
+require 'vmware/events/vmware_vcloud_event'
+require 'bunny'
+require 'thread'
+
+# Listens to RabbitMQ events
+class VmwareVcloudEventMonitor
+  DEFAULT_AMQP_PORT = 5672
+  DEFAULT_AMQP_HEARTBEAT = 30
+
+  def self.test_connection(options = {})
+    connection = nil
+    begin
+      connection = connect(options)
+      connection.start
+      return true
+    rescue Bunny::AuthenticationFailureError => e
+      $log.info("#{log_prefix} Failed testing rabbit amqp connection: #{e.message}") if $log
+      raise MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+    rescue Bunny::TCPConnectionFailedForAllHosts => e
+      raise MiqException::MiqHostError.new "Socket error: #{e.message}"
+    rescue
+      $log.info("#{log_prefix} Failed testing rabbit amqp connection for #{options[:hostname]}. ") if $log
+      raise
+    ensure
+      connection.close if connection.respond_to? :close
+    end
+  end
+
+  def self.available?(options = {})
+    test_connection(options)
+  end
+
+  def self.test_amqp_connection(options)
+    available?(options)
+  end
+
+  def self.connect(options = {})
+    connection_options = {:host => options[:hostname]}
+    connection_options[:port]               = options[:port] || DEFAULT_AMQP_PORT
+    connection_options[:heartbeat]          = options[:heartbeat] || DEFAULT_AMQP_HEARTBEAT
+    connection_options[:automatic_recovery] = options[:automatic_recovery] if options.key? :automatic_recovery
+    connection_options[:recovery_attempts]  = options[:recovery_attempts] if options.key? :recovery_attempts
+
+    if options.key? :recover_from_connection_close
+      connection_options[:recover_from_connection_close] = options[:recover_from_connection_close]
+    end
+
+    if options.key? :username
+      connection_options[:username] = options[:username]
+      connection_options[:password] = options[:password]
+    end
+    Bunny.new(connection_options)
+  end
+
+  def self.log_prefix
+    "MIQ(#{self.class.name})"
+  end
+
+  def initialize(options = {})
+    @options          = options
+    @options[:port] ||= DEFAULT_AMQP_PORT
+    @client_ip        = @options[:client_ip]
+
+    @collecting_events = false
+    @events = []
+    # protect threaded access to the events array
+    @events_array_mutex = Mutex.new
+  end
+
+  def start
+    $log.debug("#{self.class.log_prefix} Opening amqp connection to #{@options}") if $log
+    connection.start
+    @channel = connection.create_channel
+    initialize_queues(@channel)
+  end
+
+  def stop
+    @connection.close if @connection.respond_to? :close
+    @collecting_events = false
+  end
+
+  def each_batch
+    @collecting_events = true
+    subscribe_queues
+    while @collecting_events
+      @events_array_mutex.synchronize do
+        $log.debug("#{self.class.log_prefix} Yielding #{@events.size} events to" \
+                   " event_catcher: #{@events.map { |e| e.payload["event_type"] }}") if $log
+        yield @events
+        $log.debug("#{self.class.log_prefix} Clearing events") if $log
+        @events.clear
+      end
+      sleep 5
+    end
+  end
+
+  def each
+    each_batch do |events|
+      events.each { |e| yield e }
+    end
+  end
+
+  private
+
+  def connection
+    @connection ||= self.class.connect(@options)
+  end
+
+  def initialize_queues(channel)
+    @queues = {}
+    @options[:queues].each do |queue_name|
+      @queues[queue_name] = channel.queue(queue_name, :durable => true)
+    end
+  end
+
+  def subscribe_queues
+    @queues.each do |queue_name, queue|
+      # Parse amqp message
+      queue.subscribe do |delivery_info, metadata, payload|
+        begin
+          event = VmwareVcloudEvent.new(payload, metadata, delivery_info)
+          @events_array_mutex.synchronize do
+            @events << event
+            $log.debug("#{self.class.log_prefix} Received Rabbit (amqp) event"\
+                       " on #{queue_name} from #{@options[:hostname]}: #{event}") if $log
+          end
+        rescue => e
+          $log.error("#{self.class.log_prefix} Exception receiving Rabbit (amqp)"\
+                     " event on #{queue_name} from #{@options[:hostname]}: #{e}") if $log
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
This is firt part of EventCatcher integration for VMware Cloud.
This module will be used by workers to consume messages from RabbitMQ.
It's originally part of https://github.com/ManageIQ/manageiq/pull/10192

Steps for Testing/QA
-----------------
To test it I suggest to run the following code:
```ruby
monitor = VmwareVcloudEventMonitor.new(
    :hostname => "11.22.33.111",
    :username => "rabbit_user",
    :password => "password",
    :port => 5672,
    :queues => ['my-queue'],
)
monitor.start
monitor.each_batch do |events|
  if events && !events.empty?
    print("Received events:\n")
    events.each do |e|
      print("   - #{e.to_hash}\n")
    end
  else
    print("Received no events\n")
  end
end
```
Then go to VMware Cloud Director GUI, make a change (e.g. suspend instance) and see console - it should print event type and all the details.