### PR TITLE
Automate - quota fix for SCVMM number of cpus.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -110,7 +110,7 @@ end
 def requested_number_of_cpus(args_hash)
   cpu_in_request = get_option_value(args_hash[:resource], :number_of_sockets) *
                    get_option_value(args_hash[:resource], :cores_per_socket)
-  cpu_in_request = get_option_value(args_hash[:resource], args_hash[:number_of_cpus]) if cpu_in_request.zero?
+  cpu_in_request = get_option_value(args_hash[:resource], :number_of_cpus) if cpu_in_request.zero?
   args_hash[:prov_value] = args_hash[:number_of_vms] * cpu_in_request
   request_hash_value(args_hash)
 end

--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -51,5 +51,11 @@ describe "Quota Validation" do
       ws = run_automate_method(vm_attrs)
       check_results(ws.root['quota_requested'], 10.gigabytes, 4, 1, 1024)
     end
+
+    it "microsoft calculate_requested" do
+      setup_model("microsoft")
+      ws = run_automate_method(vm_attrs)
+      check_results(ws.root['quota_requested'], 512.megabytes, 2, 1, 1.gigabytes)
+    end
   end
 end

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -92,6 +92,26 @@ module Spec
                                          :tenant       => @tenant)
       end
 
+      def create_microsoft_vms
+        @active_vm = FactoryGirl.create(:vm_amazon,
+                                        :miq_group_id => @miq_group.id,
+                                        :ems_id       => @ems.id,
+                                        :storage_id   => @storage.id,
+                                        :hardware     => @hw1,
+                                        :tenant       => @tenant)
+        @archived_vm = FactoryGirl.create(:vm_amazon,
+                                          :miq_group_id => @miq_group.id,
+                                          :hardware     => @hw2)
+        @orphaned_vm = FactoryGirl.create(:vm_amazon,
+                                          :miq_group_id => @miq_group.id,
+                                          :storage_id   => @storage.id,
+                                          :hardware     => @hw3)
+        @retired_vm = FactoryGirl.create(:vm_amazon,
+                                         :miq_group_id => @miq_group.id,
+                                         :retired      => true,
+                                         :hardware     => @hw4)
+      end
+
       def create_request(prov_options)
         @miq_provision_request = FactoryGirl.create(:miq_provision_request,
                                                     :requester => @user,
@@ -130,6 +150,24 @@ module Spec
                                             :placement_auto => [true, 1],
                                             :instance_type  => [m2_small_flavor.id, m2_small_flavor.name])
         create_google_vms
+      end
+
+      def microsoft_requested_quota_values
+        {:number_of_vms    => 1,
+         :owner_email      => 'tester@miq.com',
+         :vm_memory        => [1024, '1024'],
+         :number_of_cpus   => [2, '2'],
+         :cores_per_socket => [1, '1']}
+      end
+
+      def microsoft_model
+        @ems = FactoryGirl.create(:ems_microsoft)
+        @vm_template = FactoryGirl.create(:template_microsoft,
+                                          :hardware => FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 512))
+        @storage = FactoryGirl.create(:storage_nfs)
+        create_request(microsoft_requested_quota_values)
+        create_hardware
+        create_microsoft_vms
       end
 
       def build_generic_service_item


### PR DESCRIPTION
Provider SCVMM uses different fields than the other infrastructure providers for number of cpus which caused the requested cpus to always be zero.

Updated requested method.

SCVMM doesn't use `:number_of_sockets` and `:cores_per_socket`.

https://bugzilla.redhat.com/show_bug.cgi?id=1364381