### PR TITLE
Toolbar buttons for VMs moved to separate class (part 5)

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1881,7 +1881,6 @@ module ApplicationController::CiProcessing
     assert_privileges(params[:pressed])
     vm_button_operation('shutdown_guest', 'shutdown')
   end
-  alias_method :instance_guest_shutdown, :guestshutdown
   alias_method :vm_guest_shutdown, :guestshutdown
 
   # Standby guests on all selected or single displayed vm(s)

--- a/app/helpers/application_helper/button/perf_refresh.rb
+++ b/app/helpers/application_helper/button/perf_refresh.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::PerfRefresh < ApplicationHelper::Button::Basic
+  def calculate_properties
+    self[:hidden] = false
+  end
+
+  def skip?
+    !@perf_options[:typ] == "realtime"
+  end
+end

--- a/app/helpers/application_helper/button/vm_reconfigure.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::VmReconfigure < ApplicationHelper::Button::Basic
+  needs_record
+
+  def skip?
+    !@record.reconfigurable?
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -176,7 +176,9 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           N_('Shutdown the Guest OS on this VM'),
           N_('Shutdown Guest'),
           :image   => "guest_shutdown",
-          :confirm => N_("Shutdown the Guest OS on this VM?")),
+          :confirm => N_("Shutdown the Guest OS on this VM?"),
+          :klass   => ApplicationHelper::Button::GenericFeatureButtonWithDisable,
+          :options => {:feature => :shutdown_guest}),
         button(
           :vm_guest_restart,
           nil,

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -61,7 +61,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :vm_reconfigure,
           'pficon pficon-edit fa-lg',
           N_('Reconfigure the Memory/CPU of this VM'),
-          N_('Reconfigure this VM')),
+          N_('Reconfigure this VM'),
+          :klass => ApplicationHelper::Button::VmReconfigure),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -828,8 +828,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Vm"
       case id
-      when "vm_reconfigure"
-        return true unless @record.reconfigurable?
       when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"
         return true unless @perf_options[:typ] == "realtime"
       end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -828,8 +828,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Vm"
       case id
-      when "instance_guest_shutdown"
-        return true unless @record.is_available?(:shutdown_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
       when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -90,8 +90,8 @@ class ApplicationHelper::ToolbarBuilder
     current_item[:hidden] = !any_visible
 
     if bs_children
-      @sep_added = true                                        # Separator has officially been added
-      @sep_needed = true                                       # Need a separator from now on
+      @sep_added = true # Separator has officially been added
+      @sep_needed = true # Need a separator from now on
     end
     current_item
   end
@@ -825,11 +825,6 @@ class ApplicationHelper::ToolbarBuilder
         return false
       else
         return !role_allows?(:feature => id)
-      end
-    when "Vm"
-      case id
-      when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"
-        return true unless @perf_options[:typ] == "realtime"
       end
     when "OrchestrationTemplate", "OrchestrationTemplateCfn", "OrchestrationTemplateHot", "OrchestrationTemplateAzure", "OrchestrationTemplateVnfd"
       return true unless role_allows?(:feature => id)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -828,7 +828,7 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Vm"
       case id
-      when "vm_guest_shutdown", "instance_guest_shutdown"
+      when "instance_guest_shutdown"
         return true unless @record.is_available?(:shutdown_guest)
       when "vm_reconfigure"
         return true unless @record.reconfigurable?
@@ -1248,8 +1248,6 @@ class ApplicationHelper::ToolbarBuilder
         if @record.current_state != "on"
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
-      when "vm_guest_shutdown"
-        return @record.is_available_now_error_message(:shutdown_guest) if @record.is_available_now_error_message(:shutdown_guest)
       when "instance_retire", "instance_retire_now"
         return N_("Instance is already retired") if @record.retired
       when "vm_timeline"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -828,8 +828,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Vm"
       case id
-      when "vm_guest_standby"
-        return true unless @record.is_available?(:standby_guest)
       when "vm_guest_shutdown", "instance_guest_shutdown"
         return true unless @record.is_available?(:shutdown_guest)
       when "vm_reconfigure"
@@ -1250,8 +1248,6 @@ class ApplicationHelper::ToolbarBuilder
         if @record.current_state != "on"
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
-      when "vm_guest_standby"
-        return @record.is_available_now_error_message(:standby_guest) if @record.is_available_now_error_message(:standby_guest)
       when "vm_guest_shutdown"
         return @record.is_available_now_error_message(:shutdown_guest) if @record.is_available_now_error_message(:shutdown_guest)
       when "instance_retire", "instance_retire_now"

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4660,10 +4660,6 @@
         :description: Reset Instance
         :feature_type: control
         :identifier: instance_reset
-      - :name: Shutdown Guest
-        :description: Shutdown the Guest OS on Instances
-        :feature_type: control
-        :identifier: instance_guest_shutdown
       - :name: Restart Guest
         :description: Restart the Guest OS on Instances
         :feature_type: control

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -1,6 +1,6 @@
 describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
   [:start, :stop, :suspend, :reset, :reboot_guest,
-   :collect_running_processes].each do |feature|
+   :collect_running_processes, :shutdown_guest].each do |feature|
     describe '#skip?' do
       context "when vm supports feature #{feature}" do
         before do

--- a/spec/helpers/application_helper/buttons/vm_reconfigure.rb
+++ b/spec/helpers/application_helper/buttons/vm_reconfigure.rb
@@ -1,0 +1,19 @@
+describe ApplicationHelper::Button::VmReconfigure do
+  describe '#skip?' do
+    context "record is vmware vm" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "record is vmware template" do
+      before do
+        @record = FactoryGirl.create(:template_vmware)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -365,7 +365,6 @@ describe ApplicationHelper do
      "repo_protect",
      "resource_pool_protect",
      "vm_check_compliance",
-     "vm_guest_shutdown",
      "vm_start",
      "vm_suspend",
      "vm_snapshot_add",
@@ -1165,22 +1164,6 @@ describe ApplicationHelper do
 
         it "and @lastaction = drift_history" do
           @lastaction = "drift_history"
-          expect(subject).to be_falsey
-        end
-      end
-
-      context "and id = vm_guest_shutdown" do
-        before do
-          @id = "vm_guest_shutdown"
-          allow(@record).to receive(:is_available?).with(:shutdown_guest).and_return(true)
-        end
-
-        it "and !@record.is_available?(:shutdown_guest)" do
-          allow(@record).to receive(:is_available?).with(:shutdown_guest).and_return(false)
-          expect(subject).to be_truthy
-        end
-
-        it "and @record.is_available?(:shutdown_guest)" do
           expect(subject).to be_falsey
         end
       end
@@ -2085,15 +2068,6 @@ describe ApplicationHelper do
         end
 
         it_behaves_like 'vm not powered on', "The web-based console is not available because the VM is not powered on"
-      end
-
-      context "and id = vm_guest_shutdown" do
-        before do
-          @id = "vm_guest_shutdown"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'shutdown_guest'
-        it_behaves_like 'default case'
       end
 
       context "and id = storage_scan" do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1134,25 +1134,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when with Vm" do
-      before do
-        @record = Vm.new
-        stub_user(:features => :all)
-      end
-
-      context "and id = common_drift" do
-        before do
-          @id = "common_drift"
-          @lastaction = "drift"
-        end
-
-        it "and @lastaction = drift_history" do
-          @lastaction = "drift_history"
-          expect(subject).to be_falsey
-        end
-      end
-    end # with Vm
-
     context "when with MiqTemplate" do
       before do
         @record = MiqTemplate.new

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1151,24 +1151,6 @@ describe ApplicationHelper do
           expect(subject).to be_falsey
         end
       end
-
-      ["perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"].each do |id|
-        context "and id = #{id}" do
-          before do
-            @id = id
-            @perf_options = {:typ => "realtime"}
-          end
-
-          it "and @perf_options[:typ] != realtime" do
-            @perf_options = {:typ => "Daily"}
-            expect(subject).to be_truthy
-          end
-
-          it "and @perf_options[:typ] = realtime" do
-            expect(subject).to be_falsey
-          end
-        end
-      end
     end # with Vm
 
     context "when with MiqTemplate" do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -366,7 +366,6 @@ describe ApplicationHelper do
      "resource_pool_protect",
      "vm_check_compliance",
      "vm_guest_shutdown",
-     "vm_guest_standby",
      "vm_start",
      "vm_suspend",
      "vm_snapshot_add",
@@ -1166,22 +1165,6 @@ describe ApplicationHelper do
 
         it "and @lastaction = drift_history" do
           @lastaction = "drift_history"
-          expect(subject).to be_falsey
-        end
-      end
-
-      context "and id = vm_guest_standby" do
-        before do
-          @id = "vm_guest_standby"
-          allow(@record).to receive(:is_available?).with(:standby_guest).and_return(true)
-        end
-
-        it "and !@record.is_available?(:standby_guest)" do
-          allow(@record).to receive(:is_available?).with(:standby_guest).and_return(false)
-          expect(subject).to be_truthy
-        end
-
-        it "and @record.is_available?(:standby_guest)" do
           expect(subject).to be_falsey
         end
       end
@@ -2102,15 +2085,6 @@ describe ApplicationHelper do
         end
 
         it_behaves_like 'vm not powered on', "The web-based console is not available because the VM is not powered on"
-      end
-
-      context "and id = vm_guest_standby" do
-        before do
-          @id = "vm_guest_standby"
-          allow(@record).to receive(:is_available_now_error_message).and_return(false)
-        end
-        it_behaves_like 'record with error message', 'standby_guest'
-        it_behaves_like 'default case'
       end
 
       context "and id = vm_guest_shutdown" do

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1140,22 +1140,6 @@ describe ApplicationHelper do
         stub_user(:features => :all)
       end
 
-      context "and id = vm_reconfigure" do
-        before do
-          @id = "vm_reconfigure"
-          allow(@record).to receive(:reconfigurable?).and_return(true)
-        end
-
-        it "and !@record.reconfigurable?" do
-          allow(@record).to receive(:reconfigurable?).and_return(false)
-          expect(subject).to be_truthy
-        end
-
-        it "and @record.reconfigurable?" do
-          expect(subject).to be_falsey
-        end
-      end
-
       context "and id = common_drift" do
         before do
           @id = "common_drift"


### PR DESCRIPTION
# Continuation of #10378

Purpose or Intent
-----------------

Purpose is to move toolbar buttons from helper (`app/helpers/application_helper/toolbar_builder.rb`) to separate classes.

*In this PR is converted last part of buttons for VMs.*

Links
-----
Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/126786879