### PR TITLE
Made changes to have uniq button ids in toolbar file.

### DIFF
--- a/app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb
@@ -45,7 +45,7 @@ class ApplicationHelper::Toolbar::MiqAeNamespaceCenter < ApplicationHelper::Tool
           :enabled   => false,
           :onwhen    => "1+"),
         button(
-          :miq_ae_namespace_delete,
+          :miq_ae_class_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Remove selected Items'),
           t,


### PR DESCRIPTION
- Fixed an issue where there were duplicate button ids in miq_ae_namespace_center toolbar, made changes to support the button with new id. Renamed affected method appropriately.
- Renamed method "delete_namespaces_or_classes" handles: 1 - deletion of selected Namesspaces or Classes from list view, 2 - deletion of selected Namespace in the tree and it's contents, 3 - deletion of Selected Class in the tree.
- Added/fixed spec tests to support changes in the PR

Fixes #10426

@martinpovolny please review