### PR TITLE
Remove sprockets-es6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "jquery-rails",                 "~>4.1.1"
   gem "lodash-rails",                 "~>3.10.0"
   gem "sass-rails"
-  gem "sprockets-es6",                "~>0.9.0",  :require => "sprockets/es6"
 
   # Modified gems (forked on Github)
   gem "jquery-rjs",                   "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"

--- a/config/initializers/sprockets-es6.rb
+++ b/config/initializers/sprockets-es6.rb
@@ -1,7 +1,0 @@
-Sprockets::ES6.configure do |babel5|
-  babel5.optional = %w(
-    es7.functionBind
-    es7.decorators
-    es7.objectRestSpread
-  )
-end


### PR DESCRIPTION
Purpose or Intent
-----------------
This also removes some deprecation warnings caused by this gem.

ManageIQ is currently not using any es6 functionality at the moment, and since this gem is a POC project anyway, which the functionality from it will eventually make it's way into sprockets core, we are removing this for now.



Links
-----
* https://github.com/TannerRogalsky/sprockets-es6#releases


Steps for Testing/QA
--------------------
Boot up a local rails server with this branch/patch and confirm there are no longer the following deprecation warning:

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from <module:Sprockets> at /sprockets-es6-0.9.0/lib/sprockets/es6.rb:90)
```