### PR TITLE
fix vm policy button skip function

### DIFF
--- a/app/helpers/application_helper/button/vm_policy.rb
+++ b/app/helpers/application_helper/button/vm_policy.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::VmPolicy < ApplicationHelper::Button::Basic
   needs_record
 
   def skip?
-    @record.host&.vmm_product.to_s.casecmp("workstation")
+    @record.host.vmm_product.to_s.casecmp("workstation") if @record.host
   end
 end


### PR DESCRIPTION
fix tests:
rspec ./spec/controllers/vm_infra_controller_spec.rb:333 # VmInfraController the reconfigure tab for a vm with max_cpu_cores_per_socket <= 1 should not display the cpu_cores_per_socket dropdown
rspec ./spec/controllers/vm_infra_controller_spec.rb:384 # VmInfraController the reconfigure tab displays the submit and cancel buttons
rspec ./spec/controllers/vm_infra_controller_spec.rb:350 # VmInfraController the reconfigure tab for a vm with max_cpu_cores_per_socket > 1 should display the cpu_cores_per_socket dropdown
rspec ./spec/controllers/vm_infra_controller_spec.rb:367 # VmInfraController the reconfigure tab for a single vmware vm should display the list of disks
rspec ./spec/controllers/vm_infra_controller_spec.rb:69 # VmInfraController can open the reconfigure tab