### PR TITLE
Enable Vmdb::ConsoleMethods like pry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -159,7 +159,19 @@ module Vmdb
     end
 
     console do
-      Rails::ConsoleMethods.include(Vmdb::ConsoleMethods)
+      # This is to include vmdb methods into the top level namespace of the
+      # repl session being opened (either through `pry` or IRB)
+      #
+      # This takes a page from `pry-rails` and extends the TOPLEVEL_BINDING
+      # instead of Rails::ConsoleMethods when adding the Vmdb::ConsoleMethods.
+      #
+      # https://github.com/rweng/pry-rails/blob/fe29ddcdd/lib/pry-rails/railtie.rb#L25
+      #
+      # Without pry, this isn't required and we could just include this into
+      # the `Rails::ConsoleMethods`, but with `pry-rails`, this isn't possible
+      # since the railtie for it is loaded first and will include
+      # `Rails::ConsoleMethods` before we have a chance to modify them here.
+      TOPLEVEL_BINDING.eval('self').extend(Vmdb::ConsoleMethods)
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
Allow `pry-rails` users to use the `Vmdb::ConsoleMethods` the same as the regular `IRB` users, but support both.


Overview
--------
There currently is a bit of a race condition when running the console with `pry` that prevents the following from working properly:

```ruby
console do
  Rails::ConsoleMethods.include(Vmdb::ConsoleMethods)
end
```

This is because `pry-rails` does this under the hood in it's `railtie` to inject itself into your console:

```ruby
TOPLEVEL_BINDING.eval('self').extend ::Rails::ConsoleMethods
```

Because of that, normal loading of `pry-rails` will be included before the `config/application.rb` has a chance to execute the `.include` code from above, and so it evaluates the `::Rails::ConsoleMethods` before our `Vmdb::ConsoleMethods` are applied.

By switching them to extending on the top level binding (the same way that Pry does it), we are able to include the methods in the same fashion in both use cases, and this should only affect the console environment anyway.


Links
-----
* https://github.com/rweng/pry-rails/blob/fe29ddcdd/lib/pry-rails/railtie.rb#L25


Steps for Testing/QA
--------------------
* Make sure `pry-rails` is not included in your `Gemfile.dev.rb` (or is at least commented out)
* Checkout this branch
* Run `bin/rails c`, and confirm that `enable_console_sql_logging` works
* Add `pry-rails` to your `Gemfile.dev.rb` 
* Run `bin/rails c`, and confirm that `enable_console_sql_logging` works