### PR TITLE
Add image url if no icon is present for toolbar button

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -141,10 +141,11 @@ class ApplicationHelper::ToolbarBuilder
     @sep_needed = true unless button_hide
     props = toolbar_button(
       bgi,
-      :id     => bgi[:id],
-      :type   => :button,
-      :img    => "#{get_image(bgi[:image], bgi[:id]) ? get_image(bgi[:image], bgi[:id]) : bgi[:id]}.png",
-      :imgdis => "#{bgi[:image] || bgi[:id]}.png",
+      :id      => bgi[:id],
+      :type    => :button,
+      :img     => img = "#{get_image(bgi[:image], bgi[:id]) ? get_image(bgi[:image], bgi[:id]) : bgi[:id]}.png",
+      :img_url => ActionController::Base.helpers.image_path("toolbars/#{img}"),
+      :imgdis  => "#{bgi[:image] || bgi[:id]}.png",
     )
 
     # set pdf button to be hidden if graphical summary screen is set by default


### PR DESCRIPTION
Purpose or Intent
-----------------
When navigating to VM and instance no cockpit icon is present:
![selection_062](https://cloud.githubusercontent.com/assets/3439771/17965707/33094996-6abe-11e6-8415-50b17b7c927f.png)

This is because of no `<img>` tag in toolbar button. This PR and https://github.com/ManageIQ/ui-components/pull/14 fixes this Issue. Final result is:
![selection_063](https://cloud.githubusercontent.com/assets/3439771/17965712/374e920e-6abe-11e6-9116-2239635c766e.png)

Steps for Testing/QA
--------------------
* Compute -> Infrastructure -> Virtual machines
* Select VM and instance