### PR TITLE
Fixed displaying quadicons on hover in hosts network tree

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -77,9 +77,9 @@ function miqMenuEditor(id) {
 function miqBindHoverEvent(tree_name) {
   var node_id;
 
-  $("#" + tree_name + "box a").hover(function () {
+  $("#" + tree_name + "box a").hover(function (event) {
     var node = $.ui.dynatree.getNode(this);
-    node_id = miqOnMouseInHostNet(node.data.key);
+    node_id = miqOnMouseInHostNet(node.data.key, event);
   }, function () {
     var node = $.ui.dynatree.getNode(this);
     miqOnMouseOutHostNet(node.data.key, node_id);
@@ -271,15 +271,12 @@ function miqOnClickSnapshotTree(id) {
 }
 
 // Show the hidden quad icon div when mousing over VMs in the Host Network tree
-function miqOnMouseInHostNet(id) {
+function miqOnMouseInHostNet(id, event) {
   var nid = hoverNodeId(id);
   if (nid) {
-    // div id exists
-    var node = $('#' + id); // Get html node
-    // FIXME: replace with a saner display method
-    var top  = node[0].getBoundingClientRect().top + node.scrollTop() - 220;
-    $("#" + nid).css({ top: top + "px" }); // Set quad top location
-    $("#" + nid).show(); // Show the quad div
+    var top = $(event.target).position().top;
+    $("#" + nid).css({ top: top + "px" }).show(); // Set quad top location
+    // $("#" + nid).show(); // Show the quad div
     return nid; // return current node id
   }
 }

--- a/app/views/host/_config.html.haml
+++ b/app/views/host/_config.html.haml
@@ -45,22 +45,20 @@
             %p.form-control-static
               = h(item[:description])
 - when "network"
-  %table{:style => "height: 100px;"}
-    %tr
-      %td{:width => "55%", :valign => 'top'}
-        -# Create divs for each VM to display as the mouse hovers over each VM node
-        - @tree_vms.each do |v|
-          #outer
-            #inner
-              %div{:id => "v-#{v.id}", :style => "display: none; z-index: 10; width: 72px; height: 72px; padding: 0 0 0 0;"}
-                %div{:style => "margin-left: -78px;"}
-                  = render_quadicon(v, :mode => :icon, :size => 72, :typ => :listnav)
-                  %div
-                    %center{:style => "color: #000;"}
-                      = h(v.product_name)
-                      %br
-                      = h(v.service_pack)
-        = render :partial => "network_tree"
+  .row
+    .col-md-10
+      = render :partial => "network_tree"
+    .col-md-2.hidden-sm.hidden-xs
+      - @tree_vms.each do |v|
+        %div{:id => "v-#{v.id}", :style => "display: none; z-index: 10; width: 72px; height: 72px; padding: 0 0 0 0; position: absolute;"}
+          %div{:style => "margin-left: -78px;"}
+            = render_quadicon(v, :mode => :icon, :size => 72, :typ => :listnav)
+            %div
+              %center{:style => "color: #000;"}
+                = h(v.product_name)
+                %br
+                = h(v.service_pack)
+
 - when "storage_adapters"
   %table{:style => "height: 100px;"}
     %tr


### PR DESCRIPTION
Fixes #8077 by passing the `event` to the `miqOnMouseInHostNet()` function. The styling was not refactored yet because the tree is going to be converted to bootstrap-treeview.

![screenshot from 2016-08-05 13-11-33](https://cloud.githubusercontent.com/assets/649130/17435059/83ce5796-5b0e-11e6-954a-7ea4130b2068.png)

cc @epwinchell @ZitaNemeckova @himdel @h-kataria 