### PR TITLE
Refactor default required credential fields in authentication mixin

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -75,6 +75,10 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
     at
   end
 
+  def required_credential_fields(_type)
+    [:auth_key]
+  end
+
   def verify_credentials(auth_type = nil, options = {})
     options = options.merge(:auth_type => auth_type)
     if options[:auth_type] == "hawkular"

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -292,6 +292,10 @@ class MiqRegion < ApplicationRecord
     end
   end
 
+  def required_credential_fields(_type)
+    [:auth_key]
+  end
+
   def self.api_system_auth_token_for_region(region_id, user)
     find_by_region(region_id).api_system_auth_token(user)
   end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -78,15 +78,8 @@ module AuthenticationMixin
     authentication_component(type, :service_account)
   end
 
-  def required_credential_fields(type)
-    case type.to_s
-    when "bearer", "system_api"
-      [:auth_key]
-    when "hawkular"
-      []
-    else
-      [:userid]
-    end
+  def required_credential_fields(_type)
+    [:userid]
   end
 
   def has_credentials?(type = nil)

--- a/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager_spec.rb
@@ -16,9 +16,19 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager do
         :ems_kubernetes,
         :hostname        => 'hostname',
         :authentications => [
-          FactoryGirl.build(:authentication, :authtype => 'bearer', :auth_key => 'valid-token')
+          FactoryGirl.build(:authentication, :authtype => 'bearer', :auth_key => 'valid-token'),
+          FactoryGirl.build(:authentication, :authtype => 'hawkular')
         ]
       )
+    end
+
+    it "checks for the right credential fields" do
+      expect(@ems.required_credential_fields(:bearer)).to eq([:auth_key])
+    end
+
+    it "checks for missing_credentials" do
+      expect(@ems.missing_credentials?(:bearer)).to be_falsey
+      expect(@ems.missing_credentials?(:hawkular)).to be_truthy
     end
 
     it ".scan_entity_create" do

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -186,4 +186,12 @@ describe MiqRegion do
       expect(token_hash[:timestamp]).to be > 5.minutes.ago.utc
     end
   end
+
+  describe "#required_credential_fields" do
+    let(:region) { FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number) }
+
+    it "checks the right credential fields" do
+      expect(region.required_credential_fields(:system_api)).to eq([:auth_key])
+    end
+  end
 end


### PR DESCRIPTION
**Description**
Container provider manager does not implement the function `required_credential_fields`, it relays on a wrong implementation in authentication_mixin. This PR implements the `required_credential_fields` in the container provider and remove the bad implementation in authentication_mixin
 
**Screenshot**
Before
![screenshot from 2016-08-23 11-28-38](https://cloud.githubusercontent.com/assets/2181522/17885728/2a92c384-6927-11e6-9688-5380558fd76a.jpg)
After
![screenshot from 2016-08-23 11-30-08](https://cloud.githubusercontent.com/assets/2181522/17885725/2750ee76-6927-11e6-8ccf-270b1bd9182b.jpg)

**Issue**
https://github.com/ManageIQ/manageiq/issues/10689