### PR TITLE
add quick_stats support for RHEVM host

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1297,7 +1297,7 @@ class Host < ApplicationRecord
 
   def quickStats
     return @qs if @qs
-    return {} unless is_vmware?
+    return {} unless supports_quick_stats?
 
     begin
       raise _("Host has no EMS, unable to get host statistics") unless ext_management_system

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -49,6 +49,19 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     self::EventCatcher
   end
 
+  def host_quick_stats(host)
+    qs = {}
+    with_provider_connection(:version => 4) do |connection|
+      stats_list = connection.system_service.hosts_service.host_service(host.uid_ems)
+                             .statistics_service.list
+      qs["overallMemoryUsage"] = stats_list.detect { |x| x.name == "memory.used" }
+                                           .values.first.datum
+      qs["overallCpuUsage"] = stats_list.detect { |x| x.name == "cpu.load.avg.5m" }
+                                        .values.first.datum
+    end
+    qs
+  end
+
   def self.provision_class(via)
     case via
     when "iso" then self::ProvisionViaIso

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -211,7 +211,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     end
 
     def api4_supported_features
-      [:snapshots]
+      [:quick_stats, :snapshots]
     end
 
     def api_features

--- a/app/models/manageiq/providers/redhat/infra_manager/host.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/host.rb
@@ -17,4 +17,10 @@ class ManageIQ::Providers::Redhat::InfraManager::Host < ::Host
 
     true
   end
+
+  supports :quick_stats do
+    unless ext_management_system.supports_quick_stats?
+      unsupported_reason_add(:quick_stats, 'RHV API version does not support quick_stats')
+    end
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/host.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host.rb
@@ -66,4 +66,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Host < ::Host
       port
     end
   end
+
+  supports :quick_stats
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -27,4 +27,6 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
   def supports_snapshots?
     true
   end
+
+  supports :quick_stats
 end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -81,6 +81,7 @@ module SupportsFeatureMixin
     :live_migrate               => 'Live Migration',
     :migrate                    => 'Migration',
     :provisioning               => 'Provisioning',
+    :quick_stats                => 'Quick Stats',
     :reboot_guest               => 'Reboot Guest Operation',
     :reconfigure                => 'Reconfiguration',
     :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',

--- a/spec/models/manageiq/providers/redhat/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/host_spec.rb
@@ -1,0 +1,19 @@
+describe ManageIQ::Providers::Redhat::InfraManager::Host do
+  require 'ovirtsdk4'
+  describe '#quickStats' do
+    let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+    subject { FactoryGirl.create(:host_redhat, :ems_id => ems.id) }
+    before(:each) do
+      allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
+        .to receive(:supported_api_versions).and_return([4])
+    end
+    it '.supports_quick_stats?' do
+      expect(subject.supports_quick_stats?).to be true
+    end
+
+    it 'calls list on StatisticsService' do
+      expect_any_instance_of(OvirtSDK4::StatisticsService).to receive(:list)
+      subject.quickStats
+    end
+  end
+end


### PR DESCRIPTION
Add host quickStats support for RHEVM providers so the auto provisioning of a VM will consider which host has more free memory when deciding on a host for the new VM.
(Until now this was only supported for VMWare)

see: https://bugzilla.redhat.com/show_bug.cgi?id=1323145
