### PR TITLE
Fixed bug in setting of hover message for tree nodes

### DIFF
--- a/app/assets/javascripts/miq_dynatree.js
+++ b/app/assets/javascripts/miq_dynatree.js
@@ -297,7 +297,7 @@ function hoverNodeId(id) {
   var nid = ids[ids.length - 1]; // Get the last part of the node id
   var leftNid = nid.split('-')[0];
   var rightNid = nid.split('-')[1];
-  if (typeof rightNid !== 'undefined' && rightNid.match(/r/)) {
+  if (typeof rightNid !== 'undefined' && rightNid.match(/\dr\d+/)) {
     nid = sprintf("%s-%s%012d", leftNid, rightNid.split('r')[0], rightNid.split('r')[1]);
   }
   return ((leftNid == 'v' || // Check for VM node


### PR DESCRIPTION
Purpose or Intent
-----------------
Fixed bug in setting of hover message for tree nodes

Regex is expected to match shortened ID's like `xx-1r53`, but also can have `xx-arch` or `xx-orph`, which causes error:

![screencapture-localhost-3000-vm_infra-explorer-1471598916105](https://cloud.githubusercontent.com/assets/1187051/17805736/30176efa-6601-11e6-8fe0-844444c6c08c.png)

Links
-----
Introduced in #8081

Steps for Testing/QA
--------------------
Hover over archived or orphaned node in VMs tree. No error message should be displayed
