### PR TITLE
Add parse_xml_error_string method to MiqWinRM module.

### DIFF
--- a/gems/pending/spec/util/miq_winrm_spec.rb
+++ b/gems/pending/spec/util/miq_winrm_spec.rb
@@ -40,4 +40,19 @@ describe MiqWinRM do
       expect(@winrm.port).to eq(5985)
     end
   end
+
+  context "XML Parsing" do
+    let(:xml) do
+      "#< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><S S=\"Error\">Bogus : The term 'Bogus' is not recognized as the name of a cmdlet, function, _x000D__x000A_</S><S S=\"Error\">script file, or operable program. Check the spelling of the name, or if a path _x000D__x000A_</S><S S=\"Error\">was included, verify that the path is correct and try again._x000D__x000A_</S><S S=\"Error\">At line:1 char:40_x000D__x000A_</S><S S=\"Error\">+ $ProgressPreference='SilentlyContinue';Bogus_x000D__x000A_</S><S S=\"Error\">+                                        ~~~~~_x000D__x000A_</S><S S=\"Error\">    + CategoryInfo          : ObjectNotFound: (Bogus:String) [], CommandNotFou _x000D__x000A_</S><S S=\"Error\">   ndException_x000D__x000A_</S><S S=\"Error\">    + FullyQualifiedErrorId : CommandNotFoundException_x000D__x000A_</S><S S=\"Error\"> _x000D__x000A_</S></Objs>"
+    end
+
+    it "defines a parse_xml_error_string method" do
+      expect(@winrm).to respond_to(:parse_xml_error_string)
+    end
+
+    it "returns the expected string" do
+      expected_string = "Bogus : The term 'Bogus' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again."
+      expect(@winrm.parse_xml_error_string(xml)).to eql(expected_string)
+    end
+  end
 end

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -82,6 +82,24 @@ class MiqWinRM
     end
   end
 
+  # Parse an ugly XML error string into something much more readable.
+  #
+  def parse_xml_error_string(str)
+    require 'nokogiri'
+    str = str.sub("#< CLIXML\r\n", '') # Illegal, nokogiri can't cope
+    doc = Nokogiri::XML::Document.parse(str)
+    doc.remove_namespaces!
+
+    text = doc.xpath("//S").map(&:text).join
+    array = text.split(/_x\h{1,}_/) # Split on stuff like '_x000D_'
+    array.delete('') # Delete empty elements
+
+    array.inject('') do |string, element|
+      break string if element =~ /at line:\d+/i
+      string << element
+    end
+  end
+
   private
 
   def validate_options(options)


### PR DESCRIPTION
The XML error output produced by WinRM when an error occurs is quite ugly. This PR adds a method that parses it and produces nicer output.

This is part 1 of an effort to resolve:

https://bugzilla.redhat.com/show_bug.cgi?id=1350779

Example XML error output:

```
#< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><S S=\"Error\">Bogus : The term
 'Bogus' is not recognized as the name of a cmdlet, function, _x000D__x000A_</S><S
 S=\"Error\">script file, or operable program. Check the spelling of the name, or if a path
 _x000D__x000A_</S><S S=\"Error\">was included, verify that the path is correct and try
 again._x000D__x000A_</S><S S=\"Error\">At line:1 char:40_x000D__x000A_</S><S
 S=\"Error\">+ $ProgressPreference='SilentlyContinue';Bogus_x000D__x000A_</S><S
 S=\"Error\">+                                        ~~~~~_x000D__x000A_</S><S S=\"Error\">    +
 CategoryInfo          : ObjectNotFound: (Bogus:String) [], CommandNotFou _x000D__x000A_</S>
<S S=\"Error\">   ndException_x000D__x000A_</S><S S=\"Error\">    + FullyQualifiedErrorId :
 CommandNotFoundException_x000D__x000A_</S><S S=\"Error\"> _x000D__x000A_</S>
</Objs>
```

Example output after running it through out method:

```Bogus : The term 'Bogus' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.```

