### PR TITLE
relationships: fewer queries for parents

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -791,14 +791,14 @@ class VmOrTemplate < ApplicationRecord
   # TODO: Replace all with ancestors lookup once multiple parents is sorted out
   def parent_resource_pool
     with_relationship_type('ems_metadata') do
-      parents(:of_type => "ResourcePool").first
+      parent(:of_type => "ResourcePool")
     end
   end
   alias_method :owning_resource_pool, :parent_resource_pool
 
   def parent_blue_folder
     with_relationship_type('ems_metadata') do
-      parents(:of_type => "EmsFolder").first
+      parent(:of_type => "EmsFolder")
     end
   end
   alias_method :owning_blue_folder, :parent_blue_folder


### PR DESCRIPTION
Pulled this out of #10160 

This reduced the number of queries for things like `Vm#parent_blue_folders` and `Vm#parent_resource_folders` among other queries.

This is 1/2 of my optimization for rbac and cap&u timer.

Thanks for review @Fryguy - let me know if this went in the direction you expected