### PR TITLE
Only delete storage profiles on full EMS refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -286,8 +286,18 @@ module EmsRefresh::SaveInventoryInfra
     store_ids_for_new_records(ems.resource_pools, hashes, :uid_ems)
   end
 
-  def save_storage_profiles_inventory(ems, hashes, _target = nil)
-    save_inventory_multi(ems.storage_profiles, hashes, :use_association, [:ems_ref], [:storage_profile_storages])
+  def save_storage_profiles_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+
+    ems.storage_profiles.reset
+    deletes =
+      if target == ems
+        :use_association
+      else
+        []
+      end
+
+    save_inventory_multi(ems.storage_profiles, hashes, deletes, [:ems_ref], [:storage_profile_storages])
     store_ids_for_new_records(ems.storage_profiles, hashes, [:ems_ref])
   end
 
@@ -300,7 +310,7 @@ module EmsRefresh::SaveInventoryInfra
     end
 
     save_inventory_multi(storage_profile.storage_profile_storages, hashes,
-                         :use_association, [:storage_profile_id, :storage_id])
+                         [], [:storage_profile_id, :storage_id])
   end
 
   def save_customization_specs_inventory(ems, hashes, _target = nil)

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_storage_profile_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_storage_profile_spec.rb
@@ -66,6 +66,25 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       expect(storage_profile.disks).to include(disk)
     end
 
+    it 'will not delete storage_profiles or clear the associations when target refreshing a VM' do
+      expect(StorageProfile.count).to eq(6)
+      refresher = ems.refresher.new([vm])
+      # full ems refresh
+      target, inventory = refresher.collect_inventory_for_targets(ems, [ems])[0]
+      hashes = refresher.parse_targeted_inventory(ems, target, inventory)
+      refresher.save_inventory(ems, target, hashes)
+      expect(StorageProfile.count).to eq(6)
+
+      # vm-targeted refresh
+      target, inventory = refresher.collect_inventory_for_targets(ems, [vm])[0]
+      hashes = refresher.parse_targeted_inventory(ems, target, inventory)
+      refresher.save_inventory(ems, target, hashes)
+      expect(StorageProfile.count).to eq(6)
+
+      vm.reload
+      expect(vm.storage_profile).to eq(storage_profile)
+    end
+
     it 'clears the association when the storage profile of a VM/Disk is deleted' do
       refresher = ems.refresher.new([ems])
       target, inventory = refresher.collect_inventory_for_targets(ems, [ems])[0]


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix an issue where storage profile records were being deleted when a targeted refresh of a VM or Host was run.  Now only delete storage profiles when a full EMS refresh is run (same as folders, resource pools, etc...)

Steps for Testing/QA
--------------------
Using the rails console:
1. Run a full refresh
`EmsRefresh.refresh(ExtManagementSystem.first)`
2. Check the number of storage profiles and storage profile - storage associations
`StorageProfile.count`
`StorageProfileStorage.count`
3. Run a targeted refresh
`EmsRefresh.refresh(Vm.first)`
4. Confirm the number of storage profiles hasn't changes
`StorageProfile.count`
`StorageProfileStorage.count`