### PR TITLE
refactor generic_feature_button spec

### DIFF
--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -1,131 +1,29 @@
 describe ApplicationHelper::Button::GenericFeatureButton do
   describe '#skip?' do
-    describe 'the button for the instance' do
-      [:pause, :shelve, :shelve_offload, :start, :stop,
-       :suspend, :timeline, :terminate, :reboot_guest].each do |feature|
-        context "that supports feature #{feature}" do
-          before do
-            @record = FactoryGirl.create(:vm_openstack)
-            allow(@record).to receive(:is_available?).with(feature).and_return(true)
-          end
-
-          it "will not be skipped" do
-             view_context = setup_view_context_with_sandbox({})
-             button = described_class.new(
-               view_context,
-               {},
-               {'record' => @record},
-               {:options => {:feature => feature}}
-             )
-             expect(button.skip?).to be_falsey
-          end
-        end
-
-
-        context "that does not support feature #{feature}" do
-          before do
-            @record = FactoryGirl.create(:vm_openstack)
-            allow(@record).to receive(:is_available?).with(feature).and_return(false)
-          end
-
-          it "will be skipped" do
-             view_context = setup_view_context_with_sandbox({})
-             button = described_class.new(
-               view_context,
-               {},
-               {'record' => @record},
-               {:options => {:feature => feature}}
-             )
-             expect(button.skip?).to be_truthy
-          end
-        end
-      end
+    it "that supports feature :some_feature will not be skipped" do
+      record = double
+      allow(record).to receive(:supports_some_feature?).and_return(true)
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context,
+        {},
+        {'record' => record},
+        {:options => {:feature => :some_feature}}
+      )
+      expect(button.skip?).to be_falsey
     end
 
-    describe 'the button for the service' do
-      [:reconfigure].each do |feature|
-        context "that supports feature #{feature}" do
-          before do
-            @record = FactoryGirl.create(:service)
-            allow(@record)
-              .to receive("supports_#{feature}?".to_sym)
-              .and_return(true)
-          end
-
-          it "will not be skipped" do
-             view_context = setup_view_context_with_sandbox({})
-             button = described_class.new(
-               view_context,
-               {},
-               {'record' => @record},
-               {:options => {:feature => feature}}
-             )
-             expect(button.skip?).to be_falsey
-          end
-        end
-
-
-        context "that does not support feature #{feature}" do
-          before do
-            @record = FactoryGirl.create(:service)
-            allow(@record)
-              .to receive("supports_#{feature}?".to_sym)
-              .and_return(false)
-          end
-
-          it "will be skipped" do
-             view_context = setup_view_context_with_sandbox({})
-             button = described_class.new(
-               view_context,
-               {},
-               {'record' => @record},
-               {:options => {:feature => feature}}
-             )
-             expect(button.skip?).to be_truthy
-          end
-        end
-      end
-    end
-
-    describe 'the button for the vm' do
-      [:clone].each do |feature|
-        context "that supports feature #{feature}" do
-          before do
-            @record = FactoryGirl.create(:vm_vmware)
-            allow(@record).to receive(:is_available?).with(feature).and_return(true)
-          end
-
-          it "will not be skipped" do
-             view_context = setup_view_context_with_sandbox({})
-             button = described_class.new(
-               view_context,
-               {},
-               {'record' => @record},
-               {:options => {:feature => feature}}
-             )
-             expect(button.skip?).to be_falsey
-          end
-        end
-
-
-        context "that does not support feature #{feature}" do
-          before do
-            @record = FactoryGirl.create(:vm_vmware)
-            allow(@record).to receive(:is_available?).with(feature).and_return(false)
-          end
-
-          it "will be skipped" do
-             view_context = setup_view_context_with_sandbox({})
-             button = described_class.new(
-               view_context,
-               {},
-               {'record' => @record},
-               {:options => {:feature => feature}}
-             )
-             expect(button.skip?).to be_truthy
-          end
-        end
-      end
+    it "that dont support feature :some_feature will be skipped" do
+      record = double
+      allow(record).to receive(:supports_some_feature?).and_return(false)
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(
+        view_context,
+        {},
+        {'record' => record},
+        {:options => {:feature => :some_feature}}
+      )
+      expect(button.skip?).to be_truthy
     end
   end
 end


### PR DESCRIPTION
before it was also a unit test, because it was mocking the only method used in the class.
plus it created objects for every feature.

@romanblanco @PanSpagetka as this is your code, are you ok with this?
