### PR TITLE
Added a separate disabled Reset Button

### DIFF
--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -33,10 +33,16 @@
                :class        => "btn btn-default btn-disabled",
                :alt          => _("Reset changes"),
                :title        => _("Reset changes"),
-               "ng-class"    => "{'btn-disabled': angularForm.$pristine}",
+               "ng-click"    => "disabledClick($event)",
+               :style        => "cursor:not-allowed",
+               "ng-show"     => "!newRecord && angularForm.$pristine")
+
+  = button_tag(_("Reset"),
+               :class        => "btn btn-default",
+               :alt          => _("Reset changes"),
+               :title        => _("Reset changes"),
                "ng-click"    => "resetClicked()",
-               "ng-disabled" => "angularForm.$pristine",
-               "ng-hide"     => "newRecord")
+               "ng-show"     => "!newRecord && !angularForm.$pristine")
 
   = button_tag(_("Cancel"),
                :class => "btn btn-default",


### PR DESCRIPTION
having ng-disabled in controllers with restful routes was causing reset button to send up a server transaction.

https://bugzilla.redhat.com/show_bug.cgi?id=1362167
https://bugzilla.redhat.com/show_bug.cgi?id=1362227

Steps to recreate:
Go to Infra/Cloud provider edit screen, make changes press "Reset" button

@himdel please review.
