### PR TITLE
DRY up walking the Settings by moving into a module

### DIFF
--- a/lib/vmdb/settings/walker.rb
+++ b/lib/vmdb/settings/walker.rb
@@ -1,0 +1,67 @@
+module Vmdb
+  class Settings
+    module Walker
+      PASSWORD_FIELDS = %i(bind_pwd password amazon_secret).to_set.freeze
+
+      # Walks the settings and yields each value along the way
+      #
+      # @param settings [Config::Options, Hash] The settings to walk.
+      # @param path [Array] Not to be passed by the caller as it's used
+      #   for the recursion to keep track of the depth.
+      # @yieldparam key [String] The current key.
+      # @yieldparam value [String] The current value.
+      # @yieldparam key_path [Array<String>] The key path from the top of the
+      #   settings to the current key.  Includes the current key.  If walking an
+      #   Array, this will include the index in the Array.
+      # @yieldparam owner [Config::Options, Hash] The settings object
+      #   that owns the current key
+      def self.walk(settings, path = [], &block)
+        settings.each do |key, value|
+          key_path = path.dup << key
+
+          yield key, value, key_path, settings
+
+          case value
+          when settings.class
+            walk(value, key_path, &block)
+          when Array
+            value.each_with_index do |v, i|
+              walk(v, key_path.dup << i, &block) if v.kind_of?(settings.class)
+            end
+          end
+        end
+        settings
+      end
+
+      # Walks the settings and yields only each password value along the way
+      #
+      # @param settings (see .walk)
+      def self.walk_passwords(settings)
+        walk(settings) do |key, value, _path, owner|
+          yield(key, value, owner) if value.present? && PASSWORD_FIELDS.include?(key.to_sym)
+        end
+      end
+
+      # Walks the settings and masks out passwords it finds
+      #
+      # @param settings (see .walk)
+      def self.mask_passwords!(settings)
+        walk_passwords(settings) { |k, _v, h| h[k] = "********" }
+      end
+
+      # Walks the settings and decrypts passwords it finds
+      #
+      # @param settings (see .walk)
+      def self.decrypt_passwords!(settings)
+        walk_passwords(settings) { |k, v, h| h[k] = MiqPassword.try_decrypt(v) }
+      end
+
+      # Walks the settings and encrypts passwords it finds
+      #
+      # @param settings (see .walk)
+      def self.encrypt_passwords!(settings)
+        walk_passwords(settings) { |k, v, h| h[k] = MiqPassword.try_encrypt(v) }
+      end
+    end
+  end
+end

--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -13,6 +13,7 @@ end
 
 require 'active_support/all'
 require 'active_support/concern'
+require_relative '../lib/vmdb/settings/walker'
 require 'fix_auth/auth_model'
 require 'fix_auth/auth_config_model'
 require 'fix_auth/models'

--- a/tools/fix_auth/auth_config_model.rb
+++ b/tools/fix_auth/auth_config_model.rb
@@ -35,32 +35,12 @@ module FixAuth
       def recrypt(old_value, options = {})
         hash = YAML.load(old_value)
 
-        walk(hash) do |key, value, _path, owning|
+        Vmdb::Settings::Walker.walk(hash) do |key, value, _path, owning|
           owning[key] = super(value, options) if password_field?(key) && value.present?
         end
 
         symbol_keys ? hash.deep_symbolize_keys! : hash.deep_stringify_keys!
         hash.to_yaml
-      end
-
-      # Copy of Vmdb::Setting.walk
-      # Can't reference classes over there, so this is the minimal change
-      def walk(settings, path = [], &block)
-        settings.each do |key, value|
-          new_path = path.dup << key
-
-          yield key, value, new_path, settings
-
-          case value
-          when settings.class
-            walk(value, new_path, &block)
-          when Array
-            value.each_with_index do |v, i|
-              walk(v, new_path.dup << i, &block) if v.kind_of?(settings.class)
-            end
-          end
-        end
-        settings
       end
     end
   end

--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -79,16 +79,13 @@ module FixAuth
 
   class FixSettingsChange < ActiveRecord::Base
     include FixAuth::AuthModel
-    # Sorry - duplicate of Vmdb::Settings::PASSWORD_FIELDS. Can't reference app classes from here
-    PASSWORD_FIELDS = %i(bind_pwd password amazon_secret).to_set.freeze
-
     self.table_name = "settings_changes"
     self.password_columns = %w(value)
 
     serialize :value
 
     def self.contenders
-      query = PASSWORD_FIELDS.collect do |field|
+      query = Vmdb::Settings::Walker::PASSWORD_FIELDS.collect do |field|
         "(key LIKE '%/#{field}')"
       end.join(" OR ")
 


### PR DESCRIPTION
@kbrock Please review.

This DRYs up the recent changes you made to FixAuth for walking the Settings by moving it into a standalone module.  That module can then be required by fix_auth directly.

Note that I did not change any of the Vmdb::Settings interface in this PR.  If you're good with it then we can discuss if I should kill those methods and constant from the Vmdb::Settings interface in this PR or a separate one.

cc @gtanzillo This will probably conflict with #10705 , so I'll just rebase whichever one isn't merged first.