### PR TITLE
use cached version of features

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -33,10 +33,6 @@ class MiqProductFeature < ApplicationRecord
     features[identifier.to_s].try(:[], :parent)
   end
 
-  def self.parent_for_feature(identifier)
-    find_by_identifier(feature_parent(identifier))
-  end
-
   def self.feature_children(identifier, sort = true)
     feat = features[identifier.to_s]
     if feat && !feat[:details][:hidden] && feat[:children]

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -37,8 +37,8 @@ class MiqUserRole < ApplicationRecord
   def allows?(identifier:)
     if feature_identifiers.include?(identifier)
       true
-    elsif parent = MiqProductFeature.parent_for_feature(identifier)
-      allows?(:identifier => parent.identifier)
+    elsif (parent_identifier = MiqProductFeature.feature_parent(identifier))
+      allows?(:identifier => parent_identifier)
     else
       false
     end


### PR DESCRIPTION
We are looking up user's features, but we already have them cached in memory - using the cached version.

TL;DR: `/vm_infra/explorer` queries count from 125 to 34 (73% reduction)

This effects every url, others more than the numbers below.

/cc @chrisarcand FYI

db stats
---------

|VmOrTemplate|Host|Storage|ExtManagementSystem|MiqRegion|Zone|
|-----------:|---:|------:|------------------:|--------:|---:|
|      10000 |200 |   221 |                 1 |       1 |  1 |

before
------

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  9,752.3 |  125 | 2,750.1 |   50,735 |`/vm_infra/explorer`
|  9,752.3 |      |         |          |`GET http://localhost:3000/vm_infra/explorer`
|  9,744.0 |    6 |     1.8 |        6 |`.Executing action: explorer`
|  9,728.7 |   12 |     4.6 |       41 |`..VmShowMixin#explorer`
|  1,841.2 |    2 |     0.8 |        2 |`...Rbac::Filterer#search`
|  1,837.4 |      |         |          |`....Rbac::Filterer#scope_targets`
|  1,837.3 |      |         |          |`.....Rbac::Filterer#scope_by_direct_rbac`
|  1,837.1 |    1 |     0.7 |        1 |`......Rbac::Filterer#matches_via_descendants`
|    737.6 |    1 |   698.3 |   10,000 |`.......Rbac::Filterer#search`
|  6,579.1 |    7 | 1,223.9 |   30,491 |`...TreeBuilderVmsAndTemplates#tree`
|  1,473.5 |    1 |   685.3 |   10,000 |`....Rbac::Filterer#search`
|    171.9 |    5 |    77.4 |       61 |`...MiqReport#paged_view_search`
|     41.2 |    1 |    34.5 |          |`....Rbac::Filterer#search`
|     33.7 |      |         |          |`...Rendering: vm_infra/explorer`
|    341.8 |   89 |    22.8 |      133 |`...Rendering: layouts/application`

after
-----

|       ms |queries | query (ms) |  rows |`comments`
|      ---:|    ---:|     ---:|      ---:| ---
|   8,774.5 |   37 |  2,907.7 |   50,648 |`/vm_infra/explorer`
|   8,774.5 |      |          |          |`GET http://localhost:3000/vm_infra/explorer`
|   8,767.2 |    5 |      1.6 |        5 |`.Executing action: explorer`
|   8,754.6 |   10 |      4.6 |       39 |`..VmShowMixin#explorer`
|   1,069.2 |    2 |      1.1 |        2 |`...Rbac::Filterer#search`
|   1,063.6 |      |          |          |`....Rbac::Filterer#scope_targets`
|   1,063.4 |      |          |          |`.....Rbac::Filterer#scope_by_direct_rbac`
|   1,063.1 |    1 |      0.7 |        1 |`......Rbac::Filterer#matches_via_descendants`
|     806.6 |    1 |    735.3 |   10,000 |`.......Rbac::Filterer#search`
|   6,867.2 |    7 |  1,312.5 |   30,491 |`...TreeBuilderVmsAndTemplates#tree`
|   1,075.7 |    1 |    753.8 |   10,000 |`....Rbac::Filterer#search`
|     150.4 |    5 |     68.2 |       61 |`...MiqReport#paged_view_search`
|      34.4 |    1 |     28.3 |          |`....Rbac::Filterer#search`
|      31.7 |      |          |          |`...Rendering: vm_infra/explorer`
|     164.2 |    4 |      1.6 |       49 |`...Rendering: layouts/application`
