### PR TITLE
Introduce Rbac::Authorizer and top level role_allows? in AH and User to it

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,14 +132,14 @@ module ApplicationHelper
   end
 
   # Check role based authorization for a UI task
-  def role_allows(*args)
-    Rbac::Authorizer.role_allows(*args) rescue false
+  def role_allows(**options)
+    Rbac::Authorizer.role_allows(options.merge(user: User.current_user)) rescue false
   end
   module_function :role_allows
   public :role_allows
 
-  def role_allows!(*args)
-    Rbac::Authorizer.role_allows(*args)
+  def role_allows!(**options)
+    Rbac::Authorizer.role_allows(options.merge(user: User.current_user))
   end
   module_function :role_allows!
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,12 +133,23 @@ module ApplicationHelper
 
   # Check role based authorization for a UI task
   def role_allows(**options)
+    if options[:feature].nil?
+      $log.debug("Auth failed - no feature was specified (required)")
+      return false
+    end
+
     Rbac::Authorizer.role_allows(options.merge(user: User.current_user)) rescue false
   end
   module_function :role_allows
   public :role_allows
 
+  # TODO: This only has one caller. Is this really necessary?
   def role_allows!(**options)
+    if options[:feature].nil?
+      $log.debug("Auth failed - no feature was specified (required)")
+      return false
+    end
+
     Rbac::Authorizer.role_allows(options.merge(user: User.current_user))
   end
   module_function :role_allows!

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,26 +132,16 @@ module ApplicationHelper
   end
 
   # Check role based authorization for a UI task
-  def role_allows(options = {})
-    ApplicationHelper.role_allows_intern(options) rescue false
+  def role_allows(*args)
+    Rbac::Authorizer.role_allows(*args) rescue false
   end
   module_function :role_allows
   public :role_allows
 
-  def role_allows_intern(options = {})
-    userid  = User.current_userid
-    role_id = User.current_user.miq_user_role.try(:id)
-    if options[:feature]
-      auth = options[:any] ? User.current_user.role_allows_any?(:identifiers => [options[:feature]]) :
-                             User.current_user.role_allows?(:identifier => options[:feature])
-      $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{options[:feature]}]")
-    else
-      auth = false
-      $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], no main tab or feature passed to role_allows")
-    end
-    auth
+  def role_allows!(*args)
+    Rbac::Authorizer.role_allows(*args)
   end
-  module_function :role_allows_intern
+  module_function :role_allows!
 
   # NB: This differs from controller_for_model; until they're unified,
   # make sure you have the right one.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
       return false
     end
 
-    Rbac::Authorizer.role_allows(options.merge(user: User.current_user)) rescue false
+    Rbac::Authorizer.role_allows?(options.merge(user: User.current_user)) rescue false
   end
   module_function :role_allows
   public :role_allows

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
       return false
     end
 
-    Rbac::Authorizer.role_allows?(options.merge(user: User.current_user)) rescue false
+    Rbac.role_allows?(options.merge(:user => User.current_user)) rescue false
   end
   module_function :role_allows
   public :role_allows

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,17 +143,6 @@ module ApplicationHelper
   module_function :role_allows
   public :role_allows
 
-  # TODO: This only has one caller. Is this really necessary?
-  def role_allows!(**options)
-    if options[:feature].nil?
-      $log.debug("Auth failed - no feature was specified (required)")
-      return false
-    end
-
-    Rbac::Authorizer.role_allows(options.merge(user: User.current_user))
-  end
-  module_function :role_allows!
-
   # NB: This differs from controller_for_model; until they're unified,
   # make sure you have the right one.
   def model_to_controller(record)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,27 +138,11 @@ class User < ApplicationRecord
   alias_method :miq_group_description, :ldap_group
 
   def role_allows?(options = {})
-    return false if miq_user_role.nil?
-    return true if miq_user_role.allows?(options)
-
-    ident = options[:identifier]
-    parent = MiqProductFeature.feature_parent(ident)
-    return false if parent.nil?
-
-    if MiqProductFeature.feature_hidden(ident)
-      # return true for common features that are hidden and are under hidden parent
-      # return true if any visible siblings are entitled
-      if MiqProductFeature.feature_hidden(parent)
-        true
-      else
-        miq_user_role.allows_any?(:identifiers => MiqProductFeature.feature_children(parent))
-      end
-    end
+    Rbac::Authorizer.new.user_role_allows?(self, options)
   end
 
   def role_allows_any?(options = {})
-    return false if miq_user_role.nil?
-    miq_user_role.allows_any?(options)
+    Rbac::Authorizer.new.user_role_allows_any?(self, options)
   end
 
   def miq_user_role_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,11 +138,11 @@ class User < ApplicationRecord
   alias_method :miq_group_description, :ldap_group
 
   def role_allows?(options = {})
-    Rbac::Authorizer.role_allows?(options.merge(:user => self))
+    Rbac.role_allows?(options.merge(:user => self))
   end
 
   def role_allows_any?(options = {})
-    Rbac::Authorizer.role_allows?(options.merge(:user => self, :any => true))
+    Rbac.role_allows?(options.merge(:user => self, :any => true))
   end
 
   def miq_user_role_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,11 +138,11 @@ class User < ApplicationRecord
   alias_method :miq_group_description, :ldap_group
 
   def role_allows?(options = {})
-    Rbac::Authorizer.new.user_role_allows?(self, options)
+    Rbac::Authorizer.role_allows(options.merge(:user => self))
   end
 
   def role_allows_any?(options = {})
-    Rbac::Authorizer.new.user_role_allows_any?(self, options)
+    Rbac::Authorizer.role_allows(options.merge(:user => self, :any => true))
   end
 
   def miq_user_role_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,11 +138,11 @@ class User < ApplicationRecord
   alias_method :miq_group_description, :ldap_group
 
   def role_allows?(options = {})
-    Rbac::Authorizer.role_allows(options.merge(:user => self))
+    Rbac::Authorizer.role_allows?(options.merge(:user => self))
   end
 
   def role_allows_any?(options = {})
-    Rbac::Authorizer.role_allows(options.merge(:user => self, :any => true))
+    Rbac::Authorizer.role_allows?(options.merge(:user => self, :any => true))
   end
 
   def miq_user_role_name

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -10,7 +10,7 @@ module Menu
     end
 
     def visible?
-      ApplicationHelper.role_allows_intern(rbac_feature)
+      ApplicationHelper.role_allows!(rbac_feature)
     end
 
     def url

--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -10,7 +10,7 @@ module Menu
     end
 
     def visible?
-      ApplicationHelper.role_allows!(rbac_feature)
+      ApplicationHelper.role_allows(rbac_feature)
     end
 
     def url

--- a/lib/rbac.rb
+++ b/lib/rbac.rb
@@ -1,4 +1,5 @@
 require 'rbac/filterer'
+require 'rbac/authorizer'
 
 module Rbac
   def self.search(*args)

--- a/lib/rbac.rb
+++ b/lib/rbac.rb
@@ -17,4 +17,8 @@ module Rbac
   def self.accessible_tenant_ids_strategy(*args)
     Filterer.accessible_tenant_ids_strategy(*args)
   end
+
+  def self.role_allows?(*args)
+    Authorizer.role_allows?(*args)
+  end
 end

--- a/lib/rbac.rb
+++ b/lib/rbac.rb
@@ -1,6 +1,3 @@
-require 'rbac/filterer'
-require 'rbac/authorizer'
-
 module Rbac
   def self.search(*args)
     Filterer.search(*args)

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -1,5 +1,7 @@
 module Rbac
   class Authorizer
+    include Vmdb::Logging
+
     def self.role_allows(*args)
       new.role_allows(*args)
     end
@@ -8,16 +10,16 @@ module Rbac
 
     end
 
-    def role_allows(feature: nil, any: nil)
-      userid  = User.current_userid
-      role_id = User.current_user.miq_user_role.try(:id)
+    def role_allows(user:, feature: nil, any: nil)
+      userid  = user.id
+      role_id = user.miq_user_role.try(:id)
       if feature
-        auth = any.present? ? User.current_user.role_allows_any?(:identifiers => [feature]) :
-          User.current_user.role_allows?(:identifier => feature)
-        $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{feature}]")
+        auth = any.present? ? user.role_allows_any?(:identifiers => [feature]) :
+          user.role_allows?(:identifier => feature)
+        _log.info("Auth #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{feature}]")
       else
         auth = false
-        $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], no main tab or feature passed to role_allows")
+        _log.info("Auth #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], no main tab or feature passed to role_allows")
       end
       auth
     end

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -1,0 +1,25 @@
+module Rbac
+  class Authorizer
+    def self.role_allows(*args)
+      new.role_allows(*args)
+    end
+
+    def initialize
+
+    end
+
+    def role_allows(feature: nil, any: nil)
+      userid  = User.current_userid
+      role_id = User.current_user.miq_user_role.try(:id)
+      if feature
+        auth = any.present? ? User.current_user.role_allows_any?(:identifiers => [feature]) :
+          User.current_user.role_allows?(:identifier => feature)
+        $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{feature}]")
+      else
+        auth = false
+        $log.debug("Role Authorization #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], no main tab or feature passed to role_allows")
+      end
+      auth
+    end
+  end
+end

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -10,17 +10,12 @@ module Rbac
 
     end
 
-    def role_allows(user:, feature: nil, any: nil)
+    def role_allows(user:, feature:, any: nil)
       userid  = user.id
       role_id = user.miq_user_role.try(:id)
-      if feature
-        auth = any.present? ? user.role_allows_any?(:identifiers => [feature]) :
-          user.role_allows?(:identifier => feature)
-        _log.info("Auth #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{feature}]")
-      else
-        auth = false
-        _log.info("Auth #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], no main tab or feature passed to role_allows")
-      end
+      auth = any.present? ? user.role_allows_any?(:identifiers => [feature]) : user.role_allows?(:identifier => feature)
+      _log.info("Auth #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{feature}]")
+
       auth
     end
   end

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -11,10 +11,8 @@ module Rbac
     end
 
     def role_allows(user:, feature:, any: nil)
-      userid  = user.id
-      role_id = user.miq_user_role.try(:id)
       auth = any.present? ? user.role_allows_any?(:identifiers => [feature]) : user.role_allows?(:identifier => feature)
-      _log.info("Auth #{auth ? "successful" : "failed"} for: userid [#{userid}], role id [#{role_id}], feature identifier [#{feature}]")
+      _log.debug("Auth #{auth ? "successful" : "failed"} for user '#{user.userid}', role '#{user.miq_user_role.try(:name)}', feature identifier '#{feature}'")
 
       auth
     end

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -16,5 +16,30 @@ module Rbac
 
       auth
     end
+
+    def user_role_allows?(user, options = {})
+      return false if user.miq_user_role.nil?
+      return true if user.miq_user_role.allows?(options)
+
+      ident = options[:identifier]
+      parent = MiqProductFeature.feature_parent(ident)
+      return false if parent.nil?
+
+      if MiqProductFeature.feature_hidden(ident)
+        # return true for common features that are hidden and are under hidden parent
+        # return true if any visible siblings are entitled
+        if MiqProductFeature.feature_hidden(parent)
+          true
+        else
+          user.miq_user_role.allows_any?(:identifiers => MiqProductFeature.feature_children(parent))
+        end
+      end
+    end
+
+    def user_role_allows_any?(user, options = {})
+      binding.pry if ENV["LOLZ"]
+      return false if user.miq_user_role.nil?
+      user.miq_user_role.allows_any?(options)
+    end
   end
 end

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -6,10 +6,6 @@ module Rbac
       new.role_allows?(*args)
     end
 
-    def initialize
-
-    end
-
     def role_allows?(options = {})
       user    = options[:user]
 

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -10,8 +10,17 @@ module Rbac
 
     end
 
-    def role_allows(user:, feature:, any: nil)
-      auth = any.present? ? user.role_allows_any?(:identifiers => [feature]) : user.role_allows?(:identifier => feature)
+    def role_allows(options = {})
+      # Known options:
+      user    = options[:user]
+      feature = options[:feature]
+      any     = options[:any]
+
+      auth = if any.present?
+               user.role_allows_any?(:identifiers => [feature])
+             else
+               user.role_allows?(:identifier => feature)
+             end
       _log.debug("Auth #{auth ? "successful" : "failed"} for user '#{user.userid}', role '#{user.miq_user_role.try(:name)}', feature identifier '#{feature}'")
 
       auth

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -2,15 +2,15 @@ module Rbac
   class Authorizer
     include Vmdb::Logging
 
-    def self.role_allows(*args)
-      new.role_allows(*args)
+    def self.role_allows?(*args)
+      new.role_allows?(*args)
     end
 
     def initialize
 
     end
 
-    def role_allows(options = {})
+    def role_allows?(options = {})
       user    = options[:user]
 
       # 'identifier' comes from the back end (ex: User#role_allows?)

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -28,7 +28,7 @@ module AuthHelper
                   EOS
                 end
     allow(controller).to receive(:check_privileges).and_return(stub_bool)
-    allow(Rbac::Authorizer).to receive(:role_allows).and_return(stub_bool)
+    allow(Rbac::Authorizer).to receive(:role_allows?).and_return(stub_bool)
 
     login_as user
     user

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -28,7 +28,7 @@ module AuthHelper
                   EOS
                 end
     allow(controller).to receive(:check_privileges).and_return(stub_bool)
-    allow(Rbac::Authorizer).to receive(:role_allows?).and_return(stub_bool)
+    allow(Rbac).to receive(:role_allows?).and_return(stub_bool)
 
     login_as user
     user

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -28,9 +28,7 @@ module AuthHelper
                   EOS
                 end
     allow(controller).to receive(:check_privileges).and_return(stub_bool)
-    allow(controller).to receive(:role_allows).and_return(stub_bool)
-    allow_any_instance_of(User).to receive(:role_allows?).and_return(stub_bool)
-    allow_any_instance_of(User).to receive(:role_allows_any?).and_return(stub_bool)
+    allow(Rbac::Authorizer).to receive(:role_allows).and_return(stub_bool)
 
     login_as user
     user


### PR DESCRIPTION
Purpose or Intent
-----------------
This begins the process of moving role checking in to RBAC to allow us to begin work on multiple entitlements/roles per user. It essentially takes the two top level APIs in ApplicationHelper#role_allows and User#role_allows?, combines them in Rbac, and routes all callers through it. 

Note that the code in Authorizer itself isn't exactly pristine as it's largely <The old code> + <Extra necessary things to allow for both legacy API callers to use it>. As it will be refined again and again as we move more logic to it further down the stack, I wouldn't be super critical of the code review details. 

Also note the stupid simple switch done in auth_helper.rb, all thanks to the work done in #10243 🎉 👏 👉 @jrafanie 

r? @Fryguy or @gtanzillo 
@miq-bot add_labels core, tenancy, refactoring

Steps for Testing/QA
--------------------
Firing up the app locally and clicking around wouldn't be a bad idea.
