### PR TITLE
Update ui-components to 0.0.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,6 +48,6 @@
     "qs": "^0.3.10",
     "rxjs": "^4.1.0",
     "rx-angular": "rx.angular#^1.1.3",
-    "manageiq-ui-components": "0.0.3"
+    "manageiq-ui-components": "~0.0.4"
   }
 }


### PR DESCRIPTION
Bower package `ui-components` was updated to 0.0.4 version, to fix bug fix queuing report so correspond to this. Also use tilde so we don't have to update bower each time ui-components minor version is released.