### PR TITLE
Adding missing file

### DIFF
--- a/app/assets/javascripts/directives/form_buttons.js
+++ b/app/assets/javascripts/directives/form_buttons.js
@@ -1,0 +1,8 @@
+ManageIQ.angular.app.directive('formButtons', function() {
+  return {
+    restrict: 'E',
+    scope: false,
+    controller: 'buttonGroupController',
+    templateUrl: '/static/buttons.html'
+  };
+});


### PR DESCRIPTION
Missed adding form_buttons directive in original PR from https://github.com/ManageIQ/manageiq/pull/10152

@dclarizio please review/merge. Due to this missing file form buttons were not displayed on Arbitration Profile add/edit screen