### PR TITLE
Remove old "tagstable" class styling

### DIFF
--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -116,15 +116,6 @@ table.admintable td.image{ padding: 2px 0 0 2px;text-align: top;}
 table.admintable td.image img{ width: 20px; height: 20px;}
 table.admintable td.key.vtop { vertical-align: top;}
 
-/******************************* Special table for tags tree in Prov area ******************************/
-table.tagstable td.row1   { border-bottom: 1px solid #e9e9e9;}
-table.tagstable td    { padding: 0; }
-table.tagstable td.key,
-table.tagstable td.paramlist_key { width: 200px;border-right: 1px solid #999;border-bottom: 1px solid #999;border-left: 1px solid #fff;background: #f0f0f0;color:#4b4b4b; vertical-align: top;text-align: right;font-weight: bold;}
-table.tagstable td.keyicon { padding-right: 0; width: 170px;border-bottom: 1px solid #e9e9e9;background: #f6f6f6;color: #666; text-align: right;font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;}
-table.tagstable td.icon   { padding-right: 5px;width: 24px; border-right: 1px solid #e9e9e9; border-bottom: 1px solid #e9e9e9;background: #f6f6f6;color: #666; text-align: right;font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;}
-table.tagstable td.key.vtop { vertical-align: top;}
-
 /************ Misc ************/
 /*select boxes*/
 .form .widthed{ width:400px;}

--- a/app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml
+++ b/app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml
@@ -25,17 +25,14 @@
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Select Tags to apply"),
-        :keys                       => keys,
-        :table_class                => "tagstable",
-        :extra_table_attributes     => "cellspacing=1"})
+        :keys                       => keys})
   - when :service
     - keys = [:src_configured_system_ids, :src_configuration_profile_id]
     = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Configured Systems"),
-        :keys                       => keys,
-        :extra_table_attributes     => "width=100%"})
+        :keys                       => keys})
   - when :customize
     - keys = [:root_password]
     = render(:partial => "prov_dialog_fieldset",

--- a/app/views/miq_request/_prov_host_dialog.html.haml
+++ b/app/views/miq_request/_prov_host_dialog.html.haml
@@ -25,24 +25,20 @@
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("Select Tags to apply"),
-        :keys                       => keys,
-        :table_class                => "tagstable",
-        :extra_table_attributes     => "cellspacing=1"})
+        :keys                       => keys})
   - when :service
     - keys = [:src_host_ids]
     = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => title_for_host,
-        :keys                       => keys,
-        :extra_table_attributes     => "width=100%"})
+        :keys                       => keys})
     - keys = [:pxe_server_id, :pxe_image_id]
     = render(:partial => "prov_dialog_fieldset",
       :locals         => {:workflow => wf,
         :dialog                     => dialog,
         :label                      => _("PXE"),
-        :keys                       => keys,
-        :extra_table_attributes     => "width=100%"})
+        :keys                       => keys})
   - when :environment
     - keys = [:placement_ems_name]
     = render(:partial => "prov_dialog_fieldset",

--- a/app/views/shared/views/_prov_dialog.html.haml
+++ b/app/views/shared/views/_prov_dialog.html.haml
@@ -28,9 +28,7 @@
         :dialog                     => dialog,
         :label                      => _("Select Tags to apply"),
         :prefix                     => "/miq_request/",
-        :keys                       => keys,
-        :table_class                => "tagstable",
-        :extra_table_attributes     => "cellspacing=1"})
+        :keys                       => keys})
   - when :service
     - keys = wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow) ? [:src_vm_id, :provision_type, :linked_clone] : [:vm_filter, :src_vm_id, :provision_type, :linked_clone, :snapshot]
     - label = wf.kind_of?(ManageIQ::Providers::Redhat::InfraManager::ProvisionWorkflow) ? _("Selected VM") : _("Select")
@@ -39,8 +37,7 @@
         :dialog                     => dialog,
         :label                      => label,
         :prefix                     => "/miq_request/",
-        :keys                       => keys,
-        :extra_table_attributes     => "width=100%"})
+        :keys                       => keys})
     - if wf.supports_pxe?
       - keys = [:pxe_server_id, :pxe_image_id, :windows_image_id]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
@@ -48,8 +45,7 @@
           :dialog                     => dialog,
           :label                      => _("PXE"),
           :prefix                     => "/miq_request/",
-          :keys                       => keys,
-          :extra_table_attributes     => "width=100%"})
+          :keys                       => keys})
     - if wf.supports_iso?
       - keys = [:iso_image_id]
       = render(:partial => "/miq_request/prov_dialog_fieldset",
@@ -57,8 +53,7 @@
           :dialog                     => dialog,
           :label                      => _("ISO"),
           :prefix                     => "/miq_request/",
-          :keys                       => keys,
-          :extra_table_attributes     => "width=100%"})
+          :keys                       => keys})
     - keys = [:number_of_vms]
     - label = wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow) ? _("Number of Instances") : _("Number of VMs")
     = render(:partial => "/miq_request/prov_dialog_fieldset",
@@ -127,8 +122,7 @@
           :dialog                     => dialog,
           :label                      => title_for_host,
           :prefix                     => "/miq_request/",
-          :keys                       => keys,
-          :extra_table_attributes     => "width=100%"})
+          :keys                       => keys})
       - unless wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
         - keys = [:ds_filter, :placement_storage_profile, :placement_ds_name]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
@@ -136,8 +130,7 @@
             :dialog                     => dialog,
             :label                      => _("Datastore"),
             :prefix                     => "/miq_request/",
-            :keys                       => keys,
-            :extra_table_attributes     => "width=100%"})
+            :keys                       => keys})
       - if wf.kind_of?(ManageIQ::Providers::CloudManager::ProvisionWorkflow)
         - keys = [:cloud_tenant, :availability_zone_filter, :placement_availability_zone, :cloud_network, :cloud_subnet, :security_groups, :floating_ip_address, :resource_group]
         = render(:partial => "/miq_request/prov_dialog_fieldset",
@@ -145,8 +138,7 @@
             :dialog                     => dialog,
             :label                      => _("Placement - Options"),
             :prefix                     => "/miq_request/",
-            :keys                       => keys,
-            :extra_table_attributes     => "width=100%"})
+            :keys                       => keys})
   - when :hardware
     - keys = [:instance_type, :number_of_cpus, :number_of_sockets, :cores_per_socket,
               :vm_memory, :network_adapters, :disk_format, :guest_access_key_pair, :monitoring,
@@ -203,8 +195,7 @@
             :dialog                     => dialog,
             :label                      => _("Custom Specification"),
             :prefix                     => "/miq_request/",
-            :keys                       => keys,
-            :extra_table_attributes     => "width=100%"})
+            :keys                       => keys})
         - if @sb[:vm_os] == "windows"
           - keys = [:sysprep_timezone, :sysprep_auto_logon, :sysprep_auto_logon_count, :sysprep_password]
           = render(:partial => "/miq_request/prov_dialog_fieldset",


### PR DESCRIPTION
Remove old "tagstable" css class, previously used on Provisioning screens.

https://www.pivotaltracker.com/n/projects/1613907/stories/129462395