### PR TITLE
Model for Async notification

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,6 @@
+class Notification < ApplicationRecord
+  belongs_to :notification_type
+  belongs_to :initiator, :class_name => User, :foreign_key => 'user_id'
+  belongs_to :subject, :polymorphic => true
+  belongs_to :cause, :polymorphic => true
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,4 +5,18 @@ class Notification < ApplicationRecord
   belongs_to :cause, :polymorphic => true
   has_many :notification_recipients, :dependent => :delete_all
   has_many :recipients, :class_name => User, :through => :notification_recipients, :source => :user
+
+  accepts_nested_attributes_for :notification_recipients
+  before_create :set_notification_recipients
+
+  def type=(typ)
+    self.notification_type = NotificationType.find_by_name!(typ)
+  end
+
+  private
+
+  def set_notification_recipients
+    subscribers = notification_type.subscriber_ids(subject, initiator)
+    self.notification_recipients_attributes = subscribers.collect { |id| {:user_id => id } }
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,4 +3,6 @@ class Notification < ApplicationRecord
   belongs_to :initiator, :class_name => User, :foreign_key => 'user_id'
   belongs_to :subject, :polymorphic => true
   belongs_to :cause, :polymorphic => true
+  has_many :notification_recipients, :dependent => :delete_all
+  has_many :recipients, :class_name => User, :through => :notification_recipients, :source => :user
 end

--- a/app/models/notification_recipient.rb
+++ b/app/models/notification_recipient.rb
@@ -1,0 +1,7 @@
+class NotificationRecipient < ApplicationRecord
+  belongs_to :notification
+  belongs_to :user
+  default_value_for :seen, false
+
+  scope :unseen, -> { where(:seen => false) }
+end

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -1,4 +1,5 @@
 class NotificationType < ApplicationRecord
+  has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
   validates :audience, :inclusion => { :in => %w(user tenant global) }

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -1,8 +1,22 @@
 class NotificationType < ApplicationRecord
+  AUDIENCE_USER = 'user'.freeze
+  AUDIENCE_TENANT = 'tenant'.freeze
+  AUDIENCE_GLOBAL = 'global'.freeze
   has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
-  validates :audience, :inclusion => { :in => %w(user tenant global) }
+  validates :audience, :inclusion => { :in => [AUDIENCE_USER, AUDIENCE_TENANT, AUDIENCE_GLOBAL] }
+
+  def subscriber_ids(subject, initiator)
+    case audience
+    when AUDIENCE_GLOBAL
+      User.pluck(:id)
+    when AUDIENCE_USER
+      [initiator.id]
+    when AUDIENCE_TENANT
+      subject.tenant.user_ids
+    end
+  end
 
   def self.seed
     seed_data.each do |t|

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -3,4 +3,22 @@ class NotificationType < ApplicationRecord
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
   validates :audience, :inclusion => { :in => %w(user tenant global) }
+
+  def self.seed
+    seed_data.each do |t|
+      rec = find_by_name(t[:name])
+      t[:expires_in] = $1.to_i.send($2).to_i if t[:expires_in] =~ /^(\d+) (minutes?|hours?|days?)$/
+      if rec.nil?
+        create(t)
+      else
+        rec.update_attributes(t)
+        rec.save!
+      end
+    end
+  end
+
+  def self.seed_data
+    fixture_file = File.join(FIXTURE_DIR, 'notification_types.yml')
+    File.exist?(fixture_file) ? YAML.load_file(fixture_file) : []
+  end
 end

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -1,0 +1,5 @@
+class NotificationType < ApplicationRecord
+  validates :message, :presence => true
+  validates :level, :inclusion => { :in => %w(success error warning info) }
+  validates :audience, :inclusion => { :in => %w(user tenant global) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ApplicationRecord
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
   has_many   :miq_reports, :dependent => :nullify
   has_many   :service_orders, :dependent => :nullify
+  has_many   :notification_recipients, :dependent => :delete_all
+  has_many   :notifications, :through => :notification_recipients
+  has_many   :unseen_notification_recipients, -> { unseen }, :class_name => 'NotificationRecipient'
+  has_many   :unseen_notifications, :through => :unseen_notification_recipients, :source => :notification
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
   scope      :admin, -> { where(:userid => "admin") }

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -1,0 +1,11 @@
+---
+- :name: vm_powered_off
+  :message: Virtual Machine %{subject} has been powered off
+  :expires_in: 24 hours
+  :level: :success
+  :audience: tenant
+- :name: vm_powered_on
+  :message: Virtual Machine %{subject} has been powered on
+  :expires_in: 24 hours
+  :level: :success
+  :audience: tenant

--- a/db/migrate/20160817104523_create_notification_types.rb
+++ b/db/migrate/20160817104523_create_notification_types.rb
@@ -1,0 +1,12 @@
+class CreateNotificationTypes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notification_types do |t|
+      t.string :name, :limit => 64
+      t.string :level, :limit => 16
+      t.string :audience, :limit => 16
+      t.text :message
+      t.integer :expires_in
+    end
+    add_index :notification_types, :name, :unique => true
+  end
+end

--- a/db/migrate/20160817120209_create_notifications.rb
+++ b/db/migrate/20160817120209_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notifications do |t|
+      t.references :notification_type, :foreign_key => true, :type => :bigint, :null => false
+      t.references :user, :foreign_key => true, :type => :bigint
+      t.references :subject, :polymorphic => true, :type => :bigint
+      t.references :cause, :polymorphic => true, :type => :bigint
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160817121951_create_notification_recipients.rb
+++ b/db/migrate/20160817121951_create_notification_recipients.rb
@@ -1,0 +1,9 @@
+class CreateNotificationRecipients < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notification_recipients do |t|
+      t.references :notification, :foreign_key => true, :type => :bigint
+      t.references :user, :foreign_key => true, :type => :bigint
+      t.boolean :seen
+    end
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5306,6 +5306,16 @@ notification_types:
 - audience
 - message
 - expires_in
+notifications:
+- id
+- notification_type_id
+- user_id
+- subject_type
+- subject_id
+- cause_type
+- cause_id
+- created_at
+- updated_at
 ontap_aggregate_derived_metrics:
 - id
 - statistic_time

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5299,6 +5299,13 @@ networks:
 - hostname
 - domain
 - ipv6address
+notification_types:
+- id
+- name
+- level
+- audience
+- message
+- expires_in
 ontap_aggregate_derived_metrics:
 - id
 - statistic_time

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5299,6 +5299,11 @@ networks:
 - hostname
 - domain
 - ipv6address
+notification_recipients:
+- id
+- notification_id
+- user_id
+- seen
 notification_types:
 - id
 - name

--- a/spec/factories/notification_type.rb
+++ b/spec/factories/notification_type.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :notification_type do
+    sequence(:name) { |n| "notification_type_#{seq_padded_for_sorting(n)}" }
+    sequence(:message) { |n| "message_#{seq_padded_for_sorting(n)}" }
+    level "info"
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,3 +1,21 @@
 describe Notification, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before { NotificationType.seed }
+  describe '.emit' do
+    context 'successful' do
+      let(:tenant) { FactoryGirl.create(:tenant) }
+      let(:vm) { FactoryGirl.create(:vm, :tenant => tenant) }
+      let(:tenant_group) { FactoryGirl.create(:miq_group, :tenant => tenant) }
+      let!(:user) { FactoryGirl.create(:user, :miq_groups => [tenant_group]) }
+      let(:notification_type) { :vm_powered_on }
+
+      it 'creates a new notification along with recipients' do
+        n = Notification.create(:type => notification_type, :subject => vm)
+        expect(n.notification_type.name).to eq(notification_type.to_s)
+        expect(n.subject).to eq(vm)
+        expect(n.recipients).to match_array([user])
+        expect(user.notifications.count).to eq(1)
+        expect(user.unseen_notifications.count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,3 @@
+describe Notification, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -12,4 +12,33 @@ describe NotificationType, :type => :model do
       end
     end
   end
+
+  describe '#subscribers' do
+    let(:user1) { FactoryGirl.create(:user) }
+    let(:tenant2) { FactoryGirl.create(:tenant) }
+    let(:tenant2_group) { FactoryGirl.create(:miq_group, :tenant => tenant2) }
+    let!(:user2) { FactoryGirl.create(:user, :miq_groups => [tenant2_group]) }
+    let(:vm) { FactoryGirl.create(:vm, :tenant => tenant2) }
+    subject { notification.subscriber_ids(vm, user1) }
+    context 'global notification type' do
+      let(:notification) { FactoryGirl.create(:notification_type, :audience => 'global') }
+      it 'returns all the users' do
+        is_expected.to match_array(User.pluck(:id))
+      end
+    end
+
+    context 'user specific notification type' do
+      let(:notification) { FactoryGirl.create(:notification_type, :audience => 'user') }
+      it 'returns just the user, who initiated the task' do
+        is_expected.to match_array([user1.id])
+      end
+    end
+
+    context 'tenant specific notification type' do
+      let(:notification) { FactoryGirl.create(:notification_type, :audience => 'tenant') }
+      it 'returns the users in the tenant same tenant as concerned vm' do
+        is_expected.to match_array([user2.id])
+      end
+    end
+  end
 end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -1,3 +1,15 @@
 describe NotificationType, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.seed' do
+    subject { described_class.count }
+    context 'before the seed is run' do
+      it { is_expected.to be_zero }
+    end
+    context 'after the seed is run' do
+      before { described_class.seed }
+      it { is_expected.to be > 0 }
+      it 'can be run again without any effects' do
+        expect { described_class.seed }.not_to change(described_class, :count)
+      end
+    end
+  end
 end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -1,0 +1,3 @@
+describe NotificationType, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Purpose
-----------------
The asynchronous notification will notify user about started/running/finished tasks in the backend of ManageIQ. The POC for UI was in #6809.

Sample of the requirements was:
 * be able to limit audience of notification to user/(possibly group?)/tenant/global
 * track seen/unseen flag per each user
 * allow for custom messages from automate
 * expire messages from view (different type may age differently)
 * should support message levels info/warning/error/success
 * allow hyperlinks in messages to the concerned objects
 * internationalization

Entity Relationship Diagram
-----------------
![notification_erd](https://cloud.githubusercontent.com/assets/6666052/17806696/56129e54-6606-11e6-874b-75e715b940f3.jpg)

Note: This pr does not bring NotificationSubscription as this will be delivered in later stages.

@miq-bot add_label core, darga/no, sql migration, events, enhancement
@miq-bot assign @skateman 
