### PR TITLE
Allow the user to configure a database-only appliance

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -92,7 +92,8 @@ NETWORK_INTERFACE = "eth0".freeze
 module ApplianceConsole
   eth0 = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE)
   ip = eth0.address
-  # Because it takes a few seconds, get the database information once in the outside loop
+  # Because it takes a few seconds, get the region once in the outside loop
+  region = ApplianceConsole::DatabaseConfiguration.region
   clear_screen
 
   # Calling stty to provide the equivalent line settings when the console is run via an ssh session or
@@ -119,7 +120,6 @@ module ApplianceConsole
       version     = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
       dbhost      = ApplianceConsole::DatabaseConfiguration.database_host
       database    = ApplianceConsole::DatabaseConfiguration.database_name
-      region      = ApplianceConsole::DatabaseConfiguration.region
       evm_running = LinuxAdmin::Service.new("evmserverd").running?
 
       summary_attributes = [
@@ -458,6 +458,9 @@ Static Network Configuration
         when "create_internal", /_external/
           database_configuration.run_interactive
         end
+        # Get the region again because it may have changed
+        region = ApplianceConsole::DatabaseConfiguration.region
+
         press_any_key
 
       when I18n.t("advanced_settings.tmp_config")

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -458,7 +458,8 @@ Static Network Configuration
         when "create_internal", /_external/
           database_configuration.run_interactive
         end
-        dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region
+        configured = ApplianceConsole::DatabaseConfiguration.configured?
+        dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region if configured
         press_any_key
 
       when I18n.t("advanced_settings.tmp_config")

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -24,6 +24,7 @@ require 'rubygems'
 require 'bcrypt'
 require 'linux_admin'
 require 'util/vmdb-logger'
+require 'util/postgres_admin'
 require 'awesome_spawn'
 include HighLine::SystemExtensions
 
@@ -92,9 +93,6 @@ module ApplianceConsole
   eth0 = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE)
   ip = eth0.address
   # Because it takes a few seconds, get the database information once in the outside loop
-  configured = ApplianceConsole::DatabaseConfiguration.configured?
-  dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region if configured
-
   clear_screen
 
   # Calling stty to provide the equivalent line settings when the console is run via an ssh session or
@@ -102,7 +100,7 @@ module ApplianceConsole
   system("stty -echoprt ixany iexten echoe echok")
 
   say("#{I18n.t("product.name")} Virtual Appliance\n")
-  say("To administer this appliance, browse to https://#{ip}\n") if configured
+  say("To administer this appliance, browse to https://#{ip}\n")
 
   loop do
     begin
@@ -110,16 +108,19 @@ module ApplianceConsole
       eth0.reload
       eth0.parse_conf if eth0.respond_to?(:parse_conf)
 
-      host       = LinuxAdmin::Hosts.new.hostname
-      ip         = eth0.address
-      mac        = eth0.mac_address
-      mask       = eth0.netmask
-      gw         = eth0.gateway
-      dns1, dns2 = dns.nameservers
-      order      = dns.search_order.join(' ')
-      timezone   = LinuxAdmin::TimeDate.system_timezone
-      version    = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
-      configured = ApplianceConsole::DatabaseConfiguration.configured?
+      host        = LinuxAdmin::Hosts.new.hostname
+      ip          = eth0.address
+      mac         = eth0.mac_address
+      mask        = eth0.netmask
+      gw          = eth0.gateway
+      dns1, dns2  = dns.nameservers
+      order       = dns.search_order.join(' ')
+      timezone    = LinuxAdmin::TimeDate.system_timezone
+      version     = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
+      dbhost      = ApplianceConsole::DatabaseConfiguration.database_host
+      database    = ApplianceConsole::DatabaseConfiguration.database_name
+      region      = ApplianceConsole::DatabaseConfiguration.region
+      evm_running = LinuxAdmin::Service.new("evmserverd").running?
 
       summary_attributes = [
         summary_entry("Hostname", host),
@@ -131,13 +132,12 @@ module ApplianceConsole
         summary_entry("Search Order", order),
         summary_entry("MAC Address", mac),
         summary_entry("Timezone", timezone),
-        summary_entry("Local Database", ApplianceConsole::Utilities.pg_status),
-        summary_entry("#{I18n.t("product.name")} Database",
-                      configured ? "postgres @ #{dbhost || "localhost"}" : "not configured"),
-        summary_entry("Database/Region", configured ? "#{database} / #{region || 0}" : "not configured"),
+        summary_entry("Local Database Server", PostgresAdmin.local_server_status),
+        summary_entry("#{I18n.t("product.name")} Server", evm_running ? "running" : "not running"),
+        summary_entry("#{I18n.t("product.name")} Database", dbhost || "not configured"),
+        summary_entry("Database/Region", database ? "#{database} / #{region.to_i}" : "not configured"),
         summary_entry("External Auth", ExternalHttpdAuthentication.config_status),
         summary_entry("#{I18n.t("product.name")} Version", version),
-        summary_entry("#{I18n.t("product.name")} Console", configured ? "https://#{ip}" : "not configured")
       ]
 
       clear_screen
@@ -458,8 +458,6 @@ Static Network Configuration
         when "create_internal", /_external/
           database_configuration.run_interactive
         end
-        configured = ApplianceConsole::DatabaseConfiguration.configured?
-        dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region if configured
         press_any_key
 
       when I18n.t("advanced_settings.tmp_config")

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -198,8 +198,20 @@ FRIENDLY
       decrypt_password(load_current)
     end
 
-    def self.configured?
+    def self.database_yml_configured?
       File.exist?(DB_YML)
+    end
+
+    def self.database_host
+      database_yml_configured? ? current[rails_env]['host'] || "localhost" : nil
+    end
+
+    def self.database_name
+      database_yml_configured? ? current[rails_env]['database'] : nil
+    end
+
+    def self.region
+      database_yml_configured? ? ApplianceConsole::Utilities.db_region : nil
     end
 
     def validated
@@ -225,6 +237,11 @@ FRIENDLY
     end
 
     private
+
+    def self.rails_env
+      ENV["RAILS_ENV"] || "development"
+    end
+    private_class_method :rails_env
 
     def self.encrypt_decrypt_password(settings)
       new_settings = {}

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -78,11 +78,6 @@ module ApplianceConsole
       end
     end
 
-    def post_activation
-      pid = fork { LinuxAdmin::Service.new("evmserverd").enable.start }
-      Process.detach(pid)
-    end
-
     def create_or_join_region
       region ? create_region : join_region
     end
@@ -222,6 +217,11 @@ FRIENDLY
       ensure
         ModelWithNoBackingTable.remove_connection
       end
+    end
+
+    def start_evm
+      pid = fork { LinuxAdmin::Service.new("evmserverd").enable.start }
+      Process.detach(pid)
     end
 
     private

--- a/gems/pending/appliance_console/external_database_configuration.rb
+++ b/gems/pending/appliance_console/external_database_configuration.rb
@@ -23,5 +23,9 @@ module ApplianceConsole
       say("Database Configuration\n")
       ask_for_database_credentials
     end
+
+    def post_activation
+      start_evm
+    end
   end
 end

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -17,10 +17,6 @@ module ApplianceConsole
       PostgresAdmin.template_directory.join(postgres_dir)
     end
 
-    def self.database_initialized?
-      configured? && !Dir[PostgresAdmin.data_directory.join("*")].empty?
-    end
-
     def initialize(hash = {})
       set_defaults
       super
@@ -34,7 +30,7 @@ module ApplianceConsole
     end
 
     def activate
-      if self.class.database_initialized?
+      if PostgresAdmin.initialized?
         say(<<-EOF.gsub!(/^\s+/, ""))
           An internal database already exists.
           Choose "Reset Internal Database" to reset the existing installation

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -7,8 +7,7 @@ RAILS_ROOT ||= Pathname.new(__dir__).join("../../../")
 
 module ApplianceConsole
   class InternalDatabaseConfiguration < DatabaseConfiguration
-    attr_accessor :disk
-    attr_accessor :ssl
+    attr_accessor :disk, :ssl, :run_as_evm_server
 
     def self.postgres_dir
       PostgresAdmin.data_directory.relative_path_from(Pathname.new("/"))
@@ -28,9 +27,10 @@ module ApplianceConsole
     end
 
     def set_defaults
-      self.host     = "127.0.0.1"
-      self.username = "root"
-      self.database = "vmdb_production"
+      self.host              = "127.0.0.1"
+      self.username          = "root"
+      self.database          = "vmdb_production"
+      self.run_as_evm_server = true
     end
 
     def activate
@@ -43,14 +43,16 @@ module ApplianceConsole
       end
       initialize_postgresql_disk if disk
       initialize_postgresql
-      super
+      return super if run_as_evm_server
+      true
     end
 
     def ask_questions
       choose_disk
+      self.run_as_evm_server = ask_yn?("Do you also want to use this server as an application server")
       # TODO: Assume we want to create a region for a new internal database disk
       # until we allow for the internal selection against an already initialized disk.
-      create_new_region_questions(false)
+      create_new_region_questions(false) if run_as_evm_server
       ask_for_database_credentials
     end
 
@@ -89,6 +91,10 @@ module ApplianceConsole
       copy_template "postgresql.conf.erb"
       copy_template "pg_hba.conf.erb"
       copy_template "pg_ident.conf"
+    end
+
+    def post_activation
+      start_evm if run_as_evm_server
     end
 
     private

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -33,23 +33,22 @@ module ApplianceConsole
       end
     end
 
-    def self.db_host_database_region
+    def self.db_region
       result = AwesomeSpawn.run(
         "bin/rails runner",
-        :params => ["puts Rails.configuration.database_configuration[Rails.env].values_at('host', 'database'), ApplicationRecord.my_region_number"],
+        :params => ["puts ApplicationRecord.my_region_number"],
         :chdir  => RAILS_ROOT
       )
 
-      host, database, region = result.output.split("\n").last(3)
-
-      if database.blank?
+      if result.failure?
         logger = ApplianceConsole::Logging.logger
-        logger.error "db_host_type_database: Failed to detect some/all DB configuration"
+        logger.error "db_region: Failed to detect region_number"
         logger.error "Output: #{result.output.inspect}" unless result.output.blank?
         logger.error "Error:  #{result.error.inspect}"  unless result.error.blank?
+        return
       end
 
-      return host.presence, database, region
+      result.output.strip
     end
 
     def self.pg_status

--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -374,7 +374,7 @@ describe ApplianceConsole::DatabaseConfiguration do
       end
     end
 
-    describe "#post_activation" do
+    describe "#start_evm" do
       it "forks and detaches the service start command" do
         expect(@config).to receive(:fork) do |&block|
           service = double(:service)
@@ -385,7 +385,7 @@ describe ApplianceConsole::DatabaseConfiguration do
           1234 # return a test pid
         end
         expect(Process).to receive(:detach).with(1234)
-        @config.post_activation
+        @config.start_evm
       end
     end
   end

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -16,6 +16,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
       expect(@config.host).to eq("127.0.0.1")
       expect(@config.username).to eq("root")
       expect(@config.database).to eq("vmdb_production")
+      expect(@config.run_as_evm_server).to be true
     end
   end
 
@@ -48,6 +49,20 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
     allow(PostgresAdmin).to receive_messages(:data_directory     => Pathname.new("/var/lib/pgsql/data"))
     allow(PostgresAdmin).to receive_messages(:template_directory => Pathname.new("/opt/manageiq/manageiq-appliance/TEMPLATE"))
     expect(described_class.postgresql_template.to_s).to end_with("TEMPLATE/var/lib/pgsql/data")
+  end
+
+  describe "#post_activation" do
+    it "doesnt start evm if run_as_evm_server is false" do
+      @config.run_as_evm_server = false
+      expect(@config).not_to receive(:start_evm)
+      @config.post_activation
+    end
+
+    it "starts evm if run_as_evm_server is true" do
+      @config.run_as_evm_server = true
+      expect(@config).to receive(:start_evm)
+      @config.post_activation
+    end
   end
 
   context "#update_fstab (private)" do

--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -55,5 +55,23 @@ describe PostgresAdmin do
           .to eql "su - postgres -c '/ctl/path stop -W -D /pgdata/path -s -m fast'"
       end
     end
+
+    describe ".initialized?" do
+      around do |example|
+        Dir.mktmpdir do |dir|
+          ENV["APPLIANCE_PG_DATA"] = dir
+          example.run
+        end
+      end
+
+      it "returns true with files in the data directory" do
+        FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/somefile")
+        expect(described_class.initialized?).to be true
+      end
+
+      it "returns false without files in the data directory" do
+        expect(described_class.initialized?).to be false
+      end
+    end
   end
 end

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -53,6 +53,24 @@ class PostgresAdmin
     "xfs".freeze
   end
 
+  def self.initialized?
+    !Dir[data_directory.join("*")].empty?
+  end
+
+  def self.service_running?
+    LinuxAdmin::Service.new(service_name).running?
+  end
+
+  def self.local_server_status
+    if service_running?
+      "running"
+    elsif initialized?
+      "initialized and stopped"
+    else
+      "not initialized"
+    end
+  end
+
   def self.logical_volume_path
     Pathname.new("/dev").join(volume_group_name, logical_volume_name)
   end


### PR DESCRIPTION
Ask whether the user would also want this server to function as an "application server" when configuring an internal database

This includes not starting the evmserverd service as well as not seeding the database with information about a new evm server instance (joining the region).

https://www.pivotaltracker.com/story/show/126134069