### PR TITLE
Remove duplicate code in application helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -908,8 +908,6 @@ module ApplicationHelper
       "ManageIQ::Providers::InfraManager::Vm"
     when :templates_filter_tree
       "ManageIQ::Providers::InfraManager::Template"
-    when :instances_filter_tree
-      "ManageIQ::Providers::CloudManager::Vm"
     when :templates_images_filter_tree
       "MiqTemplate"
     when :vms_instances_filter_tree


### PR DESCRIPTION
The condition 'when :instances_filter_tree'
is removed because it makes no sense to be
twice in def vm_model_from_active_tree.
