### PR TITLE
Use the correct file names for the current and failover databases

### DIFF
--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -16,8 +16,8 @@ module PostgresHaAdmin
                    environment = 'production')
       @logger = Logger.new(log_file)
       @logger.level = Logger::INFO
-      @database_yml = DatabaseYml.new(failover_yml_file, environment)
-      @failover_db = FailoverDatabases.new(db_yml_file, @logger)
+      @database_yml = DatabaseYml.new(db_yml_file, environment)
+      @failover_db = FailoverDatabases.new(failover_yml_file, @logger)
     end
 
     def monitor


### PR DESCRIPTION
Before this change the `database.yml` file and the `failover_databases.yml` file were being passed to the incorrect classes.

@yrudman @gtanzillo please review

@miq-bot add_label bug, core
@miq-bot assign @gtanzillo 