### PR TITLE
Wait for ssh port to be added into wait_for_ip method

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/wait_for_ip.rb
@@ -13,8 +13,27 @@ class WaitForIP
     vm ||= @handle.root["vm"]
     vm ? check_ip_addr_available(vm) : vm_not_found
   end
-
-  def check_ip_addr_available(vm)
+  
+  require 'timeout'  
+  require 'socket'  
+  def is_port_open?(host, port, timeout=180, sleep_period=5)
+    begin
+      Timeout::timeout(timeout) do
+        begin
+          s = TCPSocket.new(host, port)
+          s.close
+          return true
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          sleep(sleep_period)
+          retry
+        end
+      end
+    rescue Timeout::Error
+      return false
+    end
+  end
+  
+  def check_ip_addr_available(vm, port=22, timeout=600, sleep_period=10)
     ip_list = vm.ipaddresses
     @handle.log(:info, "Current Power State #{vm.power_state}")
     @handle.log(:info, "IP addresses for VM #{ip_list}")
@@ -24,7 +43,9 @@ class WaitForIP
       @handle.root['ae_result'] = 'retry'
       @handle.root['ae_retry_limit'] = 1.minute
     else
-      @handle.root['ae_result'] = 'ok'
+      if is_port_open?( ip_list.first , port, timeout, sleep_period)
+        @handle.root['ae_result'] = 'ok'
+      end
     end
   end
 

--- a/spec/automation/unit/method_validation/wait_for_ip_spec.rb
+++ b/spec/automation/unit/method_validation/wait_for_ip_spec.rb
@@ -15,7 +15,7 @@ describe WaitForIP do
     root_object['vm'] = svc_vm
     allow_any_instance_of(klass).to receive(:ipaddresses).with(no_args).and_return(ip_addr)
     allow_any_instance_of(klass).to receive(:refresh).with(no_args).and_return(nil)
-    allow_any_instance_of(klass).to receive(:is_port_open?)..and_return(true)
+    allow_any_instance_of(klass).to receive(:is_port_open?).and_return(true)
     WaitForIP.new(service).main
 
     expect(root_object['ae_result']).to eq('ok')

--- a/spec/automation/unit/method_validation/wait_for_ip_spec.rb
+++ b/spec/automation/unit/method_validation/wait_for_ip_spec.rb
@@ -15,7 +15,7 @@ describe WaitForIP do
     root_object['vm'] = svc_vm
     allow_any_instance_of(klass).to receive(:ipaddresses).with(no_args).and_return(ip_addr)
     allow_any_instance_of(klass).to receive(:refresh).with(no_args).and_return(nil)
-
+    allow_any_instance_of(klass).to receive(:is_port_open?)..and_return(true)
     WaitForIP.new(service).main
 
     expect(root_object['ae_result']).to eq('ok')


### PR DESCRIPTION
## Purpose or Intent

We have Vsphere55 deployed in our test environment. For some unknown reason, when VM is provisioned and started, it takes some time for ssh daemon to accept connections. So IP address is reachable long time before ssh is accepting new connections. It would be nice if wait_for_ip method of Ansible Tower Job class contain code which is waiting until ssh port on machine being managed is accepting TCP connections. 
## Actual results:

Because waiting for ssh port to become accessible is not implemented, Ansible Tower Jobs are failing together with CFME/ManageIQ service. Request is sent to Tower for launching ansible_job_template during time when only IP is reachable but at that time, ssh daemon is not ready to accept connections. 
## Links
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1366142
## Steps for Testing/QA

Proper functionality of this PR can be tested on any Vsphere environment, where ssh daemon is started with few minutes delay after IP address is reachable. Vsphere 55 and Tower version 2.4.3 was used during testing.
