### PR TITLE
Add downcase guard for Azure resource type

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/event_parser.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers::Azure::CloudManager::EventParser
       :full_data  => event
     }
 
-    resource_type = event["resourceType"]["value"].downcase
+    resource_type = event["resourceType"]["value"].to_s.downcase
     event_hash[:vm_ems_ref] = parse_vm_ref(event) if resource_type == INSTANCE_TYPE
 
     event_hash


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1370211

In rare circumstances the resource type could be nil, so a call to downcase will result in an error. This prevents that from happening.