### PR TITLE
allow user factory to specify tenant

### DIFF
--- a/spec/controllers/application_controller/tenancy_spec.rb
+++ b/spec/controllers/application_controller/tenancy_spec.rb
@@ -13,7 +13,7 @@ describe DashboardController do
 
     it "uses the user's tenant" do
       tenant = FactoryGirl.create(:tenant, :parent => Tenant.root_tenant)
-      user = FactoryGirl.create(:user, :miq_groups => [FactoryGirl.create(:miq_group, :tenant => tenant)])
+      user = FactoryGirl.create(:user_with_group, :tenant => tenant)
       login_as user
       get :login
       expect(controller.send(:current_tenant)).to eq(tenant)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
       role nil
       # e.g.: "miq_request_approval"
       features nil
+      tenant { Tenant.seed }
     end
 
     sequence(:userid) { |s| "user#{s}" }
@@ -17,7 +18,7 @@ FactoryGirl.define do
       if e.miq_groups.blank? && (e.role || e.features)
         u.miq_groups = [
           (e.role && MiqGroup.find_by_description("EvmGroup-#{e.role}")) ||
-          FactoryGirl.create(:miq_group, :features => e.features, :role => e.role)
+          FactoryGirl.create(:miq_group, :features => e.features, :role => e.role, :tenant => e.tenant)
         ]
       end
     end
@@ -32,10 +33,6 @@ FactoryGirl.define do
   end
 
   factory :user_with_group, :parent => :user do
-    transient do
-      tenant { Tenant.seed }
-    end
-
     miq_groups { FactoryGirl.build_list(:miq_group, 1, :tenant => tenant) }
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -4,8 +4,7 @@ describe Notification, :type => :model do
     context 'successful' do
       let(:tenant) { FactoryGirl.create(:tenant) }
       let(:vm) { FactoryGirl.create(:vm, :tenant => tenant) }
-      let(:tenant_group) { FactoryGirl.create(:miq_group, :tenant => tenant) }
-      let!(:user) { FactoryGirl.create(:user, :miq_groups => [tenant_group]) }
+      let!(:user) { FactoryGirl.create(:user_with_group, :tenant => tenant) }
       let(:notification_type) { :vm_powered_on }
 
       it 'creates a new notification along with recipients' do

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -16,8 +16,7 @@ describe NotificationType, :type => :model do
   describe '#subscribers' do
     let(:user1) { FactoryGirl.create(:user) }
     let(:tenant2) { FactoryGirl.create(:tenant) }
-    let(:tenant2_group) { FactoryGirl.create(:miq_group, :tenant => tenant2) }
-    let!(:user2) { FactoryGirl.create(:user, :miq_groups => [tenant2_group]) }
+    let!(:user2) { FactoryGirl.create(:user_with_group, :tenant => tenant2) }
     let(:vm) { FactoryGirl.create(:vm, :tenant => tenant2) }
     subject { notification.subscriber_ids(vm, user1) }
     context 'global notification type' do


### PR DESCRIPTION
Factories can create a user with a particular tenant.

Before it required a few more hoops.
And you couldn't specify a role to link to the tenant

