### PR TITLE
The Browse buttons have been renamed to Choose file

### DIFF
--- a/app/controllers/application_controller/sysprep_answer_file.rb
+++ b/app/controllers/application_controller/sysprep_answer_file.rb
@@ -19,7 +19,7 @@ class ApplicationController
         end
       else
         @edit[:new][:sysprep_upload_text] = nil
-        msg = _("Use the Browse button to locate an Upload file")
+        msg = _("Use the Choose file button to locate an Upload file")
         add_flash(msg, :error)
       end
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -441,7 +441,7 @@ class CatalogController < ApplicationController
       end
     else
       identify_catalog(params[:id])
-      msg = _("Use the Browse button to locate a .png or .jpg image file")
+      msg = _("Use the Choose file button to locate a .png or .jpg image file")
       err = true
     end
     params[:id] = x_build_node_id(@record)  # Get the tree node id

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -46,7 +46,7 @@ class MiqAeCustomizationController < ApplicationController
 
   def upload_import_file
     if params[:upload].nil? || params[:upload][:file].blank?
-      add_flash(_("Use the browse button to locate an import file"), :warning)
+      add_flash(_("Use the Choose file button to locate an import file"), :warning)
     else
       begin
         import_file = dialog_import_service.store_for_import(params[:upload][:file].read)

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -178,7 +178,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
     upload_file = params.fetch_path(:upload, :file)
 
     if upload_file.blank?
-      add_flash(_("Use the browse button to locate an import file"), :warning)
+      add_flash(_("Use the Choose file button to locate an import file"), :warning)
     else
       import_file_upload_id = automate_import_service.store_for_import(upload_file.read)
       add_flash(_("Import file was uploaded successfully"), :success)
@@ -269,7 +269,7 @@ Methods updated/added: %{method_stats}") % stat_options)
       end
     else
       @in_a_form = true
-      add_flash(_("Use the Browse button to locate an Import file"), :error)
+      add_flash(_("Use the Choose file button to locate an Import file"), :error)
       #     render :action=>"import_export"
       import_export
     end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -158,7 +158,7 @@ class MiqPolicyController < ApplicationController
                                 :action      => "export")
       end
     else
-      redirect_options.merge!(:flash_msg   => _("Use the Browse button to locate an Import file"),
+      redirect_options.merge!(:flash_msg   => _("Use the Choose file button to locate an Import file"),
                               :flash_error => true,
                               :action      => "export")
     end

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -26,7 +26,7 @@ module OpsController::Settings
         session[:imports] = @sb[:imports] = nil
       end
     else
-      msg = _("Use the Browse button to locate CSV file")
+      msg = _("Use the Choose file button to locate CSV file")
       err = true
     end
     @sb[:show_button] = err

--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -34,7 +34,7 @@ module OpsController::Settings::Upload
         err = false
       end
     else
-      msg = _("Use the Browse button to locate .png image file")
+      msg = _("Use the Choose file button to locate .png image file")
       err = true
     end
     redirect_to :action => 'explorer', :flash_msg => msg, :flash_error => err, :no_refresh => true
@@ -94,7 +94,7 @@ module OpsController::Settings::Upload
         end
       end
     else
-      msg = _("Use the Browse button to locate CSV file")
+      msg = _("Use the Choose file button to locate CSV file")
       err = true
     end
     @sb[:show_button] = (@sb[:good] && @sb[:good] > 0)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -88,7 +88,7 @@ class ReportController < ApplicationController
       end
     else
       redirect_to :action        => 'explorer',
-                  :flash_msg     => _("Use the Browse button to locate an Import file"),
+                  :flash_msg     => _("Use the Choose file button to locate an Import file"),
                   :flash_warning => true
     end
   end
@@ -219,7 +219,7 @@ class ReportController < ApplicationController
     upload_file = params.fetch_path(:upload, :file)
 
     if upload_file.blank?
-      add_flash("Use the browse button to locate an import file", :warning)
+      add_flash("Use the Choose file button to locate an import file", :warning)
     else
       begin
         @in_a_form = true

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -230,7 +230,7 @@ describe CatalogController do
 
     it "displays a message when an image file is not selected " do
       post :st_upload_image, :params => { :format => :js, :id => @st.id, :commit => 'Upload' }
-      expect(assigns(:flash_array).first[:message]).to include("Use the Browse button to locate a .png or .jpg image file")
+      expect(assigns(:flash_array).first[:message]).to include("Use the Choose file button to locate a .png or .jpg image file")
     end
   end
 

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -285,7 +285,7 @@ describe MiqAeCustomizationController do
       it "redirects with a warning message" do
         post :upload_import_file, :params => params, :xhr => true
         expect(controller.instance_variable_get(:@flash_array))
-          .to include(:message => "Use the browse button to locate an import file", :level => :warning)
+          .to include(:message => "Use the Choose file button to locate an import file", :level => :warning)
       end
     end
 

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -401,7 +401,7 @@ Methods updated/added: 10
         post :upload_import_file, :params => params, :xhr => true
         expect(response).to redirect_to(
           :action  => :review_import,
-          :message => {:message => "Use the browse button to locate an import file", :level => :warning}.to_json
+          :message => {:message => "Use the Choose file button to locate an import file", :level => :warning}.to_json
         )
       end
     end

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -60,7 +60,7 @@ describe MiqPolicyController do
         expect(response).to redirect_to(
           :action      => "export",
           :dbtype      => "dbtype",
-          :flash_msg   => "Use the Browse button to locate an Import file",
+          :flash_msg   => "Use the Choose file button to locate an Import file",
           :flash_error => true
         )
       end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -936,7 +936,7 @@ describe ReportController do
       it "returns with a warning message" do
         post :upload_widget_import_file, :params => params, :xhr => true
         expect(controller.instance_variable_get(:@flash_array))
-          .to include(:message => "Use the browse button to locate an import file", :level => :warning)
+          .to include(:message => "Use the Choose file button to locate an import file", :level => :warning)
       end
     end
 


### PR DESCRIPTION
In past we have changed the upload UI element and all the 'Browse' buttons have become 'Choose file' buttons. This pr makes the error messages consistent with that.

I have been looking into extracting these import codes to common concern. However, that is nontrivial to achieve as there are many subtle differences in the forms, javascripts, controllers and models. :disappointed: 

Addressing:
https://bugzilla.redhat.com/show_bug.cgi?id=1368113

@miq-bot add_label ui, bug