### PR TITLE
Disks management for RHEVM provider in 'Reconfigure VM'

### DIFF
--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -13,6 +13,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         hdUnit:                  'MB',
         cb_dependent:            true,
         addEnabled:              false,
+        cb_bootable:             false,
         vmAddDisks:              [],
         vmRemoveDisks:           []
       };
@@ -156,7 +157,8 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
           $scope.reconfigureModel.vmAddDisks.push({disk_size_in_mb: dsize,
                                                    persistent: dmode,
                                                    thin_provisioned: dtype,
-                                                   dependent: $scope.reconfigureModel.vmdisks[disk].cb_dependent});
+                                                   dependent: $scope.reconfigureModel.vmdisks[disk].cb_dependent,
+                                                   bootable: $scope.reconfigureModel.vmdisks[disk].cb_bootable});
         }
       }
     };
@@ -168,6 +170,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
       $scope.reconfigureModel.hdUnit = 'MB';
       $scope.reconfigureModel.cb_dependent = true;
       $scope.reconfigureModel.addEnabled = false;
+      $scope.reconfigureModel.cb_bootable = false;
     };
 
     $scope.addDisk = function() {
@@ -177,6 +180,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
                                             hdSize: $scope.reconfigureModel.hdSize,
                                             hdUnit: $scope.reconfigureModel.hdUnit,
                                             cb_dependent: $scope.reconfigureModel.cb_dependent,
+                                            cb_bootable: $scope.reconfigureModel.cb_bootable,
                                             add_remove: 'add'});
       $scope.resetAddValues();
 
@@ -216,6 +220,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
           if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'remove') {
             $scope.reconfigureModel.vmdisks[disk]['add_remove'] = '';
             $scope.reconfigureModel.vmdisks[disk]['cb_deletebacking'] = false;
+            $scope.reconfigureModel.vmdisks[disk]['cb_bootable'] = false;
           } else if ($scope.reconfigureModel.vmdisks[disk]['add_remove'] === 'add') {
             var index = $scope.reconfigureModel.vmdisks.indexOf(vmDisk);
             $scope.reconfigureModel.vmdisks.splice(index, 1);

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1495,12 +1495,13 @@ module ApplicationController::CiProcessing
     @reconfigureitems.first.hardware.disks.each do |disk|
       next if disk.device_type != 'disk'
       dsize, dunit = reconfigure_calculations(disk.size / (1024 * 1024))
-      vmdisks << {:hdFilename => disk.filename,
-                  :hdType     => disk.disk_type,
-                  :hdMode     => disk.mode,
-                  :hdSize     => dsize,
-                  :hdUnit     => dunit,
-                  :add_remove => ''}
+      vmdisks << {:hdFilename  => disk.filename,
+                  :hdType      => disk.disk_type,
+                  :hdMode      => disk.mode,
+                  :hdSize      => dsize,
+                  :hdUnit      => dunit,
+                  :add_remove  => '',
+                  :cb_bootable => disk.bootable}
     end
 
     {:objectIds              => @reconfigure_items,
@@ -1556,6 +1557,7 @@ module ApplicationController::CiProcessing
                       :hdSize       => adsize.to_s,
                       :hdUnit       => adunit,
                       :cb_dependent => disk[:dependent],
+                      :cb_bootable  => disk[:bootable],
                       :add_remove   => 'add'}
         end
       end
@@ -1581,6 +1583,7 @@ module ApplicationController::CiProcessing
                       :hdSize         => dsize.to_s,
                       :hdUnit         => dunit.to_s,
                       :delete_backing => delbacking,
+                      :cb_bootable    => disk.bootable,
                       :add_remove     => removing}
         end
       end

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -275,7 +275,34 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
       rhevm_vm.cpu_topology = cpu_options if cpu_options.present?
     end
+
+    # Removing disks
+    remove_disks(spec["disksRemove"], vm) if spec["disksRemove"]
+
+    # Adding disks
+    add_disks(spec["disksAdd"], vm) if spec["disksAdd"]
+
     _log.info("#{log_header} Completed.")
+  end
+
+  def add_disks(add_disks_spec, vm)
+    ems_storage_uid = add_disks_spec["ems_storage_uid"]
+    with_disk_attachments_service(vm) do |service|
+      add_disks_spec["disks"].each { |disk_spec| service.add(prepare_disk(disk_spec, ems_storage_uid)) }
+    end
+  end
+
+  def prepare_disk(disk_spec, ems_storage_uid)
+    {
+      :bootable  => disk_spec["bootable"],
+      :interface => "VIRTIO",
+      :disk      => {
+        :provisioned_size => disk_spec["disk_size_in_mb"].to_i * 1024 * 1024,
+        :sparse           => disk_spec["thin_provisioned"],
+        :format           => disk_spec["format"],
+        :storage_domain   => {:id => ems_storage_uid}
+      }
+    }
   end
 
   # RHEVM requires that the memory of the VM will be bigger or equal to the reserved memory at any given time.
@@ -291,10 +318,29 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     end
   end
 
+  def remove_disks(disks, vm)
+    with_disk_attachments_service(vm) do |service|
+      disks.each { |disk_id| service.attachment_service(disk_id).remove }
+    end
+  end
+
+  # Adding disks is supported only by API version 4.0
+  def with_disk_attachments_service(vm)
+    connection = connect(:version => 4)
+    service = connection.system_service.vms_service.vm_service(vm.uid_ems).disk_attachments_service
+    yield service
+  ensure
+    connection.close
+  end
+
   # Calculates an "ems_ref" from the "href" attribute provided by the oVirt REST API, removing the
   # "/ovirt-engine/" prefix, as for historic reasons the "ems_ref" stored in the database does not
   # contain it, it only contains the "/api" prefix which was used by older versions of the engine.
   def self.make_ems_ref(href)
     href && href.sub(%r{^/ovirt-engine/}, '/')
+  end
+
+  def self.extract_ems_ref_id(href)
+    href && href.split("/").last
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -506,7 +506,8 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
           :size            => (device[:provisioned_size] || device[:size]).to_i,
           :size_on_disk    => device[:actual_size] ? device[:actual_size].to_i : 0,
           :disk_type       => device[:sparse] == true ? 'thin' : 'thick',
-          :mode            => 'persistent'
+          :mode            => 'persistent',
+          :bootable        => device[:bootable]
         }
 
         new_result[:storage] = storage_uids[storage_mor] unless storage_mor.nil?

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
@@ -27,7 +27,34 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
     {
       "numCoresPerSocket" => (task_options[:cores_per_socket].to_i if task_options[:cores_per_socket]),
       "memoryMB"          => (task_options[:vm_memory].to_i if task_options[:vm_memory]),
-      "numCPUs"           => (task_options[:number_of_cpus].to_i if task_options[:number_of_cpus])
+      "numCPUs"           => (task_options[:number_of_cpus].to_i if task_options[:number_of_cpus]),
+      "disksRemove"       => (spec_for_removed_disks(task_options[:disk_remove]) if task_options[:disk_remove]),
+      "disksAdd"          => (spec_for_added_disks(task_options[:disk_add]) if task_options[:disk_add])
     }
+  end
+
+  def spec_for_removed_disks(disks)
+    disks.map { |disk| disk["disk_name"] }
+  end
+
+  def spec_for_added_disks(disks)
+    disks.each { |disk_spec| disk_spec["format"] = disk_format_for(disk_spec["thin_provisioned"]) }
+    {
+      "disks"           => disks,
+      "ems_storage_uid" => ManageIQ::Providers::Redhat::InfraManager.extract_ems_ref_id(storage.ems_ref),
+    }
+  end
+
+  FILE_STORAGE_TYPE = %w(NFS GLUSTERFS VMFS).freeze
+  BLOCK_STORAGE_TYPE = %w(FCP ISCSI).freeze
+
+  def disk_format_for(thin_provisioned)
+    if FILE_STORAGE_TYPE.include?(storage.store_type)
+      "raw"
+    elsif BLOCK_STORAGE_TYPE.include?(storage.store_type)
+      thin_provisioned ? "cow" : "raw"
+    else
+      "raw"
+    end
   end
 end

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -105,7 +105,7 @@
                                 "auto-focus"     => ""}
             %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
               = _(" Total processors value larger than the maximum allowed")
-  - if @reconfigitems.length == 1 && @reconfigitems.first.vendor && @reconfigitems.first.vendor == 'vmware'
+  - if @reconfigitems.length == 1 && @reconfigitems.first.vendor  && (@reconfigitems.first.vendor == 'vmware' || @reconfigitems.first.vendor == 'redhat')
     %hr
     %div
       %h3
@@ -124,11 +124,12 @@
         %thead
           %th= _('Name')
           %th= _('Type')
-          %th= _('Mode')
+          %th{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Mode')
           %th= _('Size')
           %th.narrow
-          %th.narrow= _('Dependent')
-          %th.narrow= _('Delete Backing')
+          %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
+          %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Delete Backing')
+          %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}= _('Bootable')
           %th= _('Actions')
         %tbody
           %tr{"ng-if"       => "reconfigureModel.addEnabled",
@@ -143,7 +144,7 @@
                            "data-width"                  => "auto",
                            "required"                    => "",
                            "selectpicker-for-select-tag" => "")
-            %td
+            %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               = select_tag('hdMode',
                             options_for_select(%w(persistent nonpersistent)),
                             "ng-model"                    => "reconfigureModel.hdMode",
@@ -171,12 +172,18 @@
                        "data-width"                  => "auto",
                        "required"                    => "",
                        "selectpicker-for-select-tag" => "")
-            %td.narrow
+            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch" => "",
                      :data       => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"      => "checkbox",
                      "name"      => "cb_dependent",
                      "ng-model"  => "reconfigureModel.cb_dependent"}
+            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
+              %input{"bs-switch" => "",
+                     :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"          => "checkbox",
+                     "name"          => "cb_bootable",
+                     "ng-model"      => "reconfigureModel.cb_bootable"}
             %td.narrow
             %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()", "ng-disabled" => "rowForm.dvcSize.$invalid"}= _(' Add ')
@@ -185,13 +192,13 @@
               {{disk.hdFilename}}
             %td
               {{disk.hdType}}
-            %td
+            %td{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               {{disk.hdMode}}
             %td
               {{disk.hdSize}}
             %td.narrow
               {{disk.hdUnit}}
-            %td.narrow
+            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -200,7 +207,7 @@
                      "switch-active" => "{{disk.add_remove!='add'}}",
                      "ng-readonly"   => "disk.add_remove=='add'",
                      "ng-if"         => "disk.add_remove=='add'"}
-            %td.narrow
+            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
@@ -209,6 +216,14 @@
                      "ng-readonly"   => "disk.add_remove=='remove'",
                      "switch-active" => "{{disk.add_remove!='remove'}}",
                      "ng-if"         => "disk.add_remove!='add'"}
+            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
+              %input{"bs-switch"     => "",
+                     :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
+                     "type"          => "checkbox",
+                     "name"          => "cb_bootable",
+                     "ng-model"      => "disk.cb_bootable",
+                     "ng-readonly"   => true,
+                     "switch-active" => false}
             %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type      => "button",
                                             "ng-if"    => "disk.add_remove == ''",

--- a/db/migrate/20160719151049_add_bootable_to_disks.rb
+++ b/db/migrate/20160719151049_add_bootable_to_disks.rb
@@ -1,0 +1,5 @@
+class AddBootableToDisks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :disks, :bootable, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1041,6 +1041,7 @@ disks:
 - backing_id
 - backing_type
 - storage_profile_id
+- bootable
 drift_states:
 - id
 - timestamp

--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -11,6 +11,14 @@ FactoryGirl.define do
     store_type "NFS"
   end
 
+  factory :storage_block, :parent => :storage do
+    store_type "FCP"
+  end
+
+  factory :storage_unknown, :parent => :storage do
+    store_type "UNKNOWN"
+  end
+
   # Factories for perf_capture_timer and perf_capture_gap testing
   factory :storage_target_vmware, :parent => :storage_vmware do
     after(:create) do |x|

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
@@ -1,5 +1,6 @@
 describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
-  let(:vm) { FactoryGirl.create(:vm_redhat) }
+  let(:storage) { FactoryGirl.create(:storage_nfs, :ems_ref => "http://example.com/storages/XYZ") }
+  let(:vm) { FactoryGirl.create(:vm_redhat, :storage => storage) }
 
   it "#reconfigurable?" do
     expect(vm.reconfigurable?).to be_truthy
@@ -23,8 +24,20 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
 
   context "#build_config_spec" do
     before do
-      @options = {:vm_memory => '1024', :number_of_cpus => '8', :cores_per_socket => '2'}
-      @vm      = FactoryGirl.create(:vm_redhat, :hardware => FactoryGirl.create(:hardware))
+      @options = {:vm_memory        => '1024',
+                  :number_of_cpus   => '8',
+                  :cores_per_socket => '2',
+                  :disk_add         => [{  "disk_size_in_mb"  => "33",
+                                           "persistent"       => true,
+                                           "thin_provisioned" => true,
+                                           "dependent"        => true,
+                                           "bootable"         => false
+                                        }],
+                  :disk_remove      => [{  "disk_name"      => "2520b46a-799b-472d-89ce-d47f5b65ee5e",
+                                           "delete_backing" => false
+                                        }]
+      }
+      @vm = FactoryGirl.create(:vm_redhat, :hardware => FactoryGirl.create(:hardware), :storage => storage)
     end
     subject { @vm.build_config_spec(@options) }
 
@@ -38,6 +51,52 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
 
     it "numCoresPerSocket" do
       expect(subject["numCoresPerSocket"]).to eq(2)
+    end
+
+    it "disksAdd" do
+      disks = subject["disksAdd"]["disks"]
+      expect(disks.size).to eq(1)
+      disk_to_add = disks[0]
+      expect(disk_to_add["disk_size_in_mb"]).to eq("33")
+      expect(disk_to_add["thin_provisioned"]).to eq(true)
+      expect(disk_to_add["bootable"]).to eq(false)
+      expect(subject["disksAdd"]["ems_storage_uid"]).to eq("XYZ")
+    end
+
+    it "disksRemove" do
+      expect(subject["disksRemove"].size).to eq(1)
+      expect(subject["disksRemove"][0]).to eq("2520b46a-799b-472d-89ce-d47f5b65ee5e")
+    end
+  end
+
+  context "#disk_format_for" do
+    context "when storage type is file system" do
+      it "returns 'raw' format for FS storage type" do
+        expect(vm.disk_format_for(false)).to eq("raw")
+      end
+
+      it "returns 'raw' format for thin provisioned" do
+        expect(vm.disk_format_for(true)).to eq("raw")
+      end
+    end
+
+    context "when storage type is block" do
+      let(:storage) { FactoryGirl.create(:storage_block) }
+
+      it "returns 'cow' format for block storage type and thin provisioned" do
+        expect(vm.disk_format_for(true)).to eq("cow")
+      end
+
+      it "returns 'raw' format for block storage type and thick provisioned" do
+        expect(vm.disk_format_for(false)).to eq("raw")
+      end
+    end
+
+    context "when storage type is not file system and not blcok" do
+      let(:storage) { FactoryGirl.create(:storage_unknown) }
+      it "returns 'raw' format as default" do
+        expect(vm.disk_format_for(false)).to eq("raw")
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -72,4 +72,10 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       expect(described_class.make_ems_ref("/api/vms/123")).to eq("/api/vms/123")
     end
   end
+
+  context ".extract_ems_ref_id" do
+    it "extracts the resource ID from the href" do
+      expect(described_class.extract_ems_ref_id("/ovirt-engine/api/vms/123")).to eq("123")
+    end
+  end
 end


### PR DESCRIPTION
The patch adds support for RHEVM provider to add or remove disks
from a VM as part of the 'Reconfigure VM' dialog.

For RHEVM there are specific requirements such as 'bootable' option
which indicates the disk for the VM to boot from.

http://bugzilla.redhat.com/1093655

Screenshot of the 'Disks' section for RHEVM:
![selection_112](https://cloud.githubusercontent.com/assets/316242/17546476/f0ceb00e-5eea-11e6-8162-aae81cdd91cc.png)