### PR TITLE
Use subscription_id method instead of parsing it for Azure provisioning

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -141,10 +141,9 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
     source.with_provider_connection do |azure|
       vms = Azure::Armrest::VirtualMachineService.new(azure)
       vm  = vms.create(dest_name, resource_group.name, clone_options)
-      subscription_id = vm.id.split('/')[2]
 
       {
-        :subscription_id   => subscription_id,
+        :subscription_id   => azure.subscription_id,
         :vm_resource_group => vm.resource_group,
         :type              => vm.type.downcase,
         :vm_name           => vm.name


### PR DESCRIPTION
This is just a minor refactoring for Azure provisioning. The `start_clone` method is manually parsing the subscription ID, but we can just call the method on the configuration object.