### PR TITLE
Middleware provider should use restful routes like other providers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -639,7 +639,12 @@ class ApplicationController < ActionController::Base
       else
         redirect_to_action = lastaction
       end
-      javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
+      model = self.class.model
+      if restful_routed?(model)
+        javascript_redirect polymorphic_path(model.find(params[:id]), :escape => false, :load_edit_err => true)
+      else
+        javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
+      end
     else
       redirect_to :action => lastaction, :id => params[:id], :escape => false
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1678,6 +1678,8 @@ class ApplicationController < ActionController::Base
         javascript_redirect edit_ems_infra_path(params[:id])
       elsif params[:pressed] == "ems_container_edit" && params[:id]
         javascript_redirect edit_ems_container_path(params[:id])
+      elsif params[:pressed] == "ems_middleware_edit" && params[:id]
+        javascript_redirect edit_ems_middleware_path(params[:id])
       elsif %w(arbitration_profile_edit arbitration_profile_new).include?(params[:pressed]) && params[:id]
         javascript_redirect :action => @refresh_partial, :id => params[:id], :show => @redirect_id
       else

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -1,5 +1,6 @@
 class EmsMiddlewareController < ApplicationController
   include EmsCommon
+  include Mixins::EmsCommonAngular
 
   before_action :check_privileges
   before_action :get_session_data
@@ -18,7 +19,24 @@ class EmsMiddlewareController < ApplicationController
     redirect_to :action => 'show_list'
   end
 
+  def show_link(ems, options = {})
+    ems_middleware_path(ems.id, options)
+  end
+
+  def ems_path(*args)
+    ems_middleware_path(*args)
+  end
+
+  def new_ems_path
+    new_ems_middleware_path
+  end
+
   def listicon_image(item, _view)
     icon = item.decorate.try(:listicon_image)
   end
+
+  def restful?
+    true
+  end
+  public :restful?
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -228,6 +228,9 @@ module ApplicationHelper
       if controller == "ems_container" && action == "show"
         return ems_containers_path
       end
+      if controller == "ems_middleware" && action == "show"
+        return ems_middlewares_path
+      end
       if parent && parent.class.base_model.to_s == "MiqCimInstance" && ["CimBaseStorageExtent", "SniaLocalFileSystem"].include?(view.db)
         return url_for(:controller => controller, :action => action, :id => parent.id) + "?show="
       else

--- a/app/helpers/application_helper/toolbar/ems_middleware_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_middleware_center.rb
@@ -17,8 +17,7 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
           :ems_middleware_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Middleware Provider'),
-          t,
-          :url => "/edit"),
+          t),
         button(
           :ems_middleware_delete,
           'pficon pficon-delete fa-lg',
@@ -41,7 +40,6 @@ class ApplicationHelper::Toolbar::EmsMiddlewareCenter < ApplicationHelper::Toolb
           'product product-timeline fa-lg',
           N_('Show Timelines for this Middleware Provider'),
           N_('Timelines'),
-          :url       => "/show",
           :url_parms => "?display=timeline"),
       ]
     ),

--- a/app/models/manageiq/providers/middleware_manager.rb
+++ b/app/models/manageiq/providers/middleware_manager.rb
@@ -1,4 +1,13 @@
 module ManageIQ::Providers
   class MiddlewareManager < BaseManager
+    class << model_name
+      def route_key
+        "ems_middleware"
+      end
+
+      def singular_route_key
+        "ems_middleware"
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1063,10 +1063,6 @@ Vmdb::Application.routes.draw do
     :ems_middleware            => {
       :get  => %w(
         download_data
-        edit
-        index
-        new
-        show
         show_list
         tagging_edit
         tag_edit_form_field_changed
@@ -2810,7 +2806,7 @@ Vmdb::Application.routes.draw do
 
   controller_routes.each do |controller_name, controller_actions|
     # Default route with no action to controller's index action
-    unless [:ems_cloud, :ems_infra, :ems_container].include?(controller_name)
+    unless [:ems_cloud, :ems_infra, :ems_container, :ems_middleware].include?(controller_name)
       match "#{controller_name}", :controller => controller_name, :action => :index, :via => :get
     end
 
@@ -2843,6 +2839,7 @@ Vmdb::Application.routes.draw do
   resources :ems_cloud, :as => :ems_clouds
   resources :ems_infra, :as => :ems_infras
   resources :ems_container, :as => :ems_containers
+  resources :ems_middleware, :as => :ems_middlewares
 
   match "/auth/:provider/callback" => "sessions#create", :via => :get
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1660,7 +1660,8 @@ describe ApplicationHelper do
         allow(helper).to receive_messages(:controller_name => "ems_middleware")
         ems = FactoryGirl.create(:ems_hawkular)
         MiddlewareDatasource.create(:ext_management_system => ems, :name => "Test Middleware")
-        expect(helper.multiple_relationship_link(ems, "middleware_datasource")).to eq("<li><a title=\"Show Middleware Datasources\" href=\"/ems_middleware/show/#{ems.id}?display=middleware_datasources\">Middleware Datasources (1)</a></li>")
+        expect(helper.multiple_relationship_link(ems, "middleware_datasource")).to eq("<li><a title=\"Show Middleware \
+Datasources\" href=\"/ems_middleware/#{ems.id}?display=middleware_datasources\">Middleware Datasources (1)</a></li>")
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Convert some routes from middleware controller to Restful style routes.

Fixes #8875

@miq-bot add-label providers/hawkular,wip

