### PR TITLE
Filter integer input from custom searches

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -918,7 +918,7 @@ class MiqExpression
       [fld, quote(description, "string")]
     elsif ops["field"]
       if ops["field"] == "<count>"
-        ["<count>", ops["value"]]
+        ["<count>", quote(ops["value"], "integer")]
       else
         case context_type
         when "hash"
@@ -938,7 +938,7 @@ class MiqExpression
     elsif ops["count"]
       ref, count = value2tag(ops["count"])
       field = ref ? "<count ref=#{ref}>#{count}</count>" : "<count>#{count}</count>"
-      [field, ops["value"]]
+      [field, quote(ops["value"], "integer")]
     elsif ops["regkey"]
       if operator == "key exists"
         "<registry key_exists=1, type=boolean>#{ops["regkey"].strip}</registry>  == 'true'"

--- a/spec/models/miq_expression_spec.rb
+++ b/spec/models/miq_expression_spec.rb
@@ -2308,4 +2308,33 @@ describe MiqExpression do
         "result" => false)
     end
   end
+
+  describe ".operands2rubyvalue" do
+    RSpec.shared_examples :coerces_value_to_integer do |value|
+      it 'coerces the value to an integer' do
+        expect(subject.last).to eq(0)
+      end
+    end
+
+    let(:operator) { ">" }
+
+    subject do
+      described_class.operands2rubyvalue(operator, ops, nil)
+    end
+
+    context "when ops field equals count" do
+      let(:ops) { {"field" => "<count>", "value" => "foo"} }
+      include_examples :coerces_value_to_integer
+    end
+
+    context "when ops key is count" do
+      let(:ops) do
+        {
+          "count" => "ManageIQ::Providers::InfraManager::Vm.advanced_settings",
+          "value" => "foo"
+        }
+      end
+      include_examples :coerces_value_to_integer
+    end
+  end
 end


### PR DESCRIPTION
Purpose
---------

In custom built searches it's possible to submit unfiltered string values into fields that expect integers. These values make their way through eval allowing for arbitrary Ruby code execution.

Addresses:
CVE-2016-5383
https://bugzilla.redhat.com/show_bug.cgi?id=1353722

Fixed in CFME 5.6.1 (Darga-3)
fcfbeae255bda843a0d5ff80e2e90071ef3d7e33

Thanks to @imtayadeway for help with the solution.

Links
-----
* https://rhn.redhat.com/errata/RHSA-2016-1634.html

