### PR TITLE
Remove the verify_local rake task

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -3,12 +3,12 @@ require 'evm_application'
 
 namespace :evm do
   desc "Start the ManageIQ EVM Application"
-  task :start => ["db:verify_local", :environment] do
+  task :start => :environment do
     EvmApplication.start
   end
 
   desc "Restart the ManageIQ EVM Application"
-  task :restart => ["db:verify_local", :environment] do
+  task :restart => :environment do
     EvmApplication.stop
     EvmApplication.start
   end

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -61,18 +61,6 @@ end
 
 namespace :evm do
   namespace :db do
-    # Verify appliance's local database is started if configured for local, otherwise stop it.
-    task :verify_local do
-      require File.expand_path(File.join(Rails.root, 'lib/miq_environment')) unless Object.const_defined? :MiqEnvironment
-      if MiqEnvironment::Command.is_appliance?
-        if EvmDba.local?
-          Rake::Task['evm:db:silent_start'].invoke
-        else
-          Rake::Task['evm:db:silent_stop'].invoke
-        end
-      end
-    end
-
     desc 'Start the local ManageIQ EVM Database (VMDB)'
     task :start do
       EvmDba.start


### PR DESCRIPTION
This is no longer useful as we may use a hostname to connect to database servers that are actually running locally to "proxy" connections so we can easily switch in a failover scenario.

Also we may run standby database servers when we are actually configured against a remote primary server. In that case we would want the local database to continue running even though we are not configured to use it.

@Fryguy @jrafanie what do you think about this.

I think this would also be helpful to the containers effort, right @fbladilo ?