### PR TITLE
Fix sporadic drb thread test

### DIFF
--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -45,10 +45,14 @@ module MiqAeEngine
       self.drb_server = nil
       # This hack was done to prevent ruby from leaking the
       # TimerIdConv thread.
-      # https://bugs.ruby-lang.org/issues/12342
+      # https://bugs.ruby-lang.org/issues/12342 (has been fixed in ruby 2.4.0 preview 1)
+      # also fixed in ruby_2_3 branch for the 2.3.2 release: https://github.com/ruby/ruby/commit/c20b07d5357d7cb73226b149431a658cde54a697
       thread = global_id_conv
                .try(:instance_variable_get, '@holder')
                .try(:instance_variable_get, '@keeper')
+      if RUBY_VERSION > "2.3.1"
+        warn "Remove me: #{__FILE__}:#{__LINE__} and my test. Ruby 2.3.2+ should not be creating timer threads."
+      end
       return unless thread
 
       thread.kill

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -2,15 +2,21 @@ module DrbRemoteInvokerSpec
   include MiqAeEngine
   describe MiqAeEngine::DrbRemoteInvoker do
     it "setup/teardown drb_for_ruby_method clears DRb threads" do
-      threads_before = Thread.list.select(&:alive?)
-
       invoker = described_class.new(double("workspace", :persist_state_hash => {}))
 
+      timer_thread = nil
+
       invoker.with_server([], "") do
-        expect(Thread.list.select(&:alive?) - threads_before).not_to be_empty
+        timer_thread = Thread.list.each do |t|
+          first = t.backtrace_locations.first
+          if first && first.path.include?("timeridconv.rb")
+            timer_thread = t
+            break
+          end
+        end
       end
 
-      expect(Thread.list.select(&:alive?)).to eq threads_before
+      expect(Thread.list).to_not include(timer_thread)
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
*    Find the timer thread and assert it's gone after invocation. We don't control the threads created/destroyed while our test is running so let's just find the one we care about and make sure it's gone after the invoker completes.
*    2.4.0 fixes timer thread issue, add reminder to remove it

Links
-----
 * https://bugs.ruby-lang.org/issues/12342
 * https://github.com/ManageIQ/manageiq/pull/8419
 * Fixes #10222 