### PR TITLE
RelationshipMixin cache: only flush_cache if there are caches to flush

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -49,7 +49,7 @@ module RelationshipMixin
   def clear_relationships_cache(*args)
     options = args.extract_options!
     to_clear = RelationshipMixin::MEMOIZED_METHODS - Array.wrap(options[:except])
-    flush_cache(*to_clear)
+    flush_cache(*to_clear) unless to_clear.empty?
 
     @association_cache.delete(:all_relationships)
   end


### PR DESCRIPTION
For performance testing and bug spelunking, I'm often setting `MEMOIZED_METHODS = []`

This makes `clear_relationships_cache` blow up.
Adding a check here to make this process easier.

ASIDE: Think this is only ever called from tests, but I may be wrong.

/cc @Fryguy may have an opinion here. otherwise, I tried to keep small / simple