### PR TITLE
Chargeback for container images

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -19,7 +19,7 @@ class Chargeback < ActsAsArModel
     end
 
     base_rollup = MetricRollup.includes(
-      :resource           => [:hardware, :tenant],
+      :resource           => [:hardware, :tenant, :tags, :vim_performance_states],
       :parent_host        => :tags,
       :parent_ems_cluster => :tags,
       :parent_storage     => :tags,
@@ -99,15 +99,20 @@ class Chargeback < ActsAsArModel
 
     tags = perf.tag_names.split("|").reject { |n| n.starts_with?("folder_path_") }.sort.join("|")
     keys = [tags, perf.parent_host_id, perf.parent_ems_cluster_id, perf.parent_storage_id, perf.parent_ems_id]
+    keys += [perf.resource.container_image, perf.timestamp] if perf.resource_type == Container.name
     tenant_resource = perf.resource.try(:tenant)
     keys.push(tenant_resource.id) unless tenant_resource.nil?
     key = keys.join("_")
     return @rates[key] if @rates.key?(key)
 
-    tag_list = perf.tag_names.split("|").inject([]) { |arr, t| arr << "vm/tag/managed/#{t}"; arr }
+    tag_list = perf.tag_names.split("|").inject([]) { |arr, t| arr << "#{Chargeback.report_cb_model(self.class.name).underscore}/tag/managed/#{t}" }
 
-    parents = [perf.parent_host, perf.parent_ems_cluster, perf.parent_storage, perf.parent_ems, @enterprise].compact
-    parents.push(tenant_resource) unless tenant_resource.nil?
+    if perf.resource_type == Container.name
+      state = perf.resource.vim_performance_state_for_ts(perf.timestamp.to_s)
+      tag_list += state.image_tag_names.split("|").inject([]) { |arr, t| arr << "container_image/tag/managed/#{t}" } if state.present?
+    end
+
+    parents = get_rate_parents(perf).compact
 
     @rates[key] = ChargebackRate.get_assigned_for_target(perf.resource, :tag_list => tag_list, :parents => parents)
   end
@@ -239,5 +244,50 @@ class Chargeback < ActsAsArModel
 
   def self.report_tag_field
     "tag_name"
+  end
+
+  def self.get_rate_parents
+    raise "Chargeback: get_rate_parents must be implemented in child class."
+  end
+
+  def self.set_chargeback_report_options(rpt, edit)
+    rpt.cols = %w(start_date display_range)
+
+    static_cols = report_static_cols
+    if edit[:new][:cb_groupby] == "date"
+      rpt.cols += static_cols
+      rpt.col_order = ["display_range"] + static_cols
+      rpt.sortby = ["start_date"] + static_cols
+    elsif edit[:new][:cb_groupby] == "vm"
+      rpt.cols += static_cols
+      rpt.col_order = static_cols + ["display_range"]
+      rpt.sortby = static_cols + ["start_date"]
+    elsif edit[:new][:cb_groupby] == "tag"
+      tag_col = report_tag_field
+      rpt.cols += tag_col
+      rpt.col_order = [tag_col, "display_range"]
+      rpt.sortby = [tag_col, "start_date"]
+    elsif edit[:new][:cb_groupby] == "project"
+      static_cols -= ["image_name"]
+      rpt.cols += static_cols
+      rpt.col_order = static_cols + ["display_range"]
+      rpt.sortby = static_cols + ["start_date"]
+    end
+    rpt.col_order.each do |c|
+      if c == tag_col
+        header = edit[:cb_cats][edit[:new][:cb_groupby_tag]]
+        rpt.headers.push(Dictionary.gettext(header, :type => :column, :notfound => :titleize))
+      else
+        rpt.headers.push(Dictionary.gettext(c, :type => :column, :notfound => :titleize))
+      end
+
+      rpt.col_formats.push(nil) # No formatting needed on the static cols
+    end
+
+    rpt.col_options = report_col_options
+    rpt.order = "Ascending"
+    rpt.group = "y"
+    rpt.tz = edit[:new][:tz]
+    rpt
   end
 end # class Chargeback

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -121,8 +121,8 @@ class ChargebackVm < Chargeback
     end
   end
 
-  def self.report_name_field
-    "vm_name"
+  def self.report_static_cols
+    %w(vm_name)
   end
 
   def self.report_col_options
@@ -165,5 +165,10 @@ class ChargebackVm < Chargeback
 
   def tags
     Vm.includes(:tags).find_by_ems_ref(vm_uid).try(:tags).to_a
+  end
+
+  def get_rate_parents(perf)
+    @enterprise ||= MiqEnterprise.my_enterprise
+    [perf.parent_host, perf.parent_ems_cluster, perf.parent_storage, perf.parent_ems, @enterprise, perf.resource.try(:tenant)]
   end
 end # class Chargeback

--- a/app/views/report/_form_filter_chargeback.html.haml
+++ b/app/views/report/_form_filter_chargeback.html.haml
@@ -12,6 +12,8 @@
           - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"], ["%s Tag" % current_tenant.name, "tag"]]
         - elsif @edit[:new][:model] == "ChargebackVm"
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_('Tenant'), "tenant"]]
+        - elsif @edit[:new][:model] == "ChargebackContainerImage"
+          - opts += [[ui_lookup(:model => @edit[:new][:cb_model]), "entity"]]
         - else
           - opts += [[_('Owner'), "owner"], ["%{tenant_name} Tag" % {:tenant_name => current_tenant.name}, "tag"], [_(@edit[:new][:cb_model].to_s), "entity"]]
         = select_tag("cb_show_typ",
@@ -108,8 +110,11 @@
     %label.control-label.col-md-2
       = _('Group by')
     .col-md-8
+      - opts = [["#{_('Date')}", "date"], ["#{_(@edit[:new][:cb_model])}", "vm"]]
+      - opts += [["#{_('Tag')}", "tag"]] unless @edit[:new][:model] == "ChargebackContainerImage"
+      - opts += [["#{_('Project')}", "project"]] if @edit[:new][:model] == "ChargebackContainerImage"
       = select_tag("cb_groupby",
-        options_for_select([["#{_('Date')}", "date"], ["#{_('VM/Instance/Project')}", "vm"], ["#{_('Tag')}", "tag"]], @edit[:new][:cb_groupby]),
+        options_for_select(opts, @edit[:new][:cb_groupby]),
         :class                 => "selectpicker")
       :javascript
         miqInitSelectPicker();

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -9,6 +9,7 @@ class MiqExpression
     BottleneckEvent
     ChargebackVm
     ChargebackContainerProject
+    ChargebackContainerImage
     CloudResourceQuota
     CloudTenant
     CloudVolume

--- a/spec/factories/vim_performance_state.rb
+++ b/spec/factories/vim_performance_state.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :vim_performance_state, :class => :VimPerformanceState do
+    timestamp { Time.now.utc }
+    state_data {{}}
+  end
+end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -59,9 +59,10 @@ describe ChargebackContainerImage do
                                                         :tag_names                => "",
                                                         :resource_name            => @project.name,
                                                         :resource_id              => @project.id)
-        state = VimPerformanceState.capture(@container)
-        state.timestamp = t
-        state.save
+        #state = VimPerformanceState.capture(@container)
+        @container.vim_performance_states << FactoryGirl.create(:vim_performance_state,
+                                                                :timestamp => t,
+                                                                :image_tag_names => "environment/prod")
       end
       @metric_size = @container.metric_rollups.size
     end
@@ -99,7 +100,7 @@ describe ChargebackContainerImage do
 
       while time < end_time
         @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
-                                                         :timestamp                => time.to_s,
+                                                         :timestamp                => time,
                                                          :cpu_usage_rate_average   => @cpu_usage_rate,
                                                          :derived_vm_numvcpus      => @cpu_count,
                                                          :derived_memory_available => @memory_available,
@@ -109,9 +110,9 @@ describe ChargebackContainerImage do
                                                          :tag_names                => "",
                                                          :resource_name            => @project.name,
                                                          :resource_id              => @project.id)
-        state = VimPerformanceState.capture(@container)
-        state.timestamp = time.to_s
-        state.save
+        @container.vim_performance_states << FactoryGirl.create(:vim_performance_state,
+                                                                :timestamp => time,
+                                                                :image_tag_names => "environment/prod")
         time += 12.hours
       end
       @metric_size = @container.metric_rollups.size

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,0 +1,140 @@
+describe ChargebackContainerImage do
+  before do
+    MiqRegion.seed
+    ChargebackRate.seed
+
+    EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryGirl.create(:ems_openshift)
+
+    @node = FactoryGirl.create(:container_node, :name => "node")
+    @image = FactoryGirl.create(:container_image, :ext_management_system => @ems)
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => @ems)
+    @group = FactoryGirl.create(:container_group, :ext_management_system => @ems, :container_project => @project,
+                                :container_node => @node)
+    @container = FactoryGirl.create(:kubernetes_container, :container_group => @group, :container_image => @image)
+    cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
+    c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
+    @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "compute")
+    ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :tag => [c, "container_image"] }])
+
+    @tag = c.tag
+    @project.tag_with(@tag.name, :ns => '*')
+    @image.tag_with(@tag.name, :ns => '*')
+
+    @hourly_rate       = 0.01
+    @count_hourly_rate = 1.00
+    @cpu_usage_rate    = 50.0
+    @cpu_count         = 1.0
+    @memory_available  = 1000.0
+    @memory_used       = 100.0
+    @net_usage_rate    = 25.0
+
+    @options = {:interval_size       => 1,
+                :end_interval_offset => 0,
+                :ext_options         => {:tz => "Pacific Time (US & Canada)"},
+    }
+
+    Timecop.travel(Time.parse("2012-09-01 00:00:00 UTC"))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context "Daily" do
+    before do
+      @options[:interval] = "daily"
+      @options[:entity_id] = @project.id
+      @options[:tag] = nil
+
+      ["2012-08-31T07:00:00Z", "2012-08-31T08:00:00Z", "2012-08-31T09:00:00Z", "2012-08-31T10:00:00Z"].each do |t|
+        @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
+                                                        :timestamp                => t,
+                                                        :cpu_usage_rate_average   => @cpu_usage_rate,
+                                                        :derived_vm_numvcpus      => @cpu_count,
+                                                        :derived_memory_available => @memory_available,
+                                                        :derived_memory_used      => @memory_used,
+                                                        :net_usage_rate_average   => @net_usage_rate,
+                                                        :parent_ems_id            => @ems.id,
+                                                        :tag_names                => "",
+                                                        :resource_name            => @project.name,
+                                                        :resource_id              => @project.id)
+        state = VimPerformanceState.capture(@container)
+        state.timestamp = t
+        state.save
+      end
+      @metric_size = @container.metric_rollups.size
+    end
+
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+
+    let(:cbt) {
+      FactoryGirl.create(:chargeback_tier,
+                         :start         => 0,
+                         :finish        => Float::INFINITY,
+                         :fixed_rate    => 0.0,
+                         :variable_rate => @hourly_rate.to_s)
+    }
+    let!(:cbrd) {
+      FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :chargeback_rate_id => @cbr.id,
+                         :per_time           => "hourly",
+                         :chargeback_tiers   => [cbt])
+    }
+    it "fixed_compute" do
+      expect(subject.fixed_compute_1_cost).to eq(@hourly_rate * @metric_size)
+    end
+  end
+
+  context "Monthly" do
+    before do
+      @options[:interval] = "monthly"
+      @options[:entity_id] = @project.id
+      @options[:tag] = nil
+
+      tz = Metric::Helper.get_time_zone(@options[:ext_options])
+      ts = Time.now.in_time_zone(tz)
+      time     = ts.beginning_of_month.utc
+      end_time = ts.end_of_month.utc
+
+      while time < end_time
+        @container.metric_rollups << FactoryGirl.create(:metric_rollup_vm_hr,
+                                                         :timestamp                => time.to_s,
+                                                         :cpu_usage_rate_average   => @cpu_usage_rate,
+                                                         :derived_vm_numvcpus      => @cpu_count,
+                                                         :derived_memory_available => @memory_available,
+                                                         :derived_memory_used      => @memory_used,
+                                                         :net_usage_rate_average   => @net_usage_rate,
+                                                         :parent_ems_id            => @ems.id,
+                                                         :tag_names                => "",
+                                                         :resource_name            => @project.name,
+                                                         :resource_id              => @project.id)
+        state = VimPerformanceState.capture(@container)
+        state.timestamp = time.to_s
+        state.save
+        time += 12.hours
+      end
+      @metric_size = @container.metric_rollups.size
+    end
+
+    subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(@options).first.first }
+
+    let(:cbt) {
+      FactoryGirl.create(:chargeback_tier,
+                         :start         => 0,
+                         :finish        => Float::INFINITY,
+                         :fixed_rate    => 0.0,
+                         :variable_rate => @hourly_rate.to_s)
+    }
+    let!(:cbrd) {
+      FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :chargeback_rate_id => @cbr.id,
+                         :per_time           => "hourly",
+                         :chargeback_tiers   => [cbt])
+    }
+    it "fixed_compute" do
+      # .to be_within(0.01) is used since theres a float error here
+      expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @metric_size)
+    end
+  end
+end


### PR DESCRIPTION
Chargeback based on the number of hours container images are running.
For this we need the following:
~~- [ ] Disconnect ContainerImages or keep them otherwise https://github.com/ManageIQ/manageiq/pull/10872~~ we might not need this
- [x] Attach `ChargebackRates` to specific image tags #11015
- [x] Keep image tags along with `Container` metrics  #11016
- [x] Add code to ChargebackContainerImage  according to the above changes (This PR)
- [x] testing (This PR)

![screencapture-localhost-3000-report-explorer-1471901848587](https://cloud.githubusercontent.com/assets/11256940/17867303/9b4c9106-68b2-11e6-8d21-bba31e833a2a.png)
![screencapture-localhost-3000-report-explorer-1471901822288](https://cloud.githubusercontent.com/assets/11256940/17867304/9c1885fe-68b2-11e6-92fa-f7e4a9f8318d.png)

~~Full functionality depends on: #10120 #10671~~
~~With just this patch, all image hours will cost the same.~~
cc @simon3z 