### PR TITLE
gems/pending/Gemfile is also ok to have long lines/extra space

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,8 @@ FileName:
 LineLength:
   Exclude:
     - Gemfile
+    - gems/pending/Gemfile
 ExtraSpacing:
   Exclude:
     - Gemfile
+    - gems/pending/Gemfile


### PR DESCRIPTION
Purpose or Intent
-----------------
Follow up to #10486.  We often WANT extra space to line up `gem` lines vertically by "version", "require", etc., so extra space and long lines are expected here too.

[skip ci]