### PR TITLE
VirtualDelegate: Fix foreign key for belongs_to

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -147,18 +147,29 @@ module VirtualDelegates
         if to_ref.macro == :has_one
           lambda do |t|
             src_model_id = arel_attribute(to_ref.association_primary_key, t)
-            to_model_id = to_model.arel_attribute(to_ref.foreign_key)
-            Arel.sql("(#{to_model.select(to_model.arel_attribute(col)).where(to_model_id.eq(src_model_id)).to_sql})")
+            VirtualDelegates.select_from_alias(to_model, to_ref, col, to_ref.foreign_key, src_model_id)
           end
         elsif to_ref.macro == :belongs_to
           lambda do |t|
             src_model_id = arel_attribute(to_ref.association_foreign_key, t)
-            to_model_id = to_model.arel_attribute(to_ref.active_record_primary_key)
-            Arel.sql("(#{to_model.select(to_model.arel_attribute(col)).where(to_model_id.eq(src_model_id)).to_sql})")
+            VirtualDelegates.select_from_alias(to_model, to_ref, col, to_ref.active_record_primary_key, src_model_id)
           end
         end
       end
     end
+  end
+
+  def self.select_from_alias(to_model, to_ref, col, to_model_col_name, src_model_id)
+    to_table = to_model.arel_table
+    # if a self join, alias the second table to a different name
+    if to_model.table_name == to_ref.table_name
+      # use a dup to not modify the primary table in the model
+      to_table = to_model.arel_table.dup
+      # use a table alias to not conflict with table name in the primary query
+      to_table.table_alias = "#{to_model.table_name}_ss"
+    end
+    to_model_id = to_model.arel_attribute(to_model_col_name, to_table)
+    Arel.sql("(#{to_table.project(to_model.arel_attribute(col, to_table)).where(to_model_id.eq(src_model_id)).to_sql})")
   end
 end
 

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -151,7 +151,7 @@ module VirtualDelegates
           end
         elsif to_ref.macro == :belongs_to
           lambda do |t|
-            src_model_id = arel_attribute(to_ref.association_foreign_key, t)
+            src_model_id = arel_attribute(to_ref.foreign_key, t)
             VirtualDelegates.select_from_alias(to_model, to_ref, col, to_ref.active_record_primary_key, src_model_id)
           end
         end

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -23,6 +23,9 @@ describe VirtualFields do
 
       require 'ostruct'
       class TestClass < TestClassBase
+        def self.connection
+          TestClassBase.connection
+        end
         belongs_to :ref1, :class_name => 'TestClass', :foreign_key => :col1
       end
     end


### PR DESCRIPTION
We are using delegates more and more.
Found a few bugs with edge cases:

1. When delegating to an association that has a `belongs_to`, and the foreign key is non-standard, then it got the foreign key wrong. Example: `belongs_to :ems_owner, :class_name => 'User'` had a foreign key of `user_id` instead of `ems_owner_id`.
2. When delegating to a self referring reference, it was not returning records. Example: `TestClass.belongs_to :parent, :class_name => "TestClass"`
3. Test was accessing postgres due to changes in active record `establish_connection`. For some reason, this is only an issue when adding a `has_one` relation.

These changes are necessary to add delegation for `ems_owner` and improve performance of the vms screen.

/cc @dmetzger57 thoughts on migrating to darga-4?
/cc @NickLaMuro thanks for all the help. pulled tests out of #10476 and puled `ar_virtual` bug out of #10704