### PR TITLE
Add container groups\images statistics for container projects

### DIFF
--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -9,7 +9,6 @@ class ContainerProject < ApplicationRecord
   has_many :container_replicators
   has_many :container_services
   has_many :containers, :through => :container_groups
-  has_many :containers, :through => :container_groups
   has_many :container_images, -> { distinct }, :through => :container_groups
   has_many :container_nodes, -> { distinct }, :through => :container_groups
   has_many :container_quotas

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -1,15 +1,18 @@
 module Metric::Statistic
   def self.calculate_stat_columns(obj, timestamp)
-    return {} unless obj.respond_to?(:container_groups)
-    return {} unless obj.respond_to?(:container_images)
-
     capture_interval = Metric::Helper.get_time_interval(obj, timestamp)
-    container_groups = ContainerGroup.where(:ems_id => obj.id).or(ContainerGroup.where(:old_ems_id => obj.id))
+    stats = {}
 
-    {
-      :stat_container_group_create_rate       => container_groups.where(:ems_created_on => capture_interval).count,
-      :stat_container_group_delete_rate       => container_groups.where(:deleted_on => capture_interval).count,
-      :stat_container_image_registration_rate => obj.container_images.where(:registered_on => capture_interval).count
-    }
+    if obj.respond_to?(:all_container_groups)
+      container_groups = obj.all_container_groups # Get disconnected entities as well
+      stats[:stat_container_group_create_rate] = container_groups.where(:ems_created_on => capture_interval).count
+      stats[:stat_container_group_delete_rate] = container_groups.where(:deleted_on => capture_interval).count
+    end
+
+    if obj.respond_to?(:all_container_images)
+      stats[:stat_container_image_registration_rate] = obj.all_container_images.where(:registered_on => capture_interval).count
+    end
+
+    stats
   end
 end

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -5,6 +5,11 @@ describe Metric::Statistic do
                          :zone => Zone.first)
     end
 
+    let(:project) do
+      FactoryGirl.create(:container_project,
+                         :name => "project")
+    end
+
     hour = Time.parse(Metric::Helper.nearest_hourly_timestamp(Time.now)).utc
 
     let(:c1) { FactoryGirl.create(:container_group, :ems_created_on => hour - 10.minutes) }
@@ -41,6 +46,20 @@ describe Metric::Statistic do
       derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
 
       expect(derived_columns[:stat_container_image_registration_rate]).to eq(2)
+    end
+
+    it "count created container groups in a project" do
+      project.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
+      derived_columns = described_class.calculate_stat_columns(project, hour)
+
+      expect(derived_columns[:stat_container_group_create_rate]).to eq(2)
+    end
+
+    it "count deleted container groups in a project" do
+      project.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
+      derived_columns = described_class.calculate_stat_columns(project, hour)
+
+      expect(derived_columns[:stat_container_group_delete_rate]).to eq(2)
     end
   end
 end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1487172
The container group calculation is relevant only for ems. This adjusts the calculation to be correct for projects too


@miq-bot add_label providers/containers 
@yaacov Please review
