### PR TITLE
Remove handling of raw type in MiqExpression

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -982,8 +982,6 @@ class MiqExpression
       val = val.split(",") if val.kind_of?(String)
       v_arr = val.to_miq_a.flat_map { |v| "'#{v.to_s.strip}'" }.uniq.sort
       "[#{v_arr.join(",")}]"
-    when "raw"
-      val
     else
       val
     end


### PR DESCRIPTION
Purpose or Intent
-----------------

The last reference to the "raw" column type was removed in
1f33b78a812dca281bd0f1cf68a736070b7672c2, so is no longer
needed. Besides, this path is the same as the default case, so is
redundant anyway.

@miq-bot add-label core, technical debt
@miq-bot assign gtanzillo