### PR TITLE
virtual_delegate: make delegation more powerful

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -66,8 +66,8 @@ module VirtualDelegates
     #
 
     def virtual_delegate(*methods)
-      options = methods.pop
-      unless options.kind_of?(Hash) && options[:to]
+      options = methods.extract_options!
+      unless (to = options[:to])
         raise ArgumentError, 'Delegation needs an association. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
       end
       delegate(*methods, options.except(:arel, :uses))

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -70,7 +70,7 @@ module VirtualDelegates
       unless (to = options[:to])
         raise ArgumentError, 'Delegation needs an association. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
       end
-      delegate(*methods, options.except(:arel, :uses))
+      define_delegate(*methods, **options.except(:arel, :uses))
 
       # put method entry per method name.
       # This better supports reloading of the class and changing the definitions
@@ -105,6 +105,70 @@ module VirtualDelegates
       raise "unknown attribute #{to_model.name}##{col} referenced in #{name}" unless type
       arel = virtual_delegate_arel(col, to, to_model, to_ref)
       define_virtual_attribute method_name, type, :uses => (options[:uses] || to), :arel => arel
+    end
+
+    def define_delegate(*methods, to: nil, prefix: nil, allow_nil: nil)
+      unless to
+        raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
+      end
+
+      if prefix == true && to =~ /^[^a-z_]/
+        raise ArgumentError, 'Can only automatically set the delegation prefix when delegating to a method.'
+      end
+
+      method_prefix = \
+        if prefix
+          "#{prefix == true ? to : prefix}_"
+        else
+          ''
+        end
+
+      location = caller_locations(1, 1).first
+      file, line = location.path, location.lineno
+
+      to = to.to_s
+      #to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)
+
+      methods.each do |method|
+        # Attribute writer methods only accept one argument. Makes sure []=
+        # methods still accept two arguments.
+        definition = (method =~ /[^\]]=$/) ? 'arg' : '*args, &block'
+
+        # The following generated method calls the target exactly once, storing
+        # the returned value in a dummy variable.
+        #
+        # Reason is twofold: On one hand doing less calls is in general better.
+        # On the other hand it could be that the target has side-effects,
+        # whereas conceptually, from the user point of view, the delegator should
+        # be doing one call.
+        if allow_nil
+          method_def = [
+            "def #{method_prefix}#{method}(#{definition})",
+            "_ = #{to}",
+            "if !_.nil? || nil.respond_to?(:#{method})",
+            "  _.#{method}(#{definition})",
+            "end",
+          "end"
+          ].join ';'
+        else
+          exception = %(raise DelegationError, "#{self}##{method_prefix}#{method} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
+
+          method_def = [
+            "def #{method_prefix}#{method}(#{definition})",
+            " _ = #{to}",
+            "  _.#{method}(#{definition})",
+            "rescue NoMethodError => e",
+            "  if _.nil? && e.name == :#{method}",
+            "    #{exception}",
+            "  else",
+            "    raise",
+            "  end",
+            "end"
+          ].join ';'
+        end
+
+        module_eval(method_def, file, line)
+      end
     end
 
     def virtual_delegate_name_prefix(prefix, to)

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -108,8 +108,9 @@ module VirtualDelegates
       define_virtual_attribute method_name, type, :uses => (options[:uses] || to), :arel => arel
     end
 
-    def define_delegate(method_name, method, to: nil, allow_nil: nil)
-      location = caller_locations(1, 1).first
+    # see activesupport module/delegation.rb
+    def define_delegate(method_name, method, to: nil, allow_nil: nil, default: nil)
+      location = caller_locations(2, 1).first
       file, line = location.path, location.lineno
 
       # Attribute writer methods only accept one argument. Makes sure []=

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -71,11 +71,15 @@ module VirtualDelegates
         raise ArgumentError, 'Delegation needs an association. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
       end
 
+      if options[:name] && methods.size > 1
+        raise ArgumentError, 'Delegation only supports :name option only when defining a single virtual method'
+      end
+
       # put method entry per method name.
       # This better supports reloading of the class and changing the definitions
       methods.each do |method|
         method_prefix = virtual_delegate_name_prefix(options[:prefix], options[:to])
-        method_name = "#{method_prefix}#{method}"
+        method_name = options[:name] || "#{method_prefix}#{method}"
 
         define_delegate(method_name, method, to: to, allow_nil: options[:allow_nil])
 

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -84,7 +84,7 @@ module VirtualDelegates
         method_prefix = virtual_delegate_name_prefix(options[:prefix], options[:to])
         method_name = options[:name] || "#{method_prefix}#{method}"
 
-        define_delegate(method_name, method, to: to, allow_nil: options[:allow_nil], default: default)
+        define_delegate(method_name, method, :to => to, :allow_nil => allow_nil, :default => default)
 
         self.virtual_delegates_to_define =
           virtual_delegates_to_define.merge(method_name => [method, options])
@@ -138,7 +138,7 @@ module VirtualDelegates
           "if !_.nil? || nil.respond_to?(:#{method})",
           "  _.#{method}(#{definition})",
           "end#{default}",
-        "end"
+          "end"
         ].join ';'
       else
         exception = %(raise DelegationError, "#{self}##{method_name} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -109,15 +109,8 @@ module VirtualDelegates
     end
 
     def define_delegate(method_name, method, to: nil, allow_nil: nil)
-      unless to
-        raise ArgumentError, 'Delegation needs a target. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
-      end
-
       location = caller_locations(1, 1).first
       file, line = location.path, location.lineno
-
-      to = to.to_s
-      #to = "self.#{to}" if DELEGATION_RESERVED_METHOD_NAMES.include?(to)
 
       # Attribute writer methods only accept one argument. Makes sure []=
       # methods still accept two arguments.

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -619,6 +619,24 @@ describe VirtualFields do
         tc = TestClass.new(:id => 2, :ref1 => parent)
         expect(tc.funky_name).to eq(4)
       end
+
+      it "defaults for to nil child (array)" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => []
+        tc = TestClass.new(:id => 2)
+        expect(tc.parent_col1).to eq([])
+      end
+
+      it "defaults for to nil child (integer)" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => 0
+        tc = TestClass.new(:id => 2)
+        expect(tc.parent_col1).to eq(0)
+      end
+
+      it "defaults for to nil child (string)" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => "def"
+        tc = TestClass.new(:id => 2)
+        expect(tc.parent_col1).to eq("def")
+      end
     end
   end
 

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -613,6 +613,12 @@ describe VirtualFields do
         TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
         expect(TestClass.virtual_attribute_names).to include("parent_col1")
       end
+
+      it "defines with a new name" do
+        TestClass.virtual_delegate :col1, :name => 'funky_name', :to => :ref1
+        tc = TestClass.new(:id => 2, :ref1 => parent)
+        expect(tc.funky_name).to eq(4)
+      end
     end
   end
 

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -554,6 +554,66 @@ describe VirtualFields do
         end
       end
     end
+
+    describe ".attribute_supported_by_sql?" do
+      it "supports real columns" do
+        expect(TestClass.attribute_supported_by_sql?(:col1)).to be_truthy
+      end
+
+      it "supports aliases" do
+        TestClass.alias_attribute :col2, :col1
+
+        expect(TestClass.attribute_supported_by_sql?(:col2)).to be_truthy
+      end
+
+      it "does not support virtual columns" do
+        class TestClass
+          virtual_attribute :col2, :integer
+          def col2
+            col1
+          end
+        end
+        expect(TestClass.attribute_supported_by_sql?(:col2)).to be_falsey
+      end
+
+      it "supports virtual columns with arel" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(t.class.arel_attribute(:col1)) })
+          def col2
+            col1
+          end
+        end
+        expect(TestClass.attribute_supported_by_sql?(:col2)).to be_truthy
+      end
+
+      it "supports delegates" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+
+        expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
+      end
+    end
+
+    describe ".virtual_delegate" do
+      # double purposing col1. It has an actual value in the child class
+      let(:parent) { TestClass.create(:id => 1, :col1 => 4)}
+
+      it "delegates to child" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        tc = TestClass.new(:id => 2, :ref1 => parent)
+        expect(tc.parent_col1).to eq(4)
+      end
+
+      it "delegates to nil child" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true
+        tc = TestClass.new(:id => 2)
+        expect(tc.parent_col1).to be_nil
+      end
+
+      it "defines virtual attribute" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        expect(TestClass.virtual_attribute_names).to include("parent_col1")
+      end
+    end
   end
 
   describe "#follow_associations" do

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -595,7 +595,7 @@ describe VirtualFields do
 
     describe ".virtual_delegate" do
       # double purposing col1. It has an actual value in the child class
-      let(:parent) { TestClass.create(:id => 1, :col1 => 4)}
+      let(:parent) { TestClass.create(:id => 1, :col1 => 4) }
 
       it "delegates to child" do
         TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -615,7 +615,7 @@ describe VirtualFields do
       end
 
       it "defines with a new name" do
-        TestClass.virtual_delegate :col1, :name => 'funky_name', :to => :ref1
+        TestClass.virtual_delegate 'funky_name', :to => "ref1.col1"
         tc = TestClass.new(:id => 2, :ref1 => parent)
         expect(tc.funky_name).to eq(4)
       end


### PR DESCRIPTION
**BLOCKED by:**
- [x] #10754 (2 commits focused on the `virtual_attribute` portion)

# background


We liberally use `virtual_attribute` in our model definitions.
The `:arel` option allows us to define SQL that will use the attributes within queries.
This arel option is very important. It allows screens to only download 20 records for the screen rather than having to download every record and pruning in ruby.

The SQL used by `:arel` is tricky to construct, so helper methods like `virtual_delegate` automatically generate it.

This PR adds 2 enhancements to `virtual_delegate` by duplicating and modifying `ActiveSupport`'s own `delegate` method:

1. allow `:to` to specify a name and description (e.g.: `:to => "hardware.cpu_sockets"`)
2. add `:default` option, so `nil` references return something other than `nil`.

# before

The method `Vm#num_cpu` is [defined as an attribute](https://github.com/ManageIQ/manageiq/blob/1cf14a1c8390404059eade5438ab30a289fca7f0/app/models/vm_or_template.rb#L161) with [ruby method definition](https://github.com/ManageIQ/manageiq/blob/1cf14a1c8390404059eade5438ab30a289fca7f0/app/models/vm_or_template.rb#L1634).

```ruby
virtual_attribute :num_cpu, :integer, :uses => :hardware

def num_cpu
  hardware.nil? ? 0 : hardware.cpu_sockets
end
```

Pages that sort by `num_cpu` bring back every `Vm` and corresponding `Hardware` records into memory. Then 20 of those records are picked and displayed on the screen.

```ruby
Vm.order(:num_cpu) # invalid
Vm.where(:num_cpu =>2) # invalid
```

# after `virtual_delegate`

```ruby
virtual_delegate :num_cpu, :to => :hardware, :allow_nil => true
```

Defines the attribute with a sql component and the delegate ruby method:


```ruby
virtual_attribute :num_cpu, :integer, :uses => :hardware, :arel => ...

def num_cpu
  hardware.try(:num_cpu)
end
```

Issues:

```ruby
vm.num_cpu # => error, undefined method hardware.num_cpu
```

We wanted `num_cpu` to call `hardware.cpu_sockets`.

# after improving `:to` option

```ruby
virtual_delegate :num_cpu, :to => "hardware.cpu_sockets"
```

Defines the attribute with a component and the delegate ruby method:


```ruby
virtual_attribute :num_cpu, :integer, :uses => :hardware, :arel => ...

def num_cpu
  hardware.try(:cpu_sockets)
end
```

Good:

It will also define a `virtual_attribute` with `arel` properly so it is valid in SQL:

```ruby
vm.num_cpu # => 2      # valid

Vm.order(:num_cpu)     # valid
Vm.where(:num_cpu =>2) # valid
```

These generate the following SQL:

```sql
SELECT "vms"."*"
FROM "vms"
ORDER BY (SELECT "hardware"."cpu_sockets" FROM "hardware" WHERE "hardware"."vm_id" = "vms"."id")

SELECT "vms"."*"
FROM "vms"
WHERE (SELECT "hardware"."cpu_sockets" FROM "hardware" WHERE "hardware"."vm_id" = "vms"."id") = 2
```

Issue:

```
vm.hardware = nil
vm.num_cpu # => nil #Invalid. want 0
```

We want `num_cpu` to default to `0`.

# after adding `:default` option

```ruby
virtual_delegate :num_cpu, :to => "hardware.cpu_sockets", :allow_nil => true, :default => 0
```

Defines the attribute with a component and the delegate ruby method:

```ruby
def num_cpu
  hardware.try(:cpu_sockets) || 0
end
```

Good:

```
vm.hardware = nil
vm.num_cpu # => 0
```

The code works as it did before, only now, on the vms page, are able to sort by `num_cpu`s - so it goes from 49s to 12s (10k vms)
