### PR TITLE
Check the request format before setting the redirection after the login page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1037,7 +1037,7 @@ class ApplicationController < ActionController::Base
     timed_out = PrivilegeCheckerService.new.user_session_timed_out?(session, current_user) if timed_out.nil?
     reset_session
 
-    session[:start_url] = request.url
+    session[:start_url] = request.url if request.method == "GET"
 
     respond_to do |format|
       format.html do


### PR DESCRIPTION
**Description**
On rare events when an ajax request triggers the session timeout, and loads the
login page, the startup page will be a `page not found` error.

This PR prevent the `page not found` error in this cases. In the cases of an ajax request that triggers the timeout, we will not set the `session[:start_url]` to the url of the ajax call.

**Sceenshot**
![screenshot-2016-08-23-19-11-56](https://cloud.githubusercontent.com/assets/2181522/17899894/9be838fa-6965-11e6-8a6a-7b89bf937a57.png)

**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1341664
https://bugzilla.redhat.com/show_bug.cgi?id=1370202