### PR TITLE
Prepare TokenManager for new tokens for web socket

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -5,8 +5,8 @@ module Api
       auth_token = Environment.user_token_service.generate_token(@auth_user, requester_type)
       res = {
         :auth_token => auth_token,
-        :token_ttl  => api_token_mgr.token_get_info(@module, auth_token, :token_ttl),
-        :expires_on => api_token_mgr.token_get_info(@module, auth_token, :expires_on)
+        :token_ttl  => api_token_mgr.token_get_info(auth_token, :token_ttl),
+        :expires_on => api_token_mgr.token_get_info(auth_token, :expires_on)
       }
       render_resource :auth, res
     end

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -12,7 +12,7 @@ module Api
     end
 
     def destroy
-      api_token_mgr.invalidate_token(@module, @auth_token)
+      api_token_mgr.invalidate_token(@auth_token)
 
       render_normal_destroy
     end

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -124,7 +124,7 @@ module Api
 
       def authenticate_with_user_token(x_auth_token)
         @auth_token = x_auth_token
-        if !api_token_mgr.token_valid?(@module, @auth_token)
+        if !api_token_mgr.token_valid?(@auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{@auth_token} specified"
         else
           @auth_user     = api_token_mgr.token_get_info(@auth_token, :userid)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -131,7 +131,7 @@ module Api
           @auth_user_obj = userid_to_userobj(@auth_user)
 
           unless request.headers['X-Auth-Skip-Token-Renewal'] == 'true'
-            api_token_mgr.reset_token(@module, @auth_token)
+            api_token_mgr.reset_token(@auth_token)
           end
 
           authorize_user_group(@auth_user_obj)

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -127,7 +127,7 @@ module Api
         if !api_token_mgr.token_valid?(@module, @auth_token)
           raise AuthenticationError, "Invalid Authentication Token #{@auth_token} specified"
         else
-          @auth_user     = api_token_mgr.token_get_info(@module, @auth_token, :userid)
+          @auth_user     = api_token_mgr.token_get_info(@auth_token, :userid)
           @auth_user_obj = userid_to_userobj(@auth_user)
 
           unless request.headers['X-Auth-Skip-Token-Renewal'] == 'true'

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -26,8 +26,7 @@ module Api
 
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
 
-      token_mgr.gen_token(base_config[:module],
-                          :userid           => userid,
+      token_mgr.gen_token(:userid           => userid,
                           :token_ttl_config => REQUESTER_TTL_CONFIG[requester_type])
     end
 

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -11,7 +11,7 @@ class TokenManager
   @config       = {:token_ttl => 10.minutes}    # Token expiration managed in seconds
 
   def self.class_initialize(_name = DEFAULT_NS, options = {})
-    configure(options)
+    @config.merge!(options)
   end
 
   def self.new(name = DEFAULT_NS, options = {})
@@ -20,10 +20,6 @@ class TokenManager
   end
 
   delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self
-
-  def self.configure(options = {})
-    @config.merge!(options)
-  end
 
   def self.gen_token(namespace, token_options = {})
     ts = global_token_store(namespace)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -23,7 +23,7 @@ class TokenManager
     @instance ||= super
   end
 
-  delegate :configure, :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self
+  delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self
 
   def self.configure(_namespace, options = {})
     @config.merge!(options)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -19,7 +19,7 @@ class TokenManager
     super(namespace, @config)
   end
 
-  delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :to => self
+  delegate :gen_token, :reset_token, :token_set_info, :token_valid?, :to => self
 
   def self.gen_token(namespace, token_options = {})
     ts = global_token_store(namespace)
@@ -53,11 +53,10 @@ class TokenManager
     ts.write(token, token_data.merge!(prune_token_options(token_options)))
   end
 
-  def self.token_get_info(namespace, token, what = nil)
-    ts = global_token_store(namespace)
-    return {} unless token_valid?(namespace, token)
+  def token_get_info(token, what = nil)
+    return {} unless self.class.token_valid?(@namespace, token)
 
-    what.nil? ? ts.read(token) : ts.read(token)[what]
+    what.nil? ? token_store.read(token) : token_store.read(token)[what]
   end
 
   def self.token_valid?(namespace, token)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -9,13 +9,14 @@ class TokenManager
 
   @config       = {:token_ttl => 10.minutes}    # Token expiration managed in seconds
 
-  def initialize(namespace)
+  def initialize(namespace, options)
     @namespace = namespace
+    @options = options
   end
 
   def self.new(namespace = DEFAULT_NS, options = {})
     class_initialize(options)
-    super(namespace)
+    super(namespace, @config)
   end
 
   delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -12,7 +12,7 @@ class TokenManager
 
   def self.new(_name = DEFAULT_NS, options = {})
     class_initialize(options)
-    @instance ||= super()
+    super()
   end
 
   delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -7,16 +7,9 @@ class TokenManager
   RESTRICTED_OPTIONS = [:expires_on]
   DEFAULT_NS         = "default"
 
-  @config       = {:token_ttl => 10.minutes}    # Token expiration managed in seconds
-
-  def initialize(namespace, options)
+  def initialize(namespace = DEFAULT_NS, options = {})
     @namespace = namespace
-    @options = options
-  end
-
-  def self.new(namespace = DEFAULT_NS, options = {})
-    class_initialize(options)
-    super(namespace, @config)
+    @options = {:token_ttl => 10.minutes}.merge(options)
   end
 
   def gen_token(token_options = {})
@@ -60,11 +53,6 @@ class TokenManager
   def token_store
     TokenStore.acquire(@namespace, @options[:token_ttl])
   end
-
-  def self.class_initialize(options = {})
-    @config.merge!(options)
-  end
-  private_class_method :class_initialize
 
   def prune_token_options(token_options = {})
     token_options.except(*RESTRICTED_OPTIONS)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -19,7 +19,7 @@ class TokenManager
     super(namespace, @config)
   end
 
-  delegate :gen_token, :reset_token, :token_set_info, :token_valid?, :to => self
+  delegate :gen_token, :reset_token, :token_set_info, :to => self
 
   def self.gen_token(namespace, token_options = {})
     ts = global_token_store(namespace)
@@ -54,13 +54,13 @@ class TokenManager
   end
 
   def token_get_info(token, what = nil)
-    return {} unless self.class.token_valid?(@namespace, token)
+    return {} unless token_valid?(token)
 
     what.nil? ? token_store.read(token) : token_store.read(token)[what]
   end
 
-  def self.token_valid?(namespace, token)
-    !global_token_store(namespace).read(token).nil?
+  def token_valid?(token)
+    !token_store.read(token).nil?
   end
 
   def invalidate_token(token)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -19,7 +19,7 @@ class TokenManager
     super(namespace, @config)
   end
 
-  delegate :gen_token, :reset_token, :to => self
+  delegate :gen_token, :to => self
 
   def self.gen_token(namespace, token_options = {})
     ts = global_token_store(namespace)
@@ -34,15 +34,14 @@ class TokenManager
     token
   end
 
-  def self.reset_token(namespace, token)
-    ts = global_token_store(namespace)
-    token_data = ts.read(token)
+  def reset_token(token)
+    token_data = token_store.read(token)
     return {} if token_data.nil?
 
     token_ttl = token_data[:token_ttl]
-    ts.write(token,
-             token_data.merge!(:expires_on => Time.now.utc + token_ttl),
-             :expires_in => token_ttl)
+    token_store.write(token,
+                      token_data.merge!(:expires_on => Time.now.utc + token_ttl),
+                      :expires_in => token_ttl)
   end
 
   def token_get_info(token, what = nil)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -19,7 +19,7 @@ class TokenManager
     super(namespace, @config)
   end
 
-  delegate :gen_token, :reset_token, :token_set_info, :to => self
+  delegate :gen_token, :reset_token, :to => self
 
   def self.gen_token(namespace, token_options = {})
     ts = global_token_store(namespace)
@@ -43,14 +43,6 @@ class TokenManager
     ts.write(token,
              token_data.merge!(:expires_on => Time.now.utc + token_ttl),
              :expires_in => token_ttl)
-  end
-
-  def self.token_set_info(namespace, token, token_options = {})
-    ts = global_token_store(namespace)
-    token_data = ts.read(token)
-    return {} if token_data.nil?
-
-    ts.write(token, token_data.merge!(prune_token_options(token_options)))
   end
 
   def token_get_info(token, what = nil)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -14,8 +14,8 @@ class TokenManager
     self.class.class_initialize(*args)
   end
 
-  def self.class_initialize(name = DEFAULT_NS, options = {})
-    configure(name, options)
+  def self.class_initialize(_name = DEFAULT_NS, options = {})
+    configure(options)
   end
 
   def self.new(name = DEFAULT_NS, options = {})
@@ -25,7 +25,7 @@ class TokenManager
 
   delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self
 
-  def self.configure(_namespace, options = {})
+  def self.configure(options = {})
     @config.merge!(options)
   end
 

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -19,7 +19,7 @@ class TokenManager
     super(namespace, @config)
   end
 
-  delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self
+  delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :to => self
 
   def self.gen_token(namespace, token_options = {})
     ts = global_token_store(namespace)
@@ -64,11 +64,15 @@ class TokenManager
     !global_token_store(namespace).read(token).nil?
   end
 
-  def self.invalidate_token(namespace, token)
-    global_token_store(namespace).delete(token)
+  def invalidate_token(token)
+    token_store.delete(token)
   end
 
   private
+
+  def token_store
+    TokenStore.acquire(@namespace, @options[:token_ttl])
+  end
 
   def self.class_initialize(options = {})
     @config.merge!(options)

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -10,12 +10,8 @@ class TokenManager
   @token_caches = {}    # Hash of Memory/Dalli Store Caches, Keyed by namespace
   @config       = {:token_ttl => 10.minutes}    # Token expiration managed in seconds
 
-  def self.class_initialize(_name = DEFAULT_NS, options = {})
-    @config.merge!(options)
-  end
-
-  def self.new(name = DEFAULT_NS, options = {})
-    class_initialize(name, options)
+  def self.new(_name = DEFAULT_NS, options = {})
+    class_initialize(options)
     @instance ||= super()
   end
 
@@ -69,6 +65,11 @@ class TokenManager
   end
 
   private
+
+  def self.class_initialize(options = {})
+    @config.merge!(options)
+  end
+  private_class_method :class_initialize
 
   def self.global_token_store(namespace)
     @token_caches[namespace] ||= begin

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -10,9 +10,13 @@ class TokenManager
   @token_caches = {}    # Hash of Memory/Dalli Store Caches, Keyed by namespace
   @config       = {:token_ttl => 10.minutes}    # Token expiration managed in seconds
 
-  def self.new(_name = DEFAULT_NS, options = {})
+  def initialize(namespace)
+    @namespace = namespace
+  end
+
+  def self.new(namespace = DEFAULT_NS, options = {})
     class_initialize(options)
-    super()
+    super(namespace)
   end
 
   delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -10,17 +10,13 @@ class TokenManager
   @token_caches = {}    # Hash of Memory/Dalli Store Caches, Keyed by namespace
   @config       = {:token_ttl => 10.minutes}    # Token expiration managed in seconds
 
-  def initialize(*args)
-    self.class.class_initialize(*args)
-  end
-
   def self.class_initialize(_name = DEFAULT_NS, options = {})
     configure(options)
   end
 
   def self.new(name = DEFAULT_NS, options = {})
     class_initialize(name, options)
-    @instance ||= super
+    @instance ||= super()
   end
 
   delegate :gen_token, :reset_token, :token_set_info, :token_get_info, :token_valid?, :invalidate_token, :to => self

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -1,0 +1,30 @@
+class TokenStore
+  @token_caches = {} # Hash of Memory/Dalli Store Caches, Keyed by namespace
+
+  def self.acquire(namespace, token_ttl)
+    @token_caches[namespace] ||= begin
+      if test_environment?
+        require 'active_support/cache/memory_store'
+        ActiveSupport::Cache::MemoryStore.new(cache_store_options(namespace, token_ttl))
+      else
+        require 'active_support/cache/dalli_store'
+        memcache_server = VMDB::Config.new("vmdb").config[:session][:memcache_server] || "127.0.0.1:11221"
+        ActiveSupport::Cache::DalliStore.new(memcache_server, cache_store_options(namespace, token_ttl))
+      end
+    end
+  end
+
+  def self.cache_store_options(namespace, token_ttl)
+    {
+      :namespace  => "MIQ:TOKENS:#{namespace.upcase}",
+      :threadsafe => true,
+      :expires_in => token_ttl
+    }
+  end
+  private_class_method :cache_store_options
+
+  def self.test_environment?
+    !Rails.env.development? && !Rails.env.production?
+  end
+  private_class_method :test_environment?
+end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -168,7 +168,7 @@ describe "Authentication API" do
       token_info = tm.token_get_info(auth_token)
       expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
 
-      expect_any_instance_of(TokenManager).to receive(:reset_token).with("api", auth_token)
+      expect_any_instance_of(TokenManager).to receive(:reset_token).with(auth_token)
       run_get entrypoint_url, :headers => {"auth_token" => auth_token}
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -165,7 +165,7 @@ describe "Authentication API" do
       token_expires_on = response.parsed_body["expires_on"]
 
       tm = TokenManager.new("api")
-      token_info = tm.token_get_info("api", auth_token)
+      token_info = tm.token_get_info(auth_token)
       expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
 
       expect_any_instance_of(TokenManager).to receive(:reset_token).with("api", auth_token)

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -212,7 +212,7 @@ describe "Authentication API" do
 
       auth_token = response.parsed_body["auth_token"]
 
-      expect_any_instance_of(TokenManager).to receive(:invalidate_token).with("api", auth_token)
+      expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
       run_delete auth_url, "auth_token" => auth_token
     end
   end


### PR DESCRIPTION
Purpose
-----------------
 * Introduce `TokenStore` to have just responsibility to offer/cache storage handles.
 * Clean up TokenManager, use poro instead of combination of singleton calling class methods

Details
-----------------
We need to introduce new type of tokens for ws (web socket), I want to do it as cleanly as possible. The TokenManager and TokenService has certain provisions for manipulating multiple namespaces. However, both classes share this responsibility. In this and subsequent refactoring, I would make clear cut in what is who's responsibility.

We need responsibilities for:
 * caching the memcache handle (that needs to be in singleton => no change)
 * keeping the namespace and the namespace settings (ttl), currently in singleton TokenManager and in TokenService shared => ideally isolate the setting into a single class, poro is enough, no need for singleton

This refactoring does not change a behavior at all, it just, step-by-step reveals how this thing work underneath. The TokenManager is basically singleton, with the only exception that with each TokenManager.new we merge the `@options` hash.

@miq-bot assign @abellotti 
@miq-bot add_label api, refactoring, darga/no

