### PR TITLE
Fix for "do not automatically refresh other fields" not being honoured

### DIFF
--- a/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
+++ b/app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml
@@ -4,7 +4,13 @@
   = select_tag(field.name, options_for_select(select_values, selected), drop_down_options(field, url))
 
   :javascript
-    dialogFieldRefresh.initializeDialogSelectPicker('#{field.name}', '#{field.id}', '#{selected}', '#{url}');
+    dialogFieldRefresh.initializeDialogSelectPicker(
+      '#{field.name}',
+      '#{field.id}',
+      '#{selected}',
+      '#{url}',
+      '#{field.trigger_auto_refresh}'
+    );
 
 - else
   = h(field.values.detect { |k, _v| [k, k.to_s].include?(wf.value(field.name)) }.try(:last) || wf.value(field.name))


### PR DESCRIPTION
Purpose or Intent
-----------------
This fixes the issue where all drop downs were triggering an auto refresh even if they were not set to trigger them by passing the 'trigger_auto_refresh' property into initializeDialogSelectPicker (as it should have been doing in the first place).

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1309802

Steps for Testing/QA
--------------------
Set up a field to listen for auto refreshes, set up a drop down that does *not* trigger auto refreshes, ensure that changing that drop down does not cause a refresh on the field listening for auto refreshes.

@gmcculloug Please review. I don't think this will solve the other issue where Kevin was seeing multiple refreshes at once, but it does resolve this BZ.