### PR TITLE
Remove the darga_migrations file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,9 +115,6 @@ public/stylesheets/jmaki-3column-footer.css
 public/stylesheets/jmaki-standard-no-sidebars.css
 public/stylesheets/jmaki-standard-right-sidebar.css
 
-# spec/
-spec/replication/util/data/darga_migrations
-
 # tmp/
 tmp/*
 


### PR DESCRIPTION
This file was removed in a0973007691d467c423fabe6f8274c64ae5de344 in favor of using git to retrieve the migrations from the darga branch when we run the spec.