### PR TITLE
Automate - Cloud Retirement - Add google specific retirement states.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__class__.yaml
@@ -211,3 +211,43 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: relationship
+      name: google_rel1
+      display_name: Google
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: google
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: google_meth1
+      display_name: Google
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: google
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.rb
@@ -1,0 +1,10 @@
+#
+# Description: This method stops a cloud Instance
+#
+
+vm = $evm.root['vm']
+if vm && vm.power_state == 'on'
+  ems = vm.ext_management_system
+  $evm.log('info', "Stopping Instance <#{vm.name}> in EMS <#{ems.try(:name)}>")
+  vm.stop if ems
+end

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/pre_retirement.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: pre_retirement
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/checkpreretirement.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/checkpreretirement.yaml
@@ -14,3 +14,5 @@ object:
       value: amazon_check_pre_retirement
   - azure_meth1:
       value: check_pre_retirement
+  - google_meth1:
+      value: check_pre_retirement

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/preretirement.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/preretirement.yaml
@@ -14,3 +14,5 @@ object:
       value: amazon_pre_retirement
   - azure_meth1:
       value: azure_pre_retirement
+  - google_meth1:
+      value: pre_retirement


### PR DESCRIPTION
The cloud retirement state machine has vendor specific entries for pre_retirement and check_pre_retirement.  Since google is a newer provider, there weren't google specific schema entries for retirement which meant that google instances would not power off the instance and not check to ensure the instance is powered off before continuing the state machine with a powered on instance.  This wouldn't be an issue if we provisioned the instance because retirement would remove the instance from the provider.   

https://bugzilla.redhat.com/show_bug.cgi?id=1364894