### PR TITLE
Correct title in downloaded Configuration Management files

### DIFF
--- a/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job.yaml
+++ b/product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job.yaml
@@ -9,10 +9,10 @@
 #
 
 # Report title
-title: Orchestration Templates
+title: Ansible Tower Jobs
 
 # Menu name
-name: Orchestration Template
+name: Ansible Tower Job
 
 # Main DB table report is based on
 db: ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix the title of the downloaded files from Configuration Management - Jobs

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1364995