### PR TITLE
Add the option to disable debug toast notifications

### DIFF
--- a/app/assets/javascripts/miq_debug.js
+++ b/app/assets/javascripts/miq_debug.js
@@ -46,6 +46,11 @@ $(function() {
   }, true);
 
   window.debug_toast = function (type, data) {
+    // Don't display debug toasts if the user doesn't want it
+    if (sessionStorage.getItem('disableDebugToasts')) {
+      return false;
+    }
+
     if (type == 'warn') {
       type = 'warning';
     }
@@ -74,6 +79,8 @@ angular.module('miq.debug', [])
       '    <div class="toast-pf alert col-xs-12" ng-click="$ctrl.clear()">',
       '      <span class="pficon pficon-close"></span>',
       '      <a href="">Clear all</a>',
+      '      &nbsp;|&nbsp;',
+      '      <a href="" ng-click="$ctrl.disable()">Disable notifications</a>',
       '    </div>',
       '  </div>',
       '',
@@ -101,6 +108,10 @@ angular.module('miq.debug', [])
       this.clear = function() {
         _.remove(this.items, _.identity);
       };
+
+      this.disable = function() {
+        sessionStorage.setItem('disableDebugToasts', true);
+      }
     }],
   })
   .component('toastItem', {


### PR DESCRIPTION
Sometimes #6623 can be really disturbing in development and I think disabling it temporarily for a current browser session can be useful for many of us who aren't working with JS. This PR introduces a link to disable toast notifications by setting a `sessionStorage` variable to `true`. 

![screenshot from 2016-08-11 15-25-02](https://cloud.githubusercontent.com/assets/649130/17590011/28e54096-5fd8-11e6-9276-c03d6656394b.png)

cc @himdel @isimluk 