### PR TITLE
Delete configuration provider when selected from tree does not work

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -88,6 +88,7 @@ class ProviderForemanController < ApplicationController
   def delete
     assert_privileges("provider_foreman_delete_provider") # TODO: Privelege name should match generic ways from Infra and Cloud
     checked_items = find_checked_items # TODO: Checked items are managers, not providers.  Make them providers
+    checked_items.push(params[:id]) if checked_items.empty? && params[:id]
     providers = ManageIQ::Providers::ConfigurationManager.where(:id => checked_items).includes(:provider).collect(&:provider)
     if providers.empty?
       add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "providers"), :task => "deletion"}, :error)

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -234,6 +234,30 @@ describe ProviderForemanController do
     end
   end
 
+  context "#delete" do
+    before do
+      stub_user(:features => :all)
+    end
+
+    it "deletes the provider when the configuration manager id is supplied" do
+      allow(controller).to receive(:replace_right_cell)
+      post :delete, :params => { :id => @config_mgr.id }
+      expect(assigns(:flash_array).first[:message]).to include("Delete initiated for 1 Provider")
+    end
+
+    it "it deletes a provider when the configuration manager id is selected from a list view" do
+      allow(controller).to receive(:replace_right_cell)
+      post :delete, :params => { :miq_grid_checks => "#{@config_mgr.id}, #{@config_mgr2.id}"}
+      expect(assigns(:flash_array).first[:message]).to include("Delete initiated for 2 Providers")
+    end
+
+    it "it deletes a provider when the configuration manager id is selected from a grid/tile" do
+      allow(controller).to receive(:replace_right_cell)
+      post :delete, :params => { "check_#{ApplicationRecord.compress_id(@config_mgr.id)}" => "1" }
+      expect(assigns(:flash_array).first[:message]).to include("Delete initiated for 1 Provider")
+    end
+  end
+
   context "renders right cell text" do
     before do
       right_cell_text = nil


### PR DESCRIPTION
Delete configuration provider when selected from tree does not work.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1364966

