### PR TITLE
Clear the `my_region` cache when changing the region name

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -18,6 +18,8 @@ class MiqRegion < ApplicationRecord
   virtual_has_many :miq_templates,          :uses => :all_relationships
   virtual_has_many :vms,                    :uses => :all_relationships
 
+  after_save :clear_my_region_cache
+
   acts_as_miq_taggable
   include UuidMixin
   include NamingSequenceMixin
@@ -312,5 +314,11 @@ class MiqRegion < ApplicationRecord
       options[type] = self.is_tagged_with?("capture_enabled", :ns => "/performance/#{type}")
     end
     @perf_capture_always = options.freeze
+  end
+
+  private
+
+  def clear_my_region_cache
+    MiqRegion.my_region_clear_cache
   end
 end


### PR DESCRIPTION
Before this change, you had to wait the 5 minute timeout before seeing the change in region name, even though it was saved successfully to the database.

After the change shows up immediately upon refreshing the page.

https://bugzilla.redhat.com/show_bug.cgi?id=1350808

@jrafanie not sure who should review this so I'll ping you :sweat_smile: 