### PR TITLE
Fix duplicate retirement_date ids in retirement screen

### DIFF
--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -8,7 +8,7 @@
     .form-group
       %label.col-md-2.control-label
         = _('Retirement Date')
-      .col-md-8#retirement_date
+      .col-md-8#retirement_date_div
         = datepicker_input_tag("retirementDate", nil,
                                 :id                  => "retirement_date",
                                 :class               => "css1",


### PR DESCRIPTION
Visible when navigating to vm details -> set retirement date.