### PR TITLE
Reports: include read_only tag categories

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -715,7 +715,9 @@ class ChargebackController < ApplicationController
 
   def get_categories_all
     @edit[:cb_assign][:cats] = {}
-    Classification.categories.collect { |c| c if !c.read_only? && c.show && c.entries.size > 0 }.compact.each { |c| @edit[:cb_assign][:cats][c.id.to_s] = c.description }
+    Classification.categories.select { |c| c.show && !c.entries.empty? }.each do |c|
+      @edit[:cb_assign][:cats][c.id.to_s] = c.description
+    end
   end
 
   def get_tags_all(category)

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -174,6 +174,47 @@ describe ReportController do
         end
       end
     end
+
+    def non_empty_category(attrs = {})
+      cat = FactoryGirl.create(:classification, :name => "non_empty", :description => "Has entries", **attrs)
+      cat.add_entry(:name => "foo", :description => "Foo")
+      cat.add_entry(:name => "bar", :description => "Bar")
+      cat
+    end
+
+    def empty_category(attrs = {})
+      FactoryGirl.create(:classification, :name => "empty", :description => "Zero entries", **attrs)
+    end
+
+    describe "#categories_hash" do
+      it "returns non-empty categories" do
+        non_empty_category
+        empty_category
+        expect(controller.send(:categories_hash)).to eq("non_empty" => "Has entries")
+      end
+
+      it "omits show: false categories" do
+        non_empty_category(:show => false)
+        expect(controller.send(:categories_hash)).to eq({})
+      end
+
+      it "includes read_only categories" do
+        non_empty_category(:read_only => true)
+        expect(controller.send(:categories_hash)).to eq("non_empty" => "Has entries")
+      end
+    end
+
+    describe "#entries_hash" do
+      it "returns entries" do
+        non_empty_category
+        expect(controller.send(:entries_hash, "non_empty")).to eq("foo" => "Foo",
+                                                                  "bar" => "Bar")
+      end
+
+      it "returns {} given invalid category name" do
+        expect(controller.send(:entries_hash, "no_such_name")).to eq({})
+      end
+    end
   end
 
   describe '#verify is_valid? flash messages' do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1388659
## Purpose or Intent

Split off [discussion on #9914](https://github.com/ManageIQ/manageiq/pull/9914#issuecomment-234917815).
Reports editor hides any `read_only` tag categories.
I suspect the condition was simply copied (it's exactly same line) from 
https://github.com/ManageIQ/manageiq/blob/62874a37/app/controllers/application_controller/tags.rb#L265
https://github.com/ManageIQ/manageiq/blob/62874a37/app/controllers/application_controller/tags.rb#L316
but that code deals with user assigning/unassigning the tags, so forbidding read only makes sense;
reports merely want to _read_ tags which I think is fine.
## Effects
- Reports editor, first "Columns" tab:
  ![screenshot-localhost 3000 2016-08-14 16-51-03 available fields](https://cloud.githubusercontent.com/assets/273688/17649512/c01bda2e-623f-11e6-98eb-0ab52bde03dc.png)
- selecting the category in "Columns", allows manipulating it in other tabs ("Consolidation", "Styling" etc) 
- Reports editor, "Filters" tab, with "Tag" expression:
  ![screenshot-localhost 3000 2016-08-14 16-29-31 read_only cat](https://cloud.githubusercontent.com/assets/273688/17649437/26c66ffc-623e-11e6-8238-16ccc6c57822.png)
  ![screenshot-localhost 3000 2016-08-14 16-30-42 read_only ent](https://cloud.githubusercontent.com/assets/273688/17649440/2ede2324-623e-11e6-8d0b-9041885ad019.png)
- Chargeback assignments, "Tagged ...", categories dropdown:
  ![screenshot](https://gist.githubusercontent.com/cben/89e0232e2e5c7429637313651775968e/raw/955f85847514d8f74c0e14310f811bbdbbbad11c/ManageIQChargebackAssign.png)

[Where do read_only tags come from?  I don't know generally, my use case is tags auto-assigned from kubernetes labels (#7460, to be exposed in UI by #11591) which I want read_only so users don't assign them manually — refresh would overwrite that anyway.]
## Steps for Testing/QA
1. If #11591 and #11806 landed, use auto-tagging UI to create a tag:
   - Label something in OpenShift, e.g. `oc label node mynode foo=entry1`.
   - Add mapping from `foo` label key to `read_only cat 1` category.
   - Refresh the OpenShift provider.  Verify the labeled entity got a "read_only cat 1 : entry1" tag.
   
   (It's important that at least one tag actually got created — reports editor won't list tag categories that have no entries, even after this change.)
   
   Alternatively, create a read_only tag directly in `rails console`:
   
   ``` ruby
   cat = Classification.create_category!(name: "rocat1", description: "read_only cat 1", read_only: true)
   cat.add_entry(name: "roent1", description: "read_only entry 1")
   ```
2. In Cloud Intel -> Reports -> Create new (or Edit), verify "read_only cat 1" tag category is in list of columns.
3. In Cloud Intel -> Chargeback -> Assignments -> Compute, choose "Assign To: Tagged VMs and Instances" and verify "read_only cat 1" is in "Tag Category" dropdown.
4. In Cloud Intel -> Chargeback -> Assignments -> Storage, choose "Assign To: Tagged Datastores" and verify "read_only cat 1" is in "Tag Category" dropdown.

@miq-bot add-labels reporting, ui, bug, darga/yes
