### PR TITLE
Validate column in Aggregation hardware select (SQL injection)

### DIFF
--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -95,7 +95,8 @@ module AggregationMixin
     select    = field == :aggregate_cpu_speed ? "cpu_total_cores, cpu_speed" : field
     targets ||= send("all_#{from}_ids")
     targets   = targets.collect(&:id) unless targets.first.kind_of?(Integer)
-    hdws      = Hardware.where("#{from}_id" => targets).select(select)
+    column_name = Hardware.column_names.detect { |col| col == "#{from}_id" }
+    hdws        = Hardware.where(column_name => targets).select(select)
 
     hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -60,25 +60,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "b7c5d0a1acf9b6e1d8241cc62f61ddde1dd9f6e1b871b9bd99982135465d1f24",
-      "message": "Possible SQL injection",
-      "file": "app/models/mixins/aggregation_mixin.rb",
-      "line": 98,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Hardware.where(\"#{from.to_s.singularize}_id\" => send(\"all_#{from.to_s.singularize}_ids\").collect(&:id))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "AggregationMixin",
-        "method": "aggregate_hardware"
-      },
-      "user_input": "from.to_s.singularize",
-      "confidence": "Medium",
-      "note": "Temporarily skipped, found in new brakeman version"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "ba770710c5b3745fe0e1ad29c0ba20fd0dd0e391c75420c43a8ba582da3f17c8",
       "message": "Possible SQL injection",
       "file": "app/models/metric/common.rb",


### PR DESCRIPTION
This is probably harmless as it looks like ActiveRecord quotes the column name anyway, but this addition whitelists the interpolated column name from the known columns to keep Brakeman happy and disallow anything that isn't a valid column.