### PR TITLE
Change in Region should trigger revalidation of credentials

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -392,7 +392,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         default_verify:            default_verify,
         realm:                     $scope.emsCommonModel.realm,
         azure_tenant_id:           $scope.emsCommonModel.azure_tenant_id,
-        subscription:              $scope.emsCommonModel.subscription
+        subscription:              $scope.emsCommonModel.subscription,
+        provider_region:           $scope.emsCommonModel.provider_region
       };
     } else if (prefix === "amqp") {
       if ($scope.newRecord) {

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -53,7 +53,9 @@
                        "ng-switch-when"              => name,
                        "required"                    => "",
                        "checkchange"                 => "",
-                       "selectpicker-for-select-tag" => "")
+                       "selectpicker-for-select-tag" => "",
+                       "prefix"                      => "default",
+                       "reset-validation-status"     => "default_auth_status")
 
     .form-group{"ng-class" => "{'has-error': angularForm.project.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
       %label.col-md-2.control-label{"for" => "ems_project"}


### PR DESCRIPTION
A revalidation requirement should trigger if the Region value is changed post validation.

The rationale being the pricing may be different for different regions, therefore, credentials validated for one region may not be valid for the other.

https://bugzilla.redhat.com/show_bug.cgi?id=1349991