### PR TITLE
Check if MW Deployment already exists on server

### DIFF
--- a/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
+++ b/app/assets/javascripts/controllers/middleware_deployment/middleware_deployment_controller.js
@@ -16,8 +16,8 @@ function MwAddDeploymentController($scope, $http, miqService) {
       headers: {'Content-Type': undefined}
     })
       .then(
-        function() { // success
-          miqService.miqFlash('success', 'Deployment "' + data.runtimeName + '" has been initiated on this server.');
+        function(result) { // success
+          miqService.miqFlash(result.data.status, result.data.msg);
         },
         function() { // error
           miqService.miqFlash('error', 'Unable to deploy "' + data.runtimeName + '" on this server.');


### PR DESCRIPTION
This checks if a deployment with the same name already exists on the
server before deploying, if so, it warns the user.

![image](https://cloud.githubusercontent.com/assets/1737954/18092859/ddf27944-6ec5-11e6-97b7-dd065ba0b842.png)

Fixes #10583 