### PR TITLE
Fix moment.js deprecation warning

### DIFF
--- a/app/assets/javascripts/directives/miq_calendar.js
+++ b/app/assets/javascripts/directives/miq_calendar.js
@@ -22,7 +22,7 @@ ManageIQ.angular.app.directive('miqCalendar', function() {
 
       ctrl.$parsers.push(function(value) {
         if (value) {
-          return moment.utc(value).toDate();
+          return moment.utc(value, 'MM/DD/YYYY').toDate();
         }
       });
 


### PR DESCRIPTION
moment construction using a non-iso string is deprecated [1], but we can still safely construct
the date with explicit date format.

[1] https://github.com/moment/moment/issues/1407