### PR TITLE
Call .all method to correctly catch exceptions

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -133,7 +133,7 @@ module ManageIQ::Providers
     end
 
     def get_host_aggregates
-      host_aggregates = safe_list { @connection.aggregates }
+      host_aggregates = safe_list { @connection.aggregates.all }
       process_collection(host_aggregates, :host_aggregates) { |ha| parse_host_aggregate(ha) }
     end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Call .all method to correctly catch exceptions, otherwise
fog is not throwing exceptions but returning string
***error in evaluation***, which fails the refresh when there
is 403.

Steps for Testing/QA
--------------------
Using a user with member role only fails on getting host aggregates.