### PR TITLE
Rename OpenShift Enterprise to OpenShift Container Platform (UI only)

### DIFF
--- a/app/models/manageiq/providers/openshift_enterprise/container_manager.rb
+++ b/app/models/manageiq/providers/openshift_enterprise/container_manager.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::OpenshiftEnterprise::ContainerManager < ManageIQ::Pro
   end
 
   def self.description
-    @description ||= "OpenShift Enterprise".freeze
+    @description ||= "OpenShift Container Platform".freeze
   end
 
   def self.event_monitor_class

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -767,7 +767,7 @@ en:
       ManageIQ::Providers::Kubernetes::ContainerManager:                    Container Provider (Kubernetes)
       ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup:    Pod (Kubernetes)
       ManageIQ::Providers::Openshift::ContainerManager:                     Container Provider (OpenShift)
-      ManageIQ::Providers::OpenshiftEnterprise::ContainerManager:           Container Provider (OpenShift Enterprise)
+      ManageIQ::Providers::OpenshiftEnterprise::ContainerManager:           Container Provider (OpenShift Container Platform)
       ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork:            Cloud Network (Amazon)
       ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet:             Cloud Subnet (Amazon)
       ManageIQ::Providers::Amazon::NetworkManager::SecurityGroup:           Security Group (Amazon)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -766,7 +766,7 @@ en:
       ManageIQ::Providers::Atomic::ContainerManager:                        Container Provider (Atomic)
       ManageIQ::Providers::Kubernetes::ContainerManager:                    Container Provider (Kubernetes)
       ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup:    Pod (Kubernetes)
-      ManageIQ::Providers::Openshift::ContainerManager:                     Container Provider (OpenShift)
+      ManageIQ::Providers::Openshift::ContainerManager:                     Container Provider (OpenShift Origin)
       ManageIQ::Providers::OpenshiftEnterprise::ContainerManager:           Container Provider (OpenShift Container Platform)
       ManageIQ::Providers::Amazon::NetworkManager::CloudNetwork:            Cloud Network (Amazon)
       ManageIQ::Providers::Amazon::NetworkManager::CloudSubnet:             Cloud Subnet (Amazon)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -32,7 +32,7 @@ describe ExtManagementSystem do
       "hawkular"                    => "Hawkular",
       "kubernetes"                  => "Kubernetes",
       "openshift"                   => "OpenShift Origin",
-      "openshift_enterprise"        => "OpenShift Enterprise",
+      "openshift_enterprise"        => "OpenShift Container Platform",
       "openstack"                   => "OpenStack",
       "openstack_infra"             => "OpenStack Platform Director",
       "openstack_network"           => "OpenStack Network",


### PR DESCRIPTION
Renamed provider in description strings only
OpenShift renamed to OpenShift Origin