### PR TITLE
Automate styling cleanup

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -514,6 +514,9 @@ body#dashboard {
   }
 }
 
+/* custom modal class for Entry Point (creates scrollable area) */
+#automate_treebox {height:350px; overflow-y: hidden !important;}
+
 /* scrollable */
 .scrollable {
   overflow: auto;

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -61,13 +61,6 @@ ul.searchtoolbar  { margin: 0;padding: 2px 0 0 5px; width:100%;height: 30px;}
 .searchtoolbar li:hover { background: #aeaeae;}
 .searchtoolbar li img.dimmed { background: none;}
 
-/* Automate Specific */
-.checkall { padding: 0 0 7px 7px;} /*styling for automate (Check All) */
-
-#automate_treebox {height:350px; overflow-y: hidden !important;}
-
-/* End Automate Specific */
-
 /************ Hover Buttons ************/
 .rollover img, input.rollover { display:block;}
 .rollover img:hover, img.rollover:hover, input.rollover:hover, i.rollover:hover { background:#e4e4e4;}

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -6,7 +6,7 @@
       %table#class_instances_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
         %thead
           %th.narrow
-            %input.checkall{:type => 'checkbox', :title => _('Check All')}
+            %input{:type => 'checkbox', :title => _('Check All')}
           %th
           %th
         %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -6,7 +6,7 @@
       %table#class_methods_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
         %thead
           %th.narrow
-            %input.checkall{:type => 'checkbox', :title => _('Check All')}
+            %input{:type => 'checkbox', :title => _('Check All')}
           %th
           %th
         %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -5,7 +5,7 @@
     %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.narrow
-          %input.checkall{:type => 'checkbox', :title => _('Check All')}
+          %input{:type => 'checkbox', :title => _('Check All')}
         %th
         %th
       %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -7,7 +7,7 @@
     %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.narrow
-          %input.checkall{:type => 'checkbox', :title => _('Check All')}
+          %input{:type => 'checkbox', :title => _('Check All')}
         %th
         %th= _('Name')
         %th= _('Description')


### PR DESCRIPTION
* remove old "checkall" class from Automate tables
* move Entry Point modal styling to patternfly_overrides.scss

https://www.pivotaltracker.com/n/projects/1613907/stories/129462395