### PR TITLE
Api for Notification Drawer

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  class NotificationsController < BaseController
+    def notifications_search_conditions
+      {:user_id => @auth_user_obj.id}
+    end
+
+    def find_notifications(id)
+      @auth_user_obj.notification_recipients.find(id)
+    end
+
+    def mark_as_seen_resource_notifications(type, id = nil, _data = nil)
+      api_action(type, id) do |klass|
+        notification = resource_search(id, type, klass)
+        action_result(notification.update_attribute(:seen, true) || false)
+      end
+    end
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,10 +13,27 @@ class Notification < ApplicationRecord
     self.notification_type = NotificationType.find_by_name!(typ)
   end
 
+  def to_h
+    {
+      :level      => notification_type.level,
+      :created_at => created_at,
+      :text       => notification_type.message,
+      :bindings   => text_bindings
+    }
+  end
+
   private
 
   def set_notification_recipients
     subscribers = notification_type.subscriber_ids(subject, initiator)
     self.notification_recipients_attributes = subscribers.collect { |id| {:user_id => id } }
+  end
+
+  def text_bindings
+    h = {}
+    h[:initiator] = { :text => initiator.name } if initiator
+    h[:subject] = { :text => subject.name } if subject
+    h[:cause] = { :text => cause.name } if cause
+    h
   end
 end

--- a/app/models/notification_recipient.rb
+++ b/app/models/notification_recipient.rb
@@ -2,6 +2,11 @@ class NotificationRecipient < ApplicationRecord
   belongs_to :notification
   belongs_to :user
   default_value_for :seen, false
+  virtual_column :details, :type => :string
 
   scope :unseen, -> { where(:seen => false) }
+
+  def details
+    notification.to_h.merge(:seen => seen)
+  end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -540,6 +540,18 @@
         :identifier: instance_guest_restart
       - :name: reset
         :identifier: instance_reset
+  :notifications:
+    :description: User's past notifications
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: NotificationRecipient
+    :collection_actions:
+      :post:
+      - :name: mark_as_seen
+    :resource_actions:
+      :post:
+      - :name: mark_as_seen
   :pictures:
     :description: Pictures
     :options:

--- a/spec/factories/notification.rb
+++ b/spec/factories/notification.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :notification do
+    notification_type
+  end
+end

--- a/spec/factories/notification_type.rb
+++ b/spec/factories/notification_type.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :notification_type do
     sequence(:name) { |n| "notification_type_#{seq_padded_for_sorting(n)}" }
     sequence(:message) { |n| "message_#{seq_padded_for_sorting(n)}" }
+    audience 'user'
     level "info"
   end
 end

--- a/spec/requests/api/notifications_spec.rb
+++ b/spec/requests/api/notifications_spec.rb
@@ -1,0 +1,53 @@
+describe 'Notifications API' do
+  let(:foreign_user) { FactoryGirl.create(:user) }
+  let(:notification) { FactoryGirl.create(:notification, :initiator => @user) }
+  let(:foreign_notification) { FactoryGirl.create(:notification, :initiator => foreign_user) }
+  let(:notification_recipient) { notification.notification_recipients.first }
+  let(:notification_url) { notifications_url(notification_recipient.id) }
+
+  describe 'notification create' do
+    it 'is not supported' do
+      api_basic_authorize
+
+      run_post(notifications_url, gen_request(:create, :notification_id => 1, :user_id => 1))
+      expect_bad_request(/Unsupported Action create/i)
+    end
+  end
+
+  describe 'notification edit' do
+    it 'is not supported' do
+      api_basic_authorize
+
+      run_post(notifications_url, gen_request(:edit, :user_id => 1, :href => notification_url))
+      expect_bad_request(/Unsupported Action edit/i)
+    end
+  end
+
+  describe 'notification delete' do
+    it 'is not supported' do
+      api_basic_authorize
+
+      run_post(notifications_url, gen_request(:delete, :href => notification_url))
+      expect_bad_request(/Unsupported Action delete/i)
+    end
+  end
+
+  describe 'mark_as_seen' do
+    subject { notification_recipient.seen }
+    it 'rejects on notification that is not owned by current user' do
+      api_basic_authorize
+
+      run_post(notifications_url(foreign_notification.notification_recipient_ids.first), gen_request(:mark_as_seen))
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'marks single notification seen and returns success' do
+      api_basic_authorize
+
+      expect(notification_recipient.seen).to be_falsey
+      run_post(notification_url, gen_request(:mark_as_seen))
+      expect_single_action_result(:success => true, :href => :notification_url)
+      expect(notification_recipient.reload.seen).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Purpose
-----------------
The API will be used by UI to fill in the [Patternfly Drawer](https://www.patternfly.org/pattern-library/communication/notification-drawer/#/api). The sample markup wip was in #10055.

**EDIT**: Firstly, I suggested slightly non-standard API. However after feedback from @abellotti, and hours of head scratching, I concluded it will be better to have /api/notifications behaving 100% consistently with the rest of the rest api.

**Updated** example output of `GET /api/notifications?expand=resources&attributes=details&filter[]=seen=false`
```
    {
        "name": "notifications",
        "count": 5,
        "subcount": 1,
        "resources":
        [
            {
                "href": "http://localhost:3000/api/notifications/1000000000013",
                "id": 1000000000013,
                "notification_id": 1000000000005,
                "user_id": 1000000000001,
                "seen": false,
                "details":
                {
                    "level": "success",
                    "created_at": "2016-08-23T07:18:20Z",
                    "text": "Virtual Machine %{subject} has been powered off",
                    "bindings":
                    {
                        "subject":
                        {
                            "text": "smoketest_provider.SmoketestRHEV",
                            "link": "TODO"
                        }
                    },
                    "seen": false
                },
                "actions":
                [
                    {
                        "name": "mark_as_seen",
                        "method": "post",
                        "href": "http://localhost:3000/api/notifications/1000000000013"
                    }
                ]
            },
        ]
    }
```
As you can see, we expect to text interpolation to be done on the client. That is because we want to render links in future. Also, the internationalization will be done on the client in next stages.

**Updated** also introduce `mark_as_read` action, that can be used on a single resource or on a collection.

Mark single notification as a seen `POST /api/notifications/:id` body:
```
      { "action" : "mark_as_seen" }
```
Mark set of notifications as a seen `POST /api/notifications` body:
```
      { "action" : "mark_as_seen",
        "resources": [
         { "href" : "http://localhost:3000/api/notifications/:id" },
         { "href" : "http://localhost:3000/api/notifications/:id" },
         ...
       ]
      }
```

@miq-bot add_label api, enhancement, wip, darga/no
@miq-bot assign @skateman 
