### PR TITLE
Skip Media&Other items in vCloud Catalogs

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -71,6 +71,9 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
         next if catalog.is_published && !@options.get_public_images
 
         catalog.catalog_items.each do |item|
+          # Skip all Catalog Items which are not vApp Templates (e.g. Media & Other)
+          next unless item.vapp_template_id.starts_with?('vappTemplate-')
+
           @inv[:vapp_templates] << {
             :vapp_template => item.vapp_template,
             :is_published  => catalog.is_published


### PR DESCRIPTION
Purpose or Intent
-----------------
VMware vCloud Catalogs contain two types of items, vApp Templates and Media&Other.  Currently we only want to inventory vApp Templates because you cannot provision anything from the Media&Other items.  This will skip all Media&Other items in a vCloud catalog.

If you call `item.vapp_template` on a media file fog throws an Access Denied exception, this checks to make sure it is a vapp template before calling `item.vapp_template`