### PR TITLE
Use stable version of oVirt SDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "omniauth",                       "~>1.3.1",       :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",       :require => false
 gem "outfielding-jqplot-rails",       "= 1.0.8"
-gem "ovirt-engine-sdk",               "~>4.0.0.alpha", :require => false # Required by the oVirt provider
+gem "ovirt-engine-sdk",               "~>4.0.0",       :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.2.0",       :require => false
 gem "paperclip",                      "~>4.3.0"
 gem "puma",                           "~>3.3.0"


### PR DESCRIPTION
The oVirt Ruby SDK has been promoted from pre-release to release, and the
current version number changed to 4.0.0, without the "alpha" suffix. This patch
updates the ManageIQ Gemfile to use that stable version.
