### PR TITLE
Add notification tables to replication excludes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1052,6 +1052,9 @@
     - miq_widgets
     - miq_widget_contents
     - miq_workers
+    - notifications
+    - notification_recipients
+    - notification_types
     - rss_feeds
     - scan_items
     - schema_migrations

--- a/db/migrate/20160826184028_add_notification_tables_to_replication_excludes.rb
+++ b/db/migrate/20160826184028_add_notification_tables_to_replication_excludes.rb
@@ -1,0 +1,29 @@
+class AddNotificationTablesToReplicationExcludes < ActiveRecord::Migration[5.0]
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  EXCLUDES_KEY = "/workers/worker_base/replication_worker/replication/exclude_tables".freeze
+
+  def up
+    say_with_time("Adding notification tables to replication excludes") do
+      SettingsChange.where(:key => EXCLUDES_KEY).each do |s|
+        s.value << "notifications"
+        s.value << "notification_recipients"
+        s.value << "notification_types"
+        s.save!
+      end
+    end
+  end
+
+  def down
+    say_with_time("Removing notification tables from replication excludes") do
+      SettingsChange.where(:key => EXCLUDES_KEY).each do |s|
+        s.value.delete("notifications")
+        s.value.delete("notification_recipients")
+        s.value.delete("notification_types")
+        s.save!
+      end
+    end
+  end
+end

--- a/spec/migrations/20160826184028_add_notification_tables_to_replication_excludes_spec.rb
+++ b/spec/migrations/20160826184028_add_notification_tables_to_replication_excludes_spec.rb
@@ -1,0 +1,47 @@
+require_migration
+
+describe AddNotificationTablesToReplicationExcludes do
+  let(:settings_change_stub) { migration_stub(:SettingsChange) }
+  let(:server_one)           { FactoryGirl.create(:miq_server) }
+  let(:server_two)           { FactoryGirl.create(:miq_server) }
+
+  migration_context :up do
+    it "adds notification tables to the replication excludes" do
+      server_one.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(schema_migrations))
+      server_two.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(ar_internal_metadata))
+
+      migrate
+
+      changes = settings_change_stub.where(:key => described_class::EXCLUDES_KEY)
+      changes.each do |c|
+        expect(c.value).to include("notifications")
+        expect(c.value).to include("notification_types")
+        expect(c.value).to include("notification_recipients")
+      end
+    end
+  end
+
+  migration_context :down do
+    it "removes notification tables from the replication excludes" do
+      server_one.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(notification_types notifications schema_migrations))
+      server_two.settings_changes
+                .create!(:key   => described_class::EXCLUDES_KEY,
+                         :value => %w(notification_types notification_recipients ar_internal_metadata))
+
+      migrate
+
+      changes = settings_change_stub.where(:key => described_class::EXCLUDES_KEY)
+      changes.each do |c|
+        expect(c.value).not_to include("notifications")
+        expect(c.value).not_to include("notification_types")
+        expect(c.value).not_to include("notification_recipients")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This table was added in 9e99b6ec416c7faad01fcbb801dd850e024bf16b.

Because this is a seeded table and there is a unique constraint on the `name` column, unique constraint errors are inevitable when doing the initial sync, so this table must be added to the excludes.

This PR adds the table to the default replication excludes (`settings.yml`) and also adds a migration to add the table to environments which have already specified changes to the default excludes.

@Fryguy @gtanzillo please review

/cc @isimluk 

@miq-bot add_label bug, replication, core
