### PR TITLE
Fix for Angular Toolbar failing to load in Production mode

### DIFF
--- a/app/assets/javascripts/angular_modules/module_toolbar.js
+++ b/app/assets/javascripts/angular_modules/module_toolbar.js
@@ -2,10 +2,10 @@ miqHttpInject(
   angular.module('ManageIQ.toolbar', [
     'miqStaticAssets', 'ui.bootstrap'
   ])
-  .config(function ($locationProvider) {
+  .config(['$locationProvider', function ($locationProvider) {
     $locationProvider.html5Mode({
       enabled: true,
       requireBase: false
     })
-  })
+  }])
 );

--- a/app/views/layouts/angular/_toolbar.html.haml
+++ b/app/views/layouts/angular/_toolbar.html.haml
@@ -4,4 +4,4 @@
                     "toolbar-views" => "toolbarCtrl.dataViews",
                     "on-view-click" => "toolbarCtrl.onViewClick(item, $event)"}
 :javascript
-  angular.bootstrap(document.getElementById('miq-toolbar-menu'), ['ManageIQ.toolbar']);
+  miq_bootstrap('#miq-toolbar-menu', 'ManageIQ.toolbar');


### PR DESCRIPTION
Purpose or Intent
-----------------
Currently angular toolbars fail to load in Production mode. The following error is seen in the JS console:
`Error: [$injector:modulerr] Failed to instantiate module ManageIQ.toolbar due to: [$injector:unpr] Unknown provider: e`

To resolve this, we need to run the new `Toolbars` angular app in strict-di mode.
More info here: https://docs.angularjs.org/error/$injector/strictdi

