### PR TITLE
Use a range of port numbers instead of a single port for load balancers

### DIFF
--- a/app/helpers/load_balancer_helper.rb
+++ b/app/helpers/load_balancer_helper.rb
@@ -1,3 +1,32 @@
 module LoadBalancerHelper
   include_concern 'TextualSummary'
+
+  # Display a protocol and port_range as a string suitable for rendering (e.g.
+  #   "TCP:1000-1010").
+  #
+  # @param protocol [#to_s] the protocol to render
+  # @param port_range [Range, nil] a range of ports (or nil, in which case "nil"
+  #   is rendered)
+  # @return [String] the resulting string
+  def self.display_protocol_port_range(protocol, port_range)
+    "#{protocol}:#{display_port_range(port_range)}"
+  end
+
+  # Convert a Range object into the string representation usually seen for port
+  # ranges (specifically, "80" or "3200-3233")
+  #
+  # @param r [Range, nil] a range of ports (or nil, in which case "nil" is
+  #   rendered)
+  # @return [String] the resulting string
+  def self.display_port_range(r)
+    if r.nil?
+      "nil"
+    elsif r.size == 0 # rubocop:disable Style/ZeroLengthPredicate
+      ""
+    elsif r.size == 1
+      r.first.to_s
+    else
+      "#{r.min}-#{r.max}"
+    end
+  end
 end

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -28,7 +28,10 @@ module LoadBalancerHelper::TextualSummary
 
   def textual_listeners
     @record.load_balancer_listeners.map do |x|
-      "Load Balancer #{x.load_balancer_protocol}:#{x.load_balancer_port}, Instance #{x.instance_protocol}:#{x.instance_port}"
+      "Load Balancer"\
+        " #{LoadBalancerHelper.display_protocol_port_range(x.load_balancer_protocol, x.load_balancer_port_range)}"\
+        ", Instance"\
+        " #{LoadBalancerHelper.display_protocol_port_range(x.instance_protocol, x.instance_port_range)}"
     end.join(" | ") if @record.load_balancer_listeners
   end
 

--- a/db/migrate/20160830233154_add_port_ranges_to_load_balancer_listener.rb
+++ b/db/migrate/20160830233154_add_port_ranges_to_load_balancer_listener.rb
@@ -1,0 +1,8 @@
+class AddPortRangesToLoadBalancerListener < ActiveRecord::Migration[5.0]
+  def change
+    change_table :load_balancer_listeners do |t|
+      t.column :load_balancer_port_range, :int4range
+      t.column :instance_port_range, :int4range
+    end
+  end
+end

--- a/db/migrate/20160830233558_migrate_ports_to_port_ranges_in_load_balancer_listener.rb
+++ b/db/migrate/20160830233558_migrate_ports_to_port_ranges_in_load_balancer_listener.rb
@@ -1,0 +1,36 @@
+class MigratePortsToPortRangesInLoadBalancerListener < ActiveRecord::Migration[5.0]
+  class LoadBalancerListener < ActiveRecord::Base
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    say_with_time("Migrating LoadBalancerListeners instance_port values to instance_port_range...") do
+      LoadBalancerListener.where.not(:instance_port => nil).each do |x|
+        x.update(:instance_port_range => x.instance_port..x.instance_port,
+                 :instance_port       => nil)
+      end
+    end
+    say_with_time("Migrating LoadBalancerListeners load_balancer_port values to load_balancer_port_range...") do
+      LoadBalancerListener.where.not(:load_balancer_port => nil).each do |x|
+        x.update(:load_balancer_port_range => x.load_balancer_port..x.load_balancer_port,
+                 :load_balancer_port       => nil)
+      end
+    end
+  end
+
+  def down
+    say_with_time("Migrating LoadBalancerListeners load_balancer_port_range values to load_balancer_port"\
+        " (where possible)...") do
+      LoadBalancerListener.where.not(:load_balancer_port_range => nil).each do |x|
+        x.update(:load_balancer_port => x.load_balancer_port_range.begin) if x.load_balancer_port_range.size == 1
+        x.update(:load_balancer_port_range => nil)
+      end
+    end
+    say_with_time("Migrating LoadBalancerListeners instance_port_range values to instance_port (where possible)...") do
+      LoadBalancerListener.where.not(:instance_port_range => nil).each do |x|
+        x.update(:instance_port => x.instance_port_range.begin) if x.instance_port_range.size == 1
+        x.update(:instance_port_range => nil)
+      end
+    end
+  end
+end

--- a/db/migrate/20160830233842_drop_ports_in_load_balancer_listener.rb
+++ b/db/migrate/20160830233842_drop_ports_in_load_balancer_listener.rb
@@ -1,0 +1,6 @@
+class DropPortsInLoadBalancerListener < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :load_balancer_listeners, :load_balancer_port, :integer
+    remove_column :load_balancer_listeners, :instance_port, :integer
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1626,6 +1626,8 @@ load_balancer_listeners:
 - created_at
 - updated_at
 - type
+- load_balancer_port_range
+- instance_port_range
 load_balancer_pool_member_pools:
 - id
 - load_balancer_pool_id

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1617,9 +1617,7 @@ load_balancer_listeners:
 - name
 - description
 - load_balancer_protocol
-- load_balancer_port
 - instance_protocol
-- instance_port
 - ems_id
 - cloud_tenant_id
 - load_balancer_id

--- a/spec/helpers/load_balancer_helper_spec.rb
+++ b/spec/helpers/load_balancer_helper_spec.rb
@@ -1,0 +1,33 @@
+describe LoadBalancerHelper do
+  context "::display_protocol_port_range" do
+    it "should display protocol and a single port" do
+      expect(LoadBalancerHelper.display_protocol_port_range("TCP", 80..80)).to eq("TCP:80")
+    end
+
+    it "should display protocol and a range of ports" do
+      expect(LoadBalancerHelper.display_protocol_port_range("UDP", 80..100)).to eq("UDP:80-100")
+    end
+  end
+
+  context "::display_port_range" do
+    it "should display an empty range as an empty string" do
+      expect(LoadBalancerHelper.display_port_range(11...11)).to eq("")
+    end
+
+    it "should display a nil range as nil" do
+      expect(LoadBalancerHelper.display_port_range(nil)).to eq("nil")
+    end
+
+    it "should display a range of size 1 as a single port" do
+      expect(LoadBalancerHelper.display_port_range(60..60)).to eq("60")
+    end
+
+    it "should display a range of size > 1 as an inclusive range" do
+      expect(LoadBalancerHelper.display_port_range(60..80)).to eq("60-80")
+    end
+
+    it "should display a range of size > 1 with exclusive endpoint as inclusive range" do
+      expect(LoadBalancerHelper.display_port_range(60...81)).to eq("60-80")
+    end
+  end
+end

--- a/spec/migrations/20160830233558_migrate_ports_to_port_ranges_in_load_balancer_listener_spec.rb
+++ b/spec/migrations/20160830233558_migrate_ports_to_port_ranges_in_load_balancer_listener_spec.rb
@@ -1,0 +1,101 @@
+require_migration
+
+describe MigratePortsToPortRangesInLoadBalancerListener do
+  let(:load_balancer_listener_stub) { migration_stub(:LoadBalancerListener) }
+
+  migration_context :up do
+    it 'migrate load_balancer_port to load_balancer_port_range when load_balancer_port set' do
+      st = load_balancer_listener_stub.create!(:load_balancer_port => 443)
+
+      migrate
+      st.reload
+
+      expect(st.load_balancer_port_range.to_a).to eq([443])
+      expect(st.load_balancer_port).to be_nil
+    end
+
+    it 'does not update load_balancer_port_range when load_balancer_port is nil' do
+      st = load_balancer_listener_stub.create!(:load_balancer_port => nil)
+
+      migrate
+
+      expect(st.reload.load_balancer_port_range).to be_nil
+    end
+
+    it 'migrates instance_port to instance_port_range when instance_port is set' do
+      st = load_balancer_listener_stub.create!(:instance_port => 45)
+
+      migrate
+      st.reload
+
+      expect(st.instance_port_range.to_a).to eq([45])
+      expect(st.instance_port).to be_nil
+    end
+
+    it 'does not update instance_port_range when instance_port is nil' do
+      st = load_balancer_listener_stub.create!(:instance_port => nil)
+
+      migrate
+
+      expect(st.reload.instance_port_range).to be_nil
+    end
+  end
+
+  migration_context :down do
+    it 'migrates load_balancer_port_range to load_balancer_port when load_balancer_port_range is a single port' do
+      st = load_balancer_listener_stub.create!(:load_balancer_port_range => 443..443)
+
+      migrate
+      st.reload
+
+      expect(st.load_balancer_port).to be(443)
+      expect(st.load_balancer_port_range).to be_nil
+    end
+
+    it 'skips migrating load_balancer_port_range when range is multiple ports' do
+      st = load_balancer_listener_stub.create!(:load_balancer_port_range => 500..699)
+
+      migrate
+      st.reload
+
+      expect(st.load_balancer_port).to be_nil
+      expect(st.load_balancer_port_range).to be_nil
+    end
+
+    it 'does not update load_balancer_port when load_balancer_port_range is nil' do
+      st = load_balancer_listener_stub.create!(:load_balancer_port_range => nil)
+
+      migrate
+
+      expect(st.load_balancer_port).to be_nil
+    end
+
+    it 'migrates instance_port_range to instance_port when instance_port_range is a single port' do
+      st = load_balancer_listener_stub.create!(:instance_port_range => 443..443)
+
+      migrate
+      st.reload
+
+      expect(st.instance_port).to be(443)
+      expect(st.instance_port_range).to be_nil
+    end
+
+    it 'skips migrating instance_port_range when range is multiple ports' do
+      st = load_balancer_listener_stub.create!(:instance_port_range => 500..699)
+
+      migrate
+      st.reload
+
+      expect(st.instance_port).to be_nil
+      expect(st.instance_port_range).to be_nil
+    end
+
+    it 'does not update instance_port when instance_port_range is nil' do
+      st = load_balancer_listener_stub.create!(:instance_port_range => nil)
+
+      migrate
+
+      expect(st.instance_port).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
GCE forwarding rules allow you to specify a range of ports to be forwarded.  Since a single port can easily be represented in a range, we should update the ManageIQ abstraction as well.