### PR TITLE
Relationships: remove unused methods (with TODO to remove)

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -656,10 +656,6 @@ module RelationshipMixin
     ancestors(*args).reverse.detect(&block)
   end
 
-  # TODO: Replace these or get rid of them
-  alias_method :clear_children_cache, :clear_relationships_cache
-  alias_method :clear_parents_cache,  :clear_relationships_cache
-
   #
   # Diagnostic methods
   #


### PR DESCRIPTION
This todo was added in 2010 - 62d7d809
But even at that time, I don't see any references to ~~`clear_relationships_cache`~~ `clear_children_cache`

removing the methods

**UPDATED:** thanks @chrisarcand 