### PR TITLE
Explicitly require a minimum nokogiri of 1.6.8+ for CVE fixes

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -30,7 +30,7 @@ gem "memory_buffer",           ">=0.1.0",           :require => false
 gem "more_core_extensions",    "~>3.0.0",           :require => false
 gem "net-scp",                 "~>1.2.1",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false
-gem "nokogiri",                "~>1.6.0",           :require => false
+gem "nokogiri",                "~>1.6.8",           :require => false
 gem "openscap",                "~>0.4.3",           :require => false
 gem "openshift_client",        "=1.2.0",            :require => false
 gem "ovirt",                   "~>0.11.0",          :require => false


### PR DESCRIPTION
Purpose or Intent
-----------------
See nokogiri's changelog[1].

Even though azure-armrest has implicitly upgraded ManageIQ dependency to ~>1.6.8
since azure-armrest 0.3.2 [2], we should make this explicit in the application.

Note, most of the CVE fixes are for the vendored libxml2 and libxslt.  If you
manage these dependencies with a package manager, they may already be patched
and unaffected.

[1] [nokogiri's changelog](https://github.com/sparklemotion/nokogiri/blob/ea09f6f82856922f0dda9e3ae72535144a4707ad/CHANGELOG.md#168--2016-06-06)

[2] [azure-armrest 0.3.2](https://rubygems.org/gems/azure-armrest/versions/0.3.2)