### PR TITLE
rubocop issues: exclude Gemfile from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,9 @@ ClassAndModuleCamelCase:
 FileName:
   Exclude:
     - lib/miq_automation_engine/service_models/*.rb
+LineLength:
+  Exclude:
+    - Gemfile
+ExtraSpacing:
+  Exclude:
+    - Gemfile


### PR DESCRIPTION
Exclude Gemfile from Rubocop check, I believe it more readable as it now

== Gemfile ==
C: 12: 35: Unnecessary spacing detected.
C: 20: 49: Unnecessary spacing detected.
C: 22: 48: Unnecessary spacing detected.
C: 32: 47: Unnecessary spacing detected.
C: 34: 49: Unnecessary spacing detected.
C: 35: 48: Unnecessary spacing detected.
C: 41: 49: Unnecessary spacing detected.
C: 43: 49: Unnecessary spacing detected.
C: 50: 32: Unnecessary spacing detected.
R: 67:121: Line is too long. [147/120]
R: 68:121: Line is too long. [151/120]
R: 69:121: Line is too long. [207/120]
C: 70: 49: Unnecessary spacing detected.
R: 70:121: Line is too long. [149/120]
R: 71:121: Line is too long. [136/120]
C: 72: 48: Unnecessary spacing detected.
R: 72:121: Line is too long. [134/120]
R: 75:121: Line is too long. [127/120]
C: 81: 49: Unnecessary spacing detected.
C: 81: 69: Unnecessary spacing detected.
C: 93: 20: Unnecessary spacing detected.
R: 93:121: Line is too long. [139/120]
R: 94:121: Line is too long. [150/120]
C:118: 23: Unnecessary spacing detected.