### PR TITLE
:cold_sweat: Don't include AvailabilityMixin into Object, that's really bad

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -1,7 +1,7 @@
-include AvailabilityMixin
-
 module ManageIQ::Providers
   class ContainerManager < BaseManager
+    include AvailabilityMixin
+
     has_many :container_nodes, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_groups, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy


### PR DESCRIPTION
Before:
```
irb(main):001:0> Object.respond_to?(:is_available?)
=> false

irb(main):002:0> ManageIQ::Providers::ContainerManager
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 1, waiting_in_queue: 0
=> ManageIQ::Providers::ContainerManager(id: integer, name: string, etc...)

irb(main):003:0> Object.respond_to?(:is_available?)
=> true
```

After:
```
irb(main):001:0> Object.respond_to?(:is_available?)
=> false

irb(main):002:0> ManageIQ::Providers::ContainerManager
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 1, waiting_in_queue: 0
=> ManageIQ::Providers::ContainerManager(id: integer, name: string, etc...)

irb(main):003:0> Object.respond_to?(:is_available?)
=> false
```