### PR TITLE
Fix a typo introduced in 4cdf4bb3.

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3346,8 +3346,7 @@
     :identifier: ems_middleware_admin
     :children:
     - :name: Remove
-      :description: Remove Middleware Provider720709
-      
+      :description: Remove Middleware Providers
       :feature_type: admin
       :identifier: ems_middleware_delete
     - :name: Edit


### PR DESCRIPTION
Fix a typo introduced in 4cdf4bb3

testing: open the RBAC tree under roles, navigate to  `Remove Middleware Provider...`

