### PR TITLE
Perform instance name validation for google provider

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -192,7 +192,12 @@ class MiqRequestWorkflow
         if fld[:required] == true
           # If :required_method is defined let it determine if the field is value
           unless fld[:required_method].nil?
-            fld[:error] = send(fld[:required_method], f, values, dlg, fld, value)
+            Array.wrap(fld[:required_method]).each do |method|
+              fld[:error] = send(method, f, values, dlg, fld, value)
+              # Bail out early if we see an error
+              break unless fld[:error].nil?
+            end
+
             unless fld[:error].nil?
               valid = false
               next

--- a/app/models/miq_request_workflow/dialog_field_validation.rb
+++ b/app/models/miq_request_workflow/dialog_field_validation.rb
@@ -31,7 +31,10 @@ module MiqRequestWorkflow::DialogFieldValidation
     regex = fld[:required_regex]
     return _("%{name} is required") % {:name => required_description(dlg, fld)} if value.blank?
     unless value.match(regex)
-      return _("%{name} must be correctly formatted") % {:name => required_description(dlg, fld)}
+      error = _("%{name} must be correctly formatted") % {:name => required_description(dlg, fld)}
+      error << _(". %{details}") % {:details => fld[:required_regex_fail_details] } if fld[:required_regex_fail_details]
+
+      error
     end
   end
 end

--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -100,7 +100,7 @@
         :owner_email:
           :description: E-Mail
           :required_method: :validate_regex
-          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
           :required: true
           :display: :edit
           :data_type: :string
@@ -205,14 +205,18 @@
           :notes_display: :show
         :vm_name:
           :description: Instance Name
-          :required_method: :validate_vm_name
+          :required_method:
+            - :validate_vm_name
+            - :validate_regex
+          :required_regex: !ruby/regexp /\A(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)\Z/
+          :required_regex_fail_details: The name must be composed only of lower-case English alphabet characters (a-z), numbers (0-9), and dashes (-). The first character must be a lower-case English alphabet character, and the last character must not be a dash.
           :required: true
           :notes:
           :display: :edit
           :data_type: :string
           :notes_display: :show
-          :min_length:
-          :max_length:
+          :min_length: 1
+          :max_length: 63
       :display: :show
     :schedule:
       :description: Schedule

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -48,6 +48,18 @@ describe MiqRequestWorkflow do
       end
     end
 
+    context 'required_method can be a list' do
+      it "multiple items" do
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :required_method, [:some_required_method_1,
+                                                                                            :some_required_method_2])
+        dialog.store_path(:dialogs, :customize, :fields, :root_password, :required, true)
+
+        expect(workflow).to receive(:some_required_method_1)
+        expect(workflow).to receive(:some_required_method_2)
+        expect(workflow.validate({})).to be true
+      end
+    end
+
     context "failures shouldn't be reverted" do
       it "validation_method" do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :validation_method, :some_validation_method)

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -327,6 +327,12 @@ describe MiqRequestWorkflow do
   context "#validate regex" do
     let(:regex) { {:required_regex => "^n@test.com$"} }
     let(:regex_two) { {:required_regex => "^n$"} }
+    let(:regex_with_details) do
+      {
+        :required_regex              => "^n@test.com$",
+        :required_regex_fail_details => "We are looking for a specific email here."
+      }
+    end
     let(:value_email) { 'n@test.com' }
     let(:value_no_email) { 'n' }
 
@@ -342,6 +348,11 @@ describe MiqRequestWorkflow do
 
     it "returns an error when no value exists" do
       expect(workflow.validate_regex(nil, {}, {}, regex, '')).to eq "'/' is required"
+    end
+
+    it "returns a detailed formatting message when fail details are defined" do
+      expect(workflow.validate_regex(nil, {}, {}, regex_with_details, value_no_email)).to eq "'/' must be correctly"\
+        " formatted. We are looking for a specific email here."
     end
   end
 


### PR DESCRIPTION
* Modify validation code to be able to use multiple validation methods
* Modify regex validation to produce detailed error message on failure
* Modify instance name dialog for Google Provider to validate according to regex

Fixes downstream bug https://bugzilla.redhat.com/show_bug.cgi?id=1330982

/cc @agrare @blomquisg @erjohnso 