### PR TITLE
Fixes incorrectly truncated title attribute.

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -214,7 +214,7 @@ module QuadiconHelper
     opts    = quadicon_build_label_options(item, row)
 
     if quadicon_hide_links?
-      content_tag(:span, content, opts)
+      content_tag(:span, content, opts[:options])
     else
       url = quadicon_build_label_url(item, row)
       quadicon_link_to(url, **opts) { content }
@@ -222,7 +222,7 @@ module QuadiconHelper
   end
 
   # FIXME: Even better would be to ask the object what name to use
-  def quadicon_label_content(item, row)
+  def quadicon_label_content(item, row, truncate: true)
     return item.address if item.kind_of? FloatingIp
 
     key = case quadicon_model_name(item)
@@ -234,7 +234,11 @@ module QuadiconHelper
             %w(evm_display_name key name).detect { |k| row[k] }
           end
 
-    truncate_for_quad(row[key], :mode => quadicon_truncate_mode)
+    if truncate
+      truncate_for_quad(row[key], :mode => quadicon_truncate_mode)
+    else
+      row[key]
+    end
   end
 
   def quadicon_build_label_url(item, row)
@@ -263,7 +267,7 @@ module QuadiconHelper
   def quadicon_build_label_options(item, row)
     link_options = {
       :options => {
-        :title => quadicon_label_content(item, row)
+        :title => quadicon_label_content(item, row, :truncate => false)
       }
     }
 

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -494,6 +494,13 @@ describe QuadiconHelper do
         FactoryGirl.create(:vm_vmware)
       end
 
+      it "renders the full name in the title tag" do
+        long_name = "A really long truncatable name"
+        row.name = long_name
+        label = helper.render_quadicon_text(item, row)
+        expect(label).to match(/title=\"#{long_name}\"/)
+      end
+
       it 'renders a link with the row evm_display_name if set' do
         row = Ruport::Data::Record.new(
           "id"               => rand(9999),


### PR DESCRIPTION
**Before**
![screen shot 2016-08-24 at 3 28 25 pm](https://cloud.githubusercontent.com/assets/39493/17950381/c50303a0-6a0f-11e6-9929-9dc9b66005f3.png)

**After**
![screen shot 2016-08-24 at 3 27 46 pm](https://cloud.githubusercontent.com/assets/39493/17950388/ce543e6a-6a0f-11e6-9ed8-93bc894cf729.png)


Resolves #10429

@miq-bot add_label ui, bug
/cc @dclarizio 