### PR TITLE
Fix the toolbar button tooltip for Providers in GTL view

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -89,7 +89,7 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
         button(
           :ems_cloud_recheck_auth_status,
           'fa fa-search fa-lg',
-          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status for the selected Cloud Providers'),
           N_('Re-check Authentication Status'),
           :url_parms => "main_div",
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -72,7 +72,7 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
   ])
   button_group('ems_container_authentication', [
     select(
-      :ems_cloud_authentication_choice,
+      :ems_container_authentication_choice,
       'fa fa-lock fa-lg',
       t = N_('Authentication'),
       t,
@@ -80,9 +80,9 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
       :onwhen  => "1+",
       :items   => [
         button(
-          :ems_cloud_recheck_auth_status,
+          :ems_container_recheck_auth_status,
           'fa fa-search fa-lg',
-          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status for the selected Containers Providers '),
           N_('Re-check Authentication Status'),
           :url_parms => "main_div",
           :enabled   => false,

--- a/app/helpers/application_helper/toolbar/ems_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infras_center.rb
@@ -79,7 +79,7 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
   ])
   button_group('ems_infra_authentication', [
     select(
-      :ems_cloud_authentication_choice,
+      :ems_infra_authentication_choice,
       'fa fa-lock fa-lg',
       t = N_('Authentication'),
       t,
@@ -87,9 +87,9 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
       :onwhen  => "1+",
       :items   => [
         button(
-          :ems_cloud_recheck_auth_status,
+          :ems_infra_recheck_auth_status,
           'fa fa-search fa-lg',
-          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status for the selected Infrastructure Providers'),
           N_('Re-check Authentication Status'),
           :url_parms => "main_div",
           :enabled   => false,


### PR DESCRIPTION
Fixed the toolbar button tooltip for Providers in GTL view.

Replaced `#{ui_lookup(:table=>"ems_cloud")}`-like usages in the Providers GTL toolbars with the actual text. 
This is being done because `ui_lookup` will not work in this situation where the Provider record is not available when we select the Provider(s) using the checkbox in the GTL view. (all we have at this point is the provider record id/ids, and not the actual provider record)

Screenshots
-------------
Before:
<img width="1440" alt="notwork" src="https://cloud.githubusercontent.com/assets/1538216/17871559/f17cf0f8-6870-11e6-9e64-57da0463fff7.png">

After:
<img width="1440" alt="works" src="https://cloud.githubusercontent.com/assets/1538216/17871381/1e12dc28-6870-11e6-957b-2ce922188ebf.png">

Related PR and discussion : https://github.com/ManageIQ/manageiq/pull/10643


