### PR TITLE
Don't create blueprint if bundle fails

### DIFF
--- a/app/controllers/api_controller/blueprints.rb
+++ b/app/controllers/api_controller/blueprints.rb
@@ -2,9 +2,10 @@ class ApiController
   module Blueprints
     def create_resource_blueprints(_type, _id, data)
       attributes = data.except("bundle")
-      blueprint = Blueprint.create!(attributes)
+      blueprint = Blueprint.new(attributes)
       bundle = data["bundle"]
       create_bundle(blueprint, bundle) if bundle
+      blueprint.save!
       blueprint
     end
 


### PR DESCRIPTION
Purpose or Intent
-----------------

Changes the create action in the API to defer saving of the blueprint
until after the bundle is created. Should it fail it will not create a
blueprint.

@miq-bot add-label api, bug
@miq-bot assign @abellotti 
/cc @bzwei 