### PR TITLE
Correct false flash message in Import service dialog

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -417,6 +417,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def render_flash_and_stop_sparkle(*args)
+    render_flash(*args) do |page|
+      page << "miqSparkle(false);"
+    end
+  end
+
   def tagging_explorer_controller?
     false
   end

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -67,6 +67,17 @@ class MiqAeCustomizationController < ApplicationController
 
   def import_service_dialogs
     if params[:commit] == _('Commit')
+
+      if params[:dialogs_to_import].blank?
+        add_flash(_("At least one Service Dialog must be selected."), :error)
+        render :update do |page|
+          page << javascript_prologue
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqSparkle(false);"
+        end
+        return
+      end
+
       import_file_upload = ImportFileUpload.find_by(:id => params[:import_file_upload_id])
 
       if import_file_upload

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -67,14 +67,8 @@ class MiqAeCustomizationController < ApplicationController
 
   def import_service_dialogs
     if params[:commit] == _('Commit')
-
       if params[:dialogs_to_import].blank?
-        add_flash(_("At least one Service Dialog must be selected."), :error)
-        render :update do |page|
-          page << javascript_prologue
-          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-          page << "miqSparkle(false);"
-        end
+        render_flash_and_stop_sparkle(_("At least one Service Dialog must be selected."), :error)
         return
       end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
In Automate -> Customization -> Import/Export -> Import file -> Commit without selecting any Service Dialogs. It continued with success/failure (depending on unrelated attributes) to following page. Now it stays on the page and shows error message. 

Before:
![screen shot 2016-08-08 at 3 11 02 pm](https://cloud.githubusercontent.com/assets/9210860/17480892/73794c0c-5d7a-11e6-83c1-60158f880c6c.png)

After:
![screen shot 2016-08-08 at 3 07 24 pm](https://cloud.githubusercontent.com/assets/9210860/17480788/e9634e14-5d79-11e6-95d8-54a6edf1166e.png)



Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1341671
Darga version: https://github.com/ManageIQ/manageiq/pull/10341
Target release: 5.6.1.

@miq-bot add_label ui, bug
