### PR TITLE
Safe storing of the ems refresh failed status

### DIFF
--- a/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -38,6 +38,9 @@ module EmsRefresh
             post_refresh_ems_cleanup(ems, targets)
           end
 
+          # We need to reload the ems, since it can try to autosave a models that did not pass a validation, and the
+          # ems status with the error would not save.
+          ems.reload
           ems.update_attributes(:last_refresh_error => nil, :last_refresh_date => Time.now.utc)
           post_refresh(ems, ems_refresh_start_time)
         end


### PR DESCRIPTION
## Purpose or Intent

Safe storing of the ems refresh failed status. We have to
reload the ems object, otherwise saving might fail with the same
validation it failed in refresh.
## Steps for Testing/QA

In a case of a DB constraint failed, like unique index, during EMS refresh saving, it also fails to store the error state of the EMS
