### PR TITLE
VirtualTotal: add Vm#v_total_snapshots

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -6,6 +6,7 @@ class VmOrTemplate < ApplicationRecord
   include NewWithTypeStiMixin
   include ScanningMixin
   include SupportsFeatureMixin
+  include VirtualTotalMixin
 
   self.table_name = 'vms'
 

--- a/app/models/vm_or_template/snapshotting.rb
+++ b/app/models/vm_or_template/snapshotting.rb
@@ -4,7 +4,7 @@ module VmOrTemplate::Snapshotting
   included do
     has_many :snapshots, :dependent => :destroy
 
-    virtual_column :v_total_snapshots,                    :type => :integer,    :uses => :snapshots
+    virtual_total  :v_total_snapshots, :snapshots
     virtual_column :v_snapshot_oldest_name,               :type => :string,     :uses => :snapshots
     virtual_column :v_snapshot_oldest_description,        :type => :string,     :uses => :snapshots
     virtual_column :v_snapshot_oldest_total_size,         :type => :integer,    :uses => :snapshots
@@ -13,10 +13,6 @@ module VmOrTemplate::Snapshotting
     virtual_column :v_snapshot_newest_description,        :type => :string,     :uses => :snapshots
     virtual_column :v_snapshot_newest_total_size,         :type => :integer,    :uses => :snapshots
     virtual_column :v_snapshot_newest_timestamp,          :type => :datetime,   :uses => :snapshots
-  end
-
-  def v_total_snapshots
-    snapshots.size
   end
 
   def newest_snapshot

--- a/spec/models/vm/snapshotting_spec.rb
+++ b/spec/models/vm/snapshotting_spec.rb
@@ -1,0 +1,82 @@
+describe "VM Snapshotting" do
+  before { EvmSpecHelper.local_miq_server }
+  let(:vm) { FactoryGirl.create(:vm) }
+
+  describe ".v_total_snapshots" do
+    it "counts many" do
+      FactoryGirl.create_list(:snapshot, 2, :create_time => 1.minute.ago, :vm_or_template => vm)
+      expect(vm.v_total_snapshots).to eq(2)
+    end
+
+    it "counts none" do
+      expect(vm.v_total_snapshots).to eq(0)
+    end
+  end
+
+  describe ".v_snapshot_oldest_name" do
+    it "returns value" do
+      FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :name => "the name")
+      expect(vm.v_snapshot_oldest_name).to eq("the name")
+    end
+
+    it "supports nil" do
+      expect(vm.v_snapshot_oldest_name).to be_nil
+    end
+  end
+
+  describe ".v_snapshot_oldest_description" do
+    it "returns value" do
+      FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :description => "the description")
+      expect(vm.v_snapshot_oldest_description).to eq("the description")
+    end
+
+    it "supports nil" do
+      expect(vm.v_snapshot_oldest_description).to be_nil
+    end
+  end
+
+  describe ".v_snapshot_oldest_total_size" do
+    it "returns value" do
+      FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :total_size => 500)
+      expect(vm.v_snapshot_oldest_total_size).to eq(500)
+    end
+
+    it "supports nil" do
+      expect(vm.v_snapshot_oldest_total_size).to be_nil
+    end
+  end
+
+
+  describe ".v_snapshot_newest_name" do
+    it "returns value" do
+      FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :name => "the name")
+      expect(vm.v_snapshot_newest_name).to eq("the name")
+    end
+
+    it "supports nil" do
+      expect(vm.v_snapshot_newest_name).to be_nil
+    end
+  end
+
+  describe ".v_snapshot_newest_description" do
+    it "returns value" do
+      FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :description => "the description")
+      expect(vm.v_snapshot_newest_description).to eq("the description")
+    end
+
+    it "supports nil" do
+      expect(vm.v_snapshot_newest_description).to be_nil
+    end
+  end
+
+  describe ".v_snapshot_newest_total_size" do
+    it "returns value" do
+      FactoryGirl.create(:snapshot, :create_time => 1.minute.ago, :vm_or_template => vm, :total_size => 500)
+      expect(vm.v_snapshot_newest_total_size).to eq(500)
+    end
+
+    it "supports nil" do
+      expect(vm.v_snapshot_newest_total_size).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
The goal is to use `virtual_total` for any total column. This will allow us to sort by this column.

to reproduce:
- login as admin
- Go to infra/vms explorer
- sort by `v_total_snapshots`

**TL;DR:** for 10,000 vms

|        ms |queries | query (ms) |     rows |comments
|       ---:|  ---:|      ---:|      ---:| ---
|  44,260.9 |   37 | 11,304.7 |   80,608 |before
|  9,296.2 |   38 | 3,528.5 |   50,658 |after
| 79.0% | -3% | 68.8% | 37% | improvement

This has a lot of room for improvement, but just focusing on the quick win w/ `+1/-4` + specs



environment
----

|VmOrTemplate|Host|Storage|ExtManagementSystem|MiqRegion|Zone|
|-----------:|---:|------:|------------------:|--------:|---:|
|     10,000 |200 |   221 |                 1 |       1 |  1 |

before
------

|        ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  44,260.9 |   37 | 11,304.7 |   80,608 |`/vm_infra/explorer`
|  44,260.9 |      |          |          |`GET http://localhost:3000/vm_infra/explorer`
|  44,251.0 |    5 |      1.4 |        5 |`.Executing action: explorer`
|       0.4 |    1 |      0.3 |        1 |`..SELECT  "users".* `
|       0.2 |    1 |      0.1 |        1 |`..SELECT  "miq_groups".* `
|       0.2 |    1 |      0.1 |        1 |`..SELECT  "tenants".* `
|       0.2 |    1 |      0.1 |        1 |`..SELECT  "miq_user_roles".* `
|       0.4 |    1 |      0.3 |        1 |`..SELECT "miq_product_features".* `
|  44,234.7 |   10 |      6.8 |       39 |`..VmShowMixin#explorer`
|       3.2 |    4 |      3.1 |          |`...SELECT "vms".* `
|       3.6 |    6 |      1.8 |       39 |`...SELECT "miq_searches".* `
|   1,007.1 |    2 |      0.7 |        2 |`...Rbac::Filterer#search`
|       0.3 |    1 |      0.2 |        1 |`....SELECT  "entitlements".* `
|       0.4 |    1 |      0.3 |        1 |`....SELECT "ext_management_systems".* `
|   1,001.8 |      |          |          |`....Rbac::Filterer#scope_targets`
|   1,001.7 |    1 |      0.5 |          |`.....Rbac::Filterer#scope_by_direct_rbac`
|       0.5 |      |      0.5 |          |`......SELECT DISTINCT "ext_management_systems"."id" `
|   1,000.0 |      |          |          |`......Rbac::Filterer#matches_via_descendants`
|     999.5 |    1 |    930.6 |   10,000 |`.......Rbac::Filterer#search`
|     930.6 |      |     49.7 |   10,000 |`........SELECT "vms".* `
|   7,545.4 |    8 |  1,406.5 |   30,492 |`...TreeBuilderVmsAndTemplates#tree`
|       0.6 |    2 |      0.5 |        2 |`....SELECT  "relationships".* `
|     400.6 |    1 |    207.7 |   20,245 |`....SELECT "relationships".* `
|       0.8 |    1 |      0.6 |        1 |`....SELECT "ext_management_systems".* `
|       0.4 |    1 |      0.2 |        4 |`....SELECT "ems_folders".* `
|       0.6 |    1 |      0.3 |       20 |`....SELECT "ems_clusters".* `
|       4.3 |    1 |      1.4 |      220 |`....SELECT "resource_pools".* `
|     999.2 |    1 |     85.1 |   10,000 |`....SELECT "vms".* `
|   1,388.4 |    1 |    838.1 |   10,000 |`....Rbac::Filterer#search`
|     838.1 |      |     83.3 |   10,000 |`.....SELECT "vms".* `
|  34,889.4 |    1 |      1.2 |        1 |`...MiqReport#paged_view_search`
|       1.2 |      |      1.0 |        1 |`....SELECT  "miq_regions".* `
|  11,159.3 |    4 |  8,116.9 |   30,020 |`....Rbac::Filterer#search`
|   7,903.5 |    1 |    357.0 |   20,000 |`.....SELECT "vms"."id" AS t0_r0, "vms"."vendor" AS t0_r1, "vms"."format" AS t0_r2, "vms"."version" AS t0_r`
|      29.2 |    1 |     29.2 |          |`.....SELECT "networks".* `
|       1.4 |    1 |      1.1 |       20 |`.....SELECT "ems_clusters".* `
|     182.8 |    1 |     63.9 |   10,000 |`.....SELECT "disks".* `
|       2.1 |      |          |          |`.....Rbac::Filterer#scope_targets`
|      48.9 |      |          |          |`...Rendering: vm_infra/explorer`
|     189.8 |    4 |      2.0 |       49 |`...Rendering: layouts/application`
|       0.8 |    1 |      0.3 |       48 |`....SELECT "miq_shortcuts".* `
|       0.6 |    1 |      0.4 |        1 |`....SELECT "miq_groups".* `
|       0.2 |    1 |      0.2 |          |`....SELECT "ext_management_systems"."id" `
|       0.4 |    1 |      0.4 |          |`....SELECT "miq_reports"."id", "miq_reports"."name", "miq_reports"."conditions" `

after
-----

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  9,296.2 |   38 | 3,528.5 |   50,658 |`/vm_infra/explorer`
|  9,296.2 |      |         |          |`GET http://localhost:3000/vm_infra/explorer`
|  9,286.1 |    5 |     2.0 |        5 |`.Executing action: explorer`
|      0.5 |    1 |     0.3 |        1 |`..SELECT  "users".* `
|      0.2 |    1 |     0.1 |        1 |`..SELECT  "miq_groups".* `
|      0.3 |    1 |     0.2 |        1 |`..SELECT  "tenants".* `
|      0.3 |    1 |     0.2 |        1 |`..SELECT  "miq_user_roles".* `
|      0.7 |    1 |     0.6 |        1 |`..SELECT "miq_product_features".* `
|  9,269.2 |   10 |     4.2 |       39 |`..VmShowMixin#explorer`
|      2.0 |    4 |     2.0 |          |`...SELECT "vms".* `
|      2.2 |    6 |     1.8 |       39 |`...SELECT "miq_searches".* `
|    871.1 |    2 |     0.8 |        2 |`...Rbac::Filterer#search`
|      0.3 |    1 |     0.2 |        1 |`....SELECT  "entitlements".* `
|      0.5 |    1 |     0.3 |        1 |`....SELECT "ext_management_systems".* `
|    866.2 |      |         |          |`....Rbac::Filterer#scope_targets`
|    866.1 |    1 |     0.6 |          |`.....Rbac::Filterer#scope_by_direct_rbac`
|      0.6 |      |     0.6 |          |`......SELECT DISTINCT "ext_management_systems"."id" `
|    864.2 |      |         |          |`......Rbac::Filterer#matches_via_descendants`
|    863.7 |    1 |   814.6 |   10,000 |`.......Rbac::Filterer#search`
|    814.6 |      |    49.2 |   10,000 |`........SELECT "vms".* `
|  7,044.9 |    8 | 1,792.6 |   30,492 |`...TreeBuilderVmsAndTemplates#tree`
|      0.6 |    2 |     0.5 |        2 |`....SELECT  "relationships".* `
|    492.6 |    1 |   209.2 |   20,245 |`....SELECT "relationships".* `
|      0.5 |    1 |     0.3 |        1 |`....SELECT "ext_management_systems".* `
|      0.4 |    1 |     0.2 |        4 |`....SELECT "ems_folders".* `
|      0.6 |    1 |     0.3 |       20 |`....SELECT "ems_clusters".* `
|      3.6 |    1 |     1.4 |      220 |`....SELECT "resource_pools".* `
|  1,294.3 |    1 |    83.1 |   10,000 |`....SELECT "vms".* `
|  1,151.2 |    1 |   812.8 |   10,000 |`....Rbac::Filterer#search`
|    812.8 |      |    81.1 |   10,000 |`.....SELECT "vms".* `
|    181.3 |    5 |    69.6 |       71 |`...MiqReport#paged_view_search`
|     45.3 |    1 |    45.3 |          |`....SELECT  DISTINCT "vms"."id", ((SELECT COUNT(*) `
|     22.5 |    1 |     8.3 |       40 |`....SELECT "vms"."id" AS t0_r0, "vms"."vendor" AS t0_r1, "vms"."format" AS t0_r2, "vms"."version" AS t0_r`
|      0.5 |    1 |     0.5 |          |`....SELECT "networks".* `
|      0.6 |    1 |     0.3 |       11 |`....SELECT "ems_clusters".* `
|      0.7 |    1 |     0.4 |       20 |`....SELECT "disks".* `
|     37.4 |    1 |    29.3 |          |`....Rbac::Filterer#search`
|     29.3 |      |    29.3 |          |`.....SELECT COUNT(DISTINCT "vms"."id") `
|     47.7 |      |         |          |`...Rendering: vm_infra/explorer`
|    661.5 |    4 |     2.0 |       49 |`...Rendering: layouts/application`
|      0.7 |    1 |     0.3 |       48 |`....SELECT "miq_shortcuts".* `
|      0.6 |    1 |     0.3 |        1 |`....SELECT "miq_groups".* `
|      0.3 |    1 |     0.3 |          |`....SELECT "ext_management_systems"."id" `
|      0.4 |    1 |     0.4 |          |`....SELECT "miq_reports"."id", "miq_reports"."name", "miq_reports"."conditions" `
