### PR TITLE
Add CloudManager relation to networks and security groups

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -27,6 +27,8 @@ module ManageIQ::Providers
     has_many :cloud_databases,               :foreign_key => :ems_id, :dependent => :destroy
     has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_networks,                :through     => :network_manager
+    has_many :security_groups,               :through     => :network_manager
 
     virtual_has_many :cloud_networks,  :uses => {:network_manager => :cloud_networks}
     virtual_has_many :security_groups, :uses => {:network_manager => :security_groups}

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -30,9 +30,6 @@ module ManageIQ::Providers
     has_many :cloud_networks,                :through     => :network_manager
     has_many :security_groups,               :through     => :network_manager
 
-    virtual_has_many :cloud_networks,  :uses => {:network_manager => :cloud_networks}
-    virtual_has_many :security_groups, :uses => {:network_manager => :security_groups}
-
     validates_presence_of :zone
 
     include HasNetworkManagerMixin

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -28,6 +28,9 @@ module ManageIQ::Providers
     has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
 
+    virtual_has_many :cloud_networks,  :uses => {:network_manager => :cloud_networks}
+    virtual_has_many :security_groups, :uses => {:network_manager => :security_groups}
+
     validates_presence_of :zone
 
     include HasNetworkManagerMixin


### PR DESCRIPTION
Purpose or Intent
-----------------
> Was working with @h-kataria to resolve missing data in dropdowns on the arbitration profiles page. This page was dependent on the call `/api/providers/:id?attributes=cloud_networks,security_groups` but due to recent changes with the network manager mixin, these were no longer being returned. Adding in the `virtual_has_many` for these attributes  fixes that.

@miq-bot darga/no, service broker