### PR TITLE
Make FailoverMonitor run monitor before sleeping

### DIFF
--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -49,13 +49,13 @@ module PostgresHaAdmin
 
     def monitor_loop
       loop do
-        sleep(db_check_frequency)
         begin
           monitor
         rescue StandardError => err
           @logger.error("#{err.class}: #{err}")
           @logger.error(err.backtrace.join("\n"))
         end
+        sleep(db_check_frequency)
       end
     end
 


### PR DESCRIPTION
This allows the failover databases file to be written right at startup instead of having 5 minutes of time where we have no coverage.

@yrudman @gtanzillo please review