### PR TITLE
Avoid NaN in C&U statistics and operating ranges

### DIFF
--- a/app/models/metric/long_term_averages.rb
+++ b/app/models/metric/long_term_averages.rb
@@ -63,6 +63,7 @@ module Metric::LongTermAverages
 
       begin
         results[:dev][c]  = vals[c].stddev
+        raise StandardError, "result was NaN" if results[:dev][c].try(:nan?)
       rescue => err
         _log.warn("Unable to calculate standard deviation, '#{err.message}', values: #{vals[c].inspect}")
         results[:dev][c] = 0

--- a/app/models/metric/long_term_averages.rb
+++ b/app/models/metric/long_term_averages.rb
@@ -62,7 +62,7 @@ module Metric::LongTermAverages
       Metric::Aggregation::Process.average(c, nil, results[:avg], counts)
 
       begin
-        results[:dev][c]  = vals[c].stddev
+        results[:dev][c] = vals[c].length == 1 ? 0 : vals[c].stddev
         raise StandardError, "result was NaN" if results[:dev][c].try(:nan?)
       rescue => err
         _log.warn("Unable to calculate standard deviation, '#{err.message}', values: #{vals[c].inspect}")


### PR DESCRIPTION
## Problem summary
When we collect C&U for first time, we may end-up with data samples of single data point. When we calculate standard deviation of such sample we get NaN. The NaN then gets propagated through C&U database. When we present C&U data, we are not prepared to handle NaN.

## Details
`LongTermAverage` is used to calculate `VimPerformanceOperatingRange`. At that point we use it to fake Low and High data based on mean and standard deviation. When sd=NaN, we calculate Low and High to be NaN as well then we fail to display it to user, as we cannot convert NaN number_to_human_size. That causes crash on any page that tries to display such data to user.

```
    Error caught: [ActionView::Template::Error] NaN
    activesupport-5.0.0.1/lib/active_support/number_helper/number_to_human_size_converter.rb:53:in `to_i'
    activesupport-5.0.0.1/lib/active_support/number_helper/number_to_human_size_converter.rb:53:in `smaller_than_base?'
    activesupport-5.0.0.1/lib/active_support/number_helper/number_to_human_size_converter.rb:21:in `convert'
    activesupport-5.0.0.1/lib/active_support/number_helper/number_converter.rb:132:in `execute'
    activesupport-5.0.0.1/lib/active_support/number_helper/number_converter.rb:118:in `convert'
    activesupport-5.0.0.1/lib/active_support/number_helper.rb:261:in `number_to_human_size'
    actionview-5.0.0.1/lib/action_view/helpers/number_helper.rb:403:in `public_send'
    actionview-5.0.0.1/lib/action_view/helpers/number_helper.rb:403:in `block in delegate_number_helper_method'
    actionview-5.0.0.1/lib/action_view/helpers/number_helper.rb:427:in `wrap_with_output_safety_handling'
    actionview-5.0.0.1/lib/action_view/helpers/number_helper.rb:402:in `delegate_number_helper_method'
    actionview-5.0.0.1/lib/action_view/helpers/number_helper.rb:287:in `number_to_human_size'
    app/helpers/number_helper.rb:5:in `block in number_to_human_size'
    app/helpers/number_helper.rb:78:in `handling_negatives'
    app/helpers/number_helper.rb:4:in `number_to_human_size'
    app/helpers/vm_helper/textual_summary.rb:783:in `block in textual_normal_operating_ranges_memory'
    app/helpers/vm_helper/textual_summary.rb:780:in `each'
    app/helpers/vm_helper/textual_summary.rb:780:in `each_slice'
    app/helpers/vm_helper/textual_summary.rb:780:in `textual_normal_operating_ranges_memory'
    app/helpers/textual_summary_helper.rb:16:in `expand_textual_summary'
    app/helpers/textual_summary_helper.rb:39:in `block in expand_textual_group'
    app/helpers/textual_summary_helper.rb:39:in `map'
    app/helpers/textual_summary_helper.rb:39:in `expand_textual_group'
    app/views/shared/summary/_textual_normal_operating_ranges.html.haml:1:in `_app_views_shared_summary__textual_normal_operating_ranges_html_haml__2011570235951108440_70235954470280'
```

Note there are two formulas for calculating standard deviation. One known as population standard deviation another known as sample standard deviation (that is our `stddev` method). The sample sd returns NaN on samples of single data point. The population-sd of single data point equals to 0.

Let's enforce sd=0 on this special case. The end-result is that user sees values like

```
CPU 	  	 
Max    	29.88 MHz
High 	29.88 MHz
Average 	29.88 MHz
Low 	        29.88 MHz
```
in that case it should be obvious that just one data point was found.

@miq-bot add_label bug, metrics, darga/no
/cc @bdunne 