### PR TITLE
Add Subscription field to Azure Discovery screen

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1117,6 +1117,7 @@ module ApplicationController::CiProcessing
     @client_id = ""
     @client_key = ""
     @azure_tenant_id = ""
+    @subscription = ""
     if session[:type] == "hosts"
       @discover_type = Host.host_discovery_types
     elsif session[:type] == "ems"
@@ -1173,6 +1174,7 @@ module ApplicationController::CiProcessing
         @client_id = params[:client_id] if params[:client_id]
         @client_key = params[:client_key] if params[:client_key]
         @azure_tenant_id = params[:azure_tenant_id] if params[:azure_tenant_id]
+        @subscription = params[:subscription] if params[:subscription]
 
         if @client_id == "" || @client_key == "" || @azure_tenant_id == ""
           add_flash(_("Client ID, Client Key and Azure Tenant ID are required"), :error)
@@ -1217,7 +1219,7 @@ module ApplicationController::CiProcessing
               ems.supports_discovery? && ems.ems_type == params[:discover_type_selected]
             end
             if cloud_manager.ems_type == 'azure'
-              cloud_manager.discover_queue(@client_id, @client_key, @azure_tenant_id)
+              cloud_manager.discover_queue(@client_id, @client_key, @azure_tenant_id, @subscription)
             else
               cloud_manager.discover_queue(@userid, @password)
             end

--- a/app/views/layouts/_discover_azure_credentials.html.haml
+++ b/app/views/layouts/_discover_azure_credentials.html.haml
@@ -29,4 +29,13 @@
                            :maxlength         => 50,
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
+  .form-group
+    %label.control-label.col-md-2
+      = _('Subscription ID')
+    .col-md-8
+      = text_field_tag("subscription",
+                           @subscription,
+                           :maxlength         => 50,
+                           :class             => "form-control",
+                           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
 %hr


### PR DESCRIPTION
Purpose or Intent
-----------------
Add `Subscription` field to Azure Discovery screen.

Fixes #10488

Screenshot
------------
<img width="1241" alt="screen shot 2016-08-16 at 3 16 20 pm" src="https://cloud.githubusercontent.com/assets/1538216/17717755/9ebdd2b6-63c4-11e6-9c63-26641df0fd55.png">

