### PR TITLE
Display total cpu cores for right sizing

### DIFF
--- a/app/views/vm_common/_right_size.html.haml
+++ b/app/views/vm_common/_right_size.html.haml
@@ -121,7 +121,7 @@
         %td
           = _("Processors")
         %td{:align => "right"}
-          = @record.num_cpu ? @record.num_cpu : notavail
+          = @record.cpu_total_cores ? @record.cpu_total_cores : notavail
         %td{:align => "right"}
           = @record.conservative_recommended_vcpus ? @record.conservative_recommended_vcpus : notavail
         %td{:align => "right"}
@@ -156,7 +156,7 @@
         %td
           = _("Processors")
         %td{:align => "right"}
-          = @record.num_cpu ? @record.num_cpu : notavail
+          = @record.cpu_total_cores ? @record.cpu_total_cores : notavail
         %td{:align => "right"}
           = @record.moderate_recommended_vcpus ? @record.moderate_recommended_vcpus : notavail
         %td{:align => "right"}
@@ -190,7 +190,7 @@
         %td
           = _("Processors")
         %td{:align => "right"}
-          = @record.num_cpu ? @record.num_cpu : notavail
+          = @record.cpu_total_cores ? @record.cpu_total_cores : notavail
         %td{:align => "right"}
           = @record.aggressive_recommended_vcpus ? @record.aggressive_recommended_vcpus : notavail
         %td{:align => "right"}


### PR DESCRIPTION
The Right Size Recommendations page currently displays `num_cpu` for current number of CPUs, but this is actually the number of sockets not the total number of CPUs (https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L1634)

https://github.com/ManageIQ/manageiq/pull/6321 fixed the recommendation methods to use the total number of CPUs for the calculations but didn't fix the display for the current number of CPUs

BZ - https://bugzilla.redhat.com/show_bug.cgi?id=1299809