### PR TITLE
Delete unused module

### DIFF
--- a/app/helpers/service_template_helper.rb
+++ b/app/helpers/service_template_helper.rb
@@ -1,3 +1,0 @@
-module ServiceTemplateHelper
-  include VmHelper
-end


### PR DESCRIPTION
module ServiceTemplateHelper in app/helpers isn't called anywhere.  I only found it is because it is named exactly the same as a spec helper. :(  Good news is that this one can go :scissors: :fire: 