### PR TITLE
Set VM storage profile in provisioning

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -60,6 +60,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
   end
 
   def dest_storage_profile
+    # Storage Profiles were added in vSphere 5.5 so make sure we
+    # don't send newer api types to an older vCenter
+    return nil if source.ext_management_system.api_version < '5.5'
+
     storage_profile_id = get_option(:placement_storage_profile)
     StorageProfile.find_by(:id => storage_profile_id) unless storage_profile_id.nil?
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
   def build_config_spec
     VimHash.new("VirtualMachineConfigSpec") do |vmcs|
       vmcs.annotation = build_vm_notes
+      vmcs.vmProfile  = build_vm_profile
 
       #####################################################################################################
       # Note: VMware currently seems to ignore the CPU/memory limit/reservation settings during a clone
@@ -58,6 +59,17 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
     end
     _log.info "Setting VM annotations to [#{vm_notes}]"
     vm_notes
+  end
+
+  def build_vm_profile
+    vm_profile = get_option(:vm_profile)
+    return nil if vm_profile.nil?
+
+    VimArray.new('ArrayOfVirtualMachineProfileSpec') do |vm_profile_spec_array|
+      vm_profile_spec_array << VimHash.new('VirtualMachineDefinedProfileSpec') do |vm_profile_spec|
+        vm_profile_spec.profileId = vm_profile
+      end
+    end
   end
 
   def set_spec_option(obj, property, key, default_value = nil, modifier = nil, override_value = nil)

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -2,7 +2,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
   def build_config_spec
     VimHash.new("VirtualMachineConfigSpec") do |vmcs|
       vmcs.annotation = build_vm_notes
-      vmcs.vmProfile  = build_vm_profile
 
       #####################################################################################################
       # Note: VMware currently seems to ignore the CPU/memory limit/reservation settings during a clone
@@ -59,17 +58,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
     end
     _log.info "Setting VM annotations to [#{vm_notes}]"
     vm_notes
-  end
-
-  def build_vm_profile
-    vm_profile = get_option(:vm_profile)
-    return nil if vm_profile.nil?
-
-    VimArray.new('ArrayOfVirtualMachineProfileSpec') do |vm_profile_spec_array|
-      vm_profile_spec_array << VimHash.new('VirtualMachineDefinedProfileSpec') do |vm_profile_spec|
-        vm_profile_spec.profileId = vm_profile
-      end
-    end
   end
 
   def set_spec_option(obj, property, key, default_value = nil, modifier = nil, override_value = nil)

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -44,6 +44,19 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
         expect(spec["annotation"]).to include(@vm_prov.phase_context[:new_vm_validation_guid])
       end
 
+      it "should set spec.vmProfile when given a vm_profile" do
+        storage_profile_id = "2f22be4d-d155-46a3-86f9-fcb0f13f876e"
+
+        @vm_prov.options.merge!(:vm_profile => storage_profile_id)
+        expect(@vm_prov).to receive(:build_config_network_adapters)
+
+        spec = @vm_prov.build_config_spec
+
+        expect(spec.vmProfile.xsiType).to      eq("ArrayOfVirtualMachineProfileSpec")
+        expect(spec.vmProfile[0].xsiType).to   eq("VirtualMachineDefinedProfileSpec")
+        expect(spec.vmProfile[0].profileId).to eq(storage_profile_id)
+      end
+
       it "should return a transform spec" do
         spec = @vm_prov.build_transform_spec
         expect(spec).to be_nil


### PR DESCRIPTION
Purpose or Intent
-----------------
Set the `profile` attribute of `VirtualMachineRelocateSpec` if `:placement_storage_profile` is given as a provision option

This was added as an option in vSphere 5.5


Links
-----
* http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.RelocateSpec.html
* http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.wssdk.apiref.doc/vim.vm.DefinedProfileSpec.html
* https://github.com/ManageIQ/manageiq/pull/10523