### PR TITLE
Rename shared examples to avoid CI warning

### DIFF
--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_cloud_network_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_cloud_network_controller')
 
 describe CloudNetworkController do
-  include_examples :cloud_network_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_cloud_network_controller, %w(openstack azure google)
 end

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_cloud_subnet_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_cloud_subnet_controller')
 
 describe CloudSubnetController do
-  include_examples :cloud_subnet_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_cloud_subnet_controller, %w(openstack azure google)
 end

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_ems_network_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_ems_network_controller')
 
 describe EmsNetworkController do
-  include_examples :ems_network_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_ems_network_controller, %w(openstack azure google)
 end

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_floating_ip_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_floating_ip_controller')
 
 describe FloatingIpController do
-  include_examples :floating_ip_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_floating_ip_controller, %w(openstack azure google)
 end

--- a/spec/controllers/load_balancer_controller_spec.rb
+++ b/spec/controllers/load_balancer_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_load_balancer_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_load_balancer_controller')
 
 describe LoadBalancerController do
-  include_examples :load_balancer_controller_spec, %w()
+  include_examples :shared_examples_for_load_balancer_controller, %w()
 end

--- a/spec/controllers/network_port_controller_spec.rb
+++ b/spec/controllers/network_port_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_network_port_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_network_port_controller')
 
 describe NetworkPortController do
-  include_examples :network_port_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_network_port_controller, %w(openstack azure google)
 end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_network_router_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_network_router_controller')
 
 describe NetworkRouterController do
-  include_examples :network_router_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_network_router_controller, %w(openstack azure google)
 end

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,5 +1,5 @@
-require Rails.root.join('spec/shared/controllers/shared_security_group_controller_spec')
+require Rails.root.join('spec/shared/controllers/shared_examples_for_security_group_controller')
 
 describe SecurityGroupController do
-  include_examples :security_group_controller_spec, %w(openstack azure google)
+  include_examples :shared_examples_for_security_group_controller, %w(openstack azure google)
 end

--- a/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
@@ -1,6 +1,6 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :cloud_network_controller_spec do |providers|
+shared_examples :shared_examples_for_cloud_network_controller do |providers|
   include CompressedIds
 
   render_views

--- a/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
@@ -1,7 +1,8 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :floating_ip_controller_spec do |providers|
+shared_examples :shared_examples_for_cloud_subnet_controller do |providers|
   include CompressedIds
+
   render_views
   before :each do
     stub_user(:features => :all)
@@ -33,21 +34,29 @@ shared_examples :floating_ip_controller_spec do |providers|
 
       describe "#show" do
         it "renders show screen" do
-          get :show, :params => {:id => @floating_ip.id}
+          get :show, :params => {:id => @cloud_subnet.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "floating_ips",
-                                                :url  => "/floating_ip/show_list?page=&refresh=y"},
-                                               {:name => "192.0.2.1 (Summary)",
-                                                :url  => "/floating_ip/show/#{@floating_ip.id}"}])
+          expect(assigns(:breadcrumbs)).to eq([{:name => "cloud_subnets",
+                                                :url  => "/cloud_subnet/show_list?page=&refresh=y"},
+                                               {:name => "Cloud Subnet (Summary)",
+                                                :url  => "/cloud_subnet/show/#{@cloud_subnet.id}"}])
 
-          is_expected.to render_template(:partial => "layouts/listnav/_floating_ip")
+          is_expected.to render_template(:partial => "layouts/listnav/_cloud_subnet")
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@cloud_subnet, [@child_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        end
+
+        it "show associated instances" do
+          assert_nested_list(@cloud_subnet, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
         end
       end
 
       describe "#test_toolbars" do
-        it 'edit floating ip tags' do
-          post :button, :params => {:miq_grid_checks => to_cid(@floating_ip.id), :pressed => "floating_ip_tag"}
+        it 'edit cloud subnet tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@cloud_subnet.id), :pressed => "cloud_subnet_tag"}
           expect(response.status).to eq(200)
         end
       end

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -1,6 +1,6 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :ems_network_controller_spec do |providers|
+shared_examples :shared_examples_for_ems_network_controller do |providers|
   include CompressedIds
   render_views
   before :each do

--- a/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
@@ -1,8 +1,7 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :network_router_controller_spec do |providers|
+shared_examples :shared_examples_for_floating_ip_controller do |providers|
   include CompressedIds
-
   render_views
   before :each do
     stub_user(:features => :all)
@@ -34,29 +33,21 @@ shared_examples :network_router_controller_spec do |providers|
 
       describe "#show" do
         it "renders show screen" do
-          get :show, :params => {:id => @network_router.id}
+          get :show, :params => {:id => @floating_ip.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "network_routers",
-                                                :url  => "/network_router/show_list?page=&refresh=y"},
-                                               {:name => "Network Router (Summary)",
-                                                :url  => "/network_router/show/#{@network_router.id}"}])
+          expect(assigns(:breadcrumbs)).to eq([{:name => "floating_ips",
+                                                :url  => "/floating_ip/show_list?page=&refresh=y"},
+                                               {:name => "192.0.2.1 (Summary)",
+                                                :url  => "/floating_ip/show/#{@floating_ip.id}"}])
 
-          is_expected.to render_template(:partial => "layouts/listnav/_network_router")
-        end
-
-        it "show associated instances" do
-          assert_nested_list(@network_router, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
-        end
-
-        it "show associated cloud_subnets" do
-          assert_nested_list(@network_router, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
+          is_expected.to render_template(:partial => "layouts/listnav/_floating_ip")
         end
       end
 
       describe "#test_toolbars" do
-        it 'edit network router tags' do
-          post :button, :params => {:miq_grid_checks => to_cid(@network_router.id), :pressed => "network_router_tag"}
+        it 'edit floating ip tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@floating_ip.id), :pressed => "floating_ip_tag"}
           expect(response.status).to eq(200)
         end
       end

--- a/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_load_balancer_controller.rb
@@ -1,6 +1,6 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :load_balancer_controller_spec do |providers|
+shared_examples :shared_examples_for_load_balancer_controller do |providers|
   include CompressedIds
 
   render_views

--- a/spec/shared/controllers/shared_examples_for_network_port_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_port_controller.rb
@@ -1,8 +1,7 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :security_group_controller_spec do |providers|
+shared_examples :shared_examples_for_network_port_controller do |providers|
   include CompressedIds
-
   render_views
   before :each do
     stub_user(:features => :all)
@@ -34,29 +33,29 @@ shared_examples :security_group_controller_spec do |providers|
 
       describe "#show" do
         it "renders show screen" do
-          get :show, :params => {:id => @security_group.id}
+          get :show, :params => {:id => @network_port.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "security_groups",
-                                                :url  => "/security_group/show_list?page=&refresh=y"},
-                                               {:name => "Security Group (Summary)",
-                                                :url  => "/security_group/show/#{@security_group.id}"}])
+          expect(assigns(:breadcrumbs)).to eq([{:name => "network_ports",
+                                                :url  => "/network_port/show_list?page=&refresh=y"},
+                                               {:name => "eth0 (Summary)",
+                                                :url  => "/network_port/show/#{@network_port.id}"}])
 
-          is_expected.to render_template(:partial => "layouts/listnav/_security_group")
+          is_expected.to render_template(:partial => "layouts/listnav/_network_port")
         end
 
-        it "show associated instances" do
-          assert_nested_list(@security_group, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        it "show associated cloud_subnets" do
+          assert_nested_list(@network_port, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
         end
 
-        it "show associated network ports" do
-          assert_nested_list(@security_group, [@network_port], 'network_ports', 'All Network Ports')
+        it "show associated floating ips" do
+          assert_nested_list(@network_port, [@floating_ip], 'floating_ips', 'All Floating Ips')
         end
       end
 
       describe "#test_toolbars" do
-        it 'edit security group tags' do
-          post :button, :params => {:miq_grid_checks => to_cid(@security_group.id), :pressed => "security_group_tag"}
+        it 'edit Network Port tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@network_port.id), :pressed => "network_port_tag"}
           expect(response.status).to eq(200)
         end
       end

--- a/spec/shared/controllers/shared_examples_for_network_router_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_router_controller.rb
@@ -1,6 +1,6 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :cloud_subnet_controller_spec do |providers|
+shared_examples :shared_examples_for_network_router_controller do |providers|
   include CompressedIds
 
   render_views
@@ -34,29 +34,29 @@ shared_examples :cloud_subnet_controller_spec do |providers|
 
       describe "#show" do
         it "renders show screen" do
-          get :show, :params => {:id => @cloud_subnet.id}
+          get :show, :params => {:id => @network_router.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "cloud_subnets",
-                                                :url  => "/cloud_subnet/show_list?page=&refresh=y"},
-                                               {:name => "Cloud Subnet (Summary)",
-                                                :url  => "/cloud_subnet/show/#{@cloud_subnet.id}"}])
+          expect(assigns(:breadcrumbs)).to eq([{:name => "network_routers",
+                                                :url  => "/network_router/show_list?page=&refresh=y"},
+                                               {:name => "Network Router (Summary)",
+                                                :url  => "/network_router/show/#{@network_router.id}"}])
 
-          is_expected.to render_template(:partial => "layouts/listnav/_cloud_subnet")
-        end
-
-        it "show associated cloud_subnets" do
-          assert_nested_list(@cloud_subnet, [@child_subnet], 'cloud_subnets', 'All Cloud Subnets')
+          is_expected.to render_template(:partial => "layouts/listnav/_network_router")
         end
 
         it "show associated instances" do
-          assert_nested_list(@cloud_subnet, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+          assert_nested_list(@network_router, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
+        end
+
+        it "show associated cloud_subnets" do
+          assert_nested_list(@network_router, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
         end
       end
 
       describe "#test_toolbars" do
-        it 'edit cloud subnet tags' do
-          post :button, :params => {:miq_grid_checks => to_cid(@cloud_subnet.id), :pressed => "cloud_subnet_tag"}
+        it 'edit network router tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@network_router.id), :pressed => "network_router_tag"}
           expect(response.status).to eq(200)
         end
       end

--- a/spec/shared/controllers/shared_examples_for_security_group_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_security_group_controller.rb
@@ -1,7 +1,8 @@
 require_relative 'shared_network_manager_context'
 
-shared_examples :network_port_controller_spec do |providers|
+shared_examples :shared_examples_for_security_group_controller do |providers|
   include CompressedIds
+
   render_views
   before :each do
     stub_user(:features => :all)
@@ -33,29 +34,29 @@ shared_examples :network_port_controller_spec do |providers|
 
       describe "#show" do
         it "renders show screen" do
-          get :show, :params => {:id => @network_port.id}
+          get :show, :params => {:id => @security_group.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "network_ports",
-                                                :url  => "/network_port/show_list?page=&refresh=y"},
-                                               {:name => "eth0 (Summary)",
-                                                :url  => "/network_port/show/#{@network_port.id}"}])
+          expect(assigns(:breadcrumbs)).to eq([{:name => "security_groups",
+                                                :url  => "/security_group/show_list?page=&refresh=y"},
+                                               {:name => "Security Group (Summary)",
+                                                :url  => "/security_group/show/#{@security_group.id}"}])
 
-          is_expected.to render_template(:partial => "layouts/listnav/_network_port")
+          is_expected.to render_template(:partial => "layouts/listnav/_security_group")
         end
 
-        it "show associated cloud_subnets" do
-          assert_nested_list(@network_port, [@cloud_subnet], 'cloud_subnets', 'All Cloud Subnets')
+        it "show associated instances" do
+          assert_nested_list(@security_group, [@vm], 'instances', 'All Instances', :child_path => 'vm_cloud')
         end
 
-        it "show associated floating ips" do
-          assert_nested_list(@network_port, [@floating_ip], 'floating_ips', 'All Floating Ips')
+        it "show associated network ports" do
+          assert_nested_list(@security_group, [@network_port], 'network_ports', 'All Network Ports')
         end
       end
 
       describe "#test_toolbars" do
-        it 'edit Network Port tags' do
-          post :button, :params => {:miq_grid_checks => to_cid(@network_port.id), :pressed => "network_port_tag"}
+        it 'edit security group tags' do
+          post :button, :params => {:miq_grid_checks => to_cid(@security_group.id), :pressed => "security_group_tag"}
           expect(response.status).to eq(200)
         end
       end


### PR DESCRIPTION
Rename shared examples to avoid CI warning:
WARNING: Shared example group 'load_balancer_controller_spec'
has been previously defined at: spec/shared/controllers/shared_load_balancer_controller_spec.rb
Occurring for all shared examples for controllers.