### PR TITLE
Changing misleading text for reset button in Automate Import/Export

### DIFF
--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -67,7 +67,7 @@
 
   %hr
   %h3
-    = (t = _('Reset all Datastore custom classes and instances to default'))
+    = (t = _("Reset all components in the following domains: %{domains}") % {:domains => MiqAeDatastore.default_domain_names.join(', ')})
   = link_to(image_tag(image_path('toolbars/reset.png'),
                       :alt => t),
             {:action              => 'reset_datastore'},

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -165,13 +165,18 @@ module MiqAeDatastore
   def self.reset_to_defaults
     raise "Datastore directory [#{DATASTORE_DIRECTORY}] not found" unless Dir.exist?(DATASTORE_DIRECTORY)
     saved_attrs = preserved_attrs_for_domains
-    Dir.glob(DATASTORE_DIRECTORY.join("*", MiqAeDomain::DOMAIN_YAML_FILENAME)).each do |domain_file|
-      domain_name = File.basename(File.dirname(domain_file))
+    default_domain_names.each do |domain_name|
       reset_domain(DATASTORE_DIRECTORY, domain_name, Tenant.root_tenant)
     end
 
     restore_attrs_for_domains(saved_attrs)
     reset_default_namespace
+  end
+
+  def self.default_domain_names
+    Dir.glob(DATASTORE_DIRECTORY.join("*", MiqAeDomain::DOMAIN_YAML_FILENAME)).collect do |domain_file|
+      File.basename(File.dirname(domain_file))
+    end
   end
 
   def self.seed

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -94,6 +94,10 @@ describe MiqAeDatastore do
     expect(MiqAeMethod.count).to         eq(3)
   end
 
+  it ".default_domain_names" do
+    expect(MiqAeDatastore.default_domain_names).to include("ManageIQ")
+  end
+
   it "temporary file cleanup for unsuccessful import" do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))


### PR DESCRIPTION
Purpose or Intent
-----------------
When you navigate to Automate, Import/Export you can click on "Reset all Datastore custom classes and instances to default" - although it says so, it only resets the ManageIQ and Red Hat domain and doesn't touch any custom domains. So I created a new method domain_names for getting domain names for reset and I also changed the text to "Reset all components in the following domains: XXX, YYY".

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1363774