### PR TITLE
Refactor method for running tasks on a remote region

### DIFF
--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -51,6 +51,44 @@ module ProcessTasksMixin
       end
     end
 
+    def invoke_tasks_remote(options)
+      ids_by_region = options[:ids].group_by { |id| ApplicationRecord.id_to_region(id.to_i) }
+      ids_by_region.each do |region, ids|
+        remote_options = options.merge(:ids => ids)
+        hostname = MiqRegion.find_by_region(region).remote_ws_address
+        if hostname.nil?
+          $log.error("An error occurred while invoking remote tasks...The remote region [#{region}] does not have a web service address.")
+          next
+        end
+
+        begin
+          raise _("SOAP services are no longer supported. Remote server operations are dependent on a REST client library.")
+          # client = VmdbwsClient.new(hostname)  FIXME: Replace with REST client library
+          client.vm_invoke_tasks(remote_options)
+        rescue => err
+          # Handle specific error case, until we can figure out how it occurs
+          if err.class == ArgumentError && err.message == "cannot interpret as DNS name: nil"
+            $log.error("An error occurred while invoking remote tasks...")
+            $log.log_backtrace(err)
+            next
+          end
+
+          $log.error("An error occurred while invoking remote tasks...Requeueing for 1 minute from now.")
+          $log.log_backtrace(err)
+          MiqQueue.put(
+            :class_name  => base_class.name,
+            :method_name => 'invoke_tasks_remote',
+            :args        => [remote_options],
+            :deliver_on  => Time.now.utc + 1.minute
+          )
+          next
+        end
+
+        msg = "'#{options[:task]}' successfully initiated for remote VMs: #{ids.sort.inspect}"
+        task_audit_event(:success, options, :message => msg)
+      end
+    end
+
     # default: invoked by task, can be overridden
     def task_invoked_by(_options)
       :task

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -50,8 +50,7 @@ module ProcessTasksMixin
     end
 
     def invoke_tasks_remote(options)
-      ids_by_region = options[:ids].group_by { |id| ApplicationRecord.id_to_region(id.to_i) }
-      ids_by_region.each do |region, ids|
+      ApplicationRecord.group_ids_by_region(options[:ids]).each do |region, ids|
         remote_options = options.merge(:ids => ids)
         hostname = MiqRegion.find_by_region(region).remote_ws_address
         if hostname.nil?

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -60,6 +60,10 @@ module ProcessTasksMixin
 
         begin
           invoke_api_tasks(hostname, remote_options)
+        rescue NotImplementedError => err
+          $log.error("#{base_class.name} is not currently able to invoke tasks for remote regions")
+          $log.log_backtrace(err)
+          next
         rescue => err
           # Handle specific error case, until we can figure out how it occurs
           if err.class == ArgumentError && err.message == "cannot interpret as DNS name: nil"

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -478,44 +478,6 @@ class VmOrTemplate < ApplicationRecord
     )
   end
 
-  def self.invoke_tasks_remote(options)
-    ids_by_region = options[:ids].group_by { |id| ApplicationRecord.id_to_region(id.to_i) }
-    ids_by_region.each do |region, ids|
-      remote_options = options.merge(:ids => ids)
-      hostname = MiqRegion.find_by_region(region).remote_ws_address
-      if hostname.nil?
-        $log.error("An error occurred while invoking remote tasks...The remote region [#{region}] does not have a web service address.")
-        next
-      end
-
-      begin
-        raise _("SOAP services are no longer supported. Remote server operations are dependent on a REST client library.")
-        # client = VmdbwsClient.new(hostname)  FIXME: Replace with REST client library
-        client.vm_invoke_tasks(remote_options)
-      rescue => err
-        # Handle specific error case, until we can figure out how it occurs
-        if err.class == ArgumentError && err.message == "cannot interpret as DNS name: nil"
-          $log.error("An error occurred while invoking remote tasks...")
-          $log.log_backtrace(err)
-          next
-        end
-
-        $log.error("An error occurred while invoking remote tasks...Requeueing for 1 minute from now.")
-        $log.log_backtrace(err)
-        MiqQueue.put(
-          :class_name  => base_class.name,
-          :method_name => 'invoke_tasks_remote',
-          :args        => [remote_options],
-          :deliver_on  => Time.now.utc + 1.minute
-        )
-        next
-      end
-
-      msg = "'#{options[:task]}' successfully initiated for remote VMs: #{ids.sort.inspect}"
-      task_audit_event(:success, options, :message => msg)
-    end
-  end
-
   def scan_data_current?
     !(last_scan_on.nil? || last_scan_on > last_sync_on)
   end

--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -124,6 +124,10 @@ module ArRegion
       ids.partition { |id| self.id_in_current_region?(id) }
     end
 
+    def group_ids_by_region(ids)
+      ids.group_by { |id| id_to_region(id) }
+    end
+
     def region_number_from_sequence
       return unless connection.data_source_exists?("miq_databases")
       id_to_region(connection.select_value("SELECT last_value FROM miq_databases_id_seq"))

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -51,6 +51,22 @@ describe "AR Regions extension" do
     expect(base_class.uncompress_id("2r5")).to eq(25)
   end
 
+  describe ".group_ids_by_region" do
+    it "works with integer ids" do
+      one_region = [1, 2, 3, 4]
+      expect(base_class.group_ids_by_region(one_region)).to eq(0 => [1, 2, 3, 4])
+      multiple_regions = [1, 2, 991, 992]
+      expect(base_class.group_ids_by_region(multiple_regions)).to eq(0 => [1, 2], 99 => [991, 992])
+    end
+
+    it "works with string ids" do
+      one_region_string = %w(1 2 3 4)
+      expect(base_class.group_ids_by_region(one_region_string)).to eq(0 => %w(1 2 3 4))
+      multiple_regions_string = %w(1 2 991 992)
+      expect(base_class.group_ids_by_region(multiple_regions_string)).to eq(0 => %w(1 2), 99 => %w(991 992))
+    end
+  end
+
   context "with some records" do
     before(:each) do
       # Add dummy records until the ids line up with the @rails_sequence_factor

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -1,0 +1,39 @@
+describe ProcessTasksMixin do
+  describe ".process_tasks" do
+    before(:each) do
+      @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      @host = FactoryGirl.create(:host_vmware, :name => "test_host",    :hostname   => "test_host", :state => 'on')
+    end
+
+    it "deletes VM via call to MiqTask#queue_callback and verifies message" do
+      @vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :name => "VM-mini1")
+
+      @vm1.class.process_tasks(:task => "destroy", :userid => "system", :ids => [@vm1.id])
+
+      expect(MiqQueue.count).to eq(1)
+      @msg1 = MiqQueue.first
+      status, message, result = @msg1.deliver
+
+      expect(@msg1.state).to eq("ready")
+      expect(@msg1.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
+      @msg1.args.each do |h|
+        expect(h[:task]).to eq("destroy")
+        expect(h[:ids]).to eq([@vm1.id])
+        expect(h[:userid]).to eq("system")
+      end
+
+      @msg1.destroy
+      expect(MiqQueue.count).to eq(1)
+      @msg2 = MiqQueue.first
+      status, message, result = @msg2.deliver
+      expect_any_instance_of(MiqTask).to receive(:queue_callback).with("Finished", status, message, result)
+      @msg2.delivered(status, message, result)
+    end
+
+    it "deletes VM via call to MiqTask#queue_callback and successfully saves object image via YAML.dump" do
+      @vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :name => "VM-mini2")
+      @vm2.destroy
+      expect { YAML.dump(@vm2) }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -1,39 +1,66 @@
 describe ProcessTasksMixin do
-  describe ".process_tasks" do
-    before(:each) do
-      @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      @host = FactoryGirl.create(:host_vmware, :name => "test_host",    :hostname   => "test_host", :state => 'on')
-    end
-
-    it "deletes VM via call to MiqTask#queue_callback and verifies message" do
-      @vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :name => "VM-mini1")
-
-      @vm1.class.process_tasks(:task => "destroy", :userid => "system", :ids => [@vm1.id])
-
-      expect(MiqQueue.count).to eq(1)
-      @msg1 = MiqQueue.first
-      status, message, result = @msg1.deliver
-
-      expect(@msg1.state).to eq("ready")
-      expect(@msg1.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
-      @msg1.args.each do |h|
-        expect(h[:task]).to eq("destroy")
-        expect(h[:ids]).to eq([@vm1.id])
-        expect(h[:userid]).to eq("system")
+  let(:test_class) do
+    Class.new(ApplicationRecord) do
+      include ProcessTasksMixin
+      def self.name
+        "ProcessTasksMixinTestClass"
       end
 
-      @msg1.destroy
-      expect(MiqQueue.count).to eq(1)
-      @msg2 = MiqQueue.first
-      status, message, result = @msg2.deliver
-      expect_any_instance_of(MiqTask).to receive(:queue_callback).with("Finished", status, message, result)
-      @msg2.delivered(status, message, result)
+      def test_method
+        "a test"
+      end
+    end
+  end
+
+  describe ".process_tasks" do
+    context "class responds to refresh_ems" do
+      before do
+        test_class.define_singleton_method(:refresh_ems, ->(_ids) { "refresh that ems" })
+      end
+
+      it "calls .refresh_ems and raises an audit event" do
+        ids = [1, 2, 3]
+        expect(test_class).to receive(:refresh_ems).with(ids)
+        expect(AuditEvent).to receive(:success)
+        test_class.process_tasks(:task => "refresh_ems", :ids => ids)
+      end
     end
 
-    it "deletes VM via call to MiqTask#queue_callback and successfully saves object image via YAML.dump" do
-      @vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :name => "VM-mini2")
-      @vm2.destroy
-      expect { YAML.dump(@vm2) }.not_to raise_error
+    it "queues a message for the specified task" do
+      EvmSpecHelper.create_guid_miq_server_zone
+      test_class.process_tasks(:task => "test_method", :ids => [5], :userid => "admin")
+
+      message = MiqQueue.first
+
+      expect(message.class_name).to eq(test_class.name)
+      message.args.each do |h|
+        expect(h[:task]).to eq("test_method")
+        expect(h[:ids]).to eq([5])
+        expect(h[:userid]).to eq("admin")
+      end
+    end
+
+    it "defaults the userid to system in the queue message" do
+      EvmSpecHelper.create_guid_miq_server_zone
+      test_class.process_tasks(:task => "test_method", :ids => [5])
+
+      message = MiqQueue.first
+
+      expect(message.class_name).to eq(test_class.name)
+      message.args.each do |h|
+        expect(h[:task]).to eq("test_method")
+        expect(h[:ids]).to eq([5])
+        expect(h[:userid]).to eq("system")
+      end
+    end
+
+    it "raises if no ids are given" do
+      expect { test_class.process_tasks(:task => "test_method", :ids => []) }.to raise_error(RuntimeError)
+      expect { test_class.process_tasks(:task => "test_method") }.to raise_error(RuntimeError)
+    end
+
+    it "raises if the task is an unknown method" do
+      expect { test_class.process_tasks(:task => "bad_method", :ids => [1]) }.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -99,6 +99,12 @@ describe ProcessTasksMixin do
         expect(message.method_name).to eq("invoke_tasks_remote")
         expect(message.args).to eq([test_options])
       end
+
+      it "does not requeue for a NotImplementedError" do
+        expect(test_class).to receive(:invoke_api_tasks).and_raise(NotImplementedError)
+        expect(MiqQueue).not_to receive(:put)
+        test_class.invoke_tasks_remote(test_options)
+      end
     end
 
     it "does not call invoke_api_tasks if the server does not have an address" do

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -218,42 +218,4 @@ describe Vm do
       :win32_services      => [],
     })
   end
-
-  context ".process_tasks" do
-    before(:each) do
-      @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      @host = FactoryGirl.create(:host_vmware, :name => "test_host",    :hostname   => "test_host", :state => 'on')
-    end
-
-    it "deletes VM via call to MiqTask#queue_callback and verifies message" do
-      @vm1 = FactoryGirl.create(:vm_vmware, :host => @host, :name => "VM-mini1")
-
-      @vm1.class.process_tasks(:task => "destroy", :userid => "system", :ids => [@vm1.id])
-
-      expect(MiqQueue.count).to eq(1)
-      @msg1 = MiqQueue.first
-      status, message, result = @msg1.deliver
-
-      expect(@msg1.state).to eq("ready")
-      expect(@msg1.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
-      @msg1.args.each do |h|
-        expect(h[:task]).to eq("destroy")
-        expect(h[:ids]).to eq([@vm1.id])
-        expect(h[:userid]).to eq("system")
-      end
-
-      @msg1.destroy
-      expect(MiqQueue.count).to eq(1)
-      @msg2 = MiqQueue.first
-      status, message, result = @msg2.deliver
-      expect_any_instance_of(MiqTask).to receive(:queue_callback).with("Finished", status, message, result)
-      @msg2.delivered(status, message, result)
-    end
-
-    it "deletes VM via call to MiqTask#queue_callback and successfully saves object image via YAML.dump" do
-      @vm2 = FactoryGirl.create(:vm_vmware, :host => @host, :name => "VM-mini2")
-      @vm2.destroy
-      expect { YAML.dump(@vm2) }.not_to raise_error
-    end
-  end
 end


### PR DESCRIPTION
This puts the common code used for finding the API endpoint and retry logic into the `ProcessTasksMixin`, rather than in `VmOrTemplate`.

@gtanzillo @Fryguy please review
@miq-bot add_label core, enhancement