### PR TITLE
Move _('locale_name') to Vmdb::FastGettextHelper

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -109,7 +109,7 @@ namespace :locale do
     FastGettext.available_locales.each do |locale|
       FastGettext.locale = locale
       # TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
-      human_locale = _("locale_name")
+      human_locale = Vmdb::FastGettextHelper.locale_name
       human_locale = locale if human_locale == "locale_name"
       locale_hash[locale] = human_locale
     end

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -63,5 +63,9 @@ module Vmdb
       fix_i18n_available_locales
       FastGettext.default_text_domain = Vmdb::Gettext::Domains::TEXT_DOMAIN
     end
+
+    def self.locale_name
+      _('locale_name')
+    end
   end
 end


### PR DESCRIPTION
This move is to make sure the string 'locale_name' is found by `rake gettext:find`, since the task
looks into ruby files, but not into rake rask sources.