### PR TITLE
Rename default region from Azure-Azure-east to Azure-east

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -72,7 +72,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
 
       # at least create the Azure-eastus region.
       if new_emses.blank? && known_emses.blank?
-        new_emses << create_discovered_region("Azure-eastus", clientid, clientkey, azure_tenant_id, subscription, all_ems_names)
+        new_emses << create_discovered_region("eastus", clientid, clientkey, azure_tenant_id, subscription, all_ems_names)
       end
 
       EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?


### PR DESCRIPTION
Purpose or Intent
-----------------
During Azure discovery, if there are no VMs in a provider and there are no EMSes in the DB, we try to create a default provider called "Azure-eastus". 
After prepending the string "Azure" this incorrectly ends up as "Azure-Azure-eastus".

This PR fixes this.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1368507

Steps for Testing/QA
--------------------
Add an Azure provider with no instances,  make sure there are no EMSes in the DB .
