### PR TITLE
Remove Metric::Common#v_find_min_max (SQL injection)

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -44,19 +44,6 @@ module Metric::Common
     virtual_column :v_derived_cpu_total_cores_used, :type => :float
   end
 
-  def v_find_min_max(vcol)
-    interval, mode = vcol.to_s.split("_")[1..2]
-    col = vcol.to_s.split("_")[3..-1].join("_")
-
-    return nil unless interval == "daily" && capture_interval == 1.day
-
-    cond = ["resource_type = ? and resource_id = ? and capture_interval_name = 'hourly' and timestamp >= ? and timestamp < ?",
-            resource_type, resource_id, timestamp.to_date.to_s,  (timestamp + 1.day).to_date.to_s]
-    direction = mode == "min" ? "ASC" : "DESC"
-    rec = MetricRollup.where(cond).order("#{col} #{direction}").first
-    rec.nil? ? nil : rec.send(col)
-  end
-
   def v_derived_storage_used
     return nil if derived_storage_total.nil? || derived_storage_free.nil?
     derived_storage_total - derived_storage_free

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -75,25 +75,6 @@
       "user_input": "from.to_s.singularize",
       "confidence": "Medium",
       "note": "Temporarily skipped, found in new brakeman version"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "ba770710c5b3745fe0e1ad29c0ba20fd0dd0e391c75420c43a8ba582da3f17c8",
-      "message": "Possible SQL injection",
-      "file": "app/models/metric/common.rb",
-      "line": 56,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "MetricRollup.where([\"resource_type = ? and resource_id = ? and capture_interval_name = 'hourly' and timestamp >= ? and timestamp < ?\", resource_type, resource_id, timestamp.to_date.to_s, (timestamp + 1.day).to_date.to_s]).order(\"#{vcol.to_s.split(\"_\")[(3..-1)].join(\"_\")} #{(\"ASC\" or \"DESC\")}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Metric::Common",
-        "method": "v_find_min_max"
-      },
-      "user_input": "vcol.to_s.split(\"_\")[(3..-1)].join(\"_\")",
-      "confidence": "Medium",
-      "note": "Temporarily skipped, found in new brakeman version"
     }
   ],
   "updated": "2016-08-29 12:33:49 -0500",

--- a/spec/models/metric/common_spec.rb
+++ b/spec/models/metric/common_spec.rb
@@ -36,7 +36,7 @@ describe Metric::Common do
       res = metric.apply_time_profile(profile)
       expect(res).to be_falsey
     end
-    
+
     it "returns true if time profile were used for aggregation (and rollup record refer to it)" do
       profile = FactoryGirl.create(:time_profile,
                                    :description => "foo",


### PR DESCRIPTION
Originally from d4e49aaba1ac26a0c22a48ac29dd2abf211e487d

Removed caller in a6bc600270d5b5b8158320c51110d894836a07b1
(And was even commented out before that)

Removes SQL injection warning