### PR TITLE
Support for gettext in ManageIQ plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "color",                          "~>1.8"
 gem "dalli",                          "~>2.7.4",       :require => false
 gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
-gem "fast_gettext",                   "~>1.1.0"
+gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     "~>0.3.0",       :require => false
 gem "fog-vcloud-director",            "~>0.1.3",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -132,4 +132,32 @@ namespace :locale do
 
     FileUtils.mv(attributes_file, 'config/model_attributes.rb')
   end
+
+  desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
+  task "plugin:find", :engine do |_, args|
+    @domain = args[:engine]
+    @engine = "#{@domain.camelize}::Engine".constantize
+    @engine_root = @engine.root
+
+    namespace :gettext do
+      def locale_path
+        @engine_root.join('locale').to_s
+      end
+
+      def files_to_translate
+        Dir.glob("#{@engine.root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
+      end
+
+      def text_domain
+        @domain
+      end
+    end
+
+    FastGettext.add_text_domain(@domain,
+                                :path           => @engine_root.join('locale').to_s,
+                                :type           => :po,
+                                :ignore_fuzzy   => true,
+                                :report_warning => false)
+    Rake::Task['gettext:find'].invoke
+  end
 end

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -1,3 +1,5 @@
+require 'vmdb/gettext/domains'
+
 module Vmdb
   module FastGettextHelper
     def self.register_human_localenames
@@ -52,16 +54,14 @@ module Vmdb
     end
 
     def self.register_locales
-      FastGettext.add_text_domain('manageiq',
-                                  :path           => locale_path,
-                                  :type           => :po,
-                                  :report_warning => false)
+      Vmdb::Gettext::Domains.add_domain(Vmdb::Gettext::Domains::TEXT_DOMAIN, locale_path, :po) # Default ManageIQ domain
+      Vmdb::Gettext::Domains.initialize_chain_repo
 
       FastGettext.default_available_locales = find_available_locales
 
       # temporary hack to fix a problem with locales including "_"
       fix_i18n_available_locales
-      FastGettext.default_text_domain = 'manageiq'
+      FastGettext.default_text_domain = Vmdb::Gettext::Domains::TEXT_DOMAIN
     end
   end
 end

--- a/lib/vmdb/gettext/domains.rb
+++ b/lib/vmdb/gettext/domains.rb
@@ -1,0 +1,29 @@
+require 'fast_gettext'
+
+module Vmdb
+  module Gettext
+    module Domains
+      TEXT_DOMAIN = 'manageiq'.freeze
+
+      def self.domains
+        @domains ||= []
+        @domains
+      end
+
+      def self.add_domain(name, path, type = :po)
+        domains << FastGettext::TranslationRepository.build(name, :path           => path,
+                                                                  :type           => type,
+                                                                  :report_warning => false)
+      end
+
+      def self.initialize_chain_repo
+        FastGettext.translation_repositories[TEXT_DOMAIN] =
+          FastGettext.add_text_domain(TEXT_DOMAIN, :type => :chain, :chain => @domains)
+      end
+
+      def self.reload
+        FastGettext.translation_repositories[TEXT_DOMAIN].reload
+      end
+    end
+  end
+end


### PR DESCRIPTION
What this pull request implements:
* A rake task `locale:plugin:find` to extract gettext strings from plugins. This task would extract gettext
strings from plugin's sources into its own `locale/` directory.
* Update gem `fast_gettex` to version 1.2.0, which supports chain & merge repositories
* Support for gettext in ManageIQ plugins / engines. ManageIQ plugins / engines would come with
their own gettext catalogs but will be running in the context of the main rails application. To make
the plugin catalogs work, we'll use `FastGettext` chain repo, which chains all catalogs (the rails
app + plugins) into one repo. This effectively leads to setup, where both the rails app and
the plugins would call standard gettext functions and their strings would be found / present.
Every ManageIQ plugin needs to do the following to hook itself into the chain repo:
```ruby    
    module MyAwesomePlugin
      class Engine < ::Rails::Engine
        isolate_namespace MyAwesomePlugin
    
        config.to_prepare do
          Vmdb::Gettext::Domains.add_domain('MyAwesomePlugin',
            MyAwesomePlugin::Engine.root.join('locale').to_s,
            :po)
        end
      end
    end
```