### PR TITLE
Display the number of access control elements based on user permission

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -909,10 +909,10 @@ module OpsController::OpsRbac
       @right_cell_text = _("Access Control %{model} \"%{name}\"") %
                          {:name  => "#{MiqRegion.my_region.description} [#{MiqRegion.my_region.region}]",
                           :model => ui_lookup(:model => "MiqRegion")}
-      @users_count   = User.in_my_region.count
-      @groups_count  = MiqGroup.non_tenant_groups.count
-      @roles_count   = MiqUserRole.count
-      @tenants_count = Tenant.roots.count
+      @users_count   = Rbac.filtered(User.in_my_region).count
+      @groups_count  = Rbac.filtered(MiqGroup.non_tenant_groups).count
+      @roles_count   = Rbac.filtered(MiqUserRole).count
+      @tenants_count = Rbac.filtered(Tenant).count
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Correct the count displayed in the Access Control Summary Tab for the logged in user for Users, Groups, Roles and Tenants.


Links 
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1347670

Steps for Testing/QA
--------------------
Steps to Reproduce:
1.Navigate to configuration->settings->access control->tenant and create a new child tenant
2.create a new group by selecting the above tenant and role as "EvmRole-super_administrator"
3.create a user based on the above group
4.login with that user and navigate to settings->configuration->access control

