### PR TITLE
Fix errorneous report result tree node

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -466,6 +466,9 @@ class TreeNodeBuilder
         _("Generating Report for - %{report_name}") % {:report_name => name},
         :expand => expand
       )
+    elsif text == "" && status == "error"
+      generic_node(_("Error Generating Report"), image,
+        _("Error Generating Report for %{report_name}") % {:report_name => name})
     else
       generic_node(text, image)
     end


### PR DESCRIPTION
In cases where the report generation fail, we still want to render nice report result tree node.

Before
![rr-before](https://cloud.githubusercontent.com/assets/6648365/18088854/32c704b6-6ebd-11e6-8136-6cf309c15c15.jpg)

After
![rr-after](https://cloud.githubusercontent.com/assets/6648365/18088860/38da44f8-6ebd-11e6-9d83-58e65950ee96.jpg)

Fixes: #10738
