### PR TITLE
Bump hawkular-client gem to 2.4.0

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -18,7 +18,7 @@ gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
 gem "fog-openstack",           "~>0.1.7",           :require => false
-gem "hawkular-client",         "=2.3.0",            :require => false
+gem "hawkular-client",         "=2.4.0",            :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.3",           :require => false
 gem "iniparse",                                     :require => false


### PR DESCRIPTION
Bump the hawkular-client gem to version 2.4.0

* metric.type.id in inventory is exposed
* Undeploy operation (for deployments) has been fixes.

See full change list at https://github.com/hawkular/hawkular-client-ruby/milestone/9?closed=1

@miq-bot add_label providers/hawkular, darga/no
