### PR TITLE
Move Ovirt::Inventory to ManageIQ

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -76,6 +76,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   # Connect to the engine using version 3 of the API and the `ovirt` gem.
   def self.raw_connect_v3(server, port, path, username, password, service)
     require 'ovirt'
+    require 'ovirt_provider/inventory/ovirt_inventory'
 
     Ovirt.logger = $rhevm_log
 
@@ -92,7 +93,8 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     params[:timeout]      = read_timeout if read_timeout
     params[:open_timeout] = open_timeout if open_timeout
 
-    Ovirt.const_get(service).new(params)
+    const = service == "Inventory" ? OvirtInventory : Ovirt.const_get(service)
+    const.new(params)
   end
 
   def connect(options = {})

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -33,7 +33,8 @@ gem "net-sftp",                "~>2.1.2",           :require => false
 gem "nokogiri",                "~>1.6.8",           :require => false
 gem "openscap",                "~>0.4.3",           :require => false
 gem "openshift_client",        "=1.2.0",            :require => false
-gem "ovirt",                   "~>0.11.0",          :require => false
+gem "ovirt",                   "~>0.13.0",          :require => false
+gem "parallel",                "~>1.9",             :require => false # For OvirtInventory
 gem "pg",                      "~>0.18.2",          :require => false
 gem "pg-dsn_parser",           "~>0.1.0",           :require => false
 gem "psych",                   "~>2.0.12"

--- a/gems/pending/MiqVm/test/rhevmTest.rb
+++ b/gems/pending/MiqVm/test/rhevmTest.rb
@@ -3,6 +3,7 @@ require 'log4r'
 require 'ostruct'
 require 'MiqVm/MiqVm'
 require 'ovirt'
+require 'ovirt_provider/inventory/ovirt_inventory'
 Ovirt.logger = $rhevm_log if $rhevm_log
 
 RHEVM_SERVER        = raise "please define RHEVM_SERVER"
@@ -25,7 +26,7 @@ $log = toplog if $log.nil?
 
 begin
 
-  $rhevm = Ovirt::Inventory.new(
+  $rhevm = OvirtInventory.new(
     :server     => RHEVM_SERVER,
     :port       => RHEVM_PORT,
     :domain     => RHEVM_DOMAIN,

--- a/gems/pending/ovirt_provider/events/ovirt_event_monitor.rb
+++ b/gems/pending/ovirt_provider/events/ovirt_event_monitor.rb
@@ -5,9 +5,10 @@ class OvirtEventMonitor
 
   def inventory
     require 'ovirt'
+    require 'ovirt_provider/inventory/ovirt_inventory'
     Ovirt.logger = $rhevm_log if $rhevm_log
 
-    @inventory ||= Ovirt::Inventory.new(@options)
+    @inventory ||= OvirtInventory.new(@options)
   end
 
   def start

--- a/gems/pending/ovirt_provider/inventory/ovirt_inventory.rb
+++ b/gems/pending/ovirt_provider/inventory/ovirt_inventory.rb
@@ -1,0 +1,205 @@
+class OvirtInventory
+  attr_accessor :service
+
+  def initialize(options = {})
+    @service = Ovirt::Service.new(options)
+  end
+
+  def api
+    standard_collection('api').first
+  end
+
+  def capabilities
+    standard_collection("capabilities")
+  end
+
+  def clusters
+    standard_collection("clusters")
+  end
+
+  def datacenters
+    standard_collection("datacenters", "data_center")
+  end
+
+  def domains
+    standard_collection("domains")
+  end
+
+  def events(options = {})
+    if options[:since]
+      standard_collection("events?from=#{options[:since]}", "event")
+    elsif options[:max]
+      standard_collection("events;max=#{options[:max]}", "event", false, "time", :desc)
+    else
+      standard_collection("events")
+    end
+  end
+
+  def groups
+    standard_collection("groups")
+  end
+
+  def hosts
+    standard_collection("hosts", nil, true)
+  end
+
+  def networks
+    standard_collection("networks")
+  end
+
+  def roles
+    standard_collection("roles")
+  end
+
+  def storagedomains
+    standard_collection("storagedomains", "storage_domain", true)
+  end
+
+  def tags
+    standard_collection("tags")
+  end
+
+  def templates
+    standard_collection("templates")
+  end
+
+  def users
+    standard_collection("users")
+  end
+
+  def vms
+    standard_collection("vms", nil, true)
+  end
+
+  def vmpools
+    standard_collection("vmpools")
+  end
+
+  def get_vm(path)
+    vm_guid = ::File.basename(path, '.*')
+    vm      = get_resource_by_ems_ref("/api/vms/#{vm_guid}") rescue nil
+    vm      = get_resource_by_ems_ref("/api/templates/#{vm_guid}") if vm.blank?
+    vm
+  end
+
+  def get_resource_by_ems_ref(uri_suffix, element_name = nil)
+    @service.get_resource_by_ems_ref(uri_suffix, element_name)
+  end
+
+  def get_resources_by_uri_path(uri_suffix, element_name = nil)
+    @service.get_resources_by_uri_path(uri_suffix, element_name)
+  end
+
+  def refresh
+    # TODO: Change to not return native objects to the caller.  The caller
+    #       should just expect raw data.
+    primary_items = collect_primary_jobs(primary_item_jobs)
+    collect_secondary_items(primary_items, SECONDARY_ITEMS)
+  end
+
+  def targeted_refresh(methods)
+    primary_items = collect_primary_targeted_jobs(methods[:primary].to_a)
+    collect_secondary_items(primary_items, methods[:secondary])
+  end
+
+  def api_path
+    @service.api_path
+  end
+
+  private
+
+  def standard_collection(uri_suffix, element_name = nil, paginate = false, sort_by = :name, direction = :asc)
+    @service.standard_collection(uri_suffix, element_name, paginate, sort_by, direction)
+  end
+
+  # TODO: Remove this key/method translation and just use the method name as
+  #       the key directly.
+  PRIMARY_ITEMS = {
+    # Key          RHEVM API method
+    :cluster    => :clusters,
+    :vmpool     => :vmpools,
+    :network    => :networks,
+    :storage    => :storagedomains,
+    :datacenter => :datacenters,
+    :host       => :hosts,
+    :vm         => :vms,
+    :template   => :templates
+  }
+
+  SECONDARY_ITEMS = {
+    # Key          RHEVM API methods
+    :datacenter => [:storagedomains],
+    :host       => [:statistics, :host_nics], # :cdroms, tags
+    :vm         => [:disks, :snapshots, :nics],
+    :template   => [:disks]
+  }
+
+  def primary_item_jobs
+    PRIMARY_ITEMS.to_a
+  end
+
+  # Returns all combinations of primary resources and the methods to run on those resources.
+  #
+  # > secondary_item_jobs({:vm, => [v1, v2]})
+  #  => [[v1, :disks], [v1, :snapshots], [v1, :nics], [v2, :disks], [v2, :snapshots], [v2, :nics]]
+  def secondary_item_jobs(primary_items, secondary_items)
+    secondary_items.flat_map do |key, methods|
+      primary_items[key].product(methods)
+    end
+  end
+
+  def collect_primary_jobs(jobs)
+    results = collect_in_parallel(jobs) do |_, method|
+      send(method)
+    end
+
+    jobs.zip(results).each_with_object({}) do |((key, _), result), hash|
+      hash[key] = result
+    end
+  end
+
+  def collect_primary_targeted_jobs(jobs)
+    results = collect_in_parallel(jobs) do |key, ems_ref|
+      if ems_ref.kind_of?(Array)
+        ems_ref.flat_map { |item| get_resources_by_uri_path(item) rescue Array.new }
+      elsif ems_ref.kind_of?(Hash)
+        collection, element_name = ems_ref.first
+        standard_collection(collection, element_name, true)
+      else
+        get_resources_by_uri_path(ems_ref) rescue Array.new
+      end
+    end
+
+    jobs.zip(results).each_with_object({}) do |((key, _), result), hash|
+      hash[key] = result
+    end
+  end
+
+  def collect_secondary_items(primary_items, secondary_items)
+    jobs = secondary_item_jobs(primary_items, secondary_items)
+
+    results = collect_in_parallel(jobs) do |resource, method|
+      resource.send(method) rescue nil
+    end
+
+    jobs.zip(results).each do |(resource, method), result|
+      resource.attributes[method] = result
+    end
+
+    primary_items
+  end
+
+  def collect_in_parallel(jobs, &block)
+    require 'parallel'
+    Parallel.map(jobs, :in_threads => num_threads, &block)
+  end
+
+  def num_threads
+    use_threads? ? 8 : 0
+  end
+
+  # HACK: VCR is not threadsafe, and so tests running under VCR fail
+  def use_threads?
+    !defined?(VCR)
+  end
+end


### PR DESCRIPTION
Ovirt::Inventory is very specific to ManageIQ.  Therefore, it should live in the ManageIQ project.