### PR TITLE
[DARGA] fix update of rhev provider after db upgrade

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -4,6 +4,13 @@ class Endpoint < ApplicationRecord
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
 
+  before_validation do |endpoint|
+    # on upgrade verify_ssl would be nil for endpoints that did not have a Provider class
+    # only needed for darga branch, since euwe this is fixed in a migration
+    # this is for https://bugzilla.redhat.com/show_bug.cgi?id=1360226
+    endpoint.verify_ssl = OpenSSL::SSL::VERIFY_PEER if endpoint.verify_ssl.nil?
+  end
+
   def verify_ssl=(val)
     val = resolve_verify_ssl_value(val)
     super

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -647,6 +647,26 @@ describe EmsInfraController do
       expect(response.status).to eq(200)
       expect(rhevm.authentications.first).to have_attributes(:userid => "bar", :password => "[FILTERED]")
     end
+
+    it 'updates a wrong migrated endpoint with verify_ssl being nil to the default valued for verify_ssl' do
+      rhevm = FactoryGirl.create(:ems_redhat_with_authentication)
+      rhevm.endpoints.first.update_attribute(:verify_ssl, nil)
+
+      expect do
+        post :update, :params => {
+            "id"               => rhevm.id,
+            "button"           => "save",
+            "default_hostname" => "host_rhevm_updated",
+            "name"             => "foo_rhevm",
+            "emstype"          => "rhevm",
+            "default_userid"   => "bar",
+            "default_password" => "[FILTERED]",
+            "default_verify"   => "[FILTERED]"
+        }
+      end.not_to change { Authentication.count }
+      expect(response.body).not_to match(/Endpoints.verify_ssl is not included in the list/)
+      expect(Endpoint.first.verify_ssl).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
   end
 
   describe "VMWare - create, update" do


### PR DESCRIPTION
on upgrade verify_ssl would be nil for endpoints that did not have a Provider class 

before trying to save a RHEV provider that was migrated from an earlier 
version of the DB (which got nil in verify_ssl) resulted in a flash
message that said "Endpoints.verify_ssl is not included in the list"

only needed for darga branch, for euwe this is fixed in a migration

this is for https://bugzilla.redhat.com/show_bug.cgi?id=1360226
