### PR TITLE
Use nested style for class and module children in API

### DIFF
--- a/lib/manageiq/api/environment.rb
+++ b/lib/manageiq/api/environment.rb
@@ -1,20 +1,24 @@
-class ManageIQ::API::Environment
-  def self.normalized_attributes
-    @normalized_attributes ||= {:time => {}, :url => {}, :resource => {}, :encrypted => {}}
-  end
+module ManageIQ
+  module API
+    class Environment
+      def self.normalized_attributes
+        @normalized_attributes ||= {:time => {}, :url => {}, :resource => {}, :encrypted => {}}
+      end
 
-  def self.user_token_service
-    @user_token_service ||= ManageIQ::API::UserTokenService.new(ManageIQ::API::Settings, :log_init => true)
-  end
+      def self.user_token_service
+        @user_token_service ||= UserTokenService.new(Settings, :log_init => true)
+      end
 
-  def self.fetch_encrypted_attribute_names(klass)
-    return [] unless klass.respond_to?(:encrypted_columns)
-    encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
-      normalized_attributes[:encrypted][attr] = true
+      def self.fetch_encrypted_attribute_names(klass)
+        return [] unless klass.respond_to?(:encrypted_columns)
+        encrypted_objects_checked[klass.name] ||= klass.encrypted_columns.each do |attr|
+          normalized_attributes[:encrypted][attr] = true
+        end
+      end
+
+      def self.encrypted_objects_checked
+        @encrypted_objects_checked ||= {}
+      end
     end
-  end
-
-  def self.encrypted_objects_checked
-    @encrypted_objects_checked ||= {}
   end
 end

--- a/lib/manageiq/api/initializer.rb
+++ b/lib/manageiq/api/initializer.rb
@@ -1,67 +1,71 @@
-class ManageIQ::API::Initializer
-  def go
-    init_env
-    gen_attr_type_hash
-  end
+module ManageIQ
+  module API
+    class Initializer
+      def go
+        init_env
+        gen_attr_type_hash
+      end
 
-  def log_kv(key, val, pref = "")
-    $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
-  end
+      def log_kv(key, val, pref = "")
+        $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
+      end
 
-  #
-  # Initializing REST API environment, called once @ startup
-  #
-  def init_env
-    $api_log.info("Initializing Environment for #{ManageIQ::API::Settings.base[:name]}")
-    log_config
-  end
+      #
+      # Initializing REST API environment, called once @ startup
+      #
+      def init_env
+        $api_log.info("Initializing Environment for #{Settings.base[:name]}")
+        log_config
+      end
 
-  def log_config
-    $api_log.info("")
-    $api_log.info("Static Configuration")
-    ManageIQ::API::Settings.base.each { |key, val| log_kv(key, val) }
+      def log_config
+        $api_log.info("")
+        $api_log.info("Static Configuration")
+        Settings.base.each { |key, val| log_kv(key, val) }
 
-    $api_log.info("")
-    $api_log.info("Dynamic Configuration")
-    ManageIQ::API::Environment.user_token_service.api_config.each { |key, val| log_kv(key, val) }
-  end
+        $api_log.info("")
+        $api_log.info("Dynamic Configuration")
+        Environment.user_token_service.api_config.each { |key, val| log_kv(key, val) }
+      end
 
-  #
-  # Let's create our attribute type hashes.
-  # Accessed as normalized_attributes[<name>], much faster than array include?
-  #
-  def gen_attr_type_hash
-    attr_types.each { |type, attrs| attrs.each { |a| ManageIQ::API::Environment.normalized_attributes[type][a] = true } }
-    gen_time_attr_type_hash
-  end
+      #
+      # Let's create our attribute type hashes.
+      # Accessed as normalized_attributes[<name>], much faster than array include?
+      #
+      def gen_attr_type_hash
+        attr_types.each { |type, attrs| attrs.each { |a| Environment.normalized_attributes[type][a] = true } }
+        gen_time_attr_type_hash
+      end
 
-  #
-  # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
-  #
-  def gen_time_attr_type_hash
-    ManageIQ::API::Settings.collections.each do |_, cspec|
-      next if cspec[:klass].blank?
-      klass = cspec[:klass].constantize
-      klass.columns_hash.collect do |name, typeobj|
-        ManageIQ::API::Environment.normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
+      #
+      # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
+      #
+      def gen_time_attr_type_hash
+        Settings.collections.each do |_, cspec|
+          next if cspec[:klass].blank?
+          klass = cspec[:klass].constantize
+          klass.columns_hash.collect do |name, typeobj|
+            Environment.normalized_attributes[:time][name] = true if %w(date datetime).include?(typeobj.type.to_s)
+          end
+        end
+      end
+
+      private
+
+      #
+      # Custom normalization on these attribute types.
+      # Converted to normalized_attributes hash at init, much faster access.
+      #
+      def attr_types
+        @attr_types ||= {
+          :time      => %w(expires_on),
+          :url       => %w(href),
+          :resource  => %w(image_href),
+          :encrypted => %w(password) |
+                        ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
+                        ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
+        }
       end
     end
-  end
-
-  private
-
-  #
-  # Custom normalization on these attribute types.
-  # Converted to normalized_attributes hash at init, much faster access.
-  #
-  def attr_types
-    @attr_types ||= {
-      :time      => %w(expires_on),
-      :url       => %w(href),
-      :resource  => %w(image_href),
-      :encrypted => %w(password) |
-                    ::MiqRequestWorkflow.all_encrypted_options_fields.map(&:to_s) |
-                    ::Vmdb::Settings::PASSWORD_FIELDS.map(&:to_s)
-    }
   end
 end

--- a/lib/manageiq/api/settings.rb
+++ b/lib/manageiq/api/settings.rb
@@ -1,6 +1,10 @@
 require "config"
 
-ManageIQ::API::Settings = ::Config::Options.new.tap do |o|
-  o.add_source!(Rails.root.join("config/api.yml").to_s)
-  o.load!
+module ManageIQ
+  module API
+    Settings = ::Config::Options.new.tap do |o|
+      o.add_source!(Rails.root.join("config/api.yml").to_s)
+      o.load!
+    end
+  end
 end

--- a/lib/manageiq/api/user_token_service.rb
+++ b/lib/manageiq/api/user_token_service.rb
@@ -1,75 +1,79 @@
-class ManageIQ::API::UserTokenService
-  def initialize(config = ManageIQ::API::Settings, args = {})
-    @config = config
-    @svc_options = args
-    @token_mgr = new_token_mgr(base_config[:module], base_config[:name], api_config)
-  end
+module ManageIQ
+  module API
+    class UserTokenService
+      def initialize(config = Settings, args = {})
+        @config = config
+        @svc_options = args
+        @token_mgr = new_token_mgr(base_config[:module], base_config[:name], api_config)
+      end
 
-  attr_accessor :token_mgr
+      attr_accessor :token_mgr
 
-  # Additional Requester type token ttl's for authentication
-  #
-  REQUESTER_TTL_CONFIG = {"ui" => :ui_token_ttl}.freeze
+      # Additional Requester type token ttl's for authentication
+      #
+      REQUESTER_TTL_CONFIG = {"ui" => :ui_token_ttl}.freeze
 
-  # API Settings with additional token ttl's
-  #
-  def api_config
-    @api_config ||= Settings[base_config[:module]].to_hash.merge(
-      REQUESTER_TTL_CONFIG["ui"] => Settings.session.timeout
-    )
-  end
+      # API Settings with additional token ttl's
+      #
+      def api_config
+        @api_config ||= ::Settings[base_config[:module]].to_hash.merge(
+          REQUESTER_TTL_CONFIG["ui"] => ::Settings.session.timeout
+        )
+      end
 
-  def generate_token(userid, requester_type)
-    validate_userid(userid)
-    validate_requester_type(requester_type)
+      def generate_token(userid, requester_type)
+        validate_userid(userid)
+        validate_requester_type(requester_type)
 
-    $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
+        $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
 
-    token_mgr.gen_token(base_config[:module],
-                        :userid           => userid,
-                        :token_ttl_config => REQUESTER_TTL_CONFIG[requester_type])
-  end
+        token_mgr.gen_token(base_config[:module],
+                            :userid           => userid,
+                            :token_ttl_config => REQUESTER_TTL_CONFIG[requester_type])
+      end
 
-  def validate_requester_type(requester_type)
-    return unless requester_type
-    REQUESTER_TTL_CONFIG.fetch(requester_type) do
-      requester_types = REQUESTER_TTL_CONFIG.keys.join(', ')
-      raise "Invalid requester_type #{requester_type} specified, valid types are: #{requester_types}"
+      def validate_requester_type(requester_type)
+        return unless requester_type
+        REQUESTER_TTL_CONFIG.fetch(requester_type) do
+          requester_types = REQUESTER_TTL_CONFIG.keys.join(', ')
+          raise "Invalid requester_type #{requester_type} specified, valid types are: #{requester_types}"
+        end
+      end
+
+      private
+
+      def base_config
+        @config[:base]
+      end
+
+      def log_kv(key, val, pref = "")
+        $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
+      end
+
+      def new_token_mgr(mod, name, api_config)
+        token_ttl    = api_config[:token_ttl]
+        ui_token_ttl = api_config[REQUESTER_TTL_CONFIG["ui"]]
+
+        options                = {}
+        options[:token_ttl]    = token_ttl.to_i_with_method if token_ttl
+        options[:ui_token_ttl] = ui_token_ttl.to_i_with_method if ui_token_ttl
+
+        log_init(mod, name, options) if @svc_options[:log_init]
+        TokenManager.new(mod, options)
+      end
+
+      def log_init(mod, name, options)
+        $api_log.info("")
+        $api_log.info("Creating new Token Manager for the #{name}")
+        $api_log.info("   Token Manager  module: #{mod}")
+        $api_log.info("   Token Manager options:")
+        options.each { |key, val| log_kv(key, val, "    ") }
+        $api_log.info("")
+      end
+
+      def validate_userid(userid)
+        raise "Invalid userid #{userid} specified" unless User.exists?(:userid => userid)
+      end
     end
-  end
-
-  private
-
-  def base_config
-    @config[:base]
-  end
-
-  def log_kv(key, val, pref = "")
-    $api_log.info("#{pref}  #{key.to_s.ljust([24, key.to_s.length].max, ' ')}: #{val}")
-  end
-
-  def new_token_mgr(mod, name, api_config)
-    token_ttl    = api_config[:token_ttl]
-    ui_token_ttl = api_config[REQUESTER_TTL_CONFIG["ui"]]
-
-    options                = {}
-    options[:token_ttl]    = token_ttl.to_i_with_method if token_ttl
-    options[:ui_token_ttl] = ui_token_ttl.to_i_with_method if ui_token_ttl
-
-    log_init(mod, name, options) if @svc_options[:log_init]
-    TokenManager.new(mod, options)
-  end
-
-  def log_init(mod, name, options)
-    $api_log.info("")
-    $api_log.info("Creating new Token Manager for the #{name}")
-    $api_log.info("   Token Manager  module: #{mod}")
-    $api_log.info("   Token Manager options:")
-    options.each { |key, val| log_kv(key, val, "    ") }
-    $api_log.info("")
-  end
-
-  def validate_userid(userid)
-    raise "Invalid userid #{userid} specified" unless User.exists?(:userid => userid)
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
To avoid having to do `ManageIQ::API` for every dependency within the
`API` module, using a nested style allows us to drop the
namespace. Constant lookup should start in the `API` module and move
upwards if it can't find what it's looking for.

@miq-bot add-label api, refactoring, wip
@miq-bot assign @abellotti 

@abellotti once https://github.com/ManageIQ/manageiq/pull/10496 is merged I'll encorporate that into this PR too. Marking as WIP for now and skipping CI to avoid wasting a run until this is ready.

/cc @jrafanie 