### PR TITLE
properly point loggers.rb to util/vmdb-logger

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -1,4 +1,4 @@
-require 'vmdb-logger'
+require 'util/vmdb-logger'
 
 Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }
 


### PR DESCRIPTION
|grep -R vmdb-logger||
---|---
`gems/pending/appliance_console.rb:26`|`require 'util/vmdb-logger'`
`gems/pending/spec/util/vmdb-logger_spec.rb:1`|`require 'util/vmdb-logger'`
`gems/pending/VixDiskLib/vdl_wrapper.rb:7`|`require 'util/vmdb-logger'`
`gems/pending/VixDiskLib/VixDiskLibServer.rb:10`|`require 'util/vmdb-logger'`
`gems/pending/VMwareWebService/test/emsRefreshTest.rb:7`|`require 'util/vmdb-logger'`
`lib/vmdb/loggers.rb:1`|**`require 'vmdb-logger'`**
