### PR TITLE
recent version of draper gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ unless dependencies.detect { |d| d.name == "manageiq-providers-amazon" }
 end
 
 # Unmodified gems
-gem "activemodel-serializers-xml",                     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",     "~>1.0.0"
 gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
@@ -18,6 +17,7 @@ gem "ansible_tower_client",           "~>0.3.2",       :require => false
 gem "aws-sdk",                        "~>2.2.19",      :require => false
 gem "color",                          "~>1.8"
 gem "dalli",                          "~>2.7.4",       :require => false
+gem "draper",                         "~>3.0.0.pre1"
 gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.1.0"
@@ -66,7 +66,6 @@ gem "websocket-driver",               "~>0.6.3"
 # Modified gems (forked on Github)
 gem "config",                         "~>1.1.0",                      :git => "git://github.com/ManageIQ/config.git", :branch => "overwrite_arrays"
 gem "deep_merge",                     "~>1.0.1",                      :git => "git://github.com/ManageIQ/deep_merge.git", :branch => "overwrite_arrays"
-gem "draper",                         "~>2.1.0",                      :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712
 gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "git://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
 gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"


### PR DESCRIPTION
draper 3.0 supports rails 5 - this changes to 3.0.0.pre1

pointing to a github repo (fork) not under our control puts us at risk.

testing:
Any pointers to screens that are using draper?
(so we can ensure this is still working)