### PR TITLE
Modify Azure Runner to use existing EMS

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/runner.rb
@@ -32,16 +32,7 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Runner <
   private
 
   def event_monitor_handle
-    unless @event_monitor_handle
-      client_id             = @ems.authentication_userid
-      client_key            = @ems.authentication_password
-      tenant_id             = @ems.azure_tenant_id
-      azure_region          = @ems.provider_region
-      subscription_id       = @ems.subscription
-      @event_monitor_handle = ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream.new(
-        client_id, client_key, azure_region, tenant_id, subscription_id)
-    end
-    @event_monitor_handle
+    @event_monitor_handle ||= ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream.new(@ems)
   end
 
   def reset_event_monitor_handle

--- a/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_catcher/stream.rb
@@ -2,13 +2,10 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   #
   # Creates an event monitor
   #
-  def initialize(client_id, client_key, azure_region, tenant_id, subscription_id)
-    @client_id         = client_id
-    @client_key        = client_key
-    @tenant_id         = tenant_id
-    @azure_region      = azure_region
-    @subscription_id   = subscription_id
+  def initialize(ems)
+    @ems = ems
     @collecting_events = false
+    @since = nil
   end
 
   # Start capturing events
@@ -63,12 +60,8 @@ class ManageIQ::Providers::Azure::CloudManager::EventCatcher::Stream
   end
 
   def create_event_service
-    conf = Azure::Armrest::ArmrestService.configure(
-      :client_id       => @client_id,
-      :client_key      => @client_key,
-      :tenant_id       => @tenant_id,
-      :subscription_id => @subscription_id
-    )
-    Azure::Armrest::Insights::EventService.new(conf)
+    @ems.with_provider_connection do |conf|
+      Azure::Armrest::Insights::EventService.new(conf)
+    end
   end
 end


### PR DESCRIPTION
Currently we are passing individual credentials directly to `Runner.new`. This is both problematic and inefficient, in the first case because we aren't including proxy information, and in the second case because we already have the connection information we need from the EMS.

This code, which is very similar to the Google provider code, alters the Runner's initialize method to accept an ems object rather than individual credentials. This, in turn, lets us use the `:with_provider_connection` method which already contains the credentials we need, including the proxy information.

It's also shorter and easier to read. :)

In addition to the specs, this can be validated by firing up a local instance of the app, deliberately triggering an event (such as a power on/off) for a VM, and then look for power events in the UI.