### PR TITLE
[WIP] Make scheduleFormController work with JS Date objects internally

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -34,7 +34,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
       $scope.scheduleModel.filter_typ = 'all';
       $scope.scheduleModel.enabled    = true;
       $scope.filterValuesEmpty        = true;
-      $scope.scheduleModel.start_date = moment(moment.utc().toDate()).format('MM/DD/YYYY');
+      $scope.scheduleModel.start_date = new Date();
       $scope.scheduleModel.timer_typ  = 'Once';
       $scope.scheduleModel.time_zone  = 'UTC';
       $scope.scheduleModel.start_hour = '0';
@@ -59,7 +59,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.name         = data.schedule_name;
         $scope.scheduleModel.timer_typ    = data.schedule_timer_type;
         $scope.scheduleModel.timer_value  = data.schedule_timer_value;
-        $scope.scheduleModel.start_date   = data.schedule_start_date;
+        $scope.scheduleModel.start_date   = moment.utc(data.schedule_start_date, 'MM/DD/YYYY').toDate()
         $scope.scheduleModel.start_hour   = data.schedule_start_hour.toString();
         $scope.scheduleModel.start_min    = data.schedule_start_min.toString();
         $scope.scheduleModel.time_zone    = data.schedule_time_zone;

--- a/app/views/ops/_schedule_form_timer.html.haml
+++ b/app/views/ops/_schedule_form_timer.html.haml
@@ -43,6 +43,7 @@
                    :name             => "start_date",
                    "ng-model"        => "scheduleModel.start_date",
                    "datepicker-init" => "",
+                   "miq-calendar"    => true,
                    :language         => FastGettext.locale,
                    :required         => true,
                    :checkchange      => "",

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -86,7 +86,7 @@ describe('scheduleFormController', function() {
     });
 
     it('sets the scheduleDate', function() {
-      expect($scope.scheduleModel.start_date).toEqual(moment('01/01/2015').format('MM/DD/YYYY'));
+      expect($scope.scheduleModel.start_date).toEqual(moment.utc('01/01/2015', 'MM/DD/YYYY').toDate());
     });
 
     it('sets the scheduleStartHour', function() {
@@ -145,7 +145,7 @@ describe('scheduleFormController', function() {
       });
 
       it('sets the scheduleDate to today', function() {
-        expect($scope.scheduleModel.start_date).toEqual(moment("01/02/2014").format('MM/DD/YYYY'));
+        expect($scope.scheduleModel.start_date).toEqual(new Date(2014, 0, 2));
       });
 
       it('sets the scheduleTimerType to once', function() {


### PR DESCRIPTION
In the JS code, we want to work with javascript `Date` objects, rather than date strings. This change
is to make the whole localization work easier.

Another thing is, that despite the fact that we have the schedule data contained in the angular
model, when submitting the schedule form, we don't submit the data from the model, but rather
serialize data from the form (i.e. the `start_date` here is not actually being used anywhere).

I'd rather address that in a different pull request though.

@himdel 
