### PR TITLE
(－‸ლ) Actually skip settings specs

### DIFF
--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,18 +1,16 @@
 describe Vmdb::Settings do
-  def skip_settings_bug
+  before do
     skip "Affected by some global state change, needs fixing"
   end
 
   describe ".on_reload" do
     it "is called on top-level ::Settings.reload!" do
-      skip_settings_bug
       expect(described_class).to receive(:on_reload)
 
       ::Settings.reload!
     end
 
     it "updates the last_loaded time" do
-      skip_settings_bug
       Timecop.freeze(Time.now.utc) do
         expect(described_class.last_loaded).to_not eq(Time.now.utc)
 
@@ -96,7 +94,6 @@ describe Vmdb::Settings do
     end
 
     it "with a previous change, now back to the default" do
-      skip_settings_bug
       default = Settings.api.token_ttl
       miq_server.settings_changes.create!(:key => "/api/token_ttl", :value => "1.hour")
 


### PR DESCRIPTION
**Skips all settings specs as there's a known failure causing a red build, for now**

@Fryguy I didn't realize it's non-deterministic enough to be different tests within that very file, and only skipped according to one failure.

Here's a cleaner skip-all instead, sorry for the noise.

@miq-bot assign @Fryguy 