### PR TITLE
Convert SmartProxy Affinity tree to use TreeBuilder

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -558,7 +558,7 @@ module OpsController::Settings::Common
     server_id, child = id.split('__')
 
     if server_id.include?('svr')
-      server_id.sub!('svr-','')
+      server_id.sub!('svr-', '')
       from_cid(server_id)
     else
       server_id.sub!('xx-', '')
@@ -606,7 +606,11 @@ module OpsController::Settings::Common
       }
     end
 
-    @smartproxy_affinity_tree  = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity, :smartproxy_affinity_tree, @sb, true, @selected_zone)
+    @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
+                                                                  :smartproxy_affinity_tree,
+                                                                  @sb,
+                                                                  true,
+                                                                  @selected_zone)
 
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -557,6 +557,12 @@ module OpsController::Settings::Common
     # Add/remove affinity based on the node that was checked
     server_id, child = id.split('__')
 
+    if server_id.include?('svr')
+      server_id.sub!('svr-','')
+      from_cid(server_id)
+    else
+      server_id.sub!('xx-', '')
+    end
     all_children = @edit[:new][:children]
     server = @edit[:new][:servers][server_id.to_i]
 

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -601,6 +601,7 @@ module OpsController::Settings::Common
     end
 
     @smartproxy_affinity_tree = build_smartproxy_affinity_tree(@selected_zone)
+    @smart  = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity, :smartproxy_affinity_tree, @sb, true, @selected_zone)
 
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -278,7 +278,7 @@ class TreeBuilder
     node = x_build_single_node(object, pid, options)
 
     # Process the node's children
-    node[:expand] = Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) || !!options[:open_all]
+    node[:expand] = Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) || !!options[:open_all] || node[:expand]
     if object[:load_children] ||
        node[:expand] ||
        @options[:lazy] == false

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -3,7 +3,7 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   has_kids_for MiqServer, [:x_get_server_kids]
 
   def initialize(name, type, sandbox, build = true, data)
-    @sb = sandbox
+    #@sb = sandbox
     @data = data
     super(name, type, sandbox, build)
   end

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -3,7 +3,6 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   has_kids_for MiqServer, [:x_get_server_kids]
 
   def initialize(name, type, sandbox, build = true, data)
-    #@sb = sandbox
     @data = data
     super(name, type, sandbox, build)
   end
@@ -21,7 +20,6 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
                   :onclick                     => false,
                   :three_checks                => true,
                   :oncheck                     => 'miqOnClickSmartProxyAffinityCheck',
-                  :enable_tree_images          => false,
                   :check_url                   => '/ops/smartproxy_affinity_field_changed/',
                   :open_close_all_on_dbl_click => true)
   end
@@ -36,12 +34,12 @@ class TreeBuilderSmartproxyAffinity < TreeBuilder
   end
 
   def x_get_server_kids(parent, count_only = false)
-    nodes = ['host','storage'].map  do |kid|
-    {:id       => "#{parent.id}__#{kid}",
-     :image    => kid,
-     :parent   => parent,
-     :text     => Dictionary.gettext(kid.camelcase, :type => :model, :notfound => :titleize, :plural => true),
-     :children => @data.send(kid.pluralize).sort_by(&:name)}
+    nodes = %w(host storage).map do |kid|
+      {:id       => "#{parent.id}__#{kid}",
+       :image    => kid,
+       :parent   => parent,
+       :text     => Dictionary.gettext(kid.camelcase, :type => :model, :notfound => :titleize, :plural => true),
+       :children => @data.send(kid.pluralize).sort_by(&:name)}
     end
     count_only_or_objects(count_only, nodes)
   end

--- a/app/presenters/tree_builder_smartproxy_affinity.rb
+++ b/app/presenters/tree_builder_smartproxy_affinity.rb
@@ -1,0 +1,60 @@
+class TreeBuilderSmartproxyAffinity < TreeBuilder
+  has_kids_for Hash, [:x_get_tree_hash_kids]
+  has_kids_for MiqServer, [:x_get_server_kids]
+
+  def initialize(name, type, sandbox, build = true, data)
+    @sb = sandbox
+    @data = data
+    super(name, type, sandbox, build)
+  end
+
+  private
+
+  def tree_init_options(_tree_name)
+    {:full_ids => false, :add_root => false, :lazy => false}
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:id_prefix                   => 'smartproxy_affinity_',
+                  :checkboxes                  => true,
+                  :onclick                     => false,
+                  :three_checks                => true,
+                  :oncheck                     => 'miqOnClickSmartProxyAffinityCheck',
+                  :enable_tree_images          => false,
+                  :check_url                   => '/ops/smartproxy_affinity_field_changed/',
+                  :open_close_all_on_dbl_click => true)
+  end
+
+  def root_options
+    []
+  end
+
+  def x_get_tree_roots(count_only = false, _options)
+    nodes = @data.miq_servers.select(&:is_a_proxy?).sort_by { |s| [s.name, s.id] }
+    count_only_or_objects(count_only, nodes)
+  end
+
+  def x_get_server_kids(parent, count_only = false)
+    nodes = ['host','storage'].map  do |kid|
+    {:id       => "#{parent.id}__#{kid}",
+     :image    => kid,
+     :parent   => parent,
+     :text     => Dictionary.gettext(kid.camelcase, :type => :model, :notfound => :titleize, :plural => true),
+     :children => @data.send(kid.pluralize).sort_by(&:name)}
+    end
+    count_only_or_objects(count_only, nodes)
+  end
+
+  def x_get_tree_hash_kids(parent, count_only = false)
+    affinities = parent[:parent].send("vm_scan_#{parent[:image]}_affinity").collect(&:id) if parent[:parent].present?
+    nodes = parent[:children].map do |kid|
+      {:id       => "#{parent[:id]}_#{kid.id}",
+       :image    => parent[:image],
+       :text     => kid.name,
+       :select   => affinities.include?(kid.id),
+       :children => []}
+    end
+    count_only_or_objects(count_only, nodes)
+  end
+end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -197,7 +197,7 @@ class TreeNodeBuilder
       :icon  => node_icon(image)
     }
     # Start with all nodes open unless expand is explicitly set to false
-    @node[:expand] = true if options[:open_all] && options[:expand] != false
+    @node[:expand] = options[:open_all].present? && options[:open_all] && options[:expand] != false
     tooltip(tip)
   end
 

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -354,6 +354,8 @@ class TreeNodeBuilder
       text = tip
     end
     generic_node(text, 'miq_server.png', tip)
+    @node[:expand] = true
+    @node
   end
 
   def miq_action_node

--- a/app/views/ops/_smartproxy_affinity.html.haml
+++ b/app/views/ops/_smartproxy_affinity.html.haml
@@ -6,9 +6,9 @@
     %strong
       = _("No Servers with the SmartProxy role are in Zone: \"%{zone_description}\"") % {:zone_description => @selected_zone.description}
 - else
-  - tree_id = "smartproxy_affinity_treebox"
-  %div{:id => tree_id}
-  = render(:partial => "layouts/dynatree",
+  -#- tree_id = "smartproxy_affinity_treebox"
+  -#%div{:id => tree_id}
+  -#= render(:partial => "layouts/dynatree",
     :locals => {:tree_id         => tree_id,
     :tree_name                   => session[:tree_name],
     :json_tree                   => @smartproxy_affinity_tree.to_json,
@@ -17,3 +17,4 @@
     :open_close_all_on_dbl_click => true,
     :check_url                   => '/ops/smartproxy_affinity_field_changed/',
     :oncheck                     => 'miqOnClickSmartProxyAffinityCheck'})
+  = render(:partial => 'shared/tree', :locals => {:tree => @smart, :name => @smart.name})

--- a/app/views/ops/_smartproxy_affinity.html.haml
+++ b/app/views/ops/_smartproxy_affinity.html.haml
@@ -6,4 +6,6 @@
     %strong
       = _("No Servers with the SmartProxy role are in Zone: \"%{zone_description}\"") % {:zone_description => @selected_zone.description}
 - else
-  = render(:partial => 'shared/tree', :locals => {:tree => @smart, :name => @smart.name})
+  :javascript
+    miqDynatreeResetState('#{j_str @smartproxy_affinity_tree.name}');
+  = render(:partial => 'shared/tree', :locals => {:tree => @smartproxy_affinity_tree, :name => @smartproxy_affinity_tree.name})

--- a/app/views/ops/_smartproxy_affinity.html.haml
+++ b/app/views/ops/_smartproxy_affinity.html.haml
@@ -6,15 +6,4 @@
     %strong
       = _("No Servers with the SmartProxy role are in Zone: \"%{zone_description}\"") % {:zone_description => @selected_zone.description}
 - else
-  -#- tree_id = "smartproxy_affinity_treebox"
-  -#%div{:id => tree_id}
-  -#= render(:partial => "layouts/dynatree",
-    :locals => {:tree_id         => tree_id,
-    :tree_name                   => session[:tree_name],
-    :json_tree                   => @smartproxy_affinity_tree.to_json,
-    :checkboxes                  => true,
-    :three_checks                => true,
-    :open_close_all_on_dbl_click => true,
-    :check_url                   => '/ops/smartproxy_affinity_field_changed/',
-    :oncheck                     => 'miqOnClickSmartProxyAffinityCheck'})
   = render(:partial => 'shared/tree', :locals => {:tree => @smart, :name => @smart.name})

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -20,7 +20,7 @@ describe OpsController do
         @svr1.vm_scan_storage_affinity = [@storage1]
         @svr2.vm_scan_storage_affinity = [@storage2]
         allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
-        allow(MiqServer).to receive(:my_server).with(true).and_return(OpenStruct.new({'id' => 0, :name => 'name'}))
+        allow(MiqServer).to receive(:my_server).with(true).and_return(OpenStruct.new('id' => 0, :name => 'name'))
 
         tree_hash = {
           :trees       => {

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -20,6 +20,7 @@ describe OpsController do
         @svr1.vm_scan_storage_affinity = [@storage1]
         @svr2.vm_scan_storage_affinity = [@storage2]
         allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
+        allow(MiqServer).to receive(:my_server).with(true).and_return(OpenStruct.new({'id' => 0, :name => 'name'}))
 
         tree_hash = {
           :trees       => {
@@ -40,168 +41,68 @@ describe OpsController do
         @edit = session[:edit]
       end
 
-      context "#build_smartproxy_affinity_tree" do
-        it "should build a SmartProxy Affinity tree" do
-          tree = controller.send(:build_smartproxy_affinity_tree, @zone)
-          expect(tree).to eq([
-            {
-              :key      => @svr1.id.to_s,
-              :icon     => ActionController::Base.helpers.image_path('100/evm_server.png'),
-              :title    => "Server: #{@svr1.name} [#{@svr1.id}]",
-              :expand   => true,
-              :children => [
-                {
-                  :key      => "#{@svr1.id}__host",
-                  :icon     => ActionController::Base.helpers.image_path('100/host.png'),
-                  :title    => "Host / Nodes",
-                  :children => [
-                    {
-                      :key    => "#{@svr1.id}__host_#{@host1.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/host.png'),
-                      :title  => @host1.name,
-                      :select => true
-                    },
-                    {
-                      :key    => "#{@svr1.id}__host_#{@host2.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/host.png'),
-                      :title  => @host2.name,
-                      :select => false
-                    }
-                  ]
-                },
-                {
-                  :key      => "#{@svr1.id}__storage",
-                  :icon     => ActionController::Base.helpers.image_path('100/storage.png'),
-                  :title    => "Datastores",
-                  :children => [
-                    {
-                      :key    => "#{@svr1.id}__storage_#{@storage1.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/storage.png'),
-                      :title  => @storage1.name,
-                      :select => true
-                    },
-                    {
-                      :key    => "#{@svr1.id}__storage_#{@storage2.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/storage.png'),
-                      :title  => @storage2.name,
-                      :select => false
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              :key      => @svr2.id.to_s,
-              :icon     => ActionController::Base.helpers.image_path('100/evm_server.png'),
-              :title    => "Server: #{@svr2.name} [#{@svr2.id}]",
-              :expand   => true,
-              :children => [
-                {
-                  :key      => "#{@svr2.id}__host",
-                  :icon     => ActionController::Base.helpers.image_path('100/host.png'),
-                  :title    => "Host / Nodes",
-                  :children => [
-                    {
-                      :key    => "#{@svr2.id}__host_#{@host1.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/host.png'),
-                      :title  => @host1.name,
-                      :select => false
-                    },
-                    {
-                      :key    => "#{@svr2.id}__host_#{@host2.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/host.png'),
-                      :title  => @host2.name,
-                      :select => true
-                    }
-                  ]
-                },
-                {
-                  :key      => "#{@svr2.id}__storage",
-                  :icon     => ActionController::Base.helpers.image_path('100/storage.png'),
-                  :title    => "Datastores",
-                  :children => [
-                    {
-                      :key    => "#{@svr2.id}__storage_#{@storage1.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/storage.png'),
-                      :title  => @storage1.name,
-                      :select => false
-                    },
-                    {
-                      :key    => "#{@svr2.id}__storage_#{@storage2.id}",
-                      :icon   => ActionController::Base.helpers.image_path('100/storage.png'),
-                      :title  => @storage2.name,
-                      :select => true
-                    }
-                  ]
-                }
-              ]
-            }
-          ])
-        end
-      end
-
       context "#smartproxy_affinity_field_changed" do
         before do
           expect(controller).to receive(:render)
         end
 
         it "should select a host when checked" do
-          controller.params = {:id => "#{@svr1.id}__host_#{@host2.id}", :check => '1'}
+          controller.params = {:id => "xx-#{@svr1.id}__host_#{@host2.id}", :check => '1'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:hosts].to_a).to include(@host2.id)
         end
 
         it "should deselect a host when unchecked" do
-          controller.params = {:id => "#{@svr1.id}__host_#{@host1.id}", :check => '0'}
+          controller.params = {:id => "xx-#{@svr1.id}__host_#{@host1.id}", :check => '0'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:hosts].to_a).not_to include(@host1.id)
         end
 
         it "should select a datastore when checked" do
-          controller.params = {:id => "#{@svr1.id}__storage_#{@storage2.id}", :check => '1'}
+          controller.params = {:id => "xx-#{@svr1.id}__storage_#{@storage2.id}", :check => '1'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:storages].to_a).to include(@storage2.id)
         end
 
         it "should deselect a datastore when unchecked" do
-          controller.params = {:id => "#{@svr1.id}__storage_#{@storage1.id}", :check => '0'}
+          controller.params = {:id => "xx-#{@svr1.id}__storage_#{@storage1.id}", :check => '0'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:storages].to_a).not_to include(@storage1.id)
         end
 
         it "should select all child hosts when checked" do
-          controller.params = {:id => "#{@svr1.id}__host", :check => '1'}
+          controller.params = {:id => "xx-#{@svr1.id}__host", :check => '1'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:hosts].to_a.sort).to eq([@host1.id, @host2.id])
         end
 
         it "should deselect all child hosts when unchecked" do
-          controller.params = {:id => "#{@svr1.id}__host", :check => '0'}
+          controller.params = {:id => "xx-#{@svr1.id}__host", :check => '0'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:hosts].to_a).to eq([])
         end
 
         it "should select all child datastores when checked" do
-          controller.params = {:id => "#{@svr1.id}__storage", :check => '1'}
+          controller.params = {:id => "xx-#{@svr1.id}__storage", :check => '1'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:storages].to_a.sort).to eq([@storage1.id, @storage2.id])
         end
 
         it "should deselect all child datastores when unchecked" do
-          controller.params = {:id => "#{@svr1.id}__storage", :check => '0'}
+          controller.params = {:id => "xx-#{@svr1.id}__storage", :check => '0'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:storages].to_a).to eq([])
         end
 
         it "should select all child hosts and datastores when checked" do
-          controller.params = {:id => "#{@svr1.id}", :check => '1'}
+          controller.params = {:id => "svr-#{@svr1.id}", :check => '1'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:hosts].to_a.sort).to eq([@host1.id, @host2.id])
           expect(@edit[:new][:servers][@svr1.id][:storages].to_a.sort).to eq([@storage1.id, @storage2.id])
         end
 
         it "should deselect all child hosts and datastores when checked" do
-          controller.params = {:id => "#{@svr1.id}", :check => '0'}
+          controller.params = {:id => "svr-#{@svr1.id}", :check => '0'}
           controller.smartproxy_affinity_field_changed
           expect(@edit[:new][:servers][@svr1.id][:hosts].to_a).to eq([])
           expect(@edit[:new][:servers][@svr1.id][:storages].to_a).to eq([])

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -1,0 +1,13 @@
+describe TreeBuilderSmartproxyAffinity do
+  context 'TreeBuilderSmartproxyAffinity' do
+    before do
+      role = MiqUserRole.find_by_name("EvmRole-operator")
+      @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "SmartProxy Affinity Group")
+      login_as FactoryGirl.create(:user, :userid => 'smartproxy_affinity_wilma', :miq_groups => [@group])
+      
+    end
+    it 'TODO' do
+      expect(true).to eq(true)
+    end
+  end
+end

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -4,7 +4,8 @@ describe TreeBuilderSmartproxyAffinity do
       role = MiqUserRole.find_by_name("EvmRole-operator")
       @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "SmartProxy Affinity Group")
       login_as FactoryGirl.create(:user, :userid => 'smartproxy_affinity_wilma', :miq_groups => [@group])
-      
+
+      @smartproxy_affinity_tree  = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity, :smartproxy_affinity_tree, {}, true, @selected_zone)
     end
     it 'TODO' do
       expect(true).to eq(true)

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -5,10 +5,94 @@ describe TreeBuilderSmartproxyAffinity do
       @group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "SmartProxy Affinity Group")
       login_as FactoryGirl.create(:user, :userid => 'smartproxy_affinity_wilma', :miq_groups => [@group])
 
-      @smartproxy_affinity_tree  = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity, :smartproxy_affinity_tree, {}, true, @selected_zone)
+      @selected_zone = FactoryGirl.create(:zone, :name => 'zone1')
+
+      @storage1 = FactoryGirl.create(:storage)
+      @storage2 = FactoryGirl.create(:storage)
+
+      @host1 = FactoryGirl.create(:host, :name => 'host1', :storages => [@storage1])
+      @host2 = FactoryGirl.create(:host, :name => 'host2', :storages => [@storage2])
+
+      @ems = FactoryGirl.create(:ext_management_system, :hosts => [@host1, @host2], :zone => @selected_zone)
+
+      @svr1 = FactoryGirl.create(:miq_server, :name => 'svr1', :zone => @selected_zone)
+      @svr2 = FactoryGirl.create(:miq_server, :name => 'svr2', :zone => @selected_zone)
+
+      @svr1.vm_scan_host_affinity = [@host1]
+      @svr2.vm_scan_host_affinity = [@host2]
+      @svr1.vm_scan_storage_affinity = [@storage1]
+      @svr2.vm_scan_storage_affinity = [@storage2]
+
+      allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
+      allow(MiqServer).to receive(:my_server).with(true).and_return(OpenStruct.new('id' => 0, :name => 'name'))
+
+      @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
+                                                                    :smartproxy_affinity_tree,
+                                                                    {},
+                                                                    true,
+                                                                    @selected_zone)
     end
-    it 'TODO' do
-      expect(true).to eq(true)
+
+    it 'set init options correctly' do
+      tree_options = @smartproxy_affinity_tree.send(:tree_init_options, :smartproxy_affinity)
+      expect(tree_options).to eq(:full_ids => false, :add_root => false, :lazy => false)
+    end
+    it 'set locals for render correctly' do
+      locals = @smartproxy_affinity_tree.send(:set_locals_for_render)
+      expect(locals[:id_prefix]).to eq('smartproxy_affinity_')
+      expect(locals[:checkboxes]).to eq(true)
+      expect(locals[:check_url]).to eq('/ops/smartproxy_affinity_field_changed/')
+      expect(locals[:onclick]).to eq(false)
+      expect(locals[:oncheck]).to eq('miqOnClickSmartProxyAffinityCheck')
+      expect(locals[:three_checks]).to eq(true)
+    end
+    it 'sets roots correctly' do
+      roots = @smartproxy_affinity_tree.send(:x_get_tree_roots, false)
+      expect(roots).to eq([@svr1, @svr2])
+    end
+    it 'sets MiqServer kids correctly' do
+      kids1 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr1, false)
+      kids2 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr2, false)
+      expect(kids1.size).to eq(2)
+      expect(kids2.size).to eq(2)
+      expect(kids1.first).to eq(:id       => "#{@svr1[:id]}__host",
+                                :image    => "host",
+                                :parent   => @svr1,
+                                :text     => "Host / Nodes",
+                                :children => @selected_zone.send('host'.pluralize).sort_by(&:name))
+      expect(kids2.first).to eq(:id       => "#{@svr2[:id]}__host",
+                                :image    => "host",
+                                :parent   => @svr2,
+                                :text     => "Host / Nodes",
+                                :children => @selected_zone.send('host'.pluralize).sort_by(&:name))
+      expect(kids1.last).to eq(:id       => "#{@svr1[:id]}__storage",
+                               :image    => "storage",
+                               :parent   => @svr1,
+                               :text     => "Datastores",
+                               :children => @selected_zone.send('storage'.pluralize).sort_by(&:name))
+      expect(kids2.last).to eq(:id       => "#{@svr2[:id]}__storage",
+                               :image    => "storage",
+                               :parent   => @svr2,
+                               :text     => "Datastores",
+                               :children => @selected_zone.send('storage'.pluralize).sort_by(&:name))
+    end
+
+    it 'sets Datastores kids correctly' do
+      parent1 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr1, false).first
+      parent2 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr2, false).first
+      parent3 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr1, false).last
+      parent4 = @smartproxy_affinity_tree.send(:x_get_server_kids, @svr2, false).last
+      parents = [parent1, parent2, parent3, parent4]
+      parents.each do |parent|
+        kids = @smartproxy_affinity_tree.send(:x_get_tree_hash_kids, parent, false)
+        parent[:children].each_with_index do |kid, i|
+          expect(kids[i][:image]).to eq(parent[:image])
+          expect(kids[i][:text]).to eq(kid.name)
+          expect(kids[i][:id]).to eq("#{parent[:id]}_#{kid.id}")
+          expect(kids[i][:children]).to eq([])
+          expect(kids[i][:select]).to eq( parent[:parent].send("vm_scan_#{parent[:image]}_affinity").collect(&:id).include?(kid.id))
+        end
+      end
     end
   end
 end

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -354,10 +354,10 @@ describe TreeNodeBuilder do
       expect(node[:expand]).to eq(true)
     end
 
-    it "expand attribute of node should be set to nil when open_all is true and expand is set to false in options" do
+    it "expand attribute of node should be set to false when open_all is true and expand is set to false in options" do
       tenant = FactoryGirl.build(:tenant)
       node = TreeNodeBuilder.build(tenant, "root", {:expand => false, :open_all => true})
-      expect(node[:expand]).to eq(nil)
+      expect(node[:expand]).to eq(false)
     end
 
     it "expand attribute of node should be set to true when open_all and expand are true in options" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Covert SmartProxy Affinity tree to use TreeBuilder.

Configuration -> Settings -> Pick a zone -> SmartProxy Affinity

Before/After: Should be same

@miq-bot add_label wip, ui, technical debt
