### PR TITLE
Make the debug toaster auto-adjust its height, scroll when necessary

### DIFF
--- a/app/assets/stylesheets/miq_debug.css
+++ b/app/assets/stylesheets/miq_debug.css
@@ -3,7 +3,8 @@
   top: 20px;
   right: 20px;
   left: 66%;
-  bottom: 20px;
   z-index: 10000;
   width: calc(34% - 20px);
+  max-height: calc(100% - 40px);
+  overflow-y: auto;
 }


### PR DESCRIPTION
The debug toaster would previously take the whole vertical space, obscuring buttons when a notification was shown.

This makes it automatically adjust its height and show a scrollbar when too large.