### PR TITLE
Handle gracefully missing number_of nil

### DIFF
--- a/lib/extensions/ar_number_of.rb
+++ b/lib/extensions/ar_number_of.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   class Base
     def number_of(assoc)
       @number_of ||= {}
-      @number_of[assoc.to_sym] ||= send(assoc).size
+      @number_of[assoc.to_sym] ||= send(assoc).try!(:size) || 0
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------

When delegate object is nil and we compute number_of association, through that delegate, we should just return 0

Steps for Testing/QA
--------------------

Delete NetworkManager and click through associated CloudManager, no error should be thrown. Optionally delete a CloudManager in DB and click through associated NetworkManager.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1364458