### PR TITLE
Allow blueprints to be deleted through the API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -86,7 +86,7 @@
         :identifier: availability_zone_show
   :blueprints:
     :description: Blueprints
-    :verbs: *gp
+    :verbs: *gpd
     :options:
     - :collection
     :klass: Blueprint
@@ -97,10 +97,21 @@
       :post:
       - :name: create
         :identifier: blueprint_new
+      - :name: delete
+        :identifier: blueprint_delete
+      :delete:
+      - :name: delete
+        :identifier: blueprint_delete
     :resource_actions:
       :get:
       - :name: read
         :identifier: blueprint_show
+      :post:
+      - :name: delete
+        :identifier: blueprint_delete
+      :delete:
+      - :name: delete
+        :identifier: blueprint_delete
   :categories:
     :description: Categories
     :identifier: ops_settings

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5152,3 +5152,7 @@
       :description: Add Blueprint
       :feature_type: admin
       :identifier: blueprint_new
+    - :name: Remove
+      :description: Remove Blueprint
+      :feature_type: admin
+      :identifier: blueprint_delete

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -176,6 +176,66 @@ RSpec.describe "Blueprints API" do
     end
   end
 
+  describe "POST /api/blueprints" do
+    it "can delete multiple blueprints" do
+      blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
+      api_basic_authorize collection_action_identifier(:blueprints, :delete)
+
+      run_post(blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "forbids multiple blueprint deletion without an appropriate role" do
+      blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
+      api_basic_authorize
+
+      run_post(blueprints_url, :action => "delete", :resources => [{:id => blueprint1.id}, {:id => blueprint2.id}])
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/blueprints/:id" do
+    it "can delete a blueprint with an appropriate role" do
+      blueprint = FactoryGirl.create(:blueprint)
+      api_basic_authorize action_identifier(:blueprints, :delete)
+
+      run_post(blueprints_url(blueprint.id), :action => "delete")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "forbids blueprint deletion without an appropriate role" do
+      blueprint = FactoryGirl.create(:blueprint)
+      api_basic_authorize
+
+      run_post(blueprints_url(blueprint.id), :action => "delete")
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "DELETE /api/blueprints/:id" do
+    it "can delete a blueprint with an appropriate role" do
+      blueprint = FactoryGirl.create(:blueprint)
+      api_basic_authorize action_identifier(:blueprints, :delete, :resource_actions, :delete)
+
+      run_delete(blueprints_url(blueprint.id))
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "forbids blueprint deletion without an appropriate role" do
+      blueprint = FactoryGirl.create(:blueprint)
+      api_basic_authorize
+
+      run_delete(blueprints_url(blueprint.id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   # TODO: factor this out of this test so it can be used elsewhere
   def build_dialog
     FactoryGirl.create(


### PR DESCRIPTION
Purpose or Intent
-----------------

* Allows authorized users (admins) to delete blueprints
* Adds a product feature for removing blueprints

Resolves https://www.pivotaltracker.com/story/show/127927919

@miq-bot add-label api, enhancement
@miq-bot assign @abellotti 