### PR TITLE
Dead code in policy_get_all_folders

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -223,7 +223,7 @@ module MiqPolicyController::Policies
 
   def policy_get_all_folders
     @folders = ["Compliance", "Control"]
-    @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "MiqPolicy")}
+    @right_cell_text = _("All Policies")
     @right_cell_div = "policy_folders"
   end
 

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -221,16 +221,10 @@ module MiqPolicyController::Policies
     event.name.end_with?("compliance_check", "perf_complete")
   end
 
-  def policy_get_all_folders(parent = nil)
-    if !parent.nil?
-      @folders = MiqPolicyController::UI_FOLDERS.collect(&:name)
-      @right_cell_text = _("%{typ} %{model}") % {:typ => parent, :model => ui_lookup(:models => "MiqPolicy")}
-      @right_cell_div = "policy_folders"
-    else
-      @folders = ["Compliance", "Control"]
-      @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "MiqPolicy")}
-      @right_cell_div = "policy_folders"
-    end
+  def policy_get_all_folders
+    @folders = ["Compliance", "Control"]
+    @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "MiqPolicy")}
+    @right_cell_div = "policy_folders"
   end
 
   # Get information for a policy


### PR DESCRIPTION
Its only caller passes no arguments:
https://github.com/ManageIQ/manageiq/blob/517652ba1ef2839efa3329bded49f8c67357025c/app/controllers/miq_policy_controller.rb#L445

Inlined an unnecessary ui_lookup while I'm at it.

@miq-bot add-label ui, technical_debt, darga/no