### PR TITLE
Add hardware state for OpenStack Hosts

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -53,9 +53,14 @@ module HostHelper::TextualSummary
     textual_openstack_nova_scheduler if @record.openstack_host?
   end
 
-  def textual_group_openstack_status
+  def textual_group_openstack_service_status
     return nil unless @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)
     textual_generate_openstack_status
+  end
+
+  def textual_group_openstack_hardware_status
+    return nil unless @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)
+    %i(introspected provision_state)
   end
 
   #
@@ -504,6 +509,14 @@ module HostHelper::TextualSummary
       :enabled_cnt  => @record.cloud_services.where(:scheduling_disabled => false).count,
       :disabled_cnt => @record.cloud_services.where(:scheduling_disabled => true).count
     }
+  end
+
+  def textual_introspected
+    {:label => _("Introspected"), :value => @record.hardware.introspected}
+  end
+
+  def textual_provision_state
+    {:label => _("Provisioning State"), :value => @record.hardware.provision_state}
   end
 
   def host_title

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -153,7 +153,12 @@ module ManageIQ
 
       def get_introspection_details(host)
         return {} unless @introspection_service
-        @introspection_service.get_introspection_details(host.uuid).body
+        begin
+          @introspection_service.get_introspection_details(host.uuid).body
+        rescue
+          # introspection data not available
+          {}
+        end
       end
 
       def get_extra_attributes(introspection_details)
@@ -231,6 +236,8 @@ module ManageIQ
           :guest_os_full_name   => nil,
           :guest_os             => nil,
           :disks                => process_host_hardware_disks(extra_attributes),
+          :introspected         => !introspection_details.blank?,
+          :provision_state      => host.provision_state,
         }
       end
 

--- a/app/views/host/_main.html.haml
+++ b/app/views/host/_main.html.haml
@@ -15,4 +15,5 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("VC Custom Attributes"), :items => textual_group_ems_custom_attributes}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Authentication Status"), :items => textual_group_authentications}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Cloud Services"), :items => textual_group_cloud_services}
-    = render :partial => "shared/summary/textual_multilink", :locals => {:title => _("OpenStack Status"), :items => textual_group_openstack_status}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Openstack Hardware"), :items => textual_group_openstack_hardware_status}
+    = render :partial => "shared/summary/textual_multilink", :locals => {:title => _("OpenStack Service Status"), :items => textual_group_openstack_service_status}

--- a/db/migrate/20160825203056_add_state_to_hardware.rb
+++ b/db/migrate/20160825203056_add_state_to_hardware.rb
@@ -1,0 +1,6 @@
+class AddStateToHardware < ActiveRecord::Migration[5.0]
+  def change
+    add_column :hardwares, :introspected, :boolean
+    add_column :hardwares, :provision_state, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1374,6 +1374,8 @@ hardwares:
 - computer_system_id
 - disk_size_minimum
 - memory_mb_minimum
+- introspected
+- provision_state
 host_aggregate_hosts:
 - id
 - host_id

--- a/gems/pending/openstack/openstack_handle/handle.rb
+++ b/gems/pending/openstack/openstack_handle/handle.rb
@@ -278,7 +278,7 @@ module OpenstackHandle
     def introspection_service(tenant_name = nil)
       connect(:service => "Introspection", :tenant_name => tenant_name)
     end
-    alias_method :connect_introspection, :metering_service
+    alias_method :connect_introspection, :introspection_service
 
     def detect_introspection_service(tenant_name = nil)
       detect_service("Introspection", tenant_name)


### PR DESCRIPTION
Purpose or Intent
-----------------
Adds an introspected and a provision_state attribute to the
Hardware model. Introspected means Ironic introspection has already
been run and has gathered the hardware details. Provisioning state
indicates whether the node is available for use or is undergoing
some sort of maintenance.

The attributes are needed to indicate where each node is at in the
Ironic workflow. Typically nodes are added an placed in manageable
state. Nodes are then introspected. And then finally placed in the
available state when ready for use.

The patch also adds the new attributes as additional fields to the
Host summary page.