### PR TITLE
get provider name by inflecting on the class

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -2,6 +2,8 @@ module ManageIQ::Providers
   class BaseManager < ExtManagementSystem
     require_nested :Refresher
 
+    include Inflector::Methods
+
     def self.metrics_collector_queue_name
       self::MetricsCollectorWorker.default_queue_name
     end

--- a/app/models/manageiq/providers/inflector.rb
+++ b/app/models/manageiq/providers/inflector.rb
@@ -1,0 +1,17 @@
+module ManageIQ::Providers::Inflector
+  class ObjectNotNamespacedError < StandardError; end
+
+  def self.provider_name(class_or_instance)
+    klass = class_or_instance.class == Class ? class_or_instance : class_or_instance.class
+    provider_module(klass).name.split('::').last
+  end
+
+  def self.provider_module(klass, original_object = nil)
+    if klass == Object
+      raise ObjectNotNamespacedError, "Cannot get provider module from non namespaced object #{original_object}"
+    end
+
+    klass.parent == ManageIQ::Providers ? klass : provider_module(klass.parent, klass)
+  end
+  private_class_method :provider_module
+end

--- a/app/models/manageiq/providers/inflector.rb
+++ b/app/models/manageiq/providers/inflector.rb
@@ -6,6 +6,12 @@ module ManageIQ::Providers::Inflector
     provider_module(klass).name.split('::').last
   end
 
+  def self.manager_type(class_or_instance)
+    klass = class_or_instance.class == Class ? class_or_instance : class_or_instance.class
+    manager = (klass.name.split('::') - provider_module(klass).name.split('::')).first
+    manager.chomp('Manager')
+  end
+
   def self.provider_module(klass, original_object = nil)
     if klass == Object
       raise ObjectNotNamespacedError, "Cannot get provider module from non namespaced object #{original_object}"

--- a/app/models/manageiq/providers/inflector/methods.rb
+++ b/app/models/manageiq/providers/inflector/methods.rb
@@ -1,0 +1,13 @@
+module ManageIQ::Providers::Inflector::Methods
+  extend ActiveSupport::Concern
+
+  included do
+    include ClassMethods
+  end
+
+  class_methods do
+    def provider_name
+      ManageIQ::Providers::Inflector.provider_name(self)
+    end
+  end
+end

--- a/app/models/manageiq/providers/inflector/methods.rb
+++ b/app/models/manageiq/providers/inflector/methods.rb
@@ -9,5 +9,9 @@ module ManageIQ::Providers::Inflector::Methods
     def provider_name
       ManageIQ::Providers::Inflector.provider_name(self)
     end
+
+    def manager_type
+      ManageIQ::Providers::Inflector.manager_type(self)
+    end
   end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -31,6 +31,7 @@ class VmOrTemplate < ApplicationRecord
   include TenancyMixin
 
   include AvailabilityMixin
+  include ManageIQ::Providers::Inflector::Methods
 
   has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy,
            :class_name => "CustomAttribute"

--- a/spec/models/manageiq/providers/inflector/methods_spec.rb
+++ b/spec/models/manageiq/providers/inflector/methods_spec.rb
@@ -1,0 +1,18 @@
+describe ManageIQ::Providers::Inflector::Methods do
+  context "#provider_name" do
+    it "returns name for an instance" do
+      manager = ManageIQ::Providers::Amazon::CloudManager.new
+      expect(manager.provider_name).to eq('Amazon')
+    end
+
+    it "returns name for a class" do
+      manager = ManageIQ::Providers::Amazon::CloudManager
+      expect(manager.provider_name).to eq('Amazon')
+    end
+
+    it "returns name for a vm" do
+      vm = ManageIQ::Providers::Amazon::CloudManager::Vm.new
+      expect(vm.provider_name).to eq('Amazon')
+    end
+  end
+end

--- a/spec/models/manageiq/providers/inflector_spec.rb
+++ b/spec/models/manageiq/providers/inflector_spec.rb
@@ -1,0 +1,25 @@
+describe ManageIQ::Providers::Inflector do
+  context "#provider_name" do
+    it "returns the name for an instance of a manager" do
+      manager = ManageIQ::Providers::Amazon::CloudManager.new
+      expect(described_class.provider_name(manager)).to eq('Amazon')
+    end
+
+    it "returns the name for a class of a manager" do
+      manager = ManageIQ::Providers::Amazon::CloudManager
+      expect(described_class.provider_name(manager)).to eq('Amazon')
+    end
+
+    it "returns the name for an instance of a Vm" do
+      vm = ManageIQ::Providers::Amazon::CloudManager::Vm.new
+      expect(described_class.provider_name(vm)).to eq('Amazon')
+    end
+
+    it "raises an error on not namespaced objects" do
+      vm = Vm.new
+      expect do
+        described_class.provider_name(vm)
+      end.to raise_error(ManageIQ::Providers::Inflector::ObjectNotNamespacedError)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/inflector_spec.rb
+++ b/spec/models/manageiq/providers/inflector_spec.rb
@@ -5,6 +5,11 @@ describe ManageIQ::Providers::Inflector do
       expect(described_class.provider_name(manager)).to eq('Amazon')
     end
 
+    it "returns the name for an instance of a manager when called on the instance" do
+      manager = ManageIQ::Providers::Amazon::CloudManager.new
+      expect(manager.provider_name).to eq('Amazon')
+    end
+
     it "returns the name for a class of a manager" do
       manager = ManageIQ::Providers::Amazon::CloudManager
       expect(described_class.provider_name(manager)).to eq('Amazon')
@@ -19,6 +24,35 @@ describe ManageIQ::Providers::Inflector do
       vm = Vm.new
       expect do
         described_class.provider_name(vm)
+      end.to raise_error(ManageIQ::Providers::Inflector::ObjectNotNamespacedError)
+    end
+  end
+
+  context "#manager_type" do
+    it "returns the type for an instance of a manager" do
+      manager = ManageIQ::Providers::Amazon::CloudManager.new
+      expect(described_class.manager_type(manager)).to eq('Cloud')
+    end
+
+    it "returns the type for an instance of a manager when called on the instance" do
+      manager = ManageIQ::Providers::Amazon::CloudManager.new
+      expect(manager.manager_type).to eq('Cloud')
+    end
+
+    it "returns the type for a class of a manager" do
+      manager = ManageIQ::Providers::Amazon::CloudManager
+      expect(described_class.manager_type(manager)).to eq('Cloud')
+    end
+
+    it "returns the type for an instance of a Vm" do
+      vm = ManageIQ::Providers::Amazon::CloudManager::Vm.new
+      expect(described_class.manager_type(vm)).to eq('Cloud')
+    end
+
+    it "raises an error on not namespaced objects" do
+      vm = Vm.new
+      expect do
+        described_class.manager_type(vm)
       end.to raise_error(ManageIQ::Providers::Inflector::ObjectNotNamespacedError)
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Automate needs to get the provider name from a ems instance or an e.g. vm instance.

I think it makes sense to have that kind of introspection outside of the providers classes, because, as @gmcculloug said, you dont want to accidentally break that. This way the automate team owns the code and you can have test coverage as high as you like :smile: 

By looking at the namespacing its not very likely to break, and I think we can take it for granted that all provider objects are under `ManageIQ::Providers` 

@mkanoor @tinaafitz @blomquisg @gmcculloug @Fryguy  what do you think?

Links
-----
* https://github.com/ManageIQ/manageiq/issues/10741

