### PR TITLE
Fix Generic toolbar button for Service model

### DIFF
--- a/app/helpers/application_helper/button/generic_feature_button.rb
+++ b/app/helpers/application_helper/button/generic_feature_button.rb
@@ -7,10 +7,8 @@ class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Butto
   end
 
   def skip?
-    begin
-      return !@record.send("supports_#{@feature}?")
-    rescue NoMethodError # TODO: remove with deleting AvailabilityMixin module
-      return !@record.is_available?(@feature)
-    end
+    ret = @record.try("supports_#{@feature}?")
+    ret = @record.try(:is_available?, @feature) if ret.nil? # TODO: remove with deleting AvailabilityMixin module
+    !ret
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
This will fix problems with showing page for models which dont support `suports_?` or `is_available?`. We probably shouldnt have such models, but since we are refactoring these it could happen.

@martinpovolny @lgalis 
Parent Issue: #10328 
Related Issue: #10434