### PR TITLE
Add orchestration stack status support for VMware Cloud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     "~>0.3.0",       :require => false
-gem "fog-vcloud-director",            "~>0.1.3",       :require => false
+gem "fog-vcloud-director",            "~>0.1.5",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
@@ -1,3 +1,18 @@
-class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack <
-    ManageIQ::Providers::CloudManager::OrchestrationStack
+class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
+  require_nested :Status
+
+  def raw_status
+    ems = ext_management_system
+    ems.with_provider_connection do |service|
+      raw_stack = service.vapps.get_single_vapp(ems_ref)
+      raise MiqException::MiqOrchestrationStackNotExistError, "#{name} does not exist on #{ems.name}" unless raw_stack
+
+      Status.new(raw_stack.human_status, nil)
+    end
+  rescue MiqException::MiqOrchestrationStackNotExistError
+    raise
+  rescue => err
+    _log.error("stack=[#{name}], error: #{err}")
+    raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
+  end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack/status.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack::Status < ::OrchestrationStack::Status
+  def succeeded?
+    status.casecmp("on") == 0
+  end
+
+  def failed?
+    status.casecmp("failed_creation") == 0
+  end
+end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -77,4 +77,7 @@ FactoryGirl.define do
 
   factory :ansible_tower_job, :class => "ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job" do
   end
+
+  factory :orchestration_stack_vmware_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack" do
+  end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
@@ -1,0 +1,51 @@
+describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack do
+  let(:ems) { FactoryGirl.create(:ems_vmware_cloud) }
+  let(:orchestration_stack) do
+    FactoryGirl.create(:orchestration_stack_vmware_cloud,
+                       :ext_management_system => ems,
+                       :name                  => 'test',
+                       :ems_ref               => 'one_id')
+  end
+
+  let(:the_raw_stack) { double(:id => 'one_id', :human_status => 'on') }
+
+  let(:raw_stacks) do
+    double.tap do |stacks|
+      handle = double
+      allow(handle).to receive(:vapps).and_return(stacks)
+      allow(ems).to receive(:connect).and_return(handle)
+      allow(stacks).to receive(:get_single_vapp).with(orchestration_stack.ems_ref).and_return(the_raw_stack)
+    end
+  end
+
+  before do
+    raw_stacks
+  end
+
+  describe 'stack status' do
+    context '#raw_status and #raw_exists' do
+      it 'gets the stack status and reason' do
+        allow(the_raw_stack).to receive(:stack_status).and_return('on')
+
+        rstatus = orchestration_stack.raw_status
+        expect(rstatus).to have_attributes(:status => 'on', :reason => nil)
+
+        expect(orchestration_stack.raw_exists?).to be_truthy
+      end
+
+      it 'determines stack not exist' do
+        allow(raw_stacks).to receive(:get_single_vapp).with(orchestration_stack.ems_ref).and_return(nil)
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+
+        expect(orchestration_stack.raw_exists?).to be_falsey
+      end
+
+      it 'catches errors from provider' do
+        allow(raw_stacks).to receive(:get_single_vapp).with(orchestration_stack.ems_ref).and_raise("bad request")
+        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+
+        expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds the ability to get the current status of the
orchestration stack (in case of VCD, this is a vApp). The status is
retrieved from the EMS on demand. Corresponding tests are used to
validate the behaviour.

The patch requires new version of `fog-vcloud-director` gem allowing
retrieval of specific vApp and providing additional statuses relevant
to vApps and VMs.

@miq-bot add_label providers/vmware/cloud, enhancement, gem changes