### PR TITLE
Use anonymous class to prevent test constant conflicts

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -769,25 +769,26 @@ describe MiqAeEngine do
 end
 
 describe MiqAeEngine do
-  before do
-    TestClass = Class.new do
-      def before_ae_starts(_options)
+  context "deliver to automate" do
+    let(:test_class) do
+      Class.new do
+        def self.name; "TestClass"; end
+        def before_ae_starts(_options); end
       end
     end
-  end
-
-  context "deliver to automate" do
-    let(:test_class) { TestClass.new }
+    let(:test_class_name) { test_class.name }
+    let(:test_class_instance) { test_class.new }
     let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
     let(:user) { FactoryGirl.create(:user_with_group) }
-    let(:options) { {:user_id => user.id, :object_type => TestClass.name} }
+    let(:options) { {:user_id => user.id, :object_type => test_class_name} }
 
     it "#before_ae_starts" do
       allow(MiqAeEngine).to receive(:create_automation_object).with(any_args).and_return(nil)
-      allow(TestClass).to receive(:find_by_id).with(any_args).and_return(test_class)
+      expect(test_class_name).to receive(:constantize).and_return(test_class)
+      expect(test_class).to receive(:find_by_id).with(any_args).and_return(test_class_instance)
       allow(MiqAeEngine).to receive(:resolve_automation_object).with(any_args).and_return(workspace)
       allow(MiqAeEngine).to receive(:create_automation_attribute_key).with(any_args).and_return("abc")
-      expect(test_class).to receive(:before_ae_starts).once.with(options)
+      expect(test_class_instance).to receive(:before_ae_starts).once.with(options)
       MiqAeEngine.deliver(options)
     end
   end


### PR DESCRIPTION
Failures:
  1) ar_base_model extension with a test class .model_suffix
     Failure/Error: before(:each) { class ::TestClass < ActiveRecord::Base; end }
     
     TypeError:
       superclass mismatch for class TestClass
     # ./spec/lib/extensions/ar_base_model_spec.rb:3:in `block (3 levels) in <top (required)>'