### PR TITLE
Fix erroneous reference to 'display_name' in OSP volume creation

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -274,7 +274,7 @@ class CloudVolumeController < ApplicationController
       if valid_action
         begin
           CloudVolume.create_volume(cloud_tenant.ext_management_system, options)
-          add_flash(_("Create %{volume} \"%{volume_name}\"") % {
+          add_flash(_("Creating %{volume} \"%{volume_name}\"") % {
             :volume      => ui_lookup(:table => 'cloud_volume'),
             :volume_name => options[:name]})
         rescue => ex

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -37,7 +37,7 @@ class CloudVolume < ApplicationRecord
     created_volume = klass.raw_create_volume(ext_management_system, options)
 
     klass.create(
-      :name                  => options[:display_name],
+      :name                  => created_volume[:name],
       :ems_ref               => created_volume[:ems_ref],
       :status                => created_volume[:status],
       :size                  => options[:size].to_i.gigabytes,

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -9,11 +9,13 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
     cloud_tenant = options.delete(:cloud_tenant)
     volume = nil
 
+    # provide display_name for Cinder V1
+    options[:display_name] |= options[:name]
     ext_management_system.with_provider_connection(cinder_connection_options(cloud_tenant)) do |service|
       volume = service.volumes.new(options)
       volume.save
     end
-    {:ems_ref => volume.id, :status => volume.status, :name => volume.name}
+    {:ems_ref => volume.id, :status => volume.status, :name => options[:name]}
   rescue => e
     _log.error "volume=[#{options[:name]}], error: #{e}"
     raise MiqException::MiqVolumeCreateError, e.to_s, e.backtrace

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -13,9 +13,9 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
       volume = service.volumes.new(options)
       volume.save
     end
-    {:ems_ref => volume.id, :status => volume.status}
+    {:ems_ref => volume.id, :status => volume.status, :name => volume.name}
   rescue => e
-    _log.error "volume=[#{options[:display_name]}], error: #{e}"
+    _log.error "volume=[#{options[:name]}], error: #{e}"
     raise MiqException::MiqVolumeCreateError, e.to_s, e.backtrace
   end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -35,7 +35,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
   describe 'volume actions' do
     context ".create_volume" do
       let(:the_new_volume) { double }
-      let(:volume_options) { {:cloud_tenant => tenant, :display_name => "new_name", :size => 2} }
+      let(:volume_options) { {:cloud_tenant => tenant, :name => "new_name", :size => 2} }
 
       before do
         allow(raw_volumes).to receive(:new).and_return(the_new_volume)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1366777 by replacing 'display_name' with 'name' when creating the MIQ volume object. This was causing volumes in MIQ to not have an assigned name until after they were refreshed.

@dclarizio @tzumainn