### PR TITLE
Add support for multi-domain docker registry

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -716,7 +716,7 @@ module ManageIQ::Providers::Kubernetes
     def parse_image_name(image, image_ref)
       parts = %r{
         \A
-          (?:(?:(?<host>[^\.:\/]+\.[^\.:\/]+)|(?:(?<host2>[^:\/]+)(?::(?<port>\d+))))\/)?
+          (?:(?:(?<host>([^\.:\/]+\.)+[^\.:\/]+)|(?:(?<host2>[^:\/]+)(?::(?<port>\d+))))\/)?
           (?<name>(?:[^:\/@]+\/)*[^\/:@]+)
           (?:(?::(?<tag>.+))|(?:\@(?<digest>.+)))?
         \z

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -112,6 +112,18 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                                        :image_ref => example_ref},
                        :registry   => {:name => "localhost", :host => "localhost", :port => "1234"}},
 
+                      # host with no port. more that one subdomain (a.b.c.com)
+                      {:image_name => "reg.access.rh.com/openshift3/image-inspector",
+                       :image      => {:name => "openshift3/image-inspector", :tag => nil, :digest => nil,
+                                       :image_ref => example_ref},
+                       :registry   => {:name => "reg.access.rh.com", :host => "reg.access.rh.com", :port => nil}},
+
+                      # host with port. more that one subdomain (a.b.c.com:1234)
+                      {:image_name => "host.access.com:1234/subname/more/names/example:tag",
+                       :image      => {:name => "subname/more/names/example", :tag => "tag", :digest => nil,
+                                       :image_ref => example_ref},
+                       :registry   => {:name => "host.access.com", :host => "host.access.com", :port => "1234"}},
+
                       {:image_name => "example@sha256:1234567abcdefg",
                        :image      => {:name => "example", :tag => nil, :digest => "sha256:1234567abcdefg",
                                        :image_ref => example_ref},


### PR DESCRIPTION
Support multi-domain registry (several dots. i.e. access.host.com).
Add tests for multi-domain registry with and without port.

Bug Url: https://bugzilla.redhat.com/show_bug.cgi?id=1365878