### PR TITLE
Update Browser Tab title for Configuration Management

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -460,7 +460,7 @@ module ApplicationHelper
     elsif layout == "ops"
       title += _(": Configuration")
     elsif layout == "provider_foreman"
-      title += ": #{ui_lookup(:ui_title => "foreman")} #{ui_lookup(:model => "ExtManagementSystem")}"
+      title += _(": Configuration Management")
     elsif layout == "pxe"
       title += _(": PXE")
     elsif layout == "explorer"


### PR DESCRIPTION
Purpose or Intent
-----------------
Update the browser title for Configuration Management tab from 'Foreman/Sattelite Provider' to 'Configuration Management'
Links
-----
Fixes https://github.com/ManageIQ/manageiq/issues/10594


After the fix:

![screenshot from 2016-08-25 14-48-51](https://cloud.githubusercontent.com/assets/12769982/17982020/1f5256ca-6ad4-11e6-8f4b-cf6f96b61438.png)
