### PR TITLE
[DARGA] Recent version of draper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ raise "Ruby versions less than 2.2.2 are unsupported!" if RUBY_VERSION < "2.2.2"
 
 gem "rails",                           "~>5.0.0"
 gem "rails-controller-testing",        :require => false
-gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>1.0.0"
 gem "websocket-driver",                "~>0.6.3"
 
@@ -50,7 +49,7 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 gem "american_date"
 gem "color",                          "~>1.8"
 gem "default_value_for",              "~>3.0.2.alpha-miq.1", :git => "git://github.com/jrafanie/default_value_for.git", :branch => "rails-50" # https://github.com/FooBarWidget/default_value_for/pull/57
-gem "draper",                         "~>2.1.0", :git => "git://github.com/janraasch/draper.git", :branch => "feature/rails5-compatibility" # https://github.com/drapergem/draper/pull/712
+gem "draper",                         "~>3.0.0.pre1"
 gem "hamlit-rails",                   "~>0.1.0"
 gem "high_voltage",                   "~>2.4.0"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)


### PR DESCRIPTION
This is #10373 for Darga. there was a merge conflict

---

draper 3.0 supports rails 5 - this changes to 3.0.0.pre1

pointing to a github repo (fork) not under our control puts us at risk.

Dan verified in the other pr