### PR TITLE
Don't use .minutes in failover_monitor.rb

### DIFF
--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -7,8 +7,8 @@ require 'linux_admin'
 module PostgresHaAdmin
   class FailoverMonitor
     FAILOVER_ATTEMPTS = 10
-    DB_CONNECTED_CHECK_FREQUENCY = 5.minutes
-    FAILOVER_CHECK_FREQUENCY = 1.minute
+    DB_CONNECTED_CHECK_FREQUENCY = 300
+    FAILOVER_CHECK_FREQUENCY = 60
 
     def initialize(db_yml_file = '/var/www/miq/vmdb/config/database.yml',
                    failover_yml_file = '/var/www/miq/vmdb/config/failover_databases.yml',


### PR DESCRIPTION
Those helpers are provided by activesupport and won't be available when run using just ruby.

@yrudman @gtanzillo 

@miq-bot add_label core, bug