### PR TITLE
Fix phantom #<Class:0x0...> RSpec output

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -23,7 +23,7 @@
             = _('Name / Description')
           .col-md-8
             #{@record.name} / #{@record.description}
-            = check_box_tag(display, true, @record.display, :disabled => true)
+            = check_box_tag("display", true, @record.display, :disabled => true)
             &nbsp;
             = _('Display in Catalog')
         - if @record.display


### PR DESCRIPTION
Interestingly enough, this check_box_tag is calling Object#display, a native method, which prints self to the screen.

This id tag is blank instead of...I don't know. I need help confirming what this id attribute should actually be called, but this clearly is not correct.

http://ruby-doc.org/core-2.3.1/Object.html#method-i-display

Thanks to @jrafanie for joining me on this fun little excursion. 