### PR TITLE
Show non-tenant groups in Set Ownership group dropdown

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -96,11 +96,12 @@ module ApplicationController::CiProcessing
     # need to do this only if 1 vm is selected and miq_group has been set for it
     group = record.miq_group if @ownership_items.length == 1
     @group = group ? group.id.to_s : nil
-    if request.parameters[:controller] == 'vm_cloud' && request.parameters[:pressed] == 'instance_ownership'
-      miq_groups = MiqGroup.non_tenant_groups
-    else
-      miq_groups = MiqGroup
-    end
+    miq_groups = if request.parameters[:controller] == 'vm_cloud' &&
+                    request.parameters[:pressed] == 'instance_ownership'
+                   MiqGroup.non_tenant_groups
+                 else
+                   MiqGroup
+                 end
     Rbac.filtered(miq_groups).each { |g| @groups[g.description] = g.id.to_s }
 
     @user = @group = DONT_CHANGE_OWNER if @ownership_items.length > 1

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -96,13 +96,7 @@ module ApplicationController::CiProcessing
     # need to do this only if 1 vm is selected and miq_group has been set for it
     group = record.miq_group if @ownership_items.length == 1
     @group = group ? group.id.to_s : nil
-    miq_groups = if request.parameters[:controller] == 'vm_cloud' &&
-                    request.parameters[:pressed] == 'instance_ownership'
-                   MiqGroup.non_tenant_groups
-                 else
-                   MiqGroup
-                 end
-    Rbac.filtered(miq_groups).each { |g| @groups[g.description] = g.id.to_s }
+    Rbac.filtered(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
 
     @user = @group = DONT_CHANGE_OWNER if @ownership_items.length > 1
 

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -96,7 +96,12 @@ module ApplicationController::CiProcessing
     # need to do this only if 1 vm is selected and miq_group has been set for it
     group = record.miq_group if @ownership_items.length == 1
     @group = group ? group.id.to_s : nil
-    Rbac.filtered(MiqGroup).each { |g| @groups[g.description] = g.id.to_s }
+    if request.parameters[:controller] == 'vm_cloud' && request.parameters[:pressed] == 'instance_ownership'
+      miq_groups = MiqGroup.non_tenant_groups
+    else
+      miq_groups = MiqGroup
+    end
+    Rbac.filtered(miq_groups).each { |g| @groups[g.description] = g.id.to_s }
 
     @user = @group = DONT_CHANGE_OWNER if @ownership_items.length > 1
 

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -206,7 +206,7 @@ describe ApplicationController do
       @user = nil
     end
 
-    it "lists all groups when (admin user is logged)" do
+    it "lists all non-tenant groups when (admin user is logged)" do
       login_as(admin_user)
       controller.instance_variable_set(:@ownership_items, @ownership_items)
       controller.instance_variable_set(:@_params, @params)
@@ -214,7 +214,7 @@ describe ApplicationController do
 
       controller.build_ownership_info
       groups = controller.instance_variable_get(:@groups)
-      expect(groups.count).to eq(MiqGroup.count)
+      expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
     end
 
     it "lists all users when (admin user is logged)" do
@@ -236,30 +236,6 @@ describe ApplicationController do
       users = controller.instance_variable_get(:@users)
       expected_ids = [great_grand_child_tenant.user_ids, grand_child_tenant.user_ids].flatten
       expect(expected_ids).to match_array(users.values(&:id).map(&:to_i))
-    end
-
-    it "lists all groups that are related to descendants tenats strategy" do
-      login_as(grand_child_user)
-      controller.instance_variable_set(:@ownership_items, @ownership_items)
-      controller.instance_variable_set(:@_params, @params)
-      controller.instance_variable_set(:@user, @user)
-      controller.build_ownership_info
-      groups = controller.instance_variable_get(:@groups)
-      expected_ids = [great_grand_child_tenant.miq_group_ids, grand_child_tenant.miq_group_ids].flatten
-      expect(expected_ids).to match_array(groups.values(&:id).map(&:to_i))
-    end
-
-    it "lists all non-tenant groups when setting ownership of an Cloud Instance" do
-      login_as(admin_user)
-      @vm_amazon = FactoryGirl.create(:vm_amazon)
-      controller.instance_variable_set(:@ownership_items, [@vm_amazon.id])
-      controller.instance_variable_set(:@user, @user)
-      controller.instance_variable_set(:@_params, :controller => 'vm_cloud')
-      controller.request.parameters['controller'] = 'vm_cloud'
-      controller.request.parameters['pressed'] = 'instance_ownership'
-      controller.build_ownership_info
-      groups = controller.instance_variable_get(:@groups)
-      expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
     end
   end
 end

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -261,7 +261,6 @@ describe ApplicationController do
       groups = controller.instance_variable_get(:@groups)
       expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
     end
-
   end
 end
 

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -248,6 +248,20 @@ describe ApplicationController do
       expected_ids = [great_grand_child_tenant.miq_group_ids, grand_child_tenant.miq_group_ids].flatten
       expect(expected_ids).to match_array(groups.values(&:id).map(&:to_i))
     end
+
+    it "lists all non-tenant groups when setting ownership of an Cloud Instance" do
+      login_as(admin_user)
+      @vm_amazon = FactoryGirl.create(:vm_amazon)
+      controller.instance_variable_set(:@ownership_items, [@vm_amazon.id])
+      controller.instance_variable_set(:@user, @user)
+      controller.instance_variable_set(:@_params, :controller => 'vm_cloud')
+      controller.request.parameters['controller'] = 'vm_cloud'
+      controller.request.parameters['pressed'] = 'instance_ownership'
+      controller.build_ownership_info
+      groups = controller.instance_variable_get(:@groups)
+      expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
+    end
+
   end
 end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
When setting the ownership of a Cloud Instance, the group drop down should only contain non-tenant groups.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1364945
