### PR TITLE
ISCSI and FCP storage types are added to the data-stores filter tree.

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -401,6 +401,26 @@
     search_type: global
     db: Storage
 - attributes:
+    name: default_Store Type / FCP
+    description: Store Type / FCP
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Storage-store_type
+          value: FCP
+    search_type: global
+    db: Storage
+- attributes:
+    name: default_Store Type / ISCSI
+    description: Store Type / ISCSI
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Storage-store_type
+          value: ISCSI
+    search_type: global
+    db: Storage
+- attributes:
     name: default_Store Type / GlusterFS
     description: Store Type / GlusterFS
     filter: !ruby/object:MiqExpression


### PR DESCRIPTION
Purpose or Intent
-----------------
Enhancement : add ISCSI and FCP storage types to the data-stores filter tree.


Links
-----
https://bugzilla.redhat.com/1351661


Steps for Testing/QA
--------------------
- Create a storage domain of ISCSI type in oVirt
- Sync in ManageIQ
- Go to Compute->Infrastructures->Datastores
- In Global Filter select "Store Type / ISCSI"
- See the created storage domain filtered in.
- Check that no other storage type datastores are in the result

Same as above for FCP type.

![iscis_fcp_filter](https://cloud.githubusercontent.com/assets/12015519/17854804/c154e31a-687d-11e6-8e52-b55a1758b590.png)
