### PR TITLE
Update fog-openstack to 0.1.11

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -17,7 +17,7 @@ gem "excon",                   "~>0.40",            :require => false
 gem "ezcrypto",                "=0.7",              :require => false
 gem "ffi",                     "~>1.9.3",           :require => false
 gem "ffi-vix_disk_lib",        "~>1.0.2",           :require => false  # used by lib/VixDiskLib
-gem "fog-openstack",           "~>0.1.7",           :require => false
+gem "fog-openstack",           "=0.1.11",           :require => false
 gem "hawkular-client",         "=2.4.0",            :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.3",           :require => false


### PR DESCRIPTION
Purpose or Intent
-----------------

Also adding =0.1.11 to gemfile, instead of optimistic ~>. Seems
like all the clients are using exact match, ~> might be a bit
fragile for a remote proxy lib.

Steps for Testing/QA
--------------------

New version can have side effect in any place. Version exact match should make it more stable.


