### PR TITLE
[WIP] Clear search text box

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1579,6 +1579,9 @@ function miqHideSearchClearButton() {
   $(".search-pf .has-clear .clear").click(function () {
     $(this).prev('.form-control').val('').focus();
     $(this).hide();
+    // Clear @search_text
+    var url = "/" + ManageIQ.controller + "/clear_search_text";
+    miqJqueryRequest(url);
   });
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -407,6 +407,18 @@ class ApplicationController < ActionController::Base
     send_data fs.contents, :filename => fs.name
   end
 
+  # Clear out search text when when requested by user
+  def clear_search_text
+    # Fix for now works for Explorer/Trees, to be made more generic and app wide later
+    if @sb.key?(:pol_search_text)
+      session[:flash_msgs] = @flash_array = nil
+      # Clear out ALL iterations of prior search text
+      @search_text = @_params[:search_text] = @sb[:search_text] = @sb[:pol_search_text][@sb[:active_tree]] = nil
+      @_params[:id] = x_node
+      tree_select
+    end
+  end
+
   protected
 
   def render_flash(add_flash_text = nil, severity = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Vmdb::Application.routes.draw do
     adv_search_load_choice
     adv_search_name_typed
     adv_search_toggle
+    clear_search_text
   )
 
   button_post = %w(


### PR DESCRIPTION
Clear Search text box of prior search criteria

Code fix now clears search box of any text and re-displays current accordion/tree data.
 Added a route to enable proper js execution when clearing search text

https://bugzilla.redhat.com/show_bug.cgi?id=1346996
