### PR TITLE
Serialize the blueprint's bundle if requested

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -2,6 +2,8 @@ class Blueprint < ApplicationRecord
   has_many :service_templates
   private  :service_templates, :service_templates=
 
+  virtual_has_one :bundle
+
   # the top of the service_templates, a bundle that contains child items
   def bundle
     service_templates.find { |st| st.parent_services.blank? }


### PR DESCRIPTION
Purpose or Intent
-----------------

Currently querying a blueprint will not display any information about its
bundle. By making the bundle a `virtual_has_one`, an API user can
request the "bundle" attribute on a blueprint, which gets returned in
serialized format.

@abellotti not sure if we should include the bundle by default - any thoughts?
@miq-bot add-label api, enhancement
@miq-bot assign @abellotti 
/cc @bzwei 