### PR TITLE
Extract OO controllers for primary collections in the API

### DIFF
--- a/app/controllers/manageiq/api/auth_controller.rb
+++ b/app/controllers/manageiq/api/auth_controller.rb
@@ -1,0 +1,32 @@
+module ManageIQ
+  module API
+    class AuthController < BaseController
+      def show
+        requester_type = fetch_and_validate_requester_type
+        auth_token = Environment.user_token_service.generate_token(@auth_user, requester_type)
+        res = {
+          :auth_token => auth_token,
+          :token_ttl  => api_token_mgr.token_get_info(@module, auth_token, :token_ttl),
+          :expires_on => api_token_mgr.token_get_info(@module, auth_token, :expires_on)
+        }
+        render_resource :auth, res
+      end
+
+      def destroy
+        api_token_mgr.invalidate_token(@module, @auth_token)
+
+        render_normal_destroy
+      end
+
+      private
+
+      def fetch_and_validate_requester_type
+        requester_type = params['requester_type']
+        Environment.user_token_service.validate_requester_type(requester_type)
+        requester_type
+      rescue => err
+        raise BadRequestError, err.to_s
+      end
+    end
+  end
+end

--- a/app/controllers/manageiq/api/base_controller/authentication.rb
+++ b/app/controllers/manageiq/api/base_controller/authentication.rb
@@ -3,27 +3,6 @@ module ManageIQ
     class BaseController
       module Authentication
         #
-        # Action Methods
-        #
-
-        def show_auth
-          requester_type = fetch_and_validate_requester_type
-          auth_token = Environment.user_token_service.generate_token(@auth_user, requester_type)
-          res = {
-            :auth_token => auth_token,
-            :token_ttl  => api_token_mgr.token_get_info(@module, auth_token, :token_ttl),
-            :expires_on => api_token_mgr.token_get_info(@module, auth_token, :expires_on)
-          }
-          render_resource :auth, res
-        end
-
-        def destroy_auth
-          api_token_mgr.invalidate_token(@module, @auth_token)
-
-          render_normal_destroy
-        end
-
-        #
         # REST APIs Authenticator and Redirector
         #
         def require_api_user_or_token
@@ -113,14 +92,6 @@ module ManageIQ
           if missing_feature
             raise AuthenticationError, "Invalid User #{user_obj.userid} specified, User's #{missing_feature} is missing"
           end
-        end
-
-        def fetch_and_validate_requester_type
-          requester_type = params['requester_type']
-          Environment.user_token_service.validate_requester_type(requester_type)
-          requester_type
-        rescue => err
-          raise BadRequestError, err.to_s
         end
 
         private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2739,6 +2739,10 @@ Vmdb::Application.routes.draw do
     "manage_i_q/a_p_i/base##{API_ACTIONS[verb]}"
   end
 
+  def action_for_collection(collection_name, verb)
+    "manage_i_q/a_p_i/#{collection_name}##{API_ACTIONS[verb]}"
+  end
+
   def create_api_route(verb, url, action)
     public_send(verb, url, :to => action, :format => "json", :version => API_VERSION_REGEX)
   end
@@ -2746,7 +2750,7 @@ Vmdb::Application.routes.draw do
   ManageIQ::API::Settings.collections.each do |collection_name, collection|
     collection.verbs.each do |verb|
       if collection.options.include?(:primary)
-        create_api_route(verb, "/api(/:version)/#{collection_name}", action_for(verb))
+        create_api_route(verb, "/api(/:version)/#{collection_name}", action_for_collection(collection_name, verb))
       end
 
       next unless collection.options.include?(:collection)


### PR DESCRIPTION
Purpose or Intent
-----------------

As it turns out this is just the "auth" resource.

Pulls out a controller for the auth resource so the routing will point
to it instead of the base controller. Implements its actions with the
methods "show" and "destroy", overriding the default implementation
which is only there to find this path for us at request time.