### PR TITLE
Update "Saved Reports" paging bar to Patternfly

### DIFF
--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -1,7 +1,7 @@
 .col-md-12
   .toolbar-pf-actions
-    - action = "saved_report_paging"
-    - url = url_for(:action => action)
+    - action_url = "saved_report_paging"
+    - url = url_for(:action => action_url)
     - @pb_occ ||= 0
     - @pb_occ += 1
     - pages ||= {:perpage => @settings[:perpage][:reports],
@@ -10,76 +10,76 @@
                 :items   => @sb[:pages][:items]}
 
     %div{:id => "rpb_div_#{@pb_occ}"}
-      %table{:border => "0",
-             :cellpadding => "0",
-             :cellspacing => "0",
-             :width => "100%"}
-        %tr
-          %td{:valign => "middle"}
-          %td{:valign => "middle", :align => "right"}
-            %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :align => "right"}
-              %tr
-                %td{:style => "padding: 4px 2px 4px 2px;", :nowrap => true}= _("Per page:")
-                %td{:style => "padding: 4px 2px 4px 2px;"}
-                  = select_tag("perpage_setting#{@pb_occ}",
-                              options_for_select(@pp_choices, pages[:perpage]),
-                              "data-miq_sparkle_on"  => true,
-                              "data-miq_sparkle_off" => true,
-                              "data-miq_observe"     => {:url => url}.to_json)
-                %td{:nowrap => true}
-                  - if pages[:current] > 1
-                    = link_to(image_tag(image_path('toolbars/first.png'), :border => "0", :class => "rollover small"),
-                              {:action => action,
-                              :page   => 1},
-                              "data-miq_sparkle_on"  => true,
-                              "data-miq_sparkle_off" => true,
-                              :remote                => true,
-                              "data-method"          => :post,
-                              :title                 => "")
-                    = link_to(image_tag(image_path('toolbars/previous.png'), :border => "0", :class => "rollover small"),
-                              {:action => action,
-                              :page   => pages[:current] - 1},
-                              "data-miq_sparkle_on"  => true,
-                              "data-miq_sparkle_off" => true,
-                              :remote                => true,
-                              "data-method"          => :post,
-                              :title                 => "")
+      .form-group.pull-right{:style => "border-right: 0"}
+        %ul.pagination
+          %li.first
+            / first button
+            - if pages[:current] > 1
+              %span{:type    => "button",
+                    :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                :complete => "miqSparkle(false);",
+                                                :url      => "#{action_url}?page=1"),
+                    :class   => "fa fa-angle-double-left",
+                    :alt     => _("First"),
+                    :title   => _("First")}
+              %li.prev
+                %span{:type    => "button",
+                      :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                  :complete => "miqSparkle(false);",
+                                                  :url      => "#{action_url}?page=#{pages[:current] - 1}"),
+                      :class   => "fa fa-angle-left",
+                      :alt     => _("Previous"),
+                      :title   => _("Previous")}
+            - else
+              %li.first.disabled
+                %span{:class => "i fa fa-angle-double-left"}
+              %li.prev.disabled
+                %span{:class => "i fa fa-angle-left"}
+
+            %li
+              %span
+                - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
+                - end_number = pages[:perpage] * pages[:current]
+                - if start_number == pages[:items]
+                  = _("Showing %{start_number} of %{total_items} items") % {:start_number => start_number, :total_items => pages[:items]}
+                - else
+                  - if end_number > pages[:items]
+                    = _("Showing %{start_number}-%{end_number} of %{total_items} items") % {:start_number => start_number, :end_number => pages[:items], :total_items => pages[:items]}
                   - else
-                    = image_tag(image_path('toolbars/first.png'), :class => "dimmed small")
-                    = image_tag(image_path('toolbars/previous.png'), :class => "dimmed small")
-                  - if pages[:current] < pages[:total]
-                    = link_to(image_tag(image_path('toolbars/next.png'), :class => "rollover small"),
-                              {:action => action,
-                              :page   => pages[:current] + 1},
-                              "data-miq_sparkle_on"  => true,
-                              "data-miq_sparkle_off" => true,
-                              :remote                => true,
-                              "data-method"          => :post,
-                              :title                 => "")
-                    = link_to(image_tag(image_path('toolbars/last.png'), :class => "rollover small"),
-                              {:action  => action,
-                              :page    => pages[:total]},
-                              "data-miq_sparkle_on"  => true,
-                              "data-miq_sparkle_off" => true,
-                              :remote                => true,
-                              "data-method"          => :post,
-                              :title                 => "")
-                  - else
-                    = image_tag(image_path('toolbars/next.png'), :class => "dimmed small")
-                    = image_tag(image_path('toolbars/last.png'), :class => "dimmed small")
-                %td{:valign => "middle", :style => "padding: 4px"}
-                  - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
-                  - end_number = pages[:perpage] * pages[:current]
-                  - if start_number == pages[:items]
-                    = _("(Row %{start_number} of %{pages})") % {:start_number => start_number,
-                                                                :pages        => pages[:items]}
-                  - else
-                    - if end_number > pages[:items]
-                      = _("(Rows %{start_number}-%{pages_items} of %{pages_items})") % {:start_number => start_number,
-                                                                                        :pages_items  => pages[:items]}
-                    - else
-                      = _("(Rows %{start_number}-%{end_number} of %{pages_items})") % {:start_number => start_number,
-                                                                                      :end_number   => end_number,
-                                                                                      :pages_items  => pages[:items]}
-                  %input{:type => "hidden", :name => 'limitstart', :value => '0'}
+                    = _("Showing %{start_number}-%{end_number} of %{total_items} items") % {:start_number => start_number, :end_number => end_number, :total_items => pages[:items]}
+                %input{:name => "limitstart", :type => "hidden", :value => "0"}/
+
+            - if pages[:current] < pages[:total]
+              %li.next
+                %span{:type    => "button",
+                      :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                  :complete => "miqSparkle(false);",
+                                                  :url      => "#{action_url}?page=#{pages[:current] +1}"),
+                      :class   => "i fa fa-angle-right",
+                      :alt     => _("Next"),
+                      :title   => _("Next")}
+              %li.last
+                %span{:type    => "button",
+                      :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                  :complete => "miqSparkle(false);",
+                                                  :url      => "#{action_url}?page=#{pages[:total]}"),
+                      :class   => "i fa fa-angle-double-right",
+                      :alt     => _("Last"),
+                      :title   => _("Last")}
+            - else
+              %li.next.disabled
+                %span{:class => "i fa fa-angle-right"}
+              %li.last.disabled
+                %span{:class => "i fa fa-angle-double-right"}
+
+      .form-group.pull-right
+        = _('Items per page:')
+        = select_tag("ppsetting",
+                    options_for_select(@pp_choices, pages[:perpage]),
+                    "data-width" => "auto",
+                    :class       => "selectpicker dropup")
+        :javascript
+          miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
     = render(:partial => '/layouts/x_form_buttons')
+    :javascript
+      miqInitSelectPicker();


### PR DESCRIPTION
This PR replaces the old html styling with PF and Bootstrap. The images have been replaced with font icons used in other paging bars.

https://www.pivotaltracker.com/n/projects/1613907/stories/129081311

Old
![screen shot 2016-08-25 at 4 16 45 pm](https://cloud.githubusercontent.com/assets/1287144/17984492/5f8f0778-6adf-11e6-909c-fd02808dba98.png)

New
![screen shot 2016-08-25 at 4 11 17 pm](https://cloud.githubusercontent.com/assets/1287144/17984309/96e5fd2c-6ade-11e6-98f1-3cf8fa430dfe.png)

