### PR TITLE
Add console option to configure failover monitor service

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -493,6 +493,38 @@ Static Network Configuration
           press_any_key
           raise MiqSignalError
         end
+      when I18n.t("advanced_settings.failover_monitor")
+        say("#{selection}\n\n")
+
+        options = {
+          "Start Database Failover Monitor" => "start",
+          "Stop Database Failover Monitor"  => "stop"
+        }
+
+        action = ask_with_menu("Failover Monitor Configuration", options)
+        failover_service = LinuxAdmin::Service.new("evm-failover-monitor")
+
+        begin
+          case action
+          when "start"
+            Logging.logger.info("Starting and enabling evm-failover-monitor service")
+            failover_service.enable.start
+          when "stop"
+            Logging.logger.info("Stopping and disabling evm-failover-monitor service")
+            failover_service.disable.stop
+          end
+        rescue AwesomeSpawn::CommandResultError => e
+          say("Failed to configure failover monitor")
+          Logging.logger.error("Failed to configure evm-failover-monitor service")
+          say(e.result.output)
+          say(e.result.error)
+          say("")
+          press_any_key
+          raise MiqSignalError
+        end
+
+        say("Failover Monitor Service configured successfully")
+        press_any_key
 
       when I18n.t("advanced_settings.tmp_config")
         say("#{selection}\n\n")

--- a/gems/pending/appliance_console/locales/appliance/en.yml
+++ b/gems/pending/appliance_console/locales/appliance/en.yml
@@ -13,6 +13,7 @@ en:
     - dbrestore
     - db_config
     - db_replication
+    - failover_monitor
     - httpdauth
     - extauth_opts
     - key_gen
@@ -31,6 +32,7 @@ en:
     dbrestore: Restore Database From Backup
     db_config: Configure Database
     db_replication: Configure Database Replication
+    failover_monitor: Configure Application Database Failover Monitor
     httpdauth: Configure External Authentication (httpd)
     extauth_opts: Update External Authentication Options
     evmstop: Stop EVM Server Processes

--- a/gems/pending/appliance_console/locales/container/en.yml
+++ b/gems/pending/appliance_console/locales/container/en.yml
@@ -8,6 +8,7 @@ en:
     - dbrestore
     - db_config
     - db_replication
+    - failover_monitor
     - key_gen
     - evmstop
     - evmstart
@@ -18,6 +19,7 @@ en:
     dbrestore: Restore Database From Backup
     db_config: Configure Database
     db_replication: Configure Database Replication
+    failover_monitor: Configure Application Database Failover Monitor
     evmstop: Stop EVM Server Processes
     key_gen: Generate Custom Encryption Key
     evmstart: Start EVM Server Processes


### PR DESCRIPTION
These new options allow the user to start or stop the failover monitor daemon service through the console.

The service should be run on the application server to alter the application's database configuration information when a database failover is detected.

@gtanzillo @Fryguy @jvlcek please review