### PR TITLE
Force jasmine-core 2.4.1 instead of 2.5

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -82,6 +82,7 @@ unless ENV['APPLIANCE']
     gem "camcorder",                    :require => false
     gem "coveralls",                    :require => false
     gem "jasmine",       "~>2.4.0",     :require => false
+    gem "jasmine-core",  "~>2.4.0",     :require => false
     gem "phantomjs",     "=1.9.8.0",    :require => false
     gem "rspec",         "~>3.5.0",     :require => false
     gem "test-unit",                    :require => false


### PR DESCRIPTION
Jasmine gem dpeends on jasmine-core ~>2.4 which is bad since it means 2.5.0 when jasmine 2.5 came out.

Forcing 2.4.1.

Fixes javascript tests under phantomjs.