### PR TITLE
Use shorter t.grouping for arel grouping

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -92,7 +92,7 @@ class Hardware < ApplicationRecord
   end
   # resulting sql: "(cast(disk_free_space as float) / (disk_capacity * 100))"
   virtual_attribute :v_pct_free_disk_space, :float, :arel => (lambda do |t|
-    Arel::Nodes::Grouping.new(Arel::Nodes::Division.new(
+    t.grouping(Arel::Nodes::Division.new(
       Arel::Nodes::NamedFunction.new("CAST", [t[:disk_free_space].as("float")]),
       t[:disk_capacity]) * 100)
   end)
@@ -104,7 +104,7 @@ class Hardware < ApplicationRecord
   # resulting sql: "(cast(disk_free_space as float) / (disk_capacity * -100) + 100)"
   # to work with arel better, put the 100 at the end
   virtual_attribute :v_pct_used_disk_space, :float, :arel => (lambda do |t|
-    Arel::Nodes::Grouping.new(Arel::Nodes::Division.new(
+    t.grouping(Arel::Nodes::Division.new(
       Arel::Nodes::NamedFunction.new("CAST", [t[:disk_free_space].as("float")]),
       t[:disk_capacity]) * -100 + 100)
   end)


### PR DESCRIPTION
`ActiveRecord::Base.arel_table` has a helper method `grouping` for `Arel::Nodes::Grouping.new`

Using this.

These two methods are [[well tested in sql and ruby]](https://github.com/kbrock/manageiq/blob/179b45d9b032377ff06cf85d94dd2086e18bed1d/spec/models/hardware_spec.rb#L31-L90)