### PR TITLE
[DARGA] - Changed supports_provisioning? logic to return false from base class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1939,7 +1939,7 @@ class ApplicationController < ActionController::Base
           templates = [params[:id]] if templates.blank?
 
           template = VmOrTemplate.find_by_id(from_cid(templates.first))
-          render_flash_not_applicable_to_model("provisioning") unless template.send("supports_provisioning?")
+          render_flash_not_applicable_to_model("provisioning") unless template.supports_provisioning?
           return if performed?
 
           @edit[:src_vm_id] = templates.first

--- a/app/helpers/application_helper/button/template_provision.rb
+++ b/app/helpers/application_helper/button/template_provision.rb
@@ -5,6 +5,6 @@ class ApplicationHelper::Button::TemplateProvision < ApplicationHelper::Button::
   end
 
   def disabled?
-    !@record.send("supports_provisioning?")
+    !@record.supports_provisioning?
   end
 end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -74,6 +74,7 @@ class ExtManagementSystem < ApplicationRecord
   include UuidMixin
   include EmsRefresh::Manager
   include TenancyMixin
+  include SupportsFeatureMixin
 
   after_destroy { |record| $log.info "MIQ(ExtManagementSystem.after_destroy) Removed EMS [#{record.name}] id [#{record.id}]" }
 

--- a/app/models/manageiq/providers/azure/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager.rb
@@ -21,6 +21,8 @@ class ManageIQ::Providers::Azure::CloudManager < ManageIQ::Providers::CloudManag
 
   has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
 
+  supports :provisioning
+
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::Azure::NetworkManager",

--- a/app/models/manageiq/providers/azure/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/template.rb
@@ -3,9 +3,7 @@ class ManageIQ::Providers::Azure::CloudManager::Template < ::ManageIQ::Providers
 
   supports :provisioning do
     if ext_management_system
-      if !ext_management_system.supports_provisioning?
-        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
-      end
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/azure/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/template.rb
@@ -1,6 +1,16 @@
 class ManageIQ::Providers::Azure::CloudManager::Template < ::ManageIQ::Providers::CloudManager::Template
   include_concern 'ManageIQ::Providers::Azure::CloudManager::VmOrTemplateShared'
 
+  supports :provisioning do
+    if ext_management_system
+      if !ext_management_system.supports_provisioning?
+        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
+      end
+    else
+      unsupported_reason_add(:provisioning, _('not connected to ems'))
+    end
+  end
+
   def provider_object(connection = nil)
     connection ||= self.ext_management_system.connect
     connection.images[self.ems_ref]

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -12,6 +12,8 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :Template
   require_nested :Vm
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "gce".freeze
   end

--- a/app/models/manageiq/providers/google/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/template.rb
@@ -1,10 +1,7 @@
 class ManageIQ::Providers::Google::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
-
   supports :provisioning do
     if ext_management_system
-      if !ext_management_system.supports_provisioning?
-        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
-      end
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/google/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/template.rb
@@ -1,4 +1,15 @@
 class ManageIQ::Providers::Google::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
+
+  supports :provisioning do
+    if ext_management_system
+      if !ext_management_system.supports_provisioning?
+        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
+      end
+    else
+      unsupported_reason_add(:provisioning, _('not connected to ems'))
+    end
+  end
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.images[ems_ref]

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -10,6 +10,8 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
 
   include_concern "Powershell"
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "scvmm".freeze
   end

--- a/app/models/manageiq/providers/microsoft/infra_manager/template.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/template.rb
@@ -1,4 +1,15 @@
 class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
+
+  supports :provisioning do
+    if ext_management_system
+      if !ext_management_system.supports_provisioning?
+        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
+      end
+    else
+      unsupported_reason_add(:provisioning, _('not connected to ems'))
+    end
+  end
+
   def proxies4job(_job = nil)
     {
       :proxies => [MiqServer.my_server],
@@ -13,4 +24,5 @@ class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Provide
   def has_proxy?
     true
   end
+
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/template.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/template.rb
@@ -1,10 +1,7 @@
 class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
-
   supports :provisioning do
     if ext_management_system
-      if !ext_management_system.supports_provisioning?
-        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
-      end
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end
@@ -24,5 +21,4 @@ class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Provide
   def has_proxy?
     true
   end
-
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -24,6 +24,8 @@ class ManageIQ::Providers::Openstack::CloudManager < EmsCloud
   include ManageIQ::Providers::Openstack::ManagerMixin
   include HasManyCloudNetworksMixin
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "openstack".freeze
   end

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -2,9 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
   belongs_to :cloud_tenant
   supports :provisioning do
     if ext_management_system
-      if !ext_management_system.supports_provisioning?
-        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
-      end
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -1,5 +1,14 @@
 class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
   belongs_to :cloud_tenant
+  supports :provisioning do
+    if ext_management_system
+      if !ext_management_system.supports_provisioning?
+        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
+      end
+    else
+      unsupported_reason_add(:provisioning, _('not connected to ems'))
+    end
+  end
 
   has_and_belongs_to_many :cloud_tenants,
                           :foreign_key             => "vm_id",

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -14,6 +14,8 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   require_nested :Template
   require_nested :Vm
 
+  supports :provisioning
+
   def self.ems_type
     @ems_type ||= "rhevm".freeze
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/template.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/template.rb
@@ -1,6 +1,16 @@
 class ManageIQ::Providers::Redhat::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'
 
+  supports :provisioning do
+    if ext_management_system
+      if !ext_management_system.supports_provisioning?
+        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
+      end
+    else
+      unsupported_reason_add(:provisioning, _('not connected to ems'))
+    end
+  end
+
   def self.supports_kickstart_provisioning?
     true
   end

--- a/app/models/manageiq/providers/redhat/infra_manager/template.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/template.rb
@@ -3,9 +3,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Template < ManageIQ::Providers:
 
   supports :provisioning do
     if ext_management_system
-      if !ext_management_system.supports_provisioning?
-        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
-      end
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -17,6 +17,8 @@ module ManageIQ::Providers
 
     include VimConnectMixin
 
+    supports :provisioning
+
     before_save :stop_event_monitor_queue_on_change
     before_destroy :stop_event_monitor
 

--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -1,6 +1,16 @@
 class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   include_concern 'ManageIQ::Providers::Vmware::InfraManager::VmOrTemplateShared'
 
+  supports :provisioning do
+    if ext_management_system
+      if !ext_management_system.supports_provisioning?
+        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
+      end
+    else
+      unsupported_reason_add(:provisioning, _('not connected to ems'))
+    end
+  end
+
   def cloneable?
     true
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/template.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/template.rb
@@ -3,9 +3,7 @@ class ManageIQ::Providers::Vmware::InfraManager::Template < ManageIQ::Providers:
 
   supports :provisioning do
     if ext_management_system
-      if !ext_management_system.supports_provisioning?
-        unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning))
-      end
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -3,6 +3,8 @@ class MiqTemplate < VmOrTemplate
 
   include_concern 'Operations'
 
+  supports_not :provisioning
+
   def self.base_model
     MiqTemplate
   end
@@ -30,8 +32,4 @@ class MiqTemplate < VmOrTemplate
   end
 
   def active?; false; end
-
-  def supports_provisioning?
-    !ems_id.nil? && ExtManagementSystem.where(:id => ems_id).exists?
-  end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1896,10 +1896,6 @@ class VmOrTemplate < ApplicationRecord
     false
   end
 
-  def supports_provisioning?
-    true
-  end
-
   def self.batch_operation_supported?(operation, ids)
     VmOrTemplate.where(:id => ids).all? { |v| v.public_send("validate_#{operation}")[:available] }
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -211,11 +211,11 @@ describe ApplicationController do
       expect(assigns(:flash_array).first[:message]).to include("does not apply to at least one of the selected")
     end
 
-    let(:ems)     { FactoryGirl.create(:ext_management_system) }
+    let(:ems)     { FactoryGirl.create(:ems_openstack) }
     let(:storage) { FactoryGirl.create(:storage) }
 
     it "sets provisioning data and skips pre provisioning dialog" do
-      template = FactoryGirl.create(:miq_template,
+      template = FactoryGirl.create(:template_openstack,
                                     :name                  => "template 1",
                                     :vendor                => "vmware",
                                     :location              => "template1.vmtx",

--- a/spec/models/miq_template_spec.rb
+++ b/spec/models/miq_template_spec.rb
@@ -44,4 +44,20 @@ describe MiqTemplate do
     expect(ManageIQ::Providers::Redhat::InfraManager::Template.new.supports_kickstart_provisioning?).to be_truthy
     expect(ManageIQ::Providers::Vmware::InfraManager::Template.new.supports_kickstart_provisioning?).to be_falsey
   end
+
+  it "#supports_provisioning?" do
+    template = FactoryGirl.create(:template_openstack)
+    FactoryGirl.create(:ems_openstack, :miq_templates => [template])
+    expect(template.supports_provisioning?).to be_truthy
+
+    template = FactoryGirl.create(:template_openstack)
+    expect(template.supports_provisioning?).to be_falsey
+
+    template = FactoryGirl.create(:template_microsoft)
+    expect(template.supports_provisioning?).to be_falsey
+
+    template = FactoryGirl.create(:template_microsoft)
+    FactoryGirl.create(:ems_openstack, :miq_templates => [template])
+    expect(template.supports_provisioning?).to be_truthy
+  end
 end


### PR DESCRIPTION
And added logic into subclasses that support template provisoning to return true/false based upon condition. Changes to address #10561 (comment)

https://bugzilla.redhat.com/show_bug.cgi?id=1344079
https://bugzilla.redhat.com/show_bug.cgi?id=1347278

@dclarizio @gmcculloug please review, this is a follow up PR to address your comment #10561 (comment).

Added provisioning support for templates to match with methods here:
https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_template.rb#L28
https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/cloud_manager/template.rb#L4
https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/infra_manager/template.rb#L4

@chessbyte this is cherry-pick of changes from https://github.com/ManageIQ/manageiq/pull/10651 to Darga, resolved any merge conflicts and in addition to that also had to make additional changes (https://github.com/ManageIQ/manageiq/commit/1c7c492d42b4d931d45487643f0a8a8c30276248) to support changes in this PR and spec tests to pass/verify cherry-picked changes.  