### PR TITLE
Remove duplicate `main_div` from ui_4

### DIFF
--- a/app/views/configuration/_ui_4.html.haml
+++ b/app/views/configuration/_ui_4.html.haml
@@ -1,5 +1,6 @@
-#main_div
-  = render :partial => "layouts/flash_msg"
+= render :partial => "layouts/flash_msg"
+
+#tab_div
   %div{:style => "padding-top:10px"}
     - if @timeprofiles.empty?
       = render :partial => 'layouts/info_msg', :locals => {:message => _("No Records Found.")}


### PR DESCRIPTION
`#main_div` is already rendered from `configuration/show`

The problem is visible when navigating to Configuration -> My Settings -> Time Profiles.