### PR TITLE
action_email should use MiqAction instead of MiqSnmp on queue

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -310,7 +310,7 @@ class MiqAction < ApplicationRecord
       }
     end
 
-    invoke_or_queue(inputs[:synchronous], __method__, "notifier", nil, MiqSnmp, 'queue_email', [email_options])
+    invoke_or_queue(inputs[:synchronous], __method__, "notifier", nil, MiqAction, 'queue_email', [email_options])
   end
 
   def self.queue_email(options)
@@ -1002,7 +1002,7 @@ class MiqAction < ApplicationRecord
     log_suffix = nil
   )
     log_prefix = "MIQ(#{calling_method}):"
-    log_suffix ||= calling_method.titleize[7..-1] # remove 'Action '
+    log_suffix ||= calling_method.to_s.titleize[7..-1] # remove 'Action '
     static = target.instance_of?(Class) || target.instance_of?(Module)
 
     if synchronous

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -359,4 +359,24 @@ describe MiqAction do
       expect(a.round_to_nearest_4mb(17)).to eq 20
     end
   end
+
+  context 'validate action email should have correct type' do
+    it 'should generate a MiqAction invoking action_email' do
+      action = MiqAction.new
+      inputs = {
+        :policy      => nil,
+        :synchronous => false
+      }
+      q_options = {
+        :class_name  => "MiqAction",
+        :method_name => "queue_email",
+        :args        => [{:to => nil, :from => "cfadmin@cfserver.com"}],
+        :role        => "notifier",
+        :priority    => 20,
+        :zone        => nil
+      }
+      expect(MiqQueue).to receive(:put).with(q_options).once
+      action.action_email(action, nil, inputs)
+    end
+  end
 end


### PR DESCRIPTION
Using MiqSnmp on invoke_or_queue inside of action_email makes to not receive alerting emails.
I think this is a bug.
