### PR TITLE
[DARGA] Fixed tenant_identity to handle storage that does not belong to an EMS

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -883,7 +883,11 @@ class Storage < ApplicationRecord
   end
 
   def tenant_identity
-    ext_management_system.tenant_identity
+    if ext_management_system
+      ext_management_system.tenant_identity
+    else
+      User.super_admin.tap { |u| u.current_group = Tenant.root_tenant.default_miq_group }
+    end
   end
 
   # @param [String, Storage] store_type upcased version of the storage type

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -45,7 +45,6 @@ class Storage < ApplicationRecord
   include StorageMixin
   include AsyncDeleteMixin
   include AvailabilityMixin
-  include TenantIdentityMixin
 
   virtual_column :v_used_space,                   :type => :integer
   virtual_column :v_used_space_percent_of_total,  :type => :integer
@@ -881,6 +880,10 @@ class Storage < ApplicationRecord
     else
       {:available => true, :message => nil}
     end
+  end
+
+  def tenant_identity
+    ext_management_system.tenant_identity
   end
 
   # @param [String, Storage] store_type upcased version of the storage type

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -536,4 +536,28 @@ describe Storage do
       expect(storage.storage_clusters).to match_array([])
     end
   end
+
+  context "#tenant_identity" do
+    let(:admin)    { FactoryGirl.create(:user_with_group, :userid => "admin") }
+    let(:tenant)   { FactoryGirl.create(:tenant) }
+    let(:ems)      { FactoryGirl.create(:ext_management_system, :tenant => tenant) }
+    let(:host)     { FactoryGirl.create(:host, :ext_management_system => ems) }
+
+    before         { admin }
+    it "has tenant from provider" do
+      storage = FactoryGirl.create(:storage, :hosts => [host])
+
+      expect(storage.tenant_identity).to                eq(admin)
+      expect(storage.tenant_identity.current_group).to  eq(ems.tenant.default_miq_group)
+      expect(storage.tenant_identity.current_tenant).to eq(ems.tenant)
+    end
+
+    it "without a provider, has tenant from root tenant" do
+      storage = FactoryGirl.create(:storage)
+
+      expect(storage.tenant_identity).to                eq(admin)
+      expect(storage.tenant_identity.current_group).to  eq(Tenant.root_tenant.default_miq_group)
+      expect(storage.tenant_identity.current_tenant).to eq(Tenant.root_tenant)
+    end
+  end
 end

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -536,28 +536,4 @@ describe Storage do
       expect(storage.storage_clusters).to match_array([])
     end
   end
-
-  context "#tenant_identity" do
-    let(:admin)    { FactoryGirl.create(:user_with_group, :userid => "admin") }
-    let(:tenant)   { FactoryGirl.create(:tenant) }
-    let(:ems)      { FactoryGirl.create(:ext_management_system, :tenant => tenant) }
-    let(:host)     { FactoryGirl.create(:host, :ext_management_system => ems) }
-
-    before         { admin }
-    it "has tenant from provider" do
-      storage = FactoryGirl.create(:storage, :hosts => [host])
-
-      expect(storage.tenant_identity).to                eq(admin)
-      expect(storage.tenant_identity.current_group).to  eq(ems.tenant.default_miq_group)
-      expect(storage.tenant_identity.current_tenant).to eq(ems.tenant)
-    end
-
-    it "without a provider, has tenant from root tenant" do
-      storage = FactoryGirl.create(:storage)
-
-      expect(storage.tenant_identity).to                eq(admin)
-      expect(storage.tenant_identity.current_group).to  eq(Tenant.root_tenant.default_miq_group)
-      expect(storage.tenant_identity.current_tenant).to eq(Tenant.root_tenant)
-    end
-  end
 end


### PR DESCRIPTION
This PR fixes a bad backport of #10419
 
Storages belong to an EMS indirectly through the hosts to which it is attached. If a storage is not attached to any hosts the EMS will be nil. In that case the root tenant will be used for the tenant_identity.
Backported from https://github.com/ManageIQ/manageiq/pull/10419. Was done manually because the change upstream was different for the draga branch.

https://bugzilla.redhat.com/show_bug.cgi?id=1365688
