### PR TITLE
[DARGA] Concurrent Automate Requests stomping on DRb 

### DIFF
--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -1,0 +1,43 @@
+require 'drb'
+module MiqAeEngine
+  class DrbRemoteInvoker
+    attr_accessor :num_methods
+
+    def initialize(workspace)
+      @workspace = workspace
+      @num_methods = 0
+    end
+
+    def drb_uri
+      DRb.uri
+    end
+
+    def setup
+      require 'drb/timeridconv'
+      @@global_id_conv = DRb.install_id_conv(DRb::TimerIdConv.new(drb_cache_timeout))
+      drb_front  = MiqAeMethodService::MiqAeServiceFront.new
+      drb        = DRb.start_service("druby://127.0.0.1:0", drb_front)
+    end
+
+    def teardown
+      DRb.stop_service
+      # Set the ID conv to nil so that the cache can be GC'ed
+      DRb.install_id_conv(nil)
+      # This hack was done to prevent ruby from leaking the
+      # TimerIdConv thread.
+      # https://bugs.ruby-lang.org/issues/12342
+      thread = @@global_id_conv
+               .try(:instance_variable_get, '@holder')
+               .try(:instance_variable_get, '@keeper')
+      @@global_id_conv = nil
+      return unless thread
+
+      thread.kill
+      Thread.pass while thread.alive?
+    end
+
+    def drb_cache_timeout
+      1.hour
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -8,9 +8,23 @@ module MiqAeEngine
       @num_methods = 0
     end
 
+    def with_server
+      setup if num_methods == 0
+      self.num_methods += 1
+
+      svc = MiqAeMethodService::MiqAeService.new(@workspace)
+      yield
+    ensure
+      svc.destroy # Reset inputs to empty to avoid storing object references
+      self.num_methods -= 1
+      teardown if num_methods == 0
+    end
+
     def drb_uri
       DRb.uri
     end
+
+    private
 
     def setup
       require 'drb/timeridconv'

--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -8,23 +8,29 @@ module MiqAeEngine
       @num_methods = 0
     end
 
-    def with_server
+    def with_server(inputs, body)
       setup if num_methods == 0
       self.num_methods += 1
 
       svc = MiqAeMethodService::MiqAeService.new(@workspace)
-      yield
+      svc.inputs     = inputs
+      svc.preamble   = method_preamble(drb_uri, svc.object_id)
+      svc.body       = body
+
+      yield [svc.preamble, svc.body, RUBY_METHOD_POSTSCRIPT]
     ensure
       svc.destroy # Reset inputs to empty to avoid storing object references
       self.num_methods -= 1
       teardown if num_methods == 0
     end
 
+    private
+
+    # invocation
+
     def drb_uri
       DRb.uri
     end
-
-    private
 
     def setup
       require 'drb/timeridconv'
@@ -53,5 +59,76 @@ module MiqAeEngine
     def drb_cache_timeout
       1.hour
     end
+
+    # code building
+
+    def method_preamble(miq_uri, miq_id)
+      "MIQ_URI = '#{miq_uri}'\nMIQ_ID = #{miq_id}\n" << RUBY_METHOD_PREAMBLE
+    end
+
+    RUBY_METHOD_PREAMBLE = <<-RUBY
+class AutomateMethodException < StandardError
+end
+
+begin
+  require 'date'
+  require 'rubygems'
+  $:.unshift("#{Gem.loaded_specs['activesupport'].full_gem_path}/lib")
+  require 'active_support/all'
+  require 'socket'
+  Socket.do_not_reverse_lookup = true  # turn off reverse DNS resolution
+
+  require 'drb'
+  require 'yaml'
+
+  Time.zone = 'UTC'
+
+  MIQ_OK    = 0
+  MIQ_WARN  = 4
+  MIQ_ERROR = 8
+  MIQ_STOP  = 8
+  MIQ_ABORT = 16
+
+  DRbObject.send(:undef_method, :inspect)
+  DRbObject.send(:undef_method, :id) if DRbObject.respond_to?(:id)
+
+  DRb.start_service
+  $evmdrb = DRbObject.new_with_uri(MIQ_URI)
+  raise AutomateMethodException,"Cannot create DRbObject for uri=\#{MIQ_URI}" if $evmdrb.nil?
+  $evm = $evmdrb.find(MIQ_ID)
+  raise AutomateMethodException,"Cannot find Service for id=\#{MIQ_ID} and uri=\#{MIQ_URI}" if $evm.nil?
+  MIQ_ARGS = $evm.inputs
+rescue Exception => err
+  STDERR.puts('The following error occurred during inline method preamble evaluation:')
+  STDERR.puts("  \#{err.class}: \#{err.message}")
+  STDERR.puts("  \#{err.backtrace.join('\n')}") unless err.kind_of?(AutomateMethodException)
+  raise
+end
+
+class Exception
+  def backtrace_with_evm
+    value = backtrace_without_evm
+    value ? $evm.backtrace(value) : value
+  end
+
+  alias backtrace_without_evm backtrace
+  alias backtrace backtrace_with_evm
+end
+
+begin
+RUBY
+
+    RUBY_METHOD_POSTSCRIPT = <<-RUBY
+rescue Exception => err
+  unless err.kind_of?(SystemExit)
+    $evm.log('error', 'The following error occurred during method evaluation:')
+    $evm.log('error', "  \#{err.class}: \#{err.message}")
+    $evm.log('error', "  \#{err.backtrace[0..-2].join('\n')}")
+  end
+  raise
+ensure
+  $evm.disconnect_sql
+end
+RUBY
   end
 end

--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -45,10 +45,14 @@ module MiqAeEngine
       self.drb_server = nil
       # This hack was done to prevent ruby from leaking the
       # TimerIdConv thread.
-      # https://bugs.ruby-lang.org/issues/12342
+      # https://bugs.ruby-lang.org/issues/12342 (has been fixed in ruby 2.4.0 preview 1)
+      # also fixed in ruby_2_3 branch for the 2.3.2 release: https://github.com/ruby/ruby/commit/c20b07d5357d7cb73226b149431a658cde54a697
       thread = global_id_conv
                .try(:instance_variable_get, '@holder')
                .try(:instance_variable_get, '@keeper')
+      if RUBY_VERSION > "2.3.1"
+        warn "Remove me: #{__FILE__}:#{__LINE__} and my test. Ruby 2.3.2+ should not be creating timer threads."
+      end
       return unless thread
 
       thread.kill

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -1,4 +1,5 @@
 require 'miq_ae_exception'
+require 'engine/drb_remote_invoker'
 require 'engine/miq_ae_workspace'
 require 'engine/miq_ae_object'
 require 'engine/miq_ae_method'

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -112,14 +112,12 @@ module MiqAeEngine
       end
     end
 
-    def self.run_ruby_method(body, preamble = nil)
+    def self.run_ruby_method(*code)
       ActiveRecord::Base.connection_pool.release_connection
       Bundler.with_clean_env do
         ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
           run_method(Gem.ruby) do |stdin|
-            stdin.puts(preamble.to_s)
-            stdin.puts(body)
-            stdin.puts(RUBY_METHOD_POSTSCRIPT) unless preamble.blank?
+            stdin.puts(code)
           end
         end
       end

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -35,7 +35,7 @@ module MiqAeEngine
   end
 
   class MiqAeWorkspaceRuntime
-    attr_accessor :graph, :num_drb_methods, :class_methods
+    attr_accessor :graph, :class_methods, :invoker
     attr_accessor :datastore_cache, :persist_state_hash, :current_state_info
     attr_accessor :ae_user
     include MiqAeStateInfo
@@ -46,7 +46,6 @@ module MiqAeEngine
       @readonly          = options[:readonly] || false
       @nodes             = []
       @current           = []
-      @num_drb_methods   = 0
       @datastore_cache   = {}
       @class_methods     = {}
       @dom_search        = MiqAeDomainSearch.new

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -1,0 +1,16 @@
+module DrbRemoteInvokerSpec
+  include MiqAeEngine
+  describe MiqAeEngine::DrbRemoteInvoker do
+    it "setup/teardown drb_for_ruby_method clears DRb threads" do
+      threads_before = Thread.list.select(&:alive?)
+
+      invoker = described_class.new(nil)
+
+      invoker.setup
+      expect(Thread.list.select(&:alive?) - threads_before).not_to be_empty
+
+      invoker.teardown
+      expect(Thread.list.select(&:alive?)).to eq threads_before
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -2,15 +2,21 @@ module DrbRemoteInvokerSpec
   include MiqAeEngine
   describe MiqAeEngine::DrbRemoteInvoker do
     it "setup/teardown drb_for_ruby_method clears DRb threads" do
-      threads_before = Thread.list.select(&:alive?)
-
       invoker = described_class.new(double("workspace", :persist_state_hash => {}))
 
+      timer_thread = nil
+
       invoker.with_server([], "") do
-        expect(Thread.list.select(&:alive?) - threads_before).not_to be_empty
+        timer_thread = Thread.list.each do |t|
+          first = t.backtrace_locations.first
+          if first && first.path.include?("timeridconv.rb")
+            timer_thread = t
+            break
+          end
+        end
       end
 
-      expect(Thread.list.select(&:alive?)).to eq threads_before
+      expect(Thread.list).to_not include(timer_thread)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -4,12 +4,12 @@ module DrbRemoteInvokerSpec
     it "setup/teardown drb_for_ruby_method clears DRb threads" do
       threads_before = Thread.list.select(&:alive?)
 
-      invoker = described_class.new(nil)
+      invoker = described_class.new(double("workspace", :persist_state_hash => {}))
 
-      invoker.setup
-      expect(Thread.list.select(&:alive?) - threads_before).not_to be_empty
+      invoker.with_server([], "") do
+        expect(Thread.list.select(&:alive?) - threads_before).not_to be_empty
+      end
 
-      invoker.teardown
       expect(Thread.list.select(&:alive?)).to eq threads_before
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_method_spec.rb
@@ -1,16 +1,6 @@
 module MiqAeMethodSpec
   include MiqAeEngine
   describe MiqAeMethod do
-    it "setup/teardown drb_for_ruby_method clears DRb threads" do
-      threads_before = Thread.list.select(&:alive?)
-
-      described_class.setup_drb_for_ruby_method
-      expect(Thread.list.select(&:alive?) - threads_before).not_to be_empty
-
-      described_class.teardown_drb_for_ruby_method
-      expect(Thread.list.select(&:alive?)).to eq threads_before
-    end
-
     context "needing datatore" do
       before(:each) do
         MiqAeDatastore.reset


### PR DESCRIPTION
Purpose or Intent
-----------------
>With Rails 5 and PUMA we are seeing concurrent requests coming into Automate, this PR is a combination of 3 different PR's which fixed the concurrency issue with our implementation of DRb in Automate.



Links
-----
> * https://bugzilla.redhat.com/show_bug.cgi?id=1364350

> * PR https://github.com/ManageIQ/manageiq/pull/10004
> * PR https://github.com/ManageIQ/manageiq/pull/10135
> * PR https://github.com/ManageIQ/manageiq/pull/10386

Undoing the changes implemented for 
> * PR https://github.com/ManageIQ/manageiq/pull/9903
> * PR https://github.com/ManageIQ/manageiq/pull/10038

Steps for Testing/QA
--------------------
> QE reported "double" clicking on a Provision Request (Services -> Request). A single click sends only one request, if you do a double click 2 requests are sent to Automate causing DRb connection error.
