### PR TITLE
[DARGA] - Changes to not build Clusters/Storages tree when there is no data in db

### DIFF
--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -192,7 +192,7 @@ module OpsController::Settings::CapAndU
       end
     end
     @edit[:current][:clusters].sort_by! { |c| c[:name] }
-    build_cl_hosts_tree(@edit[:current][:clusters])
+    build_cl_hosts_tree(@edit[:current][:clusters]) unless @edit[:current][:clusters].blank?
 
     @edit[:current][:storages] = []
     @st_recs = {}
@@ -205,7 +205,7 @@ module OpsController::Settings::CapAndU
                                       :store_type => s.store_type,
                                       :location   => s.location) # fields we need
     end
-    build_ds_tree(@edit[:current][:storages])
+    build_ds_tree(@edit[:current][:storages]) unless @edit[:current][:storages].blank?
     @edit[:new] = copy_hash(@edit[:current])
     session[:edit] = @edit
   end

--- a/spec/controllers/ops_controller/settings/cap_and_u_spec.rb
+++ b/spec/controllers/ops_controller/settings/cap_and_u_spec.rb
@@ -1,0 +1,34 @@
+describe OpsController do
+  before(:each) do
+    MiqRegion.seed
+  end
+
+  context '#cu_build_edit_screen' do
+    before do
+      tree_hash = {
+        :trees       => {
+          :settings_tree => {
+            :active_node => "root"
+          }
+        },
+        :active_tree => :settings_tree,
+        :active_tab  => 'settings_cu_collection'
+      }
+      controller.instance_variable_set(:@sb, tree_hash)
+    end
+
+    it 'should have no tree data set when there are no clusters/storage records in db' do
+      controller.send(:cu_build_edit_screen)
+      expect(assigns(:clhosts_tree)).to eq(nil)
+      expect(assigns(:cu_datastore_tree)).to eq(nil)
+    end
+
+    it 'should have tree data set when there are clusters/storage records in db' do
+      FactoryGirl.create(:ems_cluster, :name => "My Cluster")
+      FactoryGirl.create(:storage_vmware, :name => "My Datastore")
+      controller.send(:cu_build_edit_screen)
+      expect(assigns(:clhosts_tree)).to_not eq(nil)
+      expect(assigns(:cu_datastore_tree)).to_not eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
Make sure that there are clusters & datastores before building tree each tree.

https://bugzilla.redhat.com/show_bug.cgi?id=1368543
(cherry picked from commit 9c82595)

@chessbyte made some changes to fix merge conflicts, related trees in the fix are not built using TreeBuilder class on Darga