### PR TITLE
Restore the dumping of settings to the log dir for diagnostic purposes.

### DIFF
--- a/lib/patches/config_patch.rb
+++ b/lib/patches/config_patch.rb
@@ -1,9 +1,9 @@
 module ConfigDecryptPasswords
   def reload!
     Vmdb::Settings.decrypt_passwords!(super).tap do
-      # Do not set the last_loaded when accessing a remote server's settings. It
-      #   should only be set when reloading the current process' Settings.
-      Vmdb::Settings.last_loaded = Time.now.utc if equal?(::Settings)
+      # The following should only be done when loading/reloading the current
+      #   process' Settings, as opposed to a remote server's settings.
+      Vmdb::Settings.on_reload if equal?(::Settings)
     end
   end
 

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,4 +1,42 @@
 describe Vmdb::Settings do
+  describe ".on_reload" do
+    it "is called on top-level ::Settings.reload!" do
+      expect(described_class).to receive(:on_reload)
+
+      ::Settings.reload!
+    end
+
+    it "updates the last_loaded time" do
+      Timecop.freeze(Time.now.utc) do
+        expect(described_class.last_loaded).to_not eq(Time.now.utc)
+
+        described_class.on_reload
+
+        expect(described_class.last_loaded).to eq(Time.now.utc)
+      end
+    end
+
+    context "dumping the settings to the log directory" do
+      after { ::Settings.reload! }
+
+      it "writes them" do
+        ::Settings.api.token_ttl = "1.minute"
+        described_class.on_reload
+
+        dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
+        expect(dumped_yaml.fetch_path(:api, :token_ttl)).to eq "1.minute"
+      end
+
+      it "masks passwords" do
+        ::Settings.authentication.bind_pwd = "pa$$w0rd"
+        described_class.on_reload
+
+        dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
+        expect(dumped_yaml.fetch_path(:authentication, :bind_pwd)).to eq "********"
+      end
+    end
+  end
+
   it ".walk" do
     stub_settings(:a => {:b => 'c'}, :d => {:e => {:f => 'g'}}, :i => [{:j => 'k'}, {:l => 'm'}])
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,5 +1,12 @@
 describe MiqServer do
-  include_examples ".seed called multiple times"
+  describe ".seed" do
+    # Since MiqServer.seed replaces the global Settings, we need to undo
+    #   that to keep specs clean.
+    before { @orig_settings = ::Settings }
+    after  { Vmdb::Settings.send(:reset_settings_constant, @orig_settings) }
+
+    include_examples ".seed called multiple times"
+  end
 
   it ".invoke_at_startups" do
     MiqRegion.seed


### PR DESCRIPTION
Restore the dumping of settings to the log dir for diagnostic purposes.
This commit hooks the initialization and reload of the Settings constant
to also dump it to the log directory.

Previously, support used the config/vmdb.yml.db for diagnostic purposes
as it contained the last known setttings for a particular appliance.
Since this file no longer exists with the config revamp, and
config/settings.yml and friends only contain the "template" values, there
is no way for support to know what settings an appliance is configured
with.

https://bugzilla.redhat.com/show_bug.cgi?id=1368234

@gtanzillo Please review
