### PR TITLE
Fix filtering by registry in reports

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -626,6 +626,9 @@ class MiqExpression
       # => false if operand is a tag
       return false if exp[operator].keys.include?("tag")
 
+      # => false if operand is a registry
+      return false if exp[operator].keys.include?("regkey")
+
       # => TODO: support count of child relationship
       return false if exp[operator].key?("count")
 

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -167,6 +167,12 @@ describe MiqExpression do
       expect(sql).to eq("\"vms\".\"id\" IN (#{vm.id})")
     end
 
+    it "returns nil for a Registry expression" do
+      exp = {"=" => {"regkey" => "test", "regval" => "value", "value" => "data"}}
+      sql, * = MiqExpression.new(exp).to_sql
+      expect(sql).to be_nil
+    end
+
     it "raises an error for an expression with unknown operator" do
       expect do
         MiqExpression.new("FOOBAR" => {"field" => "Vm-name", "value" => "foo"}).to_sql


### PR DESCRIPTION
Purpose or Intent
-----------------
Fixes https://github.com/ManageIQ/manageiq/issues/10436. 
Generation a report with Registry condition is throwing error message(https://github.com/ManageIQ/manageiq/issues/10436)

It looks like we should return false in method MiqExpression#sql_supports_atom?(exp)
This was throwing an error:

```
 exp = {"=" => {"regkey" => "test", "regval" => "value", "value" => "data"}}
 MiqExpression.new(exp).to_sql
```
For filtering this in RBAC, there are loaded relations with RegistryItem table and then it is filtered in https://github.com/ManageIQ/manageiq/blob/master/lib/rbac/filterer.rb#L213

Links
-----
https://github.com/ManageIQ/manageiq/issues/10436

Steps for Testing/QA
--------------------
> Run report with filtering as is shown in https://github.com/ManageIQ/manageiq/issues/10436

@imtayadeway 
@miq-bot assign @gtanzillo 
@miq-bot add_label reporting, bug

