### PR TITLE
Allow rubocop to merge inherit_from correctly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,11 +37,11 @@ ClassAndModuleCamelCase:
 FileName:
   Exclude:
     - lib/miq_automation_engine/service_models/*.rb
-# LineLength: # Commenting until config loading with inheritence is fixed.
-#   Exclude:
-#     - Gemfile
-#     - gems/pending/Gemfile
-ExtraSpacing:
+Metrics/LineLength:
+  Exclude:
+    - Gemfile
+    - gems/pending/Gemfile
+Style/ExtraSpacing:
   Exclude:
     - Gemfile
     - gems/pending/Gemfile


### PR DESCRIPTION
Purpose or Intent
-----------------
Allows changes from https://github.com/ManageIQ/manageiq/pull/10486 and https://github.com/ManageIQ/manageiq/pull/10508 included without clobbering the max line length of 120 in the inherited from the ManageIQ/guides `.rubocop.yml` file.


Overview
--------
The PR https://github.com/bbatsov/rubocop/pull/3421 should mostly explain the details of the issue, but the reason we haven't run into this before is the `LineLength` is the first inherted option to exist in both the [original](https://github.com/ManageIQ/guides/blob/master/.rubocop.yml) and the `.rubocop.yml` of this project.

The change here should be backwards compatible when [the fix](https://github.com/bbatsov/rubocop/pull/3421) is released (if it is).


Links
-----
* https://github.com/bbatsov/rubocop/pull/3421
* https://github.com/ManageIQ/manageiq/pull/10486 
* https://github.com/ManageIQ/manageiq/pull/10508
* https://github.com/ManageIQ/manageiq/pull/10528
* https://github.com/ManageIQ/guides/blob/master/.rubocop.yml


Steps for Testing/QA
--------------------

Testing bash one-liner:

```
$ rubocop --format emacs lib/extensions/ar_virtual.rb | grep "Line is too long" | wc -l
```

* Checkout this branch
* Run the code snippet.  Make note of the count.
* Update the file to remove the `Metrics` namespace
* Run the code snippet.  The count should increase since there are a bunch of lines between 80-120 characters.