### PR TITLE
Remove unused and broken _oauth_button_angular.html.haml

### DIFF
--- a/app/views/layouts/angular/_oauth_button_angular.html.haml
+++ b/app/views/layouts/angular/_oauth_button_angular.html.haml
@@ -1,6 +1,0 @@
-%div{'ng-show' => ng_show}
-  %a.btn.btn-primar.btn-s{:href   => "/auth/#{auth_url}",
-                          :target => "_blank",
-                          :type   => "button"}
-    #{title}
-  %br


### PR DESCRIPTION
The partial doesn't seem to be used, and given the classes on the button (`btn-primar` is not *primary*, and `btn-s` ..is anyone's guess; also `#{title}`) it was probably never used, removing.

(Originally introduced in https://github.com/ManageIQ/manageiq/pull/4521)