### PR TITLE
Add API for tagging blueprints

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -90,6 +90,8 @@
     :options:
     - :collection
     :klass: Blueprint
+    :subcollections:
+    - :tags
     :collection_actions:
       :get:
       - :name: read
@@ -116,6 +118,12 @@
       :delete:
       - :name: delete
         :identifier: blueprint_delete
+    :tags_subcollection_actions:
+      :post:
+      - :name: assign
+        :identifier: blueprint_tag
+      - :name: unassign
+        :identifier: blueprint_tag
   :categories:
     :description: Categories
     :identifier: ops_settings

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5232,6 +5232,10 @@
       :description: Show Blueprint
       :feature_type: view
       :identifier: blueprint_show
+    - :name: Edit Tags
+      :description: Edit Blueprint Tags
+      :feature_type: control
+      :identifier: blueprint_tag
   - :name: Modify
     :description: Modify Blueprint
     :feature_type: admin

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -437,4 +437,65 @@ describe "Tag Collections API" do
       expect_resource_has_tags(tenant, tag2[:path])
     end
   end
+
+  context "Blueprint Tag subcollection" do
+    it "can list all the tags of a blueprint" do
+      api_basic_authorize
+      blueprint = FactoryGirl.create(:blueprint)
+
+      run_get("#{blueprints_url(blueprint.id)}/tags")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can assign a tag to a blueprint with an appropriate role" do
+      api_basic_authorize subcollection_action_identifier(:blueprints, :tags, :assign)
+      blueprint = FactoryGirl.create(:blueprint)
+
+      run_post("#{blueprints_url(blueprint.id)}/tags",
+               :action   => "assign",
+               :catagory => tag1[:category],
+               :name     => tag1[:name])
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can unassign a tag from a bluepring with an appropriate role" do
+      api_basic_authorize subcollection_action_identifier(:blueprints, :tags, :unassign)
+      blueprint = FactoryGirl.create(:blueprint)
+      classify_resource(blueprint)
+
+      run_post("#{blueprints_url(blueprint.id)}/tags",
+               :action   => "unassign",
+               :catagory => tag1[:category],
+               :name     => tag1[:name])
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "will not assign tags to blueprints without an appropriate role" do
+      api_basic_authorize
+      blueprint = FactoryGirl.create(:blueprint)
+
+      run_post("#{blueprints_url(blueprint.id)}/tags",
+               :action   => "assign",
+               :catagory => tag1[:category],
+               :name     => tag1[:name])
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "will not unassign tags from blueprints without an approiate role" do
+      api_basic_authorize
+      blueprint = FactoryGirl.create(:blueprint)
+      classify_resource(blueprint)
+
+      run_post("#{blueprints_url(blueprint.id)}/tags",
+               :action   => "unassign",
+               :catagory => tag1[:category],
+               :name     => tag1[:name])
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
* Adds the tags subcollection for blueprints with assign/unassign actions
* Adds a product feature for editing tags of blueprints

@miq-bot add-label api, enhancement
@miq-bot assign @abellotti 
