### PR TITLE
Move disconnecting lans logic from vm to hardware

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -127,6 +127,26 @@ class Hardware < ApplicationRecord
     end
   end
 
+  def connect_lans(lans)
+    return if lans.blank?
+    nics.each do |n|
+      # TODO: Use a different field here
+      #   model is temporarily being used here to transfer the name of the
+      #   lan to which this nic is connected.  If model ends up being an
+      #   otherwise used field, this will need to change
+      n.lan = lans.find { |l| l.name == n.model }
+      n.model = nil
+      n.save
+    end
+  end
+
+  def disconnect_lans
+    nics.each do |n|
+      n.lan = nil
+      n.save
+    end
+  end
+
   def m_controller(_parent, xmlNode, deletes)
     # $log.info("Adding controller XML elements for [#{xmlNode.attributes["type"]}]")
     xmlNode.each_element do |e|

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -184,6 +184,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_delegate :name, :to => :ems_cluster, :prefix => true, :allow_nil => true
   virtual_delegate :vmm_product, :to => :host, :prefix => :v_host, :allow_nil => true
   virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true
+  delegate :connect_lans, :disconnect_lans, :to => :hardware, :allow_nil => true
 
   before_validation :set_tenant_from_group
 
@@ -734,29 +735,6 @@ class VmOrTemplate < ApplicationRecord
 
       # Also disconnect any nics from their lans
       disconnect_lans
-    end
-  end
-
-  def connect_lans(lans)
-    unless lans.blank? || hardware.nil?
-      hardware.nics.each do |n|
-        # TODO: Use a different field here
-        #   model is temporarily being used here to transfer the name of the
-        #   lan to which this nic is connected.  If model ends up being an
-        #   otherwise used field, this will need to change
-        n.lan = lans.find { |l| l.name == n.model }
-        n.model = nil
-        n.save
-      end
-    end
-  end
-
-  def disconnect_lans
-    unless hardware.nil?
-      hardware.nics.each do |n|
-        n.lan = nil
-        n.save
-      end
     end
   end
 


### PR DESCRIPTION
Vm has a lot of logic that it does not need to hold.

Since `disconnect_lan` only access attributes from the hardware class, moving it over there.

NOTE: While this may be following the trend of moving fields from vms to hardware for performance reasons, this change provides NO performance benefit.