### PR TITLE
Fix warning about already initialized TEXT_DOMAIN constant

### DIFF
--- a/lib/vmdb/gettext/domains.rb
+++ b/lib/vmdb/gettext/domains.rb
@@ -3,7 +3,7 @@ require 'fast_gettext'
 module Vmdb
   module Gettext
     module Domains
-      TEXT_DOMAIN = 'manageiq'.freeze
+      TEXT_DOMAIN ||= 'manageiq'.freeze
 
       def self.domains
         @domains ||= []


### PR DESCRIPTION
This would happen during application start with rails engines / plugins using their own gettext catalogs:

```
$ rails console
lib/vmdb/gettext/domains.rb:6: warning: already initialized constant
Vmdb::Gettext::Domains::TEXT_DOMAIN
lib/vmdb/gettext/domains.rb:6: warning: previous definition of TEXT_DOMAIN was here
...
irb(main):001:0>
```