### PR TITLE
Keep the provision request when template is deleted.

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -61,7 +61,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
   def update_request(request, values, _requester = nil)
     request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
-    request.src_vm_id = request.get_option(:src_vm_id)
+    request.src_vm_id = get_value(values[:src_vm_id])
     super
   end
 

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -242,6 +242,14 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def validate_template
+    missing_resources = service_resources.select { |sr| sr.resource.nil? }
+
+    if missing_resources.present?
+      missing_list = missing_resources.collect { |sr| "#{sr.resource_type}:#{sr.resource_id}" }.join(", ")
+      return {:valid   => false,
+              :message => "Missing Service Resource(s): #{missing_list}"}
+    end
+
     service_resources.detect do |s|
       r = s.resource
       r.respond_to?(:template_valid?) && !r.template_valid?

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -74,7 +74,7 @@ class VmOrTemplate < ApplicationRecord
   has_one                   :miq_provision, :dependent => :nullify, :as => :destination
   has_many                  :miq_provisions_from_template, :class_name => "MiqProvision", :as => :source, :dependent => :nullify
   has_many                  :miq_provision_vms, :through => :miq_provisions_from_template, :source => :destination, :source_type => "VmOrTemplate"
-  has_many                  :miq_provision_requests, :as => :source, :dependent => :destroy
+  has_many                  :miq_provision_requests, :as => :source
 
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -152,4 +152,10 @@ describe MiqProvisionRequestTemplate do
       end
     end
   end
+
+  it 'exists after source template is deleted' do
+    provision_request_template
+    template.destroy
+    expect(provision_request_template.reload).not_to be_nil
+  end
 end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -306,4 +306,24 @@ describe MiqProvisionVirtWorkflow do
       workflow.update_field_visibility
     end
   end
+
+  context '#update_request' do
+    let(:template) do
+      FactoryGirl.create(
+        :template_vmware,
+        :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication)
+      )
+    end
+    let(:values)  { {:src_vm_id => [template.id, template.name]} }
+    let(:request) { workflow.create_request(:src_vm_id => [999, 'old_template']) }
+    before { workflow.update_request(request, values) }
+
+    it 'updates options' do
+      expect(request.options).to include(values)
+    end
+
+    it 'updates soruce_id' do
+      expect(request.source_id).to eq(template.id)
+    end
+  end
 end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -351,6 +351,14 @@ describe ServiceTemplate do
         expect(@st1.template_valid?).to be_truthy
         expect(@st1.template_valid_error_message).to be_nil
       end
+
+      it 'not existing request' do
+        @st1.save!
+        @ptr.destroy
+        expect(@st1.reload.template_valid?).to be_falsey
+        msg = "Missing Service Resource(s): #{@ptr.class.base_model.name}:#{@ptr.id}"
+        expect(@st1.template_valid_error_message).to include(msg)
+      end
     end
 
     context 'composite' do


### PR DESCRIPTION
Purpose or Intent
-----------------
We need to keep the provision request when a template is deleted somehow. So the user would be able to edit the catalog item to select a new template.

Also fix a bug with updating the request where src_vm_id is updated with the old template instead of the newly selected template.

Also improve #validate_template method to check the existence of the request first before calling method upon it. 

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1331824
