### PR TITLE
Fixed tenant_identity to handle storage that does not belong to an EMS

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -47,6 +47,7 @@ class Storage < ApplicationRecord
   include AsyncDeleteMixin
   include AvailabilityMixin
   include SupportsFeatureMixin
+  include TenantIdentityMixin
 
   virtual_column :v_used_space,                   :type => :integer
   virtual_column :v_used_space_percent_of_total,  :type => :integer
@@ -886,10 +887,6 @@ class Storage < ApplicationRecord
         s.public_send("validate_#{operation}")[:available]
       end
     end
-  end
-
-  def tenant_identity
-    ext_management_system.tenant_identity
   end
 
   # @param [String, Storage] store_type upcased version of the storage type

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -536,4 +536,28 @@ describe Storage do
       expect(storage.storage_clusters).to match_array([])
     end
   end
+
+  context "#tenant_identity" do
+    let(:admin)    { FactoryGirl.create(:user_with_group, :userid => "admin") }
+    let(:tenant)   { FactoryGirl.create(:tenant) }
+    let(:ems)      { FactoryGirl.create(:ext_management_system, :tenant => tenant) }
+    let(:host)     { FactoryGirl.create(:host, :ext_management_system => ems) }
+
+    before         { admin }
+    it "has tenant from provider" do
+      storage = FactoryGirl.create(:storage, :hosts => [host])
+
+      expect(storage.tenant_identity).to                eq(admin)
+      expect(storage.tenant_identity.current_group).to  eq(ems.tenant.default_miq_group)
+      expect(storage.tenant_identity.current_tenant).to eq(ems.tenant)
+    end
+
+    it "without a provider, has tenant from root tenant" do
+      storage = FactoryGirl.create(:storage)
+
+      expect(storage.tenant_identity).to                eq(admin)
+      expect(storage.tenant_identity.current_group).to  eq(Tenant.root_tenant.default_miq_group)
+      expect(storage.tenant_identity.current_tenant).to eq(Tenant.root_tenant)
+    end
+  end
 end


### PR DESCRIPTION
- Removed #tenant_identity method in place of mixing version that already handles nil EMS
- Storages belong to an EMS indirectly through the hosts to which it is attached. If a storage is not attached to any hosts the EMS will be nil.
In that case the root tenant will be used for the tenant_identity.

https://bugzilla.redhat.com/show_bug.cgi?id=1365688