### PR TITLE
Fix Add MW Deployment not working

### DIFF
--- a/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
+++ b/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
@@ -7,7 +7,7 @@ function MwAddDeploymentController($scope, $http, miqService) {
   $scope.$on('mwAddDeploymentEvent', function(event, data) {
 
     var fd = new FormData();
-    fd.append('file', data.file);
+    fd.append('file', data.filePath);
     fd.append('id', data.serverId);
     fd.append('enabled', data.enableDeployment);
     fd.append('runtimeName', data.runtimeName);


### PR DESCRIPTION
The correct variable holding the reference to the file is `filePath` instead of just `file`.