### PR TITLE
Check for plugin name in locale:plugin:find rake task

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -135,6 +135,10 @@ namespace :locale do
 
   desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
   task "plugin:find", :engine do |_, args|
+    unless args.key?(:engine)
+      $stderr.puts "You need to specify a plugin name: rake locale:plugin:find[plugin_name]"
+      exit 1
+    end
     @domain = args[:engine]
     @engine = "#{@domain.camelize}::Engine".constantize
     @engine_root = @engine.root


### PR DESCRIPTION
Before:
```
$ rake locale:plugin:find
rake aborted!
NoMethodError: undefined method `camelize' for nil:NilClass
lib/tasks/locale.rake:139:in `block (2 levels) in <top (required)>'
bin/bundle:23:in `load'
bin/bundle:23:in `<main>'
Tasks: TOP => locale:plugin:find
(See full trace by running task with --trace)

```

After:
```
$ rake locale:plugin:find
You need to specify a plugin name: rake locale:plugin:find[plugin_name]
```