### PR TITLE
[DARGA] Re-check Authentication button for Providers in the GTL view

### DIFF
--- a/app/helpers/application_helper/toolbar/ems_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_clouds_center.rb
@@ -77,4 +77,24 @@ class ApplicationHelper::Toolbar::EmsCloudsCenter < ApplicationHelper::Toolbar::
       ]
     ),
   ])
+  button_group('ems_cloud_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+          ]
+      ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_containers_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_containers_center.rb
@@ -70,4 +70,24 @@ class ApplicationHelper::Toolbar::EmsContainersCenter < ApplicationHelper::Toolb
       ]
     ),
   ])
+  button_group('ems_container_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
 end

--- a/app/helpers/application_helper/toolbar/ems_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_infras_center.rb
@@ -77,4 +77,24 @@ class ApplicationHelper::Toolbar::EmsInfrasCenter < ApplicationHelper::Toolbar::
       ]
     ),
   ])
+  button_group('ems_infra_authentication', [
+    select(
+      :ems_cloud_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_cloud_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for this #{ui_lookup(:table=>"ems_cloud")}'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
In #8912, a Re-check Authentication button was added for providers in the Provider detail page (Summary screen).

This PR is an extension to the above PR, in the sense, it implements the Re-check Authentication button in the GTL view so that multiple providers can be selected at a given time in order to re-check (and save) their authentication status.

Fixes #9632 

Equivalent of PR - https://github.com/ManageIQ/manageiq/pull/10609