### PR TITLE
Hawkular deployment undeploy should not use run_generic_operation.

### DIFF
--- a/app/controllers/middleware_deployment_controller.rb
+++ b/app/controllers/middleware_deployment_controller.rb
@@ -65,16 +65,16 @@ class MiddlewareDeploymentController < ApplicationController
     end
     operation_triggered = false
     items.split(/,/).each do |item|
-      mw_server = identify_record item
-      trigger_mw_operation operation_info.fetch(:op), mw_server
+      mw_deployment = identify_record item
+      trigger_mw_operation operation_info.fetch(:op), mw_deployment
       operation_triggered = true
     end
     add_flash(operation_info.fetch(:msg)) if operation_triggered
   end
 
-  def trigger_mw_operation(operation, mw_server)
-    mw_manager = mw_server.ext_management_system
+  def trigger_mw_operation(operation, mw_deployment)
+    mw_manager = mw_deployment.ext_management_system
     op = mw_manager.public_method operation
-    op.call mw_server.ems_ref
+    op.call(mw_deployment.ems_ref, mw_deployment.name)
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -165,11 +165,11 @@ module ManageIQ::Providers
       run_generic_operation(:Shutdown, ems_ref)
     end
 
-    def stop_middleware_deployment(ems_ref, name)
+    def stop_middleware_deployment(ems_ref, _name)
       run_generic_operation(:Undeploy, ems_ref)
     end
 
-    def start_middleware_deployment(ems_ref, name)
+    def start_middleware_deployment(ems_ref, _name)
       run_generic_operation(:Deploy, ems_ref)
     end
 
@@ -223,7 +223,7 @@ module ManageIQ::Providers
       ::Hawkular::Alerts::AlertsClient.new(url, credentials)
     end
 
-    def redeploy_middleware_deployment(ems_ref, name)
+    def redeploy_middleware_deployment(ems_ref, _name)
       run_generic_operation(:Redeploy, ems_ref)
     end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
The middleware deployment's undeployment operation must route to specific deployment
removal logic based on the parent server and the deployment name.  It can't be handled as a generic operation like the other operations.  It needs to use the specific support in the hawkular gem.

Links
-----
https://issues.jboss.org/browse/HWKAGENT-120

This PR Should not be merged until the hawkular gem has been updated to version 2.4.
