### PR TITLE
Only selective properties for Git based Automate domains are editable

### DIFF
--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -52,6 +52,7 @@
             = text_field_tag("ns_name",
                               @edit[:new][:ns_name],
                               :maxlength         => MAX_NAME_LEN,
+                              :readonly => @ae_ns.domain? && !@ae_ns.editable_property?(:name)  ? true : false,
                               :class => "form-control",
                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             = javascript_tag(javascript_focus('ns_name'))
@@ -62,6 +63,7 @@
             = text_field_tag("ns_description",
                               @edit[:new][:ns_description],
                               :maxlength         => MAX_NAME_LEN,
+                              :readonly => @ae_ns.domain? && !@ae_ns.editable_property?(:description) ? true : false,
                               :class => "form-control",
                               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         - if @ae_ns.domain?

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -5,6 +5,7 @@ class MiqAeDomain < MiqAeNamespace
   USER_LOCKED_SOURCE = "user_locked".freeze
   VALID_SOURCES  = [SYSTEM_SOURCE, REMOTE_SOURCE, USER_SOURCE, USER_LOCKED_SOURCE].freeze
   LOCKED_SOURCES = [SYSTEM_SOURCE, REMOTE_SOURCE, USER_LOCKED_SOURCE].freeze
+  EDITABLE_PROPERTIES_FOR_REMOTES = [:priority, :enabled].freeze
 
   default_scope { where(:parent_id => nil).where(arel_table[:name].not_eq("$")) }
   validates_inclusion_of :parent_id, :in => [nil], :message => 'should be nil for Domain'
@@ -75,6 +76,19 @@ class MiqAeDomain < MiqAeNamespace
 
   def editable_properties?
     source != SYSTEM_SOURCE
+  end
+
+  def editable_property?(property)
+    case source
+    when SYSTEM_SOURCE
+      false
+    when USER_SOURCE, USER_LOCKED_SOURCE
+      true
+    when REMOTE_SOURCE
+      EDITABLE_PROPERTIES_FOR_REMOTES.include?(property.to_sym)
+    else
+      false
+    end
   end
 
   alias editable_contents? editable?

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -243,6 +243,32 @@ describe MiqAeDomain do
     end
   end
 
+  context "editable property" do
+    it "system domain" do
+      dom = FactoryGirl.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_property?('name')).to be_falsey
+      expect(dom.editable_property?('description')).to be_falsey
+      expect(dom.editable_property?('priority')).to be_falsey
+      expect(dom.editable_property?('enabled')).to be_falsey
+    end
+
+    it "git domain" do
+      dom = FactoryGirl.create(:miq_ae_git_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_property?(:name)).to be_falsey
+      expect(dom.editable_property?(:description)).to be_falsey
+      expect(dom.editable_property?('priority')).to be_truthy
+      expect(dom.editable_property?('enabled')).to be_truthy
+    end
+
+    it "user domain" do
+      dom = FactoryGirl.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      expect(dom.editable_property?(:name)).to be_truthy
+      expect(dom.editable_property?(:description)).to be_truthy
+      expect(dom.editable_property?('priority')).to be_truthy
+      expect(dom.editable_property?('enabled')).to be_truthy
+    end
+  end
+
   context "git enabled domains" do
     let(:commit_time) { Time.now.utc }
     let(:commit_time_new) { Time.now.utc + 1.hour }

--- a/spec/views/miq_ae_class/_ns_list.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_ns_list.html.haml_spec.rb
@@ -1,0 +1,27 @@
+describe "miq_ae_class/_ns_list.html.haml" do
+  include Spec::Support::AutomationHelper
+
+  context 'display domain properties' do
+    def setup(dom)
+      assign(:in_a_form, true)
+      assign(:ae_ns, dom)
+      assign(:edit, :new => {:ns_name => dom.name, :ns_description => "test"})
+    end
+
+    it "Check Git enabled domain", :js => true do
+      dom = FactoryGirl.create(:miq_ae_git_domain)
+      setup(dom)
+      render
+      expect(response).to have_css("input#ns_name[readonly]")
+      expect(response).to have_css("input#ns_description[readonly]")
+    end
+
+    it "Check User Domain", :js => true do
+      dom = FactoryGirl.create(:miq_ae_domain)
+      setup(dom)
+      render
+      expect(response).not_to have_css("input#ns_name[readonly]")
+      expect(response).not_to have_css("input#ns_description[readonly]")
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
The name and description properties for a GIT domain are not editable, we can only edit the enabled, priority properties. 


Links
-----
> * https://github.com/ManageIQ/manageiq/pull/8897
