### PR TITLE
Add repmgrd configuration to console

### DIFF
--- a/gems/pending/appliance_console/database_replication.rb
+++ b/gems/pending/appliance_console/database_replication.rb
@@ -9,9 +9,8 @@ module ApplianceConsole
 
     REPMGR_CONFIG = '/etc/repmgr.conf'.freeze
 
-    attr_accessor :cluster_name, :node_number,
-                  :database_name, :database_user, :database_password,
-                  :primary_host, :standby_host
+    attr_accessor :cluster_name, :node_number, :database_name, :database_user,
+                  :database_password, :primary_host
 
     def ask_for_unique_cluster_node_number
       self.node_number = ask_for_integer("number uniquely identifying this node in the replication cluster")
@@ -22,7 +21,7 @@ module ApplianceConsole
       self.primary_host = ask_for_ip_or_hostname("primary database hostname or IP address", primary_host)
     end
 
-    def confirm(including_standby_host = nil)
+    def confirm
       clear_screen
       say(<<-EOL)
 Replication Server Configuration
@@ -33,9 +32,6 @@ Replication Server Configuration
         Cluster Database Password:  "********"
         Cluster Primary Host:       #{primary_host}
         EOL
-      say("        Standby Host:               #{standby_host}") unless including_standby_host.nil?
-
-      agree("Apply this Replication Server Configuration? (Y/N): ")
     end
 
     def repmgr_configured?

--- a/gems/pending/appliance_console/database_replication_primary.rb
+++ b/gems/pending/appliance_console/database_replication_primary.rb
@@ -27,6 +27,11 @@ module ApplianceConsole
       confirm
     end
 
+    def confirm
+      super
+      agree("Apply this Replication Server Configuration? (Y/N): ")
+    end
+
     def activate
       say("Configuring Primary Replication Server...")
       generate_cluster_name &&

--- a/gems/pending/appliance_console/database_replication_standby.rb
+++ b/gems/pending/appliance_console/database_replication_standby.rb
@@ -14,7 +14,7 @@ module ApplianceConsole
     REPMGRD_SERVICE = 'rh-repmgr95'.freeze
     REPMGRD_LOG     = '/var/log/repmgr/repmgrd.log'.freeze
 
-    attr_accessor :run_repmgrd_configuration
+    attr_accessor :standby_host, :run_repmgrd_configuration
 
     def initialize
       self.cluster_name      = nil
@@ -34,7 +34,13 @@ module ApplianceConsole
       ask_for_standby_host
       ask_for_repmgrd_configuration
       return false if repmgr_configured? && !confirm_reconfiguration
-      confirm(:including_standby_host)
+      confirm
+    end
+
+    def confirm
+      super
+      say("        Standby Host:               #{standby_host}")
+      agree("Apply this Replication Server Configuration? (Y/N): ")
     end
 
     def ask_for_standby_host

--- a/gems/pending/appliance_console/database_replication_standby.rb
+++ b/gems/pending/appliance_console/database_replication_standby.rb
@@ -39,7 +39,10 @@ module ApplianceConsole
 
     def confirm
       super
-      say("        Standby Host:               #{standby_host}")
+      say(<<-EOS)
+        Standby Host:               #{standby_host}
+        Automatic Failover:         #{run_repmgrd_configuration ? "enabled" : "disabled"}
+      EOS
       agree("Apply this Replication Server Configuration? (Y/N): ")
     end
 

--- a/gems/pending/appliance_console/database_replication_standby.rb
+++ b/gems/pending/appliance_console/database_replication_standby.rb
@@ -12,6 +12,7 @@ module ApplianceConsole
     REGISTER_CMD    = 'repmgr standby register'.freeze
     PGPASS_FILE     = '/var/lib/pgsql/.pgpass'.freeze
     REPMGRD_SERVICE = 'rh-repmgr95'.freeze
+    REPMGRD_LOG     = '/var/log/repmgr/repmgrd.log'.freeze
 
     attr_accessor :run_repmgrd_configuration
 
@@ -97,6 +98,7 @@ module ApplianceConsole
         f.write("failover=automatic\n")
         f.write("promote_command='repmgr standby promote'\n")
         f.write("follow_command='repmgr standby follow'\n")
+        f.write("logfile=#{REPMGRD_LOG}\n")
       end
     end
 

--- a/gems/pending/spec/appliance_console/database_replication_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_spec.rb
@@ -47,22 +47,6 @@ describe ApplianceConsole::DatabaseReplication do
     end
   end
 
-  context "#confirm" do
-    before do
-      subject.standby_host = "defaultstandby"
-    end
-
-    it "should ask for standby host when requested" do
-      expect(subject).to receive(:say).with(/standby\shost.*defaultstandby/i)
-      subject.confirm(:including_standby_host)
-    end
-
-    it "should not ask for standby host if not requested" do
-      expect(subject).to_not receive(:say).with(/standby\shost.*defaultstandby/i)
-      subject.confirm
-    end
-  end
-
   context "#confirm_reconfiguration" do
     it "should log a warning and ask to continue anyway" do
       expect(subject).to receive(:say).with(/^warning/i)

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -244,6 +244,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
         failover=automatic
         promote_command='repmgr standby promote'
         follow_command='repmgr standby follow'
+        logfile=/var/log/repmgr/repmgrd.log
       EOS
     end
   end

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -3,6 +3,7 @@ require "appliance_console/database_replication"
 require "appliance_console/database_replication_standby"
 require "linux_admin"
 require "pathname"
+require "tempfile"
 
 describe ApplianceConsole::DatabaseReplicationStandby do
   SPEC_NAME = File.basename(__FILE__).split(".rb").first.freeze
@@ -24,6 +25,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to receive(:ask_for_unique_cluster_node_number)
       expect(subject).to receive(:ask_for_database_credentials)
       expect(subject).to receive(:ask_for_standby_host)
+      expect(subject).to receive(:ask_for_repmgrd_configuration)
     end
 
     it "returns true when input is confirmed" do
@@ -63,6 +65,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to receive(:clone_standby_server).and_return(true)
       expect(subject).to receive(:start_postgres).and_return(true)
       expect(subject).to receive(:register_standby_server).and_return(true)
+      expect(subject).to receive(:configure_repmgrd).and_return(true)
       expect(subject.activate).to be true
     end
 
@@ -73,6 +76,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to_not receive(:clone_standby_server)
       expect(subject).to_not receive(:start_postgres)
       expect(subject).to_not receive(:register_standby_server)
+      expect(subject).to_not receive(:configure_repmgrd)
       expect(subject.activate).to be false
     end
 
@@ -83,6 +87,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to_not receive(:clone_standby_server)
       expect(subject).to_not receive(:start_postgres)
       expect(subject).to_not receive(:register_standby_server)
+      expect(subject).to_not receive(:configure_repmgrd)
       expect(subject.activate).to be false
     end
 
@@ -93,6 +98,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to_not receive(:clone_standby_server)
       expect(subject).to_not receive(:start_postgres)
       expect(subject).to_not receive(:register_standby_server)
+      expect(subject).to_not receive(:configure_repmgrd)
       expect(subject.activate).to be false
     end
 
@@ -103,6 +109,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to receive(:clone_standby_server).and_return(false)
       expect(subject).to_not receive(:start_postgres)
       expect(subject).to_not receive(:register_standby_server)
+      expect(subject).to_not receive(:configure_repmgrd)
       expect(subject.activate).to be false
     end
 
@@ -113,6 +120,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to receive(:clone_standby_server).and_return(true)
       expect(subject).to receive(:start_postgres).and_return(false)
       expect(subject).to_not receive(:register_standby_server)
+      expect(subject).to_not receive(:configure_repmgrd)
       expect(subject.activate).to be false
     end
 
@@ -123,6 +131,7 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(subject).to receive(:clone_standby_server).and_return(true)
       expect(subject).to receive(:start_postgres).and_return(true)
       expect(subject).to receive(:register_standby_server).and_return(false)
+      expect(subject).to_not receive(:configure_repmgrd)
       expect(subject.activate).to be false
     end
   end
@@ -170,6 +179,14 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
   end
 
+  context "#ask_for_repmgrd_configuration" do
+    it "sets the run_repmgrd_configuration attribute" do
+      expect(subject).to receive(:ask_yn?).and_return true
+      subject.ask_for_repmgrd_configuration
+      expect(subject.run_repmgrd_configuration).to be true
+    end
+  end
+
   context "#data_dir_empty?" do
     it "should log a message and return false when not empty" do
       Dir.mktmpdir do |dir|
@@ -196,6 +213,86 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(service).to receive(:enable).and_return(service)
       expect(service).to receive(:start).and_return(service)
       expect(subject.start_postgres).to be_truthy
+    end
+  end
+
+  context "#configure_repmgrd" do
+    it "returns true if not setup to do the configuration" do
+      subject.run_repmgrd_configuration = false
+      expect(subject.configure_repmgrd).to be true
+    end
+  end
+
+  context "#write_repmgrd_config" do
+    let(:config_path) { Tempfile.new("repmgr_config").path }
+
+    before do
+      stub_const("ApplianceConsole::DatabaseReplication::REPMGR_CONFIG", config_path)
+    end
+
+    after do
+      FileUtils.rm_f(config_path)
+    end
+
+    it "appends the correct data to the config file" do
+      File.write(config_path, "some other stuff here\n")
+
+      subject.write_repmgrd_config
+
+      expect(File.read(config_path)).to eq(<<-EOS.strip_heredoc)
+        some other stuff here
+        failover=automatic
+        promote_command='repmgr standby promote'
+        follow_command='repmgr standby follow'
+      EOS
+    end
+  end
+
+  context "#write_pgpass_file" do
+    let(:pgpass_path) { Tempfile.new("pgpass").path }
+
+    before do
+      stub_const("#{described_class}::PGPASS_FILE", pgpass_path)
+    end
+
+    after do
+      FileUtils.rm_f(pgpass_path)
+    end
+
+    it "writes the .pgpass file correctly" do
+      subject.database_name     = "dbname"
+      subject.database_user     = "someuser"
+      subject.database_password = "secret"
+
+      expect(FileUtils).to receive(:chown).with("postgres", "postgres", pgpass_path)
+      subject.write_pgpass_file
+
+      expect(File.read(pgpass_path)).to eq(<<-EOS.gsub(/^\s+/, ""))
+        *:*:dbname:someuser:secret
+        *:*:replication:someuser:secret
+      EOS
+
+      pgpass_stat = File.stat(pgpass_path)
+      expect(pgpass_stat.mode.to_s(8)).to eq("100600")
+    end
+  end
+
+  context "#start_repmgrd" do
+    it "starts and enables repmgrd" do
+      service = double(SPEC_NAME)
+      expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+      expect(service).to receive(:enable).and_return(service)
+      expect(service).to receive(:start).and_return(service)
+      expect(subject.start_repmgrd).to be true
+    end
+
+    it "returns false if the service fails to start" do
+      service = double(SPEC_NAME)
+      result = double(SPEC_NAME, :output => "", :error => "")
+      expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+      expect(service).to receive(:enable).and_return(service)
+      expect(service).to receive(:start).and_raise(AwesomeSpawn::CommandResultError.new("", result))
+      expect(subject.start_repmgrd).to be false
     end
   end
 end

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -21,13 +21,12 @@ describe ApplianceConsole::DatabaseReplicationStandby do
 
   context "#ask_questions" do
     before do
-      allow(PG::Connection).to receive(:new).and_return(double(SPEC_NAME, :exec => double(SPEC_NAME, :first => "1")))
-    end
-
-    it "returns true when input is confirmed" do
       expect(subject).to receive(:ask_for_unique_cluster_node_number)
       expect(subject).to receive(:ask_for_database_credentials)
       expect(subject).to receive(:ask_for_standby_host)
+    end
+
+    it "returns true when input is confirmed" do
       expect(subject).to receive(:repmgr_configured?).and_return(false)
       expect(subject).to_not receive(:confirm_reconfiguration)
       expect(subject).to receive(:confirm).and_return(true)
@@ -35,9 +34,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
 
     it "returns true when confirm_reconfigure and input is confirmed" do
-      expect(subject).to receive(:ask_for_unique_cluster_node_number)
-      expect(subject).to receive(:ask_for_database_credentials)
-      expect(subject).to receive(:ask_for_standby_host)
       expect(subject).to receive(:repmgr_configured?).and_return(true)
       expect(subject).to receive(:confirm_reconfiguration).and_return(true)
       expect(subject).to receive(:confirm).and_return(true)
@@ -45,9 +41,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
 
     it "returns false when confirm_reconfigure is canceled" do
-      expect(subject).to receive(:ask_for_unique_cluster_node_number)
-      expect(subject).to receive(:ask_for_database_credentials)
-      expect(subject).to receive(:ask_for_standby_host)
       expect(subject).to receive(:repmgr_configured?).and_return(true)
       expect(subject).to receive(:confirm_reconfiguration).and_return(false)
       expect(subject).to_not receive(:confirm)
@@ -55,9 +48,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
 
     it "returns false when input is not confirmed" do
-      expect(subject).to receive(:ask_for_unique_cluster_node_number)
-      expect(subject).to receive(:ask_for_database_credentials)
-      expect(subject).to receive(:ask_for_standby_host)
       expect(subject).to receive(:repmgr_configured?).and_return(false)
       expect(subject).to_not receive(:confirm_reconfiguration)
       expect(subject).to receive(:confirm).and_return(false)


### PR DESCRIPTION
This PR adds an option to configure and start repmgrd for automatic failover when configuring a standby database.

This change requires adding a `.pgpass` file for the `postgres` user in order for repmgrd to access the local and primary databases while monitoring and while executing a failover or follow (resetting the master to the new master for an existing standby) operation.

@jvlcek @gtanzillo please review

@kbrock I know you did some work to remove the use of a `.pgpass` file previously. What was the background behind that change and do you think we should work harder to come up with a different solution here?