### PR TITLE
Instantiate Container Template

### DIFF
--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -12,4 +12,68 @@ class ContainerTemplate < ApplicationRecord
   serialize :objects, Array
 
   acts_as_miq_taggable
+
+  MIQ_ENTITY_MAPPING = {
+    "Route"                 => ContainerRoute,
+    "Build"                 => ContainerBuildPod,
+    "BuildConfig"           => ContainerBuild,
+    "Template"              => ContainerTemplate,
+    "ResourceQuota"         => ContainerQuota,
+    "LimitRange"            => ContainerLimit,
+    "ReplicationController" => ContainerReplicator,
+    "PersistentVolumeClaim" => PersistentVolumeClaim,
+    "Pod"                   => ContainerGroup,
+    "Service"               => ContainerService,
+  }.freeze
+
+  def instantiate(params, project = nil)
+    project ||= container_project.name
+    processed_template = process_template(ext_management_system.connect,
+                                          :metadata   => {
+                                            :name      => name,
+                                            :namespace => project
+                                          },
+                                          :objects    => objects,
+                                          :parameters => params)
+    create_objects(processed_template['objects'], project)
+    @created_objects.each { |obj| obj[:kind] = MIQ_ENTITY_MAPPING[obj[:kind]] }
+  end
+
+  def process_template(client, template)
+    client.process_template(template)
+  rescue KubeException => e
+    raise MiqException::MiqProvisionError, "Unexpected Exception while processing template: #{e}"
+  end
+
+  def create_objects(objects, project)
+    @created_objects = []
+    objects.each { |obj| @created_objects << create_object(obj, project).to_h }
+  end
+
+  def create_object(obj, project)
+    obj = obj.symbolize_keys
+    obj[:metadata][:namespace] = project
+    method_name = "create_#{obj[:kind].underscore}"
+    begin
+      ext_management_system.connect_client(obj[:apiVersion], method_name).send(method_name, obj)
+    rescue KubeException => e
+      rollback_objects(@created_objects)
+      raise MiqException::MiqProvisionError, "Unexpected Exception while creating object: #{e}"
+    end
+  end
+
+  def rollback_objects(objects)
+    objects.each { |obj| rollback_object(obj) }
+  end
+
+  def rollback_object(obj)
+    method_name = "delete_#{obj[:kind].underscore}"
+    begin
+      ext_management_system.connect_client(obj[:apiVersion], method_name).send(method_name,
+                                                                               obj[:metadata][:name],
+                                                                               obj[:metadata][:namespace])
+    rescue KubeException => e
+      _log.error("Unexpected Exception while deleting object: #{e}")
+    end
+  end
 end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -17,8 +17,8 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
       require 'kubeclient'
 
       Kubeclient::Client.new(
-        raw_api_endpoint(hostname, port),
-        kubernetes_version,
+        raw_api_endpoint(hostname, port, options[:path]),
+        options[:version] || kubernetes_version,
         :ssl_options    => { :verify_ssl => verify_ssl_mode },
         :auth_options   => kubernetes_auth_options(options),
         :http_proxy_uri => VMDB::Util.http_proxy_uri

--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -23,4 +23,10 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   def supported_auth_attributes
     %w(userid password auth_key)
   end
+
+  def create_project(project)
+    connect.create_project_request(project)
+  rescue KubeException => e
+    raise MiqException::MiqProvisionError, "Unexpected Exception while creating project: #{e}"
+  end
 end


### PR DESCRIPTION
This PR is built on #10159 - Persist Container Templates. 
Changes included:
- Process a Container Template.
- Create objects from Container Template. 
- Rollback feature in case of error. 
- Create new project. 
