### PR TITLE
Targeted refresh improvements

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -146,6 +146,15 @@ class EmsEvent < EventStream
         event[:vm_name] ||= vm.name
       end
     end
+
+    event_type = event[:event_type]
+    # both event types are Rhev specific
+    if (event_type == 'USER_ADD_VM' || event_type == 'USER_ADD_VM_FINISHED_SUCCESS') && event[:vm_or_template_id].nil?
+      new_vm = ManageIQ::Providers::Redhat::InfraManager::Vm.create_from_event(event)
+
+      event[:vm_or_template_id] = new_vm.id
+      event[:vm_name] ||= new_vm.name
+    end
   end
 
   def self.process_host_in_event!(event, options = {})

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -19,6 +19,9 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
     # Clean up the temporary cluster-datacenter references
     result[:clusters].each { |c| c.delete(:datacenter_id) }
 
+    # get disk for removed vms
+    result[:vm_disks] = vm_inv_to_disk_hashes({:disks => inv[:vm_disks]}, uids[:storages])
+
     result
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -373,19 +373,15 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
 
       ems_ref = ManageIQ::Providers::Redhat::InfraManager.make_ems_ref(vm_inv[:href])
 
-      new_result = {
-        :type              => template ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
-        :ems_ref           => ems_ref,
-        :ems_ref_obj       => ems_ref,
-        :uid_ems           => vm_inv[:id],
+      data = [template, ems_ref, vm_inv[:id], URI.decode(vm_inv[:name])]
+
+      new_result = create_vm_hash(data)
+
+      additional = {
         :memory_reserve    => vm_memory_reserve(vm_inv),
-        :name              => URI.decode(vm_inv[:name]),
-        :vendor            => "redhat",
         :raw_power_state   => raw_power_state,
-        :location          => "#{vm_inv[:id]}.ovf",
         :boot_time         => boot_time,
         :connection_state  => 'connected',
-        :template          => template,
         :host              => host,
         :ems_cluster       => ems_cluster,
         :storages          => storages,
@@ -395,6 +391,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
         :custom_attributes => vm_inv_to_custom_attribute_hashes(vm_inv),
         :snapshots         => vm_inv_to_snapshot_hashes(vm_inv),
       }
+      new_result.merge!(additional)
 
       # Attach to the cluster's default resource pool
       ems_cluster[:ems_children][:resource_pools].first[:ems_children][:vms] << new_result if ems_cluster && !template
@@ -403,6 +400,20 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
       result_uids[mor] = new_result
     end
     return result, result_uids
+  end
+
+  def self.create_vm_hash(data)
+    vm_hash = {
+      :type        => data[0] ? "ManageIQ::Providers::Redhat::InfraManager::Template" : "ManageIQ::Providers::Redhat::InfraManager::Vm",
+      :ems_ref     => data[1],
+      :ems_ref_obj => data[1],
+      :uid_ems     => data[2],
+      :vendor      => "redhat",
+      :name        => data[3],
+      :location    => "#{data[2]}.ovf",
+      :template    => data[0],
+    }
+    vm_hash
   end
 
   def self.vm_inv_to_hardware_hash(inv)

--- a/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
@@ -35,7 +35,8 @@ class ManageIQ::Providers::Redhat::InfraManager
               :cluster     => target.parent_cluster.ems_ref,
               :data_center => target.parent_datacenter.ems_ref,
               :vm          => vm,
-              :template    => "/api/templates?search=vm.id=#{vm_id}"
+              :template    => "/api/templates?search=vm.id=#{vm_id}",
+              :storage     => target.storages.empty? ? {:storagedomains => "storage_domain"} : target.storages.map { |item| item.ems_ref }
             },
             :secondary => {
               :vm         => [:disks, :snapshots, :nics],

--- a/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
@@ -43,6 +43,10 @@ class ManageIQ::Providers::Redhat::InfraManager
               :template   => [:disks]
             }
           }
+          unless target.hardware.nil?
+            methods[:primary][:vm_disks] = target.hardware.disks.map { |disk| "#{disk.storage.ems_ref}/disks/#{disk.filename}" }
+          end
+
           data,  = Benchmark.realtime_block(:fetch_vm_data) { inventory.targeted_refresh(methods) }
 
         else

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_add_vm.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_add_vm.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel5:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_vm"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_add_vm_finished_success.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_add_vm_finished_success.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems"
+      value: "/System/event_handlers/event_action_refresh?target=src_vm"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
@@ -8,9 +8,7 @@ object:
     inherits: 
     description: 
   fields:
-  - rel4:
-      value: "/System/event_handlers/src_vm_disconnect_storage"
   - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_unregister&param="
   - rel6:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_vm"

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -33,7 +33,7 @@ gem "net-sftp",                "~>2.1.2",           :require => false
 gem "nokogiri",                "~>1.6.8",           :require => false
 gem "openscap",                "~>0.4.3",           :require => false
 gem "openshift_client",        "=1.2.0",            :require => false
-gem "ovirt",                   "~>0.11.0",          :require => false
+gem "ovirt",                   "~>0.12.1",          :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "pg-dsn_parser",           "~>0.1.0",           :require => false
 gem "psych",                   "~>2.0.12"

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
@@ -1,0 +1,375 @@
+describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
+  before(:each) do
+    _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.1.31", :ipaddress => "192.168.1.31", :port => 8443)
+    @ems.update_authentication(:default => {:userid => "admin@internal", :password => "engine"})
+
+    @cluster = FactoryGirl.create(:ems_cluster,
+                                  :ems_ref => "/api/clusters/00000002-0002-0002-0002-0000000001e9",
+                                  :uid_ems => "00000002-0002-0002-0002-0000000001e9",
+                                  :ems_id  => @ems.id,
+                                  :name    => "Default")
+
+    @dc = FactoryGirl.create(:datacenter,
+                             :ems_ref => "/api/datacenters/00000001-0001-0001-0001-0000000002c0",
+                             :name    => "Default",
+                             :uid_ems => "00000001-0001-0001-0001-0000000002c0")
+    @dc.with_relationship_type("ems_metadata") { @dc.add_cluster @cluster }
+
+    @rp = FactoryGirl.create(:resource_pool,
+                             :ems_id  => @ems.id,
+                             :uid_ems => "00000002-0002-0002-0002-0000000001e9_respool")
+    @cluster.with_relationship_type("ems_metadata") { @cluster.add_child @rp }
+  end
+
+  it "should refresh existing vm" do
+    storage = FactoryGirl.create(:storage,
+                                 :ems_ref  => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0",
+                                 :location => "192.168.1.106:/home/pkliczewski/export/hosted")
+
+    disk = FactoryGirl.create(:disk,
+                              :storage  => storage,
+                              :filename => "da123bb9-095a-4933-95f2-8032dfa332e1")
+    hardware = FactoryGirl.create(:hardware,
+                                  :disks => [disk])
+
+    vm = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems,
+                            :uid_ems     => "4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+                            :ems_cluster => @cluster,
+                            :ems_ref     => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+                            :storage     => storage,
+                            :storages    => [storage],
+                            :hardware    => hardware)
+    vm.with_relationship_type("ems_metadata") { vm.parent = @rp }
+
+    VCR.use_cassette("#{described_class.name.underscore}_target_existing_vm") do
+      EmsRefresh.refresh(vm)
+    end
+
+    assert_table_counts
+    assert_vm(vm, storage)
+    assert_vm_rels(vm, hardware, storage)
+    assert_cluster
+    assert_storage(storage, vm)
+  end
+
+  it "should refresh new vm" do
+    vm = FactoryGirl.create(:vm_redhat,
+                            :ext_management_system => @ems,
+                            :uid_ems               => "4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+                            :ems_cluster           => @cluster,
+                            :ems_ref               => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77")
+    vm.with_relationship_type("ems_metadata") { vm.parent = @rp }
+
+    VCR.use_cassette("#{described_class.name.underscore}_target_new_vm") do
+      EmsRefresh.refresh(vm)
+    end
+
+    assert_table_counts
+
+    storage = Storage.find_by(:ems_ref => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0")
+    assert_vm(vm, storage)
+
+    hardware = Hardware.find_by(:vm_or_template_id => vm.id)
+    assert_vm_rels(vm, hardware, storage)
+    assert_cluster
+    assert_storage(storage, vm)
+  end
+
+  def assert_table_counts
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsCluster.count).to eq(1)
+    expect(ResourcePool.count).to eq(1)
+    expect(Vm.count).to eq(1)
+    expect(Storage.count).to eq(1)
+    expect(Disk.count).to eq(1)
+    expect(GuestDevice.count).to eq(1)
+    expect(Hardware.count).to eq(1)
+    expect(OperatingSystem.count).to eq(1)
+    expect(Snapshot.count).to eq(1)
+
+    expect(Relationship.count).to eq(6)
+    expect(MiqQueue.count).to eq(3)
+  end
+
+  def assert_vm(vm, storage)
+    vm.reload
+    expect(vm).to have_attributes(
+      :template               => false,
+      :ems_ref                => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+      :ems_ref_obj            => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+      :uid_ems                => "4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+      :vendor                 => "redhat",
+      :raw_power_state        => "down",
+      :power_state            => "off",
+      :connection_state       => "connected",
+      :name                   => "123",
+      :format                 => nil,
+      :version                => nil,
+      :description            => nil,
+      :location               => "4f6dd4c3-5241-494f-8afc-f1c67254bf77.ovf",
+      :config_xml             => nil,
+      :autostart              => nil,
+      :host_id                => nil,
+      :last_sync_on           => nil,
+      :storage_id             => storage.id,
+      :last_scan_on           => nil,
+      :last_scan_attempt_on   => nil,
+      :retires_on             => nil,
+      :retired                => nil,
+      :boot_time              => nil,
+      :tools_status           => nil,
+      :standby_action         => nil,
+      :previous_state         => "up",
+      :last_perf_capture_on   => nil,
+      :registered             => nil,
+      :busy                   => nil,
+      :smart                  => nil,
+      :memory_reserve         => 1024,
+      :memory_reserve_expand  => nil,
+      :memory_limit           => nil,
+      :memory_shares          => nil,
+      :memory_shares_level    => nil,
+      :cpu_reserve            => nil,
+      :cpu_reserve_expand     => nil,
+      :cpu_limit              => nil,
+      :cpu_shares             => nil,
+      :cpu_shares_level       => nil,
+      :cpu_affinity           => nil,
+      :ems_created_on         => nil,
+      :evm_owner_id           => nil,
+      :linked_clone           => nil,
+      :fault_tolerance        => nil,
+      :type                   => "ManageIQ::Providers::Redhat::InfraManager::Vm",
+      :ems_cluster_id         => @cluster.id,
+      :retirement_warn        => nil,
+      :retirement_last_warn   => nil,
+      :vnc_port               => nil,
+      :flavor_id              => nil,
+      :availability_zone_id   => nil,
+      :cloud                  => false,
+      :retirement_state       => nil,
+      :cloud_network_id       => nil,
+      :cloud_subnet_id        => nil,
+      :cloud_tenant_id        => nil,
+      :publicly_available     => nil,
+      :orchestration_stack_id => nil,
+      :retirement_requester   => nil,
+      :resource_group_id      => nil,
+      :deprecated             => nil,
+      :storage_profile_id     => nil
+    )
+
+    expect(vm.ext_management_system).to eq(@ems)
+    expect(vm.ems_cluster).to eq(@cluster)
+    expect(vm.parent_resource_pool).to eq(@rp)
+    expect(vm.storage).to eq(storage)
+  end
+
+  def assert_vm_rels(vm, hardware, storage)
+    expect(vm.snapshots.size).to eq(1)
+    snapshot = vm.snapshots.first
+    expect(snapshot).to have_attributes(
+      :uid               => "768f1e7a-c517-4619-9d55-59e641bfd038",
+      :parent_uid        => nil,
+      :uid_ems           => "768f1e7a-c517-4619-9d55-59e641bfd038",
+      :name              => "Active VM",
+      :description       => "Active VM",
+      :current           => 1,
+      :total_size        => nil,
+      :filename          => nil,
+      :disks             => [],
+      :parent_id         => nil,
+      :vm_or_template_id => vm.id,
+      :ems_ref           => nil
+    )
+
+    expect(vm.hardware).to eq(hardware)
+    expect(vm.hardware).to have_attributes(
+      :guest_os             => "other",
+      :guest_os_full_name   => nil,
+      :bios                 => nil,
+      :cpu_cores_per_socket => 1,
+      :cpu_total_cores      => 1,
+      :cpu_sockets          => 1,
+      :annotation           => nil,
+      :memory_mb            => 1024,
+      :config_version       => nil,
+      :virtual_hw_version   => nil,
+      :bios_location        => nil,
+      :time_sync            => nil,
+      :vm_or_template_id    => vm.id,
+      :host_id              => nil,
+      :cpu_speed            => nil,
+      :cpu_type             => nil,
+      :size_on_disk         => nil,
+      :manufacturer         => "",
+      :model                => "",
+      :number_of_nics       => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil,
+      :vmotion_enabled      => nil,
+      :disk_free_space      => nil,
+      :disk_capacity        => nil,
+      :memory_console       => nil,
+      :bitness              => nil,
+      :virtualization_type  => nil,
+      :root_device_type     => nil,
+      :computer_system_id   => nil,
+      :disk_size_minimum    => nil,
+      :memory_mb_minimum    => nil
+    )
+
+    expect(vm.hardware.disks.size).to eq(1)
+    disk = vm.hardware.disks.first
+    expect(disk.storage).to eq(storage)
+    expect(disk).to have_attributes(
+      :device_name        => "GlanceDisk-73786f4",
+      :device_type        => "disk",
+      :location           => "0",
+      :filename           => "da123bb9-095a-4933-95f2-8032dfa332e1",
+      :hardware_id        => hardware.id,
+      :mode               => "persistent",
+      :controller_type    => "virtio",
+      :size               => 41126400,
+      :free_space         => nil,
+      :size_on_disk       => 2564096,
+      :present            => true,
+      :start_connected    => true,
+      :auto_detect        => nil,
+      :disk_type          => "thin",
+      :storage_id         => storage.id,
+      :backing_id         => nil,
+      :backing_type       => nil,
+      :storage_profile_id => nil
+    )
+
+    expect(vm.hardware.guest_devices.size).to eq(1)
+    guest_device = vm.hardware.guest_devices.first
+    expect(guest_device).to have_attributes(
+      :device_name       => "nic1",
+      :device_type       => "ethernet",
+      :location          => nil,
+      :filename          => nil,
+      :hardware_id       => hardware.id,
+      :mode              => nil,
+      :controller_type   => "ethernet",
+      :size              => nil,
+      :free_space        => nil,
+      :size_on_disk      => nil,
+      :address           => "00:1a:4a:16:01:52",
+      :switch_id         => nil,
+      :lan_id            => nil,
+      :model             => nil,
+      :iscsi_name        => nil,
+      :iscsi_alias       => nil,
+      :present           => true,
+      :start_connected   => true,
+      :auto_detect       => nil,
+      :uid_ems           => "6409858a-e1a1-4049-bef2-22a438442420",
+      :chap_auth_enabled => nil
+    )
+
+    expect(vm.operating_system).not_to be_nil
+    expect(vm.operating_system).to have_attributes(
+      :name                  => nil,
+      :product_name          => "other",
+      :version               => nil,
+      :build_number          => nil,
+      :system_root           => nil,
+      :distribution          => nil,
+      :product_type          => nil,
+      :service_pack          => nil,
+      :productid             => nil,
+      :vm_or_template_id     => vm.id,
+      :host_id               => nil,
+      :bitness               => nil,
+      :product_key           => nil,
+      :pw_hist               => nil,
+      :max_pw_age            => nil,
+      :min_pw_age            => nil,
+      :min_pw_len            => nil,
+      :pw_complex            => nil,
+      :pw_encrypt            => nil,
+      :lockout_threshold     => nil,
+      :lockout_duration      => nil,
+      :reset_lockout_counter => nil,
+      :system_type           => "desktop",
+      :computer_system_id    => nil,
+      :kernel_version        => nil
+    )
+  end
+
+  def assert_cluster
+    @cluster.reload
+    expect(@cluster).to have_attributes(
+      :ems_ref                 => "/api/clusters/00000002-0002-0002-0002-0000000001e9",
+      :uid_ems                 => "00000002-0002-0002-0002-0000000001e9",
+      :name                    => "Default",
+      :ha_enabled              => nil,
+      :ha_admit_control        => nil,
+      :ha_max_failures         => nil,
+      :drs_enabled             => nil,
+      :drs_automation_level    => nil,
+      :drs_migration_threshold => nil,
+      :last_perf_capture_on    => nil,
+      :effective_cpu           => nil,
+      :effective_memory        => nil,
+      :type                    => nil
+    )
+
+    @rp.reload
+    expect(@cluster.default_resource_pool).to eq(@rp)
+    expect(@rp).to have_attributes(
+      :ems_ref               => nil,
+      :ems_ref_obj           => nil,
+      :uid_ems               => "00000002-0002-0002-0002-0000000001e9_respool",
+      :name                  => "Default for Cluster Default",
+      :memory_reserve        => nil,
+      :memory_reserve_expand => nil,
+      :memory_limit          => nil,
+      :memory_shares         => nil,
+      :memory_shares_level   => nil,
+      :cpu_reserve           => nil,
+      :cpu_reserve_expand    => nil,
+      :cpu_limit             => nil,
+      :cpu_shares            => nil,
+      :cpu_shares_level      => nil,
+      :is_default            => true,
+      :vapp                  => nil
+    )
+
+    @dc.reload
+    expect(@cluster.parent_datacenter).to eq(@dc)
+    expect(@dc).to have_attributes(
+      :name    => "Default",
+      :ems_ref => "/api/datacenters/00000001-0001-0001-0001-0000000002c0",
+      :uid_ems => "00000001-0001-0001-0001-0000000002c0",
+      :type    => "Datacenter",
+      :hidden  => nil
+    )
+  end
+
+  def assert_storage(storage, vm)
+    storage.reload
+
+    expect(vm.storage).to eq(storage)
+    expect(storage).to have_attributes(
+      :name                          => "data",
+      :store_type                    => "NFS",
+      :total_space                   => 922344226816,
+      :free_space                    => 791347724288,
+      :multiplehostaccess            => 1,
+      :location                      => "192.168.1.106:/home/pkliczewski/export/hosted",
+      :last_scan_on                  => nil,
+      :uncommitted                   => 908385583104,
+      :last_perf_capture_on          => nil,
+      :directory_hierarchy_supported => nil,
+      :thin_provisioning_supported   => nil,
+      :raw_disk_mappings_supported   => nil,
+      :master                        => true,
+      :ems_ref                       => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0",
+      :storage_domain_type           => "data"
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,7 +120,8 @@ VCR.configure do |c|
 
   c.allow_http_connections_when_no_cassette = false
   c.default_cassette_options = {
-    :allow_unused_http_interactions => false
+    :allow_unused_http_interactions => false,
+    :decode_compressed_response     => true
   }
 
   # Set your config/secrets.yml file

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_existing_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_existing_vm.yml
@@ -1,0 +1,1103 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="ENGINE"
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '71'
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: UTF-8
+      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+- request:
+    method: get
+    uri: https://admin%40internal:engine@192.168.1.31:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18; path=/api; HttpOnly
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3745'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Link:
+      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+        rel=katelloerrata"
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <api>
+            <link href="/api/capabilities" rel="capabilities"/>
+            <link href="/api/clusters" rel="clusters"/>
+            <link href="/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/api/datacenters" rel="datacenters"/>
+            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/api/events" rel="events"/>
+            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/api/hosts" rel="hosts"/>
+            <link href="/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/api/networks" rel="networks"/>
+            <link href="/api/networks?search={query}" rel="networks/search"/>
+            <link href="/api/roles" rel="roles"/>
+            <link href="/api/storagedomains" rel="storagedomains"/>
+            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/api/tags" rel="tags"/>
+            <link href="/api/bookmarks" rel="bookmarks"/>
+            <link href="/api/icons" rel="icons"/>
+            <link href="/api/templates" rel="templates"/>
+            <link href="/api/templates?search={query}" rel="templates/search"/>
+            <link href="/api/instancetypes" rel="instancetypes"/>
+            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/api/users" rel="users"/>
+            <link href="/api/users?search={query}" rel="users/search"/>
+            <link href="/api/groups" rel="groups"/>
+            <link href="/api/groups?search={query}" rel="groups/search"/>
+            <link href="/api/domains" rel="domains"/>
+            <link href="/api/vmpools" rel="vmpools"/>
+            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/api/vms" rel="vms"/>
+            <link href="/api/vms?search={query}" rel="vms/search"/>
+            <link href="/api/disks" rel="disks"/>
+            <link href="/api/disks?search={query}" rel="disks/search"/>
+            <link href="/api/jobs" rel="jobs"/>
+            <link href="/api/storageconnections" rel="storageconnections"/>
+            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/api/permissions" rel="permissions"/>
+            <link href="/api/macpools" rel="macpools"/>
+            <link href="/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <special_objects>
+                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+            </special_objects>
+            <product_info>
+                <name>oVirt Engine</name>
+                <vendor>ovirt.org</vendor>
+                <version major="3" minor="6" build="7" revision="0"/>
+                <full_version>3.6.7_master</full_version>
+            </product_info>
+            <summary>
+                <vms>
+                    <total>4</total>
+                    <active>0</active>
+                </vms>
+                <hosts>
+                    <total>1</total>
+                    <active>1</active>
+                </hosts>
+                <users>
+                    <total>1</total>
+                    <active>1</active>
+                </users>
+                <storage_domains>
+                    <total>2</total>
+                    <active>1</active>
+                </storage_domains>
+            </summary>
+            <time>2016-08-19T11:43:43.326+02:00</time>
+        </api>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/clusters/00000002-0002-0002-0002-0000000001e9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '2810'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9">
+            <actions>
+                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/resetemulatedmachine" rel="resetemulatedmachine"/>
+            </actions>
+            <name>Default</name>
+            <description>The default server cluster</description>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/networks" rel="networks"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/permissions" rel="permissions"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glustervolumes" rel="glustervolumes"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glusterhooks" rel="glusterhooks"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/affinitygroups" rel="affinitygroups"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/cpuprofiles" rel="cpuprofiles"/>
+            <cpu id="Intel SandyBridge Family">
+                <architecture>X86_64</architecture>
+            </cpu>
+            <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0"/>
+            <memory_policy>
+                <overcommit percent="100"/>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <scheduling_policy href="/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812">
+                <name>none</name>
+                <policy>none</policy>
+            </scheduling_policy>
+            <version major="3" minor="6"/>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <virt_service>true</virt_service>
+            <gluster_service>false</gluster_service>
+            <threads_as_cores>false</threads_as_cores>
+            <tunnel_migration>false</tunnel_migration>
+            <trusted_service>false</trusted_service>
+            <ha_reservation>false</ha_reservation>
+            <optional_reason>false</optional_reason>
+            <maintenance_reason_required>false</maintenance_reason_required>
+            <ballooning_enabled>false</ballooning_enabled>
+            <ksm>
+                <enabled>true</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <required_rng_sources>
+                <source>RANDOM</source>
+            </required_rng_sources>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_sd_active>
+                    <enabled>false</enabled>
+                </skip_if_sd_active>
+                <skip_if_connectivity_broken>
+                    <enabled>false</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+            </fencing_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+        </cluster>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/datacenters/00000001-0001-0001-0001-0000000002c0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1354'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0">
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/storagedomains" rel="storagedomains"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/clusters" rel="clusters"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/networks" rel="networks"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/permissions" rel="permissions"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/quotas" rel="quotas"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/qoss" rel="qoss"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/iscsibonds" rel="iscsibonds"/>
+            <local>false</local>
+            <storage_format>v3</storage_format>
+            <version major="3" minor="6"/>
+            <supported_versions>
+                <version major="3" minor="6"/>
+            </supported_versions>
+            <status>
+                <state>up</state>
+            </status>
+            <mac_pool href="/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
+            <quota_mode>disabled</quota_mode>
+        </data_center>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '6098'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
+            <actions>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
+            </actions>
+            <name>123</name>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
+            <type>desktop</type>
+            <status>
+                <state>down</state>
+            </status>
+            <memory>1073741824</memory>
+            <cpu>
+                <topology sockets="1" cores="1" threads="1"/>
+                <architecture>X86_64</architecture>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <os type="other">
+                <boot dev="hd"/>
+            </os>
+            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+            <creation_time>2016-07-05T16:41:35.374+02:00</creation_time>
+            <origin>ovirt</origin>
+            <stateless>false</stateless>
+            <delete_protected>false</delete_protected>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <display>
+                <type>spice</type>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <allow_override>false</allow_override>
+                <smartcard_enabled>false</smartcard_enabled>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+            </display>
+            <sso>
+                <methods>
+                    <method id="GUEST_AGENT"/>
+                </methods>
+            </sso>
+            <timezone>Etc/GMT</timezone>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <migration_downtime>-1</migration_downtime>
+            <start_paused>false</start_paused>
+            <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <io>
+                <threads>0</threads>
+            </io>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+            <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <ballooning>false</ballooning>
+            </memory_policy>
+            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+            <stop_time>2016-08-11T12:37:33.718+02:00</stop_time>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+        </vm>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3830'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <templates>
+            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
+                <actions>
+                    <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
+                </actions>
+                <name>GlanceTemplate-7bb26f9</name>
+                <description>CirrOS 0.3.1 (73786f4)</description>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
+                <type>desktop</type>
+                <status>
+                    <state>ok</state>
+                </status>
+                <memory>1073741824</memory>
+                <cpu>
+                    <topology sockets="1" cores="1" threads="1"/>
+                    <architecture>X86_64</architecture>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <bios>
+                    <boot_menu>
+                        <enabled>false</enabled>
+                    </boot_menu>
+                </bios>
+                <os type="other">
+                    <boot dev="hd"/>
+                </os>
+                <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+                <creation_time>2016-06-03T13:43:25.838+02:00</creation_time>
+                <origin>ovirt</origin>
+                <stateless>false</stateless>
+                <delete_protected>false</delete_protected>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>0</priority>
+                </high_availability>
+                <display>
+                    <type>spice</type>
+                    <monitors>1</monitors>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <allow_override>false</allow_override>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                </display>
+                <sso>
+                    <methods>
+                        <method id="GUEST_AGENT"/>
+                    </methods>
+                </sso>
+                <timezone>Etc/GMT</timezone>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <migration_downtime>-1</migration_downtime>
+                <start_paused>false</start_paused>
+                <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+                <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                </memory_policy>
+                <version>
+                    <base_template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+                    <version_number>1</version_number>
+                    <version_name>base version</version_name>
+                </version>
+            </template>
+        </templates>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1938'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0">
+            <actions>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/isattached" rel="isattached"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/refreshluns" rel="refreshluns"/>
+            </actions>
+            <name>data</name>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/permissions" rel="permissions"/>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/templates" rel="templates"/>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/vms" rel="vms"/>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks" rel="disks"/>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/storageconnections" rel="storageconnections"/>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disksnapshots" rel="disksnapshots"/>
+            <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/diskprofiles" rel="diskprofiles"/>
+            <data_centers>
+                <data_center id="00000001-0001-0001-0001-0000000002c0"/>
+            </data_centers>
+            <type>data</type>
+            <external_status>
+                <state>ok</state>
+            </external_status>
+            <master>true</master>
+            <storage>
+                <address>192.168.1.106</address>
+                <type>nfs</type>
+                <path>/home/pkliczewski/export/hosted</path>
+                <nfs_version>v3</nfs_version>
+            </storage>
+            <available>791347724288</available>
+            <used>130996502528</used>
+            <committed>13958643712</committed>
+            <storage_format>v3</storage_format>
+            <wipe_after_delete>false</wipe_after_delete>
+            <warning_low_space_indicator>10</warning_low_space_indicator>
+            <critical_space_action_blocker>5</critical_space_action_blocker>
+        </storage_domain>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1476'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <disk href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
+            <actions>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
+            </actions>
+            <name>GlanceDisk-73786f4</name>
+            <description>CirrOS 0.3.1 (73786f4)</description>
+            <vms>
+                <vm id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+            </vms>
+            <alias>GlanceDisk-73786f4</alias>
+            <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
+            <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
+            <storage_domains>
+                <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
+            </storage_domains>
+            <size>41126400</size>
+            <provisioned_size>41126400</provisioned_size>
+            <actual_size>2564096</actual_size>
+            <status>
+                <state>ok</state>
+            </status>
+            <interface>virtio</interface>
+            <format>cow</format>
+            <sparse>true</sparse>
+            <bootable>false</bootable>
+            <shareable>false</shareable>
+            <wipe_after_delete>false</wipe_after_delete>
+            <propagate_errors>false</propagate_errors>
+            <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
+            <storage_type>image</storage_type>
+        </disk>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '2248'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <disks>
+            <disk href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
+                <actions>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
+                </actions>
+                <name>GlanceDisk-73786f4</name>
+                <description>CirrOS 0.3.1 (73786f4)</description>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
+                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <alias>GlanceDisk-73786f4</alias>
+                <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
+                <storage_domains>
+                    <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
+                </storage_domains>
+                <size>41126400</size>
+                <provisioned_size>41126400</provisioned_size>
+                <actual_size>2564096</actual_size>
+                <status>
+                    <state>ok</state>
+                </status>
+                <interface>virtio</interface>
+                <format>cow</format>
+                <sparse>true</sparse>
+                <bootable>false</bootable>
+                <shareable>false</shareable>
+                <wipe_after_delete>false</wipe_after_delete>
+                <propagate_errors>false</propagate_errors>
+                <active>true</active>
+                <read_only>false</read_only>
+                <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
+                <storage_type>image</storage_type>
+            </disk>
+        </disks>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '660'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <snapshots>
+            <snapshot href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
+                <actions>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
+                </actions>
+                <description>Active VM</description>
+                <type>active</type>
+                <date>2016-07-05T16:41:35.542+02:00</date>
+                <snapshot_status>ok</snapshot_status>
+                <persist_memorystate>false</persist_memorystate>
+            </snapshot>
+        </snapshots>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1242'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Date:
+      - Fri, 19 Aug 2016 09:43:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <nics>
+            <nic href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
+                <actions>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
+                </actions>
+                <name>nic1</name>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
+                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <network href="/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+                <linked>true</linked>
+                <interface>virtio</interface>
+                <mac address="00:1a:4a:16:01:52"/>
+                <active>true</active>
+                <plugged>true</plugged>
+                <vnic_profile href="/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
+            </nic>
+        </nics>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3745'
+      Jsessionid:
+      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      Link:
+      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+        rel=katelloerrata"
+      Date:
+      - Fri, 19 Aug 2016 09:43:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <api>
+            <link href="/api/capabilities" rel="capabilities"/>
+            <link href="/api/clusters" rel="clusters"/>
+            <link href="/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/api/datacenters" rel="datacenters"/>
+            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/api/events" rel="events"/>
+            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/api/hosts" rel="hosts"/>
+            <link href="/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/api/networks" rel="networks"/>
+            <link href="/api/networks?search={query}" rel="networks/search"/>
+            <link href="/api/roles" rel="roles"/>
+            <link href="/api/storagedomains" rel="storagedomains"/>
+            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/api/tags" rel="tags"/>
+            <link href="/api/bookmarks" rel="bookmarks"/>
+            <link href="/api/icons" rel="icons"/>
+            <link href="/api/templates" rel="templates"/>
+            <link href="/api/templates?search={query}" rel="templates/search"/>
+            <link href="/api/instancetypes" rel="instancetypes"/>
+            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/api/users" rel="users"/>
+            <link href="/api/users?search={query}" rel="users/search"/>
+            <link href="/api/groups" rel="groups"/>
+            <link href="/api/groups?search={query}" rel="groups/search"/>
+            <link href="/api/domains" rel="domains"/>
+            <link href="/api/vmpools" rel="vmpools"/>
+            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/api/vms" rel="vms"/>
+            <link href="/api/vms?search={query}" rel="vms/search"/>
+            <link href="/api/disks" rel="disks"/>
+            <link href="/api/disks?search={query}" rel="disks/search"/>
+            <link href="/api/jobs" rel="jobs"/>
+            <link href="/api/storageconnections" rel="storageconnections"/>
+            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/api/permissions" rel="permissions"/>
+            <link href="/api/macpools" rel="macpools"/>
+            <link href="/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <special_objects>
+                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+            </special_objects>
+            <product_info>
+                <name>oVirt Engine</name>
+                <vendor>ovirt.org</vendor>
+                <version major="3" minor="6" build="7" revision="0"/>
+                <full_version>3.6.7_master</full_version>
+            </product_info>
+            <summary>
+                <vms>
+                    <total>4</total>
+                    <active>0</active>
+                </vms>
+                <hosts>
+                    <total>1</total>
+                    <active>1</active>
+                </hosts>
+                <users>
+                    <total>1</total>
+                    <active>1</active>
+                </users>
+                <storage_domains>
+                    <total>2</total>
+                    <active>1</active>
+                </storage_domains>
+            </summary>
+            <time>2016-08-19T11:43:44.697+02:00</time>
+        </api>
+    http_version: 
+  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_new_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_new_vm.yml
@@ -1,0 +1,1075 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="ENGINE"
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '71'
+      Date:
+      - Mon, 22 Aug 2016 09:57:57 GMT
+    body:
+      encoding: UTF-8
+      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:56 GMT
+- request:
+    method: get
+    uri: https://admin%40internal:engine@192.168.1.31:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18; path=/api; HttpOnly
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3745'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Link:
+      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+        rel=katelloerrata"
+      Date:
+      - Mon, 22 Aug 2016 09:57:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <api>
+            <link href="/api/capabilities" rel="capabilities"/>
+            <link href="/api/clusters" rel="clusters"/>
+            <link href="/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/api/datacenters" rel="datacenters"/>
+            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/api/events" rel="events"/>
+            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/api/hosts" rel="hosts"/>
+            <link href="/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/api/networks" rel="networks"/>
+            <link href="/api/networks?search={query}" rel="networks/search"/>
+            <link href="/api/roles" rel="roles"/>
+            <link href="/api/storagedomains" rel="storagedomains"/>
+            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/api/tags" rel="tags"/>
+            <link href="/api/bookmarks" rel="bookmarks"/>
+            <link href="/api/icons" rel="icons"/>
+            <link href="/api/templates" rel="templates"/>
+            <link href="/api/templates?search={query}" rel="templates/search"/>
+            <link href="/api/instancetypes" rel="instancetypes"/>
+            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/api/users" rel="users"/>
+            <link href="/api/users?search={query}" rel="users/search"/>
+            <link href="/api/groups" rel="groups"/>
+            <link href="/api/groups?search={query}" rel="groups/search"/>
+            <link href="/api/domains" rel="domains"/>
+            <link href="/api/vmpools" rel="vmpools"/>
+            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/api/vms" rel="vms"/>
+            <link href="/api/vms?search={query}" rel="vms/search"/>
+            <link href="/api/disks" rel="disks"/>
+            <link href="/api/disks?search={query}" rel="disks/search"/>
+            <link href="/api/jobs" rel="jobs"/>
+            <link href="/api/storageconnections" rel="storageconnections"/>
+            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/api/permissions" rel="permissions"/>
+            <link href="/api/macpools" rel="macpools"/>
+            <link href="/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <special_objects>
+                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+            </special_objects>
+            <product_info>
+                <name>oVirt Engine</name>
+                <vendor>ovirt.org</vendor>
+                <version major="3" minor="6" build="7" revision="0"/>
+                <full_version>3.6.7_master</full_version>
+            </product_info>
+            <summary>
+                <vms>
+                    <total>4</total>
+                    <active>0</active>
+                </vms>
+                <hosts>
+                    <total>1</total>
+                    <active>1</active>
+                </hosts>
+                <users>
+                    <total>1</total>
+                    <active>1</active>
+                </users>
+                <storage_domains>
+                    <total>2</total>
+                    <active>1</active>
+                </storage_domains>
+            </summary>
+            <time>2016-08-22T11:57:57.869+02:00</time>
+        </api>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:56 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/clusters/00000002-0002-0002-0002-0000000001e9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '2810'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9">
+            <actions>
+                <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/resetemulatedmachine" rel="resetemulatedmachine"/>
+            </actions>
+            <name>Default</name>
+            <description>The default server cluster</description>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/networks" rel="networks"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/permissions" rel="permissions"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glustervolumes" rel="glustervolumes"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/glusterhooks" rel="glusterhooks"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/affinitygroups" rel="affinitygroups"/>
+            <link href="/api/clusters/00000002-0002-0002-0002-0000000001e9/cpuprofiles" rel="cpuprofiles"/>
+            <cpu id="Intel SandyBridge Family">
+                <architecture>X86_64</architecture>
+            </cpu>
+            <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0"/>
+            <memory_policy>
+                <overcommit percent="100"/>
+                <transparent_hugepages>
+                    <enabled>true</enabled>
+                </transparent_hugepages>
+            </memory_policy>
+            <scheduling_policy href="/api/schedulingpolicies/b4ed2332-a7ac-4d5f-9596-99a439cb2812" id="b4ed2332-a7ac-4d5f-9596-99a439cb2812">
+                <name>none</name>
+                <policy>none</policy>
+            </scheduling_policy>
+            <version major="3" minor="6"/>
+            <error_handling>
+                <on_error>migrate</on_error>
+            </error_handling>
+            <virt_service>true</virt_service>
+            <gluster_service>false</gluster_service>
+            <threads_as_cores>false</threads_as_cores>
+            <tunnel_migration>false</tunnel_migration>
+            <trusted_service>false</trusted_service>
+            <ha_reservation>false</ha_reservation>
+            <optional_reason>false</optional_reason>
+            <maintenance_reason_required>false</maintenance_reason_required>
+            <ballooning_enabled>false</ballooning_enabled>
+            <ksm>
+                <enabled>true</enabled>
+                <merge_across_nodes>true</merge_across_nodes>
+            </ksm>
+            <required_rng_sources>
+                <source>RANDOM</source>    assert_table_counts
+            </required_rng_sources>
+            <fencing_policy>
+                <enabled>true</enabled>
+                <skip_if_sd_active>
+                    <enabled>false</enabled>
+                </skip_if_sd_active>
+                <skip_if_connectivity_broken>
+                    <enabled>false</enabled>
+                    <threshold>50</threshold>
+                </skip_if_connectivity_broken>
+            </fencing_policy>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+        </cluster>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/datacenters/00000001-0001-0001-0001-0000000002c0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1354'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <data_center href="/api/datacenters/00000001-0001-0001-0001-0000000002c0" id="00000001-0001-0001-0001-0000000002c0">
+            <name>Default</name>
+            <description>The default Data Center</description>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/storagedomains" rel="storagedomains"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/clusters" rel="clusters"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/networks" rel="networks"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/permissions" rel="permissions"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/quotas" rel="quotas"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/qoss" rel="qoss"/>
+            <link href="/api/datacenters/00000001-0001-0001-0001-0000000002c0/iscsibonds" rel="iscsibonds"/>
+            <local>false</local>
+            <storage_format>v3</storage_format>
+            <version major="3" minor="6"/>
+            <supported_versions>
+                <version major="3" minor="6"/>
+            </supported_versions>
+            <status>
+                <state>up</state>
+            </status>
+            <mac_pool href="/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
+            <quota_mode>disabled</quota_mode>
+        </data_center>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '6098'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
+            <actions>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
+            </actions>
+            <name>123</name>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
+            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
+            <type>desktop</type>
+            <status>
+                <state>down</state>
+            </status>
+            <memory>1073741824</memory>
+            <cpu>
+                <topology sockets="1" cores="1" threads="1"/>
+                <architecture>X86_64</architecture>
+            </cpu>
+            <cpu_shares>0</cpu_shares>
+            <bios>
+                <boot_menu>
+                    <enabled>false</enabled>
+                </boot_menu>
+            </bios>
+            <os type="other">
+                <boot dev="hd"/>
+            </os>
+            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+            <creation_time>2016-07-05T16:41:35.374+02:00</creation_time>
+            <origin>ovirt</origin>
+            <stateless>false</stateless>
+            <delete_protected>false</delete_protected>
+            <high_availability>
+                <enabled>false</enabled>
+                <priority>1</priority>
+            </high_availability>
+            <display>
+                <type>spice</type>
+                <monitors>1</monitors>
+                <single_qxl_pci>false</single_qxl_pci>
+                <allow_override>false</allow_override>
+                <smartcard_enabled>false</smartcard_enabled>
+                <file_transfer_enabled>true</file_transfer_enabled>
+                <copy_paste_enabled>true</copy_paste_enabled>
+                <disconnect_action>LOCK_SCREEN</disconnect_action>
+            </display>
+            <sso>
+                <methods>
+                    <method id="GUEST_AGENT"/>
+                </methods>
+            </sso>
+            <timezone>Etc/GMT</timezone>
+            <usb>
+                <enabled>false</enabled>
+            </usb>
+            <migration_downtime>-1</migration_downtime>
+            <start_paused>false</start_paused>
+            <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+            <migration>
+                <auto_converge>inherit</auto_converge>
+                <compressed>inherit</compressed>
+            </migration>
+            <io>
+                <threads>0</threads>
+            </io>
+            <time_zone>
+                <name>Etc/GMT</name>
+            </time_zone>
+            <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+            <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+            <memory_policy>
+                <guaranteed>1073741824</guaranteed>
+                <ballooning>false</ballooning>
+            </memory_policy>
+            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+            <stop_time>2016-08-11T12:37:33.718+02:00</stop_time>
+            <placement_policy>
+                <affinity>migratable</affinity>
+            </placement_policy>
+            <next_run_configuration_exists>false</next_run_configuration_exists>
+            <numa_tune_mode>interleave</numa_tune_mode>
+        </vm>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3830'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <templates>
+            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
+                <actions>
+                    <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
+                </actions>
+                <name>GlanceTemplate-7bb26f9</name>
+                <description>CirrOS 0.3.1 (73786f4)</description>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
+                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
+                <type>desktop</type>
+                <status>
+                    <state>ok</state>
+                </status>
+                <memory>1073741824</memory>
+                <cpu>
+                    <topology sockets="1" cores="1" threads="1"/>
+                    <architecture>X86_64</architecture>
+                </cpu>
+                <cpu_shares>0</cpu_shares>
+                <bios>
+                    <boot_menu>
+                        <enabled>false</enabled>
+                    </boot_menu>
+                </bios>
+                <os type="other">
+                    <boot dev="hd"/>
+                </os>
+                <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
+                <creation_time>2016-06-03T13:43:25.838+02:00</creation_time>
+                <origin>ovirt</origin>
+                <stateless>false</stateless>
+                <delete_protected>false</delete_protected>
+                <high_availability>
+                    <enabled>false</enabled>
+                    <priority>0</priority>
+                </high_availability>
+                <display>
+                    <type>spice</type>
+                    <monitors>1</monitors>
+                    <single_qxl_pci>false</single_qxl_pci>
+                    <allow_override>false</allow_override>
+                    <smartcard_enabled>false</smartcard_enabled>
+                    <file_transfer_enabled>true</file_transfer_enabled>
+                    <copy_paste_enabled>true</copy_paste_enabled>
+                    <disconnect_action>LOCK_SCREEN</disconnect_action>
+                </display>
+                <sso>
+                    <methods>
+                        <method id="GUEST_AGENT"/>
+                    </methods>
+                </sso>
+                <timezone>Etc/GMT</timezone>
+                <usb>
+                    <enabled>false</enabled>
+                </usb>
+                <migration_downtime>-1</migration_downtime>
+                <start_paused>false</start_paused>
+                <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
+                <migration>
+                    <auto_converge>inherit</auto_converge>
+                    <compressed>inherit</compressed>
+                </migration>
+                <io>
+                    <threads>0</threads>
+                </io>
+                <time_zone>
+                    <name>Etc/GMT</name>
+                </time_zone>
+                <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
+                <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
+                <memory_policy>
+                    <guaranteed>1073741824</guaranteed>
+                </memory_policy>
+                <version>
+                    <base_template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
+                    <version_number>1</version_number>
+                    <version_name>base version</version_name>
+                </version>
+            </template>
+        </templates>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/storagedomains?search=sortby%20name%20asc%20page%201
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3562'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <storage_domains>
+            <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0">
+                <actions>
+                    <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/isattached" rel="isattached"/>
+                    <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/refreshluns" rel="refreshluns"/>
+                </actions>
+                <name>data</name>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/permissions" rel="permissions"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/templates" rel="templates"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/vms" rel="vms"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks" rel="disks"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/storageconnections" rel="storageconnections"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disksnapshots" rel="disksnapshots"/>
+                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/diskprofiles" rel="diskprofiles"/>
+                <data_centers>
+                    <data_center id="00000001-0001-0001-0001-0000000002c0"/>
+                </data_centers>
+                <type>data</type>
+                <external_status>
+                    <state>ok</state>
+                </external_status>
+                <master>true</master>
+                <storage>
+                    <address>192.168.1.106</address>
+                    <type>nfs</type>
+                    <path>/home/pkliczewski/export/hosted</path>
+                    <nfs_version>v3</nfs_version>
+                </storage>
+                <available>791347724288</available>
+                <used>130996502528</used>
+                <committed>13958643712</committed>
+                <storage_format>v3</storage_format>
+                <wipe_after_delete>false</wipe_after_delete>
+                <warning_low_space_indicator>10</warning_low_space_indicator>
+                <critical_space_action_blocker>5</critical_space_action_blocker>
+            </storage_domain>
+        </storage_domains>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/storagedomains?search=sortby%20name%20asc%20page%202
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '75'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <storage_domains/>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:57 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '2248'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <disks>
+            <disk href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
+                <actions>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
+                </actions>
+                <name>GlanceDisk-73786f4</name>
+                <description>CirrOS 0.3.1 (73786f4)</description>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
+                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <alias>GlanceDisk-73786f4</alias>
+                <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
+                <storage_domains>
+                    <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
+                </storage_domains>
+                <size>41126400</size>
+                <provisioned_size>41126400</provisioned_size>
+                <actual_size>2564096</actual_size>
+                <status>
+                    <state>ok</state>
+                </status>
+                <interface>virtio</interface>
+                <format>cow</format>
+                <sparse>true</sparse>
+                <bootable>false</bootable>
+                <shareable>false</shareable>
+                <wipe_after_delete>false</wipe_after_delete>
+                <propagate_errors>false</propagate_errors>
+                <active>true</active>
+                <read_only>false</read_only>
+                <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
+                <storage_type>image</storage_type>
+            </disk>
+        </disks>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '660'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <snapshots>
+            <snapshot href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
+                <actions>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
+                </actions>
+                <description>Active VM</description>
+                <type>active</type>
+                <date>2016-07-05T16:41:35.542+02:00</date>
+                <snapshot_status>ok</snapshot_status>
+                <persist_memorystate>false</persist_memorystate>
+            </snapshot>
+        </snapshots>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1242'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Date:
+      - Mon, 22 Aug 2016 09:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <nics>
+            <nic href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
+                <actions>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
+                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
+                </actions>
+                <name>nic1</name>
+                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
+                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
+                <network href="/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+                <linked>true</linked>
+                <interface>virtio</interface>
+                <mac address="00:1a:4a:16:01:52"/>
+                <active>true</active>
+                <plugged>true</plugged>
+                <vnic_profile href="/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
+            </nic>
+        </nics>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
+- request:
+    method: get
+    uri: https://192.168.1.31:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Version:
+      - '3'
+      Prefer:
+      - persistent-auth
+      Cookie:
+      - JSESSIONID=mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf.f18
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '3745'
+      Jsessionid:
+      - mwYV3UE_RAAqoOx7HlfOE7hlM5EH_cIfuOhEqiZf
+      Link:
+      - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
+        rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
+        rel=datacenters,<https://192.168.1.31:8443/api/datacenters?search={query}>;
+        rel=datacenters/search,<https://192.168.1.31:8443/api/events>; rel=events,<https://192.168.1.31:8443/api/events;from={event_id}?search={query}>;
+        rel=events/search,<https://192.168.1.31:8443/api/hosts>; rel=hosts,<https://192.168.1.31:8443/api/hosts?search={query}>;
+        rel=hosts/search,<https://192.168.1.31:8443/api/networks>; rel=networks,<https://192.168.1.31:8443/api/networks?search={query}>;
+        rel=networks/search,<https://192.168.1.31:8443/api/roles>; rel=roles,<https://192.168.1.31:8443/api/storagedomains>;
+        rel=storagedomains,<https://192.168.1.31:8443/api/storagedomains?search={query}>;
+        rel=storagedomains/search,<https://192.168.1.31:8443/api/tags>; rel=tags,<https://192.168.1.31:8443/api/bookmarks>;
+        rel=bookmarks,<https://192.168.1.31:8443/api/icons>; rel=icons,<https://192.168.1.31:8443/api/templates>;
+        rel=templates,<https://192.168.1.31:8443/api/templates?search={query}>; rel=templates/search,<https://192.168.1.31:8443/api/instancetypes>;
+        rel=instancetypes,<https://192.168.1.31:8443/api/instancetypes?search={query}>;
+        rel=instancetypes/search,<https://192.168.1.31:8443/api/users>; rel=users,<https://192.168.1.31:8443/api/users?search={query}>;
+        rel=users/search,<https://192.168.1.31:8443/api/groups>; rel=groups,<https://192.168.1.31:8443/api/groups?search={query}>;
+        rel=groups/search,<https://192.168.1.31:8443/api/domains>; rel=domains,<https://192.168.1.31:8443/api/vmpools>;
+        rel=vmpools,<https://192.168.1.31:8443/api/vmpools?search={query}>; rel=vmpools/search,<https://192.168.1.31:8443/api/vms>;
+        rel=vms,<https://192.168.1.31:8443/api/vms?search={query}>; rel=vms/search,<https://192.168.1.31:8443/api/disks>;
+        rel=disks,<https://192.168.1.31:8443/api/disks?search={query}>; rel=disks/search,<https://192.168.1.31:8443/api/jobs>;
+        rel=jobs,<https://192.168.1.31:8443/api/storageconnections>; rel=storageconnections,<https://192.168.1.31:8443/api/vnicprofiles>;
+        rel=vnicprofiles,<https://192.168.1.31:8443/api/diskprofiles>; rel=diskprofiles,<https://192.168.1.31:8443/api/cpuprofiles>;
+        rel=cpuprofiles,<https://192.168.1.31:8443/api/schedulingpolicyunits>; rel=schedulingpolicyunits,<https://192.168.1.31:8443/api/schedulingpolicies>;
+        rel=schedulingpolicies,<https://192.168.1.31:8443/api/permissions>; rel=permissions,<https://192.168.1.31:8443/api/macpools>;
+        rel=macpools,<https://192.168.1.31:8443/api/operatingsystems>; rel=operatingsystems,<https://192.168.1.31:8443/api/externalhostproviders>;
+        rel=externalhostproviders,<https://192.168.1.31:8443/api/openstackimageproviders>;
+        rel=openstackimageproviders,<https://192.168.1.31:8443/api/openstackvolumeproviders>;
+        rel=openstackvolumeproviders,<https://192.168.1.31:8443/api/openstacknetworkproviders>;
+        rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
+        rel=katelloerrata"
+      Date:
+      - Mon, 22 Aug 2016 09:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <api>
+            <link href="/api/capabilities" rel="capabilities"/>
+            <link href="/api/clusters" rel="clusters"/>
+            <link href="/api/clusters?search={query}" rel="clusters/search"/>
+            <link href="/api/datacenters" rel="datacenters"/>
+            <link href="/api/datacenters?search={query}" rel="datacenters/search"/>
+            <link href="/api/events" rel="events"/>
+            <link href="/api/events;from={event_id}?search={query}" rel="events/search"/>
+            <link href="/api/hosts" rel="hosts"/>
+            <link href="/api/hosts?search={query}" rel="hosts/search"/>
+            <link href="/api/networks" rel="networks"/>
+            <link href="/api/networks?search={query}" rel="networks/search"/>
+            <link href="/api/roles" rel="roles"/>
+            <link href="/api/storagedomains" rel="storagedomains"/>
+            <link href="/api/storagedomains?search={query}" rel="storagedomains/search"/>
+            <link href="/api/tags" rel="tags"/>
+            <link href="/api/bookmarks" rel="bookmarks"/>
+            <link href="/api/icons" rel="icons"/>
+            <link href="/api/templates" rel="templates"/>
+            <link href="/api/templates?search={query}" rel="templates/search"/>
+            <link href="/api/instancetypes" rel="instancetypes"/>
+            <link href="/api/instancetypes?search={query}" rel="instancetypes/search"/>
+            <link href="/api/users" rel="users"/>
+            <link href="/api/users?search={query}" rel="users/search"/>
+            <link href="/api/groups" rel="groups"/>
+            <link href="/api/groups?search={query}" rel="groups/search"/>
+            <link href="/api/domains" rel="domains"/>
+            <link href="/api/vmpools" rel="vmpools"/>
+            <link href="/api/vmpools?search={query}" rel="vmpools/search"/>
+            <link href="/api/vms" rel="vms"/>
+            <link href="/api/vms?search={query}" rel="vms/search"/>
+            <link href="/api/disks" rel="disks"/>
+            <link href="/api/disks?search={query}" rel="disks/search"/>
+            <link href="/api/jobs" rel="jobs"/>
+            <link href="/api/storageconnections" rel="storageconnections"/>
+            <link href="/api/vnicprofiles" rel="vnicprofiles"/>
+            <link href="/api/diskprofiles" rel="diskprofiles"/>
+            <link href="/api/cpuprofiles" rel="cpuprofiles"/>
+            <link href="/api/schedulingpolicyunits" rel="schedulingpolicyunits"/>
+            <link href="/api/schedulingpolicies" rel="schedulingpolicies"/>
+            <link href="/api/permissions" rel="permissions"/>
+            <link href="/api/macpools" rel="macpools"/>
+            <link href="/api/operatingsystems" rel="operatingsystems"/>
+            <link href="/api/externalhostproviders" rel="externalhostproviders"/>
+            <link href="/api/openstackimageproviders" rel="openstackimageproviders"/>
+            <link href="/api/openstackvolumeproviders" rel="openstackvolumeproviders"/>
+            <link href="/api/openstacknetworkproviders" rel="openstacknetworkproviders"/>
+            <link href="/api/katelloerrata" rel="katelloerrata"/>
+            <special_objects>
+                <link href="/api/templates/00000000-0000-0000-0000-000000000000" rel="templates/blank"/>
+                <link href="/api/tags/00000000-0000-0000-0000-000000000000" rel="tags/root"/>
+            </special_objects>
+            <product_info>
+                <name>oVirt Engine</name>
+                <vendor>ovirt.org</vendor>
+                <version major="3" minor="6" build="7" revision="0"/>
+                <full_version>3.6.7_master</full_version>
+            </product_info>
+            <summary>
+                <vms>
+                    <total>4</total>
+                    <active>0</active>
+                </vms>
+                <hosts>
+                    <total>1</total>
+                    <active>1</active>
+                </hosts>
+                <users>
+                    <total>1</total>
+                    <active>1</active>
+                </users>
+                <storage_domains>
+                    <total>2</total>
+                    <active>1</active>
+                </storage_domains>
+            </summary>
+            <time>2016-08-22T11:57:59.423+02:00</time>
+        </api>
+    http_version: 
+  recorded_at: Mon, 22 Aug 2016 09:57:58 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Refresh for vm creation and removal events now targets vm instead of targeting ems which saves a lot unneeded calls.