### PR TITLE
Add active_support/all to all postgres HA classes

### DIFF
--- a/gems/pending/postgres_ha_admin/database_yml.rb
+++ b/gems/pending/postgres_ha_admin/database_yml.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'util/miq-password'
 require 'fileutils'
 

--- a/gems/pending/postgres_ha_admin/failover_databases.rb
+++ b/gems/pending/postgres_ha_admin/failover_databases.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'pg'
 require 'pg/dsn_parser'
 

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'postgres_ha_admin/failover_databases'
 require 'postgres_ha_admin/database_yml'
 require 'util/postgres_admin'


### PR DESCRIPTION
Before this change, we were not able to use activesupport methods such as `Hash#symbolize_keys` or `Time#current` in production because the required active_support files were not required in the source.

The bigger problem was that we were passing the spec tests because of the way rspec is requiring the spec files it will run.

So, to be safe, we can require active_support/all to ensure that we will have access to the methods that could be added and we can be confident that we are not getting false positives in our tests.

Replacement for #10530 

@yrudman @gtanzillo @Fryguy please review
@miq-bot add_label bug, core
@miq-bot assign @gtanzillo 