### PR TITLE
Read operation for Cloud Tenant Mapping

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -38,6 +38,22 @@ class CloudTenant < ApplicationRecord
     try(:ext_management_system).try(:cloud_networks).try(:where, :shared => true) || []
   end
 
+  def update_source_tenant_associations
+    TENANT_MAPPING_ASSOCIATIONS.each do |tenant_association|
+      custom_update_method = "#{__method__}_for_#{tenant_association}"
+
+      if respond_to?(custom_update_method)
+        public_send(custom_update_method)
+      end
+    end
+  end
+
+  def update_source_tenant_associations_for_vms_and_templates
+    vms_and_templates.each do |object|
+      object.miq_group_id = source_tenant.default_miq_group_id
+      object.save!
+    end
+  end
 
   def self.with_ext_management_system(ems_id)
     where(:ext_management_system => ems_id)

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -1,8 +1,12 @@
 class CloudTenant < ApplicationRecord
+  TENANT_MAPPING_ASSOCIATIONS = %i(vms_and_templates).freeze
+
   include NewWithTypeStiMixin
   include VirtualTotalMixin
+  extend ActsAsTree::TreeWalker
 
   belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::CloudManager"
+  has_one    :source_tenant, :as => :source, :class_name => 'Tenant'
   has_many   :security_groups
   has_many   :cloud_networks
   has_many   :cloud_subnets
@@ -22,7 +26,7 @@ class CloudTenant < ApplicationRecord
 
   acts_as_miq_taggable
 
-  acts_as_tree
+  acts_as_tree :order => 'name'
 
   virtual_total :total_vms, :vms
 
@@ -32,6 +36,11 @@ class CloudTenant < ApplicationRecord
 
   def shared_cloud_networks
     try(:ext_management_system).try(:cloud_networks).try(:where, :shared => true) || []
+  end
+
+
+  def self.with_ext_management_system(ems_id)
+    where(:ext_management_system => ems_id)
   end
 
   def self.post_refresh_ems(ems_id, _)

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -101,6 +101,7 @@ module ManageIQ::Providers
           $log.info("New Tenant #{cloud_tenant.source_tenant.name} created")
         end
 
+        cloud_tenant.update_source_tenant_associations
         cloud_tenant.save!
         $log.info("CloudTenant #{cloud_tenant.name} saved")
       end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -69,6 +69,41 @@ module ManageIQ::Providers
     def sync_cloud_tenants_with_tenants
       return unless supports_cloud_tenants?
       sync_root_tenant
+      sync_tenants
+    end
+
+    def sync_tenants
+      reload
+
+      $log.info("Syncing CloudTenant with Tenants...")
+
+      CloudTenant.with_ext_management_system(id).walk_tree do |cloud_tenant, _|
+        tenant_params = {:name => cloud_tenant.name, :description => cloud_tenant.name}
+
+        if cloud_tenant.source_tenant
+          $log.info("CloudTenant #{cloud_tenant.name} has tenant #{cloud_tenant.source_tenant.name}")
+          $log.info("Updating Tenant #{cloud_tenant.source_tenant.name} with parameters: #{tenant_params.inspect}")
+          cloud_tenant.source_tenant.update(tenant_params)
+        else
+          $log.info("CloudTenant #{cloud_tenant.name} has no tenant")
+          $log.info("Creating Tenant with parameters: #{tenant_params.inspect}")
+
+          # first level of CloudTenants does not have parents - in that case
+          # source_tenant from EmsCloud is used - this is tenant which is representing
+          # provider (EmsCloud)
+          # if it is not first level of cloud tenant
+          # there is existing parent of CloudTenant and his related tenant is taken
+          tenant_parent = cloud_tenant.parent.try(:source_tenant) || source_tenant
+          $log.info("and with parent #{tenant_parent.name}")
+          tenant_params[:parent] = tenant_parent
+          tenant_params[:source] = cloud_tenant
+          cloud_tenant.source_tenant = Tenant.new(tenant_params)
+          $log.info("New Tenant #{cloud_tenant.source_tenant.name} created")
+        end
+
+        cloud_tenant.save!
+        $log.info("CloudTenant #{cloud_tenant.name} saved")
+      end
     end
 
     def sync_root_tenant

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -75,6 +75,7 @@ module ManageIQ::Providers
       ems_tenant = source_tenant || Tenant.new(:parent => Tenant.root_tenant, :source => self)
 
       ems_tenant_name = "#{self.class.description} Cloud Provider #{name}"
+
       ems_tenant.update_attributes!(:name => ems_tenant_name, :description => ems_tenant_name)
     end
   end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -6420,6 +6420,8 @@ tenants:
 - description
 - use_config_for_attributes
 - default_miq_group_id
+- source_type
+- source_id
 time_profiles:
 - id
 - description

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -26,11 +26,13 @@ describe EmsCloud do
     expect(described_class.supported_types).to match_array(expected_types)
   end
 
-  context "CloudTenant Mapping" do
+  context "OpenStack CloudTenant Mapping" do
     describe "#sync_cloud_tenants_with_tenants" do
-      let(:ems_cloud)              { FactoryGirl.create(:ems_openstack) }
-      let(:name_of_created_tenant) { "#{described_class::OPENSTACK_CLOUD_PROVIDER} #{ems_cloud.name}" }
-      let!(:default_tenant)        { Tenant.seed }
+      let(:ems_cloud)       { FactoryGirl.create(:ems_openstack) }
+      let!(:default_tenant) { Tenant.seed }
+      let(:name_of_created_tenant) do
+        "#{ManageIQ::Providers::Openstack::CloudManager.description} Cloud Provider #{ems_cloud.name}"
+      end
 
       it "creates tenant related to provider" do
         ems_cloud.sync_cloud_tenants_with_tenants
@@ -48,8 +50,11 @@ describe EmsCloud do
         ems_cloud.sync_cloud_tenants_with_tenants
 
         expect(Tenant.count).to eq(count_of_tenants + 1)
+        ems_cloud.reload
 
         ems_cloud.sync_cloud_tenants_with_tenants
+
+        ems_cloud.reload
         ems_cloud.sync_cloud_tenants_with_tenants
 
         expect(Tenant.count).to eq(count_of_tenants + 1)

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -75,6 +75,118 @@ describe EmsCloud do
         expect(ems_cloud.source_tenant.name).to eq(name_of_created_tenant)
         expect(ems_cloud.source_tenant.description).to eq(name_of_created_tenant)
       end
+
+      context "creation of tenant tree " do
+        subject! do
+          ems_cloud.sync_root_tenant
+          ems_cloud.reload
+        end
+
+        let(:vm_1) { FactoryGirl.create(:vm_openstack) }
+        let(:vm_2) { FactoryGirl.create(:vm_openstack) }
+        let(:vm_3) { FactoryGirl.create(:vm_openstack) }
+        let(:vm_4) { FactoryGirl.create(:vm_openstack) }
+
+        let!(:ct_1) do
+          FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems_cloud)
+        end
+
+        let!(:ct_2) do
+          FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems_cloud, :parent => ct_1,
+                                                      :vms_and_templates => [vm_1, vm_2])
+        end
+
+        let!(:ct_3) do
+          FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems_cloud, :parent => ct_2)
+        end
+
+        let!(:ct_4) do
+          FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems_cloud, :parent => ct_2,
+                                                      :vms_and_templates => [vm_3, vm_4])
+        end
+
+        def tenant_by(cloud_tenant)
+          Tenant.find_by(:name => cloud_tenant.name)
+        end
+
+        let(:tenant_ct_1) { tenant_by(ct_1) }
+        let(:tenant_ct_2) { tenant_by(ct_2) }
+        let(:tenant_ct_3) { tenant_by(ct_3) }
+        let(:tenant_ct_4) { tenant_by(ct_4) }
+
+        let(:tenant_names) do
+          [tenant_ct_1.name, tenant_ct_2.name, tenant_ct_3.name, tenant_ct_4.name]
+        end
+
+        let(:tenant_parent_names) do
+          [tenant_ct_1.parent.name, tenant_ct_2.parent.name, tenant_ct_3.parent.name, tenant_ct_4.parent.name]
+        end
+
+        def expect_tenant_names
+          expect(tenant_names).to eq([ct_1.name, ct_2.name, ct_3.name, ct_4.name])
+        end
+
+        def expect_tenant_parent_names
+          expect(tenant_parent_names).to eq([name_of_created_tenant, ct_1.name, ct_2.name, ct_2.name])
+        end
+
+        def expect_assigned_vms
+          expect(tenant_ct_2.vm_or_templates).to match_array([vm_1, vm_2])
+          expect(tenant_ct_4.vm_or_templates).to match_array([vm_3, vm_4])
+        end
+
+        def expect_created_tenant_tree
+          expect_tenant_names
+
+          expect_tenant_parent_names
+
+          expect_assigned_vms
+        end
+
+        it "creates tenant tree from cloud tenants with VMs" do
+          ems_cloud.sync_cloud_tenants_with_tenants
+          expect_created_tenant_tree
+        end
+
+        let(:vm_5) { FactoryGirl.create(:vm_openstack) }
+
+        let(:ct_5) do
+          FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems_cloud, :parent => ct_4,
+                                                      :vms_and_templates => [vm_5])
+        end
+
+        let(:tenant_ct_5) { tenant_by(ct_5) }
+
+        it "adds new tenant to tenant tree(new cloud tenant added)" do
+          ems_cloud.sync_cloud_tenants_with_tenants
+          expect_created_tenant_tree
+
+          ct_5
+          ems_cloud.sync_cloud_tenants_with_tenants
+          expect_created_tenant_tree
+
+          expect(tenant_ct_5.name).to eq(ct_5.name)
+          expect(tenant_ct_5.parent.name).to eq(ct_4.name)
+          expect(tenant_ct_5.vm_or_templates).to match_array([vm_5])
+        end
+
+        it "update existing tenant according to updated cloud tenant" do
+          ems_cloud.sync_cloud_tenants_with_tenants
+          expect_created_tenant_tree
+
+          ct_4.name = "New name"
+          ct_4.description = "New name"
+          ct_4.vms_and_templates << vm_5
+          ct_4.save
+
+          ems_cloud.sync_cloud_tenants_with_tenants
+          tenant_ct_4.reload
+
+          expect(tenant_ct_4.name).to eq(ct_4.name)
+          expect(tenant_ct_4.parent.name).to eq(ct_2.name)
+          expect(tenant_ct_4.vm_or_templates).to match_array([vm_3, vm_4, vm_5])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
**Mapping CloudTenant to Tenant**

Creation tree of Tenants according to CloudTenants, this tree is
attached to base tenant which is related to Openstack Provider.

CloudTenants and Tenants are tied thru relation Tenant#source and
on CloudTenant it is called CloudTenant#source_tenant

There is walking thru CloudTenant tree:

when association CloudTenant#source_tenant is found then
attributes of Tenant are updated.

when associations CloudTenant#source_tenant is not found then
Tenant is created. As parent is used CloudTenant#source_tenant
parent cloud_tenant and when such parent does not exist
it means that we are creating Tenant directly under base tenant.
So source_tenant of EmsCloud is in that case.

**Assign VMs and Template to Tenant**

updating assigments of vms_and_templates to tenants
have to be done thru assigning miq_group_id,
because saving of VmOrTemplate have before_save
where tenant for VmOrTemplate is determined by
its miq_group. For this behaviour is created
custom method for updating.

Mapping of other relations (CloudTenant) can be
added to CloudTenant#TENANT_MAPPING_ASSOCIATIONS

Scenario when cloud tenant is delete will be considered in other PR

@miq-bot add_label wip