### PR TITLE
Add the hidden column into EmsFolder's MiqHashStruct.

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -889,7 +889,7 @@ class MiqRequestWorkflow
   end
 
   def get_ems_folders(folder, dh = {}, full_path = "")
-    if folder.evm_object_class == :EmsFolder && !folder.hidden?
+    if folder.evm_object_class == :EmsFolder && !folder.hidden
       full_path += full_path.blank? ? "#{folder.name}" : " / #{folder.name}"
       dh[folder.id] = full_path unless folder.type == "Datacenter"
     end
@@ -1021,7 +1021,7 @@ class MiqRequestWorkflow
   end
 
   def ems_folder_to_hash_struct(ci)
-    build_ci_hash_struct(ci, [:name, :type])
+    build_ci_hash_struct(ci, [:name, :type, :hidden])
   end
 
   def storage_to_hash_struct(ci)

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -347,6 +347,17 @@ describe MiqRequestWorkflow do
     end
   end
 
+  context "#ems_folder_to_hash_struct" do
+    it 'contains hidden column' do
+      hs = workflow.ems_folder_to_hash_struct(FactoryGirl.create(:ems_folder, :name => 'vm', :hidden => true))
+
+      expect(hs.id).to               be_kind_of(Integer)
+      expect(hs.evm_object_class).to eq(:EmsFolder)
+      expect(hs.name).to             be_kind_of(String)
+      expect(hs.hidden).to           be true
+    end
+  end
+
   context "#validate regex" do
     let(:regex) { {:required_regex => "^n@test.com$"} }
     let(:regex_two) { {:required_regex => "^n$"} }


### PR DESCRIPTION
Purpose or Intent
-----------------
Commit 7eec1c677 has changed the way to use the hidden column to determine if an ems_folder should be displayed to the user or not.
However, the hidden column got lost when an EmsFolder object is  converted to a MiqHashStruct.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1363880

cc @gmcculloug @agrare 