### PR TITLE
Provision preemptible vms

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -36,6 +36,7 @@ module ApplicationController::MiqRequestMethods
           all_dialogs.each do |dialog_name, dialog|
             if dialog[:display] == :show && dialog_name == @edit[:new][:current_tab_key]
               page.replace_html(dialog_name, :partial => dialog_partial_for_workflow, :locals => {:wf => @edit[:wf], :dialog => dialog_name})
+              page << "$('[data-toggle=popover]').popovers()"
             end
           end
         end

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -36,7 +36,6 @@ module ApplicationController::MiqRequestMethods
           all_dialogs.each do |dialog_name, dialog|
             if dialog[:display] == :show && dialog_name == @edit[:new][:current_tab_key]
               page.replace_html(dialog_name, :partial => dialog_partial_for_workflow, :locals => {:wf => @edit[:wf], :dialog => dialog_name})
-              page << "$('[data-toggle=popover]').popovers()"
             end
           end
         end

--- a/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision/cloning.rb
@@ -17,6 +17,12 @@ module ManageIQ::Providers::Google::CloudManager::Provision::Cloning
     clone_options[:disks]        = [boot_disk]
     clone_options[:machine_type] = instance_type.ems_ref
     clone_options[:zone_name]    = dest_availability_zone.ems_ref
+    clone_options[:preemptible]  = get_option(:is_preemptible)
+    # fog-google specifies a default value that's incompatible with
+    # :preemptible; until this is fixed we need to be explicit about the host
+    # behavior on maintenance
+    # issue: https://github.com/fog/fog-google/issues/136
+    clone_options[:on_host_maintenance] = "TERMINATE" if clone_options[:preemptible]
 
     clone_options
   end

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -460,7 +460,7 @@
             -# Description is in the second, last, array element
             = options[field].last
       - elsif [:linked_clone, :placement_auto, :stateless, :sysprep_auto_logon, :sysprep_change_sid,
-               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory].include?(field)
+               :sysprep_delete_accounts, :sysprep_spec_override, :vm_auto_start, :vm_dynamic_memory, :is_preemptible].include?(field)
         -# ### Checkbox fields
         .col-md-8{:style => "vertical-align: top;"}
           - if @edit && field_hash[:display] == :edit && !@edit[:stamp_typ]

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -50,7 +50,8 @@
         = field_hash[:description]
         - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
         - if field_hash[:help]
-          %a{:tabindex => 0,
+          %a{:id               => "popover-#{field_hash.object_id}",
+             :tabindex         => 0,
              :role             => "button",
              :"data-toggle"    => "popover",
              :"data-trigger"   => "focus",
@@ -59,6 +60,8 @@
              :"data-content"   => "#{field_hash[:help]}",
              :"data-placement" => "top"}
             %span.fa.fa-info-circle
+          :javascript
+            $('#popover-#{field_hash.object_id}').popovers();
         - if field_hash[:description] == "Provision on"
           (#{get_timezone_abbr(current_user)})
         - if @edit && @edit[:new] && [:vm_description].include?(field)

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -49,6 +49,16 @@
       %label.col-md-2.control-label{:valign => "top"}
         = field_hash[:description]
         - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
+        - if field_hash[:help]
+          %a{:tabindex => 0,
+             :role             => "button",
+             :"data-toggle"    => "popover",
+             :"data-trigger"   => "focus",
+             :"data-html"      => "true",
+             :title            => "",
+             :"data-content"   => "#{field_hash[:help]}",
+             :"data-placement" => "top"}
+            %span.fa.fa-info-circle
         - if field_hash[:description] == "Provision on"
           (#{get_timezone_abbr(current_user)})
         - if @edit && @edit[:new] && [:vm_description].include?(field)

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -142,7 +142,7 @@
   - when :hardware
     - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring,
-              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size]
+              :vm_dynamic_memory, :vm_minimum_memory, :vm_maximum_memory, :boot_disk_size, :is_preemptible]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Properties") : _("Hardware")
     = render(:partial => "/miq_request/prov_dialog_fieldset",
       :locals         => {:workflow => wf,

--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -289,6 +289,15 @@
           :required: true
           :display: :edit
           :data_type: :integer
+        :is_preemptible:
+          :values:
+            false: 0
+            true: 1
+          :description: Provision VM(s) as Preemptible
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
       :display: :show
   :dialog_order:
   - :requester

--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -293,7 +293,8 @@
           :values:
             false: 0
             true: 1
-          :description: Provision VM(s) as Preemptible
+          :description: Preemptible
+          :help: "A <a target=\"_blank\" href=\"https://cloud.google.com/compute/docs/instances/preemptible\">preemptible VM</a> will run for at most 24 hours and may be prematurely-terminated."
           :required: false
           :display: :edit
           :default: false


### PR DESCRIPTION
Allow Google provider to be able to provision preemptible instances.  Also adds support for patternfly form_help element.

Posting this as a WIP PR early to get some early feedback before final posting. 

@miq-bot add_label wip

/cc @agrare @blomquisg @erjohnso 