### PR TITLE
Convert Automate tree to use shared/tree

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -431,6 +431,7 @@ function miqTreeEventSafeEval(func) {
     'miqOnClickSnapshotTree',
     'miqOnClickTagCat',
     'miqOnClickTimelineSelection',
+    'miqSetAETreeNodeSelectionClass',
   ];
 
   if (whitelist.includes(func)) {

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -508,6 +508,11 @@ body#dashboard {
   }
 }
 
+/* custom modal class for Entry Point (creates scrollable area) */
+#automate_treebox {
+  height: 350px !important;
+  overflow-y: auto !important;
+}
 /* scrollable */
 .scrollable {
   overflow: auto;

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -64,8 +64,6 @@ ul.searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px;}
 /* Automate Specific */
 .checkall { padding: 0 0 7px 7px;} /*styling for automate (Check All) */
 
-#automate_treebox {height:350px; overflow-y: hidden !important;}
-
 /* End Automate Specific */
 
 /************ Hover Buttons ************/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -486,8 +486,8 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    tree = TreeBuilderAeClass.new(name, type, @sb)
-    @automate_tree = TreeBuilderAeClass.new(name, type, @sb) if name == :automate_tree
+    tree = TreeBuilderAutomate.new(name, type, @sb)
+    @automate_tree = tree if name == :automate_tree
     tree
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -486,9 +486,8 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    node_builder = TreeBuilderAeClass.select_node_builder(controller_name, @sb[:action])
-    tree = TreeBuilderAeClass.new(name, type, @sb, true, :node_builder => node_builder)
-    @automate_tree = tree.locals_for_render[:bs_tree] if name == :automate_tree
+    tree = TreeBuilderAeClass.new(name, type, @sb)
+    @automate_tree = TreeBuilderAeClass.new(name, type, @sb) if name == :automate_tree
     tree
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -582,7 +582,6 @@ module ApplicationHelper
   def javascript_pf_toolbar_reload(div_id, toolbar)
     "sendDataWithRx({redrawToolbar: #{toolbar_from_hash.to_json}});"
   end
-  ############# End of methods that generate JS lines for render page blocks
 
   def set_edit_timer_from_schedule(schedule)
     @edit[:new][:timer] ||= ReportHelper::Timer.new

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -70,8 +70,8 @@ module AutomateTreeHelper
         self.x_active_tree = :automate_tree
         page << javascript_show("ae_tree_select_div")
         page << javascript_show("blocker_div")
-        page << javascript_show("automate_tree_div")
-        page << "$('#automate_tree_div').addClass('modal fade in');"
+        page << javascript_show("automate_div")
+        page << "$('#automate_div').addClass('modal fade in');"
         @edit[:ae_tree_select] = true
         type = @edit[:ae_field_typ] || params[:typ]
         @edit[:current][:selected] = @edit[:new][:selected].nil? ? "" : @edit[:new][:selected]

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -77,16 +77,9 @@ module AutomateTreeHelper
         @edit[:current][:selected] = @edit[:new][:selected].nil? ? "" : @edit[:new][:selected]
         unless @edit[:new][type].nil?
           @edit[:new][:selected] = @edit[:new][type]
-<<<<<<< 0a518f30ad327797c79ef829e9be767a24799af2
           if x_node(:automate_tree)
             page << "miqTreeActivateNodeSilently('automate_tree', '#{@edit[:new][:selected]}');"
           end
-=======
-        end
-        if x_node(:automate_tree)
-          page << "miqSetAETreeNodeSelectionClass('#{@edit[:new][:selected]}', '#{@edit[:current][:selected]}', #{validnode});"
-          page << "miqDynatreeActivateNodeSilently('automate_tree', '#{@edit[:new][:selected]}');"
->>>>>>> Convert Automate tree to use shared/tree
         end
       end
     end

--- a/app/helpers/automate_tree_helper.rb
+++ b/app/helpers/automate_tree_helper.rb
@@ -77,9 +77,16 @@ module AutomateTreeHelper
         @edit[:current][:selected] = @edit[:new][:selected].nil? ? "" : @edit[:new][:selected]
         unless @edit[:new][type].nil?
           @edit[:new][:selected] = @edit[:new][type]
+<<<<<<< 0a518f30ad327797c79ef829e9be767a24799af2
           if x_node(:automate_tree)
             page << "miqTreeActivateNodeSilently('automate_tree', '#{@edit[:new][:selected]}');"
           end
+=======
+        end
+        if x_node(:automate_tree)
+          page << "miqSetAETreeNodeSelectionClass('#{@edit[:new][:selected]}', '#{@edit[:current][:selected]}', #{validnode});"
+          page << "miqDynatreeActivateNodeSilently('automate_tree', '#{@edit[:new][:selected]}');"
+>>>>>>> Convert Automate tree to use shared/tree
         end
       end
     end

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -23,17 +23,12 @@ class TreeBuilderAeClass < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "datastore", :lazy => true, :full_ids => false}
+    {:leaf => "datastore"}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:id_prefix    => "",
-                  :onclick      => "miqOnClickSelectAETreeNode",
-                  :exp_tree     => false,
-                  :autoload     => true,
-                  :base_id      => "root",
-                  :highlighting => true)
+    locals.merge!(:autoload => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -23,12 +23,17 @@ class TreeBuilderAeClass < TreeBuilder
   private
 
   def tree_init_options(_tree_name)
-    {:leaf => "datastore"}
+    {:leaf => "datastore", :lazy => true, :full_ids => false}
   end
 
   def set_locals_for_render
     locals = super
-    locals.merge!(:autoload => true)
+    locals.merge!(:id_prefix    => "",
+                  :onclick      => "miqOnClickSelectAETreeNode",
+                  :exp_tree     => false,
+                  :autoload     => true,
+                  :base_id      => "root",
+                  :highlighting => true)
   end
 
   def root_options

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,4 +1,4 @@
-class TreeBuilderAutomate <TreeBuilderAeClass
+class TreeBuilderAutomate < TreeBuilderAeClass
   def tree_init_options(_tree_name)
     {:leaf => "datastore", :full_ids => false}
   end

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -1,0 +1,15 @@
+class TreeBuilderAutomate <TreeBuilderAeClass
+  def tree_init_options(_tree_name)
+    {:leaf => "datastore", :full_ids => false}
+  end
+
+  def set_locals_for_render
+    locals = super
+    locals.merge!(:id_prefix    => "",
+                  :onclick      => "miqOnClickSelectAETreeNode",
+                  :exp_tree     => false,
+                  :autoload     => true,
+                  :base_id      => "root",
+                  :highlighting => true)
+  end
+end

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -20,6 +20,7 @@
           = _("Select Entry Point %{entry_point}") % {:entry_point => entry_point}
 
       .modal-body
+<<<<<<< 0a518f30ad327797c79ef829e9be767a24799af2
         #automate_treebox
         = render(:partial => "layouts/tree",
                  :locals => {:tree_id             => "automate_treebox",
@@ -27,6 +28,9 @@
                              :bs_tree             => @automate_tree,
                              :onclick             => "miqOnClickSelectAETreeNode",
                              :autoload            => true})
+=======
+        = render(:partial => 'shared/tree', :locals => {:tree => @automate_tree, :name => @automate_tree.name})
+>>>>>>> Convert Automate tree to use shared/tree
       .modal-footer
         %div{:id => "include_domain_prefix_div"}
           %input#include_domain_prefix_chk{:onchange  => "miqOnClickIncludeDomainPrefix()",

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -20,17 +20,7 @@
           = _("Select Entry Point %{entry_point}") % {:entry_point => entry_point}
 
       .modal-body
-<<<<<<< 0a518f30ad327797c79ef829e9be767a24799af2
-        #automate_treebox
-        = render(:partial => "layouts/tree",
-                 :locals => {:tree_id             => "automate_treebox",
-                             :tree_name           => "automate_tree",
-                             :bs_tree             => @automate_tree,
-                             :onclick             => "miqOnClickSelectAETreeNode",
-                             :autoload            => true})
-=======
         = render(:partial => 'shared/tree', :locals => {:tree => @automate_tree, :name => @automate_tree.name})
->>>>>>> Convert Automate tree to use shared/tree
       .modal-footer
         %div{:id => "include_domain_prefix_div"}
           %input#include_domain_prefix_chk{:onchange  => "miqOnClickIncludeDomainPrefix()",

--- a/app/views/layouts/_ae_tree_select.html.haml
+++ b/app/views/layouts/_ae_tree_select.html.haml
@@ -1,12 +1,12 @@
 - entry_point ||= "Instance"
-.modal.fade#automate_tree_div{"tabindex"        => "-1",
-                              "role"            => "dialog",
-                              "aria-labelledby" => "ep_modal_label",
-                              "aria-describedby" => "modal",
-                              "aria-hidden"     => "true",
-                              "data-keyboard"   => "false",
-                              "data-backdrop"   => "static",
-                              :style            => "display: none"}
+.modal.fade#automate_div{"tabindex"         => "-1",
+                         "role"             => "dialog",
+                         "aria-labelledby"  => "ep_modal_label",
+                         "aria-describedby" => "modal",
+                         "aria-hidden"      => "true",
+                         "data-keyboard"    => "false",
+                         "data-backdrop"    => "static",
+                         :style             => "display: none"}
   .modal-dialog.modal-lg
     .modal-content
       .modal-header

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -1,9 +1,16 @@
+include Spec::Support::AutomationHelper
+
 describe "catalog/_form.html.haml" do
   before do
     set_controller_for_view("catalog")
     set_controller_for_view_to_be_nonrestful
     @edit = {:new => {:available_catalogs => [], :available_dialogs => {}}}
-    @sb = {:st_form_active_tab => "Basic"}
+    @sb = {:st_form_active_tab => "Basic", :trees => {:ot_tree => {:open_nodes => []}}, :active_tree => :ot_tree}
+    user = FactoryGirl.create(:user_with_group)
+    login_as user
+    create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/B/C')
+    create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace => 'C/D/E')
+    @automate_tree = TreeBuilderAeClass.new(:automate_tree, "automate", @sb)
   end
 
   it "Renders form when adding catalog bundle and st_prov_type is not set" do

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -1,6 +1,6 @@
-include Spec::Support::AutomationHelper
-
 describe "catalog/_form.html.haml" do
+  include Spec::Support::AutomationHelper
+  
   before do
     set_controller_for_view("catalog")
     set_controller_for_view_to_be_nonrestful

--- a/spec/views/catalog/_form.html.haml_spec.rb
+++ b/spec/views/catalog/_form.html.haml_spec.rb
@@ -1,6 +1,6 @@
 describe "catalog/_form.html.haml" do
   include Spec::Support::AutomationHelper
-  
+
   before do
     set_controller_for_view("catalog")
     set_controller_for_view_to_be_nonrestful


### PR DESCRIPTION
Convert `:automate_tree` to use `shared/tree`.

Services -> Catalogs -> Catalog Items -> Configuration -> Add a New Catalog Item -> choose whatever type -> Reconfigure Entry Point

Automate -> Explorer -> Datastore tree

Before/After: It should be same.

@miq-bot add_label wip, ui, technical debt