### PR TITLE
Don't Object.include(ServiceTemplateHelper)

### DIFF
--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -1,7 +1,7 @@
 include QuotaHelper
 
 describe "Quota Validation" do
-  include ServiceTemplateHelper
+  include Spec::Support::ServiceTemplateHelper
 
   def run_automate_method(attrs)
     MiqAeEngine.instantiate("/ManageIQ/system/request/Call_Instance?namespace=System/CommonMethods&" \

--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -1,7 +1,8 @@
 include QuotaHelper
-include ServiceTemplateHelper
 
 describe "Quota Validation" do
+  include ServiceTemplateHelper
+
   def run_automate_method(attrs)
     MiqAeEngine.instantiate("/ManageIQ/system/request/Call_Instance?namespace=System/CommonMethods&" \
                             "class=QuotaMethods&instance=requested&#{attrs.join('&')}", @user)

--- a/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -1,6 +1,6 @@
-include ServiceTemplateHelper
-
 describe "CatalogBundleInitialization Automate Method" do
+  include ServiceTemplateHelper
+
   before do
     @allowed_service_templates = %w(top vm_service1 vm_service2)
     user_helper

--- a/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb
@@ -1,5 +1,5 @@
 describe "CatalogBundleInitialization Automate Method" do
-  include ServiceTemplateHelper
+  include Spec::Support::ServiceTemplateHelper
 
   before do
     @allowed_service_templates = %w(top vm_service1 vm_service2)

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -1,5 +1,5 @@
 describe "CatalogItemInitialization Automate Method" do
-  include ServiceTemplateHelper
+  include Spec::Support::ServiceTemplateHelper
 
   before(:each) do
     @allowed_service_templates = %w(top vm_service1 vm_service2)

--- a/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
+++ b/spec/automation/unit/method_validation/catalog_item_initialization_spec.rb
@@ -1,6 +1,6 @@
-include ServiceTemplateHelper
-
 describe "CatalogItemInitialization Automate Method" do
+  include ServiceTemplateHelper
+
   before(:each) do
     @allowed_service_templates = %w(top vm_service1 vm_service2)
     user_helper

--- a/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -1,5 +1,5 @@
 describe "DialogParser Automate Method" do
-  include ServiceTemplateHelper
+  include Spec::Support::ServiceTemplateHelper
 
   before(:each) do
     @root_stp = FactoryGirl.create(:miq_request_task, :type => 'ServiceTemplateProvisionTask')

--- a/spec/automation/unit/method_validation/dialog_parser_spec.rb
+++ b/spec/automation/unit/method_validation/dialog_parser_spec.rb
@@ -1,6 +1,6 @@
-include ServiceTemplateHelper
-
 describe "DialogParser Automate Method" do
+  include ServiceTemplateHelper
+
   before(:each) do
     @root_stp = FactoryGirl.create(:miq_request_task, :type => 'ServiceTemplateProvisionTask')
     @user = FactoryGirl.create(:user_with_group)

--- a/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
+++ b/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
@@ -1,5 +1,5 @@
 describe "FilterByDialogParameters Automate Method" do
-  include ServiceTemplateHelper
+  include Spec::Support::ServiceTemplateHelper
 
   before do
     @allowed_service_templates = %w(top)

--- a/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
+++ b/spec/automation/unit/method_validation/filter_by_dialog_parameters_spec.rb
@@ -1,6 +1,6 @@
-include ServiceTemplateHelper
-
 describe "FilterByDialogParameters Automate Method" do
+  include ServiceTemplateHelper
+
   before do
     @allowed_service_templates = %w(top)
     user_helper

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -1,6 +1,6 @@
-include ServiceTemplateHelper
-
 describe "Service Filter" do
+  include ServiceTemplateHelper
+
   before do
     @allowed_service_templates = []
     user_helper

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -1,5 +1,5 @@
 describe "Service Filter" do
-  include ServiceTemplateHelper
+  include Spec::Support::ServiceTemplateHelper
 
   before do
     @allowed_service_templates = []

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -1,97 +1,101 @@
-module ServiceTemplateHelper
-  def build_service_template_tree(hash)
-    build_all_atomics(hash)
-    build_all_composites(hash)
-  end
+module Spec
+  module Support
+    module ServiceTemplateHelper
+      def build_service_template_tree(hash)
+        build_all_atomics(hash)
+        build_all_composites(hash)
+      end
 
-  def build_all_atomics(hash)
-    hash.each do |name, value|
-      next unless value[:type] == "atomic"
-      item = FactoryGirl.create(:service_template, :name         => name,
-                                                   :options      => {:dialog => {}},
-                                                   :service_type => 'atomic')
-      item.update_attributes(:prov_type => value[:prov_type]) if value[:prov_type].present?
-      options = value[:request]
-      options ||= {}
-      options[:dialog] = {}
-      mprt = FactoryGirl.create(:miq_provision_request_template,
-                                :requester => options[:requester],
-                                :src_vm_id => options[:src_vm_id],
-                                :options   => options)
-      add_st_resource(item, mprt)
+      def build_all_atomics(hash)
+        hash.each do |name, value|
+          next unless value[:type] == "atomic"
+          item = FactoryGirl.create(:service_template, :name         => name,
+                                                       :options      => {:dialog => {}},
+                                                       :service_type => 'atomic')
+          item.update_attributes(:prov_type => value[:prov_type]) if value[:prov_type].present?
+          options = value[:request]
+          options ||= {}
+          options[:dialog] = {}
+          mprt = FactoryGirl.create(:miq_provision_request_template,
+                                    :requester => options[:requester],
+                                    :src_vm_id => options[:src_vm_id],
+                                    :options   => options)
+          add_st_resource(item, mprt)
+        end
+      end
+
+      def build_all_composites(hash)
+        hash.each do |name, value|
+          next unless value[:type] == "composite"
+          next if ServiceTemplate.find_by_name(name)
+          build_a_composite(name, hash)
+        end
+      end
+
+      def build_a_composite(name, hash)
+        item = FactoryGirl.create(:service_template, :name         => name,
+                                                     :options      => {:dialog => {}},
+                                                     :service_type => 'composite')
+        properties = hash[name]
+        link_all_children(item, properties, hash) unless properties[:children].empty?
+        item
+      end
+
+      def link_all_children(item, properties, hash)
+        children = properties[:children]
+        child_options = properties.key?(:child_options) ? properties[:child_options] : {}
+        children.each do |name|
+          child_item = ServiceTemplate.find_by_name(name) || build_a_composite(name, hash)
+          add_st_resource(item, child_item, child_options.fetch(name, {}))
+        end
+      end
+
+      def add_st_resource(svc, resource, options = {})
+        svc.add_resource(resource, options)
+        svc.service_resources.each(&:save)
+      end
+
+      def build_service_template_request(root_st_name, user, dialog_options = {})
+        root = ServiceTemplate.find_by_name(root_st_name)
+        return nil unless root
+        options = {:src_id => root.id, :target_name => "barney"}.merge(dialog_options)
+        FactoryGirl.create(:service_template_provision_request,
+                           :description    => 'Service Request',
+                           :source_type    => 'ServiceTemplate',
+                           :type           => 'ServiceTemplateProvisionRequest',
+                           :request_type   => 'clone_to_service',
+                           :approval_state => 'approved',
+                           :source_id      => root.id,
+                           :requester      => user,
+                           :options        => options)
+      end
+
+      def request_stubs
+        allow(@request).to receive(:approved?).and_return(true)
+        allow_any_instance_of(MiqRequestTask).to receive(:approved?).and_return(true)
+        allow_any_instance_of(MiqProvision).to receive(:get_next_vm_name).and_return("fred")
+        allow(@request).to receive(:automate_event_failed?).and_return(false)
+      end
+
+      def build_small_environment
+        @miq_server = EvmSpecHelper.local_miq_server
+        @ems = FactoryGirl.create(:ems_vmware_with_authentication)
+        @host1 =  FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
+        @src_vm = FactoryGirl.create(:vm_vmware, :host   => @host1,
+                                                 :ems_id => @ems.id,
+                                                 :name   => "barney")
+      end
+
+      def service_template_stubs
+        allow(ServiceTemplate).to receive(:automate_result_include_service_template?) do |_uri, _user, name|
+          @allowed_service_templates.include?(name)
+        end
+      end
+
+      def user_helper
+        allow_any_instance_of(User).to receive(:role).and_return("admin")
+        @user = FactoryGirl.create(:user_with_group, :name => 'Wilma', :userid => 'wilma')
+      end
     end
-  end
-
-  def build_all_composites(hash)
-    hash.each do |name, value|
-      next unless value[:type] == "composite"
-      next if ServiceTemplate.find_by_name(name)
-      build_a_composite(name, hash)
-    end
-  end
-
-  def build_a_composite(name, hash)
-    item = FactoryGirl.create(:service_template, :name         => name,
-                                                 :options      => {:dialog => {}},
-                                                 :service_type => 'composite')
-    properties = hash[name]
-    link_all_children(item, properties, hash) unless properties[:children].empty?
-    item
-  end
-
-  def link_all_children(item, properties, hash)
-    children = properties[:children]
-    child_options = properties.key?(:child_options) ? properties[:child_options] : {}
-    children.each do |name|
-      child_item = ServiceTemplate.find_by_name(name) || build_a_composite(name, hash)
-      add_st_resource(item, child_item, child_options.fetch(name, {}))
-    end
-  end
-
-  def add_st_resource(svc, resource, options = {})
-    svc.add_resource(resource, options)
-    svc.service_resources.each(&:save)
-  end
-
-  def build_service_template_request(root_st_name, user, dialog_options = {})
-    root = ServiceTemplate.find_by_name(root_st_name)
-    return nil unless root
-    options = {:src_id => root.id, :target_name => "barney"}.merge(dialog_options)
-    FactoryGirl.create(:service_template_provision_request,
-                       :description    => 'Service Request',
-                       :source_type    => 'ServiceTemplate',
-                       :type           => 'ServiceTemplateProvisionRequest',
-                       :request_type   => 'clone_to_service',
-                       :approval_state => 'approved',
-                       :source_id      => root.id,
-                       :requester      => user,
-                       :options        => options)
-  end
-
-  def request_stubs
-    allow(@request).to receive(:approved?).and_return(true)
-    allow_any_instance_of(MiqRequestTask).to receive(:approved?).and_return(true)
-    allow_any_instance_of(MiqProvision).to receive(:get_next_vm_name).and_return("fred")
-    allow(@request).to receive(:automate_event_failed?).and_return(false)
-  end
-
-  def build_small_environment
-    @miq_server = EvmSpecHelper.local_miq_server
-    @ems = FactoryGirl.create(:ems_vmware_with_authentication)
-    @host1 =  FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
-    @src_vm = FactoryGirl.create(:vm_vmware, :host   => @host1,
-                                             :ems_id => @ems.id,
-                                             :name   => "barney")
-  end
-
-  def service_template_stubs
-    allow(ServiceTemplate).to receive(:automate_result_include_service_template?) do |_uri, _user, name|
-      @allowed_service_templates.include?(name)
-    end
-  end
-
-  def user_helper
-    allow_any_instance_of(User).to receive(:role).and_return("admin")
-    @user = FactoryGirl.create(:user_with_group, :name => 'Wilma', :userid => 'wilma')
   end
 end


### PR DESCRIPTION
It should be included in the rspec example group instead

Also, rename it to ServiceTemplateSpecHelper while I'm here to avoid naming conflicts with an unused helper in app/helpers.