### PR TITLE
VM provisioning using storage profile as storage filter

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -144,11 +144,12 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
   end
 
   def allowed_storage_profiles(options = {})
+    return [] if (src = resources_for_ui).blank? || src[:vm].nil?
     model_name = options[:storage_profile_filter]
     return @filters[model_name] unless @filters[model_name].nil?
-    template = VmOrTemplate.find_by_id(get_value(@values[:src_vm_id]))
+    template = VmOrTemplate.find_by_id(src[:vm].id)
     @values[:storage_profile_filter] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
-    storage_profiles = StorageProfile.where(:ems_id => get_source_and_targets[:ems].try(:id))
+    storage_profiles = StorageProfile.where(:ems_id => src[:ems].try(:id))
     @filters[model_name] = storage_profiles.each_with_object({}) { |s, m| m[s.id] = s.name }
     @filters[model_name]
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -142,4 +142,14 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
     end
     return vlans, hosts
   end
+
+  def allowed_storage_profiles(options = {})
+    model_name = options[:storage_profile_filter]
+    return @filters[model_name] unless @filters[model_name].nil?
+    template = VmOrTemplate.find_by_id(get_value(@values[:src_vm_id]))
+    @values[:storage_profile_filter] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
+    storage_profiles = StorageProfile.where(:ems_id => get_source_and_targets[:ems].try(:id))
+    @filters[model_name] = storage_profiles.each_with_object({}) { |s, m| m[s.id] = s.name }
+    @filters[model_name]
+  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -147,7 +147,7 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
     return [] if (src = resources_for_ui).blank? || src[:vm].nil?
     @filters[:StorageProfile] ||= begin
       template = load_ar_obj(src[:vm])
-      @values[:storage_profile] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
+      @values[:placement_storage_profile] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
       StorageProfile.where(:ems_id => src[:ems].try(:id)).each_with_object({}) { |s, m| m[s.id] = s.name }
     end
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -143,7 +143,7 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
     return vlans, hosts
   end
 
-  def allowed_storage_profiles(options = {})
+  def allowed_storage_profiles(_options = {})
     return [] if (src = resources_for_ui).blank? || src[:vm].nil?
     @filters['StorageProfile'] ||= begin
       template = load_ar_obj(src[:vm])

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -145,7 +145,7 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
 
   def allowed_storage_profiles(_options = {})
     return [] if (src = resources_for_ui).blank? || src[:vm].nil?
-    @filters['StorageProfile'] ||= begin
+    @filters[:StorageProfile] ||= begin
       template = load_ar_obj(src[:vm])
       @values[:storage_profile_filter] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
       StorageProfile.where(:ems_id => src[:ems].try(:id)).each_with_object({}) { |s, m| m[s.id] = s.name }
@@ -154,6 +154,6 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
 
   def set_on_vm_id_changed
     super
-    @filters['StorageProfile'] = nil
+    @filters[:StorageProfile] = nil
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -147,7 +147,7 @@ class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::P
     return [] if (src = resources_for_ui).blank? || src[:vm].nil?
     @filters[:StorageProfile] ||= begin
       template = load_ar_obj(src[:vm])
-      @values[:storage_profile_filter] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
+      @values[:storage_profile] = [template.storage_profile.try(:id), template.storage_profile.try(:name)]
       StorageProfile.where(:ems_id => src[:ems].try(:id)).each_with_object({}) { |s, m| m[s.id] = s.name }
     end
   end

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -112,7 +112,17 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     src = get_source_and_targets
     vm, ems = load_ar_obj(src[:vm]), src[:ems]
 
-    clear_field_values([:placement_host_name, :placement_ds_name, :placement_folder_name, :placement_cluster_name, :placement_rp_name, :linked_clone, :snapshot, :placement_dc_name])
+    clear_field_values(
+      [:placement_host_name,
+       :placement_ds_name,
+       :placement_folder_name,
+       :placement_cluster_name,
+       :placement_rp_name,
+       :linked_clone,
+       :snapshot,
+       :placement_dc_name,
+       :storage_profile_filter]
+    )
 
     if vm.nil?
       clear_field_values([:number_of_cpus, :number_of_sockets, :cores_per_socket, :vm_memory, :cpu_limit, :memory_limit, :cpu_reserve, :memory_reserve])

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -121,7 +121,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
        :linked_clone,
        :snapshot,
        :placement_dc_name,
-       :storage_profile_filter]
+       :storage_profile]
     )
 
     if vm.nil?

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -121,7 +121,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
        :linked_clone,
        :snapshot,
        :placement_dc_name,
-       :storage_profile]
+       :placement_storage_profile]
     )
 
     if vm.nil?

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1090,7 +1090,7 @@ class MiqRequestWorkflow
     end.values
     selected_storage_profile_id = get_value(@values[:storage_profile_filter])
     if selected_storage_profile_id
-      storages.reject!{ |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }
+      storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }
     end
     allowed_storages_cache = process_filter(:ds_filter, Storage, storages).collect do |s|
       ci_to_hash_struct(s)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1088,7 +1088,10 @@ class MiqRequestWorkflow
     storages = hosts.each_with_object({}) do |host, hash|
       host.writable_storages.each { |s| hash[s.id] = s }
     end.values
-
+    selected_storage_profile_id = get_value(@values[:storage_profile_filter])
+    if selected_storage_profile_id
+      storages.reject!{ |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }
+    end
     allowed_storages_cache = process_filter(:ds_filter, Storage, storages).collect do |s|
       ci_to_hash_struct(s)
     end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1088,7 +1088,7 @@ class MiqRequestWorkflow
     storages = hosts.each_with_object({}) do |host, hash|
       host.writable_storages.each { |s| hash[s.id] = s }
     end.values
-    selected_storage_profile_id = get_value(@values[:storage_profile])
+    selected_storage_profile_id = get_value(@values[:placement_storage_profile])
     if selected_storage_profile_id
       storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }
     end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1088,7 +1088,7 @@ class MiqRequestWorkflow
     storages = hosts.each_with_object({}) do |host, hash|
       host.writable_storages.each { |s| hash[s.id] = s }
     end.values
-    selected_storage_profile_id = get_value(@values[:storage_profile_filter])
+    selected_storage_profile_id = get_value(@values[:storage_profile])
     if selected_storage_profile_id
       storages.reject! { |s| !s.storage_profiles.pluck(:id).include?(selected_storage_profile_id) }
     end

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -12,7 +12,7 @@
   :javascript
     // Create from/to date JS vars to limit calendar starting from
     ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}");
-  - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter, :storage_profile].include?(field)
+  - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter, :placement_storage_profile].include?(field)
     -# Filter Pull Down fields, show them only if there are any values
     - unless field_hash[:values].blank?
       .form-group

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -12,7 +12,7 @@
   :javascript
     // Create from/to date JS vars to limit calendar starting from
     ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}");
-  - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter, :storage_profile_filter].include?(field)
+  - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter, :storage_profile].include?(field)
     -# Filter Pull Down fields, show them only if there are any values
     - unless field_hash[:values].blank?
       .form-group

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -12,7 +12,7 @@
   :javascript
     // Create from/to date JS vars to limit calendar starting from
     ManageIQ.calendar.calDateFrom = miqCalendarDateConversion("#{@timezone_offset}");
-  - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter].include?(field)
+  - if [:cluster_filter, :ds_filter, :host_filter, :rp_filter, :vm_filter, :storage_profile_filter].include?(field)
     -# Filter Pull Down fields, show them only if there are any values
     - unless field_hash[:values].blank?
       .form-group

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -130,7 +130,7 @@
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})
       - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
-        - keys = [:ds_filter, :storage_profile, :placement_ds_name]
+        - keys = [:ds_filter, :placement_storage_profile, :placement_ds_name]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -130,7 +130,7 @@
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})
       - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
-        - keys = [:ds_filter, :storage_profile_filter, :placement_ds_name]
+        - keys = [:ds_filter, :storage_profile, :placement_ds_name]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -130,7 +130,7 @@
           :keys                       => keys,
           :extra_table_attributes     => "width=100%"})
       - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
-        - keys = [:ds_filter, :placement_ds_name]
+        - keys = [:ds_filter, :storage_profile_filter, :placement_ds_name]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
           :locals         => {:workflow => wf,
             :dialog                     => dialog,

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -398,6 +398,14 @@
           :required: false
           :display: :edit
           :data_type: :integer
+        :storage_profile:
+          :values_from:
+            :method: :allowed_storage_profiles
+          :auto_select_single: false
+          :description: Storage Profile
+          :required: false
+          :display: :edit
+          :data_type: :integer
         :placement_host_name:
           :values_from:
             :method: :allowed_hosts

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -398,7 +398,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :storage_profile:
+        :placement_storage_profile:
           :values_from:
             :method: :allowed_storage_profiles
           :auto_select_single: false

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -407,7 +407,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :storage_profile:
+        :placement_storage_profile:
           :values_from:
             :method: :allowed_storage_profiles
           :auto_select_single: false

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -407,6 +407,14 @@
           :required: false
           :display: :edit
           :data_type: :integer
+        :storage_profile:
+          :values_from:
+            :method: :allowed_storage_profiles
+          :auto_select_single: false
+          :description: Storage Profile
+          :required: false
+          :display: :edit
+          :data_type: :integer
         :placement_host_name:
           :values_from:
             :method: :allowed_hosts

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -421,7 +421,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :storage_profile_filter:
+        :storage_profile:
           :values_from:
             :method: :allowed_storage_profiles
           :auto_select_single: false

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -421,7 +421,7 @@
           :required: false
           :display: :edit
           :data_type: :integer
-        :storage_profile:
+        :placement_storage_profile:
           :values_from:
             :method: :allowed_storage_profiles
           :auto_select_single: false

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -421,6 +421,16 @@
           :required: false
           :display: :edit
           :data_type: :integer
+        :storage_profile_filter:
+          :values_from:
+            :options:
+              :category: :StorageProfile
+            :method: :allowed_storage_profiles
+          :auto_select_single: false
+          :description: Storage Profile
+          :required: false
+          :display: :edit
+          :data_type: :integer
         :placement_host_name:
           :values_from:
             :method: :allowed_hosts

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -423,8 +423,6 @@
           :data_type: :integer
         :storage_profile_filter:
           :values_from:
-            :options:
-              :category: :StorageProfile
             :method: :allowed_storage_profiles
           :auto_select_single: false
           :description: Storage Profile

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -90,16 +90,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
 
     context '#set_on_vm_id_changed' do
       it 'clears StorageProfile filter' do
-        workflow.instance_variable_set(
-          :@filters,
-          :Host            => {21  => "Platform / ESX 6.0"},
-          :StorageProfile  => {1   => "Tag 1"},
-          :src_vm_id       => @src_vm.id
-        )
+        workflow.instance_variable_set(:@filters, :Host => {21 => "ESX 6.0"}, :StorageProfile => {1 => "Tag 1"})
         allow(workflow).to receive(:set_or_default_hardware_field_values).with(@src_vm)
         workflow.set_on_vm_id_changed
         filters = workflow.instance_variable_get(:@filters)
-        expect(filters).to eq(:Host => {21=>"Platform / ESX 6.0"}, :StorageProfile => nil, :src_vm_id => @src_vm.id)
+        expect(filters).to eq(:Host => {21=>"ESX 6.0"}, :StorageProfile => nil)
       end
     end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -93,13 +93,13 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
         workflow.instance_variable_set(
           :@filters,
           :Host            => {21  => "Platform / ESX 6.0"},
-          'StorageProfile' => {1   => "Tag 1"},
+          :StorageProfile  => {1   => "Tag 1"},
           :src_vm_id       => @src_vm.id
         )
         allow(workflow).to receive(:set_or_default_hardware_field_values).with(@src_vm)
         workflow.set_on_vm_id_changed
         filters = workflow.instance_variable_get(:@filters)
-        expect(filters).to eq(:Host => {21=>"Platform / ESX 6.0"}, 'StorageProfile' => nil, :src_vm_id => @src_vm.id)
+        expect(filters).to eq(:Host => {21=>"Platform / ESX 6.0"}, :StorageProfile => nil, :src_vm_id => @src_vm.id)
       end
     end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_workflow_spec.rb
@@ -76,7 +76,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
     end
   end
 
-  context 'network selection' do
+  context 'provisioning a VM' do
     let(:workflow) { described_class.new({}, admin.userid) }
     before do
       @ems    = FactoryGirl.create(:ems_vmware)
@@ -88,7 +88,22 @@ describe ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow do
       workflow.instance_variable_set(:@target_resource, nil)
     end
 
-    context 'vlans' do
+    context '#set_on_vm_id_changed' do
+      it 'clears StorageProfile filter' do
+        workflow.instance_variable_set(
+          :@filters,
+          :Host            => {21  => "Platform / ESX 6.0"},
+          'StorageProfile' => {1   => "Tag 1"},
+          :src_vm_id       => @src_vm.id
+        )
+        allow(workflow).to receive(:set_or_default_hardware_field_values).with(@src_vm)
+        workflow.set_on_vm_id_changed
+        filters = workflow.instance_variable_get(:@filters)
+        expect(filters).to eq(:Host => {21=>"Platform / ESX 6.0"}, 'StorageProfile' => nil, :src_vm_id => @src_vm.id)
+      end
+    end
+
+    context 'network selection' do
       let(:s11) { FactoryGirl.create(:switch, :name => "A") }
       let(:s12) { FactoryGirl.create(:switch, :name => "B") }
       let(:s13) { FactoryGirl.create(:switch, :name => "C") }


### PR DESCRIPTION
The idea is to add to the VM provisioning page a new drop-down listing storage_profiles applicable to the ems.
* if selected vm template has storage_profile attached, that storage_profile is pre-selected
* datastore listing is filtered by both existing filter and the selected storage_profile

<img width="786" alt="screen shot 2016-08-12 at 10 51 21 am" src="https://cloud.githubusercontent.com/assets/2421248/17709115/e1ced604-63b5-11e6-827e-adfd5e0b52d9.png">
