### PR TITLE
fix typo in app/presenters/menu/custom_loader.rb

### DIFF
--- a/app/presenters/menu/custom_loader.rb
+++ b/app/presenters/menu/custom_loader.rb
@@ -32,7 +32,7 @@ module Menu
 
     def create_custom_menu_item(properties)
       rbac = properties['rbac'].each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-      item_type = properties.key?('item_type') ? properties['item_type'].to_sym : :detault
+      item_type = properties.key?('item_type') ? properties['item_type'].to_sym : :default
       %w(id name rbac parent).each do |property|
         raise Menu::Manager::InvalidMenuDefinition, "incomplete definition -- missing #{property}" if properties[property].blank?
       end


### PR DESCRIPTION
A simple modification changing the typo "detault" to the correct "default" on line 35 in custom_loader.rb.

