### PR TITLE
Remove onclick in datastore tree

### DIFF
--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -91,7 +91,7 @@ module OpsController::Settings::CapAndU
           @unchanged_id_list.each do |item|
             page << "miqDynatreeNodeAddClass('#{j_str(params[:tree_name])}',
                                                   '#{j_str(item)}',
-                                                  'dynatree-title');"
+                                                  'cfme-no-cursor-node dynatree-title');"
           end
         else
           @changed_id_list   = []
@@ -140,7 +140,7 @@ module OpsController::Settings::CapAndU
             else
               page << "miqDynatreeNodeAddClass('#{j_str(params[:tree_name])}',
                                                   '#{j_str(item[0])}',
-                                                  'cfme-blue-bold-node');"
+                                                  'cfme-no-cursor-node cfme-blue-bold-node');"
               page << "miqDynatreeSelectNode('#{j_str(params[:tree_name])}', '#{j_str(item[0])}', #{j_str(!!item[1])})"
             end
           end
@@ -148,7 +148,9 @@ module OpsController::Settings::CapAndU
             if item[1] == 'unsure'
               page << "miqDynatreeNodeAddClass('#{j_str(params[:tree_name])}','#{j_str(item[0])}','dynatree-partsel');"
             else
-              page << "miqDynatreeNodeAddClass('#{j_str(params[:tree_name])}','#{j_str(item[0])}','dynatree-title');"
+              page << "miqDynatreeNodeAddClass('#{j_str(params[:tree_name])}',
+                                               '#{j_str(item[0])}',
+                                               'cfme-no-cursor-node dynatree-title');"
               page << "miqDynatreeSelectNode('#{j_str(params[:tree_name])}', '#{j_str(item[0])}', #{j_str(!!item[1])})"
             end
           end

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -50,7 +50,7 @@ class TreeBuilderClusters < TreeBuilder
         :image    => 'cluster',
         :tip      => node[:name],
         :select   => node[:capture] != 'unsure' && node[:capture],
-        :addClass => node[:capture] == 'unsure' ? 'dynatree-partsel' : '',
+        :addClass => node[:capture] == 'unsure' ? 'cfme-no-cursor-node dynatree-partsel' : 'cfme-no-cursor-node',
         :children => @data[node[:id]][:ho_enabled] + @data[node[:id]][:ho_disabled]
       }
     end
@@ -63,7 +63,7 @@ class TreeBuilderClusters < TreeBuilder
               :children => @root[:non_cl_hosts]
       }
       if non_cluster_selected == 'unsure'
-        node[:addClass] = 'dynatree-partsel'
+        node[:addClass] = 'cfme-no-cursor-node dynatree-partsel'
         node[:select] = true
       end
       nodes.push(node)
@@ -82,6 +82,7 @@ class TreeBuilderClusters < TreeBuilder
        :tip      => _("Host: %{name}") % {:name => node[:name]},
        :image    => 'host',
        :select   => node.kind_of?(Hash) ? node[:capture] : !value,
+       :addClass => 'cfme-no-cursor-node',
        :children => []}
     end
     count_only_or_objects(count_only, nodes)

--- a/app/presenters/tree_builder_clusters.rb
+++ b/app/presenters/tree_builder_clusters.rb
@@ -60,6 +60,7 @@ class TreeBuilderClusters < TreeBuilder
               :image    => 'host',
               :tip      => _("Non-clustered Hosts"),
               :select   => non_cluster_selected,
+              :addClass => 'cfme-no-cursor-node',
               :children => @root[:non_cl_hosts]
       }
       if non_cluster_selected == 'unsure'

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -19,6 +19,7 @@ class TreeBuilderDatastores < TreeBuilder
     locals = super
     locals.merge!(:id_prefix                   => 'datastore_',
                   :checkboxes                  => true,
+                  :onclick                     => false,
                   :onselect                    => "miqOnCheckCUFilters",
                   :check_url                   => "/ops/cu_collection_field_changed/",
                   :open_close_all_on_dbl_click => true)

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -42,6 +42,7 @@ class TreeBuilderDatastores < TreeBuilder
         :image    => 'storage',
         :tip      => "#{node[:name]} [#{node[:location]}]",
         :select   => node[:capture] == true,
+        :addClass => "cfme-no-cursor-node",
         :children => children
       }
     end
@@ -55,7 +56,7 @@ class TreeBuilderDatastores < TreeBuilder
         :image        => 'host',
         :tip          => node[:name],
         :hideCheckbox => true,
-        :style_class  => "cfme-no-cursor-node",
+        :addClass     => "cfme-no-cursor-node",
         :children     => []
       }
     end

--- a/spec/presenters/tree_builder_clusters_spec.rb
+++ b/spec/presenters/tree_builder_clusters_spec.rb
@@ -33,7 +33,7 @@ describe TreeBuilderClusters do
                                         :image    => "cluster",
                                         :tip      => "Name",
                                         :select   => false,
-                                        :addClass => "dynatree-partsel",
+                                        :addClass => "cfme-no-cursor-node dynatree-partsel",
                                         :children => @ho_enabled + @ho_disabled)
       # non-cluster-node
       expect(cluster_nodes.last).to eq(:id       => "NonCluster",
@@ -41,6 +41,7 @@ describe TreeBuilderClusters do
                                        :image    => 'host',
                                        :tip      => _("Non-clustered Hosts"),
                                        :select   => true,
+                                       :addClass => "cfme-no-cursor-node",
                                        :children => @non_cluster_hosts)
     end
     it 'sets non-cluster host nodes correctly' do
@@ -50,6 +51,7 @@ describe TreeBuilderClusters do
                                        :text     => "Non Cluster Host",
                                        :tip      => "Host: Non Cluster Host",
                                        :image    => "host",
+                                       :addClass => "cfme-no-cursor-node",
                                        :select   => true,
                                        :children => []}])
     end
@@ -61,6 +63,7 @@ describe TreeBuilderClusters do
          :text     => node[:name],
          :tip      => _("Host: %{name}") % {:name => node[:name]},
          :image    => 'host',
+         :addClass => "cfme-no-cursor-node",
          :select   => true,
          :children => []}
       end
@@ -69,6 +72,7 @@ describe TreeBuilderClusters do
          :text     => node[:name],
          :tip      => _("Host: %{name}") % {:name => node[:name]},
          :image    => 'host',
+         :addClass => "cfme-no-cursor-node",
          :select   => false,
          :children => []}
       end

--- a/spec/presenters/tree_builder_datastores_spec.rb
+++ b/spec/presenters/tree_builder_datastores_spec.rb
@@ -24,6 +24,7 @@ describe TreeBuilderDatastores do
       expect(parent.first[:text]).to eq("<b>Datastore</b> [#{@datastore.first[:location]}]")
       expect(parent.first[:tip]).to eq("Datastore [#{@datastore.first[:location]}]")
       expect(parent.first[:image]).to eq('storage')
+      expect(parent.first[:addClass]).to eq('cfme-no-cursor-node')
     end
     it 'sets Host node correctly' do
       parent = @datastores_tree.send(:x_get_tree_roots, false, nil)
@@ -32,7 +33,7 @@ describe TreeBuilderDatastores do
       expect(kids.first[:tip]).to eq(@host[:name])
       expect(kids.first[:image]).to eq('host')
       expect(kids.first[:hideCheckbox]).to eq(true)
-      expect(kids.first[:style_class]).to eq("cfme-no-cursor-node")
+      expect(kids.first[:addClass]).to eq("cfme-no-cursor-node")
       expect(kids.first[:children]).to eq([])
     end
   end


### PR DESCRIPTION
Removes onclick in datastore tree so it's same as cluster tree as in older versions.

Closes  #10691 

@miq-bot add_label ui, bug