### PR TITLE
delegate vm.annotation to hardware

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -160,7 +160,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
   virtual_column :cpu_total_cores,                      :type => :integer,    :uses => :hardware
   virtual_column :cpu_cores_per_socket,                 :type => :integer,    :uses => :hardware
-  virtual_column :v_annotation,                         :type => :string,     :uses => :hardware
+  virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
 
@@ -251,11 +251,6 @@ class VmOrTemplate < ApplicationRecord
     end
 
     virtual_column m, :type => :string, :uses => :all_relationships
-  end
-
-  def v_annotation
-    return nil if hardware.nil?
-    hardware.annotation
   end
 
   include RelationshipMixin

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -711,6 +711,18 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".v_annotation" do
+    let(:vm) { FactoryGirl.create(:vm) }
+    it "handles no hardware" do
+      expect(vm.v_annotation).to be_nil
+    end
+
+    it "handles hardware" do
+      FactoryGirl.create(:hardware, :vm => vm, :annotation => "the annotation")
+      expect(vm.v_annotation).to eq("the annotation")
+    end
+  end
+
   describe "#disconnect_ems" do
     let(:ems) { FactoryGirl.build(:ext_management_system) }
     let(:vm) do


### PR DESCRIPTION
Theme: if we sort by a ruby only `virtual_attribute`, then we need all vm records in memory to sort. If we can define arel for them, then we can only download 20 vms that are on the screen.

`Vm#v_annotation` delegates to `vm.hardware.annotation`, which is a db column. So this one is easy win and minimal risk.