### PR TITLE
Use SupportsFeatureMixin to support cloud tenant mapping for OSP

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -68,6 +68,6 @@ class CloudTenant < ApplicationRecord
       :instance_id => ems_id,
       :method_name => 'sync_cloud_tenants_with_tenants',
       :zone        => ems.my_zone
-    ) if ems.supports_cloud_tenants?
+    ) if ems.supports_cloud_tenant_mapping?
   end
 end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -40,6 +40,7 @@ module ManageIQ::Providers
     include HasManyOrchestrationStackMixin
 
     supports_not :discovery
+    supports_not :cloud_tenant_mapping
 
     # Development helper method for Rails console for opening a browser to the EMS.
     #
@@ -66,12 +67,8 @@ module ManageIQ::Providers
       end
     end
 
-    def supports_cloud_tenants?
-      false
-    end
-
     def sync_cloud_tenants_with_tenants
-      return unless supports_cloud_tenants?
+      return unless supports_cloud_tenant_mapping?
       sync_root_tenant
       sync_tenants
       sync_deleted_cloud_tenants

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -26,15 +26,18 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   include ManageIQ::Providers::Openstack::ManagerMixin
 
   supports :provisioning
+  supports :cloud_tenant_mapping do
+    unless defined?(self.class.parent::CloudManager::CloudTenant)
+      reason = _("CloudTenant mapping to Tenants are supported on CloudManager only when CloudTenant exists "\
+                 "on the provider")
+      unsupported_reason_add(:cloud_tenant_mapping, reason)
+    end
+  end
 
   before_validation :ensure_managers
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager
-  end
-
-  def supports_cloud_tenants?
-    true
   end
 
   def self.ems_type


### PR DESCRIPTION
Purpose or Intent
-----------------
- SupportsFeatureMixin was introduced: https://github.com/ManageIQ/manageiq/pull/8886
- Only Openstack providers supports feature cloud tenant mapping

I also changed name feature to 'cloud_tenant_mapping'

```
ManageIQ::Providers::Openstack::CloudManager.supports_cloud_tenant_mapping?
=> true

ManageIQ::Providers::CloudManager.supports_cloud_tenant_mapping?
=> false
ManageIQ::Providers::Azure::CloudManager.supports_cloud_tenant_mapping?
=> false
```

cc @durandom 

@miq-bot add_label refactoring, providers/openstack/cloud 

