### PR TITLE
Rbac: belongs to scope by ids

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -344,11 +344,10 @@ module Rbac
     # @return [Array<Array<Object>,Integer,Integer] targets, authorized count
     def scope_by_parent_ids(parent_class, scope, filtered_ids)
       if filtered_ids
-        reflection = scope.reflections[parent_class.name.underscore]
-        if reflection
-          scope.where("#{scope.table_name}.#{reflection.foreign_key} IN (?)", filtered_ids)
+        if (reflection = scope.reflections[parent_class.name.underscore])
+          scope.where(reflection.foreign_key.to_sym => filtered_ids)
         else
-          scope.where("#{scope.table_name}.resource_type = ? AND #{scope.table_name}.resource_id IN (?)", parent_class.name, filtered_ids)
+          scope.where(:resource_type => parent_class.name, :resource_id => filtered_ids)
         end
       else
         scope

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -355,7 +355,11 @@ module Rbac
     end
 
     def scope_by_ids(scope, filtered_ids)
-      filtered_ids ? scope.where("#{scope.table_name}.id IN (?)", filtered_ids) : scope
+      if filtered_ids
+        scope.where(:id => filtered_ids)
+      else
+        scope
+      end
     end
 
     def get_belongsto_filter_object_ids(klass, filter)


### PR DESCRIPTION
Part of the rbac scope initiative.
This one is working on the rbac belongs to filters.

Currently it is making many queries to lookup records.
This change allows the outer portion to access the ids by scope.

This way if `filtered_ids` is a scope, we can avoid querying the database multiple times.
