### PR TITLE
Remove outdated TODOs from save_inventory_network

### DIFF
--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -72,7 +72,6 @@ module EmsRefresh::SaveInventoryNetwork
                 []
               end
 
-    # TODO(lsmola) can be removed when refresh of all providers is moved under network provider
     hashes.each do |h|
       %i(cloud_tenant orchestration_stack).each do |relation|
         h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)
@@ -111,7 +110,6 @@ module EmsRefresh::SaveInventoryNetwork
   end
 
   def save_cloud_subnets_inventory(network, hashes)
-    # TODO(lsmola) can be removed when refresh of all providers is moved under network provider
     hashes.each do |h|
       %i(availability_zone parent_cloud_subnet).each do |relation|
         h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)
@@ -136,7 +134,6 @@ module EmsRefresh::SaveInventoryNetwork
                 []
               end
 
-    # TODO(lsmola) can be removed when refresh of all providers is moved under network provider
     hashes.each do |h|
       %i(cloud_tenant cloud_network orchestration_stack network_group).each do |relation|
         h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)
@@ -213,7 +210,6 @@ module EmsRefresh::SaveInventoryNetwork
                 []
               end
 
-    # TODO(lsmola) can be removed when refresh of all providers is moved under network provider
     hashes.each do |h|
       %i(cloud_tenant cloud_network network_group).each do |relation|
         h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)


### PR DESCRIPTION
Purpose or Intent
-----------------
Remove outdated TODOs from save_inventory_network, the todos
are no longer valid.