### PR TITLE
Commenting until config loading with inheritence is fixed in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,10 +37,10 @@ ClassAndModuleCamelCase:
 FileName:
   Exclude:
     - lib/miq_automation_engine/service_models/*.rb
-LineLength:
-  Exclude:
-    - Gemfile
-    - gems/pending/Gemfile
+# LineLength: # Commenting until config loading with inheritence is fixed.
+#   Exclude:
+#     - Gemfile
+#     - gems/pending/Gemfile
 ExtraSpacing:
   Exclude:
     - Gemfile


### PR DESCRIPTION
Don't let the bot make lots of incorrect comments on PRs while debugging the issue.