### PR TITLE
Fix mising namespaced AutomationTestSpec helper in task_finished_spec

### DIFF
--- a/spec/automation/unit/method_validation/task_finished_spec.rb
+++ b/spec/automation/unit/method_validation/task_finished_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-include AutomationSpecHelper
+include Spec::Support::AutomationHelper
 
 describe "task_finished_status" do
   def build_resolve_path


### PR DESCRIPTION
Purpose or Intent
-----------------
`AutomationTestHelper` was recently namespaced, fix task_finished_spec to use the right helper name.

Test failure: https://travis-ci.org/ManageIQ/manageiq/jobs/154226174
```
/home/travis/build/ManageIQ/manageiq/spec/automation/unit/method_validation/task_finished_spec.rb:2:in `<top (required)>': uninitialized constant AutomationSpecHelper (NameError)
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration.rb:1435:in `block in load_spec_files'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration.rb:1433:in `each'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/configuration.rb:1433:in `load_spec_files'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:100:in `setup'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:86:in `run'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:71:in `run'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.2/exe/rspec:4:in `<main>'
```