### PR TITLE
Move ApiUserTokenService under the API namespace

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -483,7 +483,7 @@ class DashboardController < ApplicationController
   end
 
   def generate_ui_api_token(userid)
-    @api_user_token_service ||= ApiUserTokenService.new
+    @api_user_token_service ||= ManageIQ::API::UserTokenService.new
     @api_user_token_service.generate_token(userid, "ui")
   end
 

--- a/lib/manageiq/api/environment.rb
+++ b/lib/manageiq/api/environment.rb
@@ -4,7 +4,7 @@ class ManageIQ::API::Environment
   end
 
   def self.user_token_service
-    @user_token_service ||= ApiUserTokenService.new(ManageIQ::API::Settings, :log_init => true)
+    @user_token_service ||= ManageIQ::API::UserTokenService.new(ManageIQ::API::Settings, :log_init => true)
   end
 
   def self.fetch_encrypted_attribute_names(klass)

--- a/lib/manageiq/api/user_token_service.rb
+++ b/lib/manageiq/api/user_token_service.rb
@@ -1,4 +1,4 @@
-class ApiUserTokenService
+class ManageIQ::API::UserTokenService
   def initialize(config = ManageIQ::API::Settings, args = {})
     @config = config
     @svc_options = args

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -119,7 +119,7 @@ describe DashboardController do
       skip_data_checks(validation_url)
 
       allow(User).to receive(:authenticate).and_return(user)
-      allow_any_instance_of(ApiUserTokenService).to receive(:generate_token)
+      allow_any_instance_of(ManageIQ::API::UserTokenService).to receive(:generate_token)
         .with(user.userid, "ui")
         .and_return(auth_token)
 


### PR DESCRIPTION
Purpose or Intent
-----------------

The `Api` in the name was a giveaway that this service belongs under the
main API namespace, and will simplify the constant lookup in later
refactorings.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 