### PR TITLE
Removed redundant code called in tree_autoload_dynatree

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -197,13 +197,6 @@ module ApplicationController::Explorer
     TreeNodeBuilder.build_id(object, nil, options)
   end
 
-  # Add the children of a node that is being expanded (autoloaded), called by generic tree_autoload method
-  def tree_add_child_nodes(id)
-    TreeBuilder.tree_add_child_nodes(@sb,
-                                     x_tree[:klass_name],
-                                     id)
-  end
-
   # FIXME: move partly to Tree once Trees are made from TreeBuilder
   def valid_active_node(treenodeid)
     modelname, rec_id, nodetype = TreeBuilder.extract_node_model_and_id(treenodeid)

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -32,11 +32,13 @@ module ApplicationController::TreeSupport
   end
 
   def tree_autoload_dynatree
-    @edit ||= session[:edit]  # Remember any previous @edit
-    klass_name = x_tree[:klass_name] if x_active_tree
-    nodes = klass_name ? TreeBuilder.tree_add_child_nodes(@sb, klass_name, params[:id]) :
-        tree_add_child_nodes(params[:id])
+    @edit ||= session[:edit] # Remember any previous @edit
+    nodes = tree_add_child_nodes(params[:id])
     render :json => nodes
+  end
+
+  def tree_add_child_nodes(id)
+    TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], id)
   end
 
   def tree_autoload_quads

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -89,11 +89,6 @@ module VmShowMixin
     end
   end
 
-  # Add the children of a node that is being expanded (autoloaded), called by generic tree_autoload method
-  def tree_add_child_nodes(id)
-    TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], id)
-  end
-
   def show_record(id = nil)
     @display = params[:display] || "main" unless control_selected?
 


### PR DESCRIPTION
`y ? f(x,y,z) : f(x,y,z)` is equivalent with `f(x,y,z)` so :scissors: :scissors: 