### PR TITLE
Enable hourly database maintenance configuration via appliance_console

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -61,6 +61,7 @@ MiqPassword.key_root = "#{RAILS_ROOT}/certs"
 # Load appliance_console libraries
 require 'appliance_console/utilities'
 require 'appliance_console/logging'
+require 'appliance_console/database_maintenance'
 require 'appliance_console/database_configuration'
 require 'appliance_console/internal_database_configuration'
 require 'appliance_console/external_database_configuration'
@@ -525,6 +526,18 @@ Static Network Configuration
 
         say("Failover Monitor Service configured successfully")
         press_any_key
+
+      when I18n.t("advanced_settings.db_maintenance")
+        say("#{selection}\n\n")
+        db_maintenance = ApplianceConsole::DatabaseMaintenance.new
+        if db_maintenance.ask_questions && db_maintenance.activate
+          say("Database maintenance configuration updated")
+          press_any_key
+        else
+          say("Database maintenance configuration unchanged")
+          press_any_key
+          raise MiqSignalError
+        end
 
       when I18n.t("advanced_settings.tmp_config")
         say("#{selection}\n\n")

--- a/gems/pending/appliance_console/database_maintenance.rb
+++ b/gems/pending/appliance_console/database_maintenance.rb
@@ -1,0 +1,61 @@
+require 'appliance_console/logging'
+require 'appliance_console/prompts'
+require 'fileutils'
+
+module ApplianceConsole
+  class DatabaseMaintenance
+    include ApplianceConsole::Logging
+
+    HOURLY_CRON = "/etc/cron.hourly/miq-pg-maintenance-hourly.cron".freeze
+
+    def ask_questions
+      clear_screen
+      confirm
+    end
+
+    def activate
+      say("Configuring Database Maintenance...")
+      if hourly_configured?
+        deactivate_hourly
+      else
+        configure_hourly
+      end
+    end
+
+    private
+
+    def configure_hourly
+      say("Configuring Hourly Database Maintenance...")
+      write_hourly_cron
+      FileUtils.chmod(0755, HOURLY_CRON)
+      true
+    end
+
+    def confirm
+      if hourly_configured?
+        agree("Hourly Database Maintenance is already configured, Un-Configure (Y/N):")
+      else
+        agree("Configure Database Maintenance? (Y/N): ")
+      end
+    end
+
+    def deactivate_hourly
+      FileUtils.rm_f(HOURLY_CRON)
+      true
+    end
+
+    def hourly_configured?
+      File.exist?(HOURLY_CRON)
+    end
+
+    def write_hourly_cron
+      File.open(HOURLY_CRON, "w") do |f|
+        f.write("#!/bin/sh\n")
+        f.write("/usr/bin/hourly_reindex_metrics_tables\n")
+        f.write("/usr/bin/hourly_reindex_miq_queue_table\n")
+        f.write("/usr/bin/hourly_reindex_miq_workers_table\n")
+        f.write("exit 0\n")
+      end
+    end
+  end # class DatabaseMaintenance < DatabaseConfiguration
+end # module ApplianceConsole

--- a/gems/pending/appliance_console/locales/appliance/en.yml
+++ b/gems/pending/appliance_console/locales/appliance/en.yml
@@ -13,6 +13,7 @@ en:
     - dbrestore
     - db_config
     - db_replication
+    - db_maintenance
     - failover_monitor
     - httpdauth
     - extauth_opts
@@ -32,6 +33,7 @@ en:
     dbrestore: Restore Database From Backup
     db_config: Configure Database
     db_replication: Configure Database Replication
+    db_maintenance: Configure Database Maintenance
     failover_monitor: Configure Application Database Failover Monitor
     httpdauth: Configure External Authentication (httpd)
     extauth_opts: Update External Authentication Options

--- a/gems/pending/appliance_console/locales/container/en.yml
+++ b/gems/pending/appliance_console/locales/container/en.yml
@@ -8,6 +8,7 @@ en:
     - dbrestore
     - db_config
     - db_replication
+    - db_maintenance
     - failover_monitor
     - key_gen
     - evmstop
@@ -19,6 +20,7 @@ en:
     dbrestore: Restore Database From Backup
     db_config: Configure Database
     db_replication: Configure Database Replication
+    db_maintenance: Configure Database Maintenance
     failover_monitor: Configure Application Database Failover Monitor
     evmstop: Stop EVM Server Processes
     key_gen: Generate Custom Encryption Key

--- a/gems/pending/spec/appliance_console/database_maintenance_spec.rb
+++ b/gems/pending/spec/appliance_console/database_maintenance_spec.rb
@@ -1,0 +1,104 @@
+require "appliance_console/prompts"
+require "appliance_console/database_maintenance"
+require "fileutils"
+require "tempfile"
+require "tmpdir"
+
+describe ApplianceConsole::DatabaseMaintenance do
+  DIRNAME = File.dirname(__FILE__).freeze
+
+  before do
+    allow(subject).to receive(:say)
+  end
+
+  describe "#ask_questions" do
+    before do
+      allow(subject).to receive(:say)
+      allow(subject).to receive(:clear_screen)
+      allow(subject).to receive(:agree)
+    end
+
+    context "when an hourly cron job does not exist" do
+      before do
+        test_hourly_cron = "#{Dir.tmpdir}/miq-pg-maintenance-hourly.cron"
+        stub_const("ApplianceConsole::DatabaseMaintenance::HOURLY_CRON", test_hourly_cron)
+      end
+
+      it "returns true when configure is confirmed" do
+        expect(subject).to receive(:agree).with(/configure database maintenance/i).and_return(true)
+        expect(subject.ask_questions).to be true
+      end
+
+      it "returns false when configure is not confirmed" do
+        expect(subject).to receive(:agree).with(/configure database maintenance/i).and_return(false)
+        expect(subject.ask_questions).to be false
+      end
+    end
+
+    context "when an hourly cron job does exist" do
+      before do
+        @test_hourly_cron = Tempfile.new(subject.class.name.split("::").last.downcase)
+        stub_const("ApplianceConsole::DatabaseMaintenance::HOURLY_CRON", @test_hourly_cron.path)
+      end
+
+      after do
+        FileUtils.rm_f(@test_hourly_cron.path)
+      end
+
+      it "returns true when un-configure is confirmed" do
+        expect(subject).to receive(:agree).with(/un-configure/i).and_return(true)
+        expect(subject.ask_questions).to be true
+      end
+
+      it "returns false when un-configure is not confirmed" do
+        expect(subject).to receive(:agree).with(/un-configure/i).and_return(false)
+        expect(subject.ask_questions).to be false
+      end
+    end
+  end
+
+  describe "#activate" do
+    context "when an hourly cron job does not exist" do
+      before do
+        @test_hourly_cron = "#{Dir.tmpdir}/miq-pg-maintenance-hourly.cron"
+        stub_const("ApplianceConsole::DatabaseMaintenance::HOURLY_CRON", @test_hourly_cron)
+      end
+
+      after do
+        FileUtils.rm_f(@test_hourly_cron)
+      end
+
+      let(:expected_cron_file) do
+        <<-EOT.strip_heredoc
+          #!/bin/sh
+          /usr/bin/hourly_reindex_metrics_tables
+          /usr/bin/hourly_reindex_miq_queue_table
+          /usr/bin/hourly_reindex_miq_workers_table
+          exit 0
+        EOT
+      end
+
+      it "adds a new hourly cron job" do
+        expect(FileUtils).to receive(:chmod).with(0755, @test_hourly_cron)
+        subject.activate
+        expect(File.read(@test_hourly_cron)).to eq(expected_cron_file)
+      end
+    end
+
+    context "when an hourly cron job does exist" do
+      before do
+        @test_hourly_cron = Tempfile.new(subject.class.name.split("::").last.downcase)
+        stub_const("ApplianceConsole::DatabaseMaintenance::HOURLY_CRON", @test_hourly_cron.path)
+      end
+
+      after do
+        FileUtils.rm_f(@test_hourly_cron.path)
+      end
+
+      it "removes the existing hourly cron job" do
+        subject.activate
+        expect(File.exist?(@test_hourly_cron.path)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
This PR adds functionality to the appliance_console to support the configuration of
hourly database maintenance.


Links
-----
* https://www.pivotaltracker.com/n/projects/1608513/stories/128645799


https://www.pivotaltracker.com/n/projects/1608513/stories/128645799