### PR TITLE
Rollup disconnected container group metrics to container projects

### DIFF
--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -34,7 +34,11 @@ class ContainerProject < ApplicationRecord
   include EventMixin
   include Metric::CiMixin
 
-  PERF_ROLLUP_CHILDREN = :container_groups
+  PERF_ROLLUP_CHILDREN = :all_container_groups
+
+  def all_container_groups
+    ContainerGroup.where(:container_project_id => id).or(ContainerGroup.where(:old_container_project_id => id))
+  end
 
   acts_as_miq_taggable
 

--- a/app/models/metric/ci_mixin/state_finders.rb
+++ b/app/models/metric/ci_mixin/state_finders.rb
@@ -45,6 +45,10 @@ module Metric::CiMixin::StateFinders
     vim_performance_state_for_ts(ts).container_groups
   end
 
+  def all_container_groups_from_vim_performance_state_for_ts(ts)
+    vim_performance_state_for_ts(ts).all_container_groups
+  end
+
   def ext_management_systems_from_vim_performance_state_for_ts(ts)
     vim_performance_state_for_ts(ts).ext_management_systems
   end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -39,7 +39,7 @@ module Metric::Rollup
       :derived_vm_numvcpus,
       :derived_vm_used_disk_storage,
     ],
-    :ContainerProject_container_groups    => [
+    :ContainerProject_all_container_groups => [
       :cpu_usage_rate_average,
       :derived_vm_numvcpus,
       :derived_memory_used,

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -3,7 +3,8 @@ class VimPerformanceState < ApplicationRecord
 
   belongs_to :resource, :polymorphic => true
 
-  ASSOCIATIONS = [:vms, :hosts, :ems_clusters, :ext_management_systems, :storages, :container_nodes, :container_groups]
+  ASSOCIATIONS = [:vms, :hosts, :ems_clusters, :ext_management_systems, :storages, :container_nodes, :container_groups,
+                  :all_container_groups]
 
   # Define accessors for state_data information
   [
@@ -126,6 +127,11 @@ class VimPerformanceState < ApplicationRecord
 
   def container_groups
     ids = get_assoc(:container_groups)
+    ids.empty? ? [] : ContainerGroup.where(:id => ids).order(:id).to_a
+  end
+
+  def all_container_groups
+    ids = get_assoc(:all_container_groups)
     ids.empty? ? [] : ContainerGroup.where(:id => ids).order(:id).to_a
   end
 


### PR DESCRIPTION
Currently, ContainerProject MetricRollups are an aggregation of only live ContainerGroups and not disconnected ContainerGroups. This includes the disconnected entities in the rollup.

@Fryguy Please review
cc @simon3z (do we need this anywhere else?)

@miq-bot add_label providers/containers