### PR TITLE
exp in MiqExpression#to_ruby can't be an array

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -435,7 +435,7 @@ class MiqExpression
   end
 
   def self._to_ruby(exp, context_type, tz)
-    return exp unless exp.kind_of?(Hash) || exp.kind_of?(Array)
+    return exp unless exp.kind_of?(Hash)
 
     operator = exp.keys.first
     case operator.downcase


### PR DESCRIPTION
Purpose or Intent
-----------------
If it is, it will raise an error on the next line where the message
`keys` is sent to it.

@miq-bot add-label core, technical debt
@miq-bot assign @gtanzillo 