### PR TITLE
Use anonymous classes in tests to avoid constant conflicts

### DIFF
--- a/gems/pending/spec/util/extensions/miq-module_spec.rb
+++ b/gems/pending/spec/util/extensions/miq-module_spec.rb
@@ -2,18 +2,18 @@ require 'util/extensions/miq-module'
 require 'timecop'
 
 describe Module do
-  class ::TestClass; end
-  module ::TestModule; end
+  let(:test_class)  { Class.new }
+  let(:test_module) { Module.new }
 
   context '#cache_with_timeout' do
     before(:each) do
       @settings = 60
 
-      expect { TestClass.cache_with_timeout(:default) { rand } }.not_to raise_error
-      expect { TestClass.cache_with_timeout(:override, 60) { rand } }.not_to raise_error
-      expect { TestClass.cache_with_timeout(:override_proc, -> { @settings }) { rand } }.not_to raise_error
+      expect { test_class.cache_with_timeout(:default) { rand } }.not_to raise_error
+      expect { test_class.cache_with_timeout(:override, 60) { rand } }.not_to raise_error
+      expect { test_class.cache_with_timeout(:override_proc, -> { @settings }) { rand } }.not_to raise_error
 
-      expect { TestModule.cache_with_timeout(:default) { rand } }.not_to raise_error
+      expect { test_module.cache_with_timeout(:default) { rand } }.not_to raise_error
     end
 
     after(:each) do
@@ -21,70 +21,70 @@ describe Module do
     end
 
     it 'will create the class method on that class/module only' do
-      expect(TestClass).to  respond_to(:default)
-      expect(TestClass.new).not_to respond_to(:default)
+      expect(test_class).to  respond_to(:default)
+      expect(test_class.new).not_to respond_to(:default)
       expect(Object).not_to respond_to(:default)
       expect(Class).not_to  respond_to(:default)
       expect(Module).not_to respond_to(:default)
 
-      expect(TestModule).to respond_to(:default)
+      expect(test_module).to respond_to(:default)
       expect(Object).not_to respond_to(:default)
       expect(Class).not_to  respond_to(:default)
       expect(Module).not_to respond_to(:default)
     end
 
     it 'will return the cached value' do
-      value = TestClass.default(true)
-      expect(TestClass.default).to eq(value)
+      value = test_class.default(true)
+      expect(test_class.default).to eq(value)
 
-      value = TestModule.default(true)
-      expect(TestModule.default).to eq(value)
+      value = test_module.default(true)
+      expect(test_module.default).to eq(value)
     end
 
     it 'will not return the cached value when passed force_reload = true' do
-      value = TestClass.default(true)
-      expect(TestClass.default(true)).not_to eq(value)
+      value = test_class.default(true)
+      expect(test_class.default(true)).not_to eq(value)
 
-      value = TestModule.default(true)
-      expect(TestModule.default(true)).not_to eq(value)
+      value = test_module.default(true)
+      expect(test_module.default(true)).not_to eq(value)
     end
 
     it 'will return the cached value if the default timeout has not passed' do
-      value = TestClass.default(true)
-      Timecop.travel(60) { expect(TestClass.default).to eq(value) }
+      value = test_class.default(true)
+      Timecop.travel(60) { expect(test_class.default).to eq(value) }
     end
 
     it 'will not return the cached value if the default timeout has passed' do
-      value = TestClass.default(true)
-      Timecop.travel(600) { expect(TestClass.default).not_to eq(value) }
+      value = test_class.default(true)
+      Timecop.travel(600) { expect(test_class.default).not_to eq(value) }
     end
 
     it 'will return the cached value if the overridden timeout has not passed' do
-      value = TestClass.override(true)
-      Timecop.travel(30) { expect(TestClass.override).to eq(value) }
+      value = test_class.override(true)
+      Timecop.travel(30) { expect(test_class.override).to eq(value) }
     end
 
     it 'will not return the cached value if the overridden timeout has passed' do
-      value = TestClass.override(true)
-      Timecop.travel(120) { expect(TestClass.override).not_to eq(value) }
+      value = test_class.override(true)
+      Timecop.travel(120) { expect(test_class.override).not_to eq(value) }
     end
 
     it 'will return the cached value if the overridden timeout (via a proc) has not passed' do
-      value = TestClass.override_proc(true)
-      Timecop.travel(30) { expect(TestClass.override_proc).to eq(value) }
+      value = test_class.override_proc(true)
+      Timecop.travel(30) { expect(test_class.override_proc).to eq(value) }
     end
 
     it 'will not return the cached value if the overridden timeout (via a proc) has passed' do
-      value = TestClass.override_proc(true)
-      Timecop.travel(120) { expect(TestClass.override_proc).not_to eq(value) }
+      value = test_class.override_proc(true)
+      Timecop.travel(120) { expect(test_class.override_proc).not_to eq(value) }
     end
 
     it 'will return the cached value if the overridden timeout (via a proc) was changed but has not passed' do
       # Test a time jump value between the old settings value and the new to
       # prove that the new value is working
       @settings = 300 # 5 minutes
-      value = TestClass.override_proc(true)
-      Timecop.travel(120) { expect(TestClass.override_proc).to eq(value) }
+      value = test_class.override_proc(true)
+      Timecop.travel(120) { expect(test_class.override_proc).to eq(value) }
       @settings = 60 # reset back to 1 minute
     end
 
@@ -92,59 +92,59 @@ describe Module do
       # Test a time jump value between the old settings value and the new to
       # prove that the new value is working
       @settings = 300 # 5 minutes
-      value = TestClass.override_proc(true)
-      Timecop.travel(600) { expect(TestClass.override_proc).not_to eq(value) }
+      value = test_class.override_proc(true)
+      Timecop.travel(600) { expect(test_class.override_proc).not_to eq(value) }
       @settings = 60 # reset back to 1 minute
     end
 
     it 'generated .*_clear_cache' do
-      TestClass.default
-      TestClass.override
-      TestClass.override_proc
-      TestModule.default
+      test_class.default
+      test_class.override
+      test_class.override_proc
+      test_module.default
 
-      TestClass.default_clear_cache
-      TestClass.override_clear_cache
-      TestClass.override_proc_clear_cache
-      TestModule.default_clear_cache
+      test_class.default_clear_cache
+      test_class.override_clear_cache
+      test_class.override_proc_clear_cache
+      test_module.default_clear_cache
 
-      expect(TestClass.default_cached?).to be_falsey
-      expect(TestClass.override_cached?).to be_falsey
-      expect(TestClass.override_proc_cached?).to be_falsey
-      expect(TestModule.default_cached?).to be_falsey
+      expect(test_class.default_cached?).to be_falsey
+      expect(test_class.override_cached?).to be_falsey
+      expect(test_class.override_proc_cached?).to be_falsey
+      expect(test_module.default_cached?).to be_falsey
     end
 
     it 'generated .*_cached?' do
-      expect(TestClass.default_cached?).to be_falsey
-      expect(TestClass.override_cached?).to be_falsey
-      expect(TestClass.override_proc_cached?).to be_falsey
-      expect(TestModule.default_cached?).to be_falsey
+      expect(test_class.default_cached?).to be_falsey
+      expect(test_class.override_cached?).to be_falsey
+      expect(test_class.override_proc_cached?).to be_falsey
+      expect(test_module.default_cached?).to be_falsey
 
-      TestClass.default
-      TestClass.override
-      TestClass.override_proc
-      TestModule.default
+      test_class.default
+      test_class.override
+      test_class.override_proc
+      test_module.default
 
-      expect(TestClass.default_cached?).to be_truthy
-      expect(TestClass.override_cached?).to be_truthy
-      expect(TestClass.override_proc_cached?).to be_truthy
-      expect(TestModule.default_cached?).to be_truthy
+      expect(test_class.default_cached?).to be_truthy
+      expect(test_class.override_cached?).to be_truthy
+      expect(test_class.override_proc_cached?).to be_truthy
+      expect(test_module.default_cached?).to be_truthy
     end
 
     it 'will cache with thread safety' do
       # If multiple threads access the in-memory cache without thread safety,
       #   and one tries to force reload, there is a small window where as it
       #   clears the current value, the other thread could get nil.
-      TestClass.cache_with_timeout(:thread_safety) { 2 }
+      test_class.cache_with_timeout(:thread_safety) { 2 }
 
       Thread.new do
         10000.times do
-          TestClass.thread_safety(true)
+          test_class.thread_safety(true)
         end
       end
 
       10000.times do
-        expect(TestClass.thread_safety).to eq(2)
+        expect(test_class.thread_safety).to eq(2)
       end
     end
   end

--- a/spec/lib/extensions/ar_base_model_spec.rb
+++ b/spec/lib/extensions/ar_base_model_spec.rb
@@ -1,26 +1,32 @@
 describe "ar_base_model extension" do
   context "with a test class" do
-    before(:each) { class ::TestClass < ActiveRecord::Base; end }
-    after(:each)  { Object.send(:remove_const, :TestClass) }
+    let(:test_class) do
+      Class.new(ActiveRecord::Base) do
+        def self.name; "TestClass"; end
+      end
+    end
 
     it ".base_model" do
-      expect(TestClass.base_model).to eq(TestClass)
+      expect(test_class.base_model).to eq(test_class)
     end
 
     it ".model_suffix" do
-      expect(TestClass.model_suffix).to eq("")
+      expect(test_class.model_suffix).to eq("")
     end
 
     context "with a subclass" do
-      before(:each) { class ::TestClassFoo < ::TestClass; end }
-      after(:each)  { Object.send(:remove_const, :TestClassFoo) }
+      let(:test_class_foo) do
+        Class.new(test_class) do
+          def self.name; "TestClassFoo"; end
+        end
+      end
 
       it ".base_model" do
-        expect(TestClassFoo.base_model).to eq(TestClass)
+        expect(test_class_foo.base_model).to eq(test_class)
       end
 
       it ".model_suffix" do
-        expect(TestClassFoo.model_suffix).to eq("Foo")
+        expect(test_class_foo.model_suffix).to eq("Foo")
       end
     end
   end

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -1,14 +1,16 @@
 describe EventMixin do
   context "Included in a test class with events" do
-    before do
-      class TestClass
+    let(:test_class) do
+      Class.new do
         include EventMixin
 
         def event_where_clause(assoc)
           ["#{events_table_name(assoc)}.ems_id = ?", 1]
         end
       end
+    end
 
+    before do
       @ts_1 = 5.days.ago
       FactoryGirl.create(:ems_event, :ems_id => 1, :timestamp => @ts_1)
       @ts_2 = 4.days.ago
@@ -17,33 +19,29 @@ describe EventMixin do
       FactoryGirl.create(:ems_event, :ems_id => 1, :timestamp => @ts_3)
     end
 
-    after do
-      Object.send(:remove_const, "TestClass")
-    end
-
     it "#first_event" do
-      expect(TestClass.new.first_event).to be_same_time_as @ts_1
+      expect(test_class.new.first_event).to be_same_time_as @ts_1
     end
 
     it "#last_event" do
-      expect(TestClass.new.last_event).to  be_same_time_as @ts_3
+      expect(test_class.new.last_event).to  be_same_time_as @ts_3
     end
 
     it "#first_and_last_event" do
-      events = TestClass.new.first_and_last_event
+      events = test_class.new.first_and_last_event
       expect(events.length).to eq(2)
       expect(events[0]).to     be_same_time_as @ts_1
       expect(events[1]).to     be_same_time_as @ts_3
     end
 
     it "#has_events?" do
-      expect(TestClass.new).to have_events
+      expect(test_class.new).to have_events
     end
   end
 
   context "Included in a test class with no events" do
-    before do
-      class TestClass
+    let(:test_class) do
+      Class.new do
         include EventMixin
 
         def event_where_clause(assoc)
@@ -52,24 +50,20 @@ describe EventMixin do
       end
     end
 
-    after do
-      Object.send(:remove_const, "TestClass")
-    end
-
     it "#first_event" do
-      expect(TestClass.new.first_event).to be_nil
+      expect(test_class.new.first_event).to be_nil
     end
 
     it "#last_event" do
-      expect(TestClass.new.last_event).to  be_nil
+      expect(test_class.new.last_event).to  be_nil
     end
 
     it "#first_and_last_event" do
-      expect(TestClass.new.first_and_last_event).to be_empty
+      expect(test_class.new.first_and_last_event).to be_empty
     end
 
     it "#has_events?" do
-      expect(TestClass.new).not_to have_events
+      expect(test_class.new).not_to have_events
     end
   end
 end

--- a/spec/models/mixins/provider_object_mixin_spec.rb
+++ b/spec/models/mixins/provider_object_mixin_spec.rb
@@ -1,56 +1,48 @@
 describe ProviderObjectMixin do
-  before do
-    class TestClass
-      include ProviderObjectMixin
-    end
-  end
-
-  after do
-    Object.send(:remove_const, "TestClass")
-  end
+  let(:test_class) { Class.new { include ProviderObjectMixin } }
 
   def mock_ems_with_connection
     @ems        = double("ems")
     @connection = double("connection")
     expect(@ems).to receive(:with_provider_connection).and_yield(@connection)
-    allow_any_instance_of(TestClass).to receive_messages(:ext_management_system => @ems)
+    allow_any_instance_of(test_class).to receive_messages(:ext_management_system => @ems)
   end
 
   it "#with_provider_connection" do
     mock_ems_with_connection
-    expect { |b| TestClass.new.with_provider_connection(&b) }.to yield_with_args(@connection)
+    expect { |b| test_class.new.with_provider_connection(&b) }.to yield_with_args(@connection)
   end
 
   context "when provider_object is written" do
     before do
       @provider_object = double("provider_object")
-      allow_any_instance_of(TestClass).to receive_messages(:provider_object => @provider_object)
+      allow_any_instance_of(test_class).to receive_messages(:provider_object => @provider_object)
     end
 
     it "#provider_object" do
-      expect { TestClass.new.provider_object(@connection) }.to_not raise_error
+      expect { test_class.new.provider_object(@connection) }.to_not raise_error
     end
 
     it "#with_provider_object" do
       mock_ems_with_connection
-      expect { |b| TestClass.new.with_provider_object(&b) }.to yield_with_args(@provider_object)
+      expect { |b| test_class.new.with_provider_object(&b) }.to yield_with_args(@provider_object)
     end
   end
 
   context "when provider_object is not written" do
     it "#provider_object" do
-      expect { TestClass.new.provider_object(@connection) }.to raise_error(NotImplementedError)
+      expect { test_class.new.provider_object(@connection) }.to raise_error(NotImplementedError)
     end
 
     it "#with_provider_object" do
       mock_ems_with_connection
-      expect { TestClass.new.with_provider_object {} }.to raise_error(NotImplementedError)
+      expect { test_class.new.with_provider_object {} }.to raise_error(NotImplementedError)
     end
   end
 
   context "when no ems or manager is available" do
     it "#connection_source" do
-      expect { TestClass.new.send(:connection_source) }.to raise_error(RuntimeError)
+      expect { test_class.new.send(:connection_source) }.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/models/mixins/yaml_import_export_mixin_spec.rb
+++ b/spec/models/mixins/yaml_import_export_mixin_spec.rb
@@ -1,19 +1,13 @@
 describe YAMLImportExportMixin do
+  let(:test_class) { Class.new { include YAMLImportExportMixin } }
+
   before do
-    class TestClass
-      include YAMLImportExportMixin
-    end
-
     @report1 = FactoryGirl.create(:miq_report, :name => "test_report_1")
-  end
-
-  after do
-    Object.send(:remove_const, "TestClass")
   end
 
   context ".export_to_array" do
     before  { @klass = MiqReport }
-    subject { TestClass.export_to_array(@list, @klass) }
+    subject { test_class.export_to_array(@list, @klass) }
 
     it "invalid class" do
       @list, @klass = [12345], "xxx"
@@ -43,12 +37,12 @@ describe YAMLImportExportMixin do
   end
 
   it ".export_to_yaml" do
-    expect(TestClass).to receive(:export_to_array).once.with([@report1.id], MiqReport)
-    TestClass.export_to_yaml([@report1.id], MiqReport)
+    expect(test_class).to receive(:export_to_array).once.with([@report1.id], MiqReport)
+    test_class.export_to_yaml([@report1.id], MiqReport)
   end
 
   context ".import" do
-    subject { TestClass }
+    subject { test_class }
 
     it "valid YAML file" do
       @fd = StringIO.new("---\na:")


### PR DESCRIPTION
Followup of more tests that were defining a class in a before block and calling `remove_const` in an after block.  Anonymous classes can do everything needed and not mess with the list of defined constants.