### PR TITLE
Fix enabling of toolbar components if item is selected in automate explorer

### DIFF
--- a/app/assets/javascripts/miq_grid.js
+++ b/app/assets/javascripts/miq_grid.js
@@ -18,11 +18,12 @@
 
     // table-checkable
     if (table.hasClass('table-checkable')) {
-      checkboxes.on('change', function (_e) {
+      checkboxes.on('change', function (e) {
         var checked = $.map(checkboxes.filter(':checked'), function (cb) {
           return cb.value;
         });
 
+        sendDataWithRx({rowSelect: e.delegateTarget});
         ManageIQ.gridChecks = checked;
         miqSetButtons(checked.length, 'center_tb');
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -596,10 +596,7 @@ module ApplicationHelper
   end
 
   def javascript_pf_toolbar_reload(div_id, toolbar)
-    out = []
-    out << javascript_update_element(div_id, buttons_to_html(toolbar))
-    out << "miqInitToolbars();"
-    out.join('')
+    "sendDataWithRx({redrawToolbar: #{toolbar_from_hash.to_json}});"
   end
 
   def javascript_for_ae_node_selection(id, prev_id, select)

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -78,6 +78,8 @@ class ApplicationHelper::ToolbarChooser
         return "x_vm_cloud_center_tb"
       elsif @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
         return "x_template_cloud_center_tb"
+      elsif @button_group.eql? "snapshot"
+        return "x_vm_center_tb"
       else
         return "x_#{@button_group}_center_tb"
       end

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -86,6 +86,8 @@ class MiqAeNamespace < ApplicationRecord
     ancestors.all? { |a| a.editable?(user) }
   end
 
+  alias editable_contents? editable?
+
   def ns_fqname
     return nil if fqname == domain_name
     fqname.sub(domain_name.to_s, '')

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -27,7 +27,7 @@ describe VmOrTemplateController do
 
     it "when snapshot is selected center toolbars are replaced" do
       post :snap_pressed, :params => { :id => @snapshot.id }
-      expect(response.body).to include("center_tb")
+      expect(response.body).to include("sendDataWithRx({redrawToolbar:")
       expect(assigns(:flash_array)).to be_blank
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -772,9 +772,8 @@ describe ApplicationHelper do
     subject { helper.javascript_pf_toolbar_reload(test_tab, 'foobar') }
 
     it "returns javascript to reload toolbar" do
-      expect(helper).to receive(:buttons_to_html).and_return('foobar')
-      is_expected.to include("$('##{test_tab}').html('foobar');")
-      is_expected.to include("miqInitToolbars();")
+      expect(helper).to receive(:toolbar_from_hash).and_return('foobar')
+      is_expected.to include("sendDataWithRx({redrawToolbar: \"foobar\"});")
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
When some item in automate explorer was selected toolbar items, stayed disabled. This was caused because automate explorer uses completely different Javascript file for listening on item selects.

This also fixes bug when selecting folder in automate explorer it threw error in console that no method `editable_contents` exists on `MiqAeNamespace`

Steps for Testing/QA
--------------------
* automate -> explorer
* select some record
* it should enable items in toolbar