### PR TITLE
Fix container scanning timeout handling.

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -162,6 +162,10 @@ class Job < ApplicationRecord
     end
   end
 
+  def target_entity
+    target_class.constantize.find_by_id(target_id)
+  end
+
   def self.check_jobs_for_timeout
     $log.debug "Checking for timed out jobs"
     begin
@@ -169,7 +173,7 @@ class Job < ApplicationRecord
         .where("state != 'finished' and (state != 'waiting_to_start' or dispatch_status = 'active')")
         .where("zone is null or zone = ?", MiqServer.my_zone)
         .each do |job|
-          next unless job.updated_on < job.current_job_timeout(timeout_adjustment(job)).seconds.ago
+          next unless job.updated_on < job.current_job_timeout(job.timeout_adjustment).seconds.ago
 
           # Allow jobs to run longer if the MiqQueue task is still active.  (Limited to MiqServer for now.)
           if job.agent_class == "MiqServer"
@@ -183,11 +187,11 @@ class Job < ApplicationRecord
     end
   end
 
-  def self.timeout_adjustment(job)
+  def timeout_adjustment
     timeout_adjustment = 1
-    vm = VmOrTemplate.find(job.target_id)
-    if vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-       vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
+    target = target_entity
+    if target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
+       target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
       timeout_adjustment = 4
     end
     timeout_adjustment

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -223,10 +223,6 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
 
   private
 
-  def target_entity
-    target_class.constantize.find_by_id(target_id)
-  end
-
   def ext_management_system
     @ext_management_system ||= ExtManagementSystem.find(options[:ems_id])
   end


### PR DESCRIPTION
Eliminates failing container scanning jobs that remain in active states.
Removes multiple occurrences of[1] seen in logs.

In other cases the timeout code would work because
a vm with an id that matches that of the target container
happen to exist.

Using find_by should also handle cases where the
target entity no longer exist. This is very common
for container entities and should also benefit vms.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1366598

[1] ERROR -- : MIQ(Job.check_jobs_for_timeout) Couldn't find VmOrTemplate
with 'id'=3