### PR TITLE
Hide internal tenant MiqGroups from API users

### DIFF
--- a/app/controllers/api_controller/groups.rb
+++ b/app/controllers/api_controller/groups.rb
@@ -2,6 +2,14 @@ class ApiController
   INVALID_GROUP_ATTRS = %w(id href group_type).freeze
 
   module Groups
+    def groups_search_conditions
+      ["group_type != ?", MiqGroup::TENANT_GROUP]
+    end
+
+    def find_groups(id)
+      MiqGroup.non_tenant_groups.find(id)
+    end
+
     def create_resource_groups(_type, _id, data)
       validate_group_data(data)
       parse_set_role(data)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -84,8 +84,12 @@ describe ApiController do
     end
 
     it "query Groups" do
+      expect(Tenant.exists?).to be_truthy
       FactoryGirl.create(:miq_group)
-      test_collection_query(:groups, groups_url, MiqGroup)
+      api_basic_authorize collection_action_identifier(:groups, :read, :get)
+      run_get groups_url, :expand => 'resources'
+      expect_query_result(:groups, MiqGroup.non_tenant_groups.count, MiqGroup.count)
+      expect_result_resources_to_include_data('resources', 'id' => MiqGroup.non_tenant_groups.pluck(:id))
     end
 
     it "query Hosts" do


### PR DESCRIPTION
The tenant groups are internal only. We don't show these groups on the ui. Follow-up on #10410

@miq-bot add_label api, bug, darga/no, tenancy
@miq-bot assign @abellotti 