### PR TITLE
No need to require "spec_helper" everywhere, it's in .rspec & .rspec_ci

### DIFF
--- a/gems/pending/spec/vmware/vcenter_thumb_print_spec.rb
+++ b/gems/pending/spec/vmware/vcenter_thumb_print_spec.rb
@@ -1,4 +1,3 @@
-require_relative "../spec_helper"
 require_relative '../../vmware/vcenter_thumb_print'
 require_relative '../../vmware/esx_thumb_print'
 

--- a/spec/automation/unit/method_validation/ansible_tower_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_check_provisioned_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned').to_s
 require Rails.root.join('spec/support/miq_ae_mock_service').to_s
 

--- a/spec/automation/unit/method_validation/ansible_tower_preprovision_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_preprovision_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/preprovision').to_s
 require Rails.root.join('spec/support/miq_ae_mock_service').to_s
 

--- a/spec/automation/unit/method_validation/ansible_tower_provision_spec.rb
+++ b/spec/automation/unit/method_validation/ansible_tower_provision_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/provision').to_s
 require Rails.root.join('spec/support/miq_ae_mock_service').to_s
 

--- a/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
+++ b/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job').to_s
 require Rails.root.join('spec/support/miq_ae_mock_service').to_s
 

--- a/spec/automation/unit/method_validation/update_provision_status_vm_cloud_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_cloud_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include AutomationSpecHelper
 
 describe "update_provision_status" do

--- a/spec/automation/unit/method_validation/update_provision_status_vm_infra_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_infra_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include AutomationSpecHelper
 
 describe "update_provision_status" do

--- a/spec/automation/unit/method_validation/update_provision_status_vm_template_infra_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_template_infra_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include AutomationSpecHelper
 
 describe "update_provision_status" do

--- a/spec/automation/unit/method_validation/update_service_provision_status_orchestration_spec.rb
+++ b/spec/automation/unit/method_validation/update_service_provision_status_orchestration_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include AutomationSpecHelper
 
 describe "update_serviceprovision_status" do

--- a/spec/automation/unit/method_validation/wait_for_completion_spec.rb
+++ b/spec/automation/unit/method_validation/wait_for_completion_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_completion').to_s
 require Rails.root.join('spec/support/miq_ae_mock_service').to_s
 

--- a/spec/automation/unit/method_validation/wait_for_ip_spec.rb
+++ b/spec/automation/unit/method_validation/wait_for_ip_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require Rails.root.join('db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip').to_s
 require Rails.root.join('spec/support/miq_ae_mock_service').to_s
 

--- a/spec/controllers/container_build_controller_spec.rb
+++ b/spec/controllers/container_build_controller_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ContainerBuildController do
   render_views
   before(:each) do

--- a/spec/controllers/persistent_volume_controller_spec.rb
+++ b/spec/controllers/persistent_volume_controller_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe PersistentVolumeController do
   render_views
   before(:each) do

--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::GenericFeatureButton do
   describe '#skip?' do
     [:pause].each do |feature|
@@ -15,7 +13,6 @@ describe ApplicationHelper::Button::GenericFeatureButton do
            expect(button.skip?).to be_falsey
         end
       end
-
 
       context "when instance does not support feature #{feature}" do
         before do

--- a/spec/helpers/application_helper/buttons/instance_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_reset_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::InstanceReset do
   describe '#skip?' do
     context "when record is resetable" do

--- a/spec/helpers/application_helper/buttons/instance_shelve_offload_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_shelve_offload_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::InstanceShelveOffload do
   describe '#skip?' do
     context "when record is shelve_offloadable" do

--- a/spec/helpers/application_helper/buttons/instance_shelve_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_shelve_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::InstanceShelve do
   describe '#skip?' do
     context "when record is shelveable" do

--- a/spec/helpers/application_helper/buttons/instance_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_start_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::InstanceStart do
   describe '#skip?' do
     context "when record is stopable" do

--- a/spec/helpers/application_helper/buttons/instance_stop_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_stop_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::InstanceStop do
   describe '#skip?' do
     context "when record is stopable" do

--- a/spec/helpers/application_helper/buttons/instance_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_suspend_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::InstanceSuspend do
   describe '#skip?' do
     context "when record is suspendable" do

--- a/spec/helpers/application_helper/buttons/service_reconfigure_spec.rb
+++ b/spec/helpers/application_helper/buttons/service_reconfigure_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::ServiceReconfigure do
   describe '#skip?' do
     context "when record is reconfigurable" do

--- a/spec/helpers/application_helper/buttons/vm_clone_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_clone_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmClone do
   describe '#skip?' do
     it_behaves_like "when record is orphaned"

--- a/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmInstanceScan do
   describe '#skip?' do
     context "when record has proxy and is not orphaned nor archived" do

--- a/spec/helpers/application_helper/buttons/vm_migrate_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_migrate_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmMigrate do
   describe '#skip?' do
     context "when record is migrateable" do

--- a/spec/helpers/application_helper/buttons/vm_publish_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_publish_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmPublish do
   describe '#skip?' do
     it_behaves_like "when record is orphaned"

--- a/spec/helpers/application_helper/buttons/vm_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_refresh_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmRefresh do
   describe '#skip?' do
     context "when record has ext_management_system and host vmm_product is workstation" do

--- a/spec/helpers/application_helper/buttons/vm_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_reset_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmReset do
   describe '#skip?' do
     context "when record is resetable" do

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmRetire do
   describe '#skip?' do
     context "when record is retireable" do

--- a/spec/helpers/application_helper/buttons/vm_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_start_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmStart do
   describe '#skip?' do
     context "when record is startable" do

--- a/spec/helpers/application_helper/buttons/vm_stop_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_stop_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmStop do
   describe '#skip?' do
     context "when record is stopable" do

--- a/spec/helpers/application_helper/buttons/vm_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_suspend_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ApplicationHelper::Button::VmSuspend do
   describe '#skip?' do
     context "when record is suspendable" do

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'wbem'
 
 RSpec.shared_examples :quadicon_with_link do

--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe GitWorktree do
   context "repository" do
     before do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_configuration_script_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_configuration_script_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module MiqAeServiceConfigurationScriptSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceConfigurationScript do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configuration_script_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configuration_script_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module MiqAeServiceManageIQProvidersAnsibleTowerConfigurationManagerConfigurationScriptSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configured_system_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager-configured_system_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module MiqAeServiceManageIQProvidersAnsibleTowerConfigurationManagerConfiguredSystemSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-configuration_manager_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module MiqAeServiceManageIQProvidersAnsibleTowerConfigurationManagerSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-provider_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-ansible_tower-provider_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module MiqAeServiceManageIQProvidersAnsibleTowerProviderSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_Provider do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_group_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module MiqAeServiceManageIQProvidersConfigurationManagerInventoryGroupSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryGroup do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_root_group_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-configuration_manager-inventory_root_group_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module MiqAeServiceManageIQProvidersConfigurationManagerInventoryRootGroupSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_ConfigurationManager_InventoryRootGroup do

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-google-cloud_manager_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-google-cloud_manager_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 module MiqAeServiceManageIQ_Providers_Google_CloudManagerSpec
   include MiqAeEngine
   describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Google_CloudManager do

--- a/spec/lib/report_formater/timeline_spec.rb
+++ b/spec/lib/report_formater/timeline_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ReportFormatter::ReportTimeline do
   context '#bubble_icon' do
     def stub_bottleneck_event(resource_type, ems_type = nil)

--- a/spec/lib/vmdb/settings/hash_differ_spec.rb
+++ b/spec/lib/vmdb/settings/hash_differ_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Vmdb::Settings::HashDiffer do
   let(:before_hash) do
     {

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Vmdb::Settings do
   it ".walk" do
     stub_settings(:a => {:b => 'c'}, :d => {:e => {:f => 'g'}}, :i => [{:j => 'k'}, {:l => 'm'}])

--- a/spec/migrations/20160127210622_migrate_old_configuration_settings_spec.rb
+++ b/spec/migrations/20160127210622_migrate_old_configuration_settings_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require_migration
 
 describe MigrateOldConfigurationSettings do

--- a/spec/migrations/20160127210624_convert_configurations_to_settings_changes_spec.rb
+++ b/spec/migrations/20160127210624_convert_configurations_to_settings_changes_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require_migration
 
 describe ConvertConfigurationsToSettingsChanges do

--- a/spec/migrations/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets_spec.rb
+++ b/spec/migrations/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require_migration
 
 describe MoveNetworkPortCloudSubnetIdToNetworkPortsCloudSubnets do

--- a/spec/migrations/20160310170333_add_service_ancestry_spec.rb
+++ b/spec/migrations/20160310170333_add_service_ancestry_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require_migration
 
 describe AddServiceAncestry do

--- a/spec/models/chargeback_rate_detail_currency_spec.rb
+++ b/spec/models/chargeback_rate_detail_currency_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ChargebackRateDetailCurrency do
   it "has a valid factory" do
     expect(FactoryGirl.create(:chargeback_rate_detail_currency_EUR)).to be_valid

--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe EmsRefresh::SaveInventoryInfra do
   let(:refresher) do
     Class.new do

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Endpoint do
   let(:endpoint) { described_class.new }
 

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe GitRepository do
   it "no url" do
     expect { FactoryGirl.create(:git_repository) }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ManageIQ::Providers::Azure::CloudManager::Provision do
   let(:provider)     { FactoryGirl.create(:ems_azure_with_authentication) }
   let(:template)     { FactoryGirl.create(:template_azure, :ext_management_system => provider) }
@@ -9,7 +7,6 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
   let(:subnet)       { FactoryGirl.create(:cloud_subnet_azure) }
   let(:network_port) { FactoryGirl.create(:network_port_azure) }
   let(:floating_ip)  { FactoryGirl.create(:floating_ip_azure) }
-
 
   context "#create vm" do
     subscription_id = "01234567890"

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
   include WorkflowSpecHelper
 

--- a/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ManageIQ::Providers::CloudManager::AuthKeyPair do
   let(:ems) { FactoryGirl.build(:ems_cloud) }
 

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'recursive-open-struct'
 require_relative 'hawkular_helper'
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require 'recursive-open-struct'
 
 describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do

--- a/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair do
   let(:ems) { FactoryGirl.create(:ems_openstack_with_authentication) }
   let(:key_pair_attributes) { {:name => "key1", :public_key => "AAA...B"} }

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
   let(:ems) { FactoryGirl.create(:ems_openstack) }
   let(:tenant) { FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems) }

--- a/spec/models/settings_change_spec.rb
+++ b/spec/models/settings_change_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe SettingsChange do
   describe "#key_path" do
     it "with multiple parts in the key" do

--- a/spec/views/layouts/perf_charts_js_spec.rb
+++ b/spec/views/layouts/perf_charts_js_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 include ChartingHelper
 
 describe 'layouts/_perf_chart_js.html.haml' do

--- a/spec/views/miq_ae_class/_instance_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_instance_fields.html.haml_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include AutomationSpecHelper
 
 describe "miq_ae_class/_instance_fields.html.haml" do

--- a/spec/views/miq_ae_class/_method_inputs.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_method_inputs.html.haml_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 include AutomationSpecHelper
 
 describe "miq_ae_class/_method_inputs.html.haml" do


### PR DESCRIPTION
Noticed this while working on a couple specs.