### PR TITLE
Authentication token for initiation web sockets

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -20,7 +20,7 @@ module Api
     private
 
     def fetch_and_validate_requester_type
-      requester_type = params['requester_type']
+      requester_type = params['requester_type'] || 'api'
       Environment.user_token_service.validate_requester_type(requester_type)
       requester_type
     rescue => err

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -2,11 +2,13 @@ module Api
   class AuthController < BaseController
     def show
       requester_type = fetch_and_validate_requester_type
-      auth_token = Environment.user_token_service.generate_token(@auth_user, requester_type)
+      token_service = Environment.user_token_service
+      auth_token = token_service.generate_token(@auth_user, requester_type)
+      token_info = token_service.token_mgr(requester_type).token_get_info(auth_token)
       res = {
         :auth_token => auth_token,
-        :token_ttl  => api_token_mgr.token_get_info(auth_token, :token_ttl),
-        :expires_on => api_token_mgr.token_get_info(auth_token, :expires_on)
+        :token_ttl  => token_info[:token_ttl],
+        :expires_on => token_info[:expires_on],
       }
       render_resource :auth, res
     end

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -119,7 +119,7 @@ module Api
       end
 
       def api_token_mgr
-        Environment.user_token_service.token_mgr
+        Environment.user_token_service.token_mgr('api')
       end
 
       def authenticate_with_user_token(x_auth_token)

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -11,14 +11,12 @@ module Api
 
     # Additional Requester type token ttl's for authentication
     #
-    REQUESTER_TTL_CONFIG = {"ui" => :ui_token_ttl}.freeze
+    REQUESTER_TTL_CONFIG = {"ui" => ::Settings.session.timeout}.freeze
 
     # API Settings with additional token ttl's
     #
     def api_config
-      @api_config ||= ::Settings[base_config[:module]].to_hash.merge(
-        REQUESTER_TTL_CONFIG["ui"] => ::Settings.session.timeout
-      )
+      @api_config ||= ::Settings[base_config[:module]].to_hash
     end
 
     def generate_token(userid, requester_type)
@@ -28,7 +26,7 @@ module Api
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
 
       token_mgr.gen_token(:userid             => userid,
-                          :token_ttl_override => api_config[REQUESTER_TTL_CONFIG[requester_type]])
+                          :token_ttl_override => REQUESTER_TTL_CONFIG[requester_type])
     end
 
     def validate_requester_type(requester_type)

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -3,10 +3,11 @@ module Api
     def initialize(config = Settings, args = {})
       @config = config
       @svc_options = args
-      @token_mgr = new_token_mgr(base_config[:module], base_config[:name], api_config)
     end
 
-    attr_accessor :token_mgr
+    def token_mgr
+      @token_mgr ||= new_token_mgr(base_config[:module], base_config[:name], api_config)
+    end
 
     # Additional Requester type token ttl's for authentication
     #

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -1,5 +1,6 @@
 module Api
   class UserTokenService
+    TYPES = %w(api ui).freeze
     # Additional Requester type token ttl's for authentication
     TYPE_TO_TTL_OVERRIDE = {'ui' => ::Settings.session.timeout}.freeze
 
@@ -29,11 +30,9 @@ module Api
     end
 
     def validate_requester_type(requester_type)
-      return unless requester_type
-      TYPE_TO_TTL_OVERRIDE.fetch(requester_type) do
-        requester_types = TYPE_TO_TTL_OVERRIDE.keys.join(', ')
-        raise "Invalid requester_type #{requester_type} specified, valid types are: #{requester_types}"
-      end
+      return if TYPES.include?(requester_type)
+      requester_types = TYPES.join(', ')
+      raise "Invalid requester_type #{requester_type} specified, valid types are: #{requester_types}"
     end
 
     private

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -27,8 +27,8 @@ module Api
 
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
 
-      token_mgr.gen_token(:userid           => userid,
-                          :token_ttl_config => REQUESTER_TTL_CONFIG[requester_type])
+      token_mgr.gen_token(:userid             => userid,
+                          :token_ttl_override => api_config[REQUESTER_TTL_CONFIG[requester_type]])
     end
 
     def validate_requester_type(requester_type)
@@ -50,12 +50,10 @@ module Api
     end
 
     def new_token_mgr(mod, name, api_config)
-      token_ttl    = api_config[:token_ttl]
-      ui_token_ttl = api_config[REQUESTER_TTL_CONFIG["ui"]]
+      token_ttl = api_config[:token_ttl]
 
       options                = {}
       options[:token_ttl]    = token_ttl.to_i_with_method if token_ttl
-      options[:ui_token_ttl] = ui_token_ttl.to_i_with_method if ui_token_ttl
 
       log_init(mod, name, options) if @svc_options[:log_init]
       TokenManager.new(mod, options)

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -1,5 +1,8 @@
 module Api
   class UserTokenService
+    # Additional Requester type token ttl's for authentication
+    TYPE_TO_TTL_OVERRIDE = {'ui' => ::Settings.session.timeout}.freeze
+
     def initialize(config = Settings, args = {})
       @config = config
       @svc_options = args
@@ -8,10 +11,6 @@ module Api
     def token_mgr
       @token_mgr ||= new_token_mgr(base_config[:module], base_config[:name], api_config)
     end
-
-    # Additional Requester type token ttl's for authentication
-    #
-    REQUESTER_TTL_CONFIG = {"ui" => ::Settings.session.timeout}.freeze
 
     # API Settings with additional token ttl's
     #
@@ -26,13 +25,13 @@ module Api
       $api_log.info("Generating Authentication Token for userid: #{userid} requester_type: #{requester_type}")
 
       token_mgr.gen_token(:userid             => userid,
-                          :token_ttl_override => REQUESTER_TTL_CONFIG[requester_type])
+                          :token_ttl_override => TYPE_TO_TTL_OVERRIDE[requester_type])
     end
 
     def validate_requester_type(requester_type)
       return unless requester_type
-      REQUESTER_TTL_CONFIG.fetch(requester_type) do
-        requester_types = REQUESTER_TTL_CONFIG.keys.join(', ')
+      TYPE_TO_TTL_OVERRIDE.fetch(requester_type) do
+        requester_types = TYPE_TO_TTL_OVERRIDE.keys.join(', ')
         raise "Invalid requester_type #{requester_type} specified, valid types are: #{requester_types}"
       end
     end

--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -14,8 +14,7 @@ class TokenManager
 
   def gen_token(token_options = {})
     token = SecureRandom.hex(16)
-    token_ttl_config = token_options.delete(:token_ttl_config)
-    token_ttl = (token_ttl_config && @options[token_ttl_config]) ? @options[token_ttl_config] : @options[:token_ttl]
+    token_ttl = token_options.delete(:token_ttl_override) || @options[:token_ttl]
     token_data = {:token_ttl => token_ttl, :expires_on => Time.now.utc + token_ttl}
 
     token_store.write(token,

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -122,6 +122,8 @@ describe "Authentication API" do
   end
 
   context "Token Based Authentication" do
+    let(:ui_token_ttl) { VMDB::Config.new("vmdb").config[:session][:timeout].to_i_with_method }
+
     it "gets a token based identifier" do
       api_basic_authorize
 
@@ -197,7 +199,6 @@ describe "Authentication API" do
     it "gets a token based identifier with a UI based token_ttl" do
       api_basic_authorize
 
-      ui_token_ttl = VMDB::Config.new("vmdb").config[:session][:timeout].to_i_with_method
       run_get auth_url, :requester_type => "ui"
 
       expect(response).to have_http_status(:ok)
@@ -214,6 +215,27 @@ describe "Authentication API" do
 
       expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
       run_delete auth_url, "auth_token" => auth_token
+    end
+
+    context 'Tokens for Web Sockets' do
+      it 'gets a UI based token_ttl when requesting token for web sockets' do
+        api_basic_authorize
+
+        run_get auth_url, :requester_type => 'ws'
+        expect(response).to have_http_status(:ok)
+        expect_result_to_have_keys(%w(auth_token token_ttl expires_on))
+        expect(response.parsed_body["token_ttl"]).to eq(ui_token_ttl)
+      end
+
+      it 'cannot authorize user to api based on token that is dedicated for web sockets' do
+        api_basic_authorize
+        run_get auth_url, :requester_type => 'ws'
+        ws_token = response.parsed_body["auth_token"]
+
+        run_get entrypoint_url, :headers => {'auth_token' => ws_token}
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Clean-up in `UserTokenService` and introduction of new type/namespace of tokens for Web Sockets. These tokens are short lived (5 minutes) and completely isolated from the existing tokens.

Usage
-----------------
API Request: `GET http://localhost:3000/api/auth?requester_type=ws`
Response
```
    {
        "auth_token": "c689f15403955e4ca68d976d7d73c420",
        "token_ttl": 300,
        "expires_on": "2016-08-30T14:57:28Z"
    }
```

The server worker (ActionCable) can authenticate the ws token using:

```
ManageIQ::API::Environment.user_token_service.token_mgr('ws').token_get_info(TOKEN, :userid)
```
sharing the existing TokenManager with API. Or by instantiating the new one using
```
TokenManager.new('ws').token_get_info(TOKEN, :userid)
```

/cc @skateman 

@miq-bot add_label api, feature, darga/no, wip
@miq-bot assign @abellotti 