### PR TITLE
Remove CloudManager relations from a NetworkManager

### DIFF
--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module EmsNetworkHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(parent_ems_cloud availability_zones cloud_tenants cloud_networks cloud_subnets network_routers security_groups
+    %i(parent_ems_cloud cloud_networks cloud_subnets network_routers security_groups
        floating_ips network_ports load_balancers)
   end
 
@@ -57,14 +57,6 @@ module EmsNetworkHelper::TextualSummary
 
   def textual_parent_ems_cloud
     @record.try(:parent_manager)
-  end
-
-  def textual_availability_zones
-    @record.try(:availability_zones)
-  end
-
-  def textual_cloud_tenants
-    @record.try(:cloud_tenants)
   end
 
   def textual_security_groups


### PR DESCRIPTION
Purpose or Intent
-----------------
Remove CloudManager relations from a NetworkManager, those
relations are available through parent cloud manager link.
having them in NetworkManager is confusing the back button
in the nested lists.

Steps for Testing/QA
--------------------
Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1342430