### PR TITLE
Re-use api code for validation of create method

### DIFF
--- a/app/controllers/api_controller/arbitration_profiles.rb
+++ b/app/controllers/api_controller/arbitration_profiles.rb
@@ -29,9 +29,8 @@ class ApiController
     end
 
     def validate_profile_data(data)
-      if data.key?('id') || data.key?('href')
-        raise BadRequestError, 'Resource id or href should not be specified when creating a new arbitration profile'
-      elsif data.key?('provider') && data.key?('ext_management_system')
+      assert_id_not_specified(data, 'arbitration profile')
+      if data.key?('provider') && data.key?('ext_management_system')
         raise BadRequestError, 'Only one of provider or ext_management_system may be specified'
       end
     end

--- a/app/controllers/api_controller/automation_requests.rb
+++ b/app/controllers/api_controller/automation_requests.rb
@@ -1,10 +1,7 @@
 class ApiController
   module AutomationRequests
     def create_resource_automation_requests(type, _id, data)
-      if data.key?("id") || data.key?("href")
-        raise BadRequestError,
-              "Resource id or href should not be specified for creating a new #{type}"
-      end
+      assert_id_not_specified(data, type)
 
       version_str = data["version"] || "1.1"
       uri_parts   = hash_fetch(data, "uri_parts")

--- a/app/controllers/api_controller/generic.rb
+++ b/app/controllers/api_controller/generic.rb
@@ -42,11 +42,8 @@ class ApiController
     # Same signature.
     #
     def add_resource(type, _id, data)
+      assert_id_not_specified(data, "#{type} resource")
       klass = collection_class(type)
-      if data.key?("id") || data.key?("href")
-        raise BadRequestError,
-              "Resource id or href should not be specified for creating a new #{type} resource"
-      end
       subcollection_data = collection_config.subcollections(type).each_with_object({}) do |sc, hash|
         if data.key?(sc.to_s)
           hash[sc] = data[sc.to_s]

--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -299,5 +299,11 @@ class ApiController
     def collection_option?(option)
       collection_config.option?(@req.collection, option) if @req.collection
     end
+
+    def assert_id_not_specified(data, type)
+      if data.key?('id') || data.key?('href')
+        raise BadRequestError, "Resource id or href should not be specified for creating a new #{type}"
+      end
+    end
   end
 end

--- a/app/controllers/api_controller/providers.rb
+++ b/app/controllers/api_controller/providers.rb
@@ -10,10 +10,7 @@ class ApiController
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"]
 
     def create_resource_providers(type, _id, data = {})
-      if data.key?("id") || data.key?("href")
-        raise BadRequestError,
-              "Resource id or href should not be specified for creating a new #{type}"
-      end
+      assert_id_not_specified(data, type)
 
       create_provider(data)
     end

--- a/app/controllers/api_controller/provision_requests.rb
+++ b/app/controllers/api_controller/provision_requests.rb
@@ -1,10 +1,7 @@
 class ApiController
   module ProvisionRequests
     def create_resource_provision_requests(type, _id, data)
-      if data.key?("id") || data.key?("href")
-        raise BadRequestError,
-              "Resource id or href should not be specified for creating a new #{type}"
-      end
+      assert_id_not_specified(data, type)
 
       version_str       = data["version"] || "1.1"
       template_fields   = hash_fetch(data, "template_fields")

--- a/app/controllers/api_controller/roles.rb
+++ b/app/controllers/api_controller/roles.rb
@@ -1,9 +1,7 @@
 class ApiController
   module Roles
     def create_resource_roles(type, _id = nil, data = {})
-      if data.key?("id") || data.key?("href")
-        raise BadRequestError, "Resource id or href should not be specified for creating a new #{type}"
-      end
+      assert_id_not_specified(data, type)
 
       # Can't create a read-only role (reserved for out-of-box roles)
       if data['read_only']

--- a/app/controllers/api_controller/tags.rb
+++ b/app/controllers/api_controller/tags.rb
@@ -43,11 +43,8 @@ class ApiController
       action_result(false, err.to_s)
     end
 
-    def create_resource_tags(_type, _id, data)
-      if data.key?("id") || data.key?("href")
-        raise BadRequestError,
-              "Resource id or href should not be specified for creating a new tag resource"
-      end
+    def create_resource_tags(type, _id, data)
+      assert_id_not_specified(data, type)
       category_data = data.delete("category") { {} }
       category = fetch_category(category_data)
       unless category


### PR DESCRIPTION
Refactor: Extract method: assert_id_not_specified

Avoid repeating the very same check multiple times.

@miq-bot add_label api, refactoring
@miq-bot assign @abellotti 

