### PR TITLE
Allow cloud subnet to show child subnets

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -259,7 +259,7 @@ module ApplicationHelper
         else
           controller = "vm_cloud" if controller == "template_cloud"
           controller = "vm_infra" if controller == "template_infra"
-          return url_for(:controller => controller, :action => action) + "/"
+          return url_for(:controller => controller, :action => action, :id => nil) + "/"
         end
       end
 

--- a/app/views/cloud_subnet/show.html.haml
+++ b/app/views/cloud_subnet/show.html.haml
@@ -1,5 +1,5 @@
 #main_div
-  - if ["instances"].include?(@display) && @showtype != "compare"
+  - if ["instances", "cloud_subnets"].include?(@display) && @showtype != "compare"
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
   - elsif @showtype == 'main'
     = render(:partial => 'main')

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -44,6 +44,24 @@ describe CloudSubnetController do
 
           is_expected.to render_template(:partial => "layouts/listnav/_cloud_subnet")
         end
+
+        it "shows associated cloud_subnets" do
+          child_subnet = FactoryGirl.create(
+            "cloud_subnet_#{t}".to_sym, :name => "Child Cloud Subnet", :parent_cloud_subnet => @cloud_subnet)
+
+          controller.instance_variable_set(:@breadcrumbs, [])
+          get :show, :params => {:id => @cloud_subnet.id, :display => 'cloud_subnets'}
+          expect(response.status).to eq(200)
+          expect(response).to render_template('cloud_subnet/show')
+          expect(response).to render_template('layouts/listnav/_cloud_subnet')
+          expect(assigns(:breadcrumbs)).to eq([{:name => "#{@cloud_subnet.name} (All Cloud Subnets)",
+                                                :url  => "/cloud_subnet/show/#{@cloud_subnet.id}?display=cloud_subnets"}])
+          child_subnet_row = "miqRowClick(&#39;#{child_subnet.compressed_id}&#39;, &#39;/cloud_subnet/show/&#39;"
+          expect(response.body).to include(child_subnet_row)
+
+          # display needs to be saved to session for GTL pagination and such
+          expect(session[:cloud_subnet_display]).to eq('cloud_subnets')
+        end
       end
 
       describe "#test_toolbars" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Allows showing of nested cloud_subnets needed for Nuage integration

Steps for Testing/QA
--------------------
If Nuage and a managed cloud provider are added, user should be able to see parent Nuage networks and managed Cloud Provider networks.

