### PR TITLE
TreeBuilder: No need to specify nil sort

### DIFF
--- a/app/presenters/tree_builder_ae_customization.rb
+++ b/app/presenters/tree_builder_ae_customization.rb
@@ -15,6 +15,6 @@ class TreeBuilderAeCustomization < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, nil, nil)
+    count_only_or_objects(count_only, nil)
   end
 end

--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -25,7 +25,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
     objects = CustomButtonSet.find_all_by_class_name(nodes[1])
     # add as first element of array
     objects.unshift(CustomButtonSet.new(:name => "[Unassigned Buttons]|ub-#{nodes[1]}", :description => "[Unassigned Buttons]"))
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def get_custom_buttons(object)

--- a/app/presenters/tree_builder_catalog_items.rb
+++ b/app/presenters/tree_builder_catalog_items.rb
@@ -49,12 +49,12 @@ class TreeBuilderCatalogItems < TreeBuilderCatalogsClass
         end
       end
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_st_kids(object, count_only, type)
     count = type == :svvcat ? 0 : object.custom_button_sets.count + object.custom_buttons.count
     objects = count > 0 ? [{:id => object.id.to_s, :text => 'Actions', :image => 'folder', :tip => 'Actions'}] : []
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/app/presenters/tree_builder_catalogs_class.rb
+++ b/app/presenters/tree_builder_catalogs_class.rb
@@ -7,7 +7,7 @@ class TreeBuilderCatalogsClass < TreeBuilder
     objects = Rbac.filtered(ServiceTemplateCatalog.all).sort_by { |o| o.name.downcase }
     case options[:type]
     when :stcat
-      return count_only_or_objects(count_only, objects, nil)
+      return count_only_or_objects(count_only, objects)
     when :sandt
       return count_only_or_objects(count_only,
                                    objects.unshift(ServiceTemplateCatalog.new(:name        => 'Unassigned',

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -34,7 +34,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
                  :image         => "folder",
                  :tip           => _("Ansible Tower Providers"),
                  :load_children => true)
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_cmat_kids(object, count_only)
@@ -65,9 +65,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
       unassigned_configuration_profile =
         [ConfigurationProfile.new(:name       => "Unassigned Profiles Group|#{unassigned_id}",
                                   :manager_id => configuration_manager_id)]
-      unassigned_configuration_profile_objs = count_only_or_objects(count_only,
-                                                                    unassigned_configuration_profile,
-                                                                    nil)
+      unassigned_configuration_profile_objs = count_only_or_objects(count_only, unassigned_configuration_profile)
     end
 
     if unassigned_configuration_profile_objs.nil?

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -39,7 +39,7 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilder
                  :image       => "folder",
                  :tip         => _("My Personal Filters"),
                  :cfmeNoClick => true)
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, options)

--- a/app/presenters/tree_builder_containers.rb
+++ b/app/presenters/tree_builder_containers.rb
@@ -34,7 +34,7 @@ class TreeBuilderContainers < TreeBuilder
         :cfmeNoClick => true
       }
     end
-    count_only_or_objects(count_only, list, nil)
+    count_only_or_objects(count_only, list)
   end
 
   # level 2 - containers

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -27,7 +27,7 @@ class TreeBuilderImages < TreeBuilder
       {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived Images")},
       {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned Images")}
     ]
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_ems_kids(object, count_only)

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -28,7 +28,7 @@ class TreeBuilderInstances < TreeBuilder
       {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived Instances")},
       {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned Instances")}
     ]
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_ems_kids(object, count_only)

--- a/app/presenters/tree_builder_ops.rb
+++ b/app/presenters/tree_builder_ops.rb
@@ -23,7 +23,7 @@ class TreeBuilderOps < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     region = MiqRegion.my_region
     objects = region.zones.sort_by { |z| z.name.downcase }
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_lr_kids(object, count_only)

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -48,7 +48,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
       end.each do |z|
         objects.push(z) if z.adhoc.nil?
       end
-      count_only_or_objects(count_only, objects, nil)
+      count_only_or_objects(count_only, objects)
     when "sis"
       count_only_or_objects(count_only, ScanItemSet.all, "name")
     when "z"

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -52,6 +52,6 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "otvnf" => OrchestrationTemplateVnfd
     }
     objects = Rbac.filtered(classes[object[:id]].where(["orderable=?", true])).sort_by { |o| o.name.downcase }
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/app/presenters/tree_builder_provisioning_dialogs.rb
+++ b/app/presenters/tree_builder_provisioning_dialogs.rb
@@ -19,11 +19,11 @@ class TreeBuilderProvisioningDialogs < TreeBuilderAeCustomization
         :tip   => typ[0]
       }
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
     objects = MiqDialog.where(:dialog_type => object[:id].split('_').last).sort_by { |a| a.description.downcase }
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/app/presenters/tree_builder_region.rb
+++ b/app/presenters/tree_builder_region.rb
@@ -17,7 +17,7 @@ class TreeBuilderRegion < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     ent = MiqEnterprise.my_enterprise
     objects = ent.miq_regions.sort_by { |a| a.description.downcase }
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_region_kids(object, count_only)
@@ -52,16 +52,16 @@ class TreeBuilderRegion < TreeBuilder
     if object_ems?(nodes, object)
       rec = MiqRegion.find_by_id(id)
       objects = rbac_filtered_sorted_objects(rec.ems_infras, "name")
-      count_only_or_objects(count_only, objects, nil)
+      count_only_or_objects(count_only, objects)
     elsif object_ds?(nodes, object)
       rec = MiqRegion.find_by_id(id)
       objects = rbac_filtered_sorted_objects(rec.storages, "name")
-      count_only_or_objects(count_only, objects, nil)
+      count_only_or_objects(count_only, objects)
     elsif object_cluster?(nodes, object)
       rec = ExtManagementSystem.find_by_id(id)
       objects = rbac_filtered_sorted_objects(rec.ems_clusters, "name") +
                 rbac_filtered_sorted_objects(rec.non_clustered_hosts, "name")
-      count_only_or_objects(count_only, objects, nil)
+      count_only_or_objects(count_only, objects)
     end
   end
 

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -29,7 +29,7 @@ class TreeBuilderReportDashboards < TreeBuilder
     text = "#{default_ws.description} (#{default_ws.name})"
     objects.push(:id => to_cid(default_ws.id), :text => text, :image => 'dashboard', :tip => text)
     objects.push(:id => 'g', :text => _('All Groups'), :image => 'folder', :tip => _('All Groups'))
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, options)

--- a/app/presenters/tree_builder_report_export.rb
+++ b/app/presenters/tree_builder_report_export.rb
@@ -31,6 +31,6 @@ class TreeBuilderReportExport < TreeBuilder
        :text  => _('Widgets'),
        :image => 'report'}
     ]
-    count_only_or_objects(count_only, export_children, nil)
+    count_only_or_objects(count_only, export_children)
   end
 end

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -39,7 +39,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
       # load next level of folders when building the tree
       @tree_state.x_tree(options[:tree])[:open_nodes].push("xx-#{i}")
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)
@@ -63,6 +63,6 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
         break if count_only
       end
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -32,7 +32,7 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
     folder_ids.sort.each_with_index do |p|
       objects.push(:id => p[1], :text => p[0], :image => 'report', :tip => p[0])
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)

--- a/app/presenters/tree_builder_report_widgets.rb
+++ b/app/presenters/tree_builder_report_widgets.rb
@@ -16,7 +16,7 @@ class TreeBuilderReportWidgets < TreeBuilder
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
     objects = WIDGET_TYPES.collect { |k, v| {:id => k, :text => _(v), :image => 'folder', :tip => _(v)} }
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)

--- a/app/presenters/tree_builder_service_dialogs.rb
+++ b/app/presenters/tree_builder_service_dialogs.rb
@@ -15,7 +15,7 @@ class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
     objects = Rbac.filtered(Dialog.all).sort_by { |a| a.label.downcase }
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_generic_dialog_kids(object, count_only, type, chk_dialog_type = false)
@@ -27,7 +27,7 @@ class TreeBuilderServiceDialogs < TreeBuilderAeCustomization
       else
         object.ordered_dialog_resources.collect(&:resource).compact
       end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_dialog_kids(object, count_only, type)

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -23,7 +23,7 @@ class TreeBuilderStorage < TreeBuilder
         {:id => "global", :text => _("Global Filters"), :image => "folder", :tip => _("Global Shared Filters"), :cfmeNoClick => true},
         {:id => "my",     :text => _("My Filters"),     :image => "folder", :tip => _("My Personal Filters"),   :cfmeNoClick => true}
       ]
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, options)

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -29,7 +29,7 @@ class TreeBuilderStoragePod < TreeBuilder
                    :tip           => item[:description],
                    :load_children => true)
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, type)
@@ -38,6 +38,6 @@ class TreeBuilderStoragePod < TreeBuilder
     if(dsc.size > 0)
       objects = dsc.first.storages
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -57,7 +57,7 @@ class TreeBuilderUtilization < TreeBuilderRegion
       when :vandt then x_get_tree_vandt_datacenter_kids(object)
       when :handc then x_get_tree_handc_datacenter_kids(object)
       end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_vandt_datacenter_kids(object)
@@ -100,7 +100,7 @@ class TreeBuilderUtilization < TreeBuilderRegion
       objects += rbac_filtered_sorted_objects(object.hosts, "name", :match_via_descendants => VmOrTemplate)
       objects += rbac_filtered_sorted_objects(object.vms_and_templates, "name")
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_cluster_kids(object, count_only)
@@ -110,6 +110,6 @@ class TreeBuilderUtilization < TreeBuilderRegion
       objects += rbac_filtered_sorted_objects(object.resource_pools, "name")
       objects += rbac_filtered_sorted_objects(object.vms, "name")
     end
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 end

--- a/app/presenters/tree_builder_vms_filter.rb
+++ b/app/presenters/tree_builder_vms_filter.rb
@@ -25,7 +25,7 @@ class TreeBuilderVmsFilter < TreeBuilder
         {:id => "global", :text => _("Global Filters"), :image => "folder", :tip => _("Global Shared Filters"), :cfmeNoClick => true},
         {:id => "my",     :text => _("My Filters"),     :image => "folder", :tip => _("My Personal Filters"),   :cfmeNoClick => true}
       ]
-    count_only_or_objects(count_only, objects, nil)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, options)

--- a/spec/presenters/tree_builder_spec.rb
+++ b/spec/presenters/tree_builder_spec.rb
@@ -117,30 +117,30 @@ describe TreeBuilder do
       a = FactoryGirl.create(:user_with_email)
       FactoryGirl.create(:user_with_email)
 
-      expect(builder.count_only_or_objects(true, User.none, nil)).to eq(0)
-      expect(builder.count_only_or_objects(true, User.where(:id => a.id), nil)).to eq(1)
-      expect(builder.count_only_or_objects(true, User.all, nil)).to eq(2)
-      expect(builder.count_only_or_objects(true, User.select('id, name'), nil)).to eq(2)
+      expect(builder.count_only_or_objects(true, User.none)).to eq(0)
+      expect(builder.count_only_or_objects(true, User.where(:id => a.id))).to eq(1)
+      expect(builder.count_only_or_objects(true, User.all)).to eq(2)
+      expect(builder.count_only_or_objects(true, User.select('id, name'))).to eq(2)
     end
 
     it 'counts things in an Array' do
-      expect(builder.count_only_or_objects(true, [], nil)).to eq(0)
-      expect(builder.count_only_or_objects(true, [:x], nil)).to eq(1)
-      expect(builder.count_only_or_objects(true, [:x, :y, :z, :z, :y], nil)).to eq(5)
+      expect(builder.count_only_or_objects(true, [])).to eq(0)
+      expect(builder.count_only_or_objects(true, [:x])).to eq(1)
+      expect(builder.count_only_or_objects(true, [:x, :y, :z, :z, :y])).to eq(5)
     end
 
     it 'returns a collection when not counting' do
       a = FactoryGirl.create(:user_with_email)
       b = FactoryGirl.create(:user_with_email)
 
-      expect(builder.count_only_or_objects(false, User.none, nil)).to eq([])
-      expect(builder.count_only_or_objects(false, User.where(:id => a.id), nil)).to eq([a])
-      expect(builder.count_only_or_objects(false, User.all, nil).sort).to eq([a, b].sort)
-      expect(builder.count_only_or_objects(false, User.select('id', 'name'), nil).sort).to eq([a, b].sort)
+      expect(builder.count_only_or_objects(false, User.none)).to eq([])
+      expect(builder.count_only_or_objects(false, User.where(:id => a.id))).to eq([a])
+      expect(builder.count_only_or_objects(false, User.all).sort).to eq([a, b].sort)
+      expect(builder.count_only_or_objects(false, User.select('id', 'name')).sort).to eq([a, b].sort)
 
-      expect(builder.count_only_or_objects(false, [], nil)).to eq([])
-      expect(builder.count_only_or_objects(false, [:x], nil)).to eq([:x])
-      expect(builder.count_only_or_objects(false, [:x, :y, :z, :z, :y], nil)).to eq([:x, :y, :z, :z, :y])
+      expect(builder.count_only_or_objects(false, [])).to eq([])
+      expect(builder.count_only_or_objects(false, [:x])).to eq([:x])
+      expect(builder.count_only_or_objects(false, [:x, :y, :z, :z, :y])).to eq([:x, :y, :z, :z, :y])
     end
 
     it 'sorts the collection' do


### PR DESCRIPTION
```
  def count_only_or_objects(count_only, objects, sort_by = nil)
```

No need to specify a `sort_by` of nil. Since that is the default value