### PR TITLE
Update the user when there are no matching groups

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -117,6 +117,7 @@ module Authenticator
           userid = userid_for(identity, username)
           user   = User.find_by_userid(userid) || User.new(:userid => userid)
           update_user_attributes(user, username, identity)
+          user.miq_groups = matching_groups
 
           if matching_groups.empty?
             msg = "Authentication failed for userid #{user.userid}, unable to match user's group membership to an EVM role"
@@ -124,11 +125,11 @@ module Authenticator
             _log.warn("#{msg}")
             task.error(msg)
             task.state_finished
+            user.save! unless user.new_record?
             return nil
           end
 
           user.lastlogon = Time.now.utc
-          user.miq_groups = matching_groups
           user.save!
 
           _log.info("Authorized User: [#{user.userid}]")


### PR DESCRIPTION
I have confirmed this PR using external auth with IPA/LDPA
Marking as WIP until I am able to confirm with LDAP directly.

Purpose or Intent
-----------------
The purpose of this PR is to address a situation where:

A valid user with valid MiQ groups had been able to successfully log into MiQ.

After which the LDAP system administrator removed all MiQ groups from the
user with the intent of preventing the user access to MiQ.

However when no valid groups were returned from LDAP the user's group
information was not updated in the DB and the UI would use the stale,
valid records.

This PR simply updates the user's miq_groups to empty when there are
no matching groups. Thereby preventing user authorization.



Steps for Testing/QA
--------------------
To test this:

1 - configure MiQ to validate using LDAP,
     either directly to an LDAP server or to an external authentication server
     that supports LDAP (e.g. IPA)

2 - Create a valid user with valid MiQ groups in LDAP

3 - log into MiQ using the valid user, then log off

4 - Remove all valid MiQ groups from the user in LDAP

5 - confirm login attempts into MiQ using the valid user that no longer has
      valid MiQ groups in LDAP fails.

Description
------------
When all MiQ groups are removed for a given user
on the "authenticator" the user's DB entry must
be updated to show no matching MiQ groups.

https://bugzilla.redhat.com/show_bug.cgi?id=1342082