### PR TITLE
Relationships filter_by_resource_type scope

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -11,6 +11,13 @@ class Relationship < ApplicationRecord
   # Filtering methods
   #
 
+  def self.filtered(of_type, except_type)
+    relationships = self
+    relationships = relationships.where(:resource_type => of_type) if of_type.present?
+    relationships = relationships.where.not(:resource_type => except_type) if except_type.present?
+    relationships
+  end
+
   def filtered?(of_type, except_type)
     (!of_type.empty? && !of_type.include?(resource_type)) ||
       (!except_type.empty? && except_type.include?(resource_type))
@@ -20,7 +27,11 @@ class Relationship < ApplicationRecord
     of_type = Array.wrap(options[:of_type])
     except_type = Array.wrap(options[:except_type])
     return relationships if of_type.empty? && except_type.empty?
-    relationships.reject { |r| r.filtered?(of_type, except_type) }
+    if relationships.kind_of?(Array)
+      relationships.reject { |r| r.filtered?(of_type, except_type) }
+    else
+      relationships.filtered(of_type, except_type)
+    end
   end
 
   #

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -17,8 +17,8 @@ class Relationship < ApplicationRecord
   end
 
   def self.filter_by_resource_type(relationships, options)
-    of_type = options[:of_type].to_miq_a
-    except_type = options[:except_type].to_miq_a
+    of_type = Array.wrap(options[:of_type])
+    except_type = Array.wrap(options[:except_type])
     return relationships if of_type.empty? && except_type.empty?
     relationships.reject { |r| r.filtered?(of_type, except_type) }
   end

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -1,5 +1,17 @@
 FactoryGirl.define do
-  factory :relationship_vm_vmware, :class => :Relationship do
+  factory :relationship do
     resource_type  "VmOrTemplate"
+  end
+
+  factory :relationship_vm_vmware, :parent => :relationship do
+    resource_type  "VmOrTemplate"
+  end
+
+  factory :relationship_host_vmware, :parent => :relationship do
+    resource_type  "Host"
+  end
+
+  factory :relationship_storage_vmware, :parent => :relationship do
+    resource_type  "Storage"
   end
 end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -79,5 +79,16 @@ describe Relationship do
     it "neither includes nor excludes" do
       expect(Relationship.filter_by_resource_type(vms, {})).to eq(vms)
     end
+
+    it "scopes" do
+      vms.map(&:save!)
+      hosts.map(&:save!)
+      storages.map(&:save!)
+      filtered_results = Relationship.filter_by_resource_type(Relationship.all,
+                                                              :of_type     => %w(Host VmOrTemplate),
+                                                              :except_type => %w(Storage))
+      expect(filtered_results).not_to be_kind_of(Array)
+      expect(filtered_results).to match_array(vms + hosts)
+    end
   end
 end


### PR DESCRIPTION
These are prep steps for #10160 - only save 1 record coming back from `vm.parent_blue_folders`
They allow the other PR to avoid many queries (from 8 -> 3)

before
-------

|     ms |  objects |queries | query (ms) |     rows |`comments`
|    ---:|     ---:|  ---:|   ---:|      ---:| ---
|   89.7 |  23,359 |    8 |  19.0 |       14 |`no name-1`
|    5.0 |             |      |   0.3 |        2 |`.SELECT "relationships".*`
|    0.3 |              |      |   0.2 |        1 |`.SELECT  "relationships".*`
|    0.3 |              |      |   0.2 |        1 |`.SELECT  "relationships".*`
|    0.5 |              |      |   0.4 |        1 |`.SELECT "ems_folders".*`
|    0.4 |              |      |   0.3 |        1 |`.SELECT  "relationships".*`
|    0.3 |              |      |   0.2 |        1 |`.SELECT  "relationships".*`
|    0.5 |              |      |   0.4 |        4 |`.SELECT "relationships".*`
|   11.7 |              |      |   0.3 |        3 |`.SELECT "ems_folders".*`

after
-----

|     ms |  objects |queries | query (ms) |     rows |`comments`
|    ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|   90.0 |   23,557 |    8 |  19.6 |       13 |`no name-1`
|    4.9 |              |      |   0.3 |        2 |`.SELECT "relationships".*`
|    0.4 |              |      |   0.3 |        1 |`.SELECT  "relationships".*`
|    0.3 |              |      |   0.2 |        1 |`.SELECT  "relationships".*`
|    0.5 |              |      |   0.4 |        1 |`.SELECT "ems_folders".*`
|    0.3 |              |      |   0.2 |        1 |`.SELECT  "relationships".*`
|    0.3 |              |      |   0.2 |        1 |`.SELECT  "relationships".*`
|    0.6 |              |      |   0.5 |        3 |`.SELECT "relationships".*`
|   12.3 |             |      |   0.3 |        3 |`.SELECT "ems_folders".*`
