### PR TITLE
miqUncompressedId - fix [sprintf] expecting number but found string

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1675,7 +1675,8 @@ function miqScrollToSelected(div_name) {
 
 function miqUncompressedId(id) {
   if (id.match(/r/)) {
-    return sprintf("%s%012s", id.split('r')[0], id.split('r')[1]);
+    var splat = id.split('r');
+    return sprintf("%s%012s", splat[0], splat[1]);
   }
   return id;
 }

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1675,7 +1675,7 @@ function miqScrollToSelected(div_name) {
 
 function miqUncompressedId(id) {
   if (id.match(/r/)) {
-    return sprintf("%s%012d", id.split('r')[0], id.split('r')[1]);
+    return sprintf("%s%012s", id.split('r')[0], id.split('r')[1]);
   }
   return id;
 }

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -439,4 +439,15 @@ describe('miq_application.js', function() {
     });
   });
 
+  describe('miqUncompressedId', function () {
+    it('returns uncompressed id unchanged', function() {
+      expect(miqUncompressedId('123')).toEqual('123');
+      expect(miqUncompressedId('12345678901234567890')).toEqual('12345678901234567890');
+    });
+
+    it('uncompresses compressed id', function() {
+      expect(miqUncompressedId('1r23')).toEqual('1000000000023');
+      expect(miqUncompressedId('999r123456789012')).toEqual('999123456789012');
+    });
+  });
 });


### PR DESCRIPTION
@chrisarcand reported seeing a `[sprintf] expecting number but found string` error..

sprintf doesn't typecast, and splitting a string yields two strings.. fixing to expect a string.

(alternatively we could convert it to a number but might get weird off-by-ones on 32 bit systems that way..)

---

Actually, the typecasting bit is a bit more complicated, it *can* treat a string as a number, as long as the native `isNaN` returns false for it..