### PR TITLE
Targeted refresh improvement for vm removal

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -19,6 +19,9 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
     # Clean up the temporary cluster-datacenter references
     result[:clusters].each { |c| c.delete(:datacenter_id) }
 
+    # get disk for removed vms
+    result[:vm_disks] = vm_inv_to_disk_hashes({:disks => inv[:vm_disks]}, uids[:storages])
+
     result
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresher.rb
@@ -43,6 +43,9 @@ class ManageIQ::Providers::Redhat::InfraManager
               :template   => [:disks]
             }
           }
+          unless target.hardware.nil?
+            methods[:primary][:vm_disks] = target.hardware.disks.map { |disk| "#{disk.storage.ems_ref}/disks/#{disk.filename}" }
+          end
           data,  = Benchmark.realtime_block(:fetch_vm_data) { inventory.targeted_refresh(methods) }
 
         else

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
@@ -8,9 +8,7 @@ object:
     inherits: 
     description: 
   fields:
-  - rel4:
-      value: "/System/event_handlers/src_vm_disconnect_storage"
   - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_unregister&param="
   - rel6:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_vm"

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
@@ -23,25 +23,10 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
   end
 
   it "should refresh a vm" do
-    storage = FactoryGirl.create(:storage,
-                                 :ems_ref  => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0",
-                                 :location => "192.168.1.106:/home/pkliczewski/export/hosted")
-
-    disk = FactoryGirl.create(:disk,
-                              :storage  => storage,
-                              :filename => "da123bb9-095a-4933-95f2-8032dfa332e1")
-    hardware = FactoryGirl.create(:hardware,
-                                  :disks => [disk])
-
-    vm = FactoryGirl.create(:vm_redhat,
-                            :ext_management_system => @ems,
-                            :uid_ems               => "4f6dd4c3-5241-494f-8afc-f1c67254bf77",
-                            :ems_cluster           => @cluster,
-                            :ems_ref               => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77",
-                            :storage               => storage,
-                            :storages              => [storage],
-                            :hardware              => hardware)
-    vm.with_relationship_type("ems_metadata") { vm.parent = @rp }
+    storage = create_storage
+    disk = create_disk(storage)
+    hardware = create_hardware(disk)
+    vm = create_existing_vm(storage, hardware)
 
     VCR.use_cassette("#{described_class.name.underscore}_target_vm") do
       EmsRefresh.refresh(vm)
@@ -49,9 +34,39 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
 
     assert_table_counts
     assert_vm(vm, storage)
-    assert_vm_rels(vm, hardware, storage)
+    assert_vm_rels(vm, hardware, storage, disk)
     assert_cluster
-    assert_storage(storage, vm)
+    assert_storage(vm, storage)
+  end
+
+  it "should remove a vm without disk" do
+    storage = create_storage
+    disk = create_disk(storage)
+    hardware = create_hardware(disk)
+    vm = create_existing_vm(storage, hardware)
+
+    VCR.use_cassette("#{described_class.name.underscore}_target_removed_vm") do
+      EmsRefresh.refresh(vm)
+    end
+
+    assert_table_counts_removed
+    assert_removed_vm(vm, storage)
+    assert_removed_vm_rels(vm, hardware, storage)
+  end
+
+  it "should remove a vm with disk" do
+    storage = create_storage
+    disk = create_disk(storage)
+    hardware = create_hardware(disk)
+    vm = create_existing_vm(storage, hardware)
+
+    VCR.use_cassette("#{described_class.name.underscore}_target_removed_vm_with_disk") do
+      EmsRefresh.refresh(vm)
+    end
+
+    assert_table_counts_removed
+    assert_removed_vm(vm, storage, true)
+    assert_removed_vm_rels(vm, hardware, storage)
   end
 
   it "should refresh new vm" do
@@ -74,7 +89,38 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     hardware = Hardware.find_by(:vm_or_template_id => vm.id)
     assert_vm_rels(vm, hardware, storage)
     assert_cluster
-    assert_storage(storage, vm)
+    assert_storage(vm, storage)
+  end
+
+  def create_storage
+    FactoryGirl.create(:storage,
+                       :ems_ref  => "/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0",
+                       :location => "192.168.1.106:/home/pkliczewski/export/hosted")
+  end
+
+  def create_disk(storage)
+    FactoryGirl.create(:disk,
+                       :storage  => storage,
+                       :filename => "da123bb9-095a-4933-95f2-8032dfa332e1")
+  end
+
+  def create_hardware(disk)
+    FactoryGirl.create(:hardware,
+                       :disks => [disk])
+  end
+
+  def create_existing_vm(storage, hardware)
+    vm = FactoryGirl.create(:vm_redhat,
+                            :ext_management_system => @ems,
+                            :uid_ems               => "4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+                            :ems_cluster           => @cluster,
+                            :ems_ref               => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+                            :storage               => storage,
+                            :storages              => [storage],
+                            :hardware              => hardware)
+    vm.with_relationship_type("ems_metadata") { vm.parent = @rp }
+
+    vm
   end
 
   def assert_table_counts
@@ -84,13 +130,103 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(Vm.count).to eq(1)
     expect(Storage.count).to eq(1)
     expect(Disk.count).to eq(1)
-    expect(GuestDevice.count).to eq(1)
     expect(Hardware.count).to eq(1)
+    expect(GuestDevice.count).to eq(1)
     expect(OperatingSystem.count).to eq(1)
     expect(Snapshot.count).to eq(1)
 
     expect(Relationship.count).to eq(6)
     expect(MiqQueue.count).to eq(3)
+  end
+
+  def assert_table_counts_removed
+    expect(ExtManagementSystem.count).to eq(1)
+    expect(EmsCluster.count).to eq(1)
+    expect(ResourcePool.count).to eq(1)
+    expect(Vm.count).to eq(1)
+    expect(Storage.count).to eq(1)
+    expect(Disk.count).to eq(1)
+    expect(Hardware.count).to eq(1)
+
+    expect(Relationship.count).to eq(5)
+    expect(MiqQueue.count).to eq(3)
+  end
+
+  def assert_removed_vm(vm, storage, with_disk = false)
+    vm.reload
+    expect(vm).to have_attributes(
+      :template               => false,
+      :ems_ref                => "/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+      :ems_ref_obj            => nil,
+      :uid_ems                => "4f6dd4c3-5241-494f-8afc-f1c67254bf77",
+      :vendor                 => "redhat",
+      :raw_power_state        => "unknown",
+      :power_state            => "unknown",
+      :connection_state       => nil,
+      :format                 => nil,
+      :version                => nil,
+      :description            => nil,
+      :location               => "unknown",
+      :config_xml             => nil,
+      :autostart              => nil,
+      :host_id                => nil,
+      :last_sync_on           => nil,
+      :storage_id             => with_disk ? nil : storage.id,
+      :last_scan_on           => nil,
+      :last_scan_attempt_on   => nil,
+      :retires_on             => nil,
+      :retired                => nil,
+      :boot_time              => nil,
+      :tools_status           => nil,
+      :standby_action         => nil,
+      :previous_state         => "up",
+      :last_perf_capture_on   => nil,
+      :registered             => nil,
+      :busy                   => nil,
+      :smart                  => nil,
+      :memory_reserve         => nil,
+      :memory_reserve_expand  => nil,
+      :memory_limit           => nil,
+      :memory_shares          => nil,
+      :memory_shares_level    => nil,
+      :cpu_reserve            => nil,
+      :cpu_reserve_expand     => nil,
+      :cpu_limit              => nil,
+      :cpu_shares             => nil,
+      :cpu_shares_level       => nil,
+      :cpu_affinity           => nil,
+      :ems_created_on         => nil,
+      :evm_owner_id           => nil,
+      :linked_clone           => nil,
+      :fault_tolerance        => nil,
+      :type                   => "ManageIQ::Providers::Redhat::InfraManager::Vm",
+      :ems_cluster_id         => nil,
+      :retirement_warn        => nil,
+      :retirement_last_warn   => nil,
+      :vnc_port               => nil,
+      :flavor_id              => nil,
+      :availability_zone_id   => nil,
+      :cloud                  => false,
+      :retirement_state       => nil,
+      :cloud_network_id       => nil,
+      :cloud_subnet_id        => nil,
+      :cloud_tenant_id        => nil,
+      :publicly_available     => nil,
+      :orchestration_stack_id => nil,
+      :retirement_requester   => nil,
+      :resource_group_id      => nil,
+      :deprecated             => nil,
+      :storage_profile_id     => nil
+    )
+
+    expect(vm.ext_management_system).not_to eq(@ems)
+    expect(vm.ems_cluster).not_to eq(@cluster)
+    expect(vm.parent_resource_pool).not_to eq(@rp)
+    if with_disk
+      expect(vm.storage).to be_nil
+    else
+      expect(vm.storage).to eq(storage)
+    end
   end
 
   def assert_vm(vm, storage)
@@ -167,7 +303,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     expect(vm.storage).to eq(storage)
   end
 
-  def assert_vm_rels(vm, hardware, storage)
+  def assert_vm_rels(vm, hardware, storage, disk = nil)
     expect(vm.snapshots.size).to eq(1)
     snapshot = vm.snapshots.first
     expect(snapshot).to have_attributes(
@@ -221,30 +357,32 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
       :memory_mb_minimum    => nil
     )
 
-    expect(vm.hardware.disks.size).to eq(1)
-    disk = vm.hardware.disks.first
-    expect(disk.storage).to eq(storage)
-    expect(disk).to have_attributes(
-      :device_name        => "GlanceDisk-73786f4",
-      :device_type        => "disk",
-      :location           => "0",
-      :filename           => "da123bb9-095a-4933-95f2-8032dfa332e1",
-      :hardware_id        => hardware.id,
-      :mode               => "persistent",
-      :controller_type    => "virtio",
-      :size               => 41.megabyte,
-      :free_space         => nil,
-      :size_on_disk       => 25.megabyte,
-      :present            => true,
-      :start_connected    => true,
-      :auto_detect        => nil,
-      :disk_type          => "thin",
-      :storage_id         => storage.id,
-      :backing_id         => nil,
-      :backing_type       => nil,
-      :storage_profile_id => nil,
-      :bootable           => false
-    )
+    unless disk.nil?
+      expect(vm.hardware.disks.size).to eq(1)
+      disk = vm.hardware.disks.first
+      expect(disk.storage).to eq(storage)
+      expect(disk).to have_attributes(
+        :device_name        => "GlanceDisk-73786f4",
+        :device_type        => "disk",
+        :location           => "0",
+        :filename           => "da123bb9-095a-4933-95f2-8032dfa332e1",
+        :hardware_id        => hardware.id,
+        :mode               => "persistent",
+        :controller_type    => "virtio",
+        :size               => 41.megabyte,
+        :free_space         => nil,
+        :size_on_disk       => 25.megabyte,
+        :present            => true,
+        :start_connected    => true,
+        :auto_detect        => nil,
+        :disk_type          => "thin",
+        :storage_id         => storage.id,
+        :backing_id         => nil,
+        :backing_type       => nil,
+        :storage_profile_id => nil,
+        :bootable           => false
+      )
+    end
 
     expect(vm.hardware.guest_devices.size).to eq(1)
     guest_device = vm.hardware.guest_devices.first
@@ -302,6 +440,50 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
   end
 
+  def assert_removed_vm_rels(vm, hardware, storage)
+    expect(vm.hardware).to eq(hardware)
+    expect(vm.hardware).to have_attributes(
+      :guest_os             => nil,
+      :guest_os_full_name   => nil,
+      :bios                 => nil,
+      :cpu_cores_per_socket => nil,
+      :cpu_total_cores      => nil,
+      :cpu_sockets          => 1,
+      :annotation           => nil,
+      :memory_mb            => nil,
+      :config_version       => nil,
+      :virtual_hw_version   => nil,
+      :bios_location        => nil,
+      :time_sync            => nil,
+      :vm_or_template_id    => vm.id,
+      :host_id              => nil,
+      :cpu_speed            => nil,
+      :cpu_type             => nil,
+      :size_on_disk         => nil,
+      :manufacturer         => "",
+      :model                => "",
+      :number_of_nics       => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil,
+      :vmotion_enabled      => nil,
+      :disk_free_space      => nil,
+      :disk_capacity        => nil,
+      :memory_console       => nil,
+      :bitness              => nil,
+      :virtualization_type  => nil,
+      :root_device_type     => nil,
+      :computer_system_id   => nil,
+      :disk_size_minimum    => nil,
+      :memory_mb_minimum    => nil
+    )
+
+    disks = vm.hardware.disks
+    disk = storage.disks.first
+    expect(disks.size).to eq(1)
+    expect(disks.first.storage).to eq(storage)
+    expect(disks.first).to eq(disk)
+  end
+
   def assert_cluster
     @cluster.reload
     expect(@cluster).to have_attributes(
@@ -352,7 +534,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     )
   end
 
-  def assert_storage(storage, vm)
+  def assert_storage(vm, storage)
     storage.reload
 
     expect(vm.storage).to eq(storage)

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_removed_vm.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_removed_vm.yml
@@ -27,12 +27,12 @@ http_interactions:
       Content-Length:
       - '71'
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: UTF-8
       string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:12 GMT
 - request:
     method: get
     uri: https://admin%40internal:engine@192.168.1.31:8443/api
@@ -58,13 +58,13 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18; path=/api; HttpOnly
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18; path=/api; HttpOnly
       Content-Type:
       - application/xml
       Content-Length:
-      - '3745'
+      - '3746'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Link:
       - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
         rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
@@ -95,7 +95,7 @@ http_interactions:
         rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
         rel=katelloerrata"
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -160,11 +160,11 @@ http_interactions:
             </product_info>
             <summary>
                 <vms>
-                    <total>4</total>
+                    <total>19</total>
                     <active>0</active>
                 </vms>
                 <hosts>
-                    <total>1</total>
+                    <total>2</total>
                     <active>1</active>
                 </hosts>
                 <users>
@@ -172,14 +172,14 @@ http_interactions:
                     <active>1</active>
                 </users>
                 <storage_domains>
-                    <total>2</total>
-                    <active>1</active>
+                    <total>4</total>
+                    <active>3</active>
                 </storage_domains>
             </summary>
-            <time>2016-08-19T11:43:43.326+02:00</time>
+            <time>2016-09-01T17:14:12.740+02:00</time>
         </api>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/clusters/00000002-0002-0002-0002-0000000001e9
@@ -198,7 +198,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -211,9 +211,9 @@ http_interactions:
       Content-Length:
       - '2810'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -279,8 +279,8 @@ http_interactions:
                 <compressed>inherit</compressed>
             </migration>
         </cluster>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/datacenters/00000001-0001-0001-0001-0000000002c0
@@ -299,7 +299,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -312,9 +312,9 @@ http_interactions:
       Content-Length:
       - '1354'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -341,8 +341,8 @@ http_interactions:
             <mac_pool href="/api/macpools/0000000d-000d-000d-000d-000000000365" id="0000000d-000d-000d-000d-000000000365"/>
             <quota_mode>disabled</quota_mode>
         </data_center>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
@@ -361,140 +361,25 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Connection:
       - keep-alive
-      Content-Type:
-      - application/xml
       Content-Length:
-      - '6098'
+      - '0'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
-            <actions>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
-            </actions>
-            <name>123</name>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
-            <type>desktop</type>
-            <status>
-                <state>down</state>
-            </status>
-            <memory>1073741824</memory>
-            <cpu>
-                <topology sockets="1" cores="1" threads="1"/>
-                <architecture>X86_64</architecture>
-            </cpu>
-            <cpu_shares>0</cpu_shares>
-            <bios>
-                <boot_menu>
-                    <enabled>false</enabled>
-                </boot_menu>
-            </bios>
-            <os type="other">
-                <boot dev="hd"/>
-            </os>
-            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
-            <creation_time>2016-07-05T16:41:35.374+02:00</creation_time>
-            <origin>ovirt</origin>
-            <stateless>false</stateless>
-            <delete_protected>false</delete_protected>
-            <high_availability>
-                <enabled>false</enabled>
-                <priority>1</priority>
-            </high_availability>
-            <display>
-                <type>spice</type>
-                <monitors>1</monitors>
-                <single_qxl_pci>false</single_qxl_pci>
-                <allow_override>false</allow_override>
-                <smartcard_enabled>false</smartcard_enabled>
-                <file_transfer_enabled>true</file_transfer_enabled>
-                <copy_paste_enabled>true</copy_paste_enabled>
-                <disconnect_action>LOCK_SCREEN</disconnect_action>
-            </display>
-            <sso>
-                <methods>
-                    <method id="GUEST_AGENT"/>
-                </methods>
-            </sso>
-            <timezone>Etc/GMT</timezone>
-            <usb>
-                <enabled>false</enabled>
-            </usb>
-            <migration_downtime>-1</migration_downtime>
-            <start_paused>false</start_paused>
-            <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
-            <migration>
-                <auto_converge>inherit</auto_converge>
-                <compressed>inherit</compressed>
-            </migration>
-            <io>
-                <threads>0</threads>
-            </io>
-            <time_zone>
-                <name>Etc/GMT</name>
-            </time_zone>
-            <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-            <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
-            <memory_policy>
-                <guaranteed>1073741824</guaranteed>
-                <ballooning>false</ballooning>
-            </memory_policy>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
-            <stop_time>2016-08-11T12:37:33.718+02:00</stop_time>
-            <placement_policy>
-                <affinity>migratable</affinity>
-            </placement_policy>
-            <next_run_configuration_exists>false</next_run_configuration_exists>
-            <numa_tune_mode>interleave</numa_tune_mode>
-        </vm>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
@@ -513,113 +398,34 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
-      code: 200
-      message: OK
+      code: 400
+      message: Bad Request
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/xml
       Content-Length:
-      - '3830'
+      - '589'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <templates>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
-                <actions>
-                    <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
-                </actions>
-                <name>GlanceTemplate-7bb26f9</name>
-                <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
-                <type>desktop</type>
-                <status>
-                    <state>ok</state>
-                </status>
-                <memory>1073741824</memory>
-                <cpu>
-                    <topology sockets="1" cores="1" threads="1"/>
-                    <architecture>X86_64</architecture>
-                </cpu>
-                <cpu_shares>0</cpu_shares>
-                <bios>
-                    <boot_menu>
-                        <enabled>false</enabled>
-                    </boot_menu>
-                </bios>
-                <os type="other">
-                    <boot dev="hd"/>
-                </os>
-                <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
-                <creation_time>2016-06-03T13:43:25.838+02:00</creation_time>
-                <origin>ovirt</origin>
-                <stateless>false</stateless>
-                <delete_protected>false</delete_protected>
-                <high_availability>
-                    <enabled>false</enabled>
-                    <priority>0</priority>
-                </high_availability>
-                <display>
-                    <type>spice</type>
-                    <monitors>1</monitors>
-                    <single_qxl_pci>false</single_qxl_pci>
-                    <allow_override>false</allow_override>
-                    <smartcard_enabled>false</smartcard_enabled>
-                    <file_transfer_enabled>true</file_transfer_enabled>
-                    <copy_paste_enabled>true</copy_paste_enabled>
-                    <disconnect_action>LOCK_SCREEN</disconnect_action>
-                </display>
-                <sso>
-                    <methods>
-                        <method id="GUEST_AGENT"/>
-                    </methods>
-                </sso>
-                <timezone>Etc/GMT</timezone>
-                <usb>
-                    <enabled>false</enabled>
-                </usb>
-                <migration_downtime>-1</migration_downtime>
-                <start_paused>false</start_paused>
-                <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
-                <migration>
-                    <auto_converge>inherit</auto_converge>
-                    <compressed>inherit</compressed>
-                </migration>
-                <io>
-                    <threads>0</threads>
-                </io>
-                <time_zone>
-                    <name>Etc/GMT</name>
-                </time_zone>
-                <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-                <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
-                <memory_policy>
-                    <guaranteed>1073741824</guaranteed>
-                </memory_policy>
-                <version>
-                    <base_template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
-                    <version_number>1</version_number>
-                    <version_name>base version</version_name>
-                </version>
-            </template>
-        </templates>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+        <fault>
+            <reason>Operation Failed</reason>
+            <detail>statementcallback; sql [select * from ((select distinct vm templates view.* from  vm templates view   left outer join vms with tags on vm templates view.vmt guid=vms with tags.vmt guid    where  vms with tags.vm guid = '1' )  order by name asc ) as t1 offset (1 -1) limit 2147483647]; error: invalid input syntax for uuid: "1"
+          position: 196; nested exception is org.postgresql.util.psqlexception: error: invalid input syntax for uuid: "4f6dd4c3-5241-494f-8afc-f1c67254bf77"
+          position: 196</detail>
+        </fault>
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0
@@ -638,7 +444,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -649,11 +455,11 @@ http_interactions:
       Content-Type:
       - application/xml
       Content-Length:
-      - '1938'
+      - '1939'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -678,23 +484,23 @@ http_interactions:
             <external_status>
                 <state>ok</state>
             </external_status>
-            <master>true</master>
+            <master>false</master>
             <storage>
                 <address>192.168.1.106</address>
                 <type>nfs</type>
                 <path>/home/pkliczewski/export/hosted</path>
                 <nfs_version>v3</nfs_version>
             </storage>
-              <available>849329782784</available>
-            <used>140660178944</used>
-            <committed>15032385536</committed>
+            <available>791347724288</available>
+            <used>130996502528</used>
+            <committed>17179869184</committed>
             <storage_format>v3</storage_format>
             <wipe_after_delete>false</wipe_after_delete>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <critical_space_action_blocker>5</critical_space_action_blocker>
         </storage_domain>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
@@ -713,7 +519,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=QbB90gh0opd5yoBCSnNOWGROi62vI_QiZmKgvA3d.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -726,9 +532,9 @@ http_interactions:
       Content-Length:
       - '1476'
       Jsessionid:
-      - QbB90gh0opd5yoBCSnNOWGROi62vI_QiZmKgvA3d
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Thu, 01 Sep 2016 14:51:45 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -765,194 +571,7 @@ http_interactions:
             <storage_type>image</storage_type>
         </disk>
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 14:51:46 GMT
-- request:
-    method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-      Version:
-      - '3'
-      Prefer:
-      - persistent-auth
-      Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '2248'
-      Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
-      Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <disks>
-            <disk href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
-                <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
-                </actions>
-                <name>GlanceDisk-73786f4</name>
-                <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-                <alias>GlanceDisk-73786f4</alias>
-                <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
-                <storage_domains>
-                    <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
-                </storage_domains>
-                <size>42991616</size>
-                <provisioned_size>42991616</provisioned_size>
-                <actual_size>26214400</actual_size>
-                <status>
-                    <state>ok</state>
-                </status>
-                <interface>virtio</interface>
-                <format>cow</format>
-                <sparse>true</sparse>
-                <bootable>false</bootable>
-                <shareable>false</shareable>
-                <wipe_after_delete>false</wipe_after_delete>
-                <propagate_errors>false</propagate_errors>
-                <active>true</active>
-                <read_only>false</read_only>
-                <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
-                <storage_type>image</storage_type>
-            </disk>
-        </disks>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
-- request:
-    method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-      Version:
-      - '3'
-      Prefer:
-      - persistent-auth
-      Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '660'
-      Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
-      Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <snapshots>
-            <snapshot href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
-                <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
-                </actions>
-                <description>Active VM</description>
-                <type>active</type>
-                <date>2016-07-05T16:41:35.542+02:00</date>
-                <snapshot_status>ok</snapshot_status>
-                <persist_memorystate>false</persist_memorystate>
-            </snapshot>
-        </snapshots>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
-- request:
-    method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-      Version:
-      - '3'
-      Prefer:
-      - persistent-auth
-      Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '1242'
-      Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
-      Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <nics>
-            <nic href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
-                <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
-                </actions>
-                <name>nic1</name>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-                <network href="/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
-                <linked>true</linked>
-                <interface>virtio</interface>
-                <mac address="00:1a:4a:16:01:52"/>
-                <active>true</active>
-                <plugged>true</plugged>
-                <vnic_profile href="/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
-            </nic>
-        </nics>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api
@@ -971,7 +590,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -982,9 +601,9 @@ http_interactions:
       Content-Type:
       - application/xml
       Content-Length:
-      - '3745'
+      - '3746'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Link:
       - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
         rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
@@ -1015,7 +634,7 @@ http_interactions:
         rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
         rel=katelloerrata"
       Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -1080,11 +699,11 @@ http_interactions:
             </product_info>
             <summary>
                 <vms>
-                    <total>4</total>
+                    <total>19</total>
                     <active>0</active>
                 </vms>
                 <hosts>
-                    <total>1</total>
+                    <total>2</total>
                     <active>1</active>
                 </hosts>
                 <users>
@@ -1092,12 +711,12 @@ http_interactions:
                     <active>1</active>
                 </users>
                 <storage_domains>
-                    <total>2</total>
-                    <active>1</active>
+                    <total>4</total>
+                    <active>3</active>
                 </storage_domains>
             </summary>
-            <time>2016-08-19T11:43:44.697+02:00</time>
+            <time>2016-09-01T17:14:13.323+02:00</time>
         </api>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_removed_vm_with_disk.yml
+++ b/spec/vcr_cassettes/manageiq/providers/redhat/infra_manager/refresher_target_removed_vm_with_disk.yml
@@ -27,12 +27,12 @@ http_interactions:
       Content-Length:
       - '71'
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: UTF-8
       string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:12 GMT
 - request:
     method: get
     uri: https://admin%40internal:engine@192.168.1.31:8443/api
@@ -58,13 +58,13 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18; path=/api; HttpOnly
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18; path=/api; HttpOnly
       Content-Type:
       - application/xml
       Content-Length:
-      - '3745'
+      - '3746'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Link:
       - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
         rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
@@ -95,7 +95,7 @@ http_interactions:
         rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
         rel=katelloerrata"
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -160,11 +160,11 @@ http_interactions:
             </product_info>
             <summary>
                 <vms>
-                    <total>4</total>
+                    <total>19</total>
                     <active>0</active>
                 </vms>
                 <hosts>
-                    <total>1</total>
+                    <total>2</total>
                     <active>1</active>
                 </hosts>
                 <users>
@@ -172,14 +172,14 @@ http_interactions:
                     <active>1</active>
                 </users>
                 <storage_domains>
-                    <total>2</total>
-                    <active>1</active>
+                    <total>4</total>
+                    <active>3</active>
                 </storage_domains>
             </summary>
-            <time>2016-08-19T11:43:43.326+02:00</time>
+            <time>2016-09-01T17:14:12.740+02:00</time>
         </api>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/clusters/00000002-0002-0002-0002-0000000001e9
@@ -198,7 +198,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -211,9 +211,9 @@ http_interactions:
       Content-Length:
       - '2810'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -280,7 +280,7 @@ http_interactions:
             </migration>
         </cluster>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/datacenters/00000001-0001-0001-0001-0000000002c0
@@ -299,7 +299,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -312,9 +312,9 @@ http_interactions:
       Content-Length:
       - '1354'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -342,7 +342,7 @@ http_interactions:
             <quota_mode>disabled</quota_mode>
         </data_center>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77
@@ -361,140 +361,25 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Connection:
       - keep-alive
-      Content-Type:
-      - application/xml
       Content-Length:
-      - '6098'
+      - '0'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:12 GMT
     body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77">
-            <actions>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reboot" rel="reboot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/undo_snapshot" rel="undo_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/clone" rel="clone"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reordermacaddresses" rel="reordermacaddresses"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/commit_snapshot" rel="commit_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/preview_snapshot" rel="preview_snapshot"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/logon" rel="logon"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/freezefilesystems" rel="freezefilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/thawfilesystems" rel="thawfilesystems"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cancelmigration" rel="cancelmigration"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/maintenance" rel="maintenance"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/ticket" rel="ticket"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/migrate" rel="migrate"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/detach" rel="detach"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/export" rel="export"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/move" rel="move"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/shutdown" rel="shutdown"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/start" rel="start"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/stop" rel="stop"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/suspend" rel="suspend"/>
-            </actions>
-            <name>123</name>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/applications" rel="applications"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks" rel="disks"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics" rel="nics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/numanodes" rel="numanodes"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/cdroms" rel="cdroms"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots" rel="snapshots"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/tags" rel="tags"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/permissions" rel="permissions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/statistics" rel="statistics"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/reporteddevices" rel="reporteddevices"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/watchdogs" rel="watchdogs"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/sessions" rel="sessions"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/katelloerrata" rel="katelloerrata"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/graphicsconsoles" rel="graphicsconsoles"/>
-            <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/hostdevices" rel="hostdevices"/>
-            <type>desktop</type>
-            <status>
-                <state>down</state>
-            </status>
-            <memory>1073741824</memory>
-            <cpu>
-                <topology sockets="1" cores="1" threads="1"/>
-                <architecture>X86_64</architecture>
-            </cpu>
-            <cpu_shares>0</cpu_shares>
-            <bios>
-                <boot_menu>
-                    <enabled>false</enabled>
-                </boot_menu>
-            </bios>
-            <os type="other">
-                <boot dev="hd"/>
-            </os>
-            <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
-            <creation_time>2016-07-05T16:41:35.374+02:00</creation_time>
-            <origin>ovirt</origin>
-            <stateless>false</stateless>
-            <delete_protected>false</delete_protected>
-            <high_availability>
-                <enabled>false</enabled>
-                <priority>1</priority>
-            </high_availability>
-            <display>
-                <type>spice</type>
-                <monitors>1</monitors>
-                <single_qxl_pci>false</single_qxl_pci>
-                <allow_override>false</allow_override>
-                <smartcard_enabled>false</smartcard_enabled>
-                <file_transfer_enabled>true</file_transfer_enabled>
-                <copy_paste_enabled>true</copy_paste_enabled>
-                <disconnect_action>LOCK_SCREEN</disconnect_action>
-            </display>
-            <sso>
-                <methods>
-                    <method id="GUEST_AGENT"/>
-                </methods>
-            </sso>
-            <timezone>Etc/GMT</timezone>
-            <usb>
-                <enabled>false</enabled>
-            </usb>
-            <migration_downtime>-1</migration_downtime>
-            <start_paused>false</start_paused>
-            <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
-            <migration>
-                <auto_converge>inherit</auto_converge>
-                <compressed>inherit</compressed>
-            </migration>
-            <io>
-                <threads>0</threads>
-            </io>
-            <time_zone>
-                <name>Etc/GMT</name>
-            </time_zone>
-            <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-            <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
-            <memory_policy>
-                <guaranteed>1073741824</guaranteed>
-                <ballooning>false</ballooning>
-            </memory_policy>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
-            <stop_time>2016-08-11T12:37:33.718+02:00</stop_time>
-            <placement_policy>
-                <affinity>migratable</affinity>
-            </placement_policy>
-            <next_run_configuration_exists>false</next_run_configuration_exists>
-            <numa_tune_mode>interleave</numa_tune_mode>
-        </vm>
+      encoding: UTF-8
+      string: ''
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:42 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/templates?search=vm.id=4f6dd4c3-5241-494f-8afc-f1c67254bf77
@@ -513,113 +398,34 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
-      code: 200
-      message: OK
+      code: 400
+      message: Bad Request
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/xml
       Content-Length:
-      - '3830'
+      - '589'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <templates>
-            <template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538">
-                <actions>
-                    <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/export" rel="export"/>
-                </actions>
-                <name>GlanceTemplate-7bb26f9</name>
-                <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/disks" rel="disks"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/nics" rel="nics"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/cdroms" rel="cdroms"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/tags" rel="tags"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/permissions" rel="permissions"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/watchdogs" rel="watchdogs"/>
-                <link href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538/graphicsconsoles" rel="graphicsconsoles"/>
-                <type>desktop</type>
-                <status>
-                    <state>ok</state>
-                </status>
-                <memory>1073741824</memory>
-                <cpu>
-                    <topology sockets="1" cores="1" threads="1"/>
-                    <architecture>X86_64</architecture>
-                </cpu>
-                <cpu_shares>0</cpu_shares>
-                <bios>
-                    <boot_menu>
-                        <enabled>false</enabled>
-                    </boot_menu>
-                </bios>
-                <os type="other">
-                    <boot dev="hd"/>
-                </os>
-                <cluster href="/api/clusters/00000002-0002-0002-0002-0000000001e9" id="00000002-0002-0002-0002-0000000001e9"/>
-                <creation_time>2016-06-03T13:43:25.838+02:00</creation_time>
-                <origin>ovirt</origin>
-                <stateless>false</stateless>
-                <delete_protected>false</delete_protected>
-                <high_availability>
-                    <enabled>false</enabled>
-                    <priority>0</priority>
-                </high_availability>
-                <display>
-                    <type>spice</type>
-                    <monitors>1</monitors>
-                    <single_qxl_pci>false</single_qxl_pci>
-                    <allow_override>false</allow_override>
-                    <smartcard_enabled>false</smartcard_enabled>
-                    <file_transfer_enabled>true</file_transfer_enabled>
-                    <copy_paste_enabled>true</copy_paste_enabled>
-                    <disconnect_action>LOCK_SCREEN</disconnect_action>
-                </display>
-                <sso>
-                    <methods>
-                        <method id="GUEST_AGENT"/>
-                    </methods>
-                </sso>
-                <timezone>Etc/GMT</timezone>
-                <usb>
-                    <enabled>false</enabled>
-                </usb>
-                <migration_downtime>-1</migration_downtime>
-                <start_paused>false</start_paused>
-                <cpu_profile href="/api/cpuprofiles/0000000e-000e-000e-000e-000000000247" id="0000000e-000e-000e-000e-000000000247"/>
-                <migration>
-                    <auto_converge>inherit</auto_converge>
-                    <compressed>inherit</compressed>
-                </migration>
-                <io>
-                    <threads>0</threads>
-                </io>
-                <time_zone>
-                    <name>Etc/GMT</name>
-                </time_zone>
-                <small_icon href="/api/icons/1f7b8c1b-c242-41a2-a3de-8bb314293c08" id="1f7b8c1b-c242-41a2-a3de-8bb314293c08"/>
-                <large_icon href="/api/icons/442339c6-6712-4188-830d-2c0b04e0a103" id="442339c6-6712-4188-830d-2c0b04e0a103"/>
-                <memory_policy>
-                    <guaranteed>1073741824</guaranteed>
-                </memory_policy>
-                <version>
-                    <base_template href="/api/templates/7cca3cf1-1033-4c01-b46d-cd4b6e573538" id="7cca3cf1-1033-4c01-b46d-cd4b6e573538"/>
-                    <version_number>1</version_number>
-                    <version_name>base version</version_name>
-                </version>
-            </template>
-        </templates>
+        <fault>
+            <reason>Operation Failed</reason>
+            <detail>statementcallback; sql [select * from ((select distinct vm templates view.* from  vm templates view   left outer join vms with tags on vm templates view.vmt guid=vms with tags.vmt guid    where  vms with tags.vm guid = '1' )  order by name asc ) as t1 offset (1 -1) limit 2147483647]; error: invalid input syntax for uuid: "1"
+          position: 196; nested exception is org.postgresql.util.psqlexception: error: invalid input syntax for uuid: "4f6dd4c3-5241-494f-8afc-f1c67254bf77"
+          position: 196</detail>
+        </fault>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0
@@ -638,7 +444,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -649,11 +455,11 @@ http_interactions:
       Content-Type:
       - application/xml
       Content-Length:
-      - '1938'
+      - '1939'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Fri, 19 Aug 2016 09:43:43 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -678,23 +484,23 @@ http_interactions:
             <external_status>
                 <state>ok</state>
             </external_status>
-            <master>true</master>
+            <master>false</master>
             <storage>
                 <address>192.168.1.106</address>
                 <type>nfs</type>
                 <path>/home/pkliczewski/export/hosted</path>
                 <nfs_version>v3</nfs_version>
             </storage>
-              <available>849329782784</available>
-            <used>140660178944</used>
-            <committed>15032385536</committed>
+            <available>791347724288</available>
+            <used>130996502528</used>
+            <committed>17179869184</committed>
             <storage_format>v3</storage_format>
             <wipe_after_delete>false</wipe_after_delete>
             <warning_low_space_indicator>10</warning_low_space_indicator>
             <critical_space_action_blocker>5</critical_space_action_blocker>
         </storage_domain>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1
@@ -713,246 +519,27 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=QbB90gh0opd5yoBCSnNOWGROi62vI_QiZmKgvA3d.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/xml
       Content-Length:
-      - '1476'
+      - '0'
       Jsessionid:
-      - QbB90gh0opd5yoBCSnNOWGROi62vI_QiZmKgvA3d
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Date:
-      - Thu, 01 Sep 2016 14:51:45 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <disk href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
-            <actions>
-                <link href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
-            </actions>
-            <name>GlanceDisk-73786f4</name>
-            <description>CirrOS 0.3.1 (73786f4)</description>
-            <vms>
-                <vm id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-            </vms>
-            <alias>GlanceDisk-73786f4</alias>
-            <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
-            <storage_domain href="/api/storagedomains/ee745353-c069-4de8-8d76-ec2e155e2ca0" id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
-            <storage_domains>
-                <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
-            </storage_domains>
-            <size>41126400</size>
-            <provisioned_size>41126400</provisioned_size>
-            <actual_size>2564096</actual_size>
-            <status>
-                <state>ok</state>
-            </status>
-            <interface>virtio</interface>
-            <format>cow</format>
-            <sparse>true</sparse>
-            <bootable>false</bootable>
-            <shareable>false</shareable>
-            <wipe_after_delete>false</wipe_after_delete>
-            <propagate_errors>false</propagate_errors>
-            <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
-            <storage_type>image</storage_type>
-        </disk>
-    http_version: 
-  recorded_at: Thu, 01 Sep 2016 14:51:46 GMT
-- request:
-    method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks
-    body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-      Version:
-      - '3'
-      Prefer:
-      - persistent-auth
-      Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '2248'
-      Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
-      Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <disks>
-            <disk href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1" id="da123bb9-095a-4933-95f2-8032dfa332e1">
-                <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/activate" rel="activate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/export" rel="export"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/move" rel="move"/>
-                </actions>
-                <name>GlanceDisk-73786f4</name>
-                <description>CirrOS 0.3.1 (73786f4)</description>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/permissions" rel="permissions"/>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/disks/da123bb9-095a-4933-95f2-8032dfa332e1/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-                <alias>GlanceDisk-73786f4</alias>
-                <image_id>cbfd10d8-6aac-4046-8b4f-0b607a6d4d1b</image_id>
-                <storage_domains>
-                    <storage_domain id="ee745353-c069-4de8-8d76-ec2e155e2ca0"/>
-                </storage_domains>
-                <size>42991616</size>
-                <provisioned_size>42991616</provisioned_size>
-                <actual_size>26214400</actual_size>
-                <status>
-                    <state>ok</state>
-                </status>
-                <interface>virtio</interface>
-                <format>cow</format>
-                <sparse>true</sparse>
-                <bootable>false</bootable>
-                <shareable>false</shareable>
-                <wipe_after_delete>false</wipe_after_delete>
-                <propagate_errors>false</propagate_errors>
-                <active>true</active>
-                <read_only>false</read_only>
-                <disk_profile href="/api/diskprofiles/5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5" id="5e1859c2-9c6b-48f7-af3c-eb7ea49d86c5"/>
-                <storage_type>image</storage_type>
-            </disk>
-        </disks>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
-- request:
-    method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-      Version:
-      - '3'
-      Prefer:
-      - persistent-auth
-      Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '660'
-      Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
-      Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <snapshots>
-            <snapshot href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038" id="768f1e7a-c517-4619-9d55-59e641bfd038">
-                <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/snapshots/768f1e7a-c517-4619-9d55-59e641bfd038/restore" rel="restore"/>
-                </actions>
-                <description>Active VM</description>
-                <type>active</type>
-                <date>2016-07-05T16:41:35.542+02:00</date>
-                <snapshot_status>ok</snapshot_status>
-                <persist_memorystate>false</persist_memorystate>
-            </snapshot>
-        </snapshots>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
-- request:
-    method: get
-    uri: https://192.168.1.31:8443/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
-      Version:
-      - '3'
-      Prefer:
-      - persistent-auth
-      Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '1242'
-      Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
-      Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-        <nics>
-            <nic href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420" id="6409858a-e1a1-4049-bef2-22a438442420">
-                <actions>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/deactivate" rel="deactivate"/>
-                    <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/activate" rel="activate"/>
-                </actions>
-                <name>nic1</name>
-                <link href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77/nics/6409858a-e1a1-4049-bef2-22a438442420/statistics" rel="statistics"/>
-                <vm href="/api/vms/4f6dd4c3-5241-494f-8afc-f1c67254bf77" id="4f6dd4c3-5241-494f-8afc-f1c67254bf77"/>
-                <network href="/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
-                <linked>true</linked>
-                <interface>virtio</interface>
-                <mac address="00:1a:4a:16:01:52"/>
-                <active>true</active>
-                <plugged>true</plugged>
-                <vnic_profile href="/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398"/>
-            </nic>
-        </nics>
-    http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 - request:
     method: get
     uri: https://192.168.1.31:8443/api
@@ -971,7 +558,7 @@ http_interactions:
       Prefer:
       - persistent-auth
       Cookie:
-      - JSESSIONID=GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5.f18
+      - JSESSIONID=SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV.f18
   response:
     status:
       code: 200
@@ -982,9 +569,9 @@ http_interactions:
       Content-Type:
       - application/xml
       Content-Length:
-      - '3745'
+      - '3746'
       Jsessionid:
-      - GTPgk66t3bb5l8wgH-jYtoYt1aj2tt5iGK26fgY5
+      - SLY6pyQUgyPvbZm6Xt1JXSghSgK40ECAQxtFKPBV
       Link:
       - "<https://192.168.1.31:8443/api/capabilities>; rel=capabilities,<https://192.168.1.31:8443/api/clusters>;
         rel=clusters,<https://192.168.1.31:8443/api/clusters?search={query}>; rel=clusters/search,<https://192.168.1.31:8443/api/datacenters>;
@@ -1015,7 +602,7 @@ http_interactions:
         rel=openstacknetworkproviders,<https://192.168.1.31:8443/api/katelloerrata>;
         rel=katelloerrata"
       Date:
-      - Fri, 19 Aug 2016 09:43:44 GMT
+      - Thu, 01 Sep 2016 15:14:13 GMT
     body:
       encoding: ASCII-8BIT
       string: |
@@ -1080,11 +667,11 @@ http_interactions:
             </product_info>
             <summary>
                 <vms>
-                    <total>4</total>
+                    <total>19</total>
                     <active>0</active>
                 </vms>
                 <hosts>
-                    <total>1</total>
+                    <total>2</total>
                     <active>1</active>
                 </hosts>
                 <users>
@@ -1092,12 +679,12 @@ http_interactions:
                     <active>1</active>
                 </users>
                 <storage_domains>
-                    <total>2</total>
-                    <active>1</active>
+                    <total>4</total>
+                    <active>3</active>
                 </storage_domains>
             </summary>
-            <time>2016-08-19T11:43:44.697+02:00</time>
+            <time>2016-09-01T17:14:13.323+02:00</time>
         </api>
     http_version:
-  recorded_at: Fri, 19 Aug 2016 09:43:43 GMT
+  recorded_at: Thu, 01 Sep 2016 15:14:13 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This change fixes
https://bugzilla.redhat.com/1334949
and improves refresh performance for vm removal events.

This change depends on https://github.com/ManageIQ/manageiq/pull/10143
