### PR TITLE
Target Ruby version for rubocop changed to 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ GlobalVars:
 # Special Exclusions
 #
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
     - db/schema.rb


### PR DESCRIPTION
Purpose or Intent
-----------------
Target Ruby version for rubocop changed to 2.3 to avoid Rubocop messages:

>  :bomb: :boom: :fire: :fire_engine: - Line 5, Col 12 - Syntax - unexpected token error (Using Ruby 2.2 parser; configure using TargetRubyVersion parameter, under AllCops)
