### PR TITLE
Fix misplaced method PivotOptions#drop_from_selection

### DIFF
--- a/app/controllers/report_controller/pivot_options.rb
+++ b/app/controllers/report_controller/pivot_options.rb
@@ -60,19 +60,19 @@ class ReportController
         self.by4 = params[:chosen_pivot4]
       end
     end
-  end
 
-  def drop_from_selection(item)
-    # Compress the pivotby fields if being moved left
-    if item == by1
-      self.by1 = by2
-      self.by2 = by3
-      self.by3 = NOTHING_STRING
-    elsif item == by2
-      self.by2 = by3
-      self.by3 = NOTHING_STRING
-    elsif item == by3
-      self.by3 = NOTHING_STRING
+    def drop_from_selection(item)
+      # Compress the pivotby fields if being moved left
+      if item == by1
+        self.by1 = by2
+        self.by2 = by3
+        self.by3 = NOTHING_STRING
+      elsif item == by2
+        self.by2 = by3
+        self.by3 = NOTHING_STRING
+      elsif item == by3
+        self.by3 = NOTHING_STRING
+      end
     end
   end
 end


### PR DESCRIPTION
In my recent refactoring (#9963), I have introduced a regression to the report editor. Please keep a close eye on me next time. :disappointed: 

Now, please let me punish myself appropriately :facepunch: :syringe: :wrench: :smoking: :ant:

The following happens when someone wants to remove a column from a selection in the report editor.
```
Error caught: [NoMethodError] undefined method `drop_from_selection' for #<ReportController::PivotOptions>
app/controllers/report_controller/reports/editor.rb:940:in `block in move_cols_left'
app/controllers/report_controller/reports/editor.rb:930:in `each'
app/controllers/report_controller/reports/editor.rb:930:in `move_cols_left'
app/controllers/report_controller/reports/editor.rb:529:in `gfv_move_cols_buttons'
app/controllers/report_controller/reports/editor.rb:395:in `get_form_vars'
app/controllers/report_controller/reports/editor.rb:116:in `form_field_changed'
```

@miq-bot add_label ui, reporting, bug
@miq-bot assign @martinpovolny 
