### PR TITLE
Fix checkbox and string appearing incorrectly when adding new Group

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1544,6 +1544,21 @@ module ApplicationHelper
     true
   end
 
+  def auth_mode_name
+    case get_vmdb_config.fetch_path(:authentication, :mode).downcase
+    when "ldap"
+      _("LDAP")
+    when "ldaps"
+      _("LDAPS")
+    when "amazon"
+      _("Amazon")
+    when "httpd"
+      _("External Authentication")
+    when "database"
+      _("Database")
+    end
+  end
+
   def ext_auth?(auth_option = nil)
     auth_config = get_vmdb_config[:authentication]
     return false unless auth_config[:mode] == "httpd"

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -22,11 +22,12 @@
                            :class => "form-control",
                            "data-miq_observe" => {:interval => '.5',
                                                   :url      => url}.to_json)
-          = check_box_tag("lookup",
-                          "1",
-                          false,
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
-          = _("(Look Up LDAP Groups)")
+          - unless auth_mode_name.downcase == "database"
+            = check_box_tag("lookup",
+                            "1",
+                            false,
+                            "data-miq_observe_checkbox" => {:url => url}.to_json)
+            = _("(Look up %{authentication_mode_name} Groups)") % {:authentication_mode_name => auth_mode_name}
           = javascript_tag(javascript_focus('description'))
     .form-group
       %label.col-md-2.control-label

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -22,7 +22,7 @@
                            :class => "form-control",
                            "data-miq_observe" => {:interval => '.5',
                                                   :url      => url}.to_json)
-          - unless auth_mode_name.downcase == "database"
+          - unless "database".include?(auth_mode_name.downcase)
             = check_box_tag("lookup",
                             "1",
                             false,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1670,7 +1670,7 @@ describe ApplicationHelper do
     modes = %w(ldap ldaps amazon httpd database)
     modes_pretty = %w(LDAP LDAPS Amazon External\ Authentication Database)
 
-    modes.zip (modes_pretty).each do | mode, mode_pretty |
+    modes.zip modes_pretty.each do |mode, mode_pretty|
       it "Returns #{mode_pretty} when mode is #{mode}" do
         stub_server_configuration(:authentication => { :mode => mode })
         expect(helper.auth_mode_name).to eq(mode_pretty)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1665,4 +1665,16 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe "#auth_mode_name" do
+    modes = %w(ldap ldaps amazon httpd database)
+    modes_pretty = %w(LDAP LDAPS Amazon External\ Authentication Database)
+
+    modes.zip (modes_pretty).each do | mode, mode_pretty |
+      it "Returns #{mode_pretty} when mode is #{mode}" do
+        stub_server_configuration(:authentication => { :mode => mode })
+        expect(helper.auth_mode_name).to eq(mode_pretty)
+      end
+    end
+  end
 end

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -2,52 +2,50 @@ describe 'ops/_rbac_group_details.html.haml' do
   context 'add new group' do
     before(:each) do
       miq_server = FactoryGirl.create(:miq_server)
-      current = VMDB::Config.new("vmdb")
-      edit = {:current             => current,
-              :new                 => copy_hash(current.config),
+      edit = {:new                 => {:description => ''},
               :key                 => "settings_authentication_edit__#{miq_server.id}",
               :ldap_groups_by_user => [],
-              :roles               => ["fred", "wilma"],
-              :projects_tenants    => [["projects", ["foo", "bar"]]]
+              :roles               => %w(fred wilma),
+              :projects_tenants    => [["projects", %w(foo bar)]]
       }
       view.instance_variable_set(:@edit, edit)
       @group = FactoryGirl.create(:miq_group, :description => 'flintstones')
       allow(view).to receive(:current_tenant).and_return(Tenant.seed)
-      allow(view).to receive(:session).and_return({:assigned_filters => []})
+      allow(view).to receive(:session).and_return(:assigned_filters => [])
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode ldap' do
       stub_server_configuration(:authentication => { :mode => 'ldap' })
       render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up LDAP Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode ldaps' do
       stub_server_configuration(:authentication => { :mode => 'ldaps' })
       render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up LDAPS Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode amazon' do
       stub_server_configuration(:authentication => { :mode => 'amazon' })
       render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up Amazon Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode httpd' do
       stub_server_configuration(:authentication => { :mode => 'httpd' })
       render :partial => 'ops/rbac_group_details'
-      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up External Authentication Groups')
     end
 
     it 'should not show "Look up groups" checkbox and label for auth mode database' do
       stub_server_configuration(:authentication => { :mode => 'database' })
       render :partial => 'ops/rbac_group_details'
-      expect(rendered).not_to have_selector('input#lookup', type='checkbox')
+      expect(rendered).not_to have_selector('input#lookup')
       expect(rendered).not_to include('Look up External Authentication Groups')
     end
   end

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -1,0 +1,45 @@
+describe 'ops/_settings_add_new_group.html.haml' do
+  context 'add new group' do
+    before(:each) do
+      @edit = nil
+      let(:current_tenant) { FactoryGirl.create(:tenant, :name => 'tenant1') }
+      let(:tenant_name) { 'tenant1' }
+      @group = FactoryGirl.create(:miq_group, :description => 'asdf')
+    end
+
+    it 'should show group LDAP Look up groups checkbox and label' do
+      stub_server_configuration(:authentication => { :mode => 'ldap' })
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to include('Look up LDAP Groups')
+    end
+
+    it 'should show group LDAPS Look up groups checkbox and label' do
+      stub_server_configuration(:authentication => { :mode => 'ldaps' })
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to include('Look up LDAPS Groups')
+    end
+
+    it 'should show group Amazon Look up groups checkbox and label' do
+      stub_server_configuration(:authentication => { :mode => 'amazon' })
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to include('Look up Amazon Groups')
+    end
+
+    it 'should show group httpd Look up groups checkbox and label' do
+      stub_server_configuration(:authentication => { :mode => 'httpd' })
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).to have_selector('input#lookup', type='checkbox')
+      expect(rendered).to include('Look up External Authentication Groups')
+    end
+
+    it 'should not show group Database Look up groups checkbox and label' do
+      stub_server_configuration(:authentication => { :mode => 'database' })
+      render :partial => 'ops/rbac_group_details'
+      expect(rendered).not_to have_selector('input#lookup', type='checkbox')
+      expect(rendered).not_to include('Look up External Authentication Groups')
+    end
+  end
+end

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -1,41 +1,50 @@
-describe 'ops/_settings_add_new_group.html.haml' do
+describe 'ops/_rbac_group_details.html.haml' do
   context 'add new group' do
     before(:each) do
-      @edit = nil
-      let(:current_tenant) { FactoryGirl.create(:tenant, :name => 'tenant1') }
-      let(:tenant_name) { 'tenant1' }
-      @group = FactoryGirl.create(:miq_group, :description => 'asdf')
+      miq_server = FactoryGirl.create(:miq_server)
+      current = VMDB::Config.new("vmdb")
+      edit = {:current             => current,
+              :new                 => copy_hash(current.config),
+              :key                 => "settings_authentication_edit__#{miq_server.id}",
+              :ldap_groups_by_user => [],
+              :roles               => ["fred", "wilma"],
+              :projects_tenants    => [["projects", ["foo", "bar"]]]
+      }
+      view.instance_variable_set(:@edit, edit)
+      @group = FactoryGirl.create(:miq_group, :description => 'flintstones')
+      allow(view).to receive(:current_tenant).and_return(Tenant.seed)
+      allow(view).to receive(:session).and_return({:assigned_filters => []})
     end
 
-    it 'should show group LDAP Look up groups checkbox and label' do
+    it 'should show "Look up groups" checkbox and label for auth mode ldap' do
       stub_server_configuration(:authentication => { :mode => 'ldap' })
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup', type='checkbox')
       expect(rendered).to include('Look up LDAP Groups')
     end
 
-    it 'should show group LDAPS Look up groups checkbox and label' do
+    it 'should show "Look up groups" checkbox and label for auth mode ldaps' do
       stub_server_configuration(:authentication => { :mode => 'ldaps' })
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup', type='checkbox')
       expect(rendered).to include('Look up LDAPS Groups')
     end
 
-    it 'should show group Amazon Look up groups checkbox and label' do
+    it 'should show "Look up groups" checkbox and label for auth mode amazon' do
       stub_server_configuration(:authentication => { :mode => 'amazon' })
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup', type='checkbox')
       expect(rendered).to include('Look up Amazon Groups')
     end
 
-    it 'should show group httpd Look up groups checkbox and label' do
+    it 'should show "Look up groups" checkbox and label for auth mode httpd' do
       stub_server_configuration(:authentication => { :mode => 'httpd' })
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup', type='checkbox')
       expect(rendered).to include('Look up External Authentication Groups')
     end
 
-    it 'should not show group Database Look up groups checkbox and label' do
+    it 'should not show "Look up groups" checkbox and label for auth mode database' do
       stub_server_configuration(:authentication => { :mode => 'database' })
       render :partial => 'ops/rbac_group_details'
       expect(rendered).not_to have_selector('input#lookup', type='checkbox')


### PR DESCRIPTION
Purpose or Intent
-----------------
When adding a new Group a checkbox and label appears to look up groups via the current authentication method.  This fixes the hardcoded 'LDAP' string to correctly reflect the current authentication method and hides the checkbox and label for database authentication.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1362697