### PR TITLE
endpoint.port should not be zero

### DIFF
--- a/db/migrate/20160825152940_fix_port_zero_on_enpoints.rb
+++ b/db/migrate/20160825152940_fix_port_zero_on_enpoints.rb
@@ -1,0 +1,16 @@
+class FixPortZeroOnEnpoints < ActiveRecord::Migration[5.0]
+  # the problem was in that migration 20141121200153_migrate_ems_attributes_to_endpoints.rb
+  # here port got converted from a string to int, but "".to_i is 0.
+  class Endpoint < ActiveRecord::Base
+  end
+
+  def up
+    say_with_time("Fixing ports 0 in Endpoint") do
+      Endpoint.where(:port => 0).update_all(:port => nil)
+    end
+  end
+
+  def down
+    # irreversible, sorry
+  end
+end

--- a/spec/migrations/20160825152940_fix_port_zero_on_enpoints_spec.rb
+++ b/spec/migrations/20160825152940_fix_port_zero_on_enpoints_spec.rb
@@ -1,0 +1,19 @@
+require_migration
+
+describe FixPortZeroOnEnpoints do
+  let(:endpoint_stub) { migration_stub(:Endpoint) }
+
+  migration_context :up do
+    it "changes ports only for those with 0" do
+      endpoint_stub.create!(:port => nil)
+      endpoint_stub.create!(:port => 0)
+      endpoint_stub.create!(:port => 443)
+
+      migrate
+
+      expect(endpoint_stub.where(:port => nil).count).to eq 2
+      expect(endpoint_stub.where(:port => 0).count).to eq 0
+      expect(endpoint_stub.where(:port => 443).count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
the problem was in that migration
[20141121200153_migrate_ems_attributes_to_endpoints.rb
](https://github.com/ManageIQ/manageiq/blob/90704fcd9bcaeb1ab3b92328d12ce336aac77043/db/migrate/20141121200153_migrate_ems_attributes_to_endpoints.rb#L15) here port got converted from a string to int, but "".to_i is 0.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1360226

darga pr is here https://github.com/ManageIQ/manageiq/pull/10780

@miq-bot add_label bug, providers, darga/no

@blomquisg @juliancheal review another Endpoint bug?

