### PR TITLE
Add condition to TreeBuilder to not read empty @sb

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -296,8 +296,6 @@ class TreeBuilder
   end
 
   def x_build_single_node(object, pid, options)
-    options[:parent_kls]  = @sb[:parent_kls] if @sb[:parent_kls]
-    options[:parent_name] = @sb[:parent_name] if @sb[:parent_name]
     node_builder.build(object, pid, options)
   end
 

--- a/app/presenters/tree_builder_diagnostics.rb
+++ b/app/presenters/tree_builder_diagnostics.rb
@@ -1,0 +1,33 @@
+class TreeBuilderDiagnostics < TreeBuilder
+  def initialize(name, type, sandbox, build = true, parent = nil)
+    @root = parent
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options(_tree_name)
+    {:add_root => false,
+     :expand   => true,
+     :lazy     => false,
+     :open_all => true
+    }
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:autoload  => false,
+                  :click_url => "/ops/diagnostics_tree_select/",
+                  :onclick   => "miqOnClickServerRoles")
+  end
+
+  def x_build_single_node(object, pid, options)
+    options[:parent_kls]  = @sb[:parent_kls] if @sb && @sb[:parent_kls]
+    options[:parent_name] = @sb[:parent_name] if @sb && @sb[:parent_name]
+    super(object, pid, options)
+  end
+
+  def root_options
+    []
+  end
+end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -24,6 +24,12 @@ class TreeBuilderRolesByServer < TreeBuilder
                   :onclick   => "miqOnClickServerRoles")
   end
 
+  def x_build_single_node(object, pid, options)
+    options[:parent_kls]  = @sb[:parent_kls] if @sb && @sb[:parent_kls]
+    options[:parent_name] = @sb[:parent_name] if @sb && @sb[:parent_name]
+    super(object, pid, options)
+  end
+
   def root_options
     []
   end

--- a/app/presenters/tree_builder_roles_by_server.rb
+++ b/app/presenters/tree_builder_roles_by_server.rb
@@ -1,38 +1,7 @@
-class TreeBuilderRolesByServer < TreeBuilder
+class TreeBuilderRolesByServer < TreeBuilderDiagnostics
   has_kids_for MiqServer, [:x_get_tree_miq_server_kids]
 
-  def initialize(name, type, sandbox, build = true, parent = nil)
-    @root = parent
-    super(name, type, sandbox, build)
-  end
-
   private
-
-  def tree_init_options(_tree_name)
-    {
-      :add_root => false,
-      :expand   => true,
-      :lazy     => false,
-      :open_all => true
-    }
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload  => false,
-                  :click_url => "/ops/diagnostics_tree_select/",
-                  :onclick   => "miqOnClickServerRoles")
-  end
-
-  def x_build_single_node(object, pid, options)
-    options[:parent_kls]  = @sb[:parent_kls] if @sb && @sb[:parent_kls]
-    options[:parent_name] = @sb[:parent_name] if @sb && @sb[:parent_name]
-    super(object, pid, options)
-  end
-
-  def root_options
-    []
-  end
 
   def x_get_tree_roots(_count_only, _options)
     x_get_tree_miq_servers

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -24,6 +24,12 @@ class TreeBuilderServersByRole < TreeBuilder
                   :onclick   => "miqOnClickServerRoles")
   end
 
+  def x_build_single_node(object, pid, options)
+    options[:parent_kls]  = @sb[:parent_kls] if @sb && @sb[:parent_kls]
+    options[:parent_name] = @sb[:parent_name] if @sb && @sb[:parent_name]
+    super(object, pid, options)
+  end
+
   def root_options
     []
   end

--- a/app/presenters/tree_builder_servers_by_role.rb
+++ b/app/presenters/tree_builder_servers_by_role.rb
@@ -1,38 +1,7 @@
-class TreeBuilderServersByRole < TreeBuilder
+class TreeBuilderServersByRole < TreeBuilderDiagnostics
   has_kids_for ServerRole, [:x_get_tree_server_role_kids]
 
-  def initialize(name, type, sandbox, build = true, parent = nil)
-    @root = parent
-    super(name, type, sandbox, build)
-  end
-
   private
-
-  def tree_init_options(_tree_name)
-    {
-      :add_root => false,
-      :expand   => true,
-      :lazy     => false,
-      :open_all => true
-    }
-  end
-
-  def set_locals_for_render
-    locals = super
-    locals.merge!(:autoload  => false,
-                  :click_url => "/ops/diagnostics_tree_select/",
-                  :onclick   => "miqOnClickServerRoles")
-  end
-
-  def x_build_single_node(object, pid, options)
-    options[:parent_kls]  = @sb[:parent_kls] if @sb && @sb[:parent_kls]
-    options[:parent_name] = @sb[:parent_name] if @sb && @sb[:parent_name]
-    super(object, pid, options)
-  end
-
-  def root_options
-    []
-  end
 
   def x_get_tree_roots(_count_only, _options)
     x_get_tree_server_roles


### PR DESCRIPTION
Purpose or Intent
-----------------
Compute -> Infrastructure -> Virtual Machines showed error: `undefined method []' for nil:NilClass [vm_infra/explorer]` . Not all trees have `@sb` so the method `x_build_single_node(object, pid, options)` that newly reads from it was moved to specific TreeBuilders.

This was introduced by https://github.com/ManageIQ/manageiq/pull/9735 .

