### PR TITLE
Add EmsRefresh.queue_merge_sync.

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -2,14 +2,14 @@ class EmsEvent
   module Automate
     extend ActiveSupport::Concern
 
-    def refresh(*targets)
+    def refresh(*targets, sync)
       targets = targets.flatten
       return if targets.blank?
 
       refresh_targets = targets.collect { |t| get_target("#{t}_refresh_target") unless t.blank? }.compact.uniq
       return if refresh_targets.empty?
 
-      EmsRefresh.queue_refresh(refresh_targets)
+      EmsRefresh.queue_refresh(refresh_targets, nil, sync)
     end
 
     def policy(target_str, policy_event, param = nil)

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/EVM.class/reconfigvm_task_complete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/EVM.class/reconfigvm_task_complete.yaml
@@ -9,6 +9,6 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/src_vm_refresh_on_reconfig"
+      value: "/System/event_handlers/event_action_refresh_sync?target=src_vm"
   - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_reconfigure&param="

--- a/db/fixtures/ae_datastore/ManageIQ/System/event_handlers.class/__methods__/event_action_refresh_sync.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/event_handlers.class/__methods__/event_action_refresh_sync.yaml
@@ -1,0 +1,32 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: event_action_refresh_sync
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: builtin
+  inputs:
+  - field:
+      aetype: 
+      name: target
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/event_handlers.class/event_action_refresh_sync.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/event_handlers.class/event_action_refresh_sync.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: event_action_refresh_sync
+    inherits: 
+    description: 
+  fields:
+  - meth1:
+      value: event_action_refresh_sync

--- a/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb
@@ -96,7 +96,11 @@ module MiqAeEngine
     end
 
     def self.miq_event_action_refresh(obj, inputs)
-      event_object_from_workspace(obj).refresh(inputs['target'])
+      event_object_from_workspace(obj).refresh(inputs['target'], false)
+    end
+
+    def self.miq_event_action_refresh_sync(obj, inputs)
+      event_object_from_workspace(obj).refresh(inputs['target'], true)
     end
 
     def self.miq_event_action_policy(obj, inputs)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ems_event.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ems_event.rb
@@ -1,7 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceEmsEvent < MiqAeServiceEventStream
-    def refresh(*targets)
-      ar_method { @object.refresh(*targets) } unless targets.blank?
+    def refresh(*targets, sync)
+      ar_method { @object.refresh(*targets, sync) } unless targets.blank?
     end
 
     def policy(target_str, policy_event, param)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_ems_event_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_ems_event_spec.rb
@@ -13,17 +13,17 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
 
   context "#refresh" do
     it "when queued" do
-      expect(EmsRefresh).to receive(:queue_refresh).once.with([@ems])
-      @service_event.refresh("src_vm")
+      expect(EmsRefresh).to receive(:queue_refresh).once.with([@ems], nil, false)
+      @service_event.refresh("src_vm", false)
     end
 
     it "when with multiple targets" do
       @vm.update_attributes(:ext_management_system => @ems)
-      expect(EmsRefresh).to receive(:queue_refresh).once do |args|
-        expect(args).to match_array([@ems, @vm])
+      expect(EmsRefresh).to receive(:queue_refresh).once do |*args|
+        expect(args[0]).to match_array([@ems, @vm])
       end
 
-      @service_event.refresh("src_vm", "dest_vm")
+      @service_event.refresh("src_vm", "dest_vm", false)
     end
 
     it "when target object is empty" do
@@ -31,27 +31,27 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
       @service_event.reload
 
       expect(EmsRefresh).not_to receive(:queue_refresh)
-      @service_event.refresh("dest_vm")
+      @service_event.refresh("dest_vm", false)
     end
 
     it "when target is empty string" do
       expect(EmsRefresh).not_to receive(:queue_refresh)
-      @service_event.refresh("")
+      @service_event.refresh("", false)
     end
 
     it "when target is empty" do
       expect(EmsRefresh).not_to receive(:queue_refresh)
-      @service_event.refresh
+      @service_event.refresh([], false)
     end
 
     it "when target is nil" do
       expect(EmsRefresh).not_to receive(:queue_refresh)
-      @service_event.refresh(nil)
+      @service_event.refresh(nil, false)
     end
 
     it "when target is an array" do
-      expect(EmsRefresh).to receive(:queue_refresh).once.with([@ems])
-      @service_event.refresh(%w(src_vm dest_vm))
+      expect(EmsRefresh).to receive(:queue_refresh).once.with([@ems], nil, false)
+      @service_event.refresh(%w(src_vm dest_vm), false)
     end
   end
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -91,4 +91,31 @@ describe EmsRefresh do
       ])
     end
   end
+
+  context '.queue_merge_async' do
+    let(:ems) { FactoryGirl.create(:ems_vmware, :name => "ems_vmware1") }
+    let(:vm)  { FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems) }
+
+    it 'sends the command to queue' do
+      EmsRefresh.queue_merge_async([vm], ems)
+      expect(MiqQueue.count).to eq(1)
+    end
+  end
+
+  context '.queue_merge_sync' do
+    let(:ems) { FactoryGirl.create(:ems_vmware, :name => "ems_vmware1") }
+    let(:vm)  { FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => ems) }
+
+    it 'sends the refresh command to queue' do
+      allow(MiqQueue).to receive(:find_by).and_return(nil)
+      EmsRefresh.queue_merge_sync([vm], ems)
+      expect(MiqQueue.count).to eq(1)
+    end
+
+    it 'returns after the refresh command is processed' do
+      allow(MiqQueue).to receive(:find_by).and_return(1, nil)
+      expect(EmsRefresh).to receive(:sleep)
+      EmsRefresh.queue_merge_sync([vm], ems)
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Event reconfigvm_task_complete needs to refresh the target first then raises vm_reconfigure event for policy. 

There are two refresh methods. And reconfigvm_task_complete calls the special refresh version. [#10176](https://github.com/ManageIQ/manageiq/pull/10176) would refactor the code and remove the special version. 

This PR adds EmsRefresh.queue_merge_sync which calls the general refresh method and waits for it to finish. 

cc @jameswnl @gmcculloug @agrare @gtanzillo 