### PR TITLE
Adding custom attributes to provider (UI + API)

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -13,6 +13,7 @@ module Api
     include Subcollections::PolicyProfiles
     include Subcollections::Tags
     include Subcollections::CloudNetworks
+    include Subcollections::CustomAttributes
 
     def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)
@@ -52,6 +53,18 @@ module Api
 
     private
 
+    def update_provider_custom_attributes(provider, custom_attributes)
+      custom_attributes.each do |attribute|
+        if CustomAttribute::ALLOWED_API_FIELD_TYPES.include? attribute["field_type"]
+          attribute["value"] = attribute["field_type"].safe_constantize.parse(attribute["value"])
+        end
+        attribute["section"] = "metadata"
+        custom_attributes_add_resource(provider, nil, nil, attribute)
+      end
+    rescue => err
+      raise BadRequestError, "Could not update the provider custom attributes - #{err}"
+    end
+
     def provider_ident(provider)
       "Provider id:#{provider.id} name:'#{provider.name}'"
     end
@@ -72,9 +85,11 @@ module Api
 
     def create_provider(data)
       provider_klass = fetch_provider_klass(collection_class(:providers), data)
+      custom_attributes = data.delete("custom_attributes")
       create_data    = fetch_provider_data(provider_klass, data, :requires_zone => true)
       provider       = provider_klass.create!(create_data)
       update_provider_authentication(provider, data)
+      update_provider_custom_attributes(provider, custom_attributes) if custom_attributes
       provider
     rescue => err
       provider.destroy if provider
@@ -82,8 +97,10 @@ module Api
     end
 
     def edit_provider(provider, data)
+      custom_attributes = data.delete("custom_attributes")
       update_data = fetch_provider_data(provider.class, data)
       provider.update_attributes(update_data) if update_data.present?
+      update_provider_custom_attributes(provider, custom_attributes) if custom_attributes
       update_provider_authentication(provider, data)
       provider
     rescue => err

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -106,4 +106,10 @@ module EmsContainerHelper::TextualSummary
      {:label => _('Hawkular API Port'),
       :value => @ems.connection_configurations.hawkular.endpoint.port}]
   end
+
+  def textual_miq_custom_attributes
+    attrs = @record.custom_attributes
+    return nil if attrs.blank?
+    attrs.collect { |a| {:label => a.name.tr("_", " "), :value => a.value} }
+  end
 end

--- a/app/models/custom_attribute.rb
+++ b/app/models/custom_attribute.rb
@@ -1,5 +1,5 @@
 class CustomAttribute < ApplicationRecord
-  ALLOWED_API_FIELD_TYPES = %w(DateTime Time Date).freeze
+  ALLOWED_API_VALUE_TYPES = %w(DateTime Time Date).freeze
   belongs_to :resource, :polymorphic => true
   serialize :serialized_value
 

--- a/app/models/custom_attribute.rb
+++ b/app/models/custom_attribute.rb
@@ -1,4 +1,5 @@
 class CustomAttribute < ApplicationRecord
+  ALLOWED_API_FIELD_TYPES = %w(DateTime Time Date).freeze
   belongs_to :resource, :polymorphic => true
   serialize :serialized_value
 

--- a/app/views/ems_container/_main.html.haml
+++ b/app/views/ems_container/_main.html.haml
@@ -9,6 +9,8 @@
     -# commented out to hide Component Statuses table since the information is currently broken (see Issue #8572)
     -# = render :partial => "shared/summary/textual_multilabel", :locals => {:title => _("Component Statuses"),
     -#                                                           :items => textual_group_component_statuses}
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Custom Attributes"),
+                                                                    :items => textual_miq_custom_attributes}
   .col-sm-12.col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
                                                                :items => textual_group_relationships}

--- a/config/api.yml
+++ b/config/api.yml
@@ -742,6 +742,7 @@
     - :policies
     - :policy_profiles
     - :cloud_networks
+    - :custom_attributes
     :collection_actions:
       :get:
       - :name: read
@@ -777,6 +778,14 @@
         :identifier: ems_infra_tag
       - :name: unassign
         :identifier: ems_infra_tag
+    :custom_attributes_subcollection_actions:
+      :post:
+      - :name: add
+        :identifier: ems_infra_edit
+      - :name: edit
+        :identifier: ems_infra_edit
+      - :name: delete
+        :identifier: ems_infra_edit
     :policies_subcollection_actions:
       :post:
       - :name: assign

--- a/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
@@ -1,6 +1,6 @@
 describe EmsContainerHelper::TextualSummary do
   context "providers custom attributes" do
-    before :each do
+    before do
       @record = FactoryGirl.build(:ems_openshift)
       allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
       allow(controller).to receive(:restful?).and_return(true)
@@ -8,7 +8,9 @@ describe EmsContainerHelper::TextualSummary do
     end
 
     it "should parse custom attributes to labels and values" do
-      @record.custom_attributes << FactoryGirl.build(:custom_attribute, :name => "Example_custom_attribute", :value => 4)
+      @record.custom_attributes << FactoryGirl.build(:custom_attribute,
+                                                     :name  => "Example_custom_attribute",
+                                                     :value => 4)
 
       expect(textual_miq_custom_attributes.first[:label]).to eq("Example custom attribute")
 

--- a/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
+++ b/spec/helpers/ems_cotainer_helper/textual_summary_spec.rb
@@ -1,0 +1,22 @@
+describe EmsContainerHelper::TextualSummary do
+  context "providers custom attributes" do
+    before :each do
+      @record = FactoryGirl.build(:ems_openshift)
+      allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
+      allow(controller).to receive(:restful?).and_return(true)
+      allow(controller).to receive(:controller_name).and_return("ems_container")
+    end
+
+    it "should parse custom attributes to labels and values" do
+      @record.custom_attributes << FactoryGirl.build(:custom_attribute, :name => "Example_custom_attribute", :value => 4)
+
+      expect(textual_miq_custom_attributes.first[:label]).to eq("Example custom attribute")
+
+      expect(textual_miq_custom_attributes.first[:value]).to eq("4")
+    end
+
+    it "should return nil if no custom attributes" do
+      expect(textual_miq_custom_attributes).to eq(nil)
+    end
+  end
+end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -100,20 +100,130 @@ describe "Providers API" do
     }
   end
 
-  let(:custom_attributes) do
-    [{
-       "name"       => "expiration_date",
-       "value"      => "2016-09-07 14:32:08 +0300",
-       "field_type" => "Date"
-     },
-     {
-       "name"  => "expected_number_of_nodes",
-       "value" => 2
-     },
-     {
-       "name"  => "sales_force_acount",
-       "value" => "ADF231fdsaVRWQ1"
-     }]
+  context "Provider custom_attributes" do
+    let(:provider) { FactoryGirl.create(:ext_management_system, sample_rhevm) }
+    let(:provider_url) { providers_url(provider.id) }
+    let(:ca1) { FactoryGirl.create(:custom_attribute, :name => "name1", :value => "value1") }
+    let(:ca2) { FactoryGirl.create(:custom_attribute, :name => "name2", :value => "value2") }
+    let(:provider_ca_url) { "#{provider_url}/custom_attributes" }
+    let(:ca1_url) { "#{provider_ca_url}/#{ca1.id}" }
+    let(:ca2_url) { "#{provider_ca_url}/#{ca2.id}" }
+    let(:provider_ca_url_list) { [ca1_url, ca2_url] }
+
+    it "getting custom_attributes from a provider with no custom_attributes" do
+      api_basic_authorize
+
+      run_get(provider_ca_url)
+
+      expect_empty_query_result(:custom_attributes)
+    end
+
+    it "getting custom_attributes from a provider" do
+      api_basic_authorize
+      provider.custom_attributes = [ca1, ca2]
+
+      run_get provider_ca_url
+
+      expect_query_result(:custom_attributes, 2)
+
+      expect_result_resources_to_include_hrefs("resources", :provider_ca_url_list)
+    end
+
+    it "getting custom_attributes from a provider in expanded form" do
+      api_basic_authorize
+      provider.custom_attributes = [ca1, ca2]
+
+      run_get provider_ca_url, :expand => "resources"
+
+      expect_query_result(:custom_attributes, 2)
+
+      expect_result_resources_to_include_data("resources", "name" => %w(name1 name2))
+    end
+
+    it "getting custom_attributes from a provider using expand" do
+      api_basic_authorize action_identifier(:providers, :read, :resource_actions, :get)
+      provider.custom_attributes = [ca1, ca2]
+
+      run_get provider_url, :expand => "custom_attributes"
+
+      expect_single_resource_query("guid" => provider.guid)
+
+      expect_result_resources_to_include_data("custom_attributes", "name" => %w(name1 name2))
+    end
+
+    it "delete a custom_attribute without appropriate role" do
+      api_basic_authorize
+      provider.custom_attributes = [ca1]
+
+      run_post(provider_ca_url, gen_request(:delete, nil, provider_url))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "delete a custom_attribute from a provider via the delete action" do
+      api_basic_authorize action_identifier(:providers, :edit)
+      provider.custom_attributes = [ca1]
+
+      run_post(provider_ca_url, gen_request(:delete, nil, ca1_url))
+
+      expect(response).to have_http_status(:ok)
+
+      expect(provider.reload.custom_attributes).to be_empty
+    end
+
+    it "add custom attribute to a provider without a name" do
+      api_basic_authorize action_identifier(:providers, :edit)
+
+      run_post(provider_ca_url, gen_request(:add, "value" => "value1"))
+
+      expect_bad_request("Must specify a name")
+    end
+
+    it "add custom attributes to a provider" do
+      api_basic_authorize action_identifier(:providers, :edit)
+
+      run_post(provider_ca_url, gen_request(:add, [{"name" => "name1", "value" => "value1"},
+                                                   {"name" => "name2", "value" => "value2"}]))
+      expected = {
+        "results" => a_collection_containing_exactly(
+          a_hash_including("name" => "name1", "value" => "value1", "section" => "metadata"),
+          a_hash_including("name" => "name2", "value" => "value2", "section" => "metadata")
+        )
+      }
+      expect(response).to have_http_status(:ok)
+
+      expect(response.parsed_body).to include(expected)
+
+      expect(provider.custom_attributes.size).to eq(2)
+    end
+
+    it "formats custom attribute of type date" do
+      api_basic_authorize action_identifier(:providers, :edit)
+      date_field = DateTime.new.in_time_zone
+
+      run_post(provider_ca_url, gen_request(:add, [{"name"       => "name1",
+                                                    "value"      => date_field,
+                                                    "field_type" => "DateTime"}]))
+
+      expect(response).to have_http_status(:ok)
+
+      expect(provider.custom_attributes.first.serialized_value).to eq(date_field)
+
+      expect(provider.custom_attributes.first.section).to eq("metadata")
+    end
+
+    it "edit a custom attribute by name" do
+      api_basic_authorize action_identifier(:providers, :edit)
+      provider.custom_attributes = [ca1]
+
+      run_post(provider_ca_url, gen_request(:edit, "name" => "name1", "value" => "value one"))
+
+      expect(response).to have_http_status(:ok)
+
+      expect_result_resources_to_include_data("results", "value" => ["value one"])
+
+      expect(provider.reload.custom_attributes.first.value).to eq("value one")
+    end
   end
 
   describe "Providers actions on Provider class" do
@@ -170,24 +280,6 @@ describe "Providers API" do
       run_post(providers_url, sample_rhevm)
 
       expect(response).to have_http_status(:forbidden)
-    end
-
-    it "creates provider with custom attributes" do
-      api_basic_authorize collection_action_identifier(:providers, :create)
-      run_post(providers_url, sample_rhevm.merge!("custom_attributes" => custom_attributes))
-      provider = ExtManagementSystem.find_by(:name => "sample rhevm")
-
-      expect(provider.custom_attributes.count).to eq(3)
-
-      expect(CustomAttribute.find_by_name("expiration_date").serialized_value.class).to eq(Date)
-
-      expect(CustomAttribute.find_by_name("expected_number_of_nodes").serialized_value.class).to eq(Fixnum)
-
-      expect(CustomAttribute.find_by_name("sales_force_acount").serialized_value.class).to eq(String)
-
-      expect(CustomAttribute.where(:section => "metadata").count).to eq(3)
-
-      expect(response).to have_http_status(:success)
     end
 
     it "rejects provider creation with id specified" do
@@ -364,21 +456,6 @@ describe "Providers API" do
       run_post(providers_url, gen_request(:edit, "name" => "provider name", "href" => providers_url(999_999)))
 
       expect(response).to have_http_status(:forbidden)
-    end
-
-    it "edits a provider custom_attribute" do
-      api_basic_authorize collection_action_identifier(:providers, :edit)
-      provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
-
-      expect(provider.custom_attributes.count).to eq(0)
-
-      run_post(providers_url, gen_request(:edit, "id" => provider.id, "custom_attributes" => custom_attributes))
-
-      expect(provider.custom_attributes.count).to eq(3)
-
-      expect(CustomAttribute.where(:section => "metadata").count).to eq(3)
-
-      expect(response).to have_http_status(:success)
     end
 
     it "rejects edits for invalid resources" do


### PR DESCRIPTION
**New view**
![selection_101](https://cloud.githubusercontent.com/assets/11405684/18248328/29cdc0e4-7380-11e6-9ea7-24dd66bb9d8c.png)

**Added a new api endpoint:**
url: http://localhost:3000/api/providers/3/custom_attributes
method: Post

Request.payload:
```json
{
	"action": "add/edit/delete",
	"resources": [{
		"name": "exp_date",
		"value": "1.2.2016",
		"field_type": "Date"
	}, {
		"name": "expected_num_of_nodes",
		"value": 2
	}, {
		"name": "sales_force_acount",
		"value": "ADF231VRWQ1"
	}]
}
```