### PR TITLE
mark vm#used_disk_storage as a virtual delegate

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -25,6 +25,8 @@ class Hardware < ApplicationRecord
   virtual_column :ipaddresses,   :type => :string_set, :uses => :networks
   virtual_column :hostnames,     :type => :string_set, :uses => :networks
   virtual_column :mac_addresses, :type => :string_set, :uses => :nics
+  virtual_attribute :used_disk_storage,      :integer, :uses => :disks
+  virtual_attribute :allocated_disk_storage, :integer, :uses => :disks
 
   def ipaddresses
     @ipaddresses ||= networks.collect(&:ipaddress).compact.uniq

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -145,8 +145,6 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :v_owning_blue_folder_path,            :type => :string,     :uses => :all_relationships
   virtual_column :v_datastore_path,                     :type => :string,     :uses => :storage
   virtual_column :thin_provisioned,                     :type => :boolean,    :uses => {:hardware => :disks}
-  virtual_column :used_disk_storage,                    :type => :integer,    :uses => {:hardware => :disks}
-  virtual_column :allocated_disk_storage,               :type => :integer,    :uses => {:hardware => :disks}
   virtual_column :provisioned_storage,                  :type => :integer,    :uses => [:allocated_disk_storage, :mem_cpu]
   virtual_column :used_storage,                         :type => :integer,    :uses => [:used_disk_storage, :mem_cpu]
   virtual_column :used_storage_by_state,                :type => :integer,    :uses => :used_storage
@@ -1591,7 +1589,8 @@ class VmOrTemplate < ApplicationRecord
   # Hardware Disks/Memory storage methods
   #
 
-  delegate :allocated_disk_storage, :used_disk_storage, :to => :hardware, :allow_nil => true
+  virtual_delegate :allocated_disk_storage, :used_disk_storage,
+                   :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}
 
   def provisioned_storage
     allocated_disk_storage.to_i + ram_size_in_bytes

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -70,7 +70,7 @@ module VirtualDelegates
       unless options.kind_of?(Hash) && options[:to]
         raise ArgumentError, 'Delegation needs an association. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
       end
-      delegate(*methods, options)
+      delegate(*methods, options.except(:arel, :uses))
 
       # put method entry per method name.
       # This better supports reloading of the class and changing the definitions
@@ -101,7 +101,7 @@ module VirtualDelegates
         type = to_model.type_for_attribute(col)
         raise "unknown attribute #{to_model.name}##{col} referenced in #{name}" unless type
         arel = virtual_delegate_arel(col, to, to_model, to_ref)
-        define_virtual_attribute "#{method_prefix}#{col}", type, :uses => to, :arel => arel
+        define_virtual_attribute "#{method_prefix}#{col}", type, :uses => (options[:uses] || to), :arel => arel
       end
     end
 


### PR DESCRIPTION
A virtual delegate is a virtual attribute that is delegated to a child class.

Added support for `virtual_delegate` option `:uses`.
In most cases, `:uses` is the table delegated (in our case `:uses => :hardware`)
In this case, it specifies a custom `:uses` clause, `:hardware => :disks`.

