### PR TITLE
Don't define VappNetwork multiple times

### DIFF
--- a/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers
   class Vmware::NetworkManager::RefreshParser
     include ManageIQ::Providers::Vmware::RefreshHelperMethods
+    VappNetwork = Struct.new(:id, :name, :type, :is_shared, :gateway, :dns1, :dns2)
 
     def initialize(ems, options = nil)
       @ems        = ems
@@ -128,8 +129,6 @@ module ManageIQ::Providers
     # Utility
 
     def get_vapp_networks
-      Struct.new("VappNetwork", :id, :name, :type, :is_shared, :gateway, :dns1, :dns2)
-
       vdc_network_names = Set.new @inv[:networks].map(&:name)
       vapp_networks = []
       @org.vdcs.each do |vdc|
@@ -139,7 +138,7 @@ module ManageIQ::Providers
 
             next if vdc_network_names.include? name
 
-            vapp_networks << Struct::VappNetwork.new(
+            vapp_networks << VappNetwork.new(
               vapp_network_id(name, vapp),
               vapp_network_name(name, vapp),
               "application/vnd.vmware.vcloud.vAppNetwork+xml"


### PR DESCRIPTION
This is a followup to #10550

before: We define a new struct every time calling `get_vapp_networks`.
after: It is defined in the global scope and accessed from that method.

Per [[rubydocs]](https://ruby-doc.org/core-2.2.0/Struct.html#method-c-new), this is the preferred usage.

This removes the test warning:

```
app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb:131:
warning: redefining constant Struct::VappNetwork
```

Which reads to me that we are redefining the constant every time we call this method.
Also, we are defining this struct in global namespace instead of our own.

---

I was not able to verify that all the behavior works as intended.

/cc @miha-plesko thanks for the contribution. I hope this still works the way you intended.