### PR TITLE
Add AuthenticationMixin to MiqRegion model

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -243,6 +243,19 @@ class MiqRegion < ApplicationRecord
     hostname.nil? ? nil : "https://#{hostname}"
   end
 
+  def generate_auth_key_queue(ssh_user, ssh_password, ssh_host = nil)
+    args = [ssh_user, ssh_password]
+    args << ssh_host if ssh_host
+
+    MiqQueue.put_unless_exists(
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :queue_name  => "generic",
+      :method_name => "generate_auth_key",
+      :args        => args
+    )
+  end
+
   def generate_auth_key(ssh_user, ssh_password, ssh_host = remote_ws_address)
     key = remote_region_v2_key(ssh_user, MiqPassword.try_decrypt(ssh_password), ssh_host)
 

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -244,7 +244,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def generate_auth_key_queue(ssh_user, ssh_password, ssh_host = nil)
-    args = [ssh_user, ssh_password]
+    args = [ssh_user, MiqPassword.try_encrypt(ssh_password)]
     args << ssh_host if ssh_host
 
     MiqQueue.put_unless_exists(

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -263,6 +263,7 @@ class MiqRegion < ApplicationRecord
     auth.auth_key = key
     auth.name = "Region #{region} API Key"
     auth.resource = self
+    auth.authtype = "system_api"
     auth.save!
   end
 
@@ -272,7 +273,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def api_system_auth_token(userid)
-    region_v2_key = authentication_token
+    region_v2_key = authentication_token("system_api")
 
     token_hash = {
       :server_guid => remote_ws_miq_server.guid,

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -80,7 +80,7 @@ module AuthenticationMixin
 
   def required_credential_fields(type)
     case type.to_s
-    when "bearer"
+    when "bearer", "system_api"
       [:auth_key]
     when "hawkular"
       []

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -166,7 +166,7 @@ describe MiqRegion do
 
       remote_region.generate_auth_key(user, password, host)
 
-      expect(remote_region.authentication_token).to eq(remote_key)
+      expect(remote_region.authentication_token("system_api")).to eq(remote_key)
     end
   end
 

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -147,4 +147,43 @@ describe MiqRegion do
       expect(described_class.replication_type = :global).to eq :global
     end
   end
+
+  describe "#generate_auth_key" do
+    let(:remote_region) { FactoryGirl.create(:miq_region) }
+    let(:remote_key)    { "this is the encryption key!" }
+
+    before { EvmSpecHelper.create_guid_miq_server_zone }
+
+    it "stores an authentication key" do
+      require 'net/scp'
+      host     = "remote-region.example.com"
+      password = "mypassword"
+      user     = "admin"
+
+      expect(Net::SCP).to receive(:download!)
+        .with(host, user, "/var/www/miq/vmdb/certs/v2_key", nil, :ssh => {:password => password})
+        .and_return(remote_key)
+
+      remote_region.generate_auth_key(user, password, host)
+
+      expect(remote_region.authentication_token).to eq(remote_key)
+    end
+  end
+
+  describe "#api_system_auth_token" do
+    let(:region) { FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number) }
+
+    it "generates the token correctly" do
+      user = "admin"
+      server = FactoryGirl.create(:miq_server, :has_active_webservices => true)
+      expect(region).to receive(:authentication_token).and_return(File.read(RAILS_ROOT.join("certs/v2_key")))
+
+      token = region.api_system_auth_token(user)
+      token_hash = YAML.load(MiqPassword.decrypt(token))
+
+      expect(token_hash[:server_guid]).to eq(server.guid)
+      expect(token_hash[:userid]).to eq(user)
+      expect(token_hash[:timestamp]).to be > 5.minutes.ago.utc
+    end
+  end
 end


### PR DESCRIPTION
This will be used to store remote region API authentication.

As a first pass, methods to fetch a remote region's `v2_key` and to generate a token compatible with the the X-MIQ-Token API authentication method added in https://github.com/ManageIQ/manageiq/pull/10351 have been added.

The ultimate goal will be to use OAuth tokens in place of the `v2_key` and contrived X-MIQ-Token authentication mechanism.

We store the entire remote region key text, encrypted using the local region's `v2_key`, as an authentication record of type `AuthToken` with the `MiqRegion` record as the resource.

https://www.pivotaltracker.com/story/show/128666883

@gtanzillo @Fryguy please review
@miq-bot add_label core, enhancement, wip