### PR TITLE
[WIP] Replaced validate_vm_control_powered_on/not_powered_on methods with supports_* methods

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
   def validate_reboot_guest
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def raw_reboot_guest

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
   def validate_reboot_guest
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def raw_reboot_guest

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
@@ -1,10 +1,10 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Guest
   def validate_reboot_guest
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_reset
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def raw_reboot_guest

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
@@ -1,10 +1,10 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Guest
   def validate_reboot_guest
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_reset
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def raw_reboot_guest

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Guest
   def validate_shutdown_guest
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def raw_shutdown_guest

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Guest
   def validate_shutdown_guest
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def raw_shutdown_guest

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -8,14 +8,14 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
   end
 
   def validate_standby_guest
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_reboot_guest
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_reset
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -8,14 +8,14 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
   end
 
   def validate_standby_guest
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_reboot_guest
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_reset
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 end

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -1,18 +1,18 @@
 module Vm::Operations::Power
   def validate_start
-    return {:available => supports_vm_control_not_powered_on?, :message => unsupported_reason(:vm_control_not_powered_on)}
+    {:available => supports_vm_control_not_powered_on?, :message => unsupported_reason(:vm_control_not_powered_on)}
   end
 
   def validate_stop
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_suspend
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_pause
-    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
+    {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_shelve

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -1,18 +1,18 @@
 module Vm::Operations::Power
   def validate_start
-    validate_vm_control_not_powered_on
+    return {:available => supports_vm_control_not_powered_on?, :message => unsupported_reason(:vm_control_not_powered_on)}
   end
 
   def validate_stop
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_suspend
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_pause
-    validate_vm_control_powered_on
+    return {:available => supports_vm_control_powered_on?, :message => unsupported_reason(:vm_control_powered_on)}
   end
 
   def validate_shelve

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -112,26 +112,29 @@ module VmOrTemplate::Operations
             end
       unsupported_reason_add(:control, msg) if msg
     end
+
+    supports :vm_control_powered_on do
+      unless supports_control?
+        unsupported_reason_add(:vm_control_powered_on, unsupported_reason(:control))
+      end
+      unless current_state == "on"
+        unsupported_reason_add(:vm_control_powered_on, _("The VM is not powered on"))
+      end
+    end
+
+    supports :vm_control_not_powered_on do
+      unless supports_control?
+        unsupported_reason_add(:vm_control_not_powered_on, unsupported_reason(:control))
+      end
+      if current_state == "on"
+        unsupported_reason_add(:vm_control_not_powered_on, _("The VM is powered on"))
+      end
+    end
   end
 
   def validate_terminate
     return {:available => false, :message => 'The VM is terminated'} if self.terminated?
     {:available => true, :message => nil}
-  end
-
-  def validate_vm_control_powered_on
-    validate_vm_control_power_state(true)
-  end
-
-  def validate_vm_control_not_powered_on
-    validate_vm_control_power_state(false)
-  end
-
-  def validate_vm_control_power_state(check_powered_on)
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
-    return {:available => true,   :message => nil}  if current_state.send(check_powered_on ? "==" : "!=", "on")
-    {:available => false,  :message => "The VM is#{" not" if check_powered_on} powered on"}
   end
 
   def validate_unsupported(message_prefix)


### PR DESCRIPTION
Purpose or Intent
-----------------
This PR focuses only on removing validate_vm_control_powered_on and validate_vm_control_not_powered_on methods.
Other methods which indirectly used these methods and themselves having the format validate_* are kept as it is as it becomes increasingly difficult to test the changes, and many more methods need to changed in case we change those methods.


Steps for Testing/QA
--------------------
Tested locally, did not see any related errors. There were few unrelated errors which were present even before making the changes.