### PR TITLE
Better errors for error in a class definition

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,7 @@ RSpec.configure do |config|
   # end
 
   config.before(:each) do |example|
-    EmsRefresh.debug_failures = true if example.metadata[:migrations].blank?
+    EmsRefresh.try(:debug_failures=, true) if example.metadata[:migrations].blank?
     ApplicationController.handle_exceptions = false if %w(controller requests).include?(example.metadata[:type])
   end
 


### PR DESCRIPTION
`EmsRefresh.debug_failures` was not defined if a class had an error in it.

This was causing an error and displaying the `debug_failures` error instead of the initial error (the one we care about and want to fix).

This change lets the initial failure flow through and display.
(so we can fix it)