### PR TITLE
API: Forbid deletion of groups that are read-only

### DIFF
--- a/app/controllers/api_controller/groups.rb
+++ b/app/controllers/api_controller/groups.rb
@@ -20,8 +20,13 @@ class ApiController
       parse_set_tenant(data)
       group = resource_search(id, type, collection_class(:groups))
       parse_set_filters(data, :entitlement_id => group.entitlement.try(:id))
-      raise BadRequestError, "Cannot edit a read-only group" if group.read_only
+      raise Forbidden, "Cannot edit a read-only group" if group.read_only
       edit_resource(type, id, data)
+    end
+
+    def delete_resource_groups(type, id, data = {})
+      raise Forbidden, "Cannot delete a read-only group" if MiqGroup.find(id).read_only?
+      delete_resource(type, id, data)
     end
 
     private

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -215,6 +215,14 @@ describe ApiController do
       expect(response).to have_http_status(:not_found)
     end
 
+    it 'rejects a request to remove a default tenant group' do
+      api_basic_authorize collection_action_identifier(:groups, :delete)
+
+      run_delete(groups_url(tenant3.default_miq_group_id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it "supports single group delete" do
       api_basic_authorize collection_action_identifier(:groups, :delete)
 


### PR DESCRIPTION
The read-only group is either `system_group` or `tenant_group`. The system groups are hard to remove as rails will issue a ROLLBACK because of cascade dependencies. The tenant_groups were introduced by @kbrock  in #5054 and we shall never allow deletion of them through api.

Also, prefer to raise Forbidden on read-only edit, as we do the same for `categories`.

Further, we shall not show list of the default tenant groups to the users on API, I will prepare separate pr for that.

@miq-bot add_label bug, api, tenancy
@miq-bot assign @abellotti 