### PR TITLE
[DARGA] Fix error on Orchestration Stacks detail page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,6 +741,7 @@ en:
       ManageIQ::Providers::Azure::CloudManager::Vm:                         Instance (Azure)
       ManageIQ::Providers::Amazon::CloudManager::Vm:                        Instance (Amazon)
       ManageIQ::Providers::CloudManager::Template:                          Image
+      ManageIQ::Providers::CloudManager::OrchestrationStack:                Orchestration Stack
       ManageIQ::Providers::ContainerManager:                                Containers Provider
       ManageIQ::Providers::InfraManager:                                    Infrastructure Provider
       ManageIQ::Providers::InfraManager::Vm:                                Virtual Machine


### PR DESCRIPTION
Purpose or Intent
-----------------
Fixes a Page Does Not Exist error when clicking on the breadcrumb in Compute > Cloud > Stacks > Stack Instance

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1362704