### PR TITLE
Ansible Tower provider url verification does not display flash error with invalid credentials or when the URL contains a space

### DIFF
--- a/app/views/provider_foreman/_form.html.haml
+++ b/app/views/provider_foreman/_form.html.haml
@@ -70,15 +70,19 @@
       %label.col-md-2.control-label{"for" => "provider_url"}
         = _("Url")
       .col-md-8
-        %input.form-control{:type        => "text",
-                            :name        => "url",
-                            'ng-model'   => "providerForemanModel.url",
-                            :maxlength   => MAX_DESC_LEN,
-                            "id"         => "provider_url",
-                            :required    => "",
-                            :checkchange => true}
+        %input.form-control{:type           => "text",
+                            :name           => "url",
+                            'ng-model'      => "providerForemanModel.url",
+                            :maxlength      => MAX_DESC_LEN,
+                            "id"            => "url",
+                            :required       => "",
+                            "ng-trim"       => false,
+                            "detect_spaces" => "",
+                            :checkchange    => true}
         %span.help-block{"ng-show" => "angularForm.url.$error.required"}
           = _("Required")
+        %span.help-block{"ng-show" => "angularForm.url.$error.detectedSpaces"}
+          = _("Spaces are prohibited")
     .form-group
       %label.col-md-2.control-label
         = _("Verify Peer Certificate")


### PR DESCRIPTION
Purpose or Intent
-----------------
When the URL entered for an Ansible tower provider contained spaces, the URI validation throws an exception - this exception was not displayed in the UI until the PR 10984 was merged.

- this PR will prevent the space being entered in the URL field in the form.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1366468

Steps for Testing/QA
--------------------
When adding a new Ansible Tower provider, add one space to the end of the URL. Enter invalid credentials. Click on Validate - there will be no flash error message displayed without the fix.
Spaces should not be allowed in the URL field.

![screenshot from 2016-10-21 17-19-24](https://cloud.githubusercontent.com/assets/12769982/19612073/a28e0272-97b2-11e6-9a27-ea6ea60596c6.png)

