### PR TITLE
container ssa: settings for proxy environment variables

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -26,6 +26,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   belongs_to :provider
+  include CustomAttributeMixin
   belongs_to :tenant
   has_many :container_deployments, :foreign_key => :deployed_on_ems_id, :inverse_of => :deployed_on_ems
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -144,6 +144,20 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
       end
     end
 
+    it 'should add correct environment variables' do
+      att_name = 'http_proxy'
+      my_value = "MY_TEST_VALUE"
+      @ems.custom_attributes.create(:section => described_class::ATTRIBUTE_SECTION,
+                                    :name    => att_name,
+                                    :value   => my_value)
+      allow_any_instance_of(described_class).to receive_messages(:kubernetes_client => MockKubeClient.new)
+      kc = @job.kubernetes_client
+      secret_name = kc.get_service_account[:imagePullSecrets][0][:name]
+      pod = @job.send(:pod_definition, secret_name)
+      expect(pod[:spec][:containers][0][:env][0][:name]).to eq(att_name.upcase)
+      expect(pod[:spec][:containers][0][:env][0][:value]).to eq(my_value)
+    end
+
     it 'should send correct dockercfg secrets' do
       allow_any_instance_of(described_class).to receive_messages(:kubernetes_client => MockKubeClient.new)
       kc = @job.kubernetes_client


### PR DESCRIPTION
This will add the option for the user to define a proxy in the node to be used by image-inspector.

custom attributes of the provider with the names `NO_PROXY` `HTTP_PROXY` `HTTPS_PROXY` will be added as environment variables to the image-inspector pod with the value of the attribute as the values of the environment variable.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1348610