### PR TITLE
Enabled availability checking method for service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -38,6 +38,7 @@ class Service < ApplicationRecord
   include NewWithTypeStiMixin
   include ProcessTasksMixin
   include TenancyMixin
+  include AvailabilityMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'
@@ -165,7 +166,7 @@ class Service < ApplicationRecord
 
   def validate_reconfigure
     ra = reconfigure_resource_action
-    ra && ra.dialog_id && ra.fqname.present?
+    {:available => ra && ra.dialog_id && ra.fqname.present?}
   end
 
   def reconfigure_resource_action

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -38,7 +38,7 @@ class Service < ApplicationRecord
   include NewWithTypeStiMixin
   include ProcessTasksMixin
   include TenancyMixin
-  include AvailabilityMixin
+  include SupportsFeatureMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'
@@ -46,6 +46,10 @@ class Service < ApplicationRecord
   virtual_column :has_parent,                               :type => :boolean
 
   validates_presence_of :name
+
+  supports :reconfigure do
+    unsupported_reason_add(:reconfigure, _("Reconfigure unsupported")) unless validate_reconfigure
+  end
 
   def add_resource(rsc, options = {})
     if rsc.kind_of?(Vm) && !rsc.service.nil?
@@ -166,7 +170,7 @@ class Service < ApplicationRecord
 
   def validate_reconfigure
     ra = reconfigure_resource_action
-    {:available => ra && ra.dialog_id && ra.fqname.present?}
+    ra && ra.dialog_id && ra.fqname.present?
   end
 
   def reconfigure_resource_action

--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -47,7 +47,9 @@ describe ApplicationHelper::Button::GenericFeatureButton do
         context "that supports feature #{feature}" do
           before do
             @record = FactoryGirl.create(:service)
-            allow(@record).to receive(:is_available?).with(feature).and_return(true)
+            allow(@record)
+              .to receive("supports_#{feature}?".to_sym)
+              .and_return(true)
           end
 
           it "will not be skipped" do
@@ -66,7 +68,9 @@ describe ApplicationHelper::Button::GenericFeatureButton do
         context "that does not support feature #{feature}" do
           before do
             @record = FactoryGirl.create(:service)
-            allow(@record).to receive(:is_available?).with(feature).and_return(false)
+            allow(@record)
+              .to receive("supports_#{feature}?".to_sym)
+              .and_return(false)
           end
 
           it "will be skipped" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix issue #10434 by allowing Service to use `supports_reconfigure?` method.

Links
-----
Fixes: #10434 
Fixes: #10328


Steps for Testing/QA
--------------------
Service -> My Services -> [Select a service]
