### PR TITLE
C&U - WEB UI crashes when moving from calendar to daily/hourly selection

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -206,12 +206,12 @@ module ApplicationController::Performance
       options[:typ] = "Hourly" if options[:typ] == "Daily" && edate_daily < sdate_daily
     end
 
-    if options[:hourly_date] && # Need to clear hourly date if not nil so it will be reset below if
+    if options[:hourly_date].present? && # Need to clear hourly date if not nil so it will be reset below if
        (options[:hourly_date].to_date < sdate.to_date || options[:hourly_date].to_date > edate.to_date || # it is out of range
          (options[:typ] == "Hourly" && options[:time_profile] && !options[:time_profile_days].include?(options[:hourly_date].to_date.wday))) # or not in profile
       options[:hourly_date] = nil
     end
-    if options[:daily_date] &&
+    if options[:daily_date].present? &&
        (options[:daily_date].to_date < sdate_daily.to_date || options[:daily_date].to_date > edate_daily.to_date)
       options[:daily_date] = nil
     end


### PR DESCRIPTION
**C&U - WEB UI crashes when moving from calendar to daily/hourly selection**
It is posible to send an empty string as a date from the UI, we currently only protect against nil date
but not against an empty string. In this PR we add a check for empty string date.

**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1366233

**Screenshots**
![screenshot from 2016-08-11 12 14 20](https://cloud.githubusercontent.com/assets/2181522/17648876/7b33346e-622d-11e6-8be0-3873ab182e18.png)
