### PR TITLE
Allow network port to have multiple fixed ips

### DIFF
--- a/db/migrate/20160830110050_change_cloud_subnets_network_ports_unique_index.rb
+++ b/db/migrate/20160830110050_change_cloud_subnets_network_ports_unique_index.rb
@@ -1,0 +1,15 @@
+class ChangeCloudSubnetsNetworkPortsUniqueIndex < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :cloud_subnets_network_ports,
+                 :column => [:cloud_subnet_id, :network_port_id],
+                 :name   => 'index_cloud_subnets_network_ports',
+                 :unique => true
+
+    add_index :cloud_subnets_network_ports, :address
+
+    add_index :cloud_subnets_network_ports,
+              [:cloud_subnet_id, :network_port_id, :address],
+              :name   => 'index_cloud_subnets_network_ports_address',
+              :unique => true
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Allow network port to have multiple fixed ips, by extending
unique index to contain address.

Steps for Testing/QA
--------------------
In Amazon, add a secondary fixed IP to ENI. Both fixed IPs should be visible in ManageIQ after refresh. Requires this 
https://github.com/ManageIQ/manageiq-providers-amazon/pull/37 to test the Amazon
