### PR TITLE
rubocop issues: tree_builder_report_roles.rb

### DIFF
--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -1,7 +1,7 @@
 class TreeBuilderReportRoles < TreeBuilder
   private
 
-  def tree_init_options(tree_name)
+  def tree_init_options(_tree_name)
     {
       :leaf     => 'Roles',
       :full_ids => true
@@ -18,11 +18,11 @@ class TreeBuilderReportRoles < TreeBuilder
 
   def root_options
     user = User.current_user
-    if user.super_admin_user?
-      title = _("All %{models}") % {:models => ui_lookup(:models => "MiqGroup")}
-    else
-      title = _("My %{models}") % {:models => ui_lookup(:models => "MiqGroup")}
-    end
+    title = if user.super_admin_user?
+              _("All %{models}") % {:models => ui_lookup(:models => "MiqGroup")}
+            else
+              _("My %{models}") % {:models => ui_lookup(:models => "MiqGroup")}
+            end
     [title, title, :miq_group]
   end
 


### PR DESCRIPTION
== app/presenters/tree_builder_report_roles.rb ==
    W:  4: 25: Unused method argument - tree_name. If it's necessary, use _
    or _tree_name as an argument name to indicate that it won't be used. You
    can also write as tree_init_options(*) if you want the method to accept
    any arguments but don't care about them.
    C: 21:  5: Use the return of the conditional for variable assignment and
    comparison.