### PR TITLE
Take 2:  Speed up "VMs & Instances in My LDAP Group" filter in /vm_or_template/explorer

### DIFF
--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,4 +1,6 @@
 describe Service do
+  include_examples "miq ownership"
+
   context "service events" do
     before(:each) do
       @service = FactoryGirl.create(:service)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1,4 +1,6 @@
 describe ServiceTemplate do
+  include_examples "miq ownership"
+
   describe "#custom_actions" do
     let(:service_template) do
       described_class.create(:name => "test", :description => "test", :custom_button_sets => [assigned_group_set])

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -1,4 +1,6 @@
 describe Vm do
+  include_examples "miq ownership"
+
   it "#corresponding_model" do
     expect(Vm.corresponding_model).to eq(MiqTemplate)
     expect(ManageIQ::Providers::Vmware::InfraManager::Vm.corresponding_model).to eq(ManageIQ::Providers::Vmware::InfraManager::Template)

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -5,19 +5,75 @@ shared_examples "miq ownership" do
   # as the `include_example`'s current context, so more likely than not, it
   # will be included in other tests that aren't part of this example group.
   context "includes mixin:  miq ownership" do
+    include ArelSpecHelper
+
+    let(:user) { User.where(:userid => "ownership_user").first }
+
+    before(:context) do
+      build_ownership_users_and_groups
+    end
+
+    describe ".owned_by_current_ldap_group" do
+      before { User.current_user = user }
+
+      it "usable as arel" do
+        group_name = user.current_group.description.downcase
+        sql        = <<-SQL.strip_heredoc.split("\n").join(' ')
+                       SELECT (LOWER("miq_groups"."description") = '#{group_name}')
+                       FROM "miq_groups"
+                       WHERE "miq_groups"."id" = "#{described_class.table_name}"."miq_group_id"
+                     SQL
+        attribute  = described_class.arel_attribute(:owned_by_current_ldap_group)
+        expect(stringify_arel(attribute)).to eq ["((#{sql}))"]
+      end
+
+      context "when miq_group is in the ldap group" do
+        it "returns true" do
+          column = "owned_by_current_ldap_group"
+          query  = described_class.where(:name => 'in_ldap')
+          expect(virtual_column_sql_value(query, column)).to eq(true)
+        end
+      end
+
+      context "when miq_group is not in the ldap group" do
+        it "returns false" do
+          column = "owned_by_current_ldap_group"
+          query  = described_class.where(:name => 'not_in_ldap')
+          expect(virtual_column_sql_value(query, column)).to eq(false)
+        end
+      end
+
+      # Since we are doing a regular inner join here, no results will be returned
+      # when there isn't an associated miq_group for the record.
+      #
+      # This was the existing behaviour of the owned_by_current_ldap_group
+      # method, so we are testing that the query (even without the
+      # virtual_attribute) will return no records.
+      context "when miq_group is in no ldap group" do
+        it "returns nil" do
+          column = "owned_by_current_ldap_group"
+          query  = described_class.where(:name => 'no_group')
+
+          expect(virtual_column_sql_value(query, column)).to eq(nil)
+        end
+
+        it "returns no results when searching by name and owned_by_current_ldap_group" do
+          column = "owned_by_current_ldap_group"
+          query  = described_class.where :name  => 'no_group',
+                                         column => false
+          expect(query.to_a.size).to eq(0)
+        end
+      end
+    end
+
     describe "reporting on ownership" do
       let(:exp_value) { "true" }
       let(:exp) { { "="=> { "field" => "#{described_class}-owned_by_current_ldap_group", "value" => exp_value } } }
       let(:report) { MiqReport.new.tap { |r| r.db = described_class.to_s } }
       let(:search_opts) { { :filter => MiqExpression.new(exp), :per_page => 20 } }
-      let(:user)              { User.where(:userid => "ownership_user").first }
       let(:owned_by_group_1)  { described_class.where(:name => 'in_ldap').first }
       let(:owned_by_group_2)  { described_class.where(:name => 'not_in_ldap').first }
       let(:owned_by_group_3)  { described_class.where(:name => 'no_group').first }
-
-      before(:context) do
-        build_ownership_users_and_groups
-      end
 
       before do
         expect(User).to receive(:server_timezone).and_return("UTC")
@@ -42,27 +98,27 @@ shared_examples "miq ownership" do
           expect(owned_ids).to match_array [owned_by_group_2.id]
         end
       end
+    end
 
-      after(:context) do
-        teardown_ownership_users_and_groups
-      end
+    after(:context) do
+      teardown_ownership_users_and_groups
+    end
 
-      def build_ownership_users_and_groups
-        user = FactoryGirl.create :user,
-                                  :userid     => "ownership_user",
-                                  :miq_groups => FactoryGirl.create_list(:miq_group, 1)
+    def build_ownership_users_and_groups
+      user = FactoryGirl.create :user,
+                                :userid     => "ownership_user",
+                                :miq_groups => FactoryGirl.create_list(:miq_group, 1)
 
-        factory = described_class.to_s.underscore.to_sym
-        FactoryGirl.create factory, :name => "in_ldap",     :miq_group_id => user.current_group.id
-        FactoryGirl.create factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group)
-        FactoryGirl.create factory, :name => "no_group"
-      end
+      factory = described_class.to_s.underscore.to_sym
+      FactoryGirl.create factory, :name => "in_ldap",     :miq_group_id => user.current_group.id
+      FactoryGirl.create factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group)
+      FactoryGirl.create factory, :name => "no_group"
+    end
 
-      def teardown_ownership_users_and_groups
-        described_class.destroy_all
-        User.destroy_all
-        MiqGroup.destroy_all
-      end
+    def teardown_ownership_users_and_groups
+      described_class.destroy_all
+      User.destroy_all
+      MiqGroup.destroy_all
     end
   end
 end

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -1,0 +1,68 @@
+shared_examples "miq ownership" do
+  # THIS TOP LEVEL CONTEXT IS REQUIRED because tests that include are database
+  # state dependent and require a clean DB.  When used with `include_examples`,
+  # the before(:context) and after(:context) in this are run on the same level
+  # as the `include_example`'s current context, so more likely than not, it
+  # will be included in other tests that aren't part of this example group.
+  context "includes mixin:  miq ownership" do
+    describe "reporting on ownership" do
+      let(:exp_value) { "true" }
+      let(:exp) { { "="=> { "field" => "#{described_class}-owned_by_current_ldap_group", "value" => exp_value } } }
+      let(:report) { MiqReport.new.tap { |r| r.db = described_class.to_s } }
+      let(:search_opts) { { :filter => MiqExpression.new(exp), :per_page => 20 } }
+      let(:user)              { User.where(:userid => "ownership_user").first }
+      let(:owned_by_group_1)  { described_class.where(:name => 'in_ldap').first }
+      let(:owned_by_group_2)  { described_class.where(:name => 'not_in_ldap').first }
+      let(:owned_by_group_3)  { described_class.where(:name => 'no_group').first }
+
+      before(:context) do
+        build_ownership_users_and_groups
+      end
+
+      before do
+        expect(User).to receive(:server_timezone).and_return("UTC")
+
+        # Needs to be done after the groups are created, otherwise the
+        # described_class will be auto-assigned with the current user's group
+        User.current_user = user
+      end
+
+      context "searching by records in current ldap group" do
+        it "returns results only part of the miq_group" do
+          owned_ids = report.paged_view_search(search_opts).first.map(&:id)
+          expect(owned_ids).to match_array [owned_by_group_1.id]
+        end
+      end
+
+      context "searching by records not in current ldap group" do
+        let(:exp_value) { "false" }
+
+        it "returns results not part of the miq_group" do
+          owned_ids = report.paged_view_search(search_opts).first.map(&:id)
+          expect(owned_ids).to match_array [owned_by_group_2.id]
+        end
+      end
+
+      after(:context) do
+        teardown_ownership_users_and_groups
+      end
+
+      def build_ownership_users_and_groups
+        user = FactoryGirl.create :user,
+                                  :userid     => "ownership_user",
+                                  :miq_groups => FactoryGirl.create_list(:miq_group, 1)
+
+        factory = described_class.to_s.underscore.to_sym
+        FactoryGirl.create factory, :name => "in_ldap",     :miq_group_id => user.current_group.id
+        FactoryGirl.create factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group)
+        FactoryGirl.create factory, :name => "no_group"
+      end
+
+      def teardown_ownership_users_and_groups
+        described_class.destroy_all
+        User.destroy_all
+        MiqGroup.destroy_all
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Speeds up "VMs & Instances in My LDAP Group" index and ajax calls in the `/vm_or_template` (Services -> Workload) section of the application, and does so without needing to affect controller or view code.


How
---
This adds `virtual_attribute` on to the `ownership_mixin`, which is used by a few classes and makes it so that MiqExpressions will evaluate filter in SQL instead of pulling down all matching records to then iterate over and filter in Ruby (causes a Massive N+1 on large datasets).  This does not require a join for the `virtual_attribute` to function, but in doing so, we lose a bit of possible performance gains.  That said, this makes the code much more flexible by skipping the join, so this is preferred for now.

The code changes that make use of a JOIN can be [found here](https://github.com/ManageIQ/manageiq/pull/10290) that you can use as a way of comparing the code change footprints.


Metrics
-------
The data set for these metrics used a DB with approximately 20k `Vm` records.


**Before (Regular User)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 7242ms (Views: 2.0ms | ActiveRecord: 884.1ms)

|      ms |   bytes |   objects | queries | query (ms) |   rows |
|    ---: |    ---: |      ---: |    ---: |       ---: |   ---: |
| 6,043.1 |     N/A | 3,769,724 |      44 |    4,158.3 | 29,709 |


**After (Regular User)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 1092ms (Views: 4.1ms | ActiveRecord: 179.3ms)

|      ms |   bytes |   objects | queries | query (ms) |   rows |
|    ---: |    ---: |      ---: |    ---: |       ---: |   ---: |
|   903.0 |     N/A |   783,617 |      30 |      397.8 |    397 |


**Before (Admin)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 94316ms (Views: 1.1ms | ActiveRecord: 13351.1ms)

|       ms | bytes |    objects | queries | query (ms) |    rows |
|     ---: |  ---: |       ---: |    ---: |       ---: |    ---: |
| 93,770.4 |   N/A | 57,852,016 |     112 |   78,603.0 | 349,084 |



**After (Admin)**

Started POST "/vm_or_template/tree_select/?id=:id"...
Completed 200 OK in 636ms (Views: 2.6ms | ActiveRecord: 319.6ms)

|       ms | bytes |    objects | queries | query (ms) |    rows |
|     ---: |  ---: |       ---: |    ---: |       ---: |    ---: |
|    524.4 |   N/A |    125,591 |      20 |      634.3 |      14 |



Links
-----
* https://www.pivotaltracker.com/story/show/127472985
* https://github.com/ManageIQ/manageiq/pull/10290 (old attempt)