### PR TITLE
Restore internationalization functionality in toolbars

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -14,7 +14,9 @@ class ApplicationHelper::Button::Basic < Hash
 
   # Return content under key such as :text or :confirm run through gettext or
   # evalated in the context of controller variables and helper methods.
-  def localized(key)
+  def localized(key, value = nil)
+    self[key] = value if value
+
     case self[key]
     when NilClass then ''
     when Proc     then instance_eval(&self[key])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -107,10 +107,12 @@ class ApplicationHelper::ToolbarBuilder
       :data    => input[:data]
     )
 
-    button[:enabled]   = input[:enabled]
-    button[:title]     = input[:title]   unless input[:title].blank?
-    button[:text]      = input[:text]    unless input[:text].blank?
-    button[:confirm]   = input[:confirm] unless input[:confirm].blank?
+    button[:enabled] = input[:enabled]
+    %i(title text confirm).each do |key|
+      unless input[key].blank?
+        button[key] = button.localized(key, input[key])
+      end
+    end
     button[:url_parms] = update_url_parms(safer_eval(input[:url_parms])) unless input[:url_parms].blank?
 
     if input[:popup] # special behavior: button opens window_url in a new window
@@ -125,7 +127,9 @@ class ApplicationHelper::ToolbarBuilder
     dis_title = build_toolbar_disable_button(button[:child_id] || button[:id])
     if dis_title
       button[:enabled] = false
-      button[:title]   = dis_title if dis_title.kind_of? String
+      if dis_title.kind_of? String
+        button[:title] = button.localized(:title, dis_title)
+      end
     end
     button
   end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2476,6 +2476,7 @@ describe ApplicationHelper do
       }
       @tb_buttons = {}
       @button = {:id => "custom_#{btn_num}"}
+      @button = ApplicationHelper::Button::Basic.new(nil, nil, {}, {:id => "custom_#{btn_num}"})
       allow_any_instance_of(Object).to receive(:query_string).and_return("")
       allow_message_expectations_on_nil
     end
@@ -2514,6 +2515,34 @@ describe ApplicationHelper do
       it "when input[:onwhen] exists" do
         @input[:onwhen] = '1+'
         expect(subject).to have_key(:onwhen)
+      end
+    end
+
+    context "internationalization" do
+      it "does translation of text title and confirm strings" do
+        %i(text title confirm).each do |key|
+          @input[key] = 'Configuration' # common button string, translated into Japanese
+        end
+        FastGettext.locale = 'ja'
+        apply_common_props(@button, @input)
+        %i(text title confirm).each do |key|
+          expect(@button[key]).not_to match('Configuration')
+        end
+        FastGettext.locale = 'en'
+      end
+
+      it "does delayed translation of text title and confirm strings" do
+        %i(text title confirm).each do |key|
+          @input[key] = proc do
+            _("Add New %{model}") % {:model => 'Model'}
+          end
+        end
+        FastGettext.locale = 'ja'
+        apply_common_props(@button, @input)
+        %i(text title confirm).each do |key|
+          expect(@button[key]).not_to match('Add New Model')
+        end
+        FastGettext.locale = 'en'
       end
     end
   end


### PR DESCRIPTION
Broken since https://github.com/ManageIQ/manageiq/pull/9753

Fixes: https://github.com/ManageIQ/manageiq/issues/10748