### PR TITLE
Create tenant for openstack provider

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -28,6 +28,8 @@ module ManageIQ::Providers
     has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
 
+    has_one  :source_tenant, :as => :source, :class_name => 'Tenant'
+
     validates_presence_of :zone
 
     include HasNetworkManagerMixin

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -34,7 +34,6 @@ module ManageIQ::Providers
 
     include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
-    include CloudTenantMixin
 
     supports_not :discovery
 
@@ -65,6 +64,18 @@ module ManageIQ::Providers
 
     def supports_cloud_tenants?
       false
+    end
+
+    def sync_cloud_tenants_with_tenants
+      return unless supports_cloud_tenants?
+      sync_root_tenant
+    end
+
+    def sync_root_tenant
+      ems_tenant = source_tenant || Tenant.new(:parent => Tenant.root_tenant, :source => self)
+
+      ems_tenant_name = "#{self.class.description} Cloud Provider #{name}"
+      ems_tenant.update_attributes!(:name => ems_tenant_name, :description => ems_tenant_name)
     end
   end
 end

--- a/app/models/mixins/cloud_tenant_mixin.rb
+++ b/app/models/mixins/cloud_tenant_mixin.rb
@@ -1,8 +1,0 @@
-module CloudTenantMixin
-  extend ActiveSupport::Concern
-
-  # TODO(lpichler) add synchronization
-  def sync_cloud_tenants_with_tenants
-    return unless supports_cloud_tenants?
-  end
-end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -33,6 +33,7 @@ class Tenant < ApplicationRecord
   has_many :services, :dependent => :destroy
 
   belongs_to :default_miq_group, :class_name => "MiqGroup", :dependent => :destroy
+  belongs_to :source, :polymorphic => true
 
   # FUTURE: /uploads/tenant/:id/logos/:basename.:extension # may want style
   has_attached_file :logo,

--- a/db/migrate/20160811081235_add_source_to_tenants.rb
+++ b/db/migrate/20160811081235_add_source_to_tenants.rb
@@ -1,0 +1,5 @@
+class AddSourceToTenants < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :tenants, :source, :type => :bigint, :polymorphic => true
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6420,6 +6420,8 @@ tenants:
 - description
 - use_config_for_attributes
 - default_miq_group_id
+- source_type
+- source_id
 time_profiles:
 - id
 - description

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -25,4 +25,51 @@ describe EmsCloud do
                       ManageIQ::Providers::Vmware::CloudManager].collect(&:ems_type)
     expect(described_class.supported_types).to match_array(expected_types)
   end
+
+  context "CloudTenant Mapping" do
+    describe "#sync_cloud_tenants_with_tenants" do
+      let(:ems_cloud)              { FactoryGirl.create(:ems_openstack) }
+      let(:name_of_created_tenant) { "#{described_class::OPENSTACK_CLOUD_PROVIDER} #{ems_cloud.name}" }
+      let!(:default_tenant)        { Tenant.seed }
+
+      it "creates tenant related to provider" do
+        ems_cloud.sync_cloud_tenants_with_tenants
+
+        ems_cloud.reload
+
+        expect(ems_cloud.source_tenant).not_to be_nil
+        expect(ems_cloud.source_tenant.name).to eq(name_of_created_tenant)
+        expect(ems_cloud.source_tenant.description).to eq(name_of_created_tenant)
+      end
+
+      it "creates only the one tenant per openstack provider when synchronization was executed multiple times" do
+        count_of_tenants = Tenant.count
+
+        ems_cloud.sync_cloud_tenants_with_tenants
+
+        expect(Tenant.count).to eq(count_of_tenants + 1)
+
+        ems_cloud.sync_cloud_tenants_with_tenants
+        ems_cloud.sync_cloud_tenants_with_tenants
+
+        expect(Tenant.count).to eq(count_of_tenants + 1)
+      end
+
+      it "name and description of tenant created by openstack is updated" do
+        ems_cloud.sync_cloud_tenants_with_tenants
+
+        ems_cloud.reload
+
+        ems_cloud.source_tenant.update_attributes(:name => "XXX", :description => "XXX")
+        ems_cloud.save
+
+        ems_cloud.sync_cloud_tenants_with_tenants
+
+        ems_cloud.reload
+
+        expect(ems_cloud.source_tenant.name).to eq(name_of_created_tenant)
+        expect(ems_cloud.source_tenant.description).to eq(name_of_created_tenant)
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -26,11 +26,13 @@ describe EmsCloud do
     expect(described_class.supported_types).to match_array(expected_types)
   end
 
-  context "CloudTenant Mapping" do
+  context "OpenStack CloudTenant Mapping" do
     describe "#sync_cloud_tenants_with_tenants" do
-      let(:ems_cloud)              { FactoryGirl.create(:ems_openstack) }
-      let(:name_of_created_tenant) { "#{described_class::OPENSTACK_CLOUD_PROVIDER} #{ems_cloud.name}" }
-      let!(:default_tenant)        { Tenant.seed }
+      let(:ems_cloud)       { FactoryGirl.create(:ems_openstack) }
+      let!(:default_tenant) { Tenant.seed }
+      let(:name_of_created_tenant) do
+        "#{ManageIQ::Providers::Openstack::CloudManager.description} Cloud Provider #{ems_cloud.name}"
+      end
 
       it "creates tenant related to provider" do
         ems_cloud.sync_cloud_tenants_with_tenants
@@ -48,8 +50,11 @@ describe EmsCloud do
         ems_cloud.sync_cloud_tenants_with_tenants
 
         expect(Tenant.count).to eq(count_of_tenants + 1)
+        ems_cloud.reload
 
         ems_cloud.sync_cloud_tenants_with_tenants
+
+        ems_cloud.reload
         ems_cloud.sync_cloud_tenants_with_tenants
 
         expect(Tenant.count).to eq(count_of_tenants + 1)


### PR DESCRIPTION
Purpose or Intent
-----------------
as part of cloud tenant mapping, this PR creating root tenants related to openstack provider.
Created on top of https://github.com/ManageIQ/manageiq/pull/10025. So this PR are this commits https://github.com/ManageIQ/manageiq/commit/97dd980573ecfbade5a8fc54d7bf2f3d16a24fdb
https://github.com/ManageIQ/manageiq/pull/10336/commits/f03d3d571098c7ce526a47b9112e0d8505e1e7df
https://github.com/ManageIQ/manageiq/pull/10336/commits/bacc72ef7cf19704aae47004bd00d0ea175f0f97

- added polymorphic relation `source` to keep associations CloudManager and Tenant, CloudTenant and Tenant
- added creating(synchronization) tenants related to openstack provider. (1 level)

Next: In next PR will be creating tenants based on CloudTenants

https://www.pivotaltracker.com/story/show/128411039

@gtanzillo @jrafanie 

@miq-bot remove_label wip