### PR TITLE
Use type_id instead of name on Hawkular LiveMetrics

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers
 
     def fetch_metrics_available
       metrics_available = @ems.metrics_resource(@target.ems_ref).collect do |metric|
-        next unless @supported_metrics[metric.name]
+        next unless @supported_metrics[metric.type_id]
         parse_metric(metric)
       end.compact
       fetch_child_metrics(@target.ems_ref, metrics_available) if @included_children
@@ -24,7 +24,7 @@ module ManageIQ::Providers
     def fetch_child_metrics(resource_path, metrics_available)
       children = @ems.child_resources(resource_path)
       children.select { |child| @included_children.include?(child.name) }.each do |child|
-        @ems.metrics_resource(child.path).select { |metric| @supported_metrics[metric.name] }.each do |metric|
+        @ems.metrics_resource(child.path).select { |metric| @supported_metrics[metric.type_id] }.each do |metric|
           metrics_available << parse_metric(metric)
         end
       end
@@ -32,7 +32,7 @@ module ManageIQ::Providers
     end
 
     def parse_metric(metric)
-      {:id => metric.id, :name => @supported_metrics[metric.name], :type => metric.type, :unit => metric.unit}
+      {:id => metric.id, :name => @supported_metrics[metric.type_id], :type => metric.type, :unit => metric.unit}
     end
 
     def collect_live_metric(metric, start_time, end_time, interval)

--- a/product/live_metrics/middleware_datasource.yaml
+++ b/product/live_metrics/middleware_datasource.yaml
@@ -6,12 +6,12 @@
 #   a LiveMetric virtual model.
 #
 #   Format:
-#   - Provider native metric id: MiQ metric id
+#   - Provider native metric type id: MiQ metric id
 #
 supported_metrics:
-  - Available Count: mw_ds_available_count
-  - In Use Count: mw_ds_in_use_count
-  - Timed Out: mw_ds_timed_out
-  - Average Get Time: mw_ds_average_get_time
-  - Average Creation Time: mw_ds_average_creation_time
-  - Max Wait Time: mw_ds_max_wait_time
+  - Datasource Pool Metrics~Available Count: mw_ds_available_count
+  - Datasource Pool Metrics~In Use Count: mw_ds_in_use_count
+  - Datasource Pool Metrics~Timed Out: mw_ds_timed_out
+  - Datasource Pool Metrics~Average Get Time: mw_ds_average_get_time
+  - Datasource Pool Metrics~Average Creation Time: mw_ds_average_creation_time
+  - Datasource Pool Metrics~Max Wait Time: mw_ds_max_wait_time

--- a/product/live_metrics/middleware_server.yaml
+++ b/product/live_metrics/middleware_server.yaml
@@ -6,33 +6,32 @@
 #   a LiveMetric virtual model.
 #
 #   Format:
-#   - Provider native metric id: MiQ metric id
+#   - Provider native metric type id: MiQ metric id
 #
 included_children:
   - Transaction Manager
 
 supported_metrics:
-  - Heap Used: mw_heap_used
-  - Heap Max: mw_heap_max
-  - Heap Committed: mw_heap_committed
-  - NonHeap Used: mw_non_heap_used
-  - NonHeap Committed: mw_non_heap_committed
-  - Accumulated GC Duration: mw_accumulated_gc_duration
-  - Aggregated Servlet Request Time: mw_agregated_servlet_time
-  - Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
-  - Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
-  - Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
-  - Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
-  - Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
-  - Thread Count: mw_thread_count
-  - Server Availability: mw_availability_app_server
-  - Number of Aborted Transactions: mw_tx_aborted
-  - Number of In-Flight Transactions: mw_tx_inflight
-  - Number of Committed Transactions: mw_tx_committed
-  - Number of Transactions: mw_tx_total
-  - Number of Application Rollbacks: mw_tx_application_rollbacks
-  - Number of Resource Rollbacks: mw_tx_resource_rollbacks
-  - Number of Timed Out Transactions: mw_tx_timeout
-  - Number of Nested Transactions: mw_tx_nested
-  - Number of Heuristics: mw_tx_heuristics
-
+  - WildFly Memory Metrics~Heap Used: mw_heap_used
+  - WildFly Memory Metrics~Heap Max: mw_heap_max
+  - WildFly Memory Metrics~Heap Committed: mw_heap_committed
+  - WildFly Memory Metrics~NonHeap Used: mw_non_heap_used
+  - WildFly Memory Metrics~NonHeap Committed: mw_non_heap_committed
+  - WildFly Memory Metrics~Accumulated GC Duration: mw_accumulated_gc_duration
+  - WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_agregated_servlet_time
+  - WildFly Aggregated Web Metrics~Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
+  - WildFly Aggregated Web Metrics~Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
+  - WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions
+  - WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions: mw_aggregated_expired_web_sessions
+  - WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions: mw_aggregated_max_active_web_sessions
+  - WildFly Threading Metrics~Thread Count: mw_thread_count
+  - Server Availability~App Server: mw_availability_app_server
+  - Transactions Metrics~Number of Aborted Transactions: mw_tx_aborted
+  - Transactions Metrics~Number of In-Flight Transactions: mw_tx_inflight
+  - Transactions Metrics~Number of Committed Transactions: mw_tx_committed
+  - Transactions Metrics~Number of Transactions: mw_tx_total
+  - Transactions Metrics~Number of Application Rollbacks: mw_tx_application_rollbacks
+  - Transactions Metrics~Number of Resource Rollbacks: mw_tx_resource_rollbacks
+  - Transactions Metrics~Number of Timed Out Transactions: mw_tx_timeout
+  - Transactions Metrics~Number of Nested Transactions: mw_tx_nested
+  - Transactions Metrics~Number of Heuristics: mw_tx_heuristics

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
@@ -82,18 +82,19 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true) do # , :record => :new_episodes) do
       capture = ds.first_and_last_capture
+      expect(capture.any?).to be true
       expect(capture[0]).to be < capture[1]
     end
   end
 
   it "#supported_metrics" do
     expected_metrics = {
-      "Available Count"       => "mw_ds_available_count",
-      "In Use Count"          => "mw_ds_in_use_count",
-      "Timed Out"             => "mw_ds_timed_out",
-      "Average Get Time"      => "mw_ds_average_get_time",
-      "Average Creation Time" => "mw_ds_average_creation_time",
-      "Max Wait Time"         => "mw_ds_max_wait_time"
+      "Datasource Pool Metrics~Available Count"       => "mw_ds_available_count",
+      "Datasource Pool Metrics~In Use Count"          => "mw_ds_in_use_count",
+      "Datasource Pool Metrics~Timed Out"             => "mw_ds_timed_out",
+      "Datasource Pool Metrics~Average Get Time"      => "mw_ds_average_get_time",
+      "Datasource Pool Metrics~Average Creation Time" => "mw_ds_average_creation_time",
+      "Datasource Pool Metrics~Max Wait Time"         => "mw_ds_max_wait_time"
     }.freeze
     supported_metrics = MiddlewareDatasource.supported_metrics
     expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -30,29 +30,29 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
 
   let(:expected_metrics) do
     {
-      "Heap Used"                          => "mw_heap_used",
-      "Heap Max"                           => "mw_heap_max",
-      "Heap Committed"                     => "mw_heap_committed",
-      "NonHeap Used"                       => "mw_non_heap_used",
-      "NonHeap Committed"                  => "mw_non_heap_committed",
-      "Accumulated GC Duration"            => "mw_accumulated_gc_duration",
-      "Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
-      "Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
-      "Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
-      "Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
-      "Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
-      "Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
-      "Thread Count"                       => "mw_thread_count",
-      "Server Availability"                => "mw_availability_app_server",
-      "Number of Aborted Transactions"     => "mw_tx_aborted",
-      "Number of In-Flight Transactions"   => "mw_tx_inflight",
-      "Number of Committed Transactions"   => "mw_tx_committed",
-      "Number of Transactions"             => "mw_tx_total",
-      "Number of Application Rollbacks"    => "mw_tx_application_rollbacks",
-      "Number of Resource Rollbacks"       => "mw_tx_resource_rollbacks",
-      "Number of Timed Out Transactions"   => "mw_tx_timeout",
-      "Number of Nested Transactions"      => "mw_tx_nested",
-      "Number of Heuristics"               => "mw_tx_heuristics"
+      "WildFly Memory Metrics~Heap Used"                                  => "mw_heap_used",
+      "WildFly Memory Metrics~Heap Max"                                   => "mw_heap_max",
+      "WildFly Memory Metrics~Heap Committed"                             => "mw_heap_committed",
+      "WildFly Memory Metrics~NonHeap Used"                               => "mw_non_heap_used",
+      "WildFly Memory Metrics~NonHeap Committed"                          => "mw_non_heap_committed",
+      "WildFly Memory Metrics~Accumulated GC Duration"                    => "mw_accumulated_gc_duration",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"    => "mw_agregated_servlet_time",
+      "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"   => "mw_aggregated_servlet_request_count",
+      "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"    => "mw_aggregated_expired_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions" => "mw_aggregated_max_active_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"     => "mw_aggregated_active_web_sessions",
+      "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"   => "mw_aggregated_rejected_web_sessions",
+      "WildFly Threading Metrics~Thread Count"                            => "mw_thread_count",
+      "Server Availability~App Server"                                    => "mw_availability_app_server",
+      "Transactions Metrics~Number of Aborted Transactions"               => "mw_tx_aborted",
+      "Transactions Metrics~Number of In-Flight Transactions"             => "mw_tx_inflight",
+      "Transactions Metrics~Number of Committed Transactions"             => "mw_tx_committed",
+      "Transactions Metrics~Number of Transactions"                       => "mw_tx_total",
+      "Transactions Metrics~Number of Application Rollbacks"              => "mw_tx_application_rollbacks",
+      "Transactions Metrics~Number of Resource Rollbacks"                 => "mw_tx_resource_rollbacks",
+      "Transactions Metrics~Number of Timed Out Transactions"             => "mw_tx_timeout",
+      "Transactions Metrics~Number of Nested Transactions"                => "mw_tx_nested",
+      "Transactions Metrics~Number of Heuristics"                         => "mw_tx_heuristics"
     }.freeze
   end
 
@@ -94,6 +94,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
                      :allow_unused_http_interactions => true,
                      :decode_compressed_response     => true) do # , :record => :new_episodes) do
       capture = eap.first_and_last_capture
+      expect(capture.any?).to be true
       expect(capture[0]).to be < capture[1]
     end
   end


### PR DESCRIPTION
With the update of gem hawkular-client 2.4.0 type_id has been exposed, so it is a better way to identify the native type metric coming from Hawkular.
Previously we used name attribute, but this one has been changed from the hawkular agent.
In a preliminar commit, we fixed the names and it was ok, but this change was not enough for alerting related work, so now it is sync.

Closes #10310