### PR TITLE
Refactoring overhaul of MiqUserRole#allows*? API

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -44,13 +44,7 @@ class MiqUserRole < ApplicationRecord
     parent = MiqProductFeature.feature_parent(ident)
     return false if parent.nil?
 
-    self.allows?(:identifier => parent)
-  end
-
-  def self.allows?(role, options = {})
-    role = get_role(role)
-    return false if role.nil?
-    role.allows?(options)
+    allows?(:identifier => parent)
   end
 
   def allows_any?(options = {})
@@ -62,19 +56,13 @@ class MiqUserRole < ApplicationRecord
 
     if [:base, :sub].include?(scope)
       # Check passed in identifiers
-      return true if idents.any? { |i| self.allows?(:identifier => i) }
+      return true if idents.any? { |i| allows?(:identifier => i) }
     end
 
     return false if scope == :base
 
     # Check children of passed in identifiers (scopes :one and :base)
-    idents.any? { |i| self.allows_any_children?(:scope => (scope == :one ? :base : :sub), :identifier => i) }
-  end
-
-  def self.allows_any?(role, options = {})
-    role = get_role(role)
-    return false if role.nil?
-    role.allows_any?(options)
+    idents.any? { |i| allows_any_children?(:scope => (scope == :one ? :base : :sub), :identifier => i) }
   end
 
   def allows_any_children?(options = {})
@@ -82,24 +70,7 @@ class MiqUserRole < ApplicationRecord
     return false if ident.nil? || !MiqProductFeature.feature_exists?(ident)
 
     child_idents = MiqProductFeature.feature_children(ident)
-    self.allows_any?(options.merge(:identifiers => child_idents))
-  end
-
-  def self.allows_any_children?(role, options = {})
-    role = get_role(role)
-    return false if role.nil?
-    role.allows_any_children?(options)
-  end
-
-  def self.get_role(role)
-    case role
-    when self, nil
-      role
-    when Integer
-      includes(:miq_product_features).find_by_id(role)
-    else
-      includes(:miq_product_features).find_by_name(role)
-    end
+    allows_any?(options.merge(:identifiers => child_idents))
   end
 
   def self_service?

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -36,8 +36,7 @@ class MiqUserRole < ApplicationRecord
 
   # @param identifier [String] Product feature identifier to check if this role allows access to it
   #   Returns true when requested feature is directly assigned or a descendant of a feature
-  # @param scope [nil] Unused option, added here for legacy callers passing it anyway
-  def allows?(identifier:, scope: nil)
+  def allows?(identifier:)
     if feature_identifiers.include?(identifier)
       true
     elsif parent = MiqProductFeature.parent_for_feature(identifier)

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -37,11 +37,6 @@ class MiqUserRole < ApplicationRecord
     ident = options[:identifier]
     raise _("No value provided for option :identifier") if ident.nil?
 
-    if ident.kind_of?(MiqProductFeature)
-      feat = ident
-      ident = feat.identifier
-    end
-
     return true if feature_identifiers.include?(ident)
 
     return false unless MiqProductFeature.feature_exists?(ident)

--- a/lib/rbac/authorizer.rb
+++ b/lib/rbac/authorizer.rb
@@ -22,13 +22,10 @@ module Rbac
 
       any     = options[:any]
 
-      # Potentially removable; MiqUserRole uses it internally
-      scope   = options[:scope]
-
       auth = if any.present?
-               user_role_allows_any?(user, :identifiers => (identifiers || [identifier]), :scope => scope)
+               user_role_allows_any?(user, :identifiers => (identifiers || [identifier]))
              else
-               user_role_allows?(user, :identifier => identifier, :scope => scope)
+               user_role_allows?(user, :identifier => identifier)
              end
       _log.debug("Auth #{auth ? "successful" : "failed"} for user '#{user.userid}', role '#{user.miq_user_role.try(:name)}', feature identifier '#{identifier}'")
 

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -78,10 +78,6 @@ describe MiqUserRole do
       expect(@role2.allows?(:identifier => "dashboard_add")).to eq(true)
       expect(@role2.allows?(:identifier => "dashboard_view")).to eq(true)
       expect(@role2.allows?(:identifier => "policy")).to eq(true)
-
-      # Test calling with an id of a role
-      ident = MiqProductFeature.find_by_identifier("dashboard_admin")
-      expect(@role1.allows?(:identifier => ident)).to eq(true)
     end
 
     it "should return the correct answer calling allows_any? with scope => :base)" do

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -90,30 +90,12 @@ describe MiqUserRole do
       expect(@role3.allows_any?(:scope => :base, :identifiers => ["everything"])).to eq(false)
     end
 
-    it "should return the correct answer calling allows_any? with scope => :one)" do
-      expect(@role1.allows_any?(:scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-
-      expect(@role2.allows_any?(:scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-
-      expect(@role3.allows_any?(:scope => :one, :identifiers => ["host_view"])).to eq(true)
-      expect(@role3.allows_any?(:scope => :one, :identifiers => ["vm"])).to eq(false)
-      expect(@role3.allows_any?(:scope => :one, :identifiers => ["everything"])).to eq(false)
-    end
-
     it "should return the correct answer calling allows_any? with default scope => :sub" do
       expect(@role1.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
       expect(@role2.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
       expect(@role3.allows_any?(:identifiers => ["host_view"])).to eq(true)
       expect(@role3.allows_any?(:identifiers => ["vm"])).to eq(false)
       expect(@role3.allows_any?(:identifiers => ["everything"])).to eq(true)
-    end
-
-    it "should return the correct answer calling allows_any_children?" do
-      expect(@role1.allows_any_children?(:identifier => "dashboard_admin")).to eq(true)
-      expect(@role2.allows_any_children?(:identifier => "dashboard_admin")).to eq(true)
-      expect(@role2.allows_any_children?(:identifier => "everything")).to eq(true)
-      expect(@role1.allows_any_children?(:identifier => "everything")).to eq(true)
-      expect(@role1.allows_any_children?(:identifier => "dashboard")).to eq(true)
     end
   end
 

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -81,8 +81,8 @@ describe MiqUserRole do
     end
 
     it "should return the correct answer calling allows_any? with default scope => :sub" do
-      expect(@role1.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-      expect(@role2.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role1.allows_any?(:identifiers => %w(dashboard_admin dashboard_add dashboard_view policy))).to eq(true)
+      expect(@role2.allows_any?(:identifiers => %w(dashboard_admin dashboard_add dashboard_view policy))).to eq(true)
       expect(@role3.allows_any?(:identifiers => ["host_view"])).to eq(true)
       expect(@role3.allows_any?(:identifiers => ["vm"])).to eq(false)
       expect(@role3.allows_any?(:identifiers => ["everything"])).to eq(true)

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -80,16 +80,6 @@ describe MiqUserRole do
       expect(@role2.allows?(:identifier => "policy")).to eq(true)
     end
 
-    it "should return the correct answer calling allows_any? with scope => :base)" do
-      expect(@role1.allows_any?(:scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-
-      expect(@role2.allows_any?(:scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-
-      expect(@role3.allows_any?(:scope => :base, :identifiers => ["host_view"])).to eq(false)
-      expect(@role3.allows_any?(:scope => :base, :identifiers => ["vm"])).to eq(false)
-      expect(@role3.allows_any?(:scope => :base, :identifiers => ["everything"])).to eq(false)
-    end
-
     it "should return the correct answer calling allows_any? with default scope => :sub" do
       expect(@role1.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
       expect(@role2.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -69,55 +69,55 @@ describe MiqUserRole do
     end
 
     it "should return the correct answer calling allows? when requested feature is directly assigned or a descendant of a feature in a role" do
-      expect(MiqUserRole.allows?(@role1.name, :identifier => "dashboard_admin")).to eq(true)
-      expect(MiqUserRole.allows?(@role1.name, :identifier => "dashboard_add")).to eq(true)
-      expect(MiqUserRole.allows?(@role1.name, :identifier => "dashboard_view")).to eq(false)
-      expect(MiqUserRole.allows?(@role1.name, :identifier => "policy")).to eq(false)
+      expect(@role1.allows?(:identifier => "dashboard_admin")).to eq(true)
+      expect(@role1.allows?(:identifier => "dashboard_add")).to eq(true)
+      expect(@role1.allows?(:identifier => "dashboard_view")).to eq(false)
+      expect(@role1.allows?(:identifier => "policy")).to eq(false)
 
-      expect(MiqUserRole.allows?(@role2.name, :identifier => "dashboard_admin")).to eq(true)
-      expect(MiqUserRole.allows?(@role2.name, :identifier => "dashboard_add")).to eq(true)
-      expect(MiqUserRole.allows?(@role2.name, :identifier => "dashboard_view")).to eq(true)
-      expect(MiqUserRole.allows?(@role2.name, :identifier => "policy")).to eq(true)
+      expect(@role2.allows?(:identifier => "dashboard_admin")).to eq(true)
+      expect(@role2.allows?(:identifier => "dashboard_add")).to eq(true)
+      expect(@role2.allows?(:identifier => "dashboard_view")).to eq(true)
+      expect(@role2.allows?(:identifier => "policy")).to eq(true)
 
       # Test calling with an id of a role
       ident = MiqProductFeature.find_by_identifier("dashboard_admin")
-      expect(MiqUserRole.allows?(@role1.id, :identifier => ident)).to eq(true)
+      expect(@role1.allows?(:identifier => ident)).to eq(true)
     end
 
     it "should return the correct answer calling allows_any? with scope => :base)" do
-      expect(MiqUserRole.allows_any?(@role1.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role1.allows_any?(:scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      expect(MiqUserRole.allows_any?(@role2.name, :scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role2.allows_any?(:scope => :base, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      expect(MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["host_view"])).to eq(false)
-      expect(MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["vm"])).to eq(false)
-      expect(MiqUserRole.allows_any?(@role3.name, :scope => :base, :identifiers => ["everything"])).to eq(false)
+      expect(@role3.allows_any?(:scope => :base, :identifiers => ["host_view"])).to eq(false)
+      expect(@role3.allows_any?(:scope => :base, :identifiers => ["vm"])).to eq(false)
+      expect(@role3.allows_any?(:scope => :base, :identifiers => ["everything"])).to eq(false)
     end
 
     it "should return the correct answer calling allows_any? with scope => :one)" do
-      expect(MiqUserRole.allows_any?(@role1.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role1.allows_any?(:scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      expect(MiqUserRole.allows_any?(@role2.name, :scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role2.allows_any?(:scope => :one, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
 
-      expect(MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["host_view"])).to eq(true)
-      expect(MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["vm"])).to eq(false)
-      expect(MiqUserRole.allows_any?(@role3.name, :scope => :one, :identifiers => ["everything"])).to eq(false)
+      expect(@role3.allows_any?(:scope => :one, :identifiers => ["host_view"])).to eq(true)
+      expect(@role3.allows_any?(:scope => :one, :identifiers => ["vm"])).to eq(false)
+      expect(@role3.allows_any?(:scope => :one, :identifiers => ["everything"])).to eq(false)
     end
 
     it "should return the correct answer calling allows_any? with default scope => :sub" do
-      expect(MiqUserRole.allows_any?(@role1.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-      expect(MiqUserRole.allows_any?(@role2.name, :identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
-      expect(MiqUserRole.allows_any?(@role3.name, :identifiers => ["host_view"])).to eq(true)
-      expect(MiqUserRole.allows_any?(@role3.name, :identifiers => ["vm"])).to eq(false)
-      expect(MiqUserRole.allows_any?(@role3.name, :identifiers => ["everything"])).to eq(true)
+      expect(@role1.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role2.allows_any?(:identifiers => ["dashboard_admin", "dashboard_add", "dashboard_view", "policy"])).to eq(true)
+      expect(@role3.allows_any?(:identifiers => ["host_view"])).to eq(true)
+      expect(@role3.allows_any?(:identifiers => ["vm"])).to eq(false)
+      expect(@role3.allows_any?(:identifiers => ["everything"])).to eq(true)
     end
 
     it "should return the correct answer calling allows_any_children?" do
-      expect(MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard_admin")).to eq(true)
-      expect(MiqUserRole.allows_any_children?(@role2.name, :identifier => "dashboard_admin")).to eq(true)
-      expect(MiqUserRole.allows_any_children?(@role2.name, :identifier => "everything")).to eq(true)
-      expect(MiqUserRole.allows_any_children?(@role1.name, :identifier => "everything")).to eq(true)
-      expect(MiqUserRole.allows_any_children?(@role1.name, :identifier => "dashboard")).to eq(true)
+      expect(@role1.allows_any_children?(:identifier => "dashboard_admin")).to eq(true)
+      expect(@role2.allows_any_children?(:identifier => "dashboard_admin")).to eq(true)
+      expect(@role2.allows_any_children?(:identifier => "everything")).to eq(true)
+      expect(@role1.allows_any_children?(:identifier => "everything")).to eq(true)
+      expect(@role1.allows_any_children?(:identifier => "dashboard")).to eq(true)
     end
   end
 

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -296,11 +296,14 @@ describe ApiController do
 
       # Confirm requested features removed first, and others remain
       @product_features.each do |feature|
-        expect(role.allows?(:identifier => feature.identifier)).to be_truthy unless features_list['features'].find do |removed_feature|
+        removed = features_list['features'].find do |removed_feature|
           removed_feature[:identifier] == feature[:identifier]
         end
-        expect(role.allows?(:identifier => feature.identifier)).to be_falsey if features_list['features'].find do |removed_feature|
-          removed_feature[:identifier] == feature[:identifier]
+
+        if removed
+          expect(role.allows?(:identifier => feature.identifier)).to be_falsey
+        else
+          expect(role.allows?(:identifier => feature.identifier)).to be_truthy
         end
       end
     end

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -272,8 +272,12 @@ describe ApiController do
       role = MiqUserRole.find(role.id)
 
       @product_features.each do |feature|
-        expect(role.allows?(:identifier => feature.identifier)).to be_truthy unless feature[:identifier].eql?('ems_infra_tag')
-        expect(role.allows?(:identifier => feature.identifier)).to be_falsey if feature[:identifier].eql?('ems_infra_tag')
+        unless feature[:identifier].eql?('ems_infra_tag')
+          expect(role.allows?(:identifier => feature.identifier)).to be_truthy
+        end
+        if feature[:identifier].eql?('ems_infra_tag')
+          expect(role.allows?(:identifier => feature.identifier)).to be_falsey
+        end
       end
     end
 

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -272,8 +272,8 @@ describe ApiController do
       role = MiqUserRole.find(role.id)
 
       @product_features.each do |feature|
-        expect(role.allows?(feature)).to be_truthy unless feature[:identifier].eql?('ems_infra_tag')
-        expect(role.allows?(feature)).to be_falsey if feature[:identifier].eql?('ems_infra_tag')
+        expect(role.allows?(:identifier => feature.identifier)).to be_truthy unless feature[:identifier].eql?('ems_infra_tag')
+        expect(role.allows?(:identifier => feature.identifier)).to be_falsey if feature[:identifier].eql?('ems_infra_tag')
       end
     end
 
@@ -292,10 +292,10 @@ describe ApiController do
 
       # Confirm requested features removed first, and others remain
       @product_features.each do |feature|
-        expect(role.allows?(feature)).to be_truthy unless features_list['features'].find do |removed_feature|
+        expect(role.allows?(:identifier => feature.identifier)).to be_truthy unless features_list['features'].find do |removed_feature|
           removed_feature[:identifier] == feature[:identifier]
         end
-        expect(role.allows?(feature)).to be_falsey if features_list['features'].find do |removed_feature|
+        expect(role.allows?(:identifier => feature.identifier)).to be_falsey if features_list['features'].find do |removed_feature|
           removed_feature[:identifier] == feature[:identifier]
         end
       end


### PR DESCRIPTION
✂️ 🔥 

This PR overhauls the role API to remove unused and needlessly complex code in preparation for upcoming tenancy work (multiple entitlements)

See commit messages for more detailed information about each change.

Paired with @jrafanie on all of this :fist:

@miq-bot add_labels core, refactoring, technical debt, tenancy
@miq-bot assign @gtanzillo