### PR TITLE
Return toolbars back on ems_infra#show after recent refactorings

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -110,7 +110,7 @@ module EmsCommon
   end
 
   def show
-    @display = params[:display]
+    @display = params[:display] || "main" unless control_selected?
 
     session[:vm_summary_cool] = (settings(:views, :vm_summary_cool).to_s == "summary")
     @summary_view = session[:vm_summary_cool]

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -433,9 +433,7 @@ class ApplicationHelper::ToolbarChooser
 
     # Original non vmx view code follows
     # toolbar buttons on sub-screens
-    if ((@lastaction == "show" && @view) ||
-        (@lastaction == "show" && @display != "main")) &&
-       !@layout.starts_with?("miq_request")
+    if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
         return "vm_infras_center_tb"
       elsif @display == "ems_clusters"


### PR DESCRIPTION
We need `@display` to be set for the first time you visit ems_infra#show. Otherwise toolbars are missing and I cannot refresh my dear relationships.

### Before #10255 
![toolbars-old](https://cloud.githubusercontent.com/assets/6666052/17521432/9b759f60-5e53-11e6-8572-0a1b20223d4e.jpg)

### After #10255 
![toolbars-new](https://cloud.githubusercontent.com/assets/6666052/17521426/94bb3018-5e53-11e6-90bf-18709e8715f6.jpg)

### Now :tulip: 
![toolbars-old](https://cloud.githubusercontent.com/assets/6666052/17521432/9b759f60-5e53-11e6-8572-0a1b20223d4e.jpg)

@miq-bot assign @martinpovolny 
@miq-bot add_label bug, ui, darga/no