### PR TITLE
Fix service_dialog update 

### DIFF
--- a/app/controllers/api/base_controller/blueprints.rb
+++ b/app/controllers/api/base_controller/blueprints.rb
@@ -60,7 +60,7 @@ module Api
       end
 
       def service_dialog_options(bundle)
-        Dialog.find(parse_id(bundle["service_dialog"], :service_dialogs)) if bundle["service_catalog"]
+        Dialog.find(parse_id(bundle["service_dialog"], :service_dialogs)) if bundle["service_dialog"]
       end
     end
   end

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -319,6 +319,7 @@ RSpec.describe "Blueprints API" do
       blueprint = FactoryGirl.create(:blueprint)
       original_service_template = FactoryGirl.create(:service_template)
       original_service_catalog = FactoryGirl.create(:service_template_catalog)
+      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
       blueprint.create_bundle(:service_templates => [original_service_template],
                               :service_catalog   => original_service_catalog)
       api_basic_authorize action_identifier(:blueprints, :edit)
@@ -328,6 +329,9 @@ RSpec.describe "Blueprints API" do
         :action   => "edit",
         :resource => {
           :bundle => {
+            :service_dialog  => {
+              :id => service_dialog.id
+            },
             :service_catalog => nil
           }
         }
@@ -351,7 +355,10 @@ RSpec.describe "Blueprints API" do
         :action   => "edit",
         :resource => {
           :bundle => {
-            :service_dialog => nil
+            :service_catalog => {
+              :id => original_service_catalog.id
+            },
+            :service_dialog  => nil
           }
         }
       )


### PR DESCRIPTION
Purpose or Intent
-----------------
> a true facepalm moment. Fixes reference from `service_catalog` to `service_dialog` in the function intended to set the `service_dialog` . Updated specs to catch this change in the future.

cc: @chriskacerguis 