### PR TITLE
[WIP] purge ui_lookup() from MiqPolicyController and children

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -8,9 +8,9 @@ module MiqPolicyController::AlertProfiles
       @alert_profile = session[:edit][:alert_profile_id] ? MiqAlertSet.find_by_id(session[:edit][:alert_profile_id]) : MiqAlertSet.new
 
       if @alert_profile && @alert_profile.id.blank?
-        add_flash(_("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:model => "MiqAlertSet")})
+        add_flash(_("Add of new Alert Profile was cancelled by the user"))
       else
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqAlertSet"), :name => @alert_profile.description})
+        add_flash(_("Edit of Alert Profile \"%{name}\" was cancelled by the user") % {:name => @alert_profile.description})
       end
       get_node_info(x_node)
       replace_right_cell(@nodetype)
@@ -33,7 +33,7 @@ module MiqPolicyController::AlertProfiles
     case params[:button]
     when "save", "add"
       assert_privileges("alert_profile_#{@alert_profile.id ? "edit" : "new"}")
-      add_flash(_("%{model} must contain at least one %{field}") % {:model => ui_lookup(:model => "MiqAlertSet"), :field => ui_lookup(:model => "MiqAlert")}, :error) if @edit[:new][:alerts].length == 0 # At least one member is required
+      add_flash(_("Alert Profile must contain at least one Alert"), :error) if @edit[:new][:alerts].length == 0 # At least one member is required
       alert_profile = @alert_profile.id.blank? ? MiqAlertSet.new : MiqAlertSet.find(@alert_profile.id)  # Get new or existing record
       alert_profile.description = @edit[:new][:description]
       alert_profile.notes = @edit[:new][:notes]
@@ -50,9 +50,9 @@ module MiqPolicyController::AlertProfiles
             {:params => params[:button], :message => bang.message}, :error)
         end
         AuditEvent.success(build_saved_audit(alert_profile, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
-                                                _("%{model} \"%{name}\" was added")
-        add_flash(flash_key % {:model => ui_lookup(:model => "MiqAlertSet"), :name => @edit[:new][:description]})
+        flash_key = params[:button] == "save" ? _("Alert Profile \"%{name}\" was saved") :
+                                                _("Alert Profile \"%{name}\" was added")
+        add_flash(flash_key % {:name => @edit[:new][:description]})
         alert_profile_get_info(MiqAlertSet.find(alert_profile.id))
         alert_profile_sync_provider(current, mems.keys)
         @edit = nil
@@ -79,7 +79,7 @@ module MiqPolicyController::AlertProfiles
     case params[:button]
     when "cancel"
       @assign = nil
-      add_flash(_("Edit %{model} assignments cancelled by user") % {:model => ui_lookup(:model => "MiqAlertSet")})
+      add_flash(_("Edit Alert Profile assignments cancelled by user"))
       get_node_info(x_node)
       replace_right_cell(@nodetype)
     when "save"
@@ -111,8 +111,7 @@ module MiqPolicyController::AlertProfiles
     alert_profiles = []
     # showing 1 alert set, delete it
     if params[:id].nil? || MiqAlertSet.find_by_id(params[:id]).nil?
-      add_flash(_("%{model} no longer exists") % {:model => ui_lookup(:model => "MiqAlertSet")},
-                :error)
+      add_flash(_("Alert Profile no longer exists"), :error)
     else
       alert_profiles.push(params[:id])
       alert_profile_get_info(MiqAlertSet.find(params[:id]))
@@ -326,7 +325,7 @@ module MiqPolicyController::AlertProfiles
       [ui_lookup(:model => db), db]
     end
     #   @folders = ["Compliance", "Control"]
-    @right_cell_text = _("All %{records}") % {:records => ui_lookup(:models => "MiqAlertSet")}
+    @right_cell_text = _("All Alert Profiles")
     @right_cell_div = "alert_profile_folders"
   end
 
@@ -334,7 +333,7 @@ module MiqPolicyController::AlertProfiles
     @alert_profiles = MiqAlertSet.all.sort_by { |as| as.description.downcase }
     set_search_text
     @alert_profiles = apply_search_filter(@search_text, @alert_profiles) unless @search_text.blank?
-    @right_cell_text = _("All %{records}") % {:records => ui_lookup(:models => "MiqAlertSet")}
+    @right_cell_text = _("All Alert Profiles")
     @right_cell_div = "alert_profile_list"
   end
 
@@ -344,7 +343,7 @@ module MiqPolicyController::AlertProfiles
     aa = @alert_profile.get_assigned_tos
     @alert_profile_tag = Classification.find(aa[:tags].first.first.parent_id) unless aa[:tags].empty?
     @alert_profile_alerts = @alert_profile.miq_alerts.sort_by { |a| a.description.downcase }
-    @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqAlertSet"), :name => alert_profile.description}
+    @right_cell_text = _("Alert Profile \"%{name}\"") % {:name => alert_profile.description}
     @right_cell_div = "alert_profile_details"
   end
 

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -8,9 +8,9 @@ module MiqPolicyController::Alerts
       @edit = nil
       @alert = session[:edit][:alert_id] ? MiqAlert.find_by_id(session[:edit][:alert_id]) : MiqAlert.new
       if @alert && @alert.id.blank?
-        add_flash(_("Add of new %{models} was cancelled by the user") % {:models => ui_lookup(:model => "MiqAlert")})
+        add_flash(_("Add of new Alert was cancelled by the user"))
       else
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqAlert"), :name => @alert.description})
+        add_flash(_("Edit of Alert \"%{name}\" was cancelled by the user") % {:name => @alert.description})
       end
       get_node_info(x_node)
       replace_right_cell(@nodetype)
@@ -22,9 +22,9 @@ module MiqPolicyController::Alerts
       alert_set_record_vars(alert)
       if alert_valid_record?(alert) && alert.valid? && !@flash_array && alert.save
         AuditEvent.success(build_saved_audit(alert, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
-                                                _("%{model} \"%{name}\" was added")
-        add_flash(flash_key % {:model => ui_lookup(:model => "MiqAlert"), :name => @edit[:new][:description]})
+        flash_key = params[:button] == "save" ? _("Alert \"%{name}\" was saved") :
+                                                _("Alert \"%{name}\" was added")
+        add_flash(flash_key % {:name => @edit[:new][:description]})
         alert_get_info(MiqAlert.find(alert.id))
         alert_sync_provider(@edit[:alert_id] ? :update : :new)
         @edit = nil
@@ -53,10 +53,9 @@ module MiqPolicyController::Alerts
     # showing 1 alert, delete it
 
     if params[:id].nil? || MiqAlert.find_by_id(params[:id]).nil?
-      add_flash(_("%{models} no longer exists") % {:models => ui_lookup(:model => "MiqAlert")},
-                :error)
+      add_flash(_("Alert no longer exists"), :error)
     elsif MiqAlert.find_by_id(params[:id]).read_only
-      add_flash(_("%{models} can not be deleted") % {:models => ui_lookup(:model => "MiqAlert")}, :error)
+      add_flash(_("Alert can not be deleted"), :error)
     else
       alerts.push(params[:id])
     end
@@ -641,7 +640,7 @@ module MiqPolicyController::Alerts
         @email_to.push(user ? "#{user.name} (#{to})" : to)
       end
     end
-    @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqAlert"), :name => alert.description}
+    @right_cell_text = _("Alert \"%{name}\"") % {:name => alert.description}
     @right_cell_div = "alert_details"
 
     @record = @alert

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -8,10 +8,11 @@ module MiqPolicyController::Conditions
       return unless load_edit("condition_edit__#{id}", "replace_cell__explorer")
       @condition = @edit[:condition_id] ? Condition.find_by_id(@edit[:condition_id]) : Condition.new
       if @condition && @condition.id
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => "#{ui_lookup(:model => @edit[:new][:towhat])} #{ui_lookup(:model => "Condition")}", :name => @condition.description})
+        add_flash(_("Edit of %{towhat} Condition \"%{name}\" was cancelled by the user") %
+                  {:towhat => ui_lookup(:model => @edit[:new][:towhat]), :name => @condition.description})
       else
-        add_flash(_("Add of new %{model} was cancelled by the user") %
-          {:model => "#{ui_lookup(:model => @edit[:new][:towhat])} #{ui_lookup(:model => "Condition")}"})
+        add_flash(_("Add of new %{towhat} Condition was cancelled by the user") %
+                  {:towhat => ui_lookup(:model => @edit[:new][:towhat])})
       end
       @edit = nil
       get_node_info(x_node)
@@ -57,9 +58,9 @@ module MiqPolicyController::Conditions
           policy.save
         end
         AuditEvent.success(build_saved_audit(condition, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
-                                                _("%{model} \"%{name}\" was added")
-        add_flash(flash_key % {:model => ui_lookup(:model => "Condition"), :name => @edit[:new][:description]})
+        flash_key = params[:button] == "save" ? _("Condition \"%{name}\" was saved") :
+                                                _("Condition \"%{name}\" was added")
+        add_flash(flash_key % {:name => @edit[:new][:description]})
         @edit = nil
         @nodetype = "co"
         if adding # If add
@@ -124,8 +125,7 @@ module MiqPolicyController::Conditions
     # showing 1 condition, delete it
     con = Condition.find_by_id(params[:id])
     if params[:id].nil? || con.nil?
-      add_flash(_("%{models} no longer exists") % {:models => ui_lookup(:model => "Condition")},
-                :error)
+      add_flash(_("Condition no longer exists"), :error)
     else
       conditions.push(params[:id])
       @new_condition_node = "xx-#{con.towhat.camelize(:lower)}"
@@ -224,7 +224,7 @@ module MiqPolicyController::Conditions
 
   def condition_get_all_folders
     @folders = MiqPolicyController::UI_FOLDERS.collect(&:name)
-    @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "Condition")}
+    @right_cell_text = _("All Conditions")
     @right_cell_div = "condition_folders"
   end
 
@@ -232,14 +232,14 @@ module MiqPolicyController::Conditions
     @conditions = Condition.all.sort_by { |c| c.description.downcase }
     set_search_text
     @conditions = apply_search_filter(@search_text, @conditions) unless @search_text.blank?
-    @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "Condition")}
+    @right_cell_text = _("All Conditions")
     @right_cell_div = "condition_list"
   end
 
   # Get information for a condition
   def condition_get_info(condition)
     @record = @condition = condition
-    @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "Condition"), :name => condition.description}
+    @right_cell_text = _("Condition \"%{name}\"") % {:name => condition.description}
     @right_cell_div = "condition_details"
     @expression_table = @condition.expression.kind_of?(MiqExpression) ? exp_build_table(@condition.expression.exp) : nil
     @applies_to_exp_table = @condition.applies_to_exp.kind_of?(MiqExpression) ? exp_build_table(@condition.applies_to_exp.exp) : nil

--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -105,7 +105,7 @@ module MiqPolicyController::Events
     @events = MiqPolicy.all_policy_events.sort_by { |e| e.description.downcase }
     set_search_text
     @events = apply_search_filter(@search_text, @events) unless @search_text.blank?
-    @right_cell_text = _("All %{tables}") % {:tables => ui_lookup(:tables => "miq_event_definition")}
+    @right_cell_text = _("All Events")
     @right_cell_div = "event_list"
   end
 
@@ -113,7 +113,7 @@ module MiqPolicyController::Events
   def event_get_info(event)
     @record = @event = event
     @policy = MiqPolicy.find(from_cid(@sb[:node_ids][x_active_tree]["p"])) unless x_active_tree == :event_tree
-    @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:tables => "miq_event_definition"), :name => event.description}
+    @right_cell_text = _("Event \"%{name}\"") % {:name => event.description}
     @right_cell_div = "event_details"
 
     if x_active_tree == :event_tree

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -8,9 +8,9 @@ module MiqPolicyController::MiqActions
       @edit = nil
       @action = MiqAction.find_by_id(session[:edit][:action_id]) if session[:edit] && session[:edit][:action_id]
       if @action && @action.id
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqAction"), :name => @action.description})
+        add_flash(_("Edit of Action \"%{name}\" was cancelled by the user") % {:name => @action.description})
       else
-        add_flash(_("Add of new %{models} was cancelled by the user") % {:models => ui_lookup(:model => "MiqAction")})
+        add_flash(_("Add of new Action was cancelled by the user"))
       end
       @sb[:action] = nil
       get_node_info(x_node)
@@ -42,9 +42,9 @@ module MiqPolicyController::MiqActions
       action_set_record_vars(action)
       if action_valid_record?(action) && !@flash_array && action.save
         AuditEvent.success(build_saved_audit(action, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
-                                                _("%{model} \"%{name}\" was added")
-        add_flash(flash_key % {:model => ui_lookup(:model => "MiqAction"), :name => @edit[:new][:description]})
+        flash_key = params[:button] == "save" ? _("Action \"%{name}\" was saved") :
+                                                _("Action \"%{name}\" was added")
+        add_flash(flash_key % {:name => @edit[:new][:description]})
         action_get_info(MiqAction.find(action.id))
         @edit = nil
         @nodetype = "a"
@@ -69,8 +69,7 @@ module MiqPolicyController::MiqActions
     actions = []
     # showing 1 action, delete it
     if params[:id].nil? || MiqAction.find_by_id(params[:id]).nil?
-      add_flash(_("%{models} no longer exists") % {:models => ui_lookup(:model => "MiqAction")},
-                :error)
+      add_flash(_("Action no longer exists"), :error)
     else
       actions.push(params[:id])
     end
@@ -419,7 +418,7 @@ module MiqPolicyController::MiqActions
   # Get information for an action
   def action_get_info(action)
     @record = @action = action
-    @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqAction"), :name => action.description}
+    @right_cell_text = _("Action \"%{name}\"") % {:name => action.description}
     @right_cell_div = "action_details"
     @alert_guids = []
     if action.options && action.options[:alert_guids]

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -270,11 +270,11 @@ module MiqPolicyController::MiqActions
     action_build_snmp_variables if @action.action_type == "snmp_trap"
 
     # Build arrays for inherit/remove_tags action types
-    @edit[:tag_parent_types] =  [["<Choose>", nil],
-                                 [ui_lookup(:table => "ems_cluster"), "ems_cluster"],
-                                 ["Host", "host"],
-                                 [ui_lookup(:table => "storage"), "storage"],
-                                 ["Resource Pool", "parent_resource_pool"]
+    @edit[:tag_parent_types] =  [[_("<Choose>"), nil],
+                                 [_("Cluster / Deployment Role"), "ems_cluster"],
+                                 [_("Host"), "host"],
+                                 [_("Datastore"), "storage"],
+                                 [_("Resource Pool"), "parent_resource_pool"]
                                 ].sort_by { |x| x.first.downcase }
     @edit[:cats] = MiqAction.inheritable_cats.sort_by { |c| c.description.downcase }.collect { |c| [c.name, c.description] }
 

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -8,9 +8,9 @@ module MiqPolicyController::Policies
       return unless load_edit("policy_edit__#{id}", "replace_cell__explorer")
       @policy = MiqPolicy.find_by_id(@edit[:policy_id]) if @edit[:policy_id]
       if @policy && @policy.id
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqPolicy"), :name => @policy.description})
+        add_flash(_("Edit of Policy \"%{name}\" was cancelled by the user") % {:name => @policy.description})
       else
-        add_flash(_("Add of new %{models} was cancelled by the user") % {:models => ui_lookup(:model => "MiqPolicy")})
+        add_flash(_("Add of new Policy was cancelled by the user"))
       end
       @edit = nil
       get_node_info(x_node)
@@ -59,9 +59,9 @@ module MiqPolicyController::Policies
         end
         policy.sync_events(@edit[:new][:events].collect { |e| MiqEventDefinition.find(e) }) if @edit[:typ] == "events"
         AuditEvent.success(build_saved_audit(policy, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
-                                                _("%{model} \"%{name}\" was added")
-        add_flash(flash_key % {:model => ui_lookup(:model => "MiqPolicy"), :name => @edit[:new][:description]})
+        flash_key = params[:button] == "save" ? _("Policy \"%{name}\" was saved") :
+                                                _("Policy \"%{name}\" was added")
+        add_flash(flash_key % {:name => @edit[:new][:description]})
         policy_get_info(MiqPolicy.find(policy.id))
         @edit = nil
         @nodetype = "p"
@@ -95,7 +95,7 @@ module MiqPolicyController::Policies
     policy = MiqPolicy.find(params[:id])
     new_desc = truncate("Copy of #{policy.description}", :length => 255, :omission => "")
     if MiqPolicy.find_by_description(new_desc)
-      add_flash(_("%{model} \"%{name}\" already exists") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc}, :error)
+      add_flash(_("Policy \"%{name}\" already exists") % {:name => new_desc}, :error)
       javascript_flash
     else
       new_pol = policy.copy(:description => new_desc, :created_by => session[:userid], :read_only => nil)
@@ -105,7 +105,7 @@ module MiqPolicyController::Policies
                          :userid       => session[:userid],
                          :message      => "New Policy ID %{new_id} was copied from Policy ID %{old_id}" %
                                           {:new_id => new_pol.id, :old_id => policy.id})
-      add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc})
+      add_flash(_("Policy \"%{name}\" was added") % {:name => new_desc})
       @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{to_cid(policy.id)}"
       get_node_info(@new_policy_node)
       replace_right_cell("p", [:policy])
@@ -118,15 +118,13 @@ module MiqPolicyController::Policies
     # showing 1 policy, delete it
     pol = MiqPolicy.find_by_id(params[:id])
     if params[:id].nil? || pol.nil?
-      add_flash(_("%{models} no longer exists") % {:models => ui_lookup(:model => "MiqPolicy")},
-                :error)
+      add_flash(_("Policy no longer exists"), :error)
     else
       policies.push(params[:id])
       self.x_node = @new_policy_node = "xx-#{pol.mode.downcase}_xx-#{pol.mode.downcase}-#{pol.towhat.downcase}"
     end
     process_policies(policies, "destroy") unless policies.empty?
-    add_flash(_("The selected %{models} was deleted") %
-      {:models => ui_lookup(:models => "MiqPolicy")}) if @flash_array.nil?
+    add_flash(_("The selected Policy was deleted")) if @flash_array.nil?
     get_node_info(@new_policy_node)
     replace_right_cell("xx", [:policy, :policy_profile])
   end
@@ -230,8 +228,8 @@ module MiqPolicyController::Policies
   # Get information for a policy
   def policy_get_info(policy)
     @record = @policy = policy
-    @right_cell_text = _("%{model} \"%{name}\"") % {
-      :model => "#{@sb[:mode]} Policy",
+    @right_cell_text = _("%{mode} Policy \"%{name}\"") % {
+      :mode => @sb[:mode],
       :name  => @policy.description.gsub(/'/, "\\'")
     }
     @right_cell_div = "policy_details"

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -7,10 +7,9 @@ module MiqPolicyController::PolicyProfiles
       @edit = nil
       @profile = MiqPolicySet.find_by_id(session[:edit][:profile_id]) if session[:edit] && session[:edit][:profile_id]
       if !@profile || (@profile && @profile.id.blank?)
-        add_flash(_("Add of new %{models} was cancelled by the user") %
-          {:models => ui_lookup(:model => "MiqPolicySet")})
+        add_flash(_("Add of new Policy Profile was cancelled by the user"))
       else
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @profile.description})
+        add_flash(_("Edit of Policy Profile \"%{name}\" was cancelled by the user") % {:name => @profile.description})
       end
       get_node_info(x_node)
       replace_right_cell(@nodetype)
@@ -33,7 +32,7 @@ module MiqPolicyController::PolicyProfiles
     case params[:button]
     when "save", "add"
       assert_privileges("profile_#{@profile.id ? "edit" : "new"}")
-      add_flash(_("%{model} must contain at least one %{field}") % {:model => ui_lookup(:model => "MiqPolicySet"), :field => ui_lookup(:model => "MiqPolicy")}, :error) if @edit[:new][:policies].length == 0 # At least one member is required
+      add_flash(_("Policy Profile must contain at least one Policy"), :error) if @edit[:new][:policies].length == 0 # At least one member is required
       profile = @profile.id.blank? ? MiqPolicySet.new : MiqPolicySet.find(@profile.id)  # Get new or existing record
       profile.description = @edit[:new][:description]
       profile.notes = @edit[:new][:notes]
@@ -50,9 +49,9 @@ module MiqPolicyController::PolicyProfiles
             {:params => params[:button], :messages => bang.message}, :error)
         end
         AuditEvent.success(build_saved_audit(profile, params[:button] == "add"))
-        flash_key = params[:button] == "save" ? _("%{model} \"%{name}\" was saved") :
-                                                _("%{model} \"%{name}\" was added")
-        add_flash(flash_key % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @edit[:new][:description]})
+        flash_key = params[:button] == "save" ? _("Policy Profile \"%{name}\" was saved") :
+                                                _("Policy Profile \"%{name}\" was added")
+        add_flash(flash_key % {:name => @edit[:new][:description]})
         profile_get_info(MiqPolicySet.find(profile.id))
         @edit = nil
         @nodetype = "pp"
@@ -76,14 +75,12 @@ module MiqPolicyController::PolicyProfiles
     profiles = []
     # showing 1 policy set, delete it
     if params[:id].nil? || MiqPolicySet.find_by_id(params[:id]).nil?
-      add_flash(_("%{models} no longer exists") % {:models => ui_lookup(:model => "MiqPolicySet")},
-                :error)
+      add_flash(_("Policy Profile no longer exists"), :error)
     else
       profiles.push(params[:id])
     end
     process_profiles(profiles, "destroy") unless profiles.empty?
-    add_flash(_("The selected %{models} was deleted") %
-      {:models => ui_lookup(:models => "MiqPolicySet")}) if @flash_array.nil?
+    add_flash(_("The selected Policy Profile was deleted")) if @flash_array.nil?
     self.x_node = @new_profile_node = 'root'
     get_node_info('root')
     replace_right_cell('root', [:policy_profile])
@@ -143,7 +140,7 @@ module MiqPolicyController::PolicyProfiles
     @profiles = MiqPolicySet.all.sort_by { |ps| ps.description.downcase }
     set_search_text
     @profiles = apply_search_filter(@search_text, @profiles) unless @search_text.blank?
-    @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "MiqPolicySet")}
+    @right_cell_text = _("All Policy Profiles")
     @right_cell_div = "profile_list"
   end
 
@@ -151,7 +148,7 @@ module MiqPolicyController::PolicyProfiles
   def profile_get_info(profile)
     @record = @profile = profile
     @profile_policies = @profile.miq_policies.sort_by { |p| [p.towhat, p.mode, p.description.downcase] }
-    @right_cell_text = _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @profile.description}
+    @right_cell_text = _("Policy Profile \"%{name}\"") % {:name => @profile.description}
     @right_cell_div = "profile_details"
   end
 end


### PR DESCRIPTION
The promised followup to #9347.
Removes ~80 `ui_lookup` calls.  Most of these will need new translations.
Also turned most `mode.capitalize` interpolations `_("... Control ...")`, `_("... Compliance ...")` pairs of strings (not all though?)

Standardizing on "%{towhat} Policy", "%{towhat} Conditions" etc in new strings.  It's already used, IMO clearer than %{typ} or %{model} and matches the actual `.towhat` field.

Unraveled (ab)use of existing translations by sticking multiple things (`:foo => "#{bar} #{baz}"`) or fixed words (`:model => "#{@sb[:mode]} Policy"`) in one parameter.

The remaining `ui_lookup` calls are "towhat"s.

@miq-bot add-label internationalization, refactoring, darga/no, wip

WIP because I want to:
- [x] double-check plural/singular (a few were deliberate corrections, probably had mistakes too)
- [ ] understand some `nil` guards that I preserved
- [ ] actually run and test :-)
