### PR TITLE
Add primary/standby to appliance console database status

### DIFF
--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -57,7 +57,7 @@ describe PostgresAdmin do
       end
     end
 
-    describe ".initialized?" do
+    context "with a data directory" do
       around do |example|
         Dir.mktmpdir do |dir|
           ENV["APPLIANCE_PG_DATA"] = dir
@@ -65,13 +65,65 @@ describe PostgresAdmin do
         end
       end
 
-      it "returns true with files in the data directory" do
-        FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/somefile")
-        expect(described_class.initialized?).to be true
+      describe ".initialized?" do
+        it "returns true with files in the data directory" do
+          FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/somefile")
+          expect(described_class.initialized?).to be true
+        end
+
+        it "returns false without files in the data directory" do
+          expect(described_class.initialized?).to be false
+        end
       end
 
-      it "returns false without files in the data directory" do
-        expect(described_class.initialized?).to be false
+      describe ".local_server_in_recovery?" do
+        it "returns true when recovery.conf exists" do
+          FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/recovery.conf")
+          expect(described_class.local_server_in_recovery?).to be true
+        end
+
+        it "returns false when recovery.conf does not exist" do
+          expect(described_class.local_server_in_recovery?).to be false
+        end
+      end
+
+      describe ".local_server_status" do
+        let(:service) { double("postgres service") }
+
+        before do
+          ENV["APPLIANCE_PG_SERVICE"] = "postgresql"
+          allow(LinuxAdmin::Service).to receive(:new).and_return(service)
+        end
+
+        context "when the server is running" do
+          before do
+            allow(service).to receive(:running?).and_return(true)
+          end
+
+          it "returns a running status and primary with no recovery file" do
+            expect(described_class.local_server_status).to eq("running (primary)")
+          end
+
+          it "returns a running status and standby with a recovery file" do
+            FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/recovery.conf")
+            expect(described_class.local_server_status).to eq("running (standby)")
+          end
+        end
+
+        context "when the server is not running" do
+          before do
+            allow(service).to receive(:running?).and_return(false)
+          end
+
+          it "returns initialized and stopped if it is initialized" do
+            FileUtils.touch("#{ENV["APPLIANCE_PG_DATA"]}/somefile")
+            expect(described_class.local_server_status).to eq("initialized and stopped")
+          end
+
+          it "returns not initialized if the data directory is empty" do
+            expect(described_class.local_server_status).to eq("not initialized")
+          end
+        end
       end
     end
   end

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -1,5 +1,6 @@
 require 'awesome_spawn'
 require 'pathname'
+require 'linux_admin'
 
 RAILS_ROOT ||= Pathname.new(__dir__).join("../../../")
 
@@ -61,9 +62,13 @@ class PostgresAdmin
     LinuxAdmin::Service.new(service_name).running?
   end
 
+  def self.local_server_in_recovery?
+    data_directory.join("recovery.conf").exist?
+  end
+
   def self.local_server_status
     if service_running?
-      "running"
+      "running (#{local_server_in_recovery? ? "standby" : "primary"})"
     elsif initialized?
       "initialized and stopped"
     else


### PR DESCRIPTION
This adds a check for recovery.conf in the PostgreSQL data directory which would indicate that the local server is in standby mode.

@gtanzillo please review

New summary screen screenshots:

Primary:
![primarysummary](https://cloud.githubusercontent.com/assets/12697904/17948442/e6242f6e-6a1e-11e6-8c63-2a7a76cb86ef.png)

Standby:
![standbysummary](https://cloud.githubusercontent.com/assets/12697904/17948449/eca3ee6a-6a1e-11e6-8f05-1885547f12d1.png)

