### PR TITLE
Clear Add Middleware Deployment form when opening

### DIFF
--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -73,9 +73,9 @@ function MwServerController($scope, miqService) {
   };
 
   $scope.resetDeployForm = function () {
-    $scope.enableDeployment = true;
-    $scope.runtimeName = undefined;
-    $scope.filePath = undefined;
+    $scope.deployAddModel.enableDeployment = true;
+    $scope.deployAddModel.runtimeName = undefined;
+    $scope.deployAddModel.filePath = undefined;
     angular.element('#deploy_div :file#upload_file').val('');
     angular.element('#deploy_div input[type="text"]:disabled').val('');
   };


### PR DESCRIPTION
When using the "Add Middleware Deployment" form (doing the deployment or
cancelling), when opening it the next time it will still have previous
values/settings.

This was a regression from PR #10687