### PR TITLE
Add generic subtype to Service Designer

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,17 +111,16 @@ class CatalogController < ApplicationController
       end
       if !@record.id.nil? && need_prov_dialogs?(@record.prov_type)
         prov_set_form_vars(MiqRequest.find(@record.service_resources[0].resource_id))      # Set vars from existing request
-        @edit[:new][:st_prov_type] = @record.prov_type
       else
         # prov_set_form_vars
         @edit ||= {}                                    # Set default vars
         @edit[:new] ||= {}
         @edit[:current] ||= {}
         @edit[:key] = "prov_edit__new"
-        @edit[:new][:st_prov_type] = @record.prov_type if @record.try(:id)
         @edit[:st_prov_types] = catalog_item_types
       end
-
+      @edit[:new][:st_prov_type] = @record.prov_type if @record.prov_type.present?
+      @edit[:new][:generic_subtype] = @record.generic_subtype if @record.try(:id) && @record.prov_type == 'generic'
       # set name and description for ServiceTemplate record
       set_form_vars
       @edit[:new][:service_type] = "atomic"
@@ -175,10 +174,12 @@ class CatalogController < ApplicationController
       @record = class_service_template(params[:st_prov_type]).new
       set_form_vars
       @edit[:new][:st_prov_type] = params[:st_prov_type] if params[:st_prov_type]
+      @edit[:new][:generic_subtype] = params[:generic_subtype] if params[:generic_subtype]
       @edit[:new][:service_type] = "atomic"
       default_entry_point(@edit[:new][:st_prov_type]) if params[:st_prov_type].start_with?('generic')
       @edit[:rec_id] = @record ? @record.id : nil
       @tabactive = @edit[:new][:current_tab_key]
+      @generic_subtypes = generic_item_subtypes if params[:st_prov_type] == 'generic'
     end
     render :update do |page|
       page << javascript_prologue
@@ -884,6 +885,9 @@ class CatalogController < ApplicationController
       # check for service template required fields before creating a request
       add_flash(_("Name is required"), :error)
     end
+    if @edit[:new][:st_prov_type] == 'generic' && @edit[:new][:generic_subtype].blank?
+      add_flash(_('Subtype is required.'), :error)
+    end
     add_flash(_("Provisioning Entry Point is required"), :error) if @edit[:new][:fqname].blank?
 
     # Check for a Dialog if Display in Catalog is selected
@@ -1270,6 +1274,7 @@ class CatalogController < ApplicationController
     st.service_template_catalog = @edit[:new][:catalog_id].nil? ?
       nil : ServiceTemplateCatalog.find_by_id(@edit[:new][:catalog_id])
     st.prov_type = @edit[:new][:st_prov_type]
+    st.generic_subtype = @edit[:new][:generic_subtype] if @edit[:new][:st_prov_type] == 'generic'
   end
 
   def st_set_record_vars(st)
@@ -1315,6 +1320,7 @@ class CatalogController < ApplicationController
     @edit[:new][:provision_cost] = @record.provision_cost
     @edit[:new][:display]  = @record.display ? @record.display : false
     @edit[:new][:catalog_id] = @record.service_template_catalog ? @record.service_template_catalog.id : nil
+    @edit[:new][:generic_subtype] = @record.generic_subtype if @record.generic_subtype.present?
     @edit[:new][:available_catalogs] = Rbac.filtered(ServiceTemplateCatalog.all).collect do |stc|
       [stc.tenant.present? && stc.tenant.ancestors.present? ? stc.name + " (#{stc.tenant.name})" : stc.name, stc.id]
     end
@@ -1455,6 +1461,7 @@ class CatalogController < ApplicationController
     @edit[:new][:dialog_id] = params[:dialog_id] if params[:dialog_id]
     # saving it in @edit as well, to use it later because prov_set_form_vars resets @edit[:new]
     @edit[:st_prov_type] = @edit[:new][:st_prov_type] = params[:st_prov_type] if params[:st_prov_type]
+    @edit[:new][:generic_subtype] = params[:generic_subtype] if params[:generic_subtype].present?
     @edit[:new][:long_description] = params[:long_description] if params[:long_description]
     @edit[:new][:long_description] = @edit[:new][:long_description].to_s + "..." if params[:transOne]
 
@@ -1889,6 +1896,8 @@ class CatalogController < ApplicationController
       end
     end
     presenter[:right_cell_text] = right_cell_text
+
+    @generic_subtypes = generic_item_subtypes
 
     # Replace right cell divs
     presenter.update(:main_div,

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -1,5 +1,15 @@
 class ServiceTemplate < ApplicationRecord
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
+
+  GENERIC_ITEM_SUBTYPES = {
+    "custom"          => _("Custom"),
+    "vm"              => _("VM"),
+    "playbook"        => _("Playbook"),
+    "hosted_database" => _("Hosted Database"),
+    "load_balancer"   => _("Load Balancer"),
+    "storage"         => _("Storage")
+  }.freeze
+
   include ServiceMixin
   include OwnershipMixin
   include NewWithTypeStiMixin

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -52,25 +52,22 @@
                         :class                => "selectpicker")
           :javascript
             miqSelectPickerEvent('dialog_id', '#{url}')
-    - if @record[:generic_subtype].blank? && @edit[:new][:st_prov_type] == "generic"
+    - if @edit[:new][:st_prov_type] == "generic"
       .form-group
         %label.col-md-2.control-label
           = _('Subtype')
         .col-md-4
           %p.form-control-static
-            - available_subtypes = @generic_subtypes.invert.to_a.sort_by { |a| a.first.downcase }
-            = select_tag('generic_subtype',
-                          options_for_select(available_subtypes, available_subtypes[0].first),
-                          "data-miq_sparkle_on" => true,
-                          :class                => "selectpicker")
-            :javascript
-              miqSelectPickerEvent('generic_subtype', '#{url}')
-    - if @edit[:new][:st_prov_type] == "generic" && @record[:generic_subtype].present?
-      .form-group
-        %label.col-md-2.control-label
-          = _('Subtype')
-        .col-md-8
-          = h(@generic_subtypes[@record[:generic_subtype]])
+            - if @record.id
+              = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@edit[:new][:generic_subtype]])
+            - else
+              - available_subtypes = ServiceTemplate::GENERIC_ITEM_SUBTYPES.invert.to_a.sort_by { |a| a.first.downcase }
+              = select_tag('generic_subtype',
+                            options_for_select(available_subtypes, @edit[:new][:generic_subtype]),
+                            "data-miq_sparkle_on" => true,
+                            :class                => "selectpicker")
+              :javascript
+                miqSelectPickerEvent('generic_subtype', '#{url}')
     - if @edit[:new][:st_prov_type] == "generic_orchestration"
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
       .form-group

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -52,7 +52,25 @@
                         :class                => "selectpicker")
           :javascript
             miqSelectPickerEvent('dialog_id', '#{url}')
-
+    - if @record[:generic_subtype].blank? && @edit[:new][:st_prov_type] == "generic"
+      .form-group
+        %label.col-md-2.control-label
+          = _('Subtype')
+        .col-md-4
+          %p.form-control-static
+            - available_subtypes = @generic_subtypes.invert.to_a.sort_by { |a| a.first.downcase }
+            = select_tag('generic_subtype',
+                          options_for_select(available_subtypes, available_subtypes[0].first),
+                          "data-miq_sparkle_on" => true,
+                          :class                => "selectpicker")
+            :javascript
+              miqSelectPickerEvent('generic_subtype', '#{url}')
+    - if @edit[:new][:st_prov_type] == "generic" && @record[:generic_subtype].present?
+      .form-group
+        %label.col-md-2.control-label
+          = _('Subtype')
+        .col-md-8
+          = h(@generic_subtypes[@record[:generic_subtype]])
     - if @edit[:new][:st_prov_type] == "generic_orchestration"
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
       .form-group

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -42,7 +42,7 @@
             %label.col-md-2.control-label
               = _('Subtype')
             .col-md-8
-              = h(@generic_subtypes[@record[:generic_subtype]])
+              = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@record[:generic_subtype]])
         - if @record.prov_type == "generic_orchestration"
           .form-group
             %label.col-md-2.control-label

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -37,6 +37,12 @@
             = _('Dialog')
           .col-md-8
             = h(@sb[:dialog_label])
+        - if @record.prov_type == "generic"
+          .form-group
+            %label.col-md-2.control-label
+              = _('Subtype')
+            .col-md-8
+              = h(@generic_subtypes[@record[:generic_subtype]])
         - if @record.prov_type == "generic_orchestration"
           .form-group
             %label.col-md-2.control-label

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -4,7 +4,6 @@ describe "catalog/_form.html.haml" do
     set_controller_for_view_to_be_nonrestful
     @edit = {:new => {:available_catalogs => [], :available_dialogs => {}}}
     @sb = {:st_form_active_tab => "Basic"}
-    @record = {}
   end
 
   it "Renders form when adding catalog bundle and st_prov_type is not set" do

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -4,6 +4,7 @@ describe "catalog/_form.html.haml" do
     set_controller_for_view_to_be_nonrestful
     @edit = {:new => {:available_catalogs => [], :available_dialogs => {}}}
     @sb = {:st_form_active_tab => "Basic"}
+    @record = {}
   end
 
   it "Renders form when adding catalog bundle and st_prov_type is not set" do


### PR DESCRIPTION
Purpose or Intent
-----------------
Service catalog item of type Generic has subtypes. Related to: https://github.com/ManageIQ/manageiq/pull/10203

Services -> Catalogs -> Catalogs Items -> Configuration -> Add new Catalog Item -> Catalog Item Type (Generic)

Before:
![screen shot 2016-08-17 at 11 16 29 am](https://cloud.githubusercontent.com/assets/9210860/17731105/1cc78100-646c-11e6-8444-79340d0eb965.png)

<img width="642" alt="screen shot 2016-08-17 at 11 21 40 am" src="https://cloud.githubusercontent.com/assets/9210860/17731275/e5f49bda-646c-11e6-8ca4-28363042de8f.png">


After:
![screen shot 2016-08-19 at 5 07 29 pm](https://cloud.githubusercontent.com/assets/9210860/17814318/9cc85298-662f-11e6-92de-29ff220aed1a.png)


<img width="633" alt="screen shot 2016-08-17 at 11 22 46 am" src="https://cloud.githubusercontent.com/assets/9210860/17731297/f7c2da84-646c-11e6-9733-0484a1ee4265.png">


@miq-bot add_label ui, wip
