### PR TITLE
Add hostname to mw server identifier in alert profiles assignment ui

### DIFF
--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -218,7 +218,7 @@ module MiqPolicyController::AlertProfiles
           end
           node = TreeNodeBuilder.generic_tree_node(
             o.id,
-            (o.name.presence || o.description),
+            choose_node_identifier(o),
             icon,
             "",
             :select => @assign[:new][:objects].include?(o.id) # Check if tag is assigned
@@ -229,6 +229,14 @@ module MiqPolicyController::AlertProfiles
       end
     end
     tree
+  end
+
+  def choose_node_identifier(o)
+    identifier = (o.name.presence || o.description)
+    if o.kind_of?(MiddlewareServer)
+      identifier += "-" + o.hostname
+    end
+    identifier
   end
 
   def alert_profile_build_edit_screen


### PR DESCRIPTION
fixes #10765
@miq-bot add_label providers/hawkular

after fix:
![alert_profiles](https://cloud.githubusercontent.com/assets/6277245/18035920/8d104942-6d68-11e6-9b91-a5bb67fede4f.png)

