### PR TITLE
Display the error flash message right inside the form instead of displaying it in the GTL view

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -196,11 +196,10 @@ class ProviderForemanController < ApplicationController
       replace_right_cell([:configuration_manager_providers])
     else
       @provider_cfgmgmt.errors.each do |field, msg|
-        @in_a_form = false
         @sb[:action] = nil
         add_flash("#{field.to_s.capitalize} #{msg}", :error)
       end
-      replace_right_cell
+      render_flash
     end
   end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -164,7 +164,7 @@ describe ProviderForemanController do
       provider2 = ManageIQ::Providers::Foreman::Provider.new(:name => "test2Foreman",
                                                              :url => "10.8.96.103", :zone => @zone)
       controller.instance_variable_set(:@provider_cfgmgmt, provider2)
-      expect(controller).to receive(:replace_right_cell).once
+      allow(controller).to receive(:render_flash)
       controller.save_provider_foreman
       expect(assigns(:flash_array).first[:message]).to include("Configuration_manager.name has already been taken")
     end


### PR DESCRIPTION
While creating a new Foreman/Ansible provider record, if there are errors during the Save operation they need to be displayed right inside the form instead of transitioning the form to the GTL view and then displaying the errors there.
This way one can take whatever corrective actions are needed while the form is active.

Screenshots
-------------
Before -- Error Flash messages in the GTL during a Save operation

<img width="1190" alt="screen shot 2016-08-30 at 4 07 32 pm" src="https://cloud.githubusercontent.com/assets/1538216/18110307/035b34ae-6ecc-11e6-8902-26f3ae67eefd.png">

After -- Error Flash messages right inside the form during a Save operation

<img width="1189" alt="screen shot 2016-08-30 at 3 56 39 pm" src="https://cloud.githubusercontent.com/assets/1538216/18110339/1d5088be-6ecc-11e6-8d27-78616d2162a8.png">



https://bugzilla.redhat.com/show_bug.cgi?id=1321973