### PR TITLE
Api options method

### DIFF
--- a/app/controllers/api/arbitration_rules_controller.rb
+++ b/app/controllers/api/arbitration_rules_controller.rb
@@ -15,6 +15,10 @@ module Api
       super(type, id, attributes)
     end
 
+    def options
+      render_options(:arbitration_rules, :field_values => ArbitrationRule.field_values)
+    end
+
     private
 
     def build_rule_attributes(data)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -15,14 +15,14 @@ module Api
     class UnsupportedMediaTypeError < StandardError; end
 
     def handle_options_request
-      head(:ok) if request.request_method == "OPTIONS"
+      head(:ok)
     end
 
     before_action :set_access_control_headers
     def set_access_control_headers
       headers['Access-Control-Allow-Origin'] = '*'
       headers['Access-Control-Allow-Headers'] = 'origin, content-type, authorization, x-auth-token'
-      headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH'
+      headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
     end
 
     # Order *Must* be from most generic to most specific
@@ -82,7 +82,8 @@ module Api
     # mechanism.
     #
     if Vmdb::Application.config.action_controller.allow_forgery_protection
-      skip_before_action :verify_authenticity_token, :only => [:show, :update, :destroy, :handle_options_request]
+      skip_before_action :verify_authenticity_token,
+                         :only => [:show, :update, :destroy, :handle_options_request, :options]
     end
 
     def base_config
@@ -106,7 +107,9 @@ module Api
       @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
     end
 
-    before_action :parse_api_request, :log_api_request, :validate_api_request, :validate_api_action
+    before_action :parse_api_request, :log_api_request, :validate_api_request
+    before_action :validate_api_action, :except => [:options]
+    before_action :log_request_initiated, :only => [:handle_options_request]
     after_action :log_api_response
   end
 end

--- a/app/controllers/api/base_controller/collection_config.rb
+++ b/app/controllers/api/base_controller/collection_config.rb
@@ -67,7 +67,7 @@ module Api
       end
 
       def klass(collection_name)
-        self[collection_name][:klass].constantize
+        self[collection_name][:klass].try(:constantize)
       end
 
       def name_for_klass(resource_klass)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -30,6 +30,10 @@ module Api
         render_normal_destroy
       end
 
+      def options
+        render_options(@req.collection)
+      end
+
       #
       # Action Helper Methods
       #

--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -54,7 +54,7 @@ module Api
           normalize_time(value)
         elsif Environment.normalized_attributes[:url].key?(attr.to_s)
           normalize_url(value)
-        elsif Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?("password")
+        elsif encrypted_attribute?(attr)
           normalize_encrypted
         elsif Environment.normalized_attributes[:resource].key?(attr.to_s)
           normalize_resource(value)
@@ -98,6 +98,13 @@ module Api
       #
       def normalize_resource(value)
         value.to_s.starts_with?("/") ? "#{@req.base}#{value}" : value
+      end
+
+      #
+      # Let's determine if an attribute is encrypted
+      #
+      def encrypted_attribute?(attr)
+        Environment.normalized_attributes[:encrypted].key?(attr.to_s) || attr.to_s.include?('password')
       end
 
       #

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -24,7 +24,7 @@ module Api
         # Method Validation for the collection or sub-collection specified
         if cname && ctype
           mname = @req.method
-          unless collection_config.supports_http_method?(cname, mname)
+          unless collection_config.supports_http_method?(cname, mname) || mname == :options
             raise BadRequestError, "Unsupported HTTP Method #{mname} for the #{ctype} #{cname} specified"
           end
         end

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -22,6 +22,7 @@ module Api
                       when :get         then 'read'
                       when :put, :patch then 'edit'
                       when :delete      then 'delete'
+                      when :options     then 'options'
                       else json_body['action'] || 'create'
                       end
         end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -190,7 +190,7 @@ module Api
           if is_subcollection
             send("#{type}_query_resource", parent_resource_obj)
           elsif by_tag_param
-            klass.find_tagged_with(:all => by_tag_param, :ns  => TAG_NAMESPACE)
+            klass.find_tagged_with(:all => by_tag_param, :ns => TAG_NAMESPACE)
           else
             klass.all
           end
@@ -470,6 +470,28 @@ module Api
           return resource.respond_to?(validate_method) && resource.send(validate_method)
         end
         true
+      end
+
+      def render_options(resource, data = {})
+        collection = collection_class(resource)
+        options =
+          if collection.blank?
+            { :attributes => [], :virtual_attributes => [], :relationships => [] }
+          else
+            {
+              :attributes         => options_attribute_list(collection.attribute_names -
+                                                              collection.virtual_attribute_names),
+              :virtual_attributes => options_attribute_list(collection.virtual_attribute_names),
+              :relationships      => (collection.reflections.keys |
+                                       collection.virtual_reflections.keys.collect(&:to_s)).sort
+            }
+          end
+        options[:data] = data
+        render :json => options
+      end
+
+      def options_attribute_list(attrlist)
+        attrlist.sort.select { |attr| !encrypted_attribute?(attr) }
       end
     end
   end

--- a/app/models/arbitration_rule.rb
+++ b/app/models/arbitration_rule.rb
@@ -1,5 +1,6 @@
 class ArbitrationRule < ApplicationRecord
   ALLOWED_OPERATIONS = %w(inject disable_engine auto_reject require_approval auto_approve).freeze
+  FIELD_OBJECTS = %w(User Blueprint ServiceTemplate).freeze
   validates :operation, :inclusion => { :in => ALLOWED_OPERATIONS }
   validates :expression, :presence => true
 
@@ -7,5 +8,11 @@ class ArbitrationRule < ApplicationRecord
 
   def self.get_by_rule_class(rule_class)
     where('expression like ?', "%#{rule_class}%").order(:priority)
+  end
+
+  def self.field_values
+    FIELD_OBJECTS.flat_map do |object|
+      object.constantize.attribute_names.flat_map { |attribute| "#{object}-#{attribute}" }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2820,7 +2820,7 @@ Vmdb::Application.routes.draw do
     root :to => "api#index"
 
     # OPTIONS requests for REST API pre-flight checks
-    match '*path' => 'base#handle_options_request', :via => [:options]
+    match '/' => 'base#handle_options_request', :via => :options
 
     unless defined?(API_ACTIONS)
       API_ACTIONS = {
@@ -2828,11 +2828,15 @@ Vmdb::Application.routes.draw do
         :post   => "update",
         :put    => "update",
         :patch  => "update",
-        :delete => "destroy"
+        :delete => "destroy",
+        :options => "options"
       }.freeze
     end
 
     Api::Settings.collections.each do |collection_name, collection|
+      # OPTIONS action for each collection
+      match collection_name.to_s, :controller => collection_name, :action => :options, :via => :options
+
       scope collection_name, :controller => collection_name do
         collection.verbs.each do |verb|
           root :action => API_ACTIONS[verb], :via => verb if collection.options.include?(:primary)

--- a/spec/requests/api/arbitration_rule_spec.rb
+++ b/spec/requests/api/arbitration_rule_spec.rb
@@ -101,4 +101,25 @@ RSpec.describe 'Arbitration Rule API' do
       end.to change(ArbitrationRule, :count).by(-2)
     end
   end
+
+  context 'OPTIONS /api/arbitration_rules' do
+    it 'returns arbitration rule field_values' do
+      api_basic_authorize
+
+      attributes = (ArbitrationRule.attribute_names - ArbitrationRule.virtual_attribute_names).sort.as_json
+      reflections = (ArbitrationRule.reflections.keys | ArbitrationRule.virtual_reflections.keys.collect(&:to_s)).sort
+      expected = {
+        'attributes'         => attributes,
+        'virtual_attributes' => ArbitrationRule.virtual_attribute_names.sort.as_json,
+        'relationships'      => reflections,
+        'data'               => {
+          'field_values' => ArbitrationRule.field_values
+        }
+      }
+
+      run_options(arbitration_rules_url)
+      expect(response.parsed_body).to eq(expected)
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
+    end
+  end
 end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -360,7 +360,7 @@ describe "Querying" do
       Classification.classify(vm1, "department", "finance")
       Classification.classify(vm3, "department", "finance")
 
-      run_get vms_url, :expand  => "resources", :by_tag => "/department/finance"
+      run_get vms_url, :expand => "resources", :by_tag => "/department/finance"
 
       expect_query_result(:vms, 2, 3)
       expect_result_resources_to_include_data("resources", "name" => [vm1.name, vm3.name])
@@ -494,6 +494,21 @@ describe "Querying" do
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_only_keys(%w(id href name disconnected))
+    end
+  end
+
+  describe 'OPTIONS /api/vms' do
+    it 'returns the options information' do
+      api_basic_authorize
+      expected = {
+        'attributes'         => (Vm.attribute_names - Vm.virtual_attribute_names).sort.as_json,
+        'virtual_attributes' => Vm.virtual_attribute_names.sort.as_json,
+        'relationships'      => (Vm.reflections.keys | Vm.virtual_reflections.keys.collect(&:to_s)).sort,
+        'data'               => {}
+      }
+      run_options(vms_url)
+      expect(response.parsed_body).to eq(expected)
+      expect(response.headers['Access-Control-Allow-Methods']).to include('OPTIONS')
     end
   end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -51,6 +51,10 @@ module Spec
         delete url, :headers => update_headers(headers)
       end
 
+      def run_options(url, headers = {})
+        options url, update_headers(headers)
+      end
+
       def resources_include_suffix?(resources, key, suffix)
         resources.any? { |r| r.key?(key) && r[key].match("#{suffix}$") }
       end

--- a/spec/support/options_request.rb
+++ b/spec/support/options_request.rb
@@ -1,0 +1,5 @@
+module ActionDispatch::Integration::RequestHelpers
+  def options(path, headers = nil)
+    process :options, path, :headers => headers
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
> This was initially the creation of an API method to return a list of field-values that can be passed to an MiqExpression to help out the API team. However, it turned out to be a bigger endeavor as we needed to add this capability to the API. Based off of this, though, it should be simple in the future to return options for an API such as this.
>
> I added in a new `generic_options` method that will return options for any collection type with the response format:
> 
```
{ "attributes" : [ ], 
 "virtual_attributes" : [ ], 
 "relationships" : [ ], 
"data" : { }
  }
```
> It has support for collections to customize this method. As an example, for `ArbitrationRules`, the method `options_arbitration_rules` adds in a `field_values` attribute into `data`. Sample output
**OPTIONS /api/arbitration_rules**:
> ```
{
  "metadata": {
    "attributes": [
      "id",
      "description",
      "operation",
      "arbitration_profile_id",
      "priority",
      "expression",
      "created_at",
      "updated_at",
      "region_number",
      "region_description"
    ],
    "virtual_attributes": [
      "region_number",
      "region_description"
    ],
    "relationships": [],
    "data": {
      "field_values": [
        "User-name",
        "User-email",
        "User-userid",
        "User-region",
        "User-current_group_id",
        "User-first_name",
        "User-last_name",
        "Blueprint-name",
        "Blueprint-description",
        "Blueprint-status",
        "Blueprint-version",
        "ServiceTemplate-name",
        "ServiceTemplate-description",
        "ServiceTemplate-options",
        "ServiceTemplate-service_type",
        "ServiceTemplate-prov_type",
        "ServiceTemplate-provision_cost",
        "ServiceTemplate-service_template_catalog_id",
        "ServiceTemplate-tenant_id",
        "ServiceTemplate-blueprint_id",
        "ServiceTemplate-generic_subtype"
      ]
    }
  }
}
```
> 

~~**note** found a bug with just OPTIONS /api unless I ignore the `after_action :log_api_response`. Hoping to have a fix for that soon~~
Fixed the above. There was no logging at request start, which was making the response logging fail.

Links
-----
> @miq-bot add_label api, service broker, wip, enhancement, darga/no

cc: @imtayadeway, @abellotti 