### PR TITLE
API - add backend version info

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -6,7 +6,8 @@ class ApiController < Api::BaseController
       :version     => @version,
       :versions    => entrypoint_versions,
       :settings    => user_settings,
-      :identity    => auth_identity
+      :identity    => auth_identity,
+      :server_info => server_info,
     }
     res[:authorization] = auth_authorization if attribute_selection.include?("authorization")
     res[:collections]   = entrypoint_collections
@@ -32,5 +33,13 @@ class ApiController < Api::BaseController
         :description => description
       }
     end
+  end
+
+  def server_info
+    {
+      :version   => vmdb_build_info(:version),
+      :build     => vmdb_build_info(:build),
+      :appliance => appliance_name,
+    }
   end
 end

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -36,4 +36,15 @@ RSpec.describe "API entrypoint" do
     collection_names = response.parsed_body['collections'].map { |c| c['name'] }
     expect(collection_names).to eq(collection_names.sort)
   end
+
+  it "returns server_info" do
+    api_basic_authorize
+
+    run_get entrypoint_url
+
+    expect(response.parsed_body['server_info']).to be_kind_of(Hash)
+    expect(response.parsed_body['server_info']['version']).to eq(Vmdb::Appliance.VERSION)
+    expect(response.parsed_body['server_info']['build']).to eq(Vmdb::Appliance.BUILD)
+    expect(response.parsed_body['server_info']['appliance']).to eq(MiqServer.my_server.name)
+  end
 end

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -42,9 +42,12 @@ RSpec.describe "API entrypoint" do
 
     run_get entrypoint_url
 
-    expect(response.parsed_body['server_info']).to be_kind_of(Hash)
-    expect(response.parsed_body['server_info']['version']).to eq(Vmdb::Appliance.VERSION)
-    expect(response.parsed_body['server_info']['build']).to eq(Vmdb::Appliance.BUILD)
-    expect(response.parsed_body['server_info']['appliance']).to eq(MiqServer.my_server.name)
+    expect(response.parsed_body).to include(
+      "server_info" => a_hash_including(
+        "version"   => Vmdb::Appliance.VERSION,
+        "build"     => Vmdb::Appliance.BUILD,
+        "appliance" => MiqServer.my_server.name
+      )
+    )
   end
 end


### PR DESCRIPTION
Something like this is needed to be able to display the About modal in SSUI.

This adds a `.backend` field to the `GET /api` request..

```json
"backend": {
  "version": "master",
  "build": "20160829165024_ecd1cb2",
  "appliance": "EVM"
}
```

The user name & role are already present under `.identity`.

I'm not sure it makes sense to send the browser name, browser version and browser os, can't simply do it the same way as in the ops ui since these are retrieved from the session. But then again, the browser probably already knows those..

(Also, `I18n.t("product.name_full")` (and `product.copyright`) probably needs to come from the SSUI catalog, not OPS UI, so don't want to send that either..)

@epwinchell it should be all we need to display, right?

@abellotti does this make sense?