### PR TITLE
DRY up dialog building in tests by extracting factories

### DIFF
--- a/spec/factories/dialog.rb
+++ b/spec/factories/dialog.rb
@@ -14,4 +14,10 @@ FactoryGirl.define do
       instance.save!
     end
   end
+
+  factory :dialog_with_tab_and_group_and_field, :parent => :dialog do
+    after(:create) do |dialog|
+      create(:dialog_tab_with_group_and_field, :dialog => dialog)
+    end
+  end
 end

--- a/spec/factories/dialog_group.rb
+++ b/spec/factories/dialog_group.rb
@@ -14,4 +14,10 @@ FactoryGirl.define do
       instance.save!
     end
   end
+
+  factory :dialog_group_with_field, :parent => :dialog_group do
+    after(:create) do |dialog_group|
+      create(:dialog_field_text_box, :dialog_group => dialog_group)
+    end
+  end
 end

--- a/spec/factories/dialog_tab.rb
+++ b/spec/factories/dialog_tab.rb
@@ -14,4 +14,10 @@ FactoryGirl.define do
       instance.save!
     end
   end
+
+  factory :dialog_tab_with_group_and_field, :parent => :dialog_tab do
+    after(:create) do |dialog_tab|
+      create(:dialog_group_with_field, :dialog_tab => dialog_tab)
+    end
+  end
 end

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Blueprints API" do
     it "will show a blueprint's bundle if requested" do
       blueprint = FactoryGirl.create(:blueprint, :name => "Test Blueprint")
       service_catalog = FactoryGirl.create(:service_template_catalog)
-      service_dialog = build_dialog
+      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
       service_templates = FactoryGirl.create_list(:service_template, 2)
       blueprint.create_bundle(service_templates, service_dialog, service_catalog)
       api_basic_authorize action_identifier(:blueprints, :read, :resource_actions, :get)
@@ -121,7 +121,7 @@ RSpec.describe "Blueprints API" do
     end
 
     it "can create a blueprint with a bundle by href with an appropriate role" do
-      service_dialog = build_dialog
+      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
       service_template_1, service_template_2 = FactoryGirl.create_list(:service_template, 2)
       service_catalog = FactoryGirl.create(:service_template_catalog)
       api_basic_authorize collection_action_identifier(:blueprints, :create)
@@ -145,7 +145,7 @@ RSpec.describe "Blueprints API" do
     end
 
     it "can create a blueprint with a bundle by id with an appropriate role" do
-      service_dialog = build_dialog
+      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
       service_template_1, service_template_2 = FactoryGirl.create_list(:service_template, 2)
       service_catalog = FactoryGirl.create(:service_template_catalog)
       api_basic_authorize collection_action_identifier(:blueprints, :create)
@@ -256,23 +256,5 @@ RSpec.describe "Blueprints API" do
 
       expect(response).to have_http_status(:forbidden)
     end
-  end
-
-  # TODO: factor this out of this test so it can be used elsewhere
-  def build_dialog
-    FactoryGirl.create(
-      :dialog,
-      :dialog_tabs => [
-        FactoryGirl.create(
-          :dialog_tab,
-          :dialog_groups => [
-            FactoryGirl.create(
-              :dialog_group,
-              :dialog_fields => [FactoryGirl.create(:dialog_field_text_box)]
-            )
-          ]
-        )
-      ]
-    )
   end
 end

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -184,20 +184,7 @@ RSpec.describe "service orders API" do
       end
 
       it "can add a service request to a shopping cart" do
-        dialog = FactoryGirl.create(
-          :dialog,
-          :dialog_tabs => [
-            FactoryGirl.create(
-              :dialog_tab,
-              :dialog_groups => [
-                FactoryGirl.create(
-                  :dialog_group,
-                  :dialog_fields => [FactoryGirl.create(:dialog_field_text_box)]
-                )
-              ]
-            )
-          ]
-        )
+        dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
         service_template = FactoryGirl.create(:service_template)
         service_template.resource_actions << FactoryGirl.create(:resource_action,
                                                                 :action => "Provision",
@@ -227,20 +214,7 @@ RSpec.describe "service orders API" do
       end
 
       it "can add muliple service requests to a shopping cart by href" do
-        dialog = FactoryGirl.create(
-          :dialog,
-          :dialog_tabs => [
-            FactoryGirl.create(
-              :dialog_tab,
-              :dialog_groups => [
-                FactoryGirl.create(
-                  :dialog_group,
-                  :dialog_fields => [FactoryGirl.create(:dialog_field_text_box)]
-                )
-              ]
-            )
-          ]
-        )
+        dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
 
         service_template_1, service_template_2 = FactoryGirl.create_list(:service_template, 2)
         service_template_1.resource_actions << FactoryGirl.create(:resource_action,
@@ -461,20 +435,7 @@ RSpec.describe "service orders API" do
       end
 
       it "will not add a service request to a shopping cart" do
-        dialog = FactoryGirl.create(
-          :dialog,
-          :dialog_tabs => [
-            FactoryGirl.create(
-              :dialog_tab,
-              :dialog_groups => [
-                FactoryGirl.create(
-                  :dialog_group,
-                  :dialog_fields => [FactoryGirl.create(:dialog_field_text_box)]
-                )
-              ]
-            )
-          ]
-        )
+        dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
         service_template = FactoryGirl.create(:service_template)
         service_template.resource_actions << FactoryGirl.create(:resource_action,
                                                                 :action => "Provision",
@@ -491,20 +452,7 @@ RSpec.describe "service orders API" do
       end
 
       it "will not add multiple service requests to a shopping cart" do
-        dialog = FactoryGirl.create(
-          :dialog,
-          :dialog_tabs => [
-            FactoryGirl.create(
-              :dialog_tab,
-              :dialog_groups => [
-                FactoryGirl.create(
-                  :dialog_group,
-                  :dialog_fields => [FactoryGirl.create(:dialog_field_text_box)]
-                )
-              ]
-            )
-          ]
-        )
+        dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
         service_template_1, service_template_2 = FactoryGirl.create_list(:service_template, 2)
         service_template_1.resource_actions << FactoryGirl.create(:resource_action,
                                                                   :action => "Provision",

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -204,10 +204,7 @@ describe ApiController do
   end
 
   describe "Service reconfiguration" do
-    let(:dialog1) { FactoryGirl.create(:dialog, :label => "Dialog1") }
-    let(:tab1)    { FactoryGirl.create(:dialog_tab, :label => "Tab1") }
-    let(:group1)  { FactoryGirl.create(:dialog_group, :label => "Group1") }
-    let(:text1)   { FactoryGirl.create(:dialog_field_text_box, :label => "TextBox1", :name => "text1") }
+    let(:dialog1) { FactoryGirl.create(:dialog_with_tab_and_group_and_field) }
     let(:st1)     { FactoryGirl.create(:service_template, :name => "template1") }
     let(:ra1) do
       FactoryGirl.create(:resource_action, :action => "Reconfigure", :dialog => dialog1,


### PR DESCRIPTION
Purpose or Intent
-----------------
In a few of these tests I've wanted to create a dialog and all the groups/tabs/fields that go under it without needing to worry about the details. It seemed appropriate to DRY this up by creating a helper method.

Naming is hard. I wanted a method that sounded roughly like "go create me a dialog with all the stuff in it", so went with `create_complete_dialog` - suggestions welcome @gmcculloug 

@miq-bot add-label api, testing, refactoring
@miq-bot assign @abellotti 


