### PR TITLE
Set default verify_ssl in db for endpoints

### DIFF
--- a/db/migrate/20160825070810_fix_null_verify_ssl_on_endpoints.rb
+++ b/db/migrate/20160825070810_fix_null_verify_ssl_on_endpoints.rb
@@ -1,0 +1,21 @@
+class FixNullVerifySslOnEndpoints < ActiveRecord::Migration[5.0]
+  # 20151222103721_migrate_provider_attributes_to_endpoints.rb
+  # this migration moved verify_ssl from the Provider class to Endpoint
+  # but a lot of ems at this point did not have a Provider
+  # That resulted in verify_ssl being nil for all Endpoint,
+  # but the Endpoint class requires it being not nil
+  class Endpoint < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Fixing defaults for verify_ssl in Endpoint") do
+      # at the point of writing this is the default for verify_ssl
+      # OpenSSL::SSL::VERIFY_PEER == 1 in ruby stdlib 2.3.1
+      Endpoint.where(:verify_ssl => nil).update_all(:verify_ssl => 1)
+    end
+  end
+
+  def down
+    # irreversible, sorry
+  end
+end

--- a/spec/migrations/20160825070810_fix_null_verify_ssl_on_endpoints_spec.rb
+++ b/spec/migrations/20160825070810_fix_null_verify_ssl_on_endpoints_spec.rb
@@ -1,0 +1,19 @@
+require_migration
+
+describe FixNullVerifySslOnEndpoints do
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+
+  migration_context :up do
+    it "changes verify_ssl to 1 only for the nil ones" do
+      endpoint_stub.create!(:verify_ssl => nil)
+      endpoint_stub.create!(:verify_ssl => 0)
+      endpoint_stub.create!(:verify_ssl => 1)
+
+      migrate
+
+      expect(endpoint_stub.where(:verify_ssl => nil).count).to eq 0
+      expect(endpoint_stub.where(:verify_ssl => 0).count).to eq 1
+      expect(endpoint_stub.where(:verify_ssl => 1).count).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
[20151222103721_migrate_provider_attributes_to_endpoints.rb](https://github.com/ManageIQ/manageiq/blob/abe1199a5009779b3325203ec2f2bed6f14fbe8a/db/migrate/20151222103721_migrate_provider_attributes_to_endpoints.rb)
this migration moved verify_ssl from the Provider class to Endpoint
but a lot of ems at this point did not have a Provider
That resulted in verify_ssl being nil for all Endpoint,
but the Endpoint class requires it being not nil

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1360226

@miq-bot add_labels darga/no, bug, sql migration

@juliancheal @blomquisg please review