### PR TITLE
Added PostgresAdmin.database_in_recovery? method to PostgresAdmin class

### DIFF
--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -1,4 +1,5 @@
 require "util/postgres_admin"
+require 'pg'
 
 describe PostgresAdmin do
   context "ENV dependent" do
@@ -54,6 +55,24 @@ describe PostgresAdmin do
         expect(described_class.stop_command(false))
           .to eql "su - postgres -c '/ctl/path stop -W -D /pgdata/path -s -m fast'"
       end
+    end
+  end
+
+  describe ".database_in_recovery?" do
+    before do
+      begin
+        @connection = PG::Connection.open(:dbname => 'travis', :user => 'travis')
+      rescue PG::ConnectionBad
+        skip "travis database does not exist"
+      end
+    end
+
+    after do
+      @connection.finish if @connection
+    end
+
+    it "returns false if postgres database not in recovery mode" do
+      expect(described_class.database_in_recovery?(@connection)).to be false
     end
   end
 end

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -259,4 +259,15 @@ class PostgresAdmin
                         "PGUSER"     => opts[:username],
                         "PGPASSWORD" => opts[:password]}).output
   end
+
+  # Checks if postgres database is in recovery mode
+  #
+  # @param pg_connection [PG::Connection] established pg connection
+  # @return [Boolean] true if database in recovery mode
+  def self.database_in_recovery?(pg_connection)
+    pg_connection.exec("SELECT pg_catalog.pg_is_in_recovery()") do |db_result|
+      result = db_result.map_types!(PG::BasicTypeMapForResults.new(pg_connection)).first
+      result['pg_is_in_recovery']
+    end
+  end
 end


### PR DESCRIPTION
During failover execution there should be no attempt to switch to database which is in recovery mode. 
In this PR: added method ```PostgresAdmin.database_in_recovery?(connection)``` 

@carbonin 

@miq-bot add-label core, wip

