### PR TITLE
Update download_template to use RestClient instead of open-uri for Azure

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -346,21 +346,15 @@ module ManageIQ::Providers
       end
 
       def download_template(uri)
-        require 'open-uri'
+        options = {
+          :method      => 'get',
+          :url         => uri,
+          :proxy       => @config.proxy,
+          :ssl_version => @config.ssl_version,
+          :ssl_verify  => @config.ssl_verify
+        }
 
-        if @config.proxy.blank?
-          open(uri) { |f| f.read }
-        else
-          proxy = Addressable::URI.parse(@config.proxy)
-          proxy_url = "#{proxy.scheme}://#{proxy.host}:#{proxy.port}"
-
-          if proxy.user.blank?
-            open(uri, :proxy => proxy_url) { |f| f.read }
-          else
-            auth_array = [proxy_url, proxy.user, proxy.password]
-            open(uri.to_s, :proxy_http_basic_authentication => auth_array) { |f| f.read }
-          end
-        end
+        RestClient::Request.execute(options).body
       rescue => e
         _log.error("Failed to download Azure template #{uri}. Reason: #{e.inspect}")
         nil

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -55,6 +55,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
         allow(VMDB::Util).to receive(:http_proxy_uri).and_return(proxy)
         setup_ems_and_cassette
         expect(OrchestrationTemplate.count).to eql(2)
+        assert_specific_orchestration_template
       end
     end
 
@@ -66,6 +67,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
         allow(VMDB::Util).to receive(:http_proxy_uri).and_return(proxy)
         setup_ems_and_cassette
         expect(OrchestrationTemplate.count).to eql(2)
+        assert_specific_orchestration_template
       end
     end
   end


### PR DESCRIPTION
Beyond the fact that the open-uri.rb code requires too much branching, there's no easy way to set ssl options that I can see. Furthermore, we already use RestClient internally.

This is easier to use, easier to read, and is more flexible to boot.

Supercedes https://github.com/ManageIQ/manageiq/pull/10356