### PR TITLE
rubocop issues: fix tree_builder_policy_simulation.rb

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -627,11 +627,12 @@ module VmCommon
     @policy_options[:passed] = true
     @policy_options[:failed] = true
     @policy_simulation_tree = TreeBuilderPolicySimulation.new(:policy_simulation_tree,
-                                                              :policy_simulation, @sb,
+                                                              :policy_simulation,
+                                                              @sb,
                                                               true,
-                                                              @polArr,
-                                                              @record.name,
-                                                              @policy_options)
+                                                              :root      => @polArr,
+                                                              :root_name => @record.name,
+                                                              :options   => @policy_options)
     @edit = session[:edit] if session[:edit]
     if @edit && @edit[:explorer]
       if session[:policies].empty?
@@ -662,9 +663,9 @@ module VmCommon
                                                               :policy_simulation,
                                                               @sb,
                                                               true,
-                                                              @polArr,
-                                                              @record.name,
-                                                              @policy_options)
+                                                              :root      => @polArr,
+                                                              :root_name => @record.name,
+                                                              :options   => @policy_options)
     replace_main_div({:partial => "vm_common/policies"}, {:flash => true})
   end
 
@@ -677,9 +678,9 @@ module VmCommon
                                                               :policy_simulation,
                                                               @sb,
                                                               true,
-                                                              @polArr,
-                                                              @record.name,
-                                                              @policy_options)
+                                                              :root      => @polArr,
+                                                              :root_name => @record.name,
+                                                              :options   => @policy_options)
     replace_main_div({:partial => "vm_common/policies"}, {:flash => true})
   end
 

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -34,9 +34,9 @@ describe TreeBuilderPolicySimulation do
                                                                 :policy_simulation,
                                                                 {},
                                                                 true,
-                                                                @data,
-                                                                'Policy Simulation',
-                                                                @policy_options)
+                                                                :root      => @data,
+                                                                :root_name => 'Policy Simulation',
+                                                                :options   => @policy_options)
     end
 
     it 'sets tree as not lazy' do
@@ -119,9 +119,9 @@ describe TreeBuilderPolicySimulation do
                                                                 :policy_simulaton,
                                                                 {},
                                                                 true,
-                                                                {},
-                                                                'Policy Simulation',
-                                                                @policy_options)
+                                                                :root      => {},
+                                                                :root_name => 'Policy Simulation',
+                                                                :options   => @policy_options)
     end
     it 'sets Policy Profile node correctly if no data found' do
       node = @policy_simulation_tree.send(:x_get_tree_roots, false).first


### PR DESCRIPTION
== app/presenters/tree_builder_policy_simulation.rb ==
R:  1:  1: Class has too many lines. [111/100]
R:  7: 17: Avoid parameter lists longer than 5 parameters.
C:  7: 39: Optional arguments should appear at the end of the argument list.
C:  7: 53: Optional arguments should appear at the end of the argument list.
R: 42:  3: Assignment Branch Condition size for x_get_tree_roots is too high. [19.52/15]
C: 42: 24: Optional arguments should appear at the end of the argument list.
C: 46:  7: Avoid multi-line chains of blocks.
R: 61:  3: Assignment Branch Condition size for skip_node is too high. [15.65/15]
R: 61:  3: Cyclomatic complexity for skip_node is too high. [8/6]
R: 61:  3: Perceived complexity for skip_node is too high. [9/7]
R: 72:  3: Assignment Branch Condition size for policy_nodes is too high. [20.25/15]
R: 86:  3: Assignment Branch Condition size for condition_node is too high. [21.12/15]
C: 89:  5: Avoid multi-line chains of blocks.
R:115:  3: Assignment Branch Condition size for x_get_tree_hash_kids is too high. [26.27/15]
R:115:  3: Cyclomatic complexity for x_get_tree_hash_kids is too high. [9/6]
R:115:  3: Perceived complexity for x_get_tree_hash_kids is too high. [9/7]