### PR TITLE
remove name from arbitration rule

### DIFF
--- a/app/models/arbitration_rule.rb
+++ b/app/models/arbitration_rule.rb
@@ -1,7 +1,7 @@
 class ArbitrationRule < ApplicationRecord
   ALLOWED_OPERATIONS = %w(inject disable_engine auto_reject require_approval auto_approve).freeze
   validates :operation, :inclusion => { :in => ALLOWED_OPERATIONS }
-  validates :name, :expression, :presence => true
+  validates :expression, :presence => true
 
   serialize :expression
 

--- a/db/migrate/20160825145949_remove_name_from_arbitration_rules.rb
+++ b/db/migrate/20160825145949_remove_name_from_arbitration_rules.rb
@@ -1,0 +1,9 @@
+class RemoveNameFromArbitrationRules < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :arbitration_rules, :name
+  end
+
+  def down
+    add_column :arbitration_rules, :name, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -50,7 +50,6 @@ arbitration_profiles:
 - profile
 arbitration_rules:
 - id
-- name
 - description
 - operation
 - arbitration_profile_id

--- a/spec/factories/arbitration_rule.rb
+++ b/spec/factories/arbitration_rule.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :arbitration_rule do
-    name 'arbitration rule'
+    description 'arbitration rule'
     operation 'inject'
     expression MiqExpression.new('EQUAL' => { 'field' => 'User-userid', 'value' => 'admin' })
   end

--- a/spec/models/arbitration_rule_spec.rb
+++ b/spec/models/arbitration_rule_spec.rb
@@ -20,13 +20,6 @@ describe ArbitrationRule do
     end
   end
 
-  describe '#name' do
-    it 'requires a name' do
-      expect { FactoryGirl.create(:arbitration_rule, :name => nil) }
-        .to raise_error(ActiveRecord::RecordInvalid, /Name can't be blank/)
-    end
-  end
-
   describe '#get_by_rule_class' do
     it 'returns only rules of the given type' do
       user_rules = FactoryGirl.create_list(:arbitration_rule, 2)

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe 'Arbitration Rule API' do
   context 'arbitration rules create' do
     let(:request_body) do
       {
-        'name'       => 'admin rule',
-        'operation'  => 'inject',
-        'expression' => {
+        'description' => 'admin rule',
+        'operation'   => 'inject',
+        'expression'  => {
           'EQUAL' => {
             'field' => 'User-userid',
             'value' => 'admin'
@@ -67,7 +67,7 @@ RSpec.describe 'Arbitration Rule API' do
     it 'rejects edit without an appropriate role' do
       api_basic_authorize
 
-      run_post(arbitration_rules_url(rule.id), gen_request(:edit, :name => 'edited name'))
+      run_post(arbitration_rules_url(rule.id), gen_request(:edit, :description => 'edited description'))
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -76,8 +76,8 @@ RSpec.describe 'Arbitration Rule API' do
       api_basic_authorize collection_action_identifier(:arbitration_rules, :edit)
 
       expect do
-        run_post(arbitration_rules_url(rule.id), gen_request(:edit, :name => 'edited name'))
-      end.to change { rule.reload.name }.to('edited name')
+        run_post(arbitration_rules_url(rule.id), gen_request(:edit, :description => 'edited description'))
+      end.to change { rule.reload.description }.to('edited description')
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
> Rule name is not necessary and is not a part of the service designer arbitration rules UI. It is  almost a duplicate of description since a rule in itself is pretty self explanatory. Removing it as an attribute as per discussion with @chriskacerguis 

@miq-bot add_label enhancement, service broker, sql migration, darga/no


