### PR TITLE
Created FailoverMonitor class to monitor and execute failover

### DIFF
--- a/gems/pending/postgres_ha_admin/failover_databases.rb
+++ b/gems/pending/postgres_ha_admin/failover_databases.rb
@@ -24,13 +24,6 @@ module PostgresHaAdmin
       @logger.error(err.backtrace.join("\n"))
     end
 
-    private
-
-    def all_databases
-      return [] unless File.exist?(yml_file)
-      YAML.load_file(yml_file)
-    end
-
     def query_repmgr(connection)
       return [] unless table_exists?(connection, TABLE_NAME)
       result = []
@@ -45,6 +38,13 @@ module PostgresHaAdmin
       @logger.error("#{err.class}: #{err}")
       @logger.error(err.backtrace.join("\n"))
       result
+    end
+
+    private
+
+    def all_databases
+      return [] unless File.exist?(yml_file)
+      YAML.load_file(yml_file)
     end
 
     def table_exists?(connection, table_name)

--- a/gems/pending/postgres_ha_admin/failover_databases.rb
+++ b/gems/pending/postgres_ha_admin/failover_databases.rb
@@ -24,6 +24,17 @@ module PostgresHaAdmin
       @logger.error(err.backtrace.join("\n"))
     end
 
+    def host_is_repmgr_primary?(host, connection)
+      query_repmgr(connection).each do |record|
+        if record[:host] == host && entry_is_active_master?(record)
+          return true
+        end
+      end
+      false
+    end
+
+    private
+
     def query_repmgr(connection)
       return [] unless table_exists?(connection, TABLE_NAME)
       result = []
@@ -40,7 +51,9 @@ module PostgresHaAdmin
       result
     end
 
-    private
+    def entry_is_active_master?(record)
+      record[:type] == 'master' && record[:active]
+    end
 
     def all_databases
       return [] unless File.exist?(yml_file)

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -10,9 +10,9 @@ module PostgresHaAdmin
     DB_CONNECTED_CHECK_FREQUENCY = 5.minutes
     FAILOVER_CHECK_FREQUENCY = 1.minute
 
-    def initialize(db_yml_file = '/var.www/miq/vmdb/config/database.yml',
-                   failover_yml_file = '/var.www/miq/vmdb/config/failover_databases.yml',
-                   log_file = '/var.www/miq/vmdb/config/ha_admin.log',
+    def initialize(db_yml_file = '/var/www/miq/vmdb/config/database.yml',
+                   failover_yml_file = '/var/www/miq/vmdb/config/failover_databases.yml',
+                   log_file = '/var/www/miq/vmdb/config/ha_admin.log',
                    environment = 'production')
       @logger = Logger.new(log_file)
       @logger.level = Logger::INFO
@@ -96,15 +96,12 @@ module PostgresHaAdmin
     end
 
     def start_evmserverd
-      service = LinuxAdmin::Service.new("evmserverd")
-      service.stop if service.running?
+      LinuxAdmin::Service.new("evmserverd").restart
       @logger.info("Starting EVM server from failover monitor")
-      service.start
     end
 
     def stop_evmserverd
-      service = LinuxAdmin::Service.new("evmserverd")
-      service.stop if service.running?
+      LinuxAdmin::Service.new("evmserverd").stop
     end
   end
 end

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -1,0 +1,130 @@
+require 'postgres_ha_admin/failover_databases'
+require 'postgres_ha_admin/database_yml'
+require 'pg'
+require 'linux_admin'
+
+module PostgresHaAdmin
+  class FailoverMonitor
+    FAILOVER_ATTEMPTS = 60
+    DB_CONNECTED_CHECK_FREQUENCY = 5.minutes
+    FAILOVER_CHECK_FREQUENCY = 1.minute
+
+    def initialize(db_yml_file = '/var.www/miq/vmdb/config/database.yml',
+                   failover_yml_file = '/var.www/miq/vmdb/config/failover_databases.yml',
+                   log_file = '/var.www/miq/vmdb/config/ha_admin.log',
+                   environment = 'production')
+      @logger = Logger.new(log_file)
+      @logger.level = Logger::INFO
+      @database_yml = DatabaseYml.new(failover_yml_file, environment)
+      @failover_db = FailoverDatabases.new(db_yml_file, @logger)
+    end
+
+    def monitor
+       connection = begin
+                      PG::Connection.open(@database_yml.pg_params_from_database_yml)
+                    rescue PG::Error
+                      nil
+                    end
+      if connection
+        @failover_db.update_failover_yml(connection)
+        connection.finish
+        return
+      end
+
+      stop_evmserverd
+
+      if execute_failover
+        start_evmserverd
+      else
+        @logger.error("Failover failed")
+      end
+    end
+
+    def monitor_loop
+      loop do
+        sleep(DB_CONNECTED_CHECK_FREQUENCY)
+        begin
+          monitor
+        rescue StandardError => err
+          @logger.error("#{err.class}: #{err}")
+          @logger.error(err.backtrace.join("\n"))
+        end
+      end
+    end
+
+    def primary_database_host(connection, params)
+      result = @failover_db.query_repmgr(connection)
+      result.each do |record|
+        next if record[:host] != params[:host]
+        next if record[:type] != 'master'
+        next unless record[:active]
+        return params[:host]
+      end
+      nil
+    end
+
+    private
+
+    def execute_failover
+      FAILOVER_ATTEMPTS.times do
+        with_each_standby_connection do |connection, params|
+          next if database_in_recovery?(connection)
+          next if primary_database_host(connection, params).nil?
+          @failover_db.update_failover_yml(connection)
+          @database_yml.update_database_yml(params)
+          return true
+        end
+        sleep(FAILOVER_CHECK_FREQUENCY)
+      end
+      false
+    end
+
+    def with_each_standby_connection
+      servers = @failover_db.active_databases
+      @logger.info("Standby Database Servers: #{servers}")
+      servers.each do |params|
+        connection = pg_connection(params)
+        unless connection.nil?
+          yield connection, params
+          connection.finish
+        end
+      end
+    end
+
+    # TODO: move database_in_recovery? move this method to gem/pending/util/postgres_admin.rb
+    def database_in_recovery?(connection)
+      db_result = connection.exec("SELECT pg_catalog.pg_is_in_recovery()")
+      result = db_result.map_types!(PG::BasicTypeMapForResults.new(connection)).first
+      result['pg_is_in_recovery']
+    rescue PG::Error => err
+      @logger.error("#{err.class}: #{err}")
+      @logger.error(err.backtrace.join("\n"))
+      true
+    ensure
+      db_result.clear
+    end
+
+    def pg_connection(params)
+      PG::Connection.open(params)
+    rescue PG::Error
+      nil
+    end
+
+    def start_evmserverd
+      @logger.info("EVM server start initiated by failover monitor")
+      service = LinuxAdmin::Service.new("evmserverd")
+      service.stop if service.running?
+      @logger.info("Starting EVM server from failover monitor")
+      service.start
+    end
+
+    def stop_evmserverd
+      @logger.error("Primary Database is not available. Starting to execute failover...")
+      service = LinuxAdmin::Service.new("evmserverd")
+      if service.running?
+        @logger.info("EVM server stop initiated by failover monitor")
+        service.stop
+      end
+    end
+  end
+end

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -20,11 +20,11 @@ module PostgresHaAdmin
     end
 
     def monitor
-       connection = begin
-                      PG::Connection.open(@database_yml.pg_params_from_database_yml)
-                    rescue PG::Error
-                      nil
-                    end
+      connection = begin
+                     PG::Connection.open(@database_yml.pg_params_from_database_yml)
+                   rescue PG::Error
+                     nil
+                   end
       if connection
         @failover_db.update_failover_yml(connection)
         connection.finish

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -12,7 +12,7 @@ module PostgresHaAdmin
 
     def initialize(db_yml_file = '/var/www/miq/vmdb/config/database.yml',
                    failover_yml_file = '/var/www/miq/vmdb/config/failover_databases.yml',
-                   log_file = '/var/www/miq/vmdb/config/ha_admin.log',
+                   log_file = '/var/www/miq/vmdb/log/ha_admin.log',
                    environment = 'production')
       @logger = Logger.new(log_file)
       @logger.level = Logger::INFO

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -24,7 +24,7 @@ describe PostgresHaAdmin::FailoverDatabases do
     end
   end
 
-  describe "#update_failover_yml" do
+  context "accessing database" do
     after do
       @connection.exec("ROLLBACK")
       @connection.finish
@@ -57,17 +57,26 @@ describe PostgresHaAdmin::FailoverDatabases do
       SQL
     end
 
-    it "updates 'failover_databases.yml'" do
-      failover_databases.update_failover_yml(@connection)
+    describe "#update_failover_yml" do
+      it "updates 'failover_databases.yml'" do
+        failover_databases.update_failover_yml(@connection)
 
-      yml_hash = YAML.load_file(@yml_file)
-      expect(yml_hash).to eq initial_db_list
+        yml_hash = YAML.load_file(@yml_file)
+        expect(yml_hash).to eq initial_db_list
 
-      add_new_record
+        add_new_record
 
-      failover_databases.update_failover_yml(@connection)
-      yml_hash = YAML.load_file(@yml_file)
-      expect(yml_hash).to eq new_db_list
+        failover_databases.update_failover_yml(@connection)
+        yml_hash = YAML.load_file(@yml_file)
+        expect(yml_hash).to eq new_db_list
+      end
+    end
+
+    describe "#query_repmgr" do
+      it "returns list of all databases registered in repmgr" do
+        result = failover_databases.query_repmgr(@connection)
+        expect(result).to eq initial_db_list
+      end
     end
   end
 

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -55,7 +55,8 @@ describe PostgresHaAdmin::FailoverDatabases do
         VALUES
           ('master', 'host=203.0.113.1 user=root dbname=vmdb_test', 'true'),
           ('standby', 'host=203.0.113.2 user=root dbname=vmdb_test', 'true'),
-          ('standby', 'host=203.0.113.3 user=root dbname=vmdb_test', 'false')
+          ('standby', 'host=203.0.113.3 user=root dbname=vmdb_test', 'false'),
+          ('master', 'host=203.0.113.5 user=root dbname=vmdb_test', 'false')
       SQL
     end
 
@@ -79,12 +80,16 @@ describe PostgresHaAdmin::FailoverDatabases do
         expect(failover_databases.host_is_repmgr_primary?('203.0.113.1', @connection)).to be true
       end
 
-      it "return false if supplied connection established with not not active database" do
+      it "return false if supplied connection established with not active standby database" do
         expect(failover_databases.host_is_repmgr_primary?('203.0.113.3', @connection)).to be false
       end
 
-      it "return false if supplied connection established with not master database" do
+      it "return false if supplied connection established with active standby database" do
         expect(failover_databases.host_is_repmgr_primary?('203.0.113.2', @connection)).to be false
+      end
+
+      it "return false if supplied connection established with not active master database" do
+        expect(failover_databases.host_is_repmgr_primary?('203.0.113.5', @connection)).to be false
       end
     end
   end
@@ -94,6 +99,7 @@ describe PostgresHaAdmin::FailoverDatabases do
     arr << {:type => 'master', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
     arr << {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
     arr << {:type => 'standby', :active => false, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'master', :active => false, :host => '203.0.113.5', :user => 'root', :dbname => 'vmdb_test'}
     arr
   end
 

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -26,8 +26,10 @@ describe PostgresHaAdmin::FailoverDatabases do
 
   context "accessing database" do
     after do
-      @connection.exec("ROLLBACK")
-      @connection.finish
+      if @connection
+        @connection.exec("ROLLBACK")
+        @connection.finish
+      end
     end
 
     before do
@@ -72,10 +74,17 @@ describe PostgresHaAdmin::FailoverDatabases do
       end
     end
 
-    describe "#query_repmgr" do
-      it "returns list of all databases registered in repmgr" do
-        result = failover_databases.query_repmgr(@connection)
-        expect(result).to eq initial_db_list
+    describe "#host_is_repmgr_primary?" do
+      it "return true if supplied connection established with primary database" do
+        expect(failover_databases.host_is_repmgr_primary?('203.0.113.1', @connection)).to be true
+      end
+
+      it "return false if supplied connection established with not not active database" do
+        expect(failover_databases.host_is_repmgr_primary?('203.0.113.3', @connection)).to be false
+      end
+
+      it "return false if supplied connection established with not master database" do
+        expect(failover_databases.host_is_repmgr_primary?('203.0.113.2', @connection)).to be false
       end
     end
   end

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -18,10 +18,6 @@ describe PostgresHaAdmin::FailoverMonitor do
     expect(PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
     expect(PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
     failover_instance = described_class.new('', '', @logger_file.path, 'test')
-    logger = double('Logger')
-    allow(logger).to receive(:info)
-    allow(logger).to receive(:error)
-    failover_instance.instance_variable_set("@logger", logger)
     failover_instance
   end
 
@@ -63,78 +59,61 @@ describe PostgresHaAdmin::FailoverMonitor do
     context "primary database is not accessable" do
       before do
         allow(PG::Connection).to receive(:open).and_return(nil, connection, connection)
+        stub_monitor_constants
       end
 
       it "stop evm server(if it is running) before failover attempt" do
         expect(linux_admin).to receive(:stop).ordered
         expect(failover_monitor).to receive(:execute_failover).ordered
-
         failover_monitor.monitor
       end
 
       it "does not update 'database.yml' and 'failover_databases.yml' if all standby DBs are in recovery mode" do
-        expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
-        expect(failover_db).not_to receive(:update_database_yml)
-        expect(db_yml).not_to receive(:update_database_yml)
-        expect(linux_admin).not_to receive(:restart)
-
-        expect(failover_monitor).to receive(:stop_evmserverd).ordered
+        failover_not_executed
         expect(PostgresAdmin).to receive(:database_in_recovery?).and_return(true, true, true).ordered
-
-        stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_ATTEMPTS", 1)
-        stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_CHECK_FREQUENCY", 1)
         failover_monitor.monitor
       end
 
       it "does not update 'database.yml' and 'failover_databases.yml' if there is no master database avaiable" do
-        expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
-        expect(failover_db).not_to receive(:update_database_yml)
-        expect(db_yml).not_to receive(:update_database_yml)
-        expect(linux_admin).not_to receive(:restart)
-
-        expect(PostgresAdmin).to receive(:database_in_recovery?).and_return(false, false, false)
-        expect(linux_admin).to receive(:stop).ordered
+        failover_not_executed
+        expect(PostgresAdmin).to receive(:database_in_recovery?).and_return(false, false, false).ordered
         expect(failover_db).to receive(:host_is_repmgr_primary?).and_return(false, false, false).ordered
-
-        stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_ATTEMPTS", 1)
-        stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_CHECK_FREQUENCY", 1)
         failover_monitor.monitor
       end
 
       it "updates 'database.yml' and 'failover_databases.yml' and restart evm server if new primary db available" do
-        allow(PostgresAdmin).to receive(:database_in_recovery?).and_return(false)
-        allow(failover_db).to receive(:host_is_repmgr_primary?).and_return(guery_repmanager_result)
-        allow(failover_db).to receive(:active_databases).and_return(active_databases_list)
-        allow(failover_db).to receive(:update_failover_yml).with(connection)
-
-        expect(linux_admin).to receive(:stop).ordered
-        expect(db_yml).to receive(:update_database_yml).ordered
-        expect(linux_admin).to receive(:restart).ordered
-
-        stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_ATTEMPTS", 1)
-        stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_CHECK_FREQUENCY", 1)
+        failover_executed
+        expect(PostgresAdmin).to receive(:database_in_recovery?).and_return(false)
+        expect(failover_db).to receive(:host_is_repmgr_primary?).and_return(true)
         failover_monitor.monitor
       end
     end
   end
 
+  def failover_executed
+    expect(linux_admin).to receive(:stop)
+    expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
+    expect(failover_db).to receive(:update_failover_yml)
+    expect(db_yml).to receive(:update_database_yml)
+    expect(linux_admin).to receive(:restart)
+  end
+
+  def failover_not_executed
+    expect(linux_admin).to receive(:stop)
+    expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
+    expect(failover_db).not_to receive(:update_failover_yml)
+    expect(db_yml).not_to receive(:update_database_yml)
+    expect(linux_admin).not_to receive(:restart)
+  end
+
+  def stub_monitor_constants
+    stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_ATTEMPTS", 1)
+    stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_CHECK_FREQUENCY", 1)
+  end
+
   def active_databases_list
     arr = []
     arr << {:type => 'master', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
-    arr << {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
-    arr << {:type => 'standby', :active => true, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
-  end
-
-  def guery_repmanager_result
-    arr = []
-    arr << {:type => 'standby', :active => false, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
-    arr << {:type => 'master', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
-    arr << {:type => 'standby', :active => true, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
-  end
-
-  def no_master_db_list
-    arr = []
-    arr << {:type => 'standby', :active => false, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
     arr << {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
     arr << {:type => 'standby', :active => true, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
   end

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -30,7 +30,7 @@ describe PostgresHaAdmin::FailoverMonitor do
     allow(LinuxAdmin::Service).to receive(:new).and_return(linux_adm)
     linux_adm
   end
-  
+
   before do
     @logger_file = Tempfile.new('ha_admin.log')
   end
@@ -61,24 +61,19 @@ describe PostgresHaAdmin::FailoverMonitor do
     end
 
     context "primary database is not accessable" do
-
       before do
         allow(PG::Connection).to receive(:open).and_return(nil, connection, connection)
       end
 
-      describe "#host_for_primary_database" do
-        it "return host if supplied connection established with primary database" do
-          params = {:host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+      describe "#host_is_repmgr_primary?" do
+        it "return true if supplied connection established with primary database" do
           expect(failover_db).to receive(:query_repmgr).and_return(guery_repmanager_result)
-          host = failover_monitor.host_for_primary_database(connection, params)
-          expect(host).to eq '203.0.113.2'
+          expect(failover_monitor.host_is_repmgr_primary?('203.0.113.2', connection)).to be true
         end
 
-        it "return nil if supplied connection established with not primary database" do
-          params = {:host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
+        it "return false if supplied connection established with not primary database" do
           expect(failover_db).to receive(:query_repmgr).and_return(guery_repmanager_result)
-          host = failover_monitor.host_for_primary_database(connection, params)
-          expect(host).to be nil
+          expect(failover_monitor.host_is_repmgr_primary?('203.0.113.3', connection)).to be false
         end
       end
 
@@ -125,7 +120,7 @@ describe PostgresHaAdmin::FailoverMonitor do
         allow(failover_db).to receive(:query_repmgr).and_return(guery_repmanager_result)
         allow(failover_db).to receive(:active_databases).and_return(active_databases_list)
         allow(failover_db).to receive(:update_failover_yml).with(connection)
-        
+
         expect(linux_admin).to receive(:stop).ordered
         expect(db_yml).to receive(:update_database_yml).ordered
         expect(linux_admin).to receive(:restart).ordered

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -1,0 +1,47 @@
+require 'postgres_ha_admin/failover_monitor'
+
+describe PostgresHaAdmin::FailoverMonitor do
+  let(:db_yml) do
+    yml = double(PostgresHaAdmin::DatabaseYml)
+    allow(yml).to receive(:pg_params_from_database_yml).and_return(:host => 'host.example.com', :user => 'root')
+    yml
+  end
+  let(:failover_db) { double(PostgresHaAdmin::FailoverDatabases) }
+  let(:connection) { double("PGConnection") }
+
+  let(:ha_admin) do
+    expect(PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
+    expect(PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
+    described_class.new('', '', @logger_file.path, 'test')
+  end
+
+  before do
+    @logger_file = Tempfile.new('ha_admin.log')
+  end
+
+  after do
+    @logger_file.close(true)
+  end
+
+  describe "#monitor" do
+    context "primary database is accessable" do
+      before do
+        allow(PG::Connection).to receive(:open).and_return(connection)
+        allow(connection).to receive(:finish)
+      end
+
+      it "updates 'failover_databases.yml'" do
+        expect(failover_db).to receive(:update_failover_yml).with(connection)
+        ha_admin.monitor
+      end
+
+      it "does not stop evm server" do
+
+      end
+
+      it "does not execute failover" do
+
+      end
+    end
+  end
+end

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -2,17 +2,26 @@ require 'postgres_ha_admin/failover_monitor'
 
 describe PostgresHaAdmin::FailoverMonitor do
   let(:db_yml) do
-    yml = double(PostgresHaAdmin::DatabaseYml)
+    yml = double('DatabaseYml')
     allow(yml).to receive(:pg_params_from_database_yml).and_return(:host => 'host.example.com', :user => 'root')
     yml
   end
-  let(:failover_db) { double(PostgresHaAdmin::FailoverDatabases) }
-  let(:connection) { double("PGConnection") }
+  let(:failover_db) { double('FailoverDatabases') }
+  let(:connection) do
+    conn = double("PGConnection")
+    allow(conn).to receive(:finish)
+    conn
+  end
 
-  let(:ha_admin) do
+  let(:failover_monitor) do
     expect(PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
     expect(PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
-    described_class.new('', '', @logger_file.path, 'test')
+    failover_instance = described_class.new('', '', @logger_file.path, 'test')
+    logger = double('Logger')
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:error)
+    failover_instance.instance_variable_set("@logger", logger)
+    failover_instance
   end
 
   before do
@@ -27,21 +36,86 @@ describe PostgresHaAdmin::FailoverMonitor do
     context "primary database is accessable" do
       before do
         allow(PG::Connection).to receive(:open).and_return(connection)
-        allow(connection).to receive(:finish)
       end
 
       it "updates 'failover_databases.yml'" do
         expect(failover_db).to receive(:update_failover_yml).with(connection)
-        ha_admin.monitor
+        failover_monitor.monitor
       end
 
-      it "does not stop evm server" do
-
-      end
-
-      it "does not execute failover" do
-
+      it "does not stop evm server and does not execute failover" do
+        expect(failover_db).to receive(:update_failover_yml).with(connection)
+        expect(failover_monitor).not_to receive(:stop_evmserverd)
+        expect(failover_monitor).not_to receive(:execute_failover)
+        expect(failover_monitor).not_to receive(:start_evmserver)
+        failover_monitor.monitor
       end
     end
+
+    context "primary database is not available" do
+      let(:linux_admin) do
+        linux_adm = double('LinuxAdmin')
+        allow(LinuxAdmin::Service).to receive(:new).and_return(linux_adm)
+        allow(linux_adm).to receive("running?").and_return(true)
+        linux_adm
+      end
+
+      before do
+        allow(PG::Connection).to receive(:open).and_return(nil)
+        allow(failover_monitor).to receive(:pg_connection).and_return(connection)
+      end
+
+      describe "#primary_database_host" do
+        it "return host if supplied connection established with primary database" do
+          params = {:host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+          expect(failover_db).to receive(:query_repmgr).with(connection).and_return(guery_repmanager_result)
+          host = failover_monitor.primary_database_host(connection, params)
+          expect(host).to eq '203.0.113.2'
+        end
+
+        it "return nil if supplied connection established with mot primary database" do
+          params = {:host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
+          expect(failover_db).to receive(:query_repmgr).with(connection).and_return(guery_repmanager_result)
+          host = failover_monitor.primary_database_host(connection, params)
+          expect(host).to be nil
+        end
+      end
+
+      it "stop evm server(if it is running) before failover attempt" do
+        expect(linux_admin).to receive(:stop)
+        expect(failover_monitor).to receive(:execute_failover).and_return(false)
+
+        failover_monitor.monitor
+      end
+
+      it "updates 'database.yml' if there is available primary database and restart evm server" do
+        allow(failover_monitor).to receive(:stop_evmserverd)
+        allow(failover_monitor).to receive(:database_in_recovery?).with(connection).and_return(false)
+        expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
+        expect(failover_db).to receive(:query_repmgr).exactly(2).times
+          .with(connection).and_return(guery_repmanager_result)
+
+        expect(failover_db).to receive(:update_failover_yml).with(connection)
+        expect(db_yml).to receive(:update_database_yml)
+        expect(linux_admin).to receive(:stop)
+        expect(linux_admin).to receive(:start)
+
+        failover_monitor.monitor
+      end
+    end
+  end
+
+  def active_databases_list
+    arr = []
+    arr << {:type => 'master', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'standby', :active => true, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
+  end
+
+  def guery_repmanager_result
+    arr = []
+    arr << {:type => 'standby', :active => false, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'master', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:type => 'standby', :active => true, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
   end
 end

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -52,7 +52,7 @@ describe PostgresHaAdmin::FailoverMonitor do
       end
     end
 
-    context "primary database is not available" do
+    context "primary database is not accessable" do
       let(:linux_admin) do
         linux_adm = double('LinuxAdmin')
         allow(LinuxAdmin::Service).to receive(:new).and_return(linux_adm)
@@ -61,22 +61,21 @@ describe PostgresHaAdmin::FailoverMonitor do
       end
 
       before do
-        allow(PG::Connection).to receive(:open).and_return(nil)
-        allow(failover_monitor).to receive(:pg_connection).and_return(connection)
+        allow(PG::Connection).to receive(:open).and_return(nil, connection, connection)
       end
 
-      describe "#primary_database_host" do
+      describe "#host_for_primary_database" do
         it "return host if supplied connection established with primary database" do
           params = {:host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
           expect(failover_db).to receive(:query_repmgr).with(connection).and_return(guery_repmanager_result)
-          host = failover_monitor.primary_database_host(connection, params)
+          host = failover_monitor.host_for_primary_database(connection, params)
           expect(host).to eq '203.0.113.2'
         end
 
         it "return nil if supplied connection established with mot primary database" do
           params = {:host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
           expect(failover_db).to receive(:query_repmgr).with(connection).and_return(guery_repmanager_result)
-          host = failover_monitor.primary_database_host(connection, params)
+          host = failover_monitor.host_for_primary_database(connection, params)
           expect(host).to be nil
         end
       end

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -1,4 +1,5 @@
 require 'postgres_ha_admin/failover_monitor'
+require 'util/postgres_admin'
 
 describe PostgresHaAdmin::FailoverMonitor do
   let(:db_yml) do
@@ -89,7 +90,7 @@ describe PostgresHaAdmin::FailoverMonitor do
 
       it "does not update 'database.yml' and 'failover_databases.yml' if all standby DBs are in recovery mode" do
         allow(failover_monitor).to receive(:stop_evmserverd)
-        allow(failover_monitor).to receive(:database_in_recovery?).and_return(true)
+        allow(PostgresAdmin).to receive(:database_in_recovery?).and_return(true)
 
         expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
         expect(failover_db).not_to receive(:update_database_yml)
@@ -103,7 +104,7 @@ describe PostgresHaAdmin::FailoverMonitor do
 
       it "does not update 'database.yml' and 'failover_databases.yml' if there is no master database avaiable" do
         allow(failover_monitor).to receive(:stop_evmserverd)
-        allow(failover_monitor).to receive(:database_in_recovery?).and_return(false)
+        allow(PostgresAdmin).to receive(:database_in_recovery?).and_return(true)
         allow(failover_db).to receive(:query_repmgr).and_return(no_master_db_list)
 
         expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
@@ -118,7 +119,7 @@ describe PostgresHaAdmin::FailoverMonitor do
 
       it "updates 'database.yml' and 'failover_databases.yml' and start evm server if new primary db available" do
         allow(failover_monitor).to receive(:stop_evmserverd)
-        allow(failover_monitor).to receive(:database_in_recovery?).and_return(false)
+        allow(PostgresAdmin).to receive(:database_in_recovery?).and_return(false)
         allow(failover_db).to receive(:query_repmgr).and_return(guery_repmanager_result)
 
         expect(failover_db).to receive(:active_databases).and_return(active_databases_list)


### PR DESCRIPTION
For failover execution we need to have 'always running' process which:
 - Attempt to connect to current master database (with connection info taken from ```database.yml```) and updates ```failover_databases.yml``` with list of standby databases if connection successful.
-  If above connection is not successful than:
     1.  stop evm server.
     2. find out which database from  ```failover_databases.yml``` become primary database.
     3. update ```database.yml``` with new connection info.
     4. start evm server.

Preparation PRs: #10297   #10103 
Pivotal: https://www.pivotaltracker.com/n/projects/1608513

Sample failover_databases.yml:
```
---
- :type: master
  :active: true
  :host: 1.1.1.1
  :user: root
  :dbname: vmdb_test
- :type: standby
  :active: true
  :host: 2.2.2.2
  :user: root
  :dbname: vmdb_test
- :type: standby
  :active: false
  :host: 3.3.3.3
  :user: root
  :dbname: vmdb_test
```
@miq-bot add-label wip, core
@carbonin 