### PR TITLE
Changes to not build Clusters/Storages tree when there is no data in db

### DIFF
--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -215,7 +215,11 @@ module OpsController::Settings::CapAndU
       end
     end
 
-    @cluster_tree = TreeBuilderClusters.new(:cluster, :cluster_tree, @sb, true, @edit[:current])
+    @cluster_tree = TreeBuilderClusters.new(:cluster,
+                                            :cluster_tree,
+                                            @sb,
+                                            true,
+                                            @edit[:current]) unless @edit[:current][:clusters].blank?
     @edit[:current][:storages] = []
     @st_recs = {}
     Storage.in_my_region.includes(:taggings, :tags, :hosts).select(:id, :name, :store_type, :location)
@@ -227,7 +231,11 @@ module OpsController::Settings::CapAndU
                                       :store_type => s.store_type,
                                       :location   => s.location) # fields we need
     end
-    @datastore_tree = TreeBuilderDatastores.new(:datastore, :datastore_tree, @sb, true, @edit[:current][:storages])
+    @datastore_tree = TreeBuilderDatastores.new(:datastore,
+                                                :datastore_tree,
+                                                @sb,
+                                                true,
+                                                @edit[:current][:storages]) unless @edit[:current][:storages].blank?
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit
   end

--- a/spec/controllers/ops_controller/settings/cap_and_u_spec.rb
+++ b/spec/controllers/ops_controller/settings/cap_and_u_spec.rb
@@ -1,0 +1,34 @@
+describe OpsController do
+  before(:each) do
+    MiqRegion.seed
+  end
+
+  context '#cu_build_edit_screen' do
+    before do
+      tree_hash = {
+        :trees       => {
+          :settings_tree => {
+            :active_node => "root"
+          }
+        },
+        :active_tree => :settings_tree,
+        :active_tab  => 'settings_cu_collection'
+      }
+      controller.instance_variable_set(:@sb, tree_hash)
+    end
+
+    it 'should have no tree data set when there are no clusters/storage records in db' do
+      controller.send(:cu_build_edit_screen)
+      expect(assigns(:cluster_tree)).to eq(nil)
+      expect(assigns(:datastore_tree)).to eq(nil)
+    end
+
+    it 'should have tree data set when there are clusters/storage records in db' do
+      FactoryGirl.create(:ems_cluster, :name => "My Cluster")
+      FactoryGirl.create(:storage_vmware, :name => "My Datastore")
+      controller.send(:cu_build_edit_screen)
+      expect(assigns(:cluster_tree)).to_not eq(nil)
+      expect(assigns(:datastore_tree)).to_not eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
Make sure that there are clusters & datastores before building each tree.

https://bugzilla.redhat.com/show_bug.cgi?id=1368543

@dclarizio please review, this issue can be recreated when database has no cluster or datastore records in database. Notice an error in log

```
NoMethodError] undefined method `[]' for nil:NilClass
/home/hkataria/dev/manageiq/app/presenters/tree_builder.rb:194:in `active_node_set'
/home/hkataria/dev/manageiq/app/presenters/tree_builder.rb:187:in `build_tree'
/home/hkataria/dev/manageiq/app/presenters/tree_builder.rb:114:in `initialize'
/home/hkataria/dev/manageiq/app/presenters/tree_builder_clusters.rb:7:in `initialize'
/home/hkataria/dev/manageiq/app/controllers/ops_controller/settings/cap_and_u.rb:218:in `new'
/home/hkataria/dev/manageiq/app/controllers/ops_controller/settings/cap_and_u.rb:218:in `cu_build_edit_screen'
/home/hkataria/dev/manageiq/app/controllers/ops_controller/settings/common.rb:1077:in `settings_get_info'
/home/hkataria/dev/manageiq/app/controllers/ops_controller.rb:183:in `change_tab'
```
screenshots
before
![before](https://cloud.githubusercontent.com/assets/3450808/17911161/37433450-695a-11e6-96fa-1586f9fbb97f.png)

after
![after](https://cloud.githubusercontent.com/assets/3450808/17911168/3c10b39a-695a-11e6-9ec4-ff48c3705c2b.png)
