### PR TITLE
Fix issues around specs replacing the global Settings object.

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -171,7 +171,7 @@ class MiqServer < ApplicationRecord
       _log.info("Creating Default MiqServer with guid=[#{my_guid}], zone=[#{Zone.default_zone.name}]")
       create!(:guid => my_guid, :zone => Zone.default_zone)
       my_server_clear_cache
-      Vmdb::Settings.init # Re-initialize the Settings now that we have a server record
+      ::Settings.reload! # Reload the Settings now that we have a server record
       _log.info("Creating Default MiqServer... Complete")
     end
     my_server

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -13,7 +13,7 @@ module Vmdb
 
     def self.init
       ::Config.overwrite_arrays = true
-      reset_settings_constant(for_resource(my_server))
+      reset_settings_constant(for_resource(:my_server))
       on_reload
     end
 
@@ -153,24 +153,5 @@ module Vmdb
       end
     end
     private_class_method :apply_settings_changes
-
-    # Since `#load` occurs very early in the boot process, we must ensure that
-    # we do not fail in cases where the database is not yet created, not yet
-    # available, or has not yet been seeded.
-    def self.my_server
-      resource_queryable? ? MiqServer.my_server(true) : nil
-    end
-    private_class_method :my_server
-
-    def self.resource_queryable?
-      database_connectivity? && SettingsChange.table_exists?
-    end
-    private_class_method :resource_queryable?
-
-    def self.database_connectivity?
-      conn = ActiveRecord::Base.connection rescue nil
-      conn && ActiveRecord::Base.connected?
-    end
-    private_class_method :database_connectivity?
   end
 end

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -17,8 +17,6 @@ describe Vmdb::Settings do
     end
 
     context "dumping the settings to the log directory" do
-      after { ::Settings.reload! }
-
       it "writes them" do
         ::Settings.api.token_ttl = "1.minute"
         described_class.on_reload

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,8 +1,4 @@
 describe Vmdb::Settings do
-  before do
-    skip "Affected by some global state change, needs fixing"
-  end
-
   describe ".on_reload" do
     it "is called on top-level ::Settings.reload!" do
       expect(described_class).to receive(:on_reload)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,12 +1,5 @@
 describe MiqServer do
-  describe ".seed" do
-    # Since MiqServer.seed replaces the global Settings, we need to undo
-    #   that to keep specs clean.
-    before { @orig_settings = ::Settings }
-    after  { Vmdb::Settings.send(:reset_settings_constant, @orig_settings) }
-
-    include_examples ".seed called multiple times"
-  end
+  include_examples ".seed called multiple times"
 
   it ".invoke_at_startups" do
     MiqRegion.seed

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -2,7 +2,6 @@ describe TimeProfile do
   before(:each) do
     @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
-    EvmSpecHelper.clear_caches
   end
 
   it "will default to the correct profile values" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,8 +97,8 @@ RSpec.configure do |config|
 
   config.before(:each, :rest_api => true) { init_api_spec_env }
 
-  config.after(:each) do
-    EvmSpecHelper.clear_caches
+  config.around(:each) do |example|
+    EvmSpecHelper.clear_caches { example.run }
   end
 
   if ENV["TRAVIS"] && ENV["TEST_SUITE"] == "vmdb"

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -23,6 +23,10 @@ module EvmSpecHelper
 
   # Clear all EVM caches
   def self.clear_caches
+    @settings_loaded = Vmdb::Settings.last_loaded
+
+    yield if block_given?
+  ensure
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
 
     clear_instance_variables(MiqEnvironment::Command)
@@ -31,6 +35,8 @@ module EvmSpecHelper
 
     # Clear the thread local variable to prevent test contamination
     User.current_user = nil if defined?(User) && User.respond_to?(:current_user=)
+
+    ::Settings.reload! if @settings_loaded != Vmdb::Settings.last_loaded
   end
 
   def self.clear_instance_variables(instance)


### PR DESCRIPTION
Prior to this change, MiqServer.seed would call Vmdb::Settings.init,
which would replace the global Settings object.  So, when this method
was called in specs, it would taint the global Settings object with one
that was attached to an MiqServer record that would eventually be
removed.  After that, any test that called Settings.reload! would fail
because that MiqServer record would not exist.

In addition, in specs, a user can create a "local" MiqServer object in a
number of ways, and it is expected that the Settings object will react
accordingly, so we can't just "ignore" the problem in specs.

This commit does 3 changes that work together.

1. Vmdb::Settings.init will no longer create a Settings object with the
  literal instance of MiqServer.my_server, but instead creates it with a
  placeholder that tells the DatabaseSource to dynamically load
  MiqServer.my_server on Settings.reload!.
2. Since Settings.reload! will dynamically fetch MiqServer.my_server,
  there is no need for MiqServer.seed to re-initialize the global
  Settings object, and can instead just call Settings.reload!
3. In specs, if the global Settings object has been reloaded, we will
  know, based on the value of Vmdb::Settings.last_loaded, so we can now
  undo any changes made by the tests.

@jrafanie Please review.
cc @chrisarcand 