### PR TITLE
Accept parameters for FailoverMonitor from ha_admin.yml

### DIFF
--- a/config/ha_admin.yml
+++ b/config/ha_admin.yml
@@ -1,0 +1,4 @@
+---
+failover_attempts: 10
+db_connected_check_frequency: 5.minutes
+failover_check_frequency: 1.minute

--- a/config/ha_admin.yml
+++ b/config/ha_admin.yml
@@ -1,4 +1,4 @@
 ---
 failover_attempts: 10
-db_connected_check_frequency: 5.minutes
-failover_check_frequency: 1.minute
+db_check_frequency: 300
+failover_check_frequency: 60

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -12,11 +12,11 @@ module PostgresHaAdmin
     FAILOVER_CHECK_FREQUENCY = 60
     attr_accessor :failover_attempts, :db_check_frequency, :failover_check_frequency
 
-    def initialize(db_yml_file = '/var/www/miq/vmdb/config/database.yml',
-                   failover_yml_file = '/var/www/miq/vmdb/config/failover_databases.yml',
-                   ha_admin_yml_file = '/var/www/miq/vmdb/config/ha_admin.yml',
-                   log_file = '/var/www/miq/vmdb/log/ha_admin.log',
-                   environment = 'production')
+    def initialize(db_yml_file: '/var/www/miq/vmdb/config/database.yml',
+                   failover_yml_file: '/var/www/miq/vmdb/config/failover_databases.yml',
+                   ha_admin_yml_file: '/var/www/miq/vmdb/config/ha_admin.yml',
+                   log_file: '/var/www/miq/vmdb/log/ha_admin.log',
+                   environment: 'production')
       @logger = Logger.new(log_file)
       @logger.level = Logger::INFO
       @database_yml = DatabaseYml.new(db_yml_file, environment)
@@ -31,9 +31,7 @@ module PostgresHaAdmin
       @failover_attempts = ha_admin_yml['failover_attempts'] || FAILOVER_ATTEMPTS
       @db_check_frequency = ha_admin_yml['db_check_frequency'] || DB_CHECK_FREQUENCY
       @failover_check_frequency = ha_admin_yml['failover_check_frequency'] || FAILOVER_CHECK_FREQUENCY
-      @logger.info("FAILOVER_ATTEMPTS=#{@failover_attempts}"\
-                   "DB_CHECK_FREQUENCY=#{@db_check_frequency}"\
-                   "FAILOVER_CHECK_FREQUENCY=#{@failover_check_frequency}")
+      @logger.info("FAILOVER_ATTEMPTS=#{@failover_attempts} DB_CHECK_FREQUENCY=#{@db_check_frequency} FAILOVER_CHECK_FREQUENCY=#{@failover_check_frequency}")
     end
 
     def monitor

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -10,8 +10,7 @@ module PostgresHaAdmin
     FAILOVER_ATTEMPTS = 10
     DB_CHECK_FREQUENCY = 300
     FAILOVER_CHECK_FREQUENCY = 60
-    attr_accessor :failover_attempts, :db_check_frequency,
-                  :failover_check_frequency
+    attr_accessor :failover_attempts, :db_check_frequency, :failover_check_frequency
 
     def initialize(db_yml_file = '/var/www/miq/vmdb/config/database.yml',
                    failover_yml_file = '/var/www/miq/vmdb/config/failover_databases.yml',
@@ -24,12 +23,11 @@ module PostgresHaAdmin
       @failover_db = FailoverDatabases.new(failover_yml_file, @logger)
       begin
         ha_admin_yml = YAML.load_file(ha_admin_yml_file)
-      rescue
+      rescue SystemCallError, IOError => err
         ha_admin_yml = {}
-        @logger.info("File not found #{ha_admin_yml_file}. "\
-                     "Default settings for failover will be used.")
+        @logger.error("#{err.class}: #{err}")
+        @logger.info("File not loaded: #{ha_admin_yml_file}. Default settings for failover will be used.")
       end
-
       @failover_attempts = ha_admin_yml['failover_attempts'] || FAILOVER_ATTEMPTS
       @db_check_frequency = ha_admin_yml['db_check_frequency'] || DB_CHECK_FREQUENCY
       @failover_check_frequency = ha_admin_yml['failover_check_frequency'] || FAILOVER_CHECK_FREQUENCY

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -13,10 +13,8 @@ describe PostgresHaAdmin::FailoverMonitor do
 
   let(:failover_monitor) do
     allow(PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
-    allow(PostgresHaAdmin::FailoverDatabases).to \
-      receive(:new).and_return(failover_db)
-    failover_instance = described_class.new('', '', '',
-                                            @logger_file.path, 'test')
+    allow(PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
+    failover_instance = described_class.new(log_file: @logger_file.path)
     failover_instance
   end
 
@@ -38,7 +36,7 @@ describe PostgresHaAdmin::FailoverMonitor do
     it "loads failover settings from 'ha_admin.yml'" do
       expect(failover_monitor.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS
       allow(YAML).to receive(:load_file).and_return('failover_attempts' => described_class::FAILOVER_ATTEMPTS + 10)
-      monitor_with_settings = described_class.new('', '', '', @logger_file.path, 'test')
+      monitor_with_settings = described_class.new(log_file: @logger_file.path)
 
       expect(monitor_with_settings.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS + 10
       expect(failover_monitor.db_check_frequency).to eq described_class::DB_CHECK_FREQUENCY

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -36,11 +36,9 @@ describe PostgresHaAdmin::FailoverMonitor do
 
   describe "#initialize" do
     it "loads failover settings from 'ha_admin.yml'" do
-      expect(failover_monitor.failover_attempts).to \
-        eq described_class::FAILOVER_ATTEMPTS
+      expect(failover_monitor.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS
       allow(YAML).to receive(:load_file).and_return('failover_attempts' => described_class::FAILOVER_ATTEMPTS + 10)
-      monitor_with_settings = described_class.new('', '', '',
-                                                  @logger_file.path, 'test')
+      monitor_with_settings = described_class.new('', '', '', @logger_file.path, 'test')
 
       expect(monitor_with_settings.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS + 10
       expect(failover_monitor.db_check_frequency).to eq described_class::DB_CHECK_FREQUENCY

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -12,9 +12,11 @@ describe PostgresHaAdmin::FailoverMonitor do
   end
 
   let(:failover_monitor) do
-    expect(PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
-    expect(PostgresHaAdmin::FailoverDatabases).to receive(:new).and_return(failover_db)
-    failover_instance = described_class.new('', '', '', @logger_file.path, 'test')
+    allow(PostgresHaAdmin::DatabaseYml).to receive(:new).and_return(db_yml)
+    allow(PostgresHaAdmin::FailoverDatabases).to \
+      receive(:new).and_return(failover_db)
+    failover_instance = described_class.new('', '', '',
+                                            @logger_file.path, 'test')
     failover_instance
   end
 
@@ -33,16 +35,20 @@ describe PostgresHaAdmin::FailoverMonitor do
   end
 
   describe "#initialize" do
-    it "loads failover settings from 'ha_admin.yml' if there are present in yml" do
-      allow(YAML).to receive(:load_file).and_return('failover_attempts' => 555)
-      monitor_with_settings = described_class.new('', '', '', @logger_file.path, 'test')
-      expect(monitor_with_settings.failover_attempts).to eq 555
-      expect(failover_monitor.db_connected_check_frequency).to eq described_class::DB_CONNECTED_CHECK_FREQUENCY
+    it "loads failover settings from 'ha_admin.yml'" do
+      expect(failover_monitor.failover_attempts).to \
+        eq described_class::FAILOVER_ATTEMPTS
+      allow(YAML).to receive(:load_file).and_return('failover_attempts' => described_class::FAILOVER_ATTEMPTS + 10)
+      monitor_with_settings = described_class.new('', '', '',
+                                                  @logger_file.path, 'test')
+
+      expect(monitor_with_settings.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS + 10
+      expect(failover_monitor.db_check_frequency).to eq described_class::DB_CHECK_FREQUENCY
     end
 
     it "uses default failover settings if 'ha_admin.yml' not found" do
       expect(failover_monitor.failover_attempts).to eq described_class::FAILOVER_ATTEMPTS
-      expect(failover_monitor.db_connected_check_frequency).to eq described_class::DB_CONNECTED_CHECK_FREQUENCY
+      expect(failover_monitor.db_check_frequency).to eq described_class::DB_CHECK_FREQUENCY
       expect(failover_monitor.failover_check_frequency).to eq described_class::FAILOVER_CHECK_FREQUENCY
     end
   end


### PR DESCRIPTION
Accepting parameters from yml, as well as ability to change them without restarting process will help to tune failover monitoring.
This if follow-up PR for #10353

in this PR:
- added ```config/ha_admin.yml``` and modified ```FailoverMonitor``` and corresponding rspec. 
Sample of ```ha_admin_yml``` : 
```
---
failover_attempts: 10
db_check_frequency: 300
failover_check_frequency: 60
```

/cc @carbonin 

@miq-bot add-label core, wip