### PR TITLE
Toolbar buttons for VMs moved to separate class (part 4)

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -92,7 +92,9 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Delete this Instance'),
             N_('Delete'),
             :image   => "power_off",
-            :confirm => N_("Delete this Instance?")),
+            :confirm => N_("Delete this Instance?"),
+            :klass   => ApplicationHelper::Button::GenericFeatureButton,
+            :options => {:feature => :terminate}),
         ]
       ),
       included_class.button(

--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -77,7 +77,9 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
             N_('Soft Reboot this Instance'),
             N_('Soft Reboot'),
             :image   => "power_reset",
-            :confirm => N_("Soft Reboot this Instance?")),
+            :confirm => N_("Soft Reboot this Instance?"),
+            :klass   => ApplicationHelper::Button::GenericFeatureButton,
+            :options => {:feature => :reboot_guest}),
           included_class.button(
             :instance_reset,
             nil,

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -178,7 +178,9 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Restart the Guest OS on this VM'),
           N_('Restart Guest'),
           :image   => "guest_restart",
-          :confirm => N_("Restart the Guest OS on this VM?")),
+          :confirm => N_("Restart the Guest OS on this VM?"),
+          :klass   => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+          :options => {:feature => :reboot_guest}),
         separator,
         button(
           :vm_start,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -834,8 +834,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:reboot_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
-      when "instance_terminate"
-        return true unless @record.is_available?(:terminate)
       when "vm_policy_sim", "vm_protect"
         return true if @record.host && @record.host.vmm_product.to_s.downcase == "workstation"
       when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -830,7 +830,7 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:standby_guest)
       when "vm_guest_shutdown", "instance_guest_shutdown"
         return true unless @record.is_available?(:shutdown_guest)
-      when "vm_guest_restart", "instance_guest_restart"
+      when "vm_guest_restart"
         return true unless @record.is_available?(:reboot_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -830,8 +830,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:standby_guest)
       when "vm_guest_shutdown", "instance_guest_shutdown"
         return true unless @record.is_available?(:shutdown_guest)
-      when "vm_guest_restart"
-        return true unless @record.is_available?(:reboot_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
       when "vm_policy_sim", "vm_protect"
@@ -1258,8 +1256,6 @@ class ApplicationHelper::ToolbarBuilder
         return @record.is_available_now_error_message(:standby_guest) if @record.is_available_now_error_message(:standby_guest)
       when "vm_guest_shutdown"
         return @record.is_available_now_error_message(:shutdown_guest) if @record.is_available_now_error_message(:shutdown_guest)
-      when "vm_guest_restart"
-        return @record.is_available_now_error_message(:reboot_guest) if @record.is_available_now_error_message(:reboot_guest)
       when "instance_retire", "instance_retire_now"
         return N_("Instance is already retired") if @record.retired
       when "vm_timeline"

--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::GenericFeatureButton do
   describe '#skip?' do
     describe 'the button for the instance' do
       [:pause, :shelve, :shelve_offload, :start, :stop,
-       :suspend, :timeline].each do |feature|
+       :suspend, :timeline, :terminate].each do |feature|
         context "that supports feature #{feature}" do
           before do
             @record = FactoryGirl.create(:vm_openstack)

--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -2,7 +2,7 @@ describe ApplicationHelper::Button::GenericFeatureButton do
   describe '#skip?' do
     describe 'the button for the instance' do
       [:pause, :shelve, :shelve_offload, :start, :stop,
-       :suspend, :timeline, :terminate].each do |feature|
+       :suspend, :timeline, :terminate, :reboot_guest].each do |feature|
         context "that supports feature #{feature}" do
           before do
             @record = FactoryGirl.create(:vm_openstack)

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
-  [:start, :stop, :suspend, :reset].each do |feature|
+  [:start, :stop, :suspend, :reset, :reboot_guest].each do |feature|
     describe '#skip?' do
       context "when vm supports feature #{feature}" do
         before do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -367,7 +367,6 @@ describe ApplicationHelper do
      "vm_check_compliance",
      "vm_guest_shutdown",
      "vm_guest_standby",
-     "vm_guest_restart",
      "vm_policy_sim",
      "vm_protect",
      "vm_start",
@@ -1229,22 +1228,6 @@ describe ApplicationHelper do
         end
 
         it "and @record.is_available?(:shutdown_guest)" do
-          expect(subject).to be_falsey
-        end
-      end
-
-      context "and id = vm_guest_restart" do
-        before do
-          @id = "vm_guest_restart"
-          allow(@record).to receive(:is_available?).with(:reboot_guest).and_return(true)
-        end
-
-        it "and !@record.is_available?(:reboot_guest)" do
-          allow(@record).to receive(:is_available?).with(:reboot_guest).and_return(false)
-          expect(subject).to be_truthy
-        end
-
-        it "and @record.is_available?(:reboot_guest)" do
           expect(subject).to be_falsey
         end
       end
@@ -2198,15 +2181,6 @@ describe ApplicationHelper do
           allow(@record).to receive(:is_available_now_error_message).and_return(false)
         end
         it_behaves_like 'record with error message', 'shutdown_guest'
-        it_behaves_like 'default case'
-      end
-
-      context "and id = vm_guest_restart" do
-        before do
-          @id = "vm_guest_restart"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'reboot_guest'
         it_behaves_like 'default case'
       end
 


### PR DESCRIPTION
# Continuation of #10218

Purpose or Intent
-----------------

Purpose is to move toolbar buttons from helper (`app/helpers/application_helper/toolbar_builder.rb`) to separate classes.

*In this PR is converted just a fourth part of buttons for VMs. I'll continue with other buttons in another PR.*

Links
-----
Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/126786879