### PR TITLE
[DARGA] Allow us to configure the rails 5 web server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ gem "puma",                           "~>3.3.0"
 gem "recursive-open-struct",          "~>1.0.0"
 gem "responders",                     "~>2.0"
 gem "secure_headers",                 "~>3.0.0"
-#gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 
 # Needed by the REST API
 gem "gettext_i18n_rails",             "~>1.4.0"
@@ -98,6 +97,7 @@ gem "savon",                          "~>2.2.0",   :require => false  # Automate
 gem "snmp",                           "~>1.2.0",   :require => false
 gem "uglifier",                       "~>2.7.1",   :require => false
 gem "sshkey",                         "~>1.8.0",   :require => false
+gem "thin",                           "~>1.7.0",   :require => false
 
 
 ### Start of gems excluded from the appliances.

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -40,7 +40,7 @@ module MiqWebServerWorkerMixin
     end
 
     def rails_server
-      VMDB::Config.new("vmdb").config.fetch_path(:server, :rails_server) || "thin"
+      ::Settings.server.rails_server
     end
 
     def all_ports_in_use
@@ -169,7 +169,8 @@ module MiqWebServerWorkerMixin
     params = {
       :Host        => self.class.binding_address,
       :environment => Rails.env.to_s,
-      :app         => rails_application
+      :app         => rails_application,
+      :server      => self.class.rails_server
     }
 
     params[:Port] = port.kind_of?(Numeric) ? port : 3000

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -991,7 +991,7 @@
   :mks_version: 2.1.0.0
   :monitor_poll: 5.seconds
   :name: EVM
-  :rails_server: thin
+  :rails_server: puma
   :remote_console_type: VMRC
   :role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,websocket,web_services,automate
   :server_dequeue_frequency: 5.seconds


### PR DESCRIPTION
Puma handles each request in a new thread, leading to possible thread issues
with the database connection pool, ActiveSupport::Dependencies interlock and our
locks, or thread unsafe code in our application.

Thin, while it may be run in threads via --threaded, does not use threads by default.
See [here](https://github.com/macournoyer/thin/blob/d0aef2e80216701b48b908dc14befe3600a44346/lib/thin/backends/base.rb#L55)

This patch allows for thin 1.7.0+ and gives us an option to use either puma or
thin.  Note, earlier versions are not compatible with rack 2.

We still default to puma.

Note: Testers/users, the proctitle for UI/Webservice and web socket workers will
look different in ps, top, etc. if you use thin instead of puma.  Puma configures
it's own proctitle and we configure the parts that we can.  Thin does not, so it
will look like all the other workers.

For example:

thin:
`43177 ttys002    0:08.20 MIQ: MiqUiWorker id: 158, uri: http://0.0.0.0:3000`

puma:
`43871 ttys004    0:00.68 puma 3.3.0 (tcp://0.0.0.0:3000) [MIQ: Web Server Worker]`

Manually back ported to darga fro #10447 due to conflicts