### PR TITLE
Sets deployments status to a default value when no metric is found.

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -146,14 +146,15 @@ module ManageIQ::Providers
       end
 
       def fetch_availability
-        metric_ids = {}
+        resources_by_metric_id = {}
         @data[:middleware_deployments].each do |deployment|
           metric_id = @ems.build_metric_id('A', deployment, 'Deployment Status~Deployment Status')
-          metric_ids[metric_id] = deployment
+          resources_by_metric_id[metric_id] = deployment
         end
-        availabilities = @ems.metrics_client.avail.raw_data(metric_ids.keys, :limit => 1, :order => 'DESC')
-        availabilities.each do |availability|
-          metric_ids[availability['id']][:status] = process_availability(availability['data'].first)
+        unless resources_by_metric_id.empty?
+          availabilities = @ems.metrics_client.avail.raw_data(resources_by_metric_id.keys,
+                                                              :limit => 1, :order => 'DESC')
+          parse_availability availabilities, resources_by_metric_id
         end
       end
 
@@ -185,6 +186,17 @@ module ManageIQ::Providers
         else
           'Unknown'
         end
+      end
+
+      def parse_availability(availabilities, resources_by_metric_id)
+        processed_availabilities_ids = availabilities.map do |availability|
+          resources_by_metric_id[availability['id']][:status] = process_availability(availability['data'].first)
+          availability['id']
+        end
+        (resources_by_metric_id.keys - processed_availabilities_ids).each do |metric_id|
+          resources_by_metric_id[metric_id][:status] = process_availability nil
+        end
+        resources_by_metric_id
       end
 
       def parse_deployment(server, deployment)

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -88,6 +88,85 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
     end
   end
 
+  describe 'parse_availability' do
+    it 'handles simple data' do
+      resources_by_metric_id = {
+        'resource_id_1' => {},
+        'resource_id_2' => {},
+        'resource_id_3' => {},
+        'resource_id_4' => {},
+      }
+      availabilities = [
+        {
+          'id'   => 'resource_id_1',
+          'data' => [{ 'value' => 'up' }]
+        },
+        {
+          'id'   => 'resource_id_2',
+          'data' => [{ 'value' => 'down' }]
+        },
+        {
+          'id'   => 'resource_id_3',
+          'data' => [{ 'value' => 'something_else' }]
+        },
+        {
+          'id'   => 'resource_id_4',
+          'data' => []
+        }
+      ]
+
+      parsed_resources_with_availability = {
+        'resource_id_1' => {
+          :status => 'Enabled'
+        },
+        'resource_id_2' => {
+          :status => 'Disabled'
+        },
+        'resource_id_3' => {
+          :status => 'Unknown'
+        },
+        'resource_id_4' => {
+          :status => 'Unknown'
+        }
+      }
+      expect(parser.send(:parse_availability,
+                         availabilities,
+                         resources_by_metric_id)).to eq(parsed_resources_with_availability)
+    end
+    it 'handles missing metrics' do
+      resources_by_metric_id = {
+        'resource_id_1' => {},
+        'resource_id_2' => {},
+        'resource_id_3' => {},
+        'resource_id_4' => {},
+      }
+      availabilities = [
+        {
+          'id'   => 'resource_id_1',
+          'data' => [{ 'value' => 'up' }]
+        }
+      ]
+
+      parsed_resources_with_availability = {
+        'resource_id_1' => {
+          :status => 'Enabled'
+        },
+        'resource_id_2' => {
+          :status => 'Unknown'
+        },
+        'resource_id_3' => {
+          :status => 'Unknown'
+        },
+        'resource_id_4' => {
+          :status => 'Unknown'
+        }
+      }
+      expect(parser.send(:parse_availability,
+                         availabilities,
+                         resources_by_metric_id)).to eq(parsed_resources_with_availability)
+    end
+  end
+
   describe 'alternate_machine_id' do
     it 'should transform machine ID to dmidecode BIOS UUID' do
       # the /etc/machine-id is usually in downcase, and the dmidecode BIOS UUID is usually upcase


### PR DESCRIPTION
![not_found_metric_is_unknow](https://cloud.githubusercontent.com/assets/3845764/17988814/57407c5a-6aee-11e6-8758-d0f346bf07a3.png)


Fixes #10727