### PR TITLE
Make disabled buttons follow patternfly styling, remove btn-disabled

### DIFF
--- a/app/assets/javascripts/controllers/buttons/paging_div_button_group_controller.js
+++ b/app/assets/javascripts/controllers/buttons/paging_div_button_group_controller.js
@@ -76,7 +76,7 @@ ManageIQ.angular.app.controller('pagingDivButtonGroupController', ['$scope', 'mi
   var resetButton = function() {
     var resetHtml = '<button name="button" id="reset_enabled_disabled" type="submit" ' +
       'class="btn btn-default disabled" alt={{resetAltText}} title={{resetAltText}} ' +
-      'ng-class="{\'disabled\': angularForm.$pristine}" ng-click="resetClicked()" ' +
+      'ng-class="{ disabled: angularForm.$pristine }" ng-click="resetClicked()" ' +
       'ng-disabled="angularForm.$pristine" ng-hide="newRecord" disabled="disabled">{{resetBtnText}}</button>';
     var compiledReset = $compile(resetHtml)($scope);
 

--- a/app/assets/javascripts/controllers/buttons/paging_div_button_group_controller.js
+++ b/app/assets/javascripts/controllers/buttons/paging_div_button_group_controller.js
@@ -51,7 +51,7 @@ ManageIQ.angular.app.controller('pagingDivButtonGroupController', ['$scope', 'mi
         }
       });
     } else {
-      var disabledSaveHtml = '<button name="button" id="save_disabled" type="submit" class="btn btn-primary btn-disabled" ' +
+      var disabledSaveHtml = '<button name="button" id="save_disabled" type="submit" class="btn btn-primary disabled" ' +
         'alt={{altText}} title={{altText}} ng-click="disabledClick($event)" ' +
         'ng-show="!newRecord && !saveable(angularForm)">{{btnText}}</button>';
       var compiledDisabledSave = $compile(disabledSaveHtml)($scope);
@@ -75,8 +75,8 @@ ManageIQ.angular.app.controller('pagingDivButtonGroupController', ['$scope', 'mi
 
   var resetButton = function() {
     var resetHtml = '<button name="button" id="reset_enabled_disabled" type="submit" ' +
-      'class="btn btn-default btn-disabled" alt={{resetAltText}} title={{resetAltText}} ' +
-      'ng-class="{\'btn-disabled\': angularForm.$pristine}" ng-click="resetClicked()" ' +
+      'class="btn btn-default disabled" alt={{resetAltText}} title={{resetAltText}} ' +
+      'ng-class="{\'disabled\': angularForm.$pristine}" ng-click="resetClicked()" ' +
       'ng-disabled="angularForm.$pristine" ng-hide="newRecord" disabled="disabled">{{resetBtnText}}</button>';
     var compiledReset = $compile(resetHtml)($scope);
 

--- a/app/assets/javascripts/controllers/buttons/paging_div_button_group_controller.js
+++ b/app/assets/javascripts/controllers/buttons/paging_div_button_group_controller.js
@@ -52,7 +52,7 @@ ManageIQ.angular.app.controller('pagingDivButtonGroupController', ['$scope', 'mi
       });
     } else {
       var disabledSaveHtml = '<button name="button" id="save_disabled" type="submit" class="btn btn-primary btn-disabled" ' +
-        'alt={{altText}} title={{altText}} ng-click="disabledClick($event)" style="cursor:not-allowed" ' +
+        'alt={{altText}} title={{altText}} ng-click="disabledClick($event)" ' +
         'ng-show="!newRecord && !saveable(angularForm)">{{btnText}}</button>';
       var compiledDisabledSave = $compile(disabledSaveHtml)($scope);
 

--- a/app/assets/javascripts/resizable_sidebar.js
+++ b/app/assets/javascripts/resizable_sidebar.js
@@ -21,7 +21,7 @@ $.fn.resizableSidebar = function() {
     var maindiv = columns.find('.resizer').parent();
     var sidebar = columns.not(maindiv);
     maindiv.find('.resizer-box .btn').click(function (_event) {
-      if ($(this).hasClass('btn-disabled')) return false;
+      if ($(this).hasClass('disabled')) return false;
       var left = $(this).hasClass('resize-left');
       var button = left ? $(this).next() : $(this);
       var ajax = 2; // the width of the sidebar which will be sent with an ajax request
@@ -43,7 +43,7 @@ $.fn.resizableSidebar = function() {
               left_class.push('col-md-0');
               break;
             case 'col-md-pull-7':
-              button.removeClass('btn-disabled'); // re-enable the button when resizing to the left from max
+              button.removeClass('disabled'); // re-enable the button when resizing to the left from max
               // pass
             case 'col-md-pull-8':
             case 'col-md-pull-9':
@@ -65,7 +65,7 @@ $.fn.resizableSidebar = function() {
               left_class.push('col-md-pull-10');
               break;
             case 'col-md-4':
-              button.addClass('btn-disabled'); // disable the right button if it reached it's limit
+              button.addClass('disabled'); // disable the right button if it reached it's limit
               // pass
             case 'col-md-3':
             case 'col-md-2':

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -4,6 +4,8 @@ textarea { width: 98.5%; border: 1px solid #d1d1d1; padding: 7px; line-height: 1
 
 /* begin modified Patternfly code */
 
+.btn.disabled,
+.btn[disabled],
 div.disabled {
   cursor: default;
 }

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -4,8 +4,6 @@ textarea { width: 98.5%; border: 1px solid #d1d1d1; padding: 7px; line-height: 1
 
 /* begin modified Patternfly code */
 
-.btn.disabled,
-.btn[disabled],
 div.disabled {
   cursor: default;
 }

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -4,14 +4,6 @@ textarea { width: 98.5%; border: 1px solid #d1d1d1; padding: 7px; line-height: 1
 
 /* begin modified Patternfly code */
 
-.btn-disabled, .disabled {
-  opacity:0.4 !important;
-  filter:alpha(opacity=40);
-  filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
-}
-
-/* disables mouse events on disabled/blocked DIVS */
-
 div.disabled {
   cursor: default;
 }

--- a/app/views/catalog/_column_lists.html.haml
+++ b/app/views/catalog/_column_lists.html.haml
@@ -16,7 +16,7 @@
       %td.text-center{:width => "40"}
         .btn-group-vertical
           - if @edit[:new][:available_fields].length == 0
-            %button.btn.btn-default.btn-disabled
+            %button.btn.btn-default.disabled
               %i.fa.fa-angle-right.fa-lg
           - else
             - t = _("Move Selected buttons right")
@@ -29,7 +29,7 @@
               %i.fa.fa-angle-right.fa-lg
 
           - if @edit[:new][:fields].length == 0
-            %button.btn.btn-default.btn-disabled
+            %button.btn.btn-default.disabled
               %i.fa.fa-angle-left.fa-lg
           - else
             - t = _("Move Selected buttons left")

--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -32,12 +32,12 @@
                        :class        => "btn btn-primary",
                        "ng-click"    => "attachClicked()",
                        "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+                       "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
           = button_tag("Reset",
                        :class        => "btn btn-primary",
                        "ng-click"    => "resetClicked()",
                        "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{'btn-disabled': angularForm.$pristine}")
+                       "ng-class"    => "{'disabled': angularForm.$pristine}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelAttachClicked()")

--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -32,12 +32,12 @@
                        :class        => "btn btn-primary",
                        "ng-click"    => "attachClicked()",
                        "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
+                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
           = button_tag("Reset",
                        :class        => "btn btn-primary",
                        "ng-click"    => "resetClicked()",
                        "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{'disabled': angularForm.$pristine}")
+                       "ng-class"    => "{ disabled: angularForm.$pristine}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelAttachClicked()")

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -22,7 +22,7 @@
                        :class        => "btn btn-primary",
                        "ng-click"    => "detachClicked()",
                        "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+                       "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelDetachClicked()")

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -22,7 +22,7 @@
                        :class        => "btn btn-primary",
                        "ng-click"    => "detachClicked()",
                        "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
+                       "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelDetachClicked()")

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -22,12 +22,12 @@
                        :class        => "btn btn-primary",
                        "ng-click"    => "saveClicked()",
                        "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'disabled': cloudVolumeForm.$pristine || angularForm.$invalid}")
+                       "ng-class"    => "{ disabled: cloudVolumeForm.$pristine || angularForm.$invalid}")
           = button_tag("Reset",
                        :class        => "btn btn-primary",
                        "ng-click"    => "resetClicked()",
                        "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{'disabled': cloudVolumeForm.$pristine}")
+                       "ng-class"    => "{ disabled: cloudVolumeForm.$pristine}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelClicked()")

--- a/app/views/cloud_volume/edit.html.haml
+++ b/app/views/cloud_volume/edit.html.haml
@@ -22,12 +22,12 @@
                        :class        => "btn btn-primary",
                        "ng-click"    => "saveClicked()",
                        "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'btn-disabled': cloudVolumeForm.$pristine || angularForm.$invalid}")
+                       "ng-class"    => "{'disabled': cloudVolumeForm.$pristine || angularForm.$invalid}")
           = button_tag("Reset",
                        :class        => "btn btn-primary",
                        "ng-click"    => "resetClicked()",
                        "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{'btn-disabled': cloudVolumeForm.$pristine}")
+                       "ng-class"    => "{'disabled': cloudVolumeForm.$pristine}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelClicked()")

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -45,7 +45,7 @@
           - if @volume.id.nil?
             = button_tag("Add",
                          :class        => "btn btn-primary",
-                         "ng-class"    => "{'disabled': angularForm.$invalid}",
+                         "ng-class"    => "{ disabled: angularForm.$invalid}",
                          "ng-disabled" => "angularForm.$invalid",
                          "ng-click"    => "addClicked()")
           - else
@@ -53,12 +53,12 @@
                          :class        => "btn btn-primary",
                          "ng-click"    => "saveClicked()",
                          "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                         "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
+                         "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
             = button_tag("Reset",
                          :class        => "btn btn-primary",
                          "ng-click"    => "resetClicked()",
                          "ng-disabled" => "angularForm.$pristine",
-                         "ng-class"    => "{'disabled': angularForm.$pristine}")
+                         "ng-class"    => "{ disabled: angularForm.$pristine}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelClicked()")

--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -45,7 +45,7 @@
           - if @volume.id.nil?
             = button_tag("Add",
                          :class        => "btn btn-primary",
-                         "ng-class"    => "{'btn-disabled': angularForm.$invalid}",
+                         "ng-class"    => "{'disabled': angularForm.$invalid}",
                          "ng-disabled" => "angularForm.$invalid",
                          "ng-click"    => "addClicked()")
           - else
@@ -53,12 +53,12 @@
                          :class        => "btn btn-primary",
                          "ng-click"    => "saveClicked()",
                          "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                         "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+                         "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
             = button_tag("Reset",
                          :class        => "btn btn-primary",
                          "ng-click"    => "resetClicked()",
                          "ng-disabled" => "angularForm.$pristine",
-                         "ng-class"    => "{'btn-disabled': angularForm.$pristine}")
+                         "ng-class"    => "{'disabled': angularForm.$pristine}")
           = button_tag("Cancel",
                         :class     => "btn btn-default",
                         "ng-click" => "cancelClicked()")

--- a/app/views/layouts/_adv_search_footer.html.haml
+++ b/app/views/layouts/_adv_search_footer.html.haml
@@ -7,7 +7,7 @@
   - if mode == "search"
     - if @edit[@expkey][:exp_search_expressions].blank? && report_expressions.blank?
       = button_tag(_("Load..."),
-                   :class => "btn btn-primary btn-disabled pull-left",
+                   :class => "btn btn-primary disabled pull-left",
                    :alt   => t = _("No saved filters or report filters are available to load"),
                    :title => t)
 
@@ -22,7 +22,7 @@
                  :title        => t)
 
     - if @edit[@expkey][:exp_table].flatten.first == "???"
-      = button_tag(_("Apply"), :class => "btn btn-primary btn-disabled")
+      = button_tag(_("Apply"), :class => "btn btn-primary disabled")
     - else
       = link_to(_("Apply"),
                 {:action => "adv_search_button",
@@ -49,7 +49,7 @@
                   "data-method"  => :post,
                   :title         => t)
     - if @edit[@expkey][:exp_table].flatten.first == "???"
-      = button_tag(_("Save..."), :class => "btn btn-primary btn-disabled")
+      = button_tag(_("Save..."), :class => "btn btn-primary disabled")
     - else
       = link_to(_("Save..."),
                 {:action => "adv_search_button",
@@ -60,7 +60,7 @@
                 "data-method" => :post,
                 :title        => t)
     - if @edit[@expkey][:exp_table].flatten.first == "???"
-      = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+      = button_tag(_("Reset"), :class => "btn btn-default disabled")
     - else
       = link_to(_("Reset"),
                 {:action => "adv_search_button",
@@ -73,7 +73,7 @@
   - elsif mode == "load"
     - if @edit[@expkey][:exp_chosen_report].nil? && @edit[@expkey][:exp_chosen_search].nil?
       = button_tag(_("Load"),
-                   :class => "btn btn-primary btn-disabled pull-left",
+                   :class => "btn btn-primary disabled pull-left",
                    :alt   => t = _("Choose a saved filter or report filter to load"),
                    :title => t)
     - else

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -56,7 +56,7 @@
                     "data-method" => :post,
                     :title        => t)
         #automate_buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
-          = button_tag(_("Apply"), :class => "btn btn-primary btn-disabled")
+          = button_tag(_("Apply"), :class => "btn btn-primary disabled")
           = link_to(t = _("Cancel"),
                     {:action => "ae_tree_select_toggle",
                      :button => "cancel"},

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -61,7 +61,7 @@
               .btn-group
                 .btn.btn-default.resize-left
                   %span.fa.fa-angle-left
-                .btn.btn-default.resize-right{:class => sidewidth == 5 ? 'btn-disabled' : ''}
+                .btn.btn-default.resize-right{:class => sidewidth == 5 ? 'disabled' : ''}
                   %span.fa.fa-angle-right
 
       #left_div.resizable.sidebar-pf.sidebar-pf-left.max-height.scrollable{:class => sidebar}

--- a/app/views/layouts/_edit_buttons.html.haml
+++ b/app/views/layouts/_edit_buttons.html.haml
@@ -40,13 +40,13 @@
       #buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
         - if record_id.blank?
           = button_tag(_("Add"),
-                       :class   => 'btn btn-default btn-disabled',
+                       :class   => 'btn btn-default disabled',
                        :alt     => t = _("Add"),
                        :title   => t)
         - else
-          = button_tag(_("Save"), :class => "btn btn-primary btn-disabled")
+          = button_tag(_("Save"), :class => "btn btn-primary disabled")
           - unless noreset
-            = button_tag(_("Verify"), :class => "btn btn-primary btn-disabled")
+            = button_tag(_("Verify"), :class => "btn btn-primary disabled")
         = button_tag(_("Cancel"),
                      :class   => 'btn btn-default',
                      :alt     => t = _("Cancel"),

--- a/app/views/layouts/_edit_form_buttons.html.haml
+++ b/app/views/layouts/_edit_form_buttons.html.haml
@@ -123,11 +123,11 @@
                       :method => :post)
       #buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
         - if continue_button
-          = button_tag(_("Continue"), :class => "btn btn-primary btn-disabled")
+          = button_tag(_("Continue"), :class => "btn btn-primary disabled")
         - else
-          = button_tag(_("Save"), :class => "btn btn-primary btn-disabled")
+          = button_tag(_("Save"), :class => "btn btn-primary disabled")
         - unless noreset
-          = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+          = button_tag(_("Reset"), :class => "btn btn-default disabled")
           - if @layout == "report" && @sb[:menu_buttons]
             = button_tag(_("Default"),
                          :class   => 'btn btn-primary',

--- a/app/views/layouts/_form_buttons.html.haml
+++ b/app/views/layouts/_form_buttons.html.haml
@@ -62,8 +62,8 @@
             :type    => "submit")
 
     #buttons_off{:style => "display: #{@changed ? 'none' : 'block'}"}
-      = button_tag(_("Save"),  :class => "btn btn-primary btn-disabled", :type => 'button')
-      = button_tag(_("Reset"), :class => "btn btn-default btn-disabled", :type => 'button')
+      = button_tag(_("Save"),  :class => "btn btn-primary disabled", :type => 'button')
+      = button_tag(_("Reset"), :class => "btn btn-default disabled", :type => 'button')
 
       - unless  @layout == "configuration" || @layout == "ops" || @layout == "chargeback" || @layout == "miq_ae_class"
         = button_tag(t = _("Cancel"),

--- a/app/views/layouts/_form_buttons_verify.html.haml
+++ b/app/views/layouts/_form_buttons_verify.html.haml
@@ -39,5 +39,5 @@
 
 %div{:id => "#{valtype}_validate_buttons_off", :style => ("display:none" if @edit[statuskey])}
   = button_tag(_("Validate"),
-               :class    => "btn btn-primary btn-disabled btn-xs pull-right",
+               :class    => "btn btn-primary disabled btn-xs pull-right",
                :disabled => true)

--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -71,7 +71,7 @@
         .modal-footer
           #buttons
             %span#quick_search_buttons_off
-              = button_tag(t = _("Apply"), :class => "btn btn-primary btn-disabled")
+              = button_tag(t = _("Apply"), :class => "btn btn-primary disabled")
             %span#quick_search_buttons_on{:style => "display:none;"}
               = link_to(t,
                         {:action => "quick_search",

--- a/app/views/layouts/_x_dialog_buttons.html.haml
+++ b/app/views/layouts/_x_dialog_buttons.html.haml
@@ -45,13 +45,13 @@
         - buttons.each do |b|
           - case b
           - when "save"
-            = button_tag(_("Save"), :class => "btn btn-primary btn-disabled")
+            = button_tag(_("Save"), :class => "btn btn-primary disabled")
           - when "submit"
-            = button_tag(_("Submit"), :class => "btn btn-primary btn-disabled")
+            = button_tag(_("Submit"), :class => "btn btn-primary disabled")
           - when "continue"
-            = button_tag(_("Continue"), :class => "btn btn-default btn-disabled")
+            = button_tag(_("Continue"), :class => "btn btn-default disabled")
           - when "reset"
-            = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+            = button_tag(_("Reset"), :class => "btn btn-default disabled")
           - when "cancel"
             = button_tag(t = _('Cancel'),
              :class   => "btn btn-default",

--- a/app/views/layouts/_x_edit_buttons.html.haml
+++ b/app/views/layouts/_x_edit_buttons.html.haml
@@ -123,21 +123,21 @@
 
   #buttons_off{:style => session[:changed] ? "display: none;" : ""}
     - if record_id.blank? && multi_record.nil? && submit_button.nil? && continue_button.nil?
-      = button_tag(_("Add"), :class => "btn btn-primary btn-disabled")
+      = button_tag(_("Add"), :class => "btn btn-primary disabled")
     - else
       - if apply_button
-        = button_tag(_("Apply"), :class => "btn btn-primary btn-disabled")
+        = button_tag(_("Apply"), :class => "btn btn-primary disabled")
       - elsif submit_button
-        = button_tag(_("Submit"), :class => "btn btn-primary btn-disabled")
+        = button_tag(_("Submit"), :class => "btn btn-primary disabled")
       - elsif continue_button
-        = button_tag(_("Continue"), :class => "btn btn-primary btn-disabled")
+        = button_tag(_("Continue"), :class => "btn btn-primary disabled")
       - elsif copy_button
-        = button_tag(_("Copy"), :class => "btn btn-primary btn-disabled")
+        = button_tag(_("Copy"), :class => "btn btn-primary disabled")
       - else
-        = button_tag(_("Save"), :class => "btn btn-primary btn-disabled")
+        = button_tag(_("Save"), :class => "btn btn-primary disabled")
 
       - unless no_reset
-        = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+        = button_tag(_("Reset"), :class => "btn btn-default disabled")
 
     - if default_button
       = button_tag(_('Default'),
@@ -173,7 +173,7 @@
     - else
       -# export_button
       = button_tag(_("Export"),
-        :class  => "btn btn-primary #{@export_reports.empty? ? "btn-disabled" : ""}",
+        :class  => "btn btn-primary #{@export_reports.empty? ? "disabled" : ""}",
         :type   => "application/txt",
         :id     => "export_button",
         :alt    => _("Download Report to YAML"))

--- a/app/views/layouts/angular/_form_button_submit_angular.html.haml
+++ b/app/views/layouts/angular/_form_button_submit_angular.html.haml
@@ -5,7 +5,7 @@
 
 %div{"ng-show" => ng_show, "ng-controller" => "buttonGroupController"}
   = button_tag(_("Submit"),
-                 :class     => "btn btn-primary btn-disabled",
+                 :class     => "btn btn-primary disabled",
                  :alt       => submit_title_off,
                  :title     => submit_title_off,
                  "ng-show"  => "!saveable(angularForm)",

--- a/app/views/layouts/angular/_form_button_submit_angular.html.haml
+++ b/app/views/layouts/angular/_form_button_submit_angular.html.haml
@@ -8,7 +8,6 @@
                  :class     => "btn btn-primary btn-disabled",
                  :alt       => submit_title_off,
                  :title     => submit_title_off,
-                 :style     => "cursor:not-allowed",
                  "ng-show"  => "!saveable(angularForm)",
                  "ng-click" => "disabledClick($event)")
   = button_tag(_("Submit"),

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -13,7 +13,6 @@
                  :class     => "btn btn-primary btn-xs btn-disabled",
                  :alt       => verify_title_off,
                  :title     => verify_title_off,
-                 :style     => "cursor:not-allowed",
                  "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()",
                  "ng-click" => "disabledClick($event)")
   = button_tag(_("Validate"),

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -10,7 +10,7 @@
   - validate = "validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 %div{"ng-show" => ng_show, "ng-controller" => "buttonGroupController"}
   = button_tag(_("Validate"),
-                 :class     => "btn btn-primary btn-xs btn-disabled",
+                 :class     => "btn btn-primary btn-xs disabled",
                  :alt       => verify_title_off,
                  :title     => verify_title_off,
                  "ng-show"  => basic_info_needed ? "!canValidateBasicInfo()" : "!canValidate()",

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -4,7 +4,6 @@
                :alt          => _("Add"),
                :title        => _("Add"),
                "ng-click"    => "disabledClick($event)",
-               :style        => "cursor:not-allowed",
                "ng-show"     => "newRecord && !saveable(angularForm)")
 
   = button_tag(_("Add"),
@@ -19,7 +18,6 @@
                :alt          => _("Save changes"),
                :title        => _("Save changes"),
                "ng-click"    => "disabledClick($event)",
-               :style        => "cursor:not-allowed",
                "ng-show"     => "!newRecord && !saveable(angularForm)")
 
   = button_tag(_("Save"),
@@ -34,7 +32,6 @@
                :alt          => _("Reset changes"),
                :title        => _("Reset changes"),
                "ng-click"    => "disabledClick($event)",
-               :style        => "cursor:not-allowed",
                "ng-show"     => "!newRecord && angularForm.$pristine")
 
   = button_tag(_("Reset"),

--- a/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
+++ b/app/views/layouts/angular/_x_edit_buttons_angular.html.haml
@@ -1,6 +1,6 @@
 .button-group{"ng-controller" => "buttonGroupController"}
   = button_tag(_("Add"),
-               "class"       => "btn btn-primary btn-disabled",
+               "class"       => "btn btn-primary disabled",
                :alt          => _("Add"),
                :title        => _("Add"),
                "ng-click"    => "disabledClick($event)",
@@ -14,7 +14,7 @@
                "ng-show"     => "newRecord && saveable(angularForm)")
 
   = button_tag(_("Save"),
-               :class        => "btn btn-primary btn-disabled",
+               :class        => "btn btn-primary disabled",
                :alt          => _("Save changes"),
                :title        => _("Save changes"),
                "ng-click"    => "disabledClick($event)",
@@ -28,7 +28,7 @@
                "ng-show"     => "!newRecord && saveable(angularForm)")
 
   = button_tag(_("Reset"),
-               :class        => "btn btn-default btn-disabled",
+               :class        => "btn btn-default disabled",
                :alt          => _("Reset changes"),
                :title        => _("Reset changes"),
                "ng-click"    => "disabledClick($event)",

--- a/app/views/layouts/listnav/_show_list.html.haml
+++ b/app/views/layouts/listnav/_show_list.html.haml
@@ -61,5 +61,5 @@
       :title                 => t)
   - else
     = button_tag(_("Set Default"),
-      :class => "btn btn-default btn-disabled pull-right",
+      :class => "btn btn-default disabled pull-right",
       :title => _("Select a filter to set it as my default"))

--- a/app/views/miq_ae_tools/_resolve_form_buttons.html.haml
+++ b/app/views/miq_ae_tools/_resolve_form_buttons.html.haml
@@ -37,7 +37,7 @@
 
   #throw_off{:style => @resolve[:throw_ready] ? "display: none;" : ""}
     = button_tag(_("Submit"),
-      :class => "btn btn-primary btn-disabled",
+      :class => "btn btn-primary disabled",
       :title => _("Starting process must be specified"))
     = link_to(_("Reset"),
       {:action => "resolve", :button => "reset"},

--- a/app/views/miq_capacity/planning.html.haml
+++ b/app/views/miq_capacity/planning.html.haml
@@ -23,7 +23,7 @@
         :title                 => t)
     #buttons_off{:style => session[:changed] ? "display: none;" : ""}
       = button_tag(_("Submit"),
-        :class => "btn btn-primary btn-disabled",
+        :class => "btn btn-primary disabled",
         :title => _("Select a reference VM or Manual Input source to Submit the Planning Options"))
       = link_to(_("Reset"),
         {:action => "planning", :button => "reset"},

--- a/app/views/miq_policy/_export.html.haml
+++ b/app/views/miq_policy/_export.html.haml
@@ -11,7 +11,7 @@
           #buttons
             - if @sb[:conflict]
               = button_tag(_("Commit"),
-                :class => "btn btn-primary btn-disabled",
+                :class => "btn btn-primary disabled",
                 :title => (t = _("Resolve conflicts to import the file")),
                 :alt   => t)
             - else

--- a/app/views/miq_policy/_rsop_options.html.haml
+++ b/app/views/miq_policy/_rsop_options.html.haml
@@ -24,7 +24,7 @@
       :title                 => t)
   #form_buttons_off{:style => session[:changed] ? "display: none;" : ""}
     = button_tag(_("Submit"),
-      :class => "btn btn-primary btn-disabled",
+      :class => "btn btn-primary disabled",
       :title => _("Select a VM to Submit the Simulation Options"))
     - t = _("Reset all Policy Simulation options")
     = link_to(_("Reset"),

--- a/app/views/miq_policy/import.html.haml
+++ b/app/views/miq_policy/import.html.haml
@@ -28,7 +28,7 @@
             #buttons
               - if @sb[:conflict]
                 = button_tag("Commit",
-                             :class => "btn btn-primary btn-disabled",
+                             :class => "btn btn-primary disabled",
                              :title => "Resolve conflicts to import the file",
                              :alt   => "Resolve conflicts to import the file")
               - else

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -113,7 +113,7 @@
             - fh = wf.get_field(:owner_load_ldap, dialog)
             - if @edit && field_hash[:display] == :edit && fh[:display] == :show && !@edit[:stamp_typ]
               #lookup_button_off{:style => "#{options[field].blank? ? '' : 'display:none'}"}
-                = button_tag(_("Lookup"), :class => "btn btn-default btn-disabled")
+                = button_tag(_("Lookup"), :class => "btn btn-default disabled")
               #lookup_button_on{:style => "#{options[field].blank? ? 'display:none' : ''}"}
                 = button_tag(_('Lookup'),
                              :class   => "btn btn-primary",

--- a/app/views/miq_request/_prov_form_buttons.html.haml
+++ b/app/views/miq_request/_prov_form_buttons.html.haml
@@ -28,9 +28,9 @@
           - @edit[:buttons].each do |button|
             - case button
             - when :continue, :submit
-              = button_tag(_("Continue"), :class => "btn btn-primary btn-disabled")
+              = button_tag(_("Continue"), :class => "btn btn-primary disabled")
             - when :submit
-              = button_tag(_("Submit"), :class => "btn btn-primary btn-disabled")
+              = button_tag(_("Submit"), :class => "btn btn-primary disabled")
             - when :cancel
               - url = url_for(:action => 'prov_edit', :id => "#{@edit[:req_id] || 'new'}", :button => button)
               = button_tag(_("Cancel"),

--- a/app/views/miq_request/_prov_options.html.haml
+++ b/app/views/miq_request/_prov_options.html.haml
@@ -61,8 +61,8 @@
       .col-md-2
       .col-md-8
         #buttons_off
-          = button_tag(_("Apply"), :id => "apply", :class => "btn btn-primary btn-disabled")
-          = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+          = button_tag(_("Apply"), :id => "apply", :class => "btn btn-primary disabled")
+          = button_tag(_("Reset"), :class => "btn btn-default disabled")
           = link_to(_("Default"),
             {:action => "prov_button", :button => "default"},
             :class                 => "btn btn-default",

--- a/app/views/miq_request/_request.html.haml
+++ b/app/views/miq_request/_request.html.haml
@@ -125,7 +125,7 @@
               "data-method"          => :post,
               :title                 => t)
           %span#buttons_off
-            = button_tag(t, :class => "btn btn-primary btn-disabled")
+            = button_tag(t, :class => "btn btn-primary disabled")
   %br
   - if @miq_request.workflow_class
     = render :partial => "prov_wf", :locals => {:wf => @miq_request.workflow_class.new({:src_vm_id => @miq_request.source_id}, current_user), :show => true}

--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -72,8 +72,8 @@
           miqSelectPickerEvent("state_choice", "#{url}");
     #form_buttons_div.clearfix{:style => "padding-right: 10px"}
       #buttons_off.pull-right
-        = button_tag(_("Apply"), :class => "btn btn-primary btn-disabled")
-        = button_tag(_("Reset"), :class => "btn btn-default btn-disabled")
+        = button_tag(_("Apply"), :class => "btn btn-primary disabled")
+        = button_tag(_("Reset"), :class => "btn btn-default disabled")
         = link_to(_('Default'),
           {:action => "tasks_button", :button => "default"},
           :class                 => "btn btn-default",

--- a/app/views/ops/_amazon_verify_button.html.haml
+++ b/app/views/ops/_amazon_verify_button.html.haml
@@ -13,5 +13,5 @@
 
 = hidden_div_if(!(@edit[:new][:authentication][:amazon_key].nil? || @edit[:new][:authentication][:amazon_secret].nil?), :id => "amazon_verify_button_off") do
   = button_tag(_("Validate"),
-    :class => "btn btn-primary btn-xs btn-disabled",
+    :class => "btn btn-primary btn-xs disabled",
     :title => _("Amazon access key and secret are needed to validate Amazon Settings"))

--- a/app/views/ops/_email_verify_button.html.haml
+++ b/app/views/ops/_email_verify_button.html.haml
@@ -12,5 +12,5 @@
     :title                 => _("Send test email"))
 
 #email_verify_button_off{:style => "#{hide_button(@test_email_button, "off")}"}
-  = button_tag(_("Verify"), :class => "btn btn-default btn-disabled",
+  = button_tag(_("Verify"), :class => "btn btn-default disabled",
     :title => _("SMTP E-mail Server settings and Test E-mail Address are needed to send test email"))

--- a/app/views/ops/_ldap_verify_button.html.haml
+++ b/app/views/ops/_ldap_verify_button.html.haml
@@ -15,5 +15,5 @@
 
 = hidden_div_if(! validate_disabled, :id => "verify_button_off") do
   = button_tag(_("Validate"),
-    :class => "btn btn-primary btn-xs btn-disabled",
+    :class => "btn btn-primary btn-xs disabled",
     :title => _("LDAP Hostname and Port fields are needed to perform verification of LDAP Settings"))

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -182,7 +182,7 @@
 
     .button-group{:align => "right"}
       = button_tag(_("Save"),
-                   :class     => "btn btn-primary btn-disabled",
+                   :class     => "btn btn-primary disabled",
                    :alt       => _("Save"),
                    "ng-click" => "disabledClick($event)",
                    "ng-show"  => "!saveEnabled(angularForm)")
@@ -192,7 +192,7 @@
                    "ng-click" => "saveClicked()",
                    "ng-show"  => "saveEnabled(angularForm)")
       = button_tag(_("Reset"),
-                   :class     => "btn btn-default btn-disabled",
+                   :class     => "btn btn-default disabled",
                    :alt       => _("Reset changes"),
                    "ng-click" => "disabledClick($event)",
                    "ng-show"  => "!saveEnabled(angularForm)")

--- a/app/views/ops/_settings_replication_tab.html.haml
+++ b/app/views/ops/_settings_replication_tab.html.haml
@@ -184,7 +184,6 @@
       = button_tag(_("Save"),
                    :class     => "btn btn-primary btn-disabled",
                    :alt       => _("Save"),
-                   :style     => "cursor:not-allowed",
                    "ng-click" => "disabledClick($event)",
                    "ng-show"  => "!saveEnabled(angularForm)")
       = button_tag(_("Save"),
@@ -195,7 +194,6 @@
       = button_tag(_("Reset"),
                    :class     => "btn btn-default btn-disabled",
                    :alt       => _("Reset changes"),
-                   :style     => "cursor:not-allowed",
                    "ng-click" => "disabledClick($event)",
                    "ng-show"  => "!saveEnabled(angularForm)")
       = button_tag(_("Reset"),

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -23,7 +23,7 @@
            ['fa-angle-up',   'left',  _("up"),   cond_up]].each do |icon, button, text, condition|
           - t = _("Move selected fields %{where}") % {:where => text}
           - if condition
-            %button.btn.btn-default.btn-disabled{:title => t, :disabled => true}
+            %button.btn.btn-default.disabled{:title => t, :disabled => true}
               %i.fa.fa-lg{:class => icon}
           - else
             %button.btn.btn-default{:title           => t,
@@ -57,7 +57,7 @@
              ['fa-angle-double-down', 'bottom', _("to bottom")]].each do |icon, button, text|
             - t = _("Move selected fields %{where}") % {:where => text}
             - if @edit[:new][:fields].length < 2
-              %button.btn.btn-default.btn-disabled{:title => t, :disabled => true}
+              %button.btn.btn-default.disabled{:title => t, :disabled => true}
                 %i.fa.fa-lg{:class => icon}
             - else
               %button.btn.btn-default{:title           => t,

--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -74,7 +74,7 @@
             :multiple => true)
 
     .pull-right
-      = submit_tag(_("Export"), :class => "btn btn-primary export-widgets btn-disabled")
+      = submit_tag(_("Export"), :class => "btn btn-primary export-widgets disabled")
 
 :javascript
   $(function() {
@@ -99,12 +99,12 @@
 
     $('.widget-export').change(function() {
       if ($('.widget-export').val() !== null) {
-        if ($('.export-widgets').hasClass('btn-disabled')) {
-          $('.export-widgets').removeClass('btn-disabled');
+        if ($('.export-widgets').hasClass('disabled')) {
+          $('.export-widgets').removeClass('disabled');
         }
       } else {
-        if (!$('.export-widgets').hasClass('btn-disabled')) {
-          $('.export-widgets').addClass('btn-disabled');
+        if (!$('.export-widgets').hasClass('disabled')) {
+          $('.export-widgets').addClass('disabled');
         }
       }
     });

--- a/app/views/shared/buttons/_column_lists.html.haml
+++ b/app/views/shared/buttons/_column_lists.html.haml
@@ -19,7 +19,7 @@
         %td.text-center{:width => "40"}
           .btn-group-vertical
             - if @edit[:new][:available_fields].length == 0
-              %button.btn.btn-default.btn-disabled
+              %button.btn.btn-default.disabled
                 %i.fa.fa-angle-right.fa-lg
             - else
               - t = _("Move selected fields right")
@@ -32,7 +32,7 @@
                                                                            :id     => @custom_button_set.id || 'new')}.to_json}
                 %i.fa.fa-angle-right.fa-lg
             - if @edit[:new][:fields].length == 0
-              %button.btn.btn-default.btn-disabled
+              %button.btn.btn-default.disabled
                 %i.fa.fa-angle-left.fa-lg
             - else
               - t = _("Move selected fields left")
@@ -53,7 +53,7 @@
           :id       => "selected_fields")
       %td{:width => "30", :valign => "middle"}
         - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.btn-disabled
+          %button.btn.btn-default.disabled
             %i.fa.fa-angle-double-up.fa-lg
         - else
           - t = _("Move selected fields to top")
@@ -66,7 +66,7 @@
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-double-up.fa-lg
         - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.btn-disabled
+          %button.btn.btn-default.disabled
             %i.fa.fa-angle-up.fa-lg
         - else
           - t = _("Move selected fields up")
@@ -79,7 +79,7 @@
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-up.fa-lg
         - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.btn-disabled
+          %button.btn.btn-default.disabled
             %i.fa.fa-angle-down.fa-lg
         - else
           - t = _("Move selected fields down")
@@ -92,7 +92,7 @@
                                                                        :id     => @custom_button_set.id || 'new')}.to_json}
             %i.fa.fa-angle-down.fa-lg
         - if @edit[:new][:fields].length < 2
-          %button.btn.btn-default.btn-disabled
+          %button.btn.btn-default.disabled
             %i.fa.fa-angle-double-down.fa-lg
         - else
           - t = _("Move selected fields to bottom")

--- a/app/views/shared/buttons/_group_order_form.html.haml
+++ b/app/views/shared/buttons/_group_order_form.html.haml
@@ -18,7 +18,7 @@
                 :id       => "selected_fields")
             %td{:width => "30", :align => "left", :valign => "middle"}
               - if @edit[:new][:fields].length < 2
-                %button.btn.btn-default.btn-disabled
+                %button.btn.btn-default.disabled
                   %i.fa.fa-angle-up.fa-lg
               - else
                 - t = _("Move selected fields up")
@@ -31,7 +31,7 @@
                                                                              :id     => "seq")}.to_json}
                   %i.fa.fa-angle-up.fa-lg
               - if @edit[:new][:fields].length < 2
-                %button.btn.btn-default.btn-disabled
+                %button.btn.btn-default.disabled
                   %i.fa.fa-angle-down.fa-lg
               - else
                 - t = _("Move selected fields down")

--- a/app/views/shared/dialogs/_dialog_field.html.haml
+++ b/app/views/shared/dialogs/_dialog_field.html.haml
@@ -34,7 +34,7 @@
       = render(:partial => "shared/dialogs/dialog_field_drop_down_list", :locals => locals)
 
     - when 'DialogFieldButton'
-      = button_tag(_("Save"), :class => edit ? 'btn btn-primary' : 'btn btn-primary btn-disabled')
+      = button_tag(_("Save"), :class => edit ? 'btn btn-primary' : 'btn btn-primary disabled')
 
     - when 'DialogFieldTagControl'
       - category_tags = DialogFieldTagControl.category_tags(field.category).map { |cat| [cat[:description], cat[:id]] }

--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -64,7 +64,7 @@
                      :alt          => _("Save"),
                      "ng-click"    => "saveClicked()",
                      "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                     "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+                     "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
         = button_tag(_("Cancel"),
                      :class     => "btn btn-default",
                      :alt          => _("Cancel"),

--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -64,7 +64,7 @@
                      :alt          => _("Save"),
                      "ng-click"    => "saveClicked()",
                      "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                     "ng-class"    => "{'disabled': angularForm.$pristine || angularForm.$invalid}")
+                     "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
         = button_tag(_("Cancel"),
                      :class     => "btn btn-default",
                      :alt          => _("Cancel"),

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -232,7 +232,6 @@
         = button_tag(_("Submit"),
                      :class     => "btn btn-primary btn-disabled",
                      :alt       => _("Submit"),
-                     :style     => "cursor:not-allowed",
                      "ng-click" => "disabledClick($event)",
                      "ng-show"  => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)")
         = button_tag(_("Submit"),

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -243,7 +243,7 @@
              :class        => "btn btn-default disabled",
              :alt          => "Reset changes",
              :title        => "Reset changes",
-             "ng-class"    => "{'disabled': angularForm.$pristine && !cb_disks}",
+             "ng-class"    => "{ disabled: angularForm.$pristine && !cb_disks}",
              "ng-click"    => "resetClicked()",
              "ng-disabled" => "angularForm.$pristine && !cb_disks",
              "ng-hide"     => "newRecord")

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -230,7 +230,7 @@
     %tr
       %td#buttons_on{:align => "right"}
         = button_tag(_("Submit"),
-                     :class     => "btn btn-primary btn-disabled",
+                     :class     => "btn btn-primary disabled",
                      :alt       => _("Submit"),
                      "ng-click" => "disabledClick($event)",
                      "ng-show"  => "(angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks)")
@@ -240,10 +240,10 @@
                      "ng-click" => "submitClicked()",
                      "ng-show"  => "!((angularForm.$pristine && !cb_disks) || angularForm.$invalid || (!cb_memory && !cb_cpu && !cb_disks))")
         = button_tag("Reset",
-             :class        => "btn btn-default btn-disabled",
+             :class        => "btn btn-default disabled",
              :alt          => "Reset changes",
              :title        => "Reset changes",
-             "ng-class"    => "{'btn-disabled': angularForm.$pristine && !cb_disks}",
+             "ng-class"    => "{'disabled': angularForm.$pristine && !cb_disks}",
              "ng-click"    => "resetClicked()",
              "ng-disabled" => "angularForm.$pristine && !cb_disks",
              "ng-hide"     => "newRecord")

--- a/app/views/vm_common/_resize.html.haml
+++ b/app/views/vm_common/_resize.html.haml
@@ -45,7 +45,7 @@
                                                                  :id     => @edit[:vm_id],
                                                                  :button => "cancel")}');")
         #buttons_off{:style => "display:#{@changed ? "none" : "display"};"}
-          = button_tag(_("Submit"), :class => "btn btn-primary btn-disabled")
+          = button_tag(_("Submit"), :class => "btn btn-primary disabled")
           = button_tag(_("Cancel"),
                            :class   => 'btn btn-default',
                            :alt     => t = _("Cancel Changes"),

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -324,7 +324,7 @@ describe OpsController do
         expect(response.status).to eq(200)
         expect(response.body).to_not be_empty
         expect(response.body).to include("<div id='buttons_on' style='display: none;'>")
-        expect(response.body).to include("<div id='buttons_off' style=''>\n<button name=\"button\" type=\"submit\" class=\"btn btn-primary btn-disabled\">Apply</button>")
+        expect(response.body).to include("<div id='buttons_off' style=''>\n<button name=\"button\" type=\"submit\" class=\"btn btn-primary disabled\">Apply</button>")
       end
 
       it "Apply button enabled when there are no flash errors" do
@@ -333,7 +333,7 @@ describe OpsController do
         expect(response.status).to eq(200)
         expect(response.body).to_not be_empty
         expect(response.body).to include("<div id='buttons_on' style=''>")
-        expect(response.body).to include("<div id='buttons_off' style='display: none;'>\n<button name=\"button\" type=\"submit\" class=\"btn btn-primary btn-disabled\">Apply</button>")
+        expect(response.body).to include("<div id='buttons_off' style='display: none;'>\n<button name=\"button\" type=\"submit\" class=\"btn btn-primary disabled\">Apply</button>")
       end
     end
   end


### PR DESCRIPTION
Patternfly has [explicitly decided](https://github.com/patternfly/patternfly/issues/405#issuecomment-239447008) that disabled buttons should all be the same color, that is, not blue/red/yellow/... just gray.

This PR makes our buttons follow that convention.

This also completely removes the `btn-disabled` class we were using for that, and replaces it with patternfly's `disabled` class.

This also removes any custom `cursor: not-allowed` styling on disabled buttons, we should do that for all or none.

@epwinchell about that cursor .. we can either change that cursor to `default` or to `not-allowed`, what do you think? Patternfly currently sets not-allowed *except* for buttons that are `<a>` underneath.