### PR TITLE
Remove RelativeDatetime.beginning_or_end_of_hour

### DIFF
--- a/app/models/miq_expression/relative_datetime.rb
+++ b/app/models/miq_expression/relative_datetime.rb
@@ -30,10 +30,7 @@ class MiqExpression::RelativeDatetime
       value, interval, ago = rt.split
       interval = interval.pluralize
 
-      if interval == "hours"
-        t = value.to_i.hours.ago.in_time_zone(tz)
-        mode == "beginning" ? t.beginning_of_hour : t.end_of_hour
-      elsif interval == "quarters"
+      if interval == "quarters"
         ts = Time.now.in_time_zone(tz).beginning_of_quarter
         (ts - (value.to_i * 3.months)).send("#{mode}_of_quarter")
       else

--- a/app/models/miq_expression/relative_datetime.rb
+++ b/app/models/miq_expression/relative_datetime.rb
@@ -1,10 +1,4 @@
 class MiqExpression::RelativeDatetime
-  def self.beginning_or_end_of_hour(ts, mode)
-    ts_str = ts.iso8601
-    ts_str[14..18] = mode == "end" ? "59:59.999999" : "00:00"
-    Time.parse(ts_str)
-  end
-
   def self.relative?(value)
     v = value.downcase
     v.starts_with?("this", "last") || v.ends_with?("ago") || ["today", "yesterday", "now"].include?(v)
@@ -37,7 +31,8 @@ class MiqExpression::RelativeDatetime
       interval = interval.pluralize
 
       if interval == "hours"
-        beginning_or_end_of_hour(value.to_i.hours.ago.in_time_zone(tz), mode)
+        t = value.to_i.hours.ago.in_time_zone(tz)
+        mode == "beginning" ? t.beginning_of_hour : t.end_of_hour
       elsif interval == "quarters"
         ts = Time.now.in_time_zone(tz).beginning_of_quarter
         (ts - (value.to_i * 3.months)).send("#{mode}_of_quarter")
@@ -49,7 +44,8 @@ class MiqExpression::RelativeDatetime
     elsif rt == "yesterday"
       1.day.ago.in_time_zone(tz).send("#{mode}_of_day")
     elsif rt == "now"
-      beginning_or_end_of_hour(Time.now.in_time_zone(tz), mode)
+      t = Time.now.in_time_zone(tz)
+      mode == "beginning" ? t.beginning_of_hour : t.end_of_hour
     else
       # Assume it's an absolute date or time
       value_is_date = !rel_time.include?(":")

--- a/spec/models/miq_expression/relative_datetime_spec.rb
+++ b/spec/models/miq_expression/relative_datetime_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MiqExpression::RelativeDatetime do
 
       it "end mode" do
         result = described_class.normalize("3 Hours Ago", "UTC", "end")
-        expect(result).to eq("2011-01-11 14:59:59.999999 UTC")
+        expect(result).to eq("2011-01-11 14:59:59.999999999 UTC")
       end
     end
 
@@ -112,7 +112,7 @@ RSpec.describe MiqExpression::RelativeDatetime do
 
       it "end mode" do
         result = described_class.normalize("Now", "UTC", "end")
-        expect(result).to eq("2011-01-11 17:59:59.999999 UTC")
+        expect(result).to eq("2011-01-11 17:59:59.999999999 UTC")
       end
     end
 
@@ -163,7 +163,7 @@ RSpec.describe MiqExpression::RelativeDatetime do
 
       it "end mode" do
         result = described_class.normalize("Last Hour", "UTC", "end")
-        expect(result).to eq("2011-01-11 16:59:59.999999 UTC")
+        expect(result).to eq("2011-01-11 16:59:59.999999999 UTC")
       end
     end
 
@@ -231,7 +231,7 @@ RSpec.describe MiqExpression::RelativeDatetime do
 
       it "end mode" do
         result = described_class.normalize("This Hour", "UTC", "end")
-        expect(result).to eq("2011-01-11 17:59:59.999999 UTC")
+        expect(result).to eq("2011-01-11 17:59:59.999999999 UTC")
       end
     end
 


### PR DESCRIPTION
Purpose or Intent
-----------------

By using AS's `(beginning|end)_of_hour` instead, this not only makes our
method redundant but improves on it by defining the end of day in
microsecond accuracy.

@miq-bot add-label core, technical debt, refactoring
@miq-bot assign @gtanzillo 