### PR TITLE
[DARGA] fix port 0 for endpoints

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -20,6 +20,14 @@ class Endpoint < ApplicationRecord
     verify_ssl != OpenSSL::SSL::VERIFY_NONE
   end
 
+  def port
+    # fix for https://bugzilla.redhat.com/show_bug.cgi?id=1360226
+    # the problem was in that migration 20141121200153_migrate_ems_attributes_to_endpoints.rb
+    # here port got converted from a string to int, but "".to_i is 0.
+    # This is for darga only. On euwe this is solved by a migration
+    (super == 0) ? nil : super
+  end
+
   private
 
   def resolve_verify_ssl_value(val)

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -47,4 +47,22 @@ describe Endpoint do
       end
     end
   end
+
+  it "#port returns nil for port 0 in the db" do
+    allow(MiqServer).to receive(:my_zone).and_return("default")
+    rhev = FactoryGirl.create(:ems_redhat_with_authentication)
+    Endpoint.update_all(:port => 0)
+    rhev.reload
+    expect(rhev.class).to receive(:raw_connect).with(rhev.address, nil, any_args)
+    rhev.authentication_check
+  end
+
+  it "#port returns the real value for other than 0" do
+    allow(MiqServer).to receive(:my_zone).and_return("default")
+    rhev = FactoryGirl.create(:ems_redhat_with_authentication)
+    Endpoint.update_all(:port => 443)
+    rhev.reload
+    expect(rhev.class).to receive(:raw_connect).with(rhev.address, 443, any_args)
+    rhev.authentication_check
+  end
 end


### PR DESCRIPTION
fix for https://bugzilla.redhat.com/show_bug.cgi?id=1360226
the problem was in that migration 20141121200153_migrate_ems_attributes_to_endpoints.rb
here port got converted from a string to int, but "".to_i is 0.
This is for darga only. On euwe this is solved by a migration

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1360226

@miq-bot add_label bug, providers
@miq-bot assign chessbyte 