### PR TITLE
A few enhancements and bug fixes to blueprint model

### DIFF
--- a/app/controllers/api_controller/blueprints.rb
+++ b/app/controllers/api_controller/blueprints.rb
@@ -12,16 +12,18 @@ class ApiController
     private
 
     def create_bundle(blueprint, bundle)
-      service_catalog = ServiceTemplateCatalog.find(parse_id(bundle["service_catalog"], :service_catalogs))
-      service_dialog = Dialog.find(parse_id(bundle["service_dialog"], :service_dialogs))
-      service_templates = bundle["service_templates"].collect do |st|
+      options = {}
+      if bundle["service_catalog"]
+        options[:service_catalog] = ServiceTemplateCatalog.find(parse_id(bundle["service_catalog"], :service_catalogs))
+      end
+      if bundle["service_dialog"]
+        options[:service_dialog] = Dialog.find(parse_id(bundle["service_dialog"], :service_dialogs))
+      end
+      options[:service_templates] = bundle.fetch("service_templates", []).collect do |st|
         ServiceTemplate.find(parse_id(st, :service_templates))
       end
-      automate_entrypoints = bundle["automate_entrypoints"]
-      blueprint.create_bundle(service_templates,
-                              service_dialog,
-                              service_catalog,
-                              "entry_points" => automate_entrypoints)
+      options[:entry_points] = bundle["automate_entrypoints"] if bundle["automate_entrypoints"]
+      blueprint.create_bundle(options)
     rescue => e
       raise BadRequestError, "Couldn't create the bundle - #{e}"
     end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -81,7 +81,9 @@ describe Blueprint do
 
   describe '#create_bundle' do
     it 'create a bundle from existing items' do
-      bundle = subject.create_bundle([catalog_vm_provisioning], dialog, catalog)
+      bundle = subject.create_bundle(:service_templates => [catalog_vm_provisioning],
+                                     :service_dialog    => dialog,
+                                     :service_catalog   => catalog)
       expect(Dialog.count).to eq(2)
       expect(subject.bundle).to eq(bundle)
       expect(bundle.display).to be_falsey

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -41,10 +41,13 @@ RSpec.describe "Blueprints API" do
 
     it "will show a blueprint's bundle if requested" do
       blueprint = FactoryGirl.create(:blueprint, :name => "Test Blueprint")
-      service_catalog = FactoryGirl.create(:service_template_catalog)
-      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
       service_templates = FactoryGirl.create_list(:service_template, 2)
-      blueprint.create_bundle(service_templates, service_dialog, service_catalog)
+      service_catalog   = FactoryGirl.create(:service_template_catalog)
+      service_dialog    = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
+      blueprint.create_bundle(:service_templates => service_templates,
+                              :service_catalog   => service_catalog,
+                              :service_dialog    => service_dialog)
+
       api_basic_authorize action_identifier(:blueprints, :read, :resource_actions, :get)
 
       run_get(blueprints_url(blueprint.id), :attributes => "bundle")


### PR DESCRIPTION
Purpose or Intent
-----------------
Allow `create_bundle` arguments to be `nil`, required by #10416
/cc @imtayadeway The first argument `catalog_items` is expected to be `[]` if no item is provided.
 
Add `update_bundle` method, required by #10385 
Actual implementation is to be added by a follow-up PR.

A minor fix to custom_button copy: they need to be copied only at the top bundle level.

Links
-----
#10416 
#10385 

@gmcculloug please review