### PR TITLE
window_sizes cleanup - part 1

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -481,11 +481,10 @@ function DoNav(theUrl) {
 
 // Routines to get the size of the window
 function miqResetSizeTimer() {
-  var sizes = miqGetSize();
+  var height = window.innerHeight;
   var offset = 427;
-  var h = sizes[1] - offset;
+  var h = height - offset;
   var url = "/dashboard/window_sizes";
-  var args = {width: sizes[0], height: sizes[1]};
 
   if (h < 200) {
     h = 200;
@@ -499,32 +498,7 @@ function miqResetSizeTimer() {
   }
 
   // Send the new values to the server
-  miqJqueryRequest(miqPassFields(url, args));
-}
-
-// Get the size and pass to the server
-function miqGetSize() {
-  var myWidth = 0;
-  var myHeight = 0;
-
-  if (typeof window.innerWidth == 'number') {
-    // Non-IE
-    myWidth = window.innerWidth;
-    myHeight = window.innerHeight;
-  } else if (document.documentElement &&
-             (document.documentElement.clientWidth ||
-              document.documentElement.clientHeight)) {
-    // IE 6+ in 'standards compliant mode'
-    myWidth = document.documentElement.clientWidth;
-    myHeight = document.documentElement.clientHeight;
-  } else if (document.body &&
-             (document.body.clientWidth ||
-              document.body.clientHeight)) {
-    // IE 4 compatible
-    myWidth = document.body.clientWidth;
-    myHeight = document.body.clientHeight;
-  }
-  return [ myWidth, myHeight ];
+  miqJqueryRequest(miqPassFields(url, { height: height }));
 }
 
 // Pass fields to server given a URL and fields in name/value pairs

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -52,10 +52,6 @@ class DashboardController < ApplicationController
   # Accept window sizes from the client
   def window_sizes
     session[:winH] = params[:height] if params[:height]
-    if params[:exp_left] && params[:exp_controller]
-      # Set the left divider position in the controller's sandbox
-      session[:sandboxes][params[:exp_controller]][:exp_left] = params[:exp_left]
-    end
     head :ok # No response required
   end
 

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -20,7 +20,6 @@
                                     :row_url_ajax    => ajax_url}})
   - else
     -# TODO: is this still even relevant? haven't seen it yet (--mhradil)
-    -# substracting leftcol 219 from @winW to calculate width of div
     -# FYI: found a screen here: /auth_key_pair_cloud/show_list (--@hayesr)
     #list_grid
       = render(:partial => 'layouts/list_grid',


### PR DESCRIPTION
This is a minor cleanup of our `onresize` `window_sizes` logic:

 * `window_sizes` completely ignores width, so no sense in computing and sending it
 * we never send `:exp_left`, so no point in trying to save it
 * IE9+ supports `window.innerHeight`, `miqGetSize` is no longer needed
 * + remove obsolete `@winW` reference

I'm hoping to remove it completely in a subsequent PR, but it's still used in `log_viewer`...

```
app/views/layouts/_log_viewer.html.haml
4:- h = @winH < 627 ? 200 : @winH - 427

app/helpers/application_helper.rb (def center_div_height - only used from ops/_log_viewer)
1033:    height = @winH < max ? min : @winH - (max - min)
```
(also should merge `ops/_log_viewer` and `layouts/_log_viewer`)