### PR TITLE
Correct wrong image for Cloud Tenant in Button tree

### DIFF
--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -58,6 +58,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
     case node
     when "ExtManagementSystem" then "ext_management_system"
     when "MiqTemplate"         then "vm"
+    when 'CloudTenant'         then 'cloud_tenant'
     else                            node.downcase
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Correct wrong image name for Cloud Tenant in Automate-> Customization->Buttons that raises this error: `Failed to load resource: the server responded with a status of 404 (Not Found) http://localhost:3005/images/100/cloudtenant.png`

Before:
![screen shot 2016-08-08 at 2 07 25 pm](https://cloud.githubusercontent.com/assets/9210860/17479232/8efd4054-5d71-11e6-937c-010d1c7037be.png)

After:
![screen shot 2016-08-08 at 2 04 06 pm](https://cloud.githubusercontent.com/assets/9210860/17479227/8a10163e-5d71-11e6-959f-1bf81634fb95.png)

@miq-bot add_label ui, bug