### PR TITLE
refactor validates_timeline to supports :timeline

### DIFF
--- a/app/helpers/application_helper/button/ems_timeline.rb
+++ b/app/helpers/application_helper/button/ems_timeline.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::EmsTimeline < ApplicationHelper::Button::Basic
   def visible?
-    @record.is_available?(:timeline)
+    @record.supports_timeline?
   end
 
   def disabled?

--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -1,4 +1,5 @@
 class AvailabilityZone < ApplicationRecord
+  include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include Metric::CiMixin
   include EventMixin

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,4 +1,5 @@
 class Container < ApplicationRecord
+  include SupportsFeatureMixin
   include NewWithTypeStiMixin
 
   has_one    :container_group, :through => :container_definition

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -1,4 +1,5 @@
 class ContainerGroup < ApplicationRecord
+  include SupportsFeatureMixin
   include ComplianceMixin
   include CustomAttributeMixin
   include MiqPolicyMixin

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -1,4 +1,5 @@
 class ContainerNode < ApplicationRecord
+  include SupportsFeatureMixin
   include ComplianceMixin
   include MiqPolicyMixin
   include NewWithTypeStiMixin

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -1,4 +1,5 @@
 class ContainerProject < ApplicationRecord
+  include SupportsFeatureMixin
   include CustomAttributeMixin
   include VirtualTotalMixin
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -1,4 +1,5 @@
 class ContainerReplicator < ApplicationRecord
+  include SupportsFeatureMixin
   include ComplianceMixin
   include CustomAttributeMixin
   include MiqPolicyMixin

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -1,4 +1,5 @@
 class EmsCluster < ApplicationRecord
+  include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include_concern 'CapacityPlanning'
   include EventMixin

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -7,6 +7,7 @@ require 'metadata/linux/LinuxUtils'
 require 'metadata/ScanProfile/HostScanProfiles'
 
 class Host < ApplicationRecord
+  include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include VirtualTotalMixin
   include TenantIdentityMixin

--- a/app/models/host_aggregate.rb
+++ b/app/models/host_aggregate.rb
@@ -1,4 +1,5 @@
 class HostAggregate < ApplicationRecord
+  include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include Metric::CiMixin
   include EventMixin

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -48,10 +48,6 @@ module ManageIQ::Providers
       MiqSystem.open_browser(browser_url)
     end
 
-    def validate_timeline
-      {:available => true, :message => nil}
-    end
-
     def validate_authentication_status
       {:available => true, :message => nil}
     end

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -119,10 +119,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raw_resize_revert
   end
 
-  def validate_timeline
-    {:available => true, :message => nil}
-  end
-
   def disconnect_ems(e = nil)
     self.availability_zone = nil if e.nil? || ext_management_system == e
     super

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -44,10 +44,6 @@ module ManageIQ::Providers
       "ManageIQ_Providers_ContainerManager"
     end
 
-    def validate_timeline
-      {:available => true, :message => nil}
-    end
-
     def validate_performance
       {:available => true, :message => nil}
     end

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -44,10 +44,6 @@ module ManageIQ::Providers
       [read_timeout, open_timeout]
     end
 
-    def validate_timeline
-      {:available => true, :message => nil}
-    end
-
     def validate_authentication_status
       {:available => true, :message => nil}
     end

--- a/app/models/mixins/event_mixin.rb
+++ b/app/models/mixins/event_mixin.rb
@@ -1,5 +1,11 @@
 # EventMixin expects that event_where_clause is defined in the model.
 module EventMixin
+  extend ActiveSupport::Concern
+
+  included do
+    supports :timeline
+  end
+
   def first_event(assoc = :ems_events)
     event = find_one_event(assoc, "timestamp ASC")
     event.nil? ? nil : event.timestamp

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -83,6 +83,7 @@ module SupportsFeatureMixin
     :provisioning               => 'Provisioning',
     :reboot_guest               => 'Reboot Guest Operation',
     :reconfigure                => 'Reconfiguration',
+    :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',
     :refresh_new_target         => 'Refresh non-existing record',
     :regions                    => 'Regions of a Provider',
     :remove_host                => 'Remove Host',
@@ -93,8 +94,8 @@ module SupportsFeatureMixin
     :snapshots                  => 'Snapshots',
     :shutdown_guest             => 'Shutdown Guest Operation',
     :terminate                  => 'Terminate a VM',
+    :timeline                   => 'Query for events',
     :update_aggregate           => 'Host Aggregate Update',
-    :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',
     :update                     => 'Update',
     :update_network_router      => 'Network Router Update',
   }.freeze

--- a/spec/helpers/application_helper/buttons/ems_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/ems_timeline_spec.rb
@@ -3,7 +3,7 @@ describe ApplicationHelper::Button::EmsTimeline do
     it "when the timeline action is available then the button is not disabled" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :has_events? => true)}, {}
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_timeline? => true, :has_events? => true)}, {}
       )
       expect(button.disabled?).to be false
     end
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::EmsTimeline do
     it "when the timeline action is unavailable then the button is disabled" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false, :has_events? => false)}, {}
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_timeline? => false, :has_events? => false)}, {}
       )
       expect(button.disabled?).to be true
     end
@@ -21,7 +21,7 @@ describe ApplicationHelper::Button::EmsTimeline do
     it "when the timeline action is unavailable the button has the error in the title" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => false, :has_events? => false)}, {}
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_timeline? => false, :has_events? => false)}, {}
       )
       button.calculate_properties
       expect(button[:title]).to eq("No Timeline data has been collected for this Provider")
@@ -30,7 +30,7 @@ describe ApplicationHelper::Button::EmsTimeline do
     it "when the timeline is available, the button has no error in the title" do
       view_context = setup_view_context_with_sandbox({})
       button = described_class.new(
-        view_context, {}, {"record" => object_double(VmCloud.new, :is_available? => true, :has_events? => true)}, {}
+        view_context, {}, {"record" => object_double(VmCloud.new, :supports_timeline? => true, :has_events? => true)}, {}
       )
       button.calculate_properties
       expect(button[:title]).to be nil

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -2,6 +2,7 @@ describe EventMixin do
   context "Included in a test class with events" do
     let(:test_class) do
       Class.new do
+        include SupportsFeatureMixin
         include EventMixin
 
         def event_where_clause(assoc)
@@ -42,6 +43,7 @@ describe EventMixin do
   context "Included in a test class with no events" do
     let(:test_class) do
       Class.new do
+        include SupportsFeatureMixin
         include EventMixin
 
         def event_where_clause(assoc)


### PR DESCRIPTION
From a UI perspective, every model, that includes `EventMixin` should basically support a timeline, because all methods that are used are in that mixin. 

Now have a look at all those models in the files list...
I guess that means, that all those now have a timeline button?!

@blomquisg makes sense?
@h-kataria can you have a look?
@simon3z can you check this for the Containers team?