### PR TITLE
[WIP] Remove activesupport use from PostgresHaAdmin classes

### DIFF
--- a/gems/pending/postgres_ha_admin/database_yml.rb
+++ b/gems/pending/postgres_ha_admin/database_yml.rb
@@ -19,7 +19,7 @@ module PostgresHaAdmin
       db_yml[environment].merge!(pg_parameters_to_rails(params))
       remove_empty(db_yml[environment])
 
-      new_name = "#{db_yml_file}_#{Time.current.strftime("%d-%B-%Y_%H.%M.%S")}"
+      new_name = "#{db_yml_file}_#{Time.now.strftime("%d-%B-%Y_%H.%M.%S")}"
       FileUtils.copy(db_yml_file, new_name)
       begin
         File.write(db_yml_file, db_yml.to_yaml)

--- a/gems/pending/postgres_ha_admin/failover_databases.rb
+++ b/gems/pending/postgres_ha_admin/failover_databases.rb
@@ -41,7 +41,7 @@ module PostgresHaAdmin
       db_result = connection.exec("SELECT type, conninfo, active FROM #{TABLE_NAME}")
       db_result.map_types!(PG::BasicTypeMapForResults.new(connection)).each do |record|
         dsn = PG::DSNParser.parse(record.delete("conninfo"))
-        result << record.symbolize_keys.merge(dsn)
+        result << symbolize_record_keys(record).merge(dsn)
       end
       db_result.clear
       result
@@ -49,6 +49,10 @@ module PostgresHaAdmin
       @logger.error("#{err.class}: #{err}")
       @logger.error(err.backtrace.join("\n"))
       result
+    end
+
+    def symbolize_record_keys(record)
+      record.each_with_object({}) { |(k, v), new_record| new_record[k.to_sym] = v }
     end
 
     def entry_is_active_master?(record)


### PR DESCRIPTION
Remove more usage of activesupport methods from the `PostgresHaAdmin` classes.

These methods will not be available to us when running as a plain ruby daemon process.

@yrudman @gtanzillo please review.
