### PR TITLE
Update azure-armrest to 0.3.5.

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -8,7 +8,7 @@ gem "activerecord",            "~> 5.0.0" # used by appliance_console
 gem "activesupport",           "~> 5.0.0"
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.4",            :require => false
-gem "azure-armrest",           "~> 0.3.3",          :require => false
+gem "azure-armrest",           "~> 0.3.5",          :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/


### PR DESCRIPTION
This updates the azure-armrest gem to 0.3.5 which fixes a potential issue with proxies that was introduced accidentally in 0.3.2.