### PR TITLE
Fix NetworkPort saving of SecurityGroups

### DIFF
--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -259,7 +259,7 @@ module EmsRefresh::SaveInventoryNetwork
         h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)
       end
 
-      h[:security_groups] = h.fetch_path(:security_groups).map { |x| x[:_object] } if h.fetch_path(:security_groups, 0, :_object)
+      h[:security_groups] = (h.fetch_path(:security_groups) || []).map { |x| x.try(:[], :_object) }.compact.uniq
     end
 
     save_inventory_multi(ems.network_ports, hashes, deletes, [:ems_ref], :cloud_subnet_network_ports)


### PR DESCRIPTION
Purpose or Intent
-----------------

Due to various AWS role based access settings, we might not be
able to access all Security Groups, that are linked to
NetworkPort. This applies to role based settings of other
providers too.

This way does a proper filtering of only accessible Security
Groups, which will be then saved.

Steps for Testing/QA
--------------------

Have a mix of security groups assigned to the ENI, where subset of them is now visible for current AWS user used for MIQ provider. The we should see only the list of security groups visible to our AWS user. 
