### PR TITLE
Miq report rbac extract user_info

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -412,13 +412,7 @@ module Rbac
 
     def get_user_info(user, userid, miq_group, miq_group_id)
       user, miq_group = lookup_user_group(user, userid, miq_group, miq_group_id)
-      # for reports, user is currently nil, so use the group filter
-      user_filters = user.try(:get_filters) || miq_group.try(:get_filters) || {}
-      user_filters = user_filters.dup
-      user_filters["managed"] ||= []
-      user_filters["belongsto"] ||= []
-
-      [user, miq_group, user_filters]
+      [user, miq_group, lookup_user_filters(user || miq_group)]
     end
 
     def lookup_user_group(user, userid, miq_group, miq_group_id)
@@ -432,6 +426,14 @@ module Rbac
       [user, miq_group]
     end
 
+    # for reports, user is currently nil, so use the group filter
+    # the user.get_filters delegates to user.current_group anyway
+    def lookup_user_filters(miq_group)
+      filters = miq_group.try!(:get_filters).try!(:dup) || {}
+      filters["managed"] ||= []
+      filters["belongsto"] ||= []
+      filters
+    end
 
     # @param klass [Class] base_class found in CLASSES_THAT_PARTICIPATE_IN_RBAC
     # @option options :user [User]

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -411,13 +411,7 @@ module Rbac
     end
 
     def get_user_info(user, userid, miq_group, miq_group_id)
-      user      ||= (userid && User.find_by_userid(userid)) || User.current_user
-      miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
-      miq_group_id ||= miq_group.try!(:id)
-      if user && miq_group && user.current_group_id != miq_group_id
-        user.current_group = miq_group if user.miq_groups.include?(miq_group)
-      end
-      miq_group ||= user.try(:current_group)
+      user, miq_group = lookup_user_group(user, userid, miq_group, miq_group_id)
       # for reports, user is currently nil, so use the group filter
       user_filters = user.try(:get_filters) || miq_group.try(:get_filters) || {}
       user_filters = user_filters.dup
@@ -426,6 +420,18 @@ module Rbac
 
       [user, miq_group, user_filters]
     end
+
+    def lookup_user_group(user, userid, miq_group, miq_group_id)
+      user      ||= (userid && User.find_by_userid(userid)) || User.current_user
+      miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
+      miq_group_id ||= miq_group.try!(:id)
+      if user && miq_group && user.current_group_id != miq_group_id
+        user.current_group = miq_group if user.miq_groups.include?(miq_group)
+      end
+      miq_group ||= user.try(:current_group)
+      [user, miq_group]
+    end
+
 
     # @param klass [Class] base_class found in CLASSES_THAT_PARTICIPATE_IN_RBAC
     # @option options :user [User]

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -418,8 +418,10 @@ module Rbac
     def lookup_user_group(user, userid, miq_group, miq_group_id)
       user ||= (userid && User.find_by_userid(userid)) || User.current_user
       miq_group_id ||= miq_group.try!(:id)
+      return [user, user.current_group] if user && user.current_group_id.to_s == miq_group_id.to_s
+
       miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
-      if user && miq_group && user.current_group_id != miq_group_id
+      if user && miq_group
         user.current_group = miq_group if user.super_admin_user? || user.miq_groups.include?(miq_group)
       end
       [user, user.try(:current_group) || miq_group]

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -420,10 +420,9 @@ module Rbac
       miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
       miq_group_id ||= miq_group.try!(:id)
       if user && miq_group && user.current_group_id != miq_group_id
-        user.current_group = miq_group if user.miq_groups.include?(miq_group)
+        user.current_group = miq_group if user.super_admin_user? || user.miq_groups.include?(miq_group)
       end
-      miq_group ||= user.try(:current_group)
-      [user, miq_group]
+      [user, user.try(:current_group) || miq_group]
     end
 
     # for reports, user is currently nil, so use the group filter

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -416,9 +416,9 @@ module Rbac
     end
 
     def lookup_user_group(user, userid, miq_group, miq_group_id)
-      user      ||= (userid && User.find_by_userid(userid)) || User.current_user
-      miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
+      user ||= (userid && User.find_by_userid(userid)) || User.current_user
       miq_group_id ||= miq_group.try!(:id)
+      miq_group ||= miq_group_id && MiqGroup.find_by_id(miq_group_id)
       if user && miq_group && user.current_group_id != miq_group_id
         user.current_group = miq_group if user.super_admin_user? || user.miq_groups.include?(miq_group)
       end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1089,6 +1089,48 @@ describe Rbac::Filterer do
     end
   end
 
+  context ".lookup_user_group" do
+    let(:filter) { described_class.new }
+    let(:user1) { FactoryGirl.create(:user_with_group) }
+    let(:group_list) { FactoryGirl.create_list(:miq_group, 2) }
+    let(:user2) { FactoryGirl.create(:user, :miq_groups => group_list) }
+
+    context "user_group" do
+      it "uses user.current_group" do
+        _, group = filter.send(:lookup_user_group, user1, nil, nil, nil)
+        expect(group).to eq(user1.current_group)
+      end
+
+      it "uses group passed" do
+        _, group = filter.send(:lookup_user_group, user2, nil, group_list.first, nil)
+        expect(group).to eq(group_list.first)
+
+        _, group = filter.send(:lookup_user_group, user2, nil, group_list.last, nil)
+        expect(group).to eq(group_list.last)
+      end
+
+      it "uses group passed in when not member of group when super admin" do
+        admin = FactoryGirl.create(:user_admin)
+        random_group = FactoryGirl.create(:miq_group)
+        _, group = filter.send(:lookup_user_group, admin, nil, random_group, nil)
+        expect(group).to eq(random_group)
+      end
+    end
+
+    context "user" do
+      it "uses user passed in" do
+        user, = filter.send(:lookup_user_group, user1, nil, nil, nil)
+        expect(user).to eq(user1)
+      end
+
+      it "uses string user passed in" do
+        user, = filter.send(:lookup_user_group, nil, user1.userid, nil, nil)
+        expect(user).to eq(user1)
+      end
+    end
+  end
+
+
   private
 
   # separate them to match easier for failures

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1118,6 +1118,23 @@ describe Rbac::Filterer do
         end.to match_query_limit_of(0)
       end
 
+      it "skips lookup when group passed in" do
+        # ensure user is looked up outside group block
+        user2.miq_groups.to_a
+        expect do
+          _, group = filter.send(:lookup_user_group, user2, nil, nil, group_list.first.id.to_s)
+          expect(group).to eq(group_list.first)
+        end.to match_query_limit_of(0)
+        expect do
+          _, group = filter.send(:lookup_user_group, user2, nil, nil, group_list.last.id)
+          expect(group).to eq(group_list.last)
+        end.to match_query_limit_of(0)
+        expect do
+          _, group = filter.send(:lookup_user_group, user2, nil, group_list.first, nil)
+          expect(group).to eq(group_list.first)
+        end.to match_query_limit_of(0)
+      end
+
       it "uses group passed" do
         _, group = filter.send(:lookup_user_group, user2, nil, group_list.first, nil)
         expect(group).to eq(group_list.first)
@@ -1136,6 +1153,13 @@ describe Rbac::Filterer do
         admin = FactoryGirl.create(:user_admin)
         random_group = FactoryGirl.create(:miq_group)
         _, group = filter.send(:lookup_user_group, admin, nil, random_group, nil)
+        expect(group).to eq(random_group)
+      end
+
+      it "uses group_id passed in when not member of group when super admin" do
+        admin = FactoryGirl.create(:user_admin)
+        random_group = FactoryGirl.create(:miq_group)
+        _, group = filter.send(:lookup_user_group, admin, nil, nil, random_group.id)
         expect(group).to eq(random_group)
       end
     end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1101,6 +1101,23 @@ describe Rbac::Filterer do
         expect(group).to eq(user1.current_group)
       end
 
+      it "skips lookup if current_group_id passed" do
+        # ensuring same_group is a different object from user1.current_group
+        same_group = MiqGroup.find_by_id(user1.current_group.id)
+        expect do
+          _, group = filter.send(:lookup_user_group, user1, nil, same_group, nil)
+          expect(group).to eq(same_group)
+        end.to match_query_limit_of(0)
+        expect do
+          _, group = filter.send(:lookup_user_group, user1, nil, nil, user1.current_group.id)
+          expect(group).to eq(same_group)
+        end.to match_query_limit_of(0)
+        expect do
+          _, group = filter.send(:lookup_user_group, user1, nil, nil, user1.current_group.id.to_s)
+          expect(group).to eq(same_group)
+        end.to match_query_limit_of(0)
+      end
+
       it "uses group passed" do
         _, group = filter.send(:lookup_user_group, user2, nil, group_list.first, nil)
         expect(group).to eq(group_list.first)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1109,6 +1109,12 @@ describe Rbac::Filterer do
         expect(group).to eq(group_list.last)
       end
 
+      it "fallsback to current_group if not member of group" do
+        user1_group = user1.current_group
+        _, group = filter.send(:lookup_user_group, user1, nil, FactoryGirl.create(:miq_group), nil)
+        expect(group).to eq(user1_group)
+      end
+
       it "uses group passed in when not member of group when super admin" do
         admin = FactoryGirl.create(:user_admin)
         random_group = FactoryGirl.create(:miq_group)


### PR DESCRIPTION
Split rbac user_info into 2 methods, looking up user/group and looking up user filter

changes:

1. allow super admin to assume any group. This logic exists all over the code, but wasn't here
2. Don't allow a user to assume a group they are not privileged to use. The logic was already in there, but the original group was still used. Think only the wrong filter would be applied, but best to plug this up.
3. Don't lookup the user's group(s) if using the user's `current_group`. This is the default case and was performed multiple times, especially when going through the controller.
