### PR TITLE
[DARGA] Update x1.32xlarge to enhanced and clustered networking.

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/instance_types.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/instance_types.rb
@@ -969,8 +969,8 @@ module ManageIQ::Providers::Amazon::InstanceTypes
       :intel_avx2              => true,
       :intel_turbo             => true,
       :ebs_optimized_available => true,
-      :enhanced_networking     => false,
-      :cluster_networking      => false,
+      :enhanced_networking     => true,
+      :cluster_networking      => true,
       :vpc_only                => false,
     },
   }


### PR DESCRIPTION
This is a cherry pick of the commit from https://github.com/ManageIQ/manageiq-providers-amazon/pull/10

Should have already been in darga-2

http://aws.amazon.com/ec2/instance-types/ updated, so reflecting the
changes here.

@chessbyte there is no BZ for that, but in this case I guess its ok

@miq-bot assign chessbyte