### PR TITLE
Instruct explicit removal of log files instead of all log/*

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -56,7 +56,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  execute "rm -f log/*"
+  execute "find log/ -type 'f' | xargs rm"
   execute "rm -rf tmp/cache"
 
   if options[:do_tests]


### PR DESCRIPTION
@bdunne @bazulay @Fryguy 

Docker builds broke as we recently started to check the return status value of all system calls on bin/setup : 

```
== Copying sample files ==

== Removing old logs and tempfiles ==
rm: cannot remove ‘log/apache’: Is a directory
ERROR: Command failed: rm -f log/*
```
We require return values to be 0 in all layers of MIQ Dockerfile so this one fails , as apache dir can't be removed.
We need to be more explicit in what we remove, I added a find/args combo to just check for files and remove. Let me know what you think...