### PR TITLE
Exclude cloud tenant option when it is an empty string

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -43,7 +43,7 @@ class ServiceOrchestration < Service
 
   def build_stack_options_from_dialog(dialog_options)
     tenant_name = OptionConverter.get_tenant_name(dialog_options)
-    tenant_option = tenant_name ? {:tenant_name => tenant_name} : {}
+    tenant_option = tenant_name.blank? ? {} : {:tenant_name => tenant_name}
 
     converter = OptionConverter.get_converter(dialog_options || {}, orchestration_manager.class)
     converter.stack_create_options.merge(tenant_option)

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -61,6 +61,23 @@ describe ServiceOrchestration do
       expect(service_with_dialog_options.stack_options).to eq(dialog_options)
     end
 
+    context "cloud tenant option" do
+      it "parses a valid tenant option" do
+        dialog_options['dialog_tenant_name'] = 'abc'
+        expect(service_with_dialog_options.stack_options).to include(:tenant_name => 'abc')
+      end
+
+      it "excludes the tenant option when it is nil" do
+        dialog_options['dialog_tenant_name'] = nil
+        expect(service_with_dialog_options.stack_options).not_to include(:tenant_name)
+      end
+
+      it "excludes thetenant option when it is empty" do
+        dialog_options['dialog_tenant_name'] = ''
+        expect(service_with_dialog_options.stack_options).not_to include(:tenant_name)
+      end
+    end
+
     it "gets stack options from overridden values" do
       new_options = {"any_key" => "any_value"}
       service_with_dialog_options.stack_options = new_options


### PR DESCRIPTION
Purpose or Intent
-----------------
If there is no user selected cloud tenant, the backend expect the `tenant_name` to be `nil`. For SSUI since the options need to be passed through REST, `nil` was converted to an empty string. The fix is to treat an empty string as no tenant option.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1370502


Steps for Testing/QA
--------------------
> Follow the steps in
https://bugzilla.redhat.com/show_bug.cgi?id=1370502
The reported provider is Amazon