### PR TITLE
Remove unused and broken ruport_ize_filtered method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2248,11 +2248,6 @@ class ApplicationController < ActionController::Base
     result
   end
 
-  def ruport_ize_filtered(report, options = {})
-    options[:tag_filters] = current_user.try(:get_filters) || []
-    report.ruport_ize!(options)
-  end
-
   VISIBILITY_TYPES = {'role' => 'role', 'group' => 'group', 'all' => 'all'}
 
   def visibility_box_edit


### PR DESCRIPTION
The method is unused since Nov 2010. The MiqReport does not respond to `ruport_ize!` since Dec 2010.

:hocho: :scissors: :toilet: 

@miq-bot add_label technical debt, ui, darga/no
@miq-bot assign @martinpovolny 