### PR TITLE
Generate the API_TOKEN and pass it to the Method

### DIFF
--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -11,8 +11,12 @@ module MiqAeEngine
     def with_server(inputs, body)
       setup if num_methods == 0
       self.num_methods += 1
+
+      svc = MiqAeMethodService::MiqAeService.new(@workspace)
       svc = MiqAeMethodService::MiqAeService.new(@workspace, inputs, body)
-      svc.preamble = method_preamble(drb_uri, svc.object_id)
+      svc.inputs     = inputs
+      svc.preamble   = method_preamble(drb_uri, svc.object_id, api_token)
+      svc.body       = body
 
       yield [svc.preamble, svc.body, RUBY_METHOD_POSTSCRIPT]
     ensure
@@ -71,10 +75,15 @@ module MiqAeEngine
       1.hour
     end
 
+    def api_token
+      uts = Api::UserTokenService.new
+      uts.generate_token(@workspace.ae_user.userid, "api")
+    end
+
     # code building
 
-    def method_preamble(miq_uri, miq_id)
-      "MIQ_URI = '#{miq_uri}'\nMIQ_ID = #{miq_id}\n" << RUBY_METHOD_PREAMBLE
+    def method_preamble(miq_uri, miq_id, miq_api_token)
+      "MIQ_URI = '#{miq_uri}'\nMIQ_ID = #{miq_id}\nMIQ_API_TOKEN = '#{miq_api_token}'\n" << RUBY_METHOD_PREAMBLE
     end
 
     RUBY_METHOD_PREAMBLE = <<-RUBY.freeze

--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -12,7 +12,6 @@ module MiqAeEngine
       setup if num_methods == 0
       self.num_methods += 1
 
-      svc = MiqAeMethodService::MiqAeService.new(@workspace)
       svc = MiqAeMethodService::MiqAeService.new(@workspace, inputs, body)
       svc.inputs     = inputs
       svc.preamble   = method_preamble(drb_uri, svc.object_id, api_token)

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -1,11 +1,12 @@
+require 'spec_helper'
 module DrbRemoteInvokerSpec
   include MiqAeEngine
   describe MiqAeEngine::DrbRemoteInvoker do
+    let(:user) { FactoryGirl.create(:user_with_group) }
     it "setup/teardown drb_for_ruby_method clears DRb threads" do
-      workspace = double("workspace", :persist_state_hash => {})
+      workspace = double("workspace", :persist_state_hash => {}, :ae_user => user)
       allow(workspace).to receive(:disable_rbac).with(no_args)
       invoker = described_class.new(workspace)
-
       timer_thread = nil
 
       invoker.with_server([], "") do
@@ -19,6 +20,29 @@ module DrbRemoteInvokerSpec
       end
 
       expect(Thread.list).to_not include(timer_thread)
+    end
+  end
+
+  describe MiqAeEngine::DrbRemoteInvoker do
+    include Spec::Support::AutomationHelper
+    context "#api_token" do
+      let(:user) { FactoryGirl.create(:user_with_group) }
+
+      def token_script
+         <<-'RUBY'
+           $evm.root['miq_api_token'] = MIQ_API_TOKEN
+         RUBY
+      end
+
+      it "check if the token is acessible in the method" do
+         user
+         create_ae_model_with_method(:name => 'FLINTSTONE', :ae_namespace => 'FRED',
+                                     :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                     :method_name => 'OBELIX',
+                                     :method_script => token_script)
+         ws = MiqAeEngine.instantiate("/FRED/WILMA/DOGMATIX", user)
+         expect(ws.root['miq_api_token']).not_to be_nil
+      end
     end
   end
 end

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -29,9 +29,9 @@ module DrbRemoteInvokerSpec
       let(:user) { FactoryGirl.create(:user_with_group) }
 
       def token_script
-         <<-'RUBY'
-           $evm.root['miq_api_token'] = MIQ_API_TOKEN
-         RUBY
+        <<-'RUBY'
+          $evm.root['miq_api_token'] = MIQ_API_TOKEN
+        RUBY
       end
 
       it "check if the token is acessible in the method" do

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 module DrbRemoteInvokerSpec
   include MiqAeEngine
   describe MiqAeEngine::DrbRemoteInvoker do
@@ -21,13 +20,9 @@ module DrbRemoteInvokerSpec
 
       expect(Thread.list).to_not include(timer_thread)
     end
-  end
 
-  describe MiqAeEngine::DrbRemoteInvoker do
     include Spec::Support::AutomationHelper
     context "#api_token" do
-      let(:user) { FactoryGirl.create(:user_with_group) }
-
       def token_script
         <<-'RUBY'
           $evm.root['miq_api_token'] = MIQ_API_TOKEN
@@ -35,13 +30,13 @@ module DrbRemoteInvokerSpec
       end
 
       it "check if the token is acessible in the method" do
-         user
-         create_ae_model_with_method(:name => 'FLINTSTONE', :ae_namespace => 'FRED',
-                                     :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
-                                     :method_name => 'OBELIX',
-                                     :method_script => token_script)
-         ws = MiqAeEngine.instantiate("/FRED/WILMA/DOGMATIX", user)
-         expect(ws.root['miq_api_token']).not_to be_nil
+        user
+        create_ae_model_with_method(:name => 'FLINTSTONE', :ae_namespace => 'FRED',
+                                    :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                    :method_name => 'OBELIX',
+                                    :method_script => token_script)
+        ws = MiqAeEngine.instantiate("/FRED/WILMA/DOGMATIX", user)
+        expect(ws.root['miq_api_token']).not_to be_nil
       end
     end
   end

--- a/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
@@ -18,6 +18,10 @@ describe MiqAeEngine::MiqAeMethod do
 
         def disable_rbac
         end
+
+        def ae_user
+          @ae_user ||= FactoryGirl.create(:user_with_group)
+        end
       end.new
 
       logger_klass = Class.new do


### PR DESCRIPTION
## Purpose or Intent

> Automate methods are currently being used by customers to connect to our REST Web Server. When these methods connect to the web server, they don't have the context of the user that started the Automate Request, this PR exposes a variable in the preamble called MIQ_API_TOKEN that the automate scripts can use to connect.
## Steps for Testing/QA

  code snippet using RestClient and JSON

 url = https://.../api/vms
  options = {:method  => :get,
               :url     => url,
              :headers => {'X-Auth-Token' => MIQ_API_TOKEN}}

  body = RestClient::Request.new(options).execute.body
 JSON.parse(body)
