### PR TITLE
Use only valid conninfo keys for postgres connections

### DIFF
--- a/gems/pending/postgres_ha_admin/failover_databases.rb
+++ b/gems/pending/postgres_ha_admin/failover_databases.rb
@@ -12,6 +12,13 @@ module PostgresHaAdmin
       @logger = logger
     end
 
+    def active_databases_conninfo_hash
+      valid_keys = PG::Connection.conndefaults_hash.keys + [:requiressl]
+      active_databases.map! do |db_info|
+        db_info.keep_if { |k, _v| valid_keys.include?(k) }
+      end
+    end
+
     def active_databases
       all_databases.select { |record| record[:active] }
     end

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -67,7 +67,7 @@ module PostgresHaAdmin
     end
 
     def with_each_standby_connection
-      servers = @failover_db.active_databases
+      servers = @failover_db.active_databases_conninfo_hash
       @logger.info("Standby Database Servers: #{servers}")
       servers.each do |params|
         connection = pg_connection(params)

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -82,7 +82,8 @@ module PostgresHaAdmin
 
     def pg_connection(params)
       PG::Connection.open(params)
-    rescue PG::Error
+    rescue PG::Error => e
+      @logger.error("Failed to establish PG connection: #{e.message}")
       nil
     end
 

--- a/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_databases_spec.rb
@@ -15,6 +15,17 @@ describe PostgresHaAdmin::FailoverDatabases do
     @logger_file.close(true)
   end
 
+  describe "#active_databases_conninfo_hash" do
+    it "returns a list of active databases connection info" do
+      expected = [
+        {:host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'},
+        {:host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+      ]
+      File.write(@yml_file, initial_db_list.to_yaml)
+      expect(failover_databases.active_databases_conninfo_hash).to contain_exactly(*expected)
+    end
+  end
+
   describe "#active_databases" do
     it "return list of active databases saved in 'config/failover_databases.yml'" do
       File.write(@yml_file, initial_db_list.to_yaml)

--- a/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
+++ b/gems/pending/spec/postgres_ha_admin/failover_monitor_spec.rb
@@ -92,7 +92,7 @@ describe PostgresHaAdmin::FailoverMonitor do
 
   def failover_executed
     expect(linux_admin).to receive(:stop)
-    expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
+    expect(failover_db).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
     expect(failover_db).to receive(:update_failover_yml)
     expect(db_yml).to receive(:update_database_yml)
     expect(linux_admin).to receive(:restart)
@@ -100,7 +100,7 @@ describe PostgresHaAdmin::FailoverMonitor do
 
   def failover_not_executed
     expect(linux_admin).to receive(:stop)
-    expect(failover_db).to receive(:active_databases).and_return(active_databases_list)
+    expect(failover_db).to receive(:active_databases_conninfo_hash).and_return(active_databases_conninfo)
     expect(failover_db).not_to receive(:update_failover_yml)
     expect(db_yml).not_to receive(:update_database_yml)
     expect(linux_admin).not_to receive(:restart)
@@ -111,10 +111,10 @@ describe PostgresHaAdmin::FailoverMonitor do
     stub_const("PostgresHaAdmin::FailoverMonitor::FAILOVER_CHECK_FREQUENCY", 1)
   end
 
-  def active_databases_list
+  def active_databases_conninfo
     arr = []
-    arr << {:type => 'master', :active => true, :host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
-    arr << {:type => 'standby', :active => true, :host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
-    arr << {:type => 'standby', :active => true, :host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:host => '203.0.113.1', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:host => '203.0.113.2', :user => 'root', :dbname => 'vmdb_test'}
+    arr << {:host => '203.0.113.3', :user => 'root', :dbname => 'vmdb_test'}
   end
 end


### PR DESCRIPTION
Previously we were attempting to establish a PG connection using all the parameters in the server entry from failover_databases.yml

These include non-conninfo arguments such as :type and :active. This was causing us to fail to establish a connection to the standby after a failover occurred.

@yrudman @gtanzillo please review
@miq-bot add_label core, bug
@miq-bot assign @gtanzillo 