### PR TITLE
Fixed failing validation on saved replication subscriptions.

### DIFF
--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -231,7 +231,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       data["id"] = subscription.id
     }
     miqService.sparkleOn();
-    var url = '/ops/pglogical_;validate_subscription'
+    var url = '/ops/pglogical_validate_subscription'
     miqService.miqAjaxButton(url, data);
   };
 

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -228,6 +228,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       data["user"] = subscription.user;
       data["password"] = subscription.password;
       data["port"]     = subscription.port;
+      data["subscription_id"] = subscription.id
     }
     miqService.sparkleOn();
     var url = '/ops/pglogical_validate_subscription/' + pglogicalReplicationFormId;

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -228,10 +228,10 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       data["user"] = subscription.user;
       data["password"] = subscription.password;
       data["port"]     = subscription.port;
-      data["subscription_id"] = subscription.id
+      data["id"] = subscription.id
     }
     miqService.sparkleOn();
-    var url = '/ops/pglogical_validate_subscription/' + pglogicalReplicationFormId;
+    var url = '/ops/pglogical_;validate_subscription'
     miqService.miqAjaxButton(url, data);
   };
 

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -190,24 +190,20 @@ module OpsController::Settings::Common
     if replication_type == :global
       MiqRegion.replication_type = replication_type
       subscriptions_to_save = []
-      params[:subscriptions].each do |_, subscription|
-        sub = subscription['id'] ? PglogicalSubscription.find(subscription['id']) : PglogicalSubscription.new
-        sub.dbname   = subscription['dbname']
-        sub.host     = subscription['host']
-        sub.user     = subscription['user']
-        sub.password = subscription['password'] == '●●●●●●●●' ? nil : subscription['password']
-        sub.port     = subscription['port']
-        if sub.id && subscription['remove'] == "true"
-          sub.delete
+      params[:subscriptions].each do |_, subscription_params|
+        subscription = find_or_new_subscription(subscription_params['id'])
+        if subscription.id && subscription_params['remove'] == "true"
+          subscription.delete
         else
-          subscriptions_to_save.push(sub)
+          set_subscription_attributes(subscription, subscription_params)
+          subscriptions_to_save.push(subscription)
         end
       end
       begin
         PglogicalSubscription.save_all!(subscriptions_to_save)
       rescue  StandardError => bang
         add_flash(_("Error during replication configuration save: %{message}") %
-                    {:message => bang}, :error)
+                      {:message => bang}, :error)
       else
         add_flash(_("Replication configuration save was successful"))
       end
@@ -216,7 +212,7 @@ module OpsController::Settings::Common
         MiqRegion.replication_type = replication_type
       rescue StandardError => bang
         add_flash(_("Error during replication configuration save: ") %
-                    {:message => bang.message}, :error)
+                      {:message => bang.message}, :error)
       else
         add_flash(_("Replication configuration save was successful"))
       end
@@ -230,12 +226,8 @@ module OpsController::Settings::Common
   end
 
   def pglogical_validate_subscription
-    valid = PglogicalSubscription.validate(params[:subscription_id],
-                                           :host     => params[:host],
-                                           :port     => params[:port],
-                                           :user     => params[:user],
-                                           :password => params[:password],
-                                           :dbname   => params[:dbname])
+    subscription = find_or_new_subscription(params[:id])
+    valid = subscription.validate(params_for_connection_validation(params))
     if valid.nil?
       add_flash(_("Subscription Credentials validated successfully"))
     else
@@ -247,6 +239,27 @@ module OpsController::Settings::Common
   end
 
   private
+
+  PASSWORD_MASK = '●●●●●●●●'.freeze
+
+  def find_or_new_subscription(id = nil)
+    id.nil? ? PglogicalSubscription.new : PglogicalSubscription.find(id)
+  end
+
+  def set_subscription_attributes(subscription, params)
+    params_for_connection_validation(params).each do |k, v|
+      subscription.send("#{k}=".to_sym, v)
+    end
+  end
+
+  def params_for_connection_validation(subscription_params)
+    {'host'     => subscription_params['host'],
+     'port'     => subscription_params['port'],
+     'user'     => subscription_params['user'],
+     'dbname'   => subscription_params['dbname'],
+     'password' => subscription_params['password'] == PASSWORD_MASK ? nil : subscription_params['password']
+    }.delete_blanks
+  end
 
   def get_subscriptions_array(subscriptions)
     subscriptions.collect { |sub|

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -203,7 +203,7 @@ module OpsController::Settings::Common
         PglogicalSubscription.save_all!(subscriptions_to_save)
       rescue  StandardError => bang
         add_flash(_("Error during replication configuration save: %{message}") %
-                      {:message => bang}, :error)
+                    {:message => bang}, :error)
       else
         add_flash(_("Replication configuration save was successful"))
       end
@@ -212,7 +212,7 @@ module OpsController::Settings::Common
         MiqRegion.replication_type = replication_type
       rescue StandardError => bang
         add_flash(_("Error during replication configuration save: ") %
-                      {:message => bang.message}, :error)
+                    {:message => bang.message}, :error)
       else
         add_flash(_("Replication configuration save was successful"))
       end

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -230,11 +230,12 @@ module OpsController::Settings::Common
   end
 
   def pglogical_validate_subscription
-    valid = MiqRegionRemote.validate_connection_settings(params[:host],
-                                                         params[:port],
-                                                         params[:user],
-                                                         params[:password],
-                                                         params[:dbname])
+    valid = PglogicalSubscription.validate(params[:subscription_id],
+                                           :host     => params[:host],
+                                           :port     => params[:port],
+                                           :user     => params[:user],
+                                           :password => params[:password],
+                                           :dbname   => params[:dbname])
     if valid.nil?
       add_flash(_("Subscription Credentials validated successfully"))
     else

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -86,36 +86,14 @@ class PglogicalSubscription < ActsAsArModel
     self.class.pglogical(refresh)
   end
 
-  def self.validate(id, connection_hash)
-    connection_hash ||= {}
-    if id.nil?
-      return MiqRegionRemote.validate_connection_settings(connection_hash[:host],
-                                                          connection_hash[:port],
-                                                          connection_hash[:user],
-                                                          connection_hash[:password],
-                                                          connection_hash[:dbname])
-    end
-    begin
-      subscription = find(id)
-    rescue ActiveRecord::RecordNotFound => err
-      return ["#{err.message}"]
-    end
-    subscription.validate(connection_hash)
-  end
-
-  def validate(connection_hash)
-    connection_hash ||= {}
+  def validate(some_connection_params = {})
     find_password
-    password = decrypted_password
-    connection_hash[:host] ||= host
-    connection_hash[:port] ||= port
-    connection_hash[:user] ||= user
-    connection_hash[:dbname] ||= dbname
-    MiqRegionRemote.validate_connection_settings(connection_hash[:host],
-                                                 connection_hash[:port],
-                                                 connection_hash[:user],
-                                                 password,
-                                                 connection_hash[:dbname])
+    connection_hash = attributes.merge(some_connection_params.delete_blanks)
+    MiqRegionRemote.validate_connection_settings(connection_hash['host'],
+                                                 connection_hash['port'],
+                                                 connection_hash['user'],
+                                                 connection_hash['password'],
+                                                 connection_hash['dbname'])
   end
 
   # translate the output from the pglogical stored proc to our object columns

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -86,9 +86,9 @@ class PglogicalSubscription < ActsAsArModel
     self.class.pglogical(refresh)
   end
 
-  def validate(some_connection_params = {})
+  def validate(new_connection_params = {})
     find_password
-    connection_hash = attributes.merge(some_connection_params.delete_blanks)
+    connection_hash = attributes.merge(new_connection_params.delete_blanks)
     MiqRegionRemote.validate_connection_settings(connection_hash['host'],
                                                  connection_hash['port'],
                                                  connection_hash['user'],

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -358,4 +358,21 @@ describe PglogicalSubscription do
       sub.delete
     end
   end
+
+  describe "#validate" do
+    it "validates existing subscriptions with new parameters" do
+      allow(pglogical).to receive(:enabled?).and_return(true)
+      allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first])
+      allow(pglogical).to receive(:subscription_show_status).and_return(subscriptions.first)
+
+      sub = described_class.find(:first)
+      expect(sub.host).to eq "example.com"
+      expect(sub.port).to be_blank
+      expect(sub.user).to eq "root"
+
+      expect(MiqRegionRemote).to receive(:validate_connection_settings)
+        .with("another-example.net", 5423, "root", "p=as' s'", "vmdb's_test")
+      sub.validate('host' => "another-example.net", 'port' => 5423)
+    end
+  end
 end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1334951

**Issue:** Current implementation of validation works in the same way for validating new records and existing records.  However  password is not accepted from user for existing subscriptions and not send to UI when showing records (and password field is disabled). As result validation on existing subscription failing since password is not available

**Fix:** Added ```PgLogicalSubscription.validate``` method which accept parameter  ```subscription_id``` (in addition to other connection parameters entered in UI) and  validate saved subscription records without exposing saved password to UI

@miq-bot add-label wip, bug, core

/cc @carbonin
