### PR TITLE
Add a method to serialize the bundle

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -49,6 +49,16 @@ class Blueprint < ApplicationRecord
     # TODO
   end
 
+  def content
+    result = bundle.as_json.dup
+    result["service_templates"] = bundle.descendants.map(&:as_json)
+    result["service_catalog"] = bundle.service_template_catalog.as_json
+    provision_action = bundle.resource_actions.find_by(:action => "Provision")
+    result["service_dialog"] = provision_action.dialog.as_json if provision_action
+    result["automate_entrypoints"] = bundle.resource_actions.map(&:as_json)
+    result
+  end
+
   private
 
   # Copy a service template and link its blueprint;

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -101,6 +101,45 @@ describe Blueprint do
       expect(retire.dialog).to eq(prov.dialog)
     end
   end
+
+  describe "#content" do
+    it "serializes the bundle" do
+      blueprint = FactoryGirl.build(:blueprint)
+      service_template_1 = FactoryGirl.create(:service_template, :name => "Foo Template")
+      service_template_2 = FactoryGirl.create(:service_template, :name => "Bar Template")
+      service_catalog = FactoryGirl.create(:service_template_catalog, :name => "Baz Catalog")
+      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field, :description => "Qux Dialog")
+      automate_entrypoints = {"Provision" => "a/b/c", "Reconfigure" => "x/y/z"}
+      blueprint.create_bundle(:service_templates => [service_template_1, service_template_2],
+                              :service_catalog   => service_catalog,
+                              :service_dialog    => service_dialog,
+                              :entry_points      => automate_entrypoints)
+
+      expected = {
+        "service_templates"    => a_collection_containing_exactly(
+          a_hash_including("name" => "Foo Template"),
+          a_hash_including("name" => "Bar Template")
+        ),
+        "service_catalog"      => a_hash_including("name" => "Baz Catalog"),
+        "service_dialog"       => a_hash_including("description" => "Qux Dialog"),
+        "automate_entrypoints" => a_collection_containing_exactly(
+          a_hash_including(
+            "action"       => "Provision",
+            "ae_namespace" => "a",
+            "ae_class"     => "b",
+            "ae_instance"  => "c"
+          ),
+          a_hash_including(
+            "action"       => "Reconfigure",
+            "ae_namespace" => "x",
+            "ae_class"     => "y",
+            "ae_instance"  => "z"
+          )
+        )
+      }
+      expect(blueprint.content).to include(expected)
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
Purpose or Intent
-----------------
~~Opening this as a WIP to discuss implementation details with @bzwei and @abellotti .~~

~~In an ideal world, I think since we send the bundle in a certain format, we should return the bundle in the response in the same format. That's not currently possible because `Blueprint#bundle` just returns the composite service template object without any of its descendents, etc... So not sure how to bridge the gap here. Ideally I'd like the response to include:~~

```ruby
{
  # ....
  "bundle" => bundle.serialized_bundle
}
```

~~But not sure about the feasibility of that. @bzwei @abellotti any thoughts?~~

EDIT:

Updating to reflect the new content signature:

```ruby
{
  # ....
  "content" => blueprint.content # => serialized bundle with service templates, etc....
}
```

@miq-bot add-label api, enhancement, wip
@miq-bot assign @abellotti 

