### PR TITLE
Double flash problem

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1090,14 +1090,18 @@ module ApplicationHelper
   def record_no_longer_exists?(what, model = nil)
     return false unless what.nil?
 
-    unless @bang && !@flash_array.empty?
+    if !@bang || @flash_array.empty?
       # We already added a better flash message in 'identify_record'
       # in that case we keep that flash message
       # otherwise we make a new one.
       # FIXME: a refactoring of identify_record and related is needed
-      add_flash(model.present? ?
-        _("%{model} no longer exists") % {:model => ui_lookup(:model => model)} :
-        _("Error: Record no longer exists in the database"), :error, true)
+      add_flash(
+        if model.present?
+          _("%{model} no longer exists") % {:model => ui_lookup(:model => model)}
+        else
+          _("Error: Record no longer exists in the database")
+        end,
+        :error, true)
       session[:flash_msgs] = @flash_array
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1089,10 +1089,18 @@ module ApplicationHelper
 
   def record_no_longer_exists?(what, model = nil)
     return false unless what.nil?
-    add_flash(@bang || model.present? ?
-      _("%{model} no longer exists") % {:model => ui_lookup(:model => model)} :
-      _("Error: Record no longer exists in the database"))
-    session[:flash_msgs] = @flash_array
+
+    unless @bang && !@flash_array.empty?
+      # We already added a better flash message in 'identify_record'
+      # in that case we keep that flash message
+      # otherwise we make a new one.
+      # FIXME: a refactoring of identify_record and related is needed
+      add_flash(model.present? ?
+        _("%{model} no longer exists") % {:model => ui_lookup(:model => model)} :
+        _("Error: Record no longer exists in the database"), :error, true)
+      session[:flash_msgs] = @flash_array
+    end
+
     # Error message is displayed in 'show_list' action if such action exists
     # otherwise we assume that the 'explorer' action must exist that will display it.
     redirect_to(:action => respond_to?(:show_list) ? 'show_list' : 'explorer')


### PR DESCRIPTION
Purpose or Intent
-----------------

fix double flash message when deleting a provider

fixes https://github.com/ManageIQ/manageiq/issues/9646

Steps for Testing/QA
--------------------

 1. Go to a list of providers (any type)
 1. Check a provider (checkbox).
 1. delete the provider
 1. click the provider you just deleted

w/o patch you get 2 flash messages

w/ patch you get one, the nicer one