### PR TITLE
Speed up "VMs & Instances in My LDAP Group" filter in /vm_or_template/explorer

### DIFF
--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -70,6 +70,25 @@ module VmShowMixin
 
   private
 
+  def set_named_scope
+    @named_scope =
+      if miq_search_exp_fields.include? "owned_by_current_ldap_group"
+        :with_miq_group
+      end
+  end
+
+  def miq_search_exp_fields
+    @miq_search_exp_fields ||=
+      MiqExpression.get_cols_from_expression(miq_exp_in_edit).map do |key, _|
+        key.to_s.split("-").last
+      end
+  end
+
+  def miq_exp_in_edit
+    exp = (@edit || session[:edit] || {})[:adv_search_applied] || {}
+    exp[:exp] || exp[:qs_exp] || {}
+  end
+
   def set_active_elements(feature)
     if feature
       self.x_active_tree ||= feature.tree_list_name

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -4,6 +4,7 @@ class VmCloudController < ApplicationController
 
   before_action :check_privileges
   before_action :get_session_data
+  before_action :set_named_scope, :only => :explorer
   after_action :cleanup_action
   after_action :set_session_data
 

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1071,6 +1071,7 @@ module VmCommon
       adv_search_build(vm_model_from_active_tree(x_active_tree))
       session[:edit] = @edit              # Set because next method will restore @edit from session
       listnav_search_selected(search_id) unless params.key?(:search_text) # Clear or set the adv search filter
+      set_named_scope
       if @edit[:adv_search_applied] &&
          MiqExpression.quick_search?(@edit[:adv_search_applied][:exp]) &&
          %w(reload tree_select).include?(params[:action])

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1270,6 +1270,7 @@ module VmCommon
                                end
           end
         elsif TreeBuilder.get_model_for_prefix(@nodetype) == "MiqSearch"
+          options[:named_scope] = @named_scope if @named_scope
           process_show_list(options)  # Get all VMs & Templates
           @right_cell_text = if model
                                _("All %{models}") % {:models => ui_lookup(:models => model)}

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -4,6 +4,7 @@ class VmInfraController < ApplicationController
 
   before_action :check_privileges
   before_action :get_session_data
+  before_action :set_named_scope, :only => :explorer
 
   after_action :cleanup_action
   after_action :set_session_data

--- a/app/controllers/vm_or_template_controller.rb
+++ b/app/controllers/vm_or_template_controller.rb
@@ -4,6 +4,7 @@ class VmOrTemplateController < ApplicationController
 
   before_action :check_privileges
   before_action :get_session_data
+  before_action :set_named_scope, :only => :explorer
   after_action :cleanup_action
   after_action :set_session_data
 

--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -10,10 +10,27 @@ module OwnershipMixin
     virtual_column :evm_owner_userid,                     :type => :string,     :uses => :evm_owner
     virtual_column :owned_by_current_user,                :type => :boolean,    :uses => :evm_owner_userid
     virtual_column :owning_ldap_group,                    :type => :string,     :uses => :miq_group
-    virtual_column :owned_by_current_ldap_group,          :type => :boolean,    :uses => :owning_ldap_group
+
+    # Determine whether to return objects owned by the current user's miq_group
+    # or not. Requires `with_miq_group` scope to function
+    #
+    # Resulting SQL: "(LOWER("miq_groups"."description") = 'some_miq_group')"
+    #
+    # Will result in the following when used with MiqExpression:
+    #
+    #   WHERE ((LOWER("miq_groups"."description") = 'some_miq_group') = 'true')
+    virtual_attribute :owned_by_current_ldap_group, :boolean, :arel => (lambda do |t|
+      ldap_group = User.current_user.try(:ldap_group).to_s.downcase
+
+      t.grouping(MiqGroup.arel_table[:description].lower.eq(ldap_group))
+    end)
   end
 
   module ClassMethods
+    def with_miq_group
+      select(arel_table[Arel.star]).joins(:miq_group)
+    end
+
     def set_ownership(ids, options)
       errors = ActiveModel::Errors.new(self)
       objects = where(:id => ids)

--- a/spec/controllers/mixins/vm_show_mixin_spec.rb
+++ b/spec/controllers/mixins/vm_show_mixin_spec.rb
@@ -1,0 +1,134 @@
+class FakeController
+  include VmShowMixin
+
+  attr_writer :edit
+  attr_accessor :session
+end
+
+describe VmShowMixin do
+  subject { FakeController.new }
+  let(:edit)         { nil }
+  let(:my_session)   { {} }
+  let(:miq_exp_col)  { "Vm-name" }
+  let(:simple_exp)   { {"=" => {"field" => miq_exp_col, "value" => "foo"}} }
+  let(:exp)          { {:adv_search_applied => {:exp => simple_exp}} }
+  let(:qs_exp)       { {:adv_search_applied => {:qs_exp => simple_exp}} }
+  let(:empty_search) { {:adv_search_applied => {:exp => {}}} }
+
+  before do
+    subject.edit = edit
+    subject.session = my_session
+  end
+
+  describe "set_named_scope" do
+    let(:edit)        { exp }
+    let(:named_scope) { subject.instance_variable_get(:@named_scope) }
+
+    it "sets @named_scope to nil by default" do
+      subject.send(:set_named_scope)
+      expect(named_scope).to eq(nil)
+    end
+
+    context "when miq_search_exp_fields includes other fields" do
+      let(:exp1) { {"=" => {"field" => "Vm-name"}} }
+      let(:exp2) { {"=" => {"field" => "Vm-description"}} }
+      let(:simple_exp) { [exp1, exp2] }
+
+      it "sets @named_scope to nil" do
+        subject.send(:set_named_scope)
+        expect(named_scope).to eq(nil)
+      end
+    end
+
+    context "when miq_search_exp_fields includes owned_by_current_ldap_group" do
+      let(:simple_exp) { {"=" => {"field" => "Vm-owned_by_current_ldap_group"}} }
+
+      it "sets @named_scope to :with_miq_group" do
+        subject.send(:set_named_scope)
+        expect(named_scope).to eq(:with_miq_group)
+      end
+    end
+  end
+
+  describe "#miq_search_exp_fields" do
+    context "if @edit and session or not set" do
+      it "returns an empty_array" do
+        expect(subject.send(:miq_search_exp_fields)).to eq([])
+      end
+    end
+
+    context "if @edit is set" do
+      context "without [:adv_search_applied][:qs_exp]" do
+        let(:edit) { {} }
+        it "returns an empty_array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq([])
+        end
+      end
+
+      context "when [:adv_search_applied] is nil" do
+        let(:edit) { {} }
+        it "returns an empty_array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq([])
+        end
+      end
+
+      context "with an empty search" do
+        let(:edit) { empty_search }
+        it "returns an empty_array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq([])
+        end
+      end
+
+      context "with an valid exp" do
+        let(:edit) { exp }
+        it "returns the fields in an array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq(["name"])
+        end
+      end
+
+      context "with an valid qs_exp" do
+        let(:edit) { qs_exp }
+        it "returns the fields in an array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq(["name"])
+        end
+      end
+    end
+
+    context "if session[:edit] is set" do
+      context "without [:adv_search_applied][:qs_exp]" do
+        let(:my_session) { {:edit => {}} }
+        it "returns an empty_array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq([])
+        end
+      end
+
+      context "when [:adv_search_applied] is nil" do
+        let(:edit) { {} }
+        it "returns an empty_array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq([])
+        end
+      end
+
+      context "with an empty search" do
+        let(:my_session) { {:edit => empty_search} }
+        it "returns an empty_array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq([])
+        end
+      end
+
+      context "with an valid exp" do
+        let(:my_session) { {:edit => exp} }
+        it "returns the fields in an array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq(["name"])
+        end
+      end
+
+      context "with an valid qs_exp" do
+        let(:my_session) { {:edit => qs_exp} }
+        it "returns the fields in an array" do
+          expect(subject.send(:miq_search_exp_fields)).to eq(["name"])
+        end
+      end
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,4 +1,6 @@
 describe Service do
+  include_examples "miq ownership"
+
   context "service events" do
     before(:each) do
       @service = FactoryGirl.create(:service)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1,4 +1,6 @@
 describe ServiceTemplate do
+  include_examples "miq ownership"
+
   describe "#custom_actions" do
     let(:service_template) do
       described_class.create(:name => "test", :description => "test", :custom_button_sets => [assigned_group_set])

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -1,4 +1,6 @@
 describe Vm do
+  include_examples "miq ownership"
+
   it "#corresponding_model" do
     expect(Vm.corresponding_model).to eq(MiqTemplate)
     expect(ManageIQ::Providers::Vmware::InfraManager::Vm.corresponding_model).to eq(ManageIQ::Providers::Vmware::InfraManager::Template)

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -1,0 +1,68 @@
+shared_examples "miq ownership" do
+  # THIS TOP LEVEL CONTEXT IS REQUIRED because tests that include are database
+  # state dependent and require a clean DB.  When used with `include_examples`,
+  # the before(:context) and after(:context) in this are run on the same level
+  # as the `include_example`'s current context, so more likely than not, it
+  # will be included in other tests that aren't part of this example group.
+  context "includes mixin:  miq ownership" do
+    describe "reporting on ownership" do
+      let(:exp_value) { "true" }
+      let(:exp) { { "="=> { "field" => "#{described_class}-owned_by_current_ldap_group", "value" => exp_value } } }
+      let(:report) { MiqReport.new.tap { |r| r.db = described_class.to_s } }
+      let(:search_opts) { { :filter => MiqExpression.new(exp), :per_page => 20 } }
+      let(:user)              { User.where(:userid => "ownership_user").first }
+      let(:owned_by_group_1)  { described_class.where(:name => 'in_ldap').first }
+      let(:owned_by_group_2)  { described_class.where(:name => 'not_in_ldap').first }
+      let(:owned_by_group_3)  { described_class.where(:name => 'no_group').first }
+
+      before(:context) do
+        build_ownership_users_and_groups
+      end
+
+      before do
+        expect(User).to receive(:server_timezone).and_return("UTC")
+
+        # Needs to be done after the groups are created, otherwise the
+        # described_class will be auto-assigned with the current user's group
+        User.current_user = user
+      end
+
+      context "searching by records in current ldap group" do
+        it "returns results only part of the miq_group" do
+          owned_ids = report.paged_view_search(search_opts).first.map(&:id)
+          expect(owned_ids).to match_array [owned_by_group_1.id]
+        end
+      end
+
+      context "searching by records not in current ldap group" do
+        let(:exp_value) { "false" }
+
+        it "returns results not part of the miq_group" do
+          owned_ids = report.paged_view_search(search_opts).first.map(&:id)
+          expect(owned_ids).to match_array [owned_by_group_2.id]
+        end
+      end
+
+      after(:context) do
+        teardown_ownership_users_and_groups
+      end
+
+      def build_ownership_users_and_groups
+        user = FactoryGirl.create :user,
+                                  :userid     => "ownership_user",
+                                  :miq_groups => FactoryGirl.create_list(:miq_group, 1)
+
+        factory = described_class.to_s.underscore.to_sym
+        FactoryGirl.create factory, :name => "in_ldap",     :miq_group_id => user.current_group.id
+        FactoryGirl.create factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group)
+        FactoryGirl.create factory, :name => "no_group"
+      end
+
+      def teardown_ownership_users_and_groups
+        described_class.destroy_all
+        User.destroy_all
+        MiqGroup.destroy_all
+      end
+    end
+  end
+end

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -5,19 +5,62 @@ shared_examples "miq ownership" do
   # as the `include_example`'s current context, so more likely than not, it
   # will be included in other tests that aren't part of this example group.
   context "includes mixin:  miq ownership" do
+    include ArelSpecHelper
+
+    let(:user) { User.where(:userid => "ownership_user").first }
+
+    before(:context) do
+      build_ownership_users_and_groups
+    end
+
+    describe ".owned_by_current_ldap_group" do
+      before { User.current_user = user }
+
+      it "usable as arel" do
+        group_name = user.current_group.description.downcase
+        sql        = %`(LOWER("miq_groups"."description") = '#{group_name}')`
+        attribute  = described_class.arel_attribute(:owned_by_current_ldap_group)
+        expect(stringify_arel(attribute)).to eq [sql]
+      end
+
+      context "when miq_group is in the ldap group" do
+        it "returns true" do
+          column = "owned_by_current_ldap_group"
+          query  = described_class.with_miq_group.where(:name => 'in_ldap')
+          expect(virtual_column_sql_value(query, column)).to eq(true)
+        end
+      end
+
+      context "when miq_group is not in the ldap group" do
+        it "returns false" do
+          column = "owned_by_current_ldap_group"
+          query  = described_class.with_miq_group.where(:name => 'not_in_ldap')
+          expect(virtual_column_sql_value(query, column)).to eq(false)
+        end
+      end
+
+      # Since we are doing a regular inner join here, no results will be returned
+      # when there isn't an associated miq_group for the record.
+      #
+      # This was the existing behaviour of the owned_by_current_ldap_group
+      # method, so we are testing that the query (even without the
+      # virtual_attribute) will return no records.
+      context "when miq_group is in no ldap group" do
+        it "returns no results" do
+          query = described_class.with_miq_group.where(:name => 'no_group')
+          expect(query.to_a.size).to eq(0)
+        end
+      end
+    end
+
     describe "reporting on ownership" do
       let(:exp_value) { "true" }
       let(:exp) { { "="=> { "field" => "#{described_class}-owned_by_current_ldap_group", "value" => exp_value } } }
       let(:report) { MiqReport.new.tap { |r| r.db = described_class.to_s } }
-      let(:search_opts) { { :filter => MiqExpression.new(exp), :per_page => 20 } }
-      let(:user)              { User.where(:userid => "ownership_user").first }
+      let(:search_opts) { { :filter => MiqExpression.new(exp), :per_page => 20, :named_scope => :with_miq_group } }
       let(:owned_by_group_1)  { described_class.where(:name => 'in_ldap').first }
       let(:owned_by_group_2)  { described_class.where(:name => 'not_in_ldap').first }
       let(:owned_by_group_3)  { described_class.where(:name => 'no_group').first }
-
-      before(:context) do
-        build_ownership_users_and_groups
-      end
 
       before do
         expect(User).to receive(:server_timezone).and_return("UTC")
@@ -42,27 +85,27 @@ shared_examples "miq ownership" do
           expect(owned_ids).to match_array [owned_by_group_2.id]
         end
       end
+    end
 
-      after(:context) do
-        teardown_ownership_users_and_groups
-      end
+    after(:context) do
+      teardown_ownership_users_and_groups
+    end
 
-      def build_ownership_users_and_groups
-        user = FactoryGirl.create :user,
-                                  :userid     => "ownership_user",
-                                  :miq_groups => FactoryGirl.create_list(:miq_group, 1)
+    def build_ownership_users_and_groups
+      user = FactoryGirl.create :user,
+                                :userid     => "ownership_user",
+                                :miq_groups => FactoryGirl.create_list(:miq_group, 1)
 
-        factory = described_class.to_s.underscore.to_sym
-        FactoryGirl.create factory, :name => "in_ldap",     :miq_group_id => user.current_group.id
-        FactoryGirl.create factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group)
-        FactoryGirl.create factory, :name => "no_group"
-      end
+      factory = described_class.to_s.underscore.to_sym
+      FactoryGirl.create factory, :name => "in_ldap",     :miq_group_id => user.current_group.id
+      FactoryGirl.create factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group)
+      FactoryGirl.create factory, :name => "no_group"
+    end
 
-      def teardown_ownership_users_and_groups
-        described_class.destroy_all
-        User.destroy_all
-        MiqGroup.destroy_all
-      end
+    def teardown_ownership_users_and_groups
+      described_class.destroy_all
+      User.destroy_all
+      MiqGroup.destroy_all
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Speeds up "VMs & Instances in My LDAP Group" index and ajax calls in the `/vm_or_template` (Services -> Workload) section of the application.


How
---
This adds `virtual_attribute` on to the `ownership_mixin`, which is used by a few classes and makes it so that MiqExpressions will evaluate filter in SQL instead of pulling down all matching records to then interate over and filter in Ruby (causes a Massive N+1 on large datasets).  This requires a join for the `virtual_attribute` to function, so the `with_miq_group` scope does that with out pulling in any extra data, which is added in the controller which uses `MiqReport#paged_view_search` with an `MiqExpression`.


Metrics
-------
The data set for these metrics used a DB with approximately 20k `Vm` records.


**Before (Regular User)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 7242ms (Views: 2.0ms | ActiveRecord: 884.1ms)

|      ms |   bytes |   objects | queries | query (ms) |   rows |
|    ---: |    ---: |      ---: |    ---: |       ---: |   ---: |
| 6,043.1 |     N/A | 3,769,724 |      44 |    4,158.3 | 29,709 |


**After (Regular User)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 823ms (Views: 2.2ms | ActiveRecord: 46.6ms)

|      ms |   bytes |   objects | queries | query (ms) | rows |
|    ---: |    ---: |      ---: |    ---: |       ---: | ---: |
|   659.0 |     N/A |   816,802 |      30 |      131.9 |  397 |


**Before (Admin)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 94316ms (Views: 1.1ms | ActiveRecord: 13351.1ms)

|        ms | bytes |    objects | queries | query (ms) |    rows |
|      ---: |  ---: |       ---: |    ---: |       ---: |    ---: |
|  93,770.4 |   N/A | 57,852,016 |     112 |   78,603.0 | 349,084 |



**After (Admin)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 283ms (Views: 1.0ms | ActiveRecord: 12.6ms)

|      ms | bytes |   objects | queries | query (ms) | rows |
|    ---: |  ---: |      ---: |    ---: |       ---: | ---: |
|   190.2 |   N/A |    91,554 |      20 |       20.3 |   14 |


Additional Notes
----------------

This change drastically reduces the number of `rows` returns, time spend churning in ruby (sometimes to return nothing), decreases bandwidth and memory footprints, but the implementation in the controller is a bit hacky, and most likely requires some other changes now in other places to restore previous functionality.  It also attaches the `with_miq_group` scope to all other calls.  This should be fine for the most part, but could cause other regressions.  Not sure of a better way to limit the inclusion of this scope using the current mechanisms available without some other heavier refactoring required.


_Update:_

> It also attaches the `with_miq_group` scope to all other calls.

This is no longer the case as I have added controller methods to only add that scope when the MiqExpression "expression" includes the `owned_by_current_ldap_group` field.