### PR TITLE
Allow use of compressed IDs (like 1r21) in API

### DIFF
--- a/app/controllers/api_controller/parser.rb
+++ b/app/controllers/api_controller/parser.rb
@@ -83,20 +83,20 @@ class ApiController
       collection, c_id    = path_array[cidx..cidx + 1]
       subcollection, s_id = path_array[cidx + 2..cidx + 3]
 
-      subcollection ? [subcollection.to_sym, s_id] : [collection.to_sym, c_id]
+      subcollection ? [subcollection.to_sym, from_cid(s_id)] : [collection.to_sym, from_cid(c_id)]
     end
 
     def parse_id(resource, collection)
       return nil if resource.blank?
 
       href_id = href_id(resource["href"], collection)
-      return href_id if href_id.present?
+      return from_cid(href_id) if href_id.present?
 
       resource["id"].kind_of?(Integer) ? resource["id"] : nil
     end
 
     def href_id(href, collection)
-      href.match(%r{^.*/#{collection}/([0-9]+)$}) && Regexp.last_match(1) if href.present?
+      href.match(%r{^.*/#{collection}/([0-9r]+)$}) && Regexp.last_match(1) if href.present?
     end
 
     def parse_by_attr(resource, type, attr_list)

--- a/app/controllers/api_controller/parser/request_adapter.rb
+++ b/app/controllers/api_controller/parser/request_adapter.rb
@@ -1,6 +1,8 @@
 class ApiController
   module Parser
     class RequestAdapter
+      include CompressedIds
+
       def initialize(req, params)
         @request = req
         @params = params
@@ -39,7 +41,8 @@ class ApiController
       end
 
       def c_id
-        @params[:c_id] || c_path_parts[1]
+        id = @params[:c_id] || c_path_parts[1]
+        id =~ /\A[0-9]/ ? from_cid(id) : id
       end
 
       def subcollection
@@ -47,7 +50,7 @@ class ApiController
       end
 
       def s_id
-        @params[:s_id] || c_path_parts[3]
+        from_cid(@params[:s_id] || c_path_parts[3])
       end
 
       def expand?(what)

--- a/app/controllers/api_controller/policies.rb
+++ b/app/controllers/api_controller/policies.rb
@@ -65,7 +65,7 @@ class ApiController
       return klass.find_by_guid(guid) if guid.present?
 
       href = data["href"]
-      href.match(%r{^.*/#{collection}/[0-9]+$}) ? klass.find(href.split('/').last) : {}
+      href.match(%r{^.*/#{collection}/[0-9r]+$}) ? klass.find(from_cid(href.split('/').last)) : {}
     end
 
     def policy_subcollection_action(ctype, policy)

--- a/app/controllers/api_controller/tags.rb
+++ b/app/controllers/api_controller/tags.rb
@@ -140,9 +140,9 @@ class ApiController
 
     def parse_tag_from_href(data)
       href = data["href"]
-      tag  = if href && href.match(%r{^.*/tags/[0-9]+$})
+      tag  = if href && href.match(%r{^.*/tags/[0-9r]+$})
                klass = collection_class(:tags)
-               klass.find(href.split('/').last)
+               klass.find(from_cid(href.split('/').last))
              end
       tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
First we want to enable users to just pick IDs from their web browser. So far, they need to guess how many zeroes they need to put instead of 'r'.

At the first stage we allow users to supply compressed ids. At the second stage we can output `href`s in this form. I stopped at the first stage, as we will need to amend all the test expectations in the second stage.

Links
-----
> * https://www.pivotaltracker.com/n/projects/1610125/stories/121850823

@miq-bot add_label api, darga/no, enhancement
@miq-bot assign @abellotti 