### PR TITLE
[DARGA] Correct flash message in commiting service dialog

### DIFF
--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -69,6 +69,15 @@ class MiqAeCustomizationController < ApplicationController
     if params[:commit] == _('Commit')
       import_file_upload = ImportFileUpload.find_by(:id => params[:import_file_upload_id])
 
+      if params[:dialogs_to_import].blank?
+        add_flash(_("At least one Service Dialog must be selected."), :error)
+        render :update do |page|
+          page << javascript_prologue
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
+          page << "miqSparkle(false);"
+        end
+        return
+      end
       if import_file_upload
         dialog_import_service.import_service_dialogs(import_file_upload, params[:dialogs_to_import])
         add_flash(_("Service dialogs imported successfully"), :success)


### PR DESCRIPTION
Purpose or Intent
-----------------
In Automate -> Customization -> Import/Export -> Import file -> Commit without selecting any Service Dialogs. It continued with success/failure (depending on unrelated attributes) to following page. Now it stays on the page and shows error message. 

Before:
![screen shot 2016-08-08 at 3 11 02 pm](https://cloud.githubusercontent.com/assets/9210860/17480892/73794c0c-5d7a-11e6-83c1-60158f880c6c.png)

After:
![screen shot 2016-08-08 at 3 07 24 pm](https://cloud.githubusercontent.com/assets/9210860/17480788/e9634e14-5d79-11e6-95d8-54a6edf1166e.png)



Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1341671
Master version: https://github.com/ManageIQ/manageiq/pull/10315
Target release: 5.6.1.

@miq-bot add_label ui, bug