### PR TITLE
debug toasts - Fix an error when closing an error message

### DIFF
--- a/app/assets/javascripts/miq_debug.js
+++ b/app/assets/javascripts/miq_debug.js
@@ -77,7 +77,7 @@ angular.module('miq.debug', [])
       '    </div>',
       '  </div>',
       '',
-      '  <toast-item ng-repeat="item in $ctrl.items" data="item" close="close"></toast-item>',
+      '  <toast-item ng-repeat="item in $ctrl.items" data="item" close="$ctrl.close"></toast-item>',
       '</div>',
     ].join("\n"),
     controller: ['$timeout', function($timeout) {


### PR DESCRIPTION
Closing an error popup triggers `TypeError: $ctrl._close is not a function at close`

Now passing in the right function..

Introduced in #6623