### PR TITLE
Fixes Issue Middleware Provider crashes to validate password 

### DIFF
--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -1,6 +1,5 @@
 class EmsMiddlewareController < ApplicationController
   include EmsCommon
-  include Mixins::EmsCommonAngular
 
   before_action :check_privileges
   before_action :get_session_data


### PR DESCRIPTION
Fixes Issue##10901

I removed the` Mixins::EmsCommonAngular` from `ems_middleware` provider because the way that Mixin operates is different from the way we are working now, and the changes probably imply angularize this part.

Instead, I validate on ems_commons if the actual controller is restful and redirect according to it.

This seems to fix  the issues with `ems_middleware`.

@lucasponce @abonas  could you look at it?

Thanks.