### PR TITLE
[WIP] Fix search button on topology view

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -20,6 +20,7 @@ ManageIQ.angular.app.service('topologyService', function() {
 
   this.searchNode = function(svg, query) {
     var nodes = svg.selectAll("g");
+    svg.selectAll('g, line').style('opacity', 1);
     if (query != "") {
       var selected = nodes.filter(function (d) {
         return d.item.name.indexOf(query) == -1;


### PR DESCRIPTION

According to [this issue](https://github.com/ManageIQ/manageiq/issues/8577)
Fixed search button on topology page. Now it reverts graying icons.

![search_button](https://cloud.githubusercontent.com/assets/8054645/17849985/7e21b5c2-685b-11e6-8ce6-321a9cbb0b53.jpg)
