### PR TITLE
Restrict relative datetime handling to operators that support them in MiqExpression#to_ruby

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -446,7 +446,7 @@ class MiqExpression
     when "before"
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       col_name = exp[operator]["field"]
-      col_ruby, _ = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning")
       clause = if col_type == :date
                  "val=#{col_ruby}; !val.nil? && val.to_date < #{quote(val.to_date, :date)}"
@@ -456,7 +456,7 @@ class MiqExpression
     when "after"
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       col_name = exp[operator]["field"]
-      col_ruby, _ = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      col_ruby, = operands2rubyvalue(operator, {"field" => col_name}, context_type)
       val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end")
       clause = if col_type == :date
                  "val=#{col_ruby}; !val.nil? && val.to_date > #{quote(val.to_date, :date)}"

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -439,31 +439,28 @@ class MiqExpression
 
     operator = exp.keys.first
     case operator.downcase
-    when "equal", "=", "<", ">", ">=", "<=", "!=", "before", "after"
+    when "equal", "=", "<", ">", ">=", "<=", "!="
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
-      if col_type == :date || col_type == :datetime
-        col_name = exp[operator]["field"]
-        col_ruby, _ = operands2rubyvalue(operator, {"field" => col_name}, context_type)
+      operands = operands2rubyvalue(operator, exp[operator], context_type)
+      clause = operands.join(" #{normalize_ruby_operator(operator)} ")
+    when "before", "after"
+      col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
+      col_name = exp[operator]["field"]
+      col_ruby, _ = operands2rubyvalue(operator, {"field" => col_name}, context_type)
 
-        normalized_operator = normalize_ruby_operator(operator)
-        mode = case normalized_operator
-               when ">", "<="  then "end"        # (>  <date> 23::59:59), (<= <date> 23::59:59)
-               when "<", ">="  then "beginning"  # (<  <date> 00::00:00), (>= <date> 00::00:00)
+      normalized_operator = normalize_ruby_operator(operator)
+      mode = case normalized_operator
+             when ">", "<="  then "end"        # (>  <date> 23::59:59), (<= <date> 23::59:59)
+             when "<", ">="  then "beginning"  # (<  <date> 00::00:00), (>= <date> 00::00:00)
+             end
+
+      clause = if col_type == :date
+                 val = RelativeDatetime.normalize(exp[operator]["value"], tz, mode)
+                 "val=#{col_ruby}; !val.nil? && val.to_date #{normalized_operator} #{quote(val.to_date, :date)}"
+               else
+                 val = RelativeDatetime.normalize(exp[operator]["value"], tz, mode)
+                 "val=#{col_ruby}; !val.nil? && val.to_time #{normalized_operator} #{quote(val.utc, :datetime)}"
                end
-
-        if col_type == :date
-          val = RelativeDatetime.normalize(exp[operator]["value"], tz, mode)
-
-          clause = "val=#{col_ruby}; !val.nil? && val.to_date #{normalized_operator} #{quote(val.to_date, :date)}"
-        else
-          val = RelativeDatetime.normalize(exp[operator]["value"], tz, mode)
-
-          clause = "val=#{col_ruby}; !val.nil? && val.to_time #{normalized_operator} #{quote(val.utc, :datetime)}"
-        end
-      else
-        operands = operands2rubyvalue(operator, exp[operator], context_type)
-        clause = operands.join(" #{normalize_ruby_operator(operator)} ")
-      end
     when "includes all"
       operands = operands2rubyvalue(operator, exp[operator], context_type)
       clause = "(#{operands[0]} & #{operands[1]}) == #{operands[1]}"

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -447,24 +447,20 @@ class MiqExpression
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       col_name = exp[operator]["field"]
       col_ruby, _ = operands2rubyvalue(operator, {"field" => col_name}, context_type)
-
+      val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning")
       clause = if col_type == :date
-                 val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning")
                  "val=#{col_ruby}; !val.nil? && val.to_date < #{quote(val.to_date, :date)}"
                else
-                 val = RelativeDatetime.normalize(exp[operator]["value"], tz, "beginning")
                  "val=#{col_ruby}; !val.nil? && val.to_time < #{quote(val.utc, :datetime)}"
                end
     when "after"
       col_type = get_col_type(exp[operator]["field"]) if exp[operator]["field"]
       col_name = exp[operator]["field"]
       col_ruby, _ = operands2rubyvalue(operator, {"field" => col_name}, context_type)
-
+      val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end")
       clause = if col_type == :date
-                 val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end")
                  "val=#{col_ruby}; !val.nil? && val.to_date > #{quote(val.to_date, :date)}"
                else
-                 val = RelativeDatetime.normalize(exp[operator]["value"], tz, "end")
                  "val=#{col_ruby}; !val.nil? && val.to_time > #{quote(val.utc, :datetime)}"
                end
     when "includes all"

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -957,38 +957,13 @@ describe MiqExpression do
           expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
         end
 
-        it "generates the ruby for a > expression date value" do
-          exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
-        end
-
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
           expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
         end
 
-        it "generates the ruby for a < expression with date value" do
-          exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
-        end
-
-        it "generates the ruby for a >= expression with date value" do
-          exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date")
-        end
-
-        it "generates the ruby for a <= expression with date value" do
-          exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date")
-        end
-
         it "generates the ruby for a AFTER expression with datetime value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)")
-        end
-
-        it "generates the ruby for a > expression with datetime value" do
-          exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
           expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T09:00:00Z'.to_time(:utc)")
         end
 
@@ -1031,29 +1006,9 @@ describe MiqExpression do
           expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
         end
 
-        it "generates the ruby for a > expression with date value" do
-          exp = MiqExpression.new(">" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
-        end
-
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
           expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
-        end
-
-        it "generates the ruby for a < expression with date value" do
-          exp = MiqExpression.new("<" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
-        end
-
-        it "generates the ruby for a >= expression with date value" do
-          exp = MiqExpression.new(">=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-10'.to_date")
-        end
-
-        it "generates the ruby for a <= expression with date value" do
-          exp = MiqExpression.new("<=" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
@@ -1061,8 +1016,8 @@ describe MiqExpression do
           expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)")
         end
 
-        it "generates the ruby for a > expression with datetime value" do
-          exp = MiqExpression.new(">" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
+        it "generates the ruby for a AFTER expression with datetime value" do
+          exp = MiqExpression.new("AFTER" => {"field" => "Vm-last_scan_on", "value" => "2011-01-10 9:00"})
           expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/last_scan_on</value>; !val.nil? && val.to_time > '2011-01-10T14:00:00Z'.to_time(:utc)")
         end
 
@@ -1092,28 +1047,16 @@ describe MiqExpression do
       around { |example| Timecop.freeze("2011-01-11 17:30 UTC") { example.run } }
 
       context "given a non-UTC timezone" do
-        it "generates the SQL for a > expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new(">" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+        it "generates the SQL for a AFTER expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("AFTER" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
           expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-11'.to_date")
         end
 
-        it "generates the RUBY for a >= expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new(">=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
-          ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date")
-        end
-
-        it "generates the RUBY for a < expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new("<" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
+        it "generates the RUBY for a BEFORE expression with a value of 'Yesterday' for a date field" do
+          exp = described_class.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
           expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-11'.to_date")
-        end
-
-        it "generates the RUBY for a <= expression with a value of 'Yesterday' for a date field" do
-          exp = described_class.new("<=" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
-          ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for an IS expression with a value of 'Yesterday' for a date field" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Companion to https://github.com/ManageIQ/manageiq/pull/10246 and https://github.com/ManageIQ/manageiq/pull/9960. Does the same in the `#to_ruby` path that we did in those PRs for `#to_sql`, i.e. only handle relative datetimes in operators that officially support them.

@miq-bot add-label core, technical debt, refactoring
@miq-bot assign @gtanzillo 