### PR TITLE
Convert SQL to AR in FixServiceOrderPlacedAt migration

### DIFF
--- a/db/migrate/20160628140841_fix_service_order_placed_at.rb
+++ b/db/migrate/20160628140841_fix_service_order_placed_at.rb
@@ -2,11 +2,8 @@ class FixServiceOrderPlacedAt < ActiveRecord::Migration[5.0]
   class ServiceOrder < ActiveRecord::Base; end
 
   def up
-    update <<-SQL
-      UPDATE "service_orders"
-      SET "placed_at" = "updated_at"
-      WHERE "state" = 'ordered'
-      AND "placed_at" IS NULL
-    SQL
+    say_with_time('Update placed_at in ordered ServiceOrders') do
+      ServiceOrder.where(:state => 'ordered', :placed_at => nil).update_all('placed_at = updated_at')
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
refactoring: using ActiveRecord instead of sql

cc @himdel 

Links
-----
https://github.com/ManageIQ/manageiq/pull/9539

@miq-bot add_label refactoring,  sql migration



