### PR TITLE
rake locale:plugin:find -- use _ instead of :: in plugin domain name

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -139,8 +139,8 @@ namespace :locale do
       $stderr.puts "You need to specify a plugin name: rake locale:plugin:find[plugin_name]"
       exit 1
     end
-    @domain = args[:engine]
-    @engine = "#{@domain.camelize}::Engine".constantize
+    @domain = args[:engine].gsub('::', '_')
+    @engine = "#{args[:engine].camelize}::Engine".constantize
     @engine_root = @engine.root
 
     namespace :gettext do


### PR DESCRIPTION
This is to avoid potential problems with having `::` in catalog file names (as suggested
by @durandom in PR https://github.com/ManageIQ/manageiq-providers-amazon/pull/28).