### PR TITLE
Fix allow user to skip Region name in Openstack provider

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -38,7 +38,7 @@ module EmsCloudHelper::TextualSummary
   end
 
   def textual_region
-    return nil if @ems.provider_region.nil?
+    return nil if @ems.provider_region.blank?
     label_val = _('Region')
     {:label => label_val, :value => @ems.provider_region}
   end

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -45,7 +45,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
         :ssl_cert_store => OpenSSL::X509::Store.new
       }
       extra_options[:domain_id] = keystone_v3_domain_id
-      extra_options[:region]    = provider_region
+      extra_options[:region]    = provider_region if provider_region.present?
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}
@@ -135,7 +135,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   end
 
   def verify_api_credentials(options = {})
-    options[:service] = "Identity"
+    options[:service] = "Compute"
     with_provider_connection(options) {}
     true
   rescue => err


### PR DESCRIPTION
Region name in Openstack provider can be empty when Openstack deployment contains only one region. Previous state forced user to fill region name field always.

Fixed by not passing Openstack Region name into Fog calls when Region field was not filled.