### PR TITLE
Make aggregate_cpu_speed a sql accessible column

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -84,9 +84,16 @@ class Hardware < ApplicationRecord
   end
 
   def aggregate_cpu_speed
-    return nil if cpu_total_cores.blank? || cpu_speed.blank?
-    (cpu_total_cores * cpu_speed)
+    if has_attribute?("aggregate_cpu_speed")
+      self["aggregate_cpu_speed"]
+    elsif try(:cpu_total_cores) && try(:cpu_speed)
+      cpu_total_cores * cpu_speed
+    end
   end
+
+  virtual_attribute :aggregate_cpu_speed, :integer, :arel => (lambda do |t|
+    t.grouping(t[:cpu_total_cores] * t[:cpu_speed])
+  end)
 
   def v_pct_free_disk_space
     return nil if disk_free_space.nil? || disk_capacity.nil? || disk_capacity.zero?

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -28,6 +28,33 @@ describe Hardware do
     expect(host.hardware.host).to eq(host)
   end
 
+  describe ".aggregate_cpu_speed" do
+    context "with empty hardware" do
+      let(:hardware) { FactoryGirl.build(:hardware) }
+      it "bails ruby calculation" do
+        expect(hardware.aggregate_cpu_speed).to be_nil
+      end
+
+      it "bails database calculation" do
+        hardware.save
+        expect(virtual_column_sql_value(Hardware, "aggregate_cpu_speed")).to be_nil
+      end
+    end
+
+    context "with values" do
+      let(:hardware) { FactoryGirl.build(:hardware, :cpu_total_cores => 4, :cpu_speed => 1000) }
+
+      it "calculates in ruby" do
+        expect(hardware.aggregate_cpu_speed).to eq(4000)
+      end
+
+      it "calculates in the database" do
+        hardware.save
+        expect(virtual_column_sql_value(Hardware, "aggregate_cpu_speed")).to eq(4000)
+      end
+    end
+  end
+
   describe ".v_pct_free_disk_space" do
     context "with empty hardware" do
       let(:hardware) { FactoryGirl.build(:hardware) }

--- a/spec/models/mixins/aggregation_mixin_spec.rb
+++ b/spec/models/mixins/aggregation_mixin_spec.rb
@@ -11,9 +11,9 @@ describe AggregationMixin do
                                                            :disk_capacity        => 40
                                                           )
                           )
-      end
+      end +
+      [FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware))]
                                 )
-
     expect(cluster.aggregate_cpu_speed).to eq(47_984) # 2999 cpu_speed * 8 cpu_total_cores * 2 hardwares
     expect(cluster.aggregate_disk_capacity).to eq(80)
   end


### PR DESCRIPTION
Theme
-------
Aggregate hardware speedup for ems.aggregate_*

We currently bring back all hardware records to sum them up in memory.
The goal is to aggregate them in the database so we're bringing back a single value rather than so many records.
The goal is to also not bring back all the ids but rather use an inner query in the database.

I can build up on this PR if it is too small

This PR
-------

`aggregate_cpu_speed` needs to be calculated in the database if we are to `sum()` it in the database.

/cc @Fryguy @gtanzillo This is the first step for the talk I almost gave at miq-conf.