### PR TITLE
Re-check Authentication button for Providers in the GTL view

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -460,15 +460,24 @@ module EmsCommon
          params[:pressed] == "ems_infra_recheck_auth_status"     ||
          params[:pressed] == "ems_middleware_recheck_auth_status" ||
          params[:pressed] == "ems_container_recheck_auth_status"
-        @record = find_by_id_filtered(model, params[:id])
-        result, details = @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype),
-                                                                   :save => true)
-        if result
-          add_flash(_("Authentication status will be saved and workers will be restarted for this %{controller_name}") %
-            {:controller_name => ui_lookup(:table => controller_name)})
+        if params[:id]
+          table_key = :table
+          _result, details = recheck_authentication
+          add_flash(_("Re-checking Authentication status for this %{controller_name} was not successful: %{details}") %
+                        {:controller_name => ui_lookup(:table => controller_name), :details => details}, :error) if details
         else
-          add_flash(_("Re-checking Authentication status for this #{ui_lookup(:table => "ems_cloud")} was not successful: %{details}") % {:details => details}, :error)
+          table_key = :tables
+          ems_ids = find_checked_items
+          ems_ids.each do |ems_id|
+            _result, details = recheck_authentication(ems_id)
+            add_flash(_("Re-checking Authentication status for the selected %{controller_name} %{name} was not successful: %{details}") %
+                          {:controller_name => ui_lookup(:table => controller_name),
+                           :name            => @record.name,
+                           :details         => details}, :error) if details
+          end
         end
+        add_flash(_("Authentication status will be saved and workers will be restarted for the selected %{controller_name}") %
+                      {:controller_name => ui_lookup(table_key => controller_name)})
         render_flash
         return
       end
@@ -493,6 +502,11 @@ module EmsCommon
         render_flash unless performed?
       end
     end
+  end
+
+  def recheck_authentication(id = nil)
+    @record = find_by_id_filtered(model, id || params[:id])
+    @record.authentication_check_types_queue(@record.authentication_for_summary.pluck(:authtype), :save => true)
   end
 
   def arbitration_profile_edit

--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -77,4 +77,24 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
       ]
     ),
   ])
+  button_group('ems_cloud_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+          ]
+      ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -70,4 +70,24 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
       ]
     ),
   ])
+  button_group('ems_container_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infras_center.rb
@@ -77,4 +77,24 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
       ]
     ),
   ])
+  button_group('ems_infra_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
In https://github.com/ManageIQ/manageiq/pull/8912, a `Re-check Authentication` button was added for providers in the Provider detail page (Summary screen).

This PR is an extension to the above PR, in the sense, it implements the `Re-check Authentication` button in the GTL view so that multiple providers can be selected at a given time in order to re-check (and save) their authentication status.

This PR is also darga specific, meaning, `middleware` is deliberately left out here.
A separate PR for `middleware` would be created (for upstream), once this one gets merged.

Fixes https://github.com/ManageIQ/manageiq/issues/9632