### PR TITLE
Fix non numeric port

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -3,6 +3,7 @@ class Endpoint < ApplicationRecord
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
+  validates :port, :numericality => {:only_integer => true, :allow_nil => true, :greater_than => 0}
 
   def verify_ssl=(val)
     val = resolve_verify_ssl_value(val)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -339,6 +339,25 @@ describe ExtManagementSystem do
               expect { FactoryGirl.create(t, :hostname => nil) }.to raise_error(ActiveRecord::RecordInvalid)
             end
           end
+
+          if ems.new.supports_port?
+            it "numeric port" do
+              expect { FactoryGirl.create(t, :port => "555") }.to_not raise_error
+            end
+
+            it "non-numeric port" do
+              expect { FactoryGirl.create(t, :port => "g55") }.to raise_error(ActiveRecord::RecordInvalid)
+            end
+
+            it "greater than 0 port" do
+              expect { FactoryGirl.create(t, :port => "-1") }.to raise_error(ActiveRecord::RecordInvalid)
+              expect { FactoryGirl.create(t, :port => "0") }.to raise_error(ActiveRecord::RecordInvalid)
+            end
+
+            it "nil port" do
+              expect { FactoryGirl.create(t, :port => nil) }.to_not raise_error
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
We want to validate port field when user creates new provider to not allow non numerical values for the provider's port.

Links
-----
GH Issue reference: https://github.com/ManageIQ/manageiq/issues/8241

Closes #8241 