### PR TITLE
Renamed method to display toolbar buttons

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -37,14 +37,12 @@ class ApplicationHelper::Button::Basic < Hash
   def skipped?
     return true if self.class.record_needed && @record.nil?
     calculate_properties
-    skip?
+    !visible?
   end
 
-  # Tells whether the button should displayed in the toolbar or not:
-  #   false => button will be displayed
-  #   true => button will be hidden
-  def skip?
-    false
+  # Tells whether the button should displayed in the toolbar or not
+  def visible?
+    true
   end
 
   # Tells whether the displayed button should be disabled or not

--- a/app/helpers/application_helper/button/basic_image.rb
+++ b/app/helpers/application_helper/button/basic_image.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::BasicImage < ApplicationHelper::Button::Basic
-  def skip?
-    @sb.fetch_path(:trees, :vandt_tree, :active_node).present? && (
-      @sb[:trees][:vandt_tree][:active_node] == "xx-arch" ||
-      @sb[:trees][:vandt_tree][:active_node] == "xx-orph")
+  def visible?
+    @sb.fetch_path(:trees, :vandt_tree, :active_node).blank? ||
+      (@sb[:trees][:vandt_tree][:active_node] != "xx-arch" &&
+       @sb[:trees][:vandt_tree][:active_node] != "xx-orph")
   end
 end

--- a/app/helpers/application_helper/button/ems_timeline.rb
+++ b/app/helpers/application_helper/button/ems_timeline.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::EmsTimeline < ApplicationHelper::Button::Basic
-  def skip?
-    !@record.is_available?(:timeline)
+  def visible?
+    @record.is_available?(:timeline)
   end
 
   def disabled?
@@ -9,7 +9,7 @@ class ApplicationHelper::Button::EmsTimeline < ApplicationHelper::Button::Basic
 
   def calculate_properties
     super
-    self[:hidden] = true if skip?
+    self[:hidden] = true if !visible?
     self[:title] = N_("No Timeline data has been collected for this Provider") if disabled?
   end
 end

--- a/app/helpers/application_helper/button/ems_timeline.rb
+++ b/app/helpers/application_helper/button/ems_timeline.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Button::EmsTimeline < ApplicationHelper::Button::Basic
 
   def calculate_properties
     super
-    self[:hidden] = true if !visible?
+    self[:hidden] = true unless visible?
     self[:title] = N_("No Timeline data has been collected for this Provider") if disabled?
   end
 end

--- a/app/helpers/application_helper/button/generic_feature_button.rb
+++ b/app/helpers/application_helper/button/generic_feature_button.rb
@@ -6,11 +6,11 @@ class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Butto
     @feature = props[:options][:feature]
   end
 
-  def skip?
+  def visible?
     begin
-      return !@record.send("supports_#{@feature}?")
+      return @record.send("supports_#{@feature}?")
     rescue NoMethodError # TODO: remove with deleting AvailabilityMixin module
-      return !@record.is_available?(@feature)
+      return @record.is_available?(@feature)
     end
   end
 end

--- a/app/helpers/application_helper/button/history_item.rb
+++ b/app/helpers/application_helper/button/history_item.rb
@@ -14,7 +14,7 @@ class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::Basic
     @history_item_id
   end
 
-  def skip?
-    !@view_context.x_tree_history[history_item_id] && history_item_id != 1
+  def visible?
+    @view_context.x_tree_history[history_item_id] || history_item_id == 1
   end
 end

--- a/app/helpers/application_helper/button/instance_reset.rb
+++ b/app/helpers/application_helper/button/instance_reset.rb
@@ -1,8 +1,8 @@
 class ApplicationHelper::Button::InstanceReset < ApplicationHelper::Button::Basic
   needs_record
 
-  def skip?
-    return false if @display == "instances"
-    !@record.is_available?(:reset)
+  def visible?
+    return true if @display == "instances"
+    @record.is_available?(:reset)
   end
 end

--- a/app/helpers/application_helper/button/pdf.rb
+++ b/app/helpers/application_helper/button/pdf.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::Pdf < ApplicationHelper::Button::Basic
-  def skip?
-    !PdfGenerator.available?
+  def visible?
+    PdfGenerator.available?
   end
 end

--- a/app/helpers/application_helper/button/perf_refresh.rb
+++ b/app/helpers/application_helper/button/perf_refresh.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Button::PerfRefresh < ApplicationHelper::Button::Basic
     self[:hidden] = false
   end
 
-  def skip?
-    !@perf_options[:typ] == "realtime"
+  def visible?
+    @perf_options[:typ] == "realtime"
   end
 end

--- a/app/helpers/application_helper/button/view.rb
+++ b/app/helpers/application_helper/button/view.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::View < ApplicationHelper::Button::Basic
-  def skip?
+  def visible?
     # only hide gtl button if they are not in @gtl_buttons
-    @gtl_buttons && !@gtl_buttons.include?(self[:id].to_s)
+    !@gtl_buttons || @gtl_buttons.include?(self[:id].to_s)
   end
 end

--- a/app/helpers/application_helper/button/vm_instance_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_scan.rb
@@ -12,10 +12,10 @@ class ApplicationHelper::Button::VmInstanceScan < ApplicationHelper::Button::Bas
     end
   end
 
-  def skip?
-    return false if @display == "instances"
-    !(@record.supports_smartstate_analysis? || @record.unsupported_reason(:smartstate_analysis)) ||
-      !@record.has_proxy?
+  def visible?
+    return true if @display == "instances"
+    (@record.supports_smartstate_analysis? || @record.unsupported_reason(:smartstate_analysis)) &&
+     @record.has_proxy?
   end
 
   def disabled?

--- a/app/helpers/application_helper/button/vm_policy.rb
+++ b/app/helpers/application_helper/button/vm_policy.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::VmPolicy < ApplicationHelper::Button::Basic
   needs_record
 
-  def skip?
-    @record.host.try(:vmm_product).to_s.casecmp("workstation")
+  def visible?
+    @record.host.try(:vmm_product).to_s.casecmp("workstation").nonzero?
   end
 end

--- a/app/helpers/application_helper/button/vm_publish.rb
+++ b/app/helpers/application_helper/button/vm_publish.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::VmPublish < ApplicationHelper::Button::Basic
   needs_record
 
-  def skip?
-    !@record.is_available?(:publish) || @is_redhat
+  def visible?
+    @record.is_available?(:publish) && !@is_redhat
   end
 end

--- a/app/helpers/application_helper/button/vm_reconfigure.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::VmReconfigure < ApplicationHelper::Button::Basic
   needs_record
 
-  def skip?
-    !@record.reconfigurable?
+  def visible?
+    @record.reconfigurable?
   end
 end

--- a/app/helpers/application_helper/button/vm_refresh.rb
+++ b/app/helpers/application_helper/button/vm_refresh.rb
@@ -1,9 +1,8 @@
 class ApplicationHelper::Button::VmRefresh < ApplicationHelper::Button::Basic
   needs_record
 
-  def skip?
-    !@record.ext_management_system &&
-    !(@record.host &&
-      @record.host.vmm_product.casecmp("workstation").zero?)
+  def visible?
+    @record.ext_management_system ||
+    @record.host.try(:vmm_product).to_s.casecmp("workstation").zero?
   end
 end

--- a/app/helpers/application_helper/button/vm_retire.rb
+++ b/app/helpers/application_helper/button/vm_retire.rb
@@ -5,8 +5,8 @@ class ApplicationHelper::Button::VmRetire < ApplicationHelper::Button::Basic
     self[:enabled] = !(self[:title] = N_("VM is already retired") if disabled?)
   end
 
-  def skip?
-    !@record.supports_retire?
+  def visible?
+    @record.supports_retire?
   end
 
   def disabled?

--- a/spec/helpers/application_helper/buttons/basic_image_spec.rb
+++ b/spec/helpers/application_helper/buttons/basic_image_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::BasicImage do
-  describe '#skip?' do
+  describe '#visible?' do
     context "in list of archived VMs" do
       before do
         allow(ApplicationHelper).to receive(:get_record_cls).and_return(nil)
@@ -9,7 +9,7 @@ describe ApplicationHelper::Button::BasicImage do
       it "will be skipped" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'sb' => @sb}, {})
-        expect(button.skip?).to be_truthy
+        expect(button.visible?).to be_falsey
       end
     end
 
@@ -22,7 +22,7 @@ describe ApplicationHelper::Button::BasicImage do
       it "will be skipped" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'sb' => @sb}, {})
-        expect(button.skip?).to be_truthy
+        expect(button.visible?).to be_falsey
       end
     end
   end

--- a/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::GenericFeatureButton do
-  describe '#skip?' do
+  describe '#visible?' do
     it "that supports feature :some_feature will not be skipped" do
       record = double
       allow(record).to receive(:supports_some_feature?).and_return(true)
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::GenericFeatureButton do
         {'record' => record},
         {:options => {:feature => :some_feature}}
       )
-      expect(button.skip?).to be_falsey
+      expect(button.visible?).to be_truthy
     end
 
     it "that dont support feature :some_feature will be skipped" do
@@ -23,7 +23,7 @@ describe ApplicationHelper::Button::GenericFeatureButton do
         {'record' => record},
         {:options => {:feature => :some_feature}}
       )
-      expect(button.skip?).to be_truthy
+      expect(button.visible?).to be_falsey
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -1,7 +1,7 @@
 describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
   [:start, :stop, :suspend, :reset, :reboot_guest,
    :collect_running_processes, :shutdown_guest].each do |feature|
-    describe '#skip?' do
+    describe '#visible?' do
       context "when vm supports feature #{feature}" do
         before do
           @record = FactoryGirl.create(:vm_vmware)
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
         it "will not be skipped for this vm" do
           view_context = setup_view_context_with_sandbox({})
           button = described_class.new(view_context, {}, {'record' => @record}, {:options => {:feature => feature}})
-          expect(button.skip?).to be_falsey
+          expect(button.visible?).to be_truthy
         end
       end
 
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
         it "will be skipped for this vm" do
           view_context = setup_view_context_with_sandbox({})
           button = described_class.new(view_context, {}, {'record' => @record}, {:options => {:feature => feature}})
-          expect(button.skip?).to be_truthy
+          expect(button.visible?).to be_falsey
         end
       end
     end

--- a/spec/helpers/application_helper/buttons/history_item_spec.rb
+++ b/spec/helpers/application_helper/buttons/history_item_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::HistoryItem do
-  describe '#skip?' do
+  describe '#visible?' do
     subject do
       sandbox = @sandbox || {
         :history     => {:testing => %w(some thing to test with)},
@@ -8,24 +8,24 @@ describe ApplicationHelper::Button::HistoryItem do
 
       view_context = setup_view_context_with_sandbox(sandbox)
       button = described_class.new(view_context, {}, {}, :id => @id)
-      button.skip?
+      button.visible?
     end
 
     %w(1 2 3 4).each do |n|
       it "when with existing history_#{n}" do
         @id = "history_#{n}".to_sym
-        expect(subject).to be_falsey
+        expect(subject).to be_truthy
       end
     end
 
     it "when not history_1 and the tree history not exist" do
       @id = :history_10
-      expect(subject).to be_truthy
+      expect(subject).to be_falsey
     end
 
     it "when with history_1" do
       @id = :history_1
-      expect(subject).to be_falsey
+      expect(subject).to be_truthy
     end
   end
 end

--- a/spec/helpers/application_helper/buttons/instance_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_reset_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::InstanceReset do
-  describe '#skip?' do
+  describe '#visible?' do
     context "when record is resetable" do
       before do
         @record = FactoryGirl.create(:vm_openstack)

--- a/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_instance_scan_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::VmInstanceScan do
-  describe '#skip?' do
+  describe '#visible?' do
     context "when record has proxy and is not orphaned nor archived" do
       before do
         @record = FactoryGirl.create(:vm_vmware)

--- a/spec/helpers/application_helper/buttons/vm_publish_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_publish_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::VmPublish do
-  describe '#skip?' do
+  describe '#visible?' do
     it_behaves_like "when record is orphaned"
     it_behaves_like "when record is archived"
 
@@ -11,7 +11,7 @@ describe ApplicationHelper::Button::VmPublish do
       it "will be skipped" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        expect(button.skip?).to be_truthy
+        expect(button.visible?).to be_falsey
       end
     end
 
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::VmPublish do
       it "will not be skipped" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        expect(button.skip?).to be_falsey
+        expect(button.visible?).to be_truthy
       end
     end
   end

--- a/spec/helpers/application_helper/buttons/vm_reconfigure.rb
+++ b/spec/helpers/application_helper/buttons/vm_reconfigure.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::VmReconfigure do
-  describe '#skip?' do
+  describe '#visible?' do
     context "record is vmware vm" do
       before do
         @record = FactoryGirl.create(:vm_vmware)

--- a/spec/helpers/application_helper/buttons/vm_refresh_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_refresh_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::VmRefresh do
-  describe '#skip?' do
+  describe '#visible?' do
     context "when record has ext_management_system and host vmm_product is workstation" do
       before do
         @record = FactoryGirl.create(:vm_vmware)

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::VmRetire do
-  describe '#skip?' do
+  describe '#visible?' do
     context "when record is retireable" do
       before do
         @record = FactoryGirl.create(:vm_vmware)

--- a/spec/support/examples_group/shared_examples_for_application_helper.rb
+++ b/spec/support/examples_group/shared_examples_for_application_helper.rb
@@ -44,7 +44,7 @@ shared_examples_for 'will be skipped for this record' do |message|
   it message.to_s do
     view_context = setup_view_context_with_sandbox({})
     button = described_class.new(view_context, {}, {'record' => @record}, {})
-    expect(button.skip?).to be_truthy
+    expect(button.visible?).to be_falsey
   end
 end
 
@@ -52,7 +52,7 @@ shared_examples_for 'will not be skipped for this record' do |message|
   it message.to_s do
     view_context = setup_view_context_with_sandbox({})
     button = described_class.new(view_context, {}, {'record' => @record}, {})
-    expect(button.skip?).to be_falsey
+    expect(button.visible?).to be_truthy
   end
 end
 
@@ -69,7 +69,7 @@ shared_examples_for 'when record is archived' do |message|
     record = FactoryGirl.create(:vm_microsoft)
     allow(record).to receive(:archived?).and_return(true)
     button = described_class.new(view_context, {}, {'record' => record}, {})
-    expect(button.skip?).to be_truthy
+    expect(button.visible?).to be_falsey
   end
 end
 
@@ -79,6 +79,6 @@ shared_examples_for 'when record is orphaned' do |message|
     record = FactoryGirl.create(:vm_microsoft)
     allow(record).to receive(:orphaned?).and_return(true)
     button = described_class.new(view_context, {}, {'record' => record}, {})
-    expect(button.skip?).to be_truthy
+    expect(button.visible?).to be_falsey
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
It quite often hurts my brain :goberserk:, when I try to realize what actually does the `skip?` method do with the button.
The name `skip?` comes from previous logic, where the button was skipped in the method, if it was not meant to be hidden. But with the new way of deciding, whether the button should be displayed or not, I think that name `display?` may be a little less confusing.  :suspect:

@martinpovolny, @PanSpagetka what do you think? 

Links
-----
Related to issue #6259