### PR TITLE
Rake::TaskArguments doesn't have key? implemented

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -135,7 +135,7 @@ namespace :locale do
 
   desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
   task "plugin:find", :engine do |_, args|
-    unless args.key?(:engine)
+    unless args.has_key?(:engine)
       $stderr.puts "You need to specify a plugin name: rake locale:plugin:find[plugin_name]"
       exit 1
     end


### PR DESCRIPTION
We need to use `has_key?` instead. `key?` would always return `nil`.

Before:
```
$ be rake locale:plugin:find
You need to specify a plugin name: rake locale:plugin:find[plugin_name]
$ be rake locale:plugin:find[ManageIQ::Providers::Amazon]
You need to specify a plugin name: rake locale:plugin:find[plugin_name]
```

After:
```
$ be rake locale:plugin:find
You need to specify a plugin name: rake locale:plugin:find[plugin_name]
$ be rake locale:plugin:find[ManageIQ::Providers::Amazon]
** Using session_store: ActionDispatch::Session::MemCacheStore
...
```