### PR TITLE
[WIP] Do not delete container images on refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -305,11 +305,7 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
 
     ems.container_images.reset
-    deletes = if target.kind_of?(ExtManagementSystem)
-                :use_association
-              else
-                []
-              end
+    deletes = []
 
     hashes.each do |h|
       h[:container_image_registry_id] = h[:container_image_registry][:id] unless h[:container_image_registry].nil?


### PR DESCRIPTION
I think that we should keep ContainerImages as long as the provider they came from has not been deleted.
 * Theres a need for history on these images for Chargeback reports
 * We run openscap compliance tests on them and would like to have them available to view even when there are no containers running them

The alternative is disconnecting them like containers\pods\projects but I dont think theres a meaning to a 'dead' image. Its always in a constant state and may be re-used later if we decide to run a container with it.  

@simon3z @moolitayer @enoodle What do you think?

@miq-bot add_label providers/containers

