### PR TITLE
Azure discovery - set default subscription ID to NIL 

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -81,7 +81,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
       new_emses
     end
 
-    def discover_queue(clientid, clientkey, azure_tenant_id, subscription)
+    def discover_queue(clientid, clientkey, azure_tenant_id, subscription = nil)
       MiqQueue.put(
         :class_name  => name,
         :method_name => "discover_from_queue",


### PR DESCRIPTION
**Bug description:**
In 5.5 a subscription ID was added as an optional parameter for connecting to the Azure ARM API. If omitted, the azure-armrest gem selected the first active one. However, the Azure Cloud Manager discovery code expected a subscription ID to be supplied and, since it was optional, an error was thrown if the user did not enter one.  

**Fix:**
This PR sets a default value of NIL when making the connection from ManageIQ to Azure.

https://bugzilla.redhat.com/show_bug.cgi?id=1362654

