### PR TITLE
Displaying middleware messaging entities in the topology graph.

### DIFF
--- a/app/models/mixins/ui_service_mixin.rb
+++ b/app/models/mixins/ui_service_mixin.rb
@@ -14,6 +14,7 @@ module UiServiceMixin
       :MiddlewareDeploymentEar => {:type => "glyph", :icon => "\uE626", :fontfamily => "icomoon"},                 # product-file-ear-o
       :MiddlewareDeploymentWar => {:type => "glyph", :icon => "\uE627", :fontfamily => "icomoon"},                 # product-file-war-o
       :MiddlewareDomain        => {:type => "glyph", :icon => "\uF0E8", :fontfamily => "FontAwesome"},             # fa-sitemap
+      :MiddlewareMessaging     => {:type => "glyph", :icon => "\uF0EC", :fontfamily => "FontAwesome"},             # fa-exchange (placeholder)
       :MiddlewareServerGroup   => {:type => "glyph", :icon => "\uF00A", :fontfamily => "FontAwesome"},             # fa-th
       :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
       :Openshift               => {:type => "image", :icon => provider_icon(:Openshift)},

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -20,7 +20,7 @@ class MiddlewareTopologyService < TopologyService
         :MiddlewareServers => {
           :MiddlewareDeployments => nil,
           :MiddlewareDatasources => nil,
-          :MiddlewareMessagings => nil,
+          :MiddlewareMessagings  => nil,
           :lives_on              => {:Host => nil}
         }}}
 

--- a/app/services/middleware_topology_service.rb
+++ b/app/services/middleware_topology_service.rb
@@ -20,6 +20,7 @@ class MiddlewareTopologyService < TopologyService
         :MiddlewareServers => {
           :MiddlewareDeployments => nil,
           :MiddlewareDatasources => nil,
+          :MiddlewareMessagings => nil,
           :lives_on              => {:Host => nil}
         }}}
 
@@ -69,13 +70,13 @@ class MiddlewareTopologyService < TopologyService
   end
 
   def glyph?(entity)
-    [MiddlewareDatasource, MiddlewareDeployment, Vm, MiddlewareDomain, MiddlewareServerGroup]
+    [MiddlewareDatasource, MiddlewareDeployment, Vm, MiddlewareDomain, MiddlewareServerGroup, MiddlewareMessaging]
       .any? { |klass| entity.kind_of? klass }
   end
 
   def build_kinds
     kinds = [:MiddlewareDeployment, :MiddlewareDatasource, :MiddlewareDomain, :MiddlewareManager, :Vm,
-             :MiddlewareServer, :MiddlewareServerGroup]
+             :MiddlewareServer, :MiddlewareServerGroup, :MiddlewareMessaging]
     build_legend_kinds(kinds)
   end
 end

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -29,6 +29,14 @@
             %text{:x => "0", :y => "6", :class => "fa fa-database glyph"} &#xF1C0;
         %label
           = _("Middleware Datasources")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareMessaging"}
+        %svg.kube-topology
+          %g.MiddlewareMessaging{:transform => "translate(21, 21)"}
+            %circle{:r => "17"}
+            -# fa-exchange (placeholder)
+            %text{:x => "0", :y => "6", :class => "fa fa-exchange glyph"} &#xF0EC;
+        %label
+          = _("Message Destinations")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
         %svg.kube-topology
           %g.EntityLegend.Infra

--- a/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
+++ b/spec/javascripts/controllers/middleware/middleware_topology_controller_spec.js
@@ -79,6 +79,17 @@ describe('middlewareTopologyController', function () {
     }
   };
 
+  var mw_messaging = {
+    id: "MiddlewareMessaging1",
+    item: {
+      "name": "JMS Topic [HawkularMetricData]",
+      "kind": "MiddlewareMessaging",
+      "miq_id": 1,
+      "status": "Unknown",
+      "display_kind": "MiddlewareMessaging"
+    }
+  };
+
   beforeEach(module('mwTopologyApp'));
 
   beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, $location) {
@@ -108,7 +119,7 @@ describe('middlewareTopologyController', function () {
 
   describe('kinds contains all expected mw kinds', function () {
     it('in all main objects', function () {
-      expect(Object.keys(scope.kinds).length).toBe(7);
+      expect(Object.keys(scope.kinds).length).toBe(8);
       expect(scope.kinds["MiddlewareManager"]).toBeDefined();
       expect(scope.kinds["MiddlewareServer"]).toBeDefined();
       expect(scope.kinds["MiddlewareDeployment"]).toBeDefined();
@@ -116,6 +127,7 @@ describe('middlewareTopologyController', function () {
       expect(scope.kinds["Vm"]).toBeDefined();
       expect(scope.kinds["MiddlewareDomain"]).toBeDefined();
       expect(scope.kinds["MiddlewareServerGroup"]).toBeDefined();
+      expect(scope.kinds["MiddlewareMessaging"]).toBeDefined();
     });
   });
 
@@ -129,6 +141,7 @@ describe('middlewareTopologyController', function () {
       expect($controller.getIcon(vm).fontfamily).toEqual("PatternFlyIcons-webfont");
       expect($controller.getIcon(mw_domain).fontfamily).toEqual("FontAwesome");
       expect($controller.getIcon(mw_server_group).fontfamily).toEqual("FontAwesome");
+      expect($controller.getIcon(mw_messaging).fontfamily).toEqual("FontAwesome");
     });
   });
 
@@ -141,6 +154,7 @@ describe('middlewareTopologyController', function () {
       expect($controller.getCircleDimensions(vm)).toEqual({ x: 0, y: 9, height: 40, width: 40, r: 21 });
       expect($controller.getCircleDimensions(mw_domain)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
       expect($controller.getCircleDimensions(mw_server_group)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
+      expect($controller.getCircleDimensions(mw_messaging)).toEqual({x: -9, y: -9, height: 18, width: 18, r: 17});
     });
   });
 
@@ -153,6 +167,7 @@ describe('middlewareTopologyController', function () {
       expect($controller.getIcon(vm).type).toEqual("glyph");
       expect($controller.getIcon(mw_domain).type).toEqual("glyph");
       expect($controller.getIcon(mw_server_group).type).toEqual("glyph");
+      expect($controller.getIcon(mw_messaging).type).toEqual("glyph");
     });
   });
 

--- a/spec/javascripts/fixtures/json/middleware_topology_response.json
+++ b/spec/javascripts/fixtures/json/middleware_topology_response.json
@@ -119,7 +119,8 @@
       "MiddlewareManager": true,
       "Vm": true,
       "MiddlewareServer": true,
-      "MiddlewareServerGroup": true
+      "MiddlewareServerGroup": true,
+      "MiddlewareMessaging": true
     },
     "icons": {
       "ContainerReplicator": {
@@ -185,6 +186,11 @@
       "MiddlewareDomain": {
         "type": "glyph",
         "icon": "",
+        "fontfamily": "FontAwesome"
+      },
+      "MiddlewareMessaging": {
+        "type": "glyph",
+        "icon": "",
         "fontfamily": "FontAwesome"
       },
       "MiddlewareServerGroup": {

--- a/spec/services/middleware_topology_service_spec.rb
+++ b/spec/services/middleware_topology_service_spec.rb
@@ -8,7 +8,7 @@ describe MiddlewareTopologyService do
   describe "#build_kinds" do
     it "creates the expected number of entity types" do
       supported_kinds = [:MiddlewareServer, :MiddlewareDeployment, :MiddlewareDatasource, :MiddlewareManager, :Vm,
-                         :MiddlewareDomain, :MiddlewareServerGroup]
+                         :MiddlewareDomain, :MiddlewareServerGroup, :MiddlewareMessaging]
       expect(middleware_topology_service.build_kinds.keys).to match_array(supported_kinds)
     end
   end
@@ -45,6 +45,13 @@ describe MiddlewareTopologyService do
                                                       :name                  => "ExampleDS",
                                                       :nativeid              => "Local~/subsystem=datasources/"\
                                                             "data-source=ExampleDS")
+
+      md_messaging = MiddlewareMessaging.create(:ext_management_system => ems_hawkular,
+                                                :middleware_server     => middleware_server,
+                                                :ems_ref               => long_id_2,
+                                                :name                  => "JMS Topic [HawkularMetricData]",
+                                                :nativeid              => "Local~/subsystem=messaging-"\
+                                                      "activemq/server=default/jms-topic=HawkularMetricData")
       expect(subject[:items]).to eq(
         "MiddlewareManager" + ems_hawkular.compressed_id.to_s              => {:name         => ems_hawkular.name,
                                                                                :status       => "Unknown",
@@ -77,9 +84,15 @@ describe MiddlewareTopologyService do
                                                                                :kind         => "MiddlewareDatasource",
                                                                                :display_kind => "MiddlewareDatasource",
                                                                                :miq_id       => mddlwr_datasource.id},
+
+        "MiddlewareMessaging" + md_messaging.compressed_id.to_s            => {:name         => md_messaging.name,
+                                                                               :status       => "Unknown",
+                                                                               :kind         => "MiddlewareMessaging",
+                                                                               :display_kind => "MiddlewareMessaging",
+                                                                               :miq_id       => md_messaging.id},
       )
 
-      expect(subject[:relations].size).to eq(4)
+      expect(subject[:relations].size).to eq(5)
       expect(subject[:relations]).to include(
         {:source => "MiddlewareManager" + ems_hawkular.compressed_id.to_s,
          :target => "MiddlewareServer" + middleware_server.compressed_id.to_s},
@@ -88,7 +101,9 @@ describe MiddlewareTopologyService do
         {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s,
          :target => "MiddlewareDeployment" + middleware_deployment2.compressed_id.to_s},
         {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s,
-         :target => "MiddlewareDatasource" + mddlwr_datasource.compressed_id.to_s}
+         :target => "MiddlewareDatasource" + mddlwr_datasource.compressed_id.to_s},
+        {:source => "MiddlewareServer" + middleware_server.compressed_id.to_s,
+         :target => "MiddlewareMessaging" + md_messaging.compressed_id.to_s}
       )
     end
   end


### PR DESCRIPTION
SSIA :]

todo:
- [x] tests

![screenshot from 2016-08-31 12-45-33](https://cloud.githubusercontent.com/assets/535866/18125918/17c402f6-6f79-11e6-82de-ebfad96791f6.png)


cc @abonas 
@miq-bot add_labels enhancement, providers/hawkular, ui, topology, wip, darga/no