### PR TITLE
Show the name of the StorageProfile on the summary

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -168,7 +168,7 @@ module VmHelper::TextualSummary
 
   def textual_storage_profile
     return nil if @record.storage_profile.nil?
-    {:label => _("Storage Profile"), :value => @record.storage_profile}
+    {:label => _("Storage Profile"), :value => @record.storage_profile.name}
   end
 
   def textual_discovered


### PR DESCRIPTION
Fix for showing the name of a storage profile on the UI

Before:
![screenshot from 2016-08-22 16-30-20](https://cloud.githubusercontent.com/assets/12851112/17870557/01f75f9e-6886-11e6-9411-3f63da94675e.png)
After:
![screenshot from 2016-08-22 16-29-58](https://cloud.githubusercontent.com/assets/12851112/17870560/04068120-6886-11e6-9325-221c65ddec20.png)