### PR TITLE
Added Provisoning button on Templates/Images list & summary screen

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1852,6 +1852,20 @@ class ApplicationController < ActionController::Base
       if typ
         prov_edit
       else
+        if %w(image_miq_request_new miq_template_miq_request_new).include?(params[:pressed])
+          # skip pre prov grid
+          set_pre_prov_vars
+          templates = find_checked_items
+          templates = [params[:id]] if templates.blank?
+
+          template = VmOrTemplate.find_by_id(from_cid(templates.first))
+          render_flash_not_applicable_to_model("provisioning") unless template.send("supports_provisioning?")
+          return if performed?
+
+          @edit[:src_vm_id] = templates.first
+          session[:edit] = @edit
+          @_params[:button] = "continue"
+        end
         vm_pre_prov
       end
     end
@@ -1859,6 +1873,7 @@ class ApplicationController < ActionController::Base
   alias_method :image_miq_request_new, :prov_redirect
   alias_method :instance_miq_request_new, :prov_redirect
   alias_method :vm_miq_request_new, :prov_redirect
+  alias_method :miq_template_miq_request_new, :prov_redirect
 
   def vm_clone
     prov_redirect("clone")

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -143,22 +143,28 @@ module ApplicationController::MiqRequestMethods
         @edit[:src_vm_id] = params[:sel_id].to_i
       end
     else                                                        # First time in, build pre-provision screen
-      @layout = "miq_request_vm"
-      @edit = {}
-      @edit[:explorer] = @explorer
-      @edit[:vm_sortdir] ||= "ASC"
-      @edit[:vm_sortcol] ||= "name"
-      @edit[:prov_type] = "VM Provision"
-      @edit[:template_kls] = get_template_kls
-      templates = Rbac.filtered(@edit[:template_kls].eligible_for_provisioning).sort_by { |a| a.name.downcase }
-      build_vm_grid(templates, @edit[:vm_sortdir], @edit[:vm_sortcol])
-      session[:changed] = false                                 # Turn off the submit button
-      @edit[:explorer] = true if @explorer
-      @in_a_form = true
+      set_pre_prov_vars
     end
   end
   alias_method :instance_pre_prov, :pre_prov
   alias_method :vm_pre_prov, :pre_prov
+
+  def set_pre_prov_vars
+    @layout = "miq_request_vm"
+    @edit = {}
+    @edit[:explorer] = @explorer
+    @edit[:vm_sortdir] ||= "ASC"
+    @edit[:vm_sortcol] ||= "name"
+    @edit[:prov_type] = "VM Provision"
+    unless %w(image_miq_request_new miq_template_miq_request_new).include?(params[:pressed])
+      @edit[:template_kls] = get_template_kls
+      templates = Rbac.filtered(@edit[:template_kls].eligible_for_provisioning).sort_by { |a| a.name.downcase }
+      build_vm_grid(templates, @edit[:vm_sortdir], @edit[:vm_sortcol])
+    end
+    session[:changed] = false                                 # Turn off the submit button
+    @edit[:explorer] = true if @explorer
+    @in_a_form = true
+  end
 
   def get_template_kls
     # when clone/migrate buttons are pressed from a sub list view,

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -161,7 +161,7 @@ module ApplicationController::MiqRequestMethods
       templates = Rbac.filtered(@edit[:template_kls].eligible_for_provisioning).sort_by { |a| a.name.downcase }
       build_vm_grid(templates, @edit[:vm_sortdir], @edit[:vm_sortcol])
     end
-    session[:changed] = false                                 # Turn off the submit button
+    session[:changed] = false # Turn off the submit button
     @edit[:explorer] = true if @explorer
     @in_a_form = true
   end

--- a/app/helpers/application_helper/button/template_provision.rb
+++ b/app/helpers/application_helper/button/template_provision.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::TemplateProvision < ApplicationHelper::Button::Basic
   def calculate_properties
     super
-      self[:title] = _("Selected item is not eligible for Provisioning") if disabled?
+    self[:title] = _("Selected item is not eligible for Provisioning") if disabled?
   end
 
   def disabled?

--- a/app/helpers/application_helper/button/template_provision.rb
+++ b/app/helpers/application_helper/button/template_provision.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::TemplateProvision < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+      self[:title] = _("Selected item is not eligible for Provisioning") if disabled?
+  end
+
+  def disabled?
+    !@record.send("supports_provisioning?")
+  end
+end

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -80,6 +80,24 @@ class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Tool
       ]
     ),
   ])
+  button_group('image_lifecycle', [
+    select(
+      :image_lifecycle_choice,
+      'pficon pficon-add-circle-o fa-lg',
+      t = N_('Lifecycle'),
+      t,
+      :items => [
+        button(
+          :image_miq_request_new,
+          'product product-clone fa-lg',
+          N_('Select a single Image to Provision Instances'),
+          N_('Provision Instances using selected Image'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1"),
+      ]
+    ),
+  ])
   button_group('image_policy', [
     select(
       :image_policy_choice,

--- a/app/helpers/application_helper/toolbar/template_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/template_clouds_center.rb
@@ -1,146 +1,149 @@
 class ApplicationHelper::Toolbar::TemplateCloudsCenter < ApplicationHelper::Toolbar::Basic
   button_group('image_vmdb', [
-    select(
-      :image_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :enabled => false,
-      :onwhen  => "1+",
-      :items   => [
-        button(
-          :image_refresh,
-          'fa fa-refresh fa-lg',
-          N_('Refresh relationships and power states for all items related to the selected items'),
-          N_('Refresh Relationships and Power States'),
-          :url_parms => "main_div",
-          :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :image_scan,
-          'fa fa-search fa-lg',
-          N_('Perform SmartState Analysis on the selected items'),
-          N_('Perform SmartState Analysis'),
-          :url_parms => "main_div",
-          :confirm   => N_("Perform SmartState Analysis on the selected items?"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :image_compare,
-          'product product-compare fa-lg',
-          N_('Select two or more items to compare'),
-          N_('Compare Selected items'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "2+"),
-        separator,
-        button(
-          :image_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single item to edit'),
-          N_('Edit Selected item'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1"),
-        button(
-          :image_ownership,
-          'pficon pficon-user fa-lg',
-          N_('Set Ownership for the selected items'),
-          N_('Set Ownership'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :image_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove selected items'),
-          t,
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-        separator,
-        button(
-          :image_right_size,
-          'product product-custom-6 fa-lg',
-          N_('CPU/Memory Recommendations of selected item'),
-          N_('Right-Size Recommendations'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1"),
-        button(
-          :image_reconfigure,
-          'pficon pficon-edit fa-lg',
-          N_('Reconfigure the Memory/CPUs of selected items'),
-          N_('Reconfigure Selected items'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+                 select(
+                   :image_vmdb_choice,
+                   'fa fa-cog fa-lg',
+                   t = N_('Configuration'),
+                   t,
+                   :enabled => false,
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :image_refresh,
+                       'fa fa-refresh fa-lg',
+                       N_('Refresh relationships and power states for all items related to the selected items'),
+                       N_('Refresh Relationships and Power States'),
+                       :url_parms => "main_div",
+                       # rubocop:disable LineLength
+                       :confirm   => N_("Refresh relationships and power states for all items related to the selected items?"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :image_scan,
+                       'fa fa-search fa-lg',
+                       N_('Perform SmartState Analysis on the selected items'),
+                       N_('Perform SmartState Analysis'),
+                       :url_parms => "main_div",
+                       :confirm   => N_("Perform SmartState Analysis on the selected items?"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :image_compare,
+                       'product product-compare fa-lg',
+                       N_('Select two or more items to compare'),
+                       N_('Compare Selected items'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "2+"),
+                     separator,
+                     button(
+                       :image_edit,
+                       'pficon pficon-edit fa-lg',
+                       N_('Select a single item to edit'),
+                       N_('Edit Selected item'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1"),
+                     button(
+                       :image_ownership,
+                       'pficon pficon-user fa-lg',
+                       N_('Set Ownership for the selected items'),
+                       N_('Set Ownership'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :image_delete,
+                       'pficon pficon-delete fa-lg',
+                       t = N_('Remove selected items'),
+                       t,
+                       :url_parms => "main_div",
+                       # rubocop:disable LineLength
+                       :confirm   => N_("Warning: The selected items and ALL of their components will be permanently removed!"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     separator,
+                     button(
+                       :image_right_size,
+                       'product product-custom-6 fa-lg',
+                       N_('CPU/Memory Recommendations of selected item'),
+                       N_('Right-Size Recommendations'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1"),
+                     button(
+                       :image_reconfigure,
+                       'pficon pficon-edit fa-lg',
+                       N_('Reconfigure the Memory/CPUs of selected items'),
+                       N_('Reconfigure Selected items'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                   ]
+                 ),
+               ])
   button_group('image_lifecycle', [
-    select(
-      :image_lifecycle_choice,
-      'pficon pficon-add-circle-o fa-lg',
-      t = N_('Lifecycle'),
-      t,
-      :items => [
-        button(
-          :image_miq_request_new,
-          'product product-clone fa-lg',
-          N_('Select a single Image to Provision Instances'),
-          N_('Provision Instances using selected Image'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1"),
-      ]
-    ),
-  ])
+                 select(
+                   :image_lifecycle_choice,
+                   'pficon pficon-add-circle-o fa-lg',
+                   t = N_('Lifecycle'),
+                   t,
+                   :items => [
+                     button(
+                       :image_miq_request_new,
+                       'product product-clone fa-lg',
+                       N_('Select a single Image to Provision Instances'),
+                       N_('Provision Instances using selected Image'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1"),
+                   ]
+                 ),
+               ])
   button_group('image_policy', [
-    select(
-      :image_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :enabled => false,
-      :onwhen  => "1+",
-      :items   => [
-        button(
-          :image_protect,
-          'pficon pficon-edit fa-lg',
-          N_('Manage Policies for the selected items'),
-          N_('Manage Policies'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :image_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected items'),
-          N_('Policy Simulation'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :image_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit tags for the selected items'),
-          N_('Edit Tags'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :image_check_compliance,
-          'fa fa-search fa-lg',
-          N_('Check Compliance of the last known configuration for the selected items'),
-          N_('Check Compliance of Last Known Configuration'),
-          :url_parms => "main_div",
-          :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+                 select(
+                   :image_policy_choice,
+                   'fa fa-shield fa-lg',
+                   t = N_('Policy'),
+                   t,
+                   :enabled => false,
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :image_protect,
+                       'pficon pficon-edit fa-lg',
+                       N_('Manage Policies for the selected items'),
+                       N_('Manage Policies'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :image_policy_sim,
+                       'fa fa-play-circle-o fa-lg',
+                       N_('View Policy Simulation for the selected items'),
+                       N_('Policy Simulation'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :image_tag,
+                       'pficon pficon-edit fa-lg',
+                       N_('Edit tags for the selected items'),
+                       N_('Edit Tags'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :image_check_compliance,
+                       'fa fa-search fa-lg',
+                       N_('Check Compliance of the last known configuration for the selected items'),
+                       N_('Check Compliance of Last Known Configuration'),
+                       :url_parms => "main_div",
+                       # rubocop:disable LineLength
+                       :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected items?"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                   ]
+                 ),
+               ])
 end

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -116,6 +116,14 @@ class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Tool
       t,
       :items => [
         button(
+          :miq_template_miq_request_new,
+          'pficon pficon-add-circle-o fa-lg',
+          N_('Select a single Template to Provision VMs'),
+          N_('Provision VMs using selected Template'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1"),
+        button(
           :miq_template_clone,
           'product product-clone fa-lg',
           N_('Clone this Template'),

--- a/app/helpers/application_helper/toolbar/template_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/template_infras_center.rb
@@ -1,137 +1,137 @@
 class ApplicationHelper::Toolbar::TemplateInfrasCenter < ApplicationHelper::Toolbar::Basic
   button_group('miq_template_vmdb', [
-    select(
-      :miq_template_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :enabled => false,
-      :onwhen  => "1+",
-      :items   => [
-        button(
-          :miq_template_refresh,
-          'fa fa-refresh fa-lg',
-          N_('Refresh relationships and power states for all items related to the selected Templates'),
-          N_('Refresh Relationships and Power States'),
-          :url_parms => "main_div",
-          :confirm   => N_("Refresh relationships and power states for all items related to the selected Templates?"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :miq_template_scan,
-          'fa fa-search fa-lg',
-          N_('Perform SmartState Analysis on the selected Templates'),
-          N_('Perform SmartState Analysis'),
-          :url_parms => "main_div",
-          :confirm   => N_("Perform SmartState Analysis on the selected Templates?"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :miq_template_compare,
-          'product product-compare fa-lg',
-          N_('Select two or more Templates to compare'),
-          N_('Compare Selected Templates'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "2+"),
-        separator,
-        button(
-          :miq_template_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Template to edit'),
-          N_('Edit Selected Template'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1"),
-        button(
-          :miq_template_ownership,
-          'pficon pficon-user fa-lg',
-          N_('Set Ownership for the selected Templates'),
-          N_('Set Ownership'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :miq_template_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Templates'),
-          N_('Remove Templates'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed!"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+                 select(
+                   :miq_template_vmdb_choice,
+                   'fa fa-cog fa-lg',
+                   t = N_('Configuration'),
+                   t,
+                   :enabled => false,
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :miq_template_refresh,
+                       'fa fa-refresh fa-lg',
+                       N_('Refresh relationships and power states for all items related to the selected Templates'),
+                       N_('Refresh Relationships and Power States'),
+                       :url_parms => "main_div",
+                       :confirm   => N_("Refresh relationships and power states for all items related to the selected Templates?"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :miq_template_scan,
+                       'fa fa-search fa-lg',
+                       N_('Perform SmartState Analysis on the selected Templates'),
+                       N_('Perform SmartState Analysis'),
+                       :url_parms => "main_div",
+                       :confirm   => N_("Perform SmartState Analysis on the selected Templates?"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :miq_template_compare,
+                       'product product-compare fa-lg',
+                       N_('Select two or more Templates to compare'),
+                       N_('Compare Selected Templates'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "2+"),
+                     separator,
+                     button(
+                       :miq_template_edit,
+                       'pficon pficon-edit fa-lg',
+                       N_('Select a single Template to edit'),
+                       N_('Edit Selected Template'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1"),
+                     button(
+                       :miq_template_ownership,
+                       'pficon pficon-user fa-lg',
+                       N_('Set Ownership for the selected Templates'),
+                       N_('Set Ownership'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :miq_template_delete,
+                       'pficon pficon-delete fa-lg',
+                       N_('Remove selected Templates'),
+                       N_('Remove Templates'),
+                       :url_parms => "main_div",
+                       :confirm   => N_("Warning: The selected Templates and ALL of their components will be permanently removed!"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                   ]
+                 ),
+               ])
   button_group('miq_template_policy', [
-    select(
-      :miq_template_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :enabled => false,
-      :onwhen  => "1+",
-      :items   => [
-        button(
-          :miq_template_protect,
-          'pficon pficon-edit fa-lg',
-          N_('Manage Policies for the selected Templates'),
-          N_('Manage Policies'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :miq_template_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for the selected Templates'),
-          N_('Policy Simulation'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :miq_template_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit tags for the selected Templates'),
-          N_('Edit Tags'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1+"),
-        button(
-          :miq_template_check_compliance,
-          'fa fa-search fa-lg',
-          N_('Check Compliance of the last known configuration for the selected Templates'),
-          N_('Check Compliance of Last Known Configuration'),
-          :url_parms => "main_div",
-          :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected Templates?"),
-          :enabled   => false,
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
+                 select(
+                   :miq_template_policy_choice,
+                   'fa fa-shield fa-lg',
+                   t = N_('Policy'),
+                   t,
+                   :enabled => false,
+                   :onwhen  => "1+",
+                   :items   => [
+                     button(
+                       :miq_template_protect,
+                       'pficon pficon-edit fa-lg',
+                       N_('Manage Policies for the selected Templates'),
+                       N_('Manage Policies'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :miq_template_policy_sim,
+                       'fa fa-play-circle-o fa-lg',
+                       N_('View Policy Simulation for the selected Templates'),
+                       N_('Policy Simulation'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :miq_template_tag,
+                       'pficon pficon-edit fa-lg',
+                       N_('Edit tags for the selected Templates'),
+                       N_('Edit Tags'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                     button(
+                       :miq_template_check_compliance,
+                       'fa fa-search fa-lg',
+                       N_('Check Compliance of the last known configuration for the selected Templates'),
+                       N_('Check Compliance of Last Known Configuration'),
+                       :url_parms => "main_div",
+                       :confirm   => N_("Initiate Check Compliance of the last known configuration for the selected Templates?"),
+                       :enabled   => false,
+                       :onwhen    => "1+"),
+                   ]
+                 ),
+               ])
   button_group('miq_template_lifecycle', [
-    select(
-      :miq_template_lifecycle_choice,
-      'fa fa-recycle fa-lg',
-      t = N_('Lifecycle'),
-      t,
-      :items => [
-        button(
-          :miq_template_miq_request_new,
-          'pficon pficon-add-circle-o fa-lg',
-          N_('Select a single Template to Provision VMs'),
-          N_('Provision VMs using selected Template'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1"),
-        button(
-          :miq_template_clone,
-          'product product-clone fa-lg',
-          N_('Clone this Template'),
-          N_('Clone selected Template'),
-          :url_parms => "main_div",
-          :enabled   => false,
-          :onwhen    => "1"),
-      ]
-    ),
-  ])
+                 select(
+                   :miq_template_lifecycle_choice,
+                   'fa fa-recycle fa-lg',
+                   t = N_('Lifecycle'),
+                   t,
+                   :items => [
+                     button(
+                       :miq_template_miq_request_new,
+                       'pficon pficon-add-circle-o fa-lg',
+                       N_('Select a single Template to Provision VMs'),
+                       N_('Provision VMs using selected Template'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1"),
+                     button(
+                       :miq_template_clone,
+                       'product product-clone fa-lg',
+                       N_('Clone this Template'),
+                       N_('Clone selected Template'),
+                       :url_parms => "main_div",
+                       :enabled   => false,
+                       :onwhen    => "1"),
+                   ]
+                 ),
+               ])
 end

--- a/app/helpers/application_helper/toolbar/x_miq_template_center.rb
+++ b/app/helpers/application_helper/toolbar/x_miq_template_center.rb
@@ -78,6 +78,12 @@ class ApplicationHelper::Toolbar::XMiqTemplateCenter < ApplicationHelper::Toolba
       t,
       :items => [
         button(
+          :miq_template_miq_request_new,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Provision VMs using this Template'),
+          t,
+          :klass => ApplicationHelper::Button::TemplateProvision),
+        button(
           :miq_template_clone,
           'product product-clone fa-lg',
           t = N_('Clone this Template'),

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -50,6 +50,22 @@ class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Tool
       ]
     ),
   ])
+  button_group('image_lifecycle', [
+    select(
+      :image_lifecycle_choice,
+      'fa fa-recycle fa-lg',
+      t = N_('Lifecycle'),
+      t,
+      :items => [
+        button(
+          :image_miq_request_new,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Provision Instances using this Image'),
+          t,
+          :klass => ApplicationHelper::Button::TemplateProvision)
+      ]
+    ),
+  ])
   button_group('image_policy', [
     select(
       :image_policy_choice,

--- a/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_template_cloud_center.rb
@@ -1,100 +1,100 @@
 class ApplicationHelper::Toolbar::XTemplateCloudCenter < ApplicationHelper::Toolbar::Basic
   button_group('image_vmdb', [
-    select(
-      :image_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :image_refresh,
-          'fa fa-refresh fa-lg',
-          N_('Refresh relationships and power states for all items related to this Image'),
-          N_('Refresh Relationships and Power States'),
-          :confirm => N_("Refresh relationships and power states for all items related to this Image?")),
-        button(
-          :image_scan,
-          'fa fa-search fa-lg',
-          N_('Perform SmartState Analysis on this Image'),
-          N_('Perform SmartState Analysis'),
-          :confirm => N_("Perform SmartState Analysis on this Image?")),
-        separator,
-        button(
-          :image_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Image'),
-          t),
-        button(
-          :image_ownership,
-          'pficon pficon-user fa-lg',
-          N_('Set Ownership for this Image'),
-          N_('Set Ownership')),
-        button(
-          :image_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove this Image'),
-          N_('Remove Image'),
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Image and ALL of its components will be permanently removed!")),
-        separator,
-        button(
-          :image_right_size,
-          'product product-custom-6 fa-lg',
-          N_('CPU/Memory Recommendations of this Image'),
-          N_('Right-Size Recommendations')),
-        button(
-          :image_reconfigure,
-          'pficon pficon-edit fa-lg',
-          N_('Reconfigure the Memory/CPU of this Image'),
-          N_('Reconfigure this Image')),
-      ]
-    ),
-  ])
+                 select(
+                   :image_vmdb_choice,
+                   'fa fa-cog fa-lg',
+                   t = N_('Configuration'),
+                   t,
+                   :items => [
+                     button(
+                       :image_refresh,
+                       'fa fa-refresh fa-lg',
+                       N_('Refresh relationships and power states for all items related to this Image'),
+                       N_('Refresh Relationships and Power States'),
+                       :confirm => N_("Refresh relationships and power states for all items related to this Image?")),
+                     button(
+                       :image_scan,
+                       'fa fa-search fa-lg',
+                       N_('Perform SmartState Analysis on this Image'),
+                       N_('Perform SmartState Analysis'),
+                       :confirm => N_("Perform SmartState Analysis on this Image?")),
+                     separator,
+                     button(
+                       :image_edit,
+                       'pficon pficon-edit fa-lg',
+                       t = N_('Edit this Image'),
+                       t),
+                     button(
+                       :image_ownership,
+                       'pficon pficon-user fa-lg',
+                       N_('Set Ownership for this Image'),
+                       N_('Set Ownership')),
+                     button(
+                       :image_delete,
+                       'pficon pficon-delete fa-lg',
+                       N_('Remove this Image'),
+                       N_('Remove Image'),
+                       :url_parms => "&refresh=y",
+                       :confirm   => N_("Warning: This Image and ALL of its components will be permanently removed!")),
+                     separator,
+                     button(
+                       :image_right_size,
+                       'product product-custom-6 fa-lg',
+                       N_('CPU/Memory Recommendations of this Image'),
+                       N_('Right-Size Recommendations')),
+                     button(
+                       :image_reconfigure,
+                       'pficon pficon-edit fa-lg',
+                       N_('Reconfigure the Memory/CPU of this Image'),
+                       N_('Reconfigure this Image')),
+                   ]
+                 ),
+               ])
   button_group('image_lifecycle', [
-    select(
-      :image_lifecycle_choice,
-      'fa fa-recycle fa-lg',
-      t = N_('Lifecycle'),
-      t,
-      :items => [
-        button(
-          :image_miq_request_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Provision Instances using this Image'),
-          t,
-          :klass => ApplicationHelper::Button::TemplateProvision)
-      ]
-    ),
-  ])
+                 select(
+                   :image_lifecycle_choice,
+                   'fa fa-recycle fa-lg',
+                   t = N_('Lifecycle'),
+                   t,
+                   :items => [
+                     button(
+                       :image_miq_request_new,
+                       'pficon pficon-add-circle-o fa-lg',
+                       t = N_('Provision Instances using this Image'),
+                       t,
+                       :klass => ApplicationHelper::Button::TemplateProvision)
+                   ]
+                 ),
+               ])
   button_group('image_policy', [
-    select(
-      :image_policy_choice,
-      'fa fa-shield fa-lg',
-      t = N_('Policy'),
-      t,
-      :items => [
-        button(
-          :image_protect,
-          'pficon pficon-edit fa-lg',
-          N_('Manage Policies for this Image'),
-          N_('Manage Policies')),
-        button(
-          :image_policy_sim,
-          'fa fa-play-circle-o fa-lg',
-          N_('View Policy Simulation for this Image'),
-          N_('Policy Simulation')),
-        button(
-          :image_tag,
-          'pficon pficon-edit fa-lg',
-          N_('Edit Tags for this Image'),
-          N_('Edit Tags')),
-        button(
-          :image_check_compliance,
-          'fa fa-search fa-lg',
-          N_('Check Compliance of the last known configuration for this Image'),
-          N_('Check Compliance of Last Known Configuration'),
-          :confirm => N_("Initiate Check Compliance of the last known configuration for this Image?")),
-      ]
-    ),
-  ])
+                 select(
+                   :image_policy_choice,
+                   'fa fa-shield fa-lg',
+                   t = N_('Policy'),
+                   t,
+                   :items => [
+                     button(
+                       :image_protect,
+                       'pficon pficon-edit fa-lg',
+                       N_('Manage Policies for this Image'),
+                       N_('Manage Policies')),
+                     button(
+                       :image_policy_sim,
+                       'fa fa-play-circle-o fa-lg',
+                       N_('View Policy Simulation for this Image'),
+                       N_('Policy Simulation')),
+                     button(
+                       :image_tag,
+                       'pficon pficon-edit fa-lg',
+                       N_('Edit Tags for this Image'),
+                       N_('Edit Tags')),
+                     button(
+                       :image_check_compliance,
+                       'fa fa-search fa-lg',
+                       N_('Check Compliance of the last known configuration for this Image'),
+                       N_('Check Compliance of Last Known Configuration'),
+                       :confirm => N_("Initiate Check Compliance of the last known configuration for this Image?")),
+                   ]
+                 ),
+               ])
 end

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -32,6 +32,6 @@ class MiqTemplate < VmOrTemplate
   def active?; false; end
 
   def supports_provisioning?
-    !ems_id.nil?
+    !ems_id.nil? && ExtManagementSystem.where(:id => ems_id).exists?
   end
 end

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -30,4 +30,8 @@ class MiqTemplate < VmOrTemplate
   end
 
   def active?; false; end
+
+  def supports_provisioning?
+    !ems_id.nil?
+  end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1884,6 +1884,10 @@ class VmOrTemplate < ApplicationRecord
     false
   end
 
+  def supports_provisioning?
+    true
+  end
+
   def self.batch_operation_supported?(operation, ids)
     VmOrTemplate.where(:id => ids).all? do |vm_or_template|
       if vm_or_template.respond_to?("supports_#{operation}?")

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4803,6 +4803,10 @@
         :description: Edit EVM Server Relationship
         :feature_type: admin
         :identifier: image_evm_relationship
+      - :name: Provision Instances from Images
+        :description: Request to Provision Instances from Images
+        :feature_type: admin
+        :identifier: image_miq_request_new
   # Virtual Machines access rules
   - :name: VM Access Rules
     :description: Access Rules for Virtual Machines
@@ -5083,6 +5087,10 @@
       :feature_type: admin
       :identifier: miq_template_admin
       :children:
+      - :name: Provision VMs
+        :description: Request to Provision VMs
+        :feature_type: admin
+        :identifier: miq_template_miq_request_new
       - :name: Clone Templates
         :description: Clone Templates
         :feature_type: admin

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -178,7 +178,10 @@ describe ApplicationController do
     end
 
     it "returns flash message when Provisioning button is pressed from list and selected Image is archived" do
-      template = FactoryGirl.create(:miq_template, :name => "template 1", :vendor => "vmware", :location => "template1.vmtx")
+      template = FactoryGirl.create(:miq_template,
+                                    :name     => "template 1",
+                                    :vendor   => "vmware",
+                                    :location => "template1.vmtx")
       controller.instance_variable_set(:@_params,
                                        :pressed         => "image_miq_request_new",
                                        :miq_grid_checks => template.id.to_s)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -169,6 +169,49 @@ describe ApplicationController do
     end
   end
 
+  context "#prov_redirect" do
+    before do
+      login_as FactoryGirl.create(:user, :features => "image_miq_request_new")
+      allow(User).to receive(:server_timezone).and_return("UTC")
+      controller.request.parameters[:pressed] = "image_miq_request_new"
+      controller.instance_variable_set(:@explorer, true)
+    end
+
+    it "returns flash message when Provisioning button is pressed from list and selected Image is archived" do
+      template = FactoryGirl.create(:miq_template, :name => "template 1", :vendor => "vmware", :location => "template1.vmtx")
+      controller.instance_variable_set(:@_params,
+                                       :pressed         => "image_miq_request_new",
+                                       :miq_grid_checks => template.id.to_s)
+      controller.set_response!(response)
+      expect(controller).not_to receive(:vm_pre_prov)
+      controller.send(:prov_redirect)
+      expect(assigns(:flash_array).first[:message]).to include("does not apply to at least one of the selected")
+    end
+
+    let(:ems)     { FactoryGirl.create(:ext_management_system) }
+    let(:storage) { FactoryGirl.create(:storage) }
+
+    it "sets provisioning data and skips pre provisioning dialog" do
+      template = FactoryGirl.create(:miq_template,
+                                    :name                  => "template 1",
+                                    :vendor                => "vmware",
+                                    :location              => "template1.vmtx",
+                                    :ext_management_system => ems)
+      controller.instance_variable_set(:@_params,
+                                       :pressed         => "image_miq_request_new",
+                                       :miq_grid_checks => template.id.to_s)
+      controller.instance_variable_set(:@breadcrumbs, [])
+      controller.instance_variable_set(:@sb, {})
+      controller.set_response!(response)
+      expect(controller).to receive(:vm_pre_prov)
+      expect(controller).not_to receive(:build_vm_grid)
+      allow(controller).to receive(:replace_right_cell)
+      controller.send(:prov_redirect)
+      expect(controller.send(:flash_errors?)).to be_falsey
+      expect(assigns(:org_controller)).to eq("vm")
+    end
+  end
+
   context "#determine_record_id_for_presenter" do
     context "when in a form" do
       before do


### PR DESCRIPTION
- Added changes to be able to Select a single Template or Image from respective list view and start Provisioning. This will skip the Pre-Provisioning grid where user selects a template to be used for provisioning and instead will use the one that is selected from the list view.
- Provisioning can also be initiated from a single Temple or Image summary screen, this will skip pro provisioning template selection screen and present user with Provisioning dialogs.
- Added checks and model support to make Provisioning task available for Templates/Images that are not archived or orphaned.
- Added spec tests to support changes in prov_redirect method

https://bugzilla.redhat.com/show_bug.cgi?id=1344079
https://bugzilla.redhat.com/show_bug.cgi?id=1347278


Screenshots showing Provisioning button on Template list & summary screens, same changes can be found on Images list & Summary screen on cloud side.

![templates_shot1](https://cloud.githubusercontent.com/assets/3450808/17752165/9ff9d1c8-6498-11e6-9daf-8060ddd0e53e.png)

![template_prov_shot2](https://cloud.githubusercontent.com/assets/3450808/17752172/a58b8f6e-6498-11e6-83c6-0c8515bcb7e2.png)

![template_prov_shot3](https://cloud.githubusercontent.com/assets/3450808/17752175/a994bf68-6498-11e6-8db5-89fb98de4ae5.png)

![templates_prov_shot4](https://cloud.githubusercontent.com/assets/3450808/17752177/acddf932-6498-11e6-84be-58c76458b19d.png)

![templates_prov_shot5](https://cloud.githubusercontent.com/assets/3450808/17752183/afb7f522-6498-11e6-80c0-e8addaf6b878.png)
