### PR TITLE
SmartProxy Affinity Tree without data is not generated

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -620,11 +620,13 @@ module OpsController::Settings::Common
       }
     end
 
-    @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
-                                                                  :smartproxy_affinity_tree,
-                                                                  @sb,
-                                                                  true,
-                                                                  @selected_zone)
+    if @selected_zone.miq_servers.select(&:is_a_proxy?).present?
+      @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
+                                                                    :smartproxy_affinity_tree,
+                                                                    @sb,
+                                                                    true,
+                                                                    @selected_zone)
+    end
 
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit


### PR DESCRIPTION
SmartProxy Affinity Tree is not  generated if no data is found.

Configuration -> Zone (without servers) -> SmartProxy Affinity

Before:
![screen shot 2016-08-29 at 2 40 51 pm](https://cloud.githubusercontent.com/assets/9210860/18051725/987c1386-6df6-11e6-859e-b4617645004e.png)
`FATAL -- : Error caught: [NoMethodError] undefined method 'miq_servers' for nil:NilClass`

After:
![screen shot 2016-08-29 at 2 39 42 pm](https://cloud.githubusercontent.com/assets/9210860/18051696/7bc6b37c-6df6-11e6-95ee-ea2eedf744fb.png)

@miq-bot add_label ui, bug

@skateman please have a look as you found this bug, thanks :)

