### PR TITLE
Added missing routes for Network resources

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1354,6 +1354,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         quick_search
+        listnav_search_selected
         show
         show_list
         tag_edit_form_field_changed
@@ -1361,6 +1362,7 @@ Vmdb::Application.routes.draw do
       ) +
         adv_search_post +
         compare_post +
+        save_post +
         exp_post
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1288,11 +1288,13 @@ Vmdb::Application.routes.draw do
         quick_search
         show
         show_list
+        listnav_search_selected
         tag_edit_form_field_changed
         tagging_edit
       ) +
         adv_search_post +
         compare_post +
+        save_post +
         exp_post
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1314,6 +1314,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         quick_search
+        listnav_search_selected
         show
         show_list
         tag_edit_form_field_changed
@@ -1321,6 +1322,7 @@ Vmdb::Application.routes.draw do
       ) +
         adv_search_post +
         compare_post +
+        save_post +
         exp_post
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1242,6 +1242,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         quick_search
+        listnav_search_selected
         show
         show_list
         tag_edit_form_field_changed
@@ -1249,6 +1250,7 @@ Vmdb::Application.routes.draw do
       ) +
         adv_search_post +
         compare_post +
+        save_post +
         exp_post
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1266,6 +1266,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         quick_search
+        listnav_search_selected
         show
         show_list
         tag_edit_form_field_changed
@@ -1273,6 +1274,7 @@ Vmdb::Application.routes.draw do
       ) +
         adv_search_post +
         compare_post +
+        save_post +
         exp_post
     },
 


### PR DESCRIPTION
This PR is fixing usage of the advanced filters in some of the Network resources. For more details see: https://bugzilla.redhat.com/show_bug.cgi?id=1364089