### PR TITLE
Leverage existing method instead of hardcoding another reg-exp

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -21,7 +21,7 @@ class NotificationType < ApplicationRecord
   def self.seed
     seed_data.each do |t|
       rec = find_by_name(t[:name])
-      t[:expires_in] = $1.to_i.send($2).to_i if t[:expires_in] =~ /^(\d+) (minutes?|hours?|days?)$/
+      t[:expires_in] = t[:expires_in].to_i_with_method
       if rec.nil?
         create(t)
       else

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -1,11 +1,11 @@
 ---
 - :name: vm_powered_off
   :message: Virtual Machine %{subject} has been powered off
-  :expires_in: 24 hours
+  :expires_in: 24.hours
   :level: :success
   :audience: tenant
 - :name: vm_powered_on
   :message: Virtual Machine %{subject} has been powered on
-  :expires_in: 24 hours
+  :expires_in: 24.hours
   :level: :success
   :audience: tenant


### PR DESCRIPTION
Make a use of existing method "to_i_with_method" instead of hardcoding another regular expression. Just noticed there is a method for something I needed a week ago.

@miq-bot add_label refactoring, core