### PR TITLE
Ensure default value is being set correctly via automate

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -2,6 +2,7 @@ class DialogField < ApplicationRecord
   include NewWithTypeStiMixin
   attr_accessor :value
   attr_accessor :dialog
+  attr_accessor :default_value
 
   belongs_to :dialog_group
   has_one :resource_action, :as => :resource, :dependent => :destroy

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -1,13 +1,4 @@
 class DialogFieldDropDownList < DialogFieldSortedItem
-  def initialize_with_values(dialog_values)
-    if load_values_on_init?
-      raw_values
-      @value = value_from_dialog_fields(dialog_values) || default_value
-    else
-      @raw_values = initial_values
-    end
-  end
-
   def show_refresh_button?
     !!show_refresh_button
   end
@@ -35,13 +26,5 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def load_values_on_init?
     return true unless show_refresh_button
     load_values_on_init
-  end
-
-  def raw_values
-    @raw_values ||= dynamic ? values_from_automate : super
-    @default_value ||= sort_data(@raw_values).first.first if @raw_values
-    self.value ||= @default_value
-
-    @raw_values
   end
 end

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -1,13 +1,4 @@
 class DialogFieldRadioButton < DialogFieldSortedItem
-  def initialize_with_values(dialog_values)
-    if load_values_on_init?
-      raw_values
-      @value = value_from_dialog_fields(dialog_values) || default_value
-    else
-      @raw_values = initial_values
-    end
-  end
-
   def show_refresh_button?
     !!show_refresh_button
   end
@@ -24,7 +15,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
     if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
       @value = checked_value
     else
-      @value = default_value
+      @value = @default_value
     end
 
     {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?, :visible => visible?}
@@ -35,13 +26,5 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   def load_values_on_init?
     return true unless show_refresh_button
     load_values_on_init
-  end
-
-  def raw_values
-    if dynamic
-      @raw_values = values_from_automate
-    else
-      @raw_values = super
-    end
   end
 end

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -26,6 +26,6 @@ class DialogFieldSerializer < Serializer
       dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
     end
 
-    included_attributes(dialog_field.attributes).merge(extra_attributes)
+    included_attributes(dialog_field.as_json(:methods => [:type, :values])).merge(extra_attributes)
   end
 end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -1,5 +1,15 @@
 class DialogFieldSortedItem < DialogField
   AUTOMATE_VALUE_FIELDS = %w(sort_by sort_order data_type default_value required read_only visible).freeze
+
+  def initialize_with_values(dialog_values)
+    if load_values_on_init?
+      raw_values
+      @value = value_from_dialog_fields(dialog_values) || default_value
+    else
+      @raw_values = initial_values
+    end
+  end
+
   def sort_by
     options[:sort_by] || :description
   end
@@ -22,10 +32,6 @@ class DialogFieldSortedItem < DialogField
     options[:sort_order] = value.to_sym
   end
 
-  def raw_values
-    read_attribute(:values).to_miq_a
-  end
-
   # Sort values before sending back
   def values
     values_data = raw_values
@@ -33,12 +39,8 @@ class DialogFieldSortedItem < DialogField
   end
 
   def get_default_value
-    values_data = values
-    if values_data.count == 1
-      values_data.first.first
-    elsif values_data.detect { |v| v.first == default_value }
-      default_value
-    end
+    trigger_automate_value_updates
+    default_value
   end
 
   def script_error_values
@@ -55,7 +57,8 @@ class DialogFieldSortedItem < DialogField
   end
 
   def trigger_automate_value_updates
-    @raw_values = @default_value = nil
+    @default_value = nil if dynamic
+    @raw_values = nil
     raw_values
   end
 
@@ -70,5 +73,19 @@ class DialogFieldSortedItem < DialogField
     data_to_sort = data_to_sort.sort_by { |d| d.send(value_position).send(value_modifier) }
     return data_to_sort.reverse! if sort_order == :descending
     data_to_sort
+  end
+
+  def raw_values
+    @raw_values ||= dynamic ? values_from_automate : self[:values].to_miq_a
+    unless @raw_values.collect { |value_pair| value_pair[0] }.include?(@default_value)
+      @default_value = sort_data(@raw_values).first.first
+    end
+    self.value ||= @default_value
+
+    @raw_values
+  end
+
+  def initial_values
+    [[nil, "<None>"]]
   end
 end

--- a/app/models/dialog_field_tag_control.rb
+++ b/app/models/dialog_field_tag_control.rb
@@ -1,4 +1,8 @@
 class DialogFieldTagControl < DialogFieldSortedItem
+  def initialize_with_values(dialog_values)
+    @value = value_from_dialog_fields(dialog_values) || get_default_value
+  end
+
   def category=(id)
     options[:category_id] = id
   end

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -62,12 +62,13 @@ describe DialogFieldDropDownList do
     context "#initialize_with_values" do
       before(:each) do
         @df.values = [["3", "X"], ["2", "Y"], ["1", "Z"]]
+        @df.load_values_on_init = true
       end
 
-      it "no default value" do
+      it "uses the first as the default value" do
         @df.default_value = nil
         @df.initialize_with_values({})
-        expect(@df.value).to be_nil
+        expect(@df.value).to eq("3")
       end
 
       it "with default value" do
@@ -76,10 +77,10 @@ describe DialogFieldDropDownList do
         expect(@df.value).to eq("1")
       end
 
-      it "with non-matching default value" do
+      it "uses the first when there is a non-matching default value" do
         @df.default_value = "4"
         @df.initialize_with_values({})
-        expect(@df.value).to be_nil
+        expect(@df.value).to eq("3")
       end
     end
 

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -21,19 +21,19 @@ describe DialogFieldRadioButton do
         end
 
         context "when the dialog field is dynamic" do
+          let(:processed_values) { [["processor", 123], ["test", 456]] }
+
           before do
             dialog_field_radio_button.dynamic = true
             dialog_field_radio_button.default_value = "test"
             allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate)
-              .with(dialog_field_radio_button).and_return(
-                [["processor", 123]]
-              )
+              .with(dialog_field_radio_button).and_return(processed_values)
 
             dialog_field_radio_button.initialize_with_values("lolvalues" => 321)
           end
 
           it "gets values from automate" do
-            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq([["processor", 123]])
+            expect(dialog_field_radio_button.instance_variable_get(:@raw_values)).to eq(processed_values)
           end
 
           it "sets value from default value attribute" do
@@ -155,7 +155,7 @@ describe DialogFieldRadioButton do
     end
 
     context "when the checked value is not in the list of refreshed values" do
-      let(:refreshed_values_from_automate) { %w(123 123) }
+      let(:refreshed_values_from_automate) { [%w(123 123)] }
 
       it "returns the list of refreshed values and checked (default) value as a hash" do
         expect(dialog_field_radio_button.refresh_json_value("321")).to eq(

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -82,6 +82,7 @@ describe DialogFieldSerializer do
 
       before do
         allow(Category).to receive(:find_by).with(:id => "123").and_return(category)
+        allow(dialog_field).to receive(:values).and_return("values")
       end
 
       it "serializes the category name and description" do

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -7,9 +7,9 @@ describe DialogFieldSortedItem do
       expect(df.get_default_value).to eq("value1")
     end
 
-    it "returns nil when no default and multiple values are available" do
+    it "returns the first value when no default and multiple values are available" do
       df.values = [%w(value1 text1), %w(value2 text2)]
-      expect(df.get_default_value).to be_nil
+      expect(df.get_default_value).to eq("value1")
     end
   end
 

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -174,4 +174,8 @@ describe DialogField do
       dialog_field.update_and_serialize_values
     end
   end
+
+  it "has default_value as an accessible attribute" do
+    expect(described_class.new).to have_attr_accessor(:default_value)
+  end
 end

--- a/spec/services/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/services/ansible_tower_job_template_dialog_service_spec.rb
@@ -5,7 +5,7 @@ describe AnsibleTowerJobTemplateDialogService do
     it "creates a dialog from a job template" do
       survey =
         "{\"spec\":[{\"index\": 0, \"question_name\": \"Param1\", \"min\": 10, \
-        \"default\": 19, \"max\": 100, \"question_description\": \"param 1\", \"required\": true, \"variable\": \
+        \"default\": \"19\", \"max\": 100, \"question_description\": \"param 1\", \"required\": true, \"variable\": \
         \"param1\", \"choices\": \"\", \"type\": \"integer\"}, {\"index\": 1, \"question_name\": \"Param2\", \"min\": \
         2, \"default\": \"as\", \"max\": 5, \"question_description\": \"param 2\", \"required\": true, \"variable\": \
         \"param2\", \"choices\": \"\", \"type\": \"text\"}, {\"index\": 2, \"question_name\": \"Param3\", \"min\": \
@@ -18,8 +18,9 @@ describe AnsibleTowerJobTemplateDialogService do
         \"multiplechoice\"}, {\"index\": 5, \"question_description\": \"param 6\", \"min\": \"\", \"default\": \
         \"opt1\\n222\", \"max\": \"\", \"question_name\": \"Param6\", \"required\": true, \"variable\": \"param6\", \
         \"choices\": \"opt1\\n222\\nopt3\", \"type\": \"multiselect\"}, {\"index\": 6, \"question_name\": \"Param7\", \
-        \"min\": \"\", \"default\": 14.5, \"max\": \"\", \"question_description\": \"param 7\", \"required\": true, \
-        \"variable\": \"param7\", \"choices\": \"\", \"type\": \"float\"}],\"name\":\"\",\"description\":\"\"}"
+        \"min\": \"\", \"default\": \"14.5\", \"max\": \"\", \"question_description\": \"param 7\", \
+        \"required\": true, \"variable\": \"param7\", \"choices\": \"\", \"type\": \"float\"}],\"name\":\"\", \
+        \"description\":\"\"}"
       allow(template).to receive(:survey_spec).and_return(JSON.parse(survey))
 
       allow(template).to receive(:variables).and_return('some_extra_var'  => 'blah',

--- a/spec/support/custom_matchers/have_attr_accessor.rb
+++ b/spec/support/custom_matchers/have_attr_accessor.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :have_attr_accessor do |field_name|
+  match do |object_instance|
+    object_instance.respond_to?(field_name) && object_instance.respond_to?("#{field_name}=")
+  end
+
+  failure_message do |object_instance|
+    "expected attr_accessor #{field_name} for #{object_instance}"
+  end
+
+  failure_message_when_negated do |object_instance|
+    "expected attr_accessor #{field_name} not to be defined for #{object_instance}"
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Previously, when trying to determine the default value for a dialog field (specifically in the case of testing, a drop down), we would use the instance variable `@default_value`, which wasn't actually being set by automate because there was no `attr_accessor` for it. This ensures that when automate sets a default value, it is actually preserved to the instance variable `@default_value`. The `default_value=` method is being called via a dynamic send in all of the individual dialog field's `normalize_automate_values` methods.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1332910

@miq-bot assign @gmcculloug 

@gmcculloug Please Review, I think this might solve the issue they are seeing in https://bugzilla.redhat.com/show_bug.cgi?id=1346952 (the 5.6.z version of the above mentioned BZ).