### PR TITLE
When opening a RHEVM provider for editing, the saved blank default_api_port is set to 5000 

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -74,12 +74,12 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         $scope.emsCommonModel.zone                            = data.zone;
         $scope.emsCommonModel.emstype_vm                      = data.emstype_vm;
         $scope.emsCommonModel.openstack_infra_providers_exist = data.openstack_infra_providers_exist;
-        $scope.emsCommonModel.default_api_port                = '5000';
+        $scope.emsCommonModel.default_api_port                = '';
         $scope.emsCommonModel.amqp_api_port                   = '5672';
         $scope.emsCommonModel.hawkular_api_port               = '443';
         $scope.emsCommonModel.api_version                     = 'v2';
         $scope.emsCommonModel.ems_controller                  = data.ems_controller;
-        $scope.emsCommonModel.ems_controller == 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '5000';
+        $scope.emsCommonModel.ems_controller == 'ems_container' ? $scope.emsCommonModel.default_api_port = '8443' : $scope.emsCommonModel.default_api_port = '';
         $scope.emsCommonModel.default_auth_status             = data.default_auth_status;
         $scope.emsCommonModel.amqp_auth_status                = data.amqp_auth_status;
         $scope.emsCommonModel.service_account_auth_status     = data.service_account_auth_status;
@@ -110,7 +110,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
         $scope.emsCommonModel.provider_id                     = angular.isDefined(data.provider_id) ? data.provider_id.toString() : "";
 
-        $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port != '' ? data.default_api_port.toString() : '5000';
+        $scope.emsCommonModel.default_api_port                = angular.isDefined(data.default_api_port) && data.default_api_port != '' ? data.default_api_port.toString() : $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
         $scope.emsCommonModel.amqp_api_port                   = angular.isDefined(data.amqp_api_port) && data.amqp_api_port != '' ? data.amqp_api_port.toString() : '5672';
         $scope.emsCommonModel.hawkular_api_port               = angular.isDefined(data.hawkular_api_port) && data.hawkular_api_port != '' ? data.hawkular_api_port.toString() : '443';
         $scope.emsCommonModel.metrics_api_port                = angular.isDefined(data.metrics_api_port) && data.metrics_api_port != '' ? data.metrics_api_port.toString() : '';
@@ -178,11 +178,11 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
   $scope.changeAuthTab = function(id) {
     $scope.currentTab = id;
-  }
+  };
 
   $scope.canValidateBasicInfo = function () {
     return $scope.isBasicInfoValid()
-  }
+  };
 
   $scope.isBasicInfoValid = function() {
     if(($scope.currentTab == "default" && $scope.emsCommonModel.emstype != "azure") &&
@@ -304,13 +304,14 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.emsCommonModel.default_security_protocol = "";
     $scope.note = "";
     if ($scope.emsCommonModel.emstype === 'openstack' || $scope.emsCommonModel.emstype === 'openstack_infra') {
-      $scope.emsCommonModel.default_api_port = "5000";
+      $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.event_stream_selection = "ceilometer";
       $scope.emsCommonModel.amqp_security_protocol = 'non-ssl';
     } else if ($scope.emsCommonModel.emstype === 'scvmm' && $scope.emsCommonModel.default_security_protocol === 'kerberos') {
       $scope.note = $scope.realmNote;
     } else if ($scope.emsCommonModel.emstype === 'rhevm') {
       $scope.emsCommonModel.metrics_api_port = "5432";
+      $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       $scope.emsCommonModel.metrics_database_name = "ovirt_engine_history";
     } else if ($scope.emsCommonModel.ems_controller === 'ems_container') {
       $scope.emsCommonModel.default_api_port = "8443";
@@ -322,7 +323,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   $scope.openstackSecurityProtocolChanged = function() {
     if ($scope.emsCommonModel.emstype === 'openstack' || $scope.emsCommonModel.emstype === 'openstack_infra') {
       if ($scope.emsCommonModel.default_security_protocol === 'non-ssl') {
-        $scope.emsCommonModel.default_api_port = "5000";
+        $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);
       } else {
         $scope.emsCommonModel.default_api_port = "13000";
       }
@@ -333,6 +334,15 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.note = "";
     if ($scope.emsCommonModel.emstype === 'scvmm' && $scope.emsCommonModel.default_security_protocol === 'kerberos') {
       $scope.note = $scope.realmNote;
+    }
+  };
+
+  $scope.getDefaultApiPort = function(emstype) {
+    if( emstype=='openstack' || emstype === 'openstack_infra') {
+      return '5000';
+    }
+    else {
+      return '';
     }
   };
 

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -18,7 +18,7 @@ describe('emsCommonFormController', function() {
       zone: 'default',
       emstype_vm: false,
       openstack_infra_providers_exist: false,
-      api_port: '5000',
+      api_port: '',
       api_version: 'v2'
     };
     $httpBackend = _$httpBackend_;
@@ -63,8 +63,8 @@ describe('emsCommonFormController', function() {
       expect($scope.emsCommonModel.openstack_infra_providers_exist).toEqual(false);
     });
 
-    it('sets the default_api_port to 5000', function() {
-      expect($scope.emsCommonModel.default_api_port).toEqual('5000');
+    it('sets the default_api_port to blank', function() {
+      expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
 
     it('sets the amqp_api_port to 5672', function() {
@@ -402,7 +402,7 @@ describe('emsCommonFormController in the context of ems infra provider', functio
       zone: 'default',
       emstype_vm: false,
       openstack_infra_providers_exist: false,
-      default_api_port: '5000',
+      default_api_port: '',
       api_version: 'v2'
     };
     $httpBackend = _$httpBackend_;
@@ -442,8 +442,8 @@ describe('emsCommonFormController in the context of ems infra provider', functio
       expect($scope.emsCommonModel.zone).toEqual('default');
     });
 
-    it('sets the api_port to 5000', function () {
-      expect($scope.emsCommonModel.default_api_port).toEqual('5000');
+    it('sets the api_port to blank', function () {
+      expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
 
     it('sets the api_version to v2', function () {
@@ -585,6 +585,63 @@ describe('emsCommonFormController in the context of ems infra provider', functio
 
     it('sets the ssh_keypair_password', function () {
       expect($scope.emsCommonModel.ssh_keypair_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+  });
+
+  describe('when the emsCommonFormId is a RHEV Id', function () {
+    var emsCommonFormResponse = {
+      id: 12345,
+      name: 'myRhevm',
+      hostname: '10.22.33.44',
+      emstype: 'rhevm',
+      zone: 'default',
+      api_port: '',
+      default_userid: "default_user",
+    };
+
+    beforeEach(inject(function (_$controller_) {
+      $httpBackend.whenGET('/ems_infra/ems_infra_form_fields/12345').respond(emsCommonFormResponse);
+
+      $controller = _$controller_('emsCommonFormController',
+        {
+          $scope: $scope,
+          $attrs: {
+            'formFieldsUrl': '/ems_infra/ems_infra_form_fields/',
+            'createUrl': '/ems_infra',
+            'updateUrl': '/ems_infra/update/'
+          },
+          emsCommonFormId: 12345,
+          miqService: miqService
+        });
+      $httpBackend.flush();
+    }));
+
+    it('sets the name to the RHEVM Provider', function () {
+      expect($scope.emsCommonModel.name).toEqual('myRhevm');
+    });
+
+    it('sets the type to openstack', function () {
+      expect($scope.emsCommonModel.emstype).toEqual('rhevm');
+    });
+
+    it('sets the hostname', function () {
+      expect($scope.emsCommonModel.hostname).toEqual('10.22.33.44');
+    });
+
+    it('sets the zone to default', function () {
+      expect($scope.emsCommonModel.zone).toEqual('default');
+    });
+
+    it('sets the default_userid', function () {
+      expect($scope.emsCommonModel.default_userid).toEqual("default_user");
+    });
+
+    it('sets the default_password', function () {
+      expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+
+    it('sets the default api port', function () {
+      expect($scope.emsCommonModel.default_api_port).toEqual('');
     });
   });
 });


### PR DESCRIPTION
Purpose or Intent
-----------------
When opening an existing RHEVM provider for editing, a default_api_port saved as blank( default for RHEVM), is set to 5000 ( default for openstack)

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1361258


Steps for Testing/QA
--------------------
Add a RHEVM provider, leave the default_api_port blank, save, then edit - the default_api_port should be blank