### PR TITLE
Removing sql munging and 2 queries for views (that reference parents)

### DIFF
--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -101,17 +101,10 @@ module MiqReport::Search
 
     if options[:parent]
       targets = get_parent_targets(options[:parent], options[:association] || options[:parent_method])
-      # necessary? is targets = [] or targets.nil?
-      if targets.empty?
-        search_results, attrs = [targets, {:auth_count => 0}]
-      else
-        search_results, attrs = Rbac.search(search_options.merge(:targets => targets))
-      end
     else
-      search_results, attrs = Rbac.search(search_options)
+      targets = db_class
     end
-
-    search_results ||= []
+    search_results, attrs = Rbac.search(search_options.merge(:targets => targets))
 
     if order.nil?
       options[:limit]   = limit

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -36,8 +36,8 @@ module MiqReport::Search
     end
   end
 
-  def get_cached_page(ids, includes, options)
-    data         = db_class.where(:id => ids).includes(includes).to_a
+  def get_cached_page(ids, includes, includes2, options)
+    data         = db_class.where(:id => ids).includes(includes).includes(includes2).to_a
     targets_hash = data.index_by(&:id) if options[:targets_hash]
     build_table(data, db, options)
     return table, extras[:attrs_for_paging].merge(:paged_read_from_cache => true, :targets_hash => targets_hash)
@@ -86,10 +86,13 @@ module MiqReport::Search
     self.display_filter = options.delete(:display_filter_hash)  if options[:display_filter_hash]
     self.display_filter = options.delete(:display_filter_block) if options[:display_filter_block]
 
-    includes = MiqExpression.merge_includes(get_include_for_find(include), include_for_find)
+    includes1 = get_include_for_find(include)
+    includes = MiqExpression.merge_includes(includes1, include_for_find)
 
     self.extras ||= {}
-    return get_cached_page(limited_ids(limit, offset), includes, options) if self.extras[:target_ids_for_paging] && db_class.column_names.include?('id')
+    if extras[:target_ids_for_paging] && db_class.column_names.include?('id')
+      return get_cached_page(limited_ids(limit, offset), includes1, include_for_find, options)
+    end
 
     order = get_order_info
 

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -68,14 +68,7 @@ module MiqReport::Search
       parent = klass.find(id)
     end
     assoc ||= db_class.base_model.to_s.pluralize.underscore  # Derive association from base model
-    ref = parent.class.reflection_with_virtual(assoc.to_sym)
-    if ref.nil? || parent.class.virtual_reflection?(assoc)
-      # why ID?
-      targets = parent.send(assoc).collect(&:id) # assoc is either a virtual reflection or a method so just call the association and collect the ids
-    else
-      targets = parent.send(assoc).ids
-    end
-    targets
+    parent.send(assoc)
   end
 
   def paged_view_search(options = {})

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -287,12 +287,10 @@ describe MiqReport do
       host1 = FactoryGirl.create(:host)
       FactoryGirl.create(:vm_vmware, :host => host1, :name => "a")
 
+      ems   = FactoryGirl.create(:ems_vmware)
       host2 = FactoryGirl.create(:host)
-      vmb   = FactoryGirl.create(:vm_vmware, :host => host2, :name => "b")
-      allow(vmb).to receive(:archived?).and_return(false)
-      vmc   = FactoryGirl.create(:vm_vmware, :host => host2, :name => "c")
-      allow(vmc).to receive(:archived?).and_return(false)
-      allow(Vm).to receive(:find_by).and_return(vmb)
+      vmb   = FactoryGirl.create(:vm_vmware, :host => host2, :name => "b", :ext_management_system => ems)
+      vmc   = FactoryGirl.create(:vm_vmware, :host => host2, :name => "c", :ext_management_system => ems)
 
       report = MiqReport.new(:db => "Vm", :sortby => "name", :order => "Descending")
       results, = report.paged_view_search(


### PR DESCRIPTION
Remove munging of sql

This code is the last piece that manipulate sql `where` and `includes`.
Only able to remove half of it, but the rbac scoping work will soon take care of the other half.

- Extracted the looking up and limiting of cached page ids to a single method
- Removed `.empty?` (potential sql query)
- for parent associations, use scope (removes sql query)

Help: where in the ui is `:parent => association` used?