### PR TITLE
Do not use &. notation just yet

### DIFF
--- a/app/helpers/application_helper/button/vm_policy.rb
+++ b/app/helpers/application_helper/button/vm_policy.rb
@@ -2,6 +2,6 @@ class ApplicationHelper::Button::VmPolicy < ApplicationHelper::Button::Basic
   needs_record
 
   def skip?
-    @record.host&.vmm_product.to_s.casecmp("workstation")
+    @record.host.try(:vmm_product).to_s.casecmp("workstation")
   end
 end


### PR DESCRIPTION
Purpose
-----------------
As per [developer_setup.md](https://github.com/ManageIQ/guides/blob/master/developer_setup.md#install-ruby-and-bundler) we support Ruby 2.2.2+. Thus, until we change this guide we need to write code that complies with Ruby 2.2.2.

The abuse was introduced in #10218. /cc @romanblanco. I am guilty of discussing this with @mzazrivec and not noticing this problem during the review. :feelsgood: 

@miq-bot assign @mzazrivec 
@miq-bot add_label ui, bug