### PR TITLE
MiqReport::Search reduce limit/offset calculation

### DIFF
--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -3,13 +3,7 @@ module MiqReport::Search
 
   module ClassMethods
     def get_limit_offset(page, per_page)
-      limit  = nil
-      offset = nil
-      unless per_page.nil?
-        offset = (page - 1) * per_page
-        limit  = per_page
-      end
-      return limit, offset
+      [per_page, (page - 1) * per_page] if per_page
     end
   end
 
@@ -43,6 +37,9 @@ module MiqReport::Search
     return table, extras[:attrs_for_paging].merge(:paged_read_from_cache => true, :targets_hash => targets_hash)
   end
 
+  # @return [Nil] for sorting in ruby
+  # @return [Array<>] (empty array) for no sorting
+  # @return [Array<Arel::Nodes>] for sorting in sql
   def get_order_info
     return [] if sortby.nil? # apply limits (note: without order it is non-deterministic)
     # Convert sort cols from sub-tables from the form of assoc_name.column to arel


### PR DESCRIPTION
working through reports and saw these.  They are minor:

1. `get_limit_offset` is only used once [a little further down the file](https://github.com/kbrock/manageiq/blob/d529c88367c2c8f13411c0d2ac92eca17d4171a2/app/models/miq_report/search.rb#L73).
2. I'm converting all the `[offset..offset + limit - 1]` => `[offset...offset + limit]`.