### PR TITLE
Fix sort of class instances in Automate

### DIFF
--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -10,7 +10,7 @@
           %th
           %th
         %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
-          - @record.ae_instances.each do |record|
+          - @record.ae_instances.order(:name).each do |record|
             - next if record.name == '$'
             - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
             %tr{'data-click-id' => cls_cid}


### PR DESCRIPTION
Fixes mismatched sorting in Automate; instances on the left would be sorted alphabetically by name but on the right it was unsorted. 

**Before**
![screen shot 2016-08-08 at 11 24 08 am](https://cloud.githubusercontent.com/assets/39493/17491180/5d5464ee-5d5b-11e6-84f7-9079472159c9.png)

**After**
![screen shot 2016-08-08 at 11 24 58 am](https://cloud.githubusercontent.com/assets/39493/17491186/69ead77e-5d5b-11e6-9299-3a1234a99f2b.png)


@miq-bot add_label ui, bug
@h-kataria 

https://bugzilla.redhat.com/show_bug.cgi?id=1359932