### PR TITLE
Toolbar refactoring for Catalog Items

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -1,6 +1,8 @@
 class ApplicationHelper::Button::Basic < Hash
   include ActionView::Helpers::TextHelper
 
+  delegate :role_allows?, :to => :@view_context
+
   def initialize(view_context, view_binding, instance_data, props)
     @view_context  = view_context
     @view_binding  = view_binding
@@ -60,8 +62,6 @@ class ApplicationHelper::Button::Basic < Hash
   def disabled?
     false
   end
-
-  delegate :role_allows?, :to => :@view_context
 
   class << self
     attr_reader :record_needed

--- a/app/helpers/application_helper/button/catalog_item_button.rb
+++ b/app/helpers/application_helper/button/catalog_item_button.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::CatalogItemButton < ApplicationHelper::Button::Basic
+
+  def role_allows_feature?
+    # when user has the privilege to edit Catalog Item, he can also add/edit buttons/button groups
+    @view_context.current_user.role_allows_any?(:identifiers => %w(catalogitem_new catalogitem_edit atomic_catalogitem_new atomic_catalogitem_edit))
+  end
+end
+

--- a/app/helpers/application_helper/toolbar/catalogitem_button_center.rb
+++ b/app/helpers/application_helper/toolbar/catalogitem_button_center.rb
@@ -1,0 +1,36 @@
+class ApplicationHelper::Toolbar::CatalogitemButtonCenter < ApplicationHelper::Toolbar::Basic
+  button_group('catalogitem_button_vmdb', [
+    select(
+      :catalogitem_button_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :ab_button_edit,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit this Button'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+          :url_parms => "main_div"),
+        button(
+          :ab_button_delete,
+          'pficon pficon-delete fa-lg',
+          t = N_('Remove this Button'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+          :url_parms => "main_div",
+          :confirm   => N_("Warning: This Button will be permanently removed from the Virtual Management Database!")),
+        separator,
+        button(
+          :ab_button_simulate,
+          'fa fa-play-circle-o fa-lg',
+          N_('Simulate using Button details'),
+          N_('Simulate'),
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+          :url       => "resolve",
+          :url_parms => "?button=simulate"),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/catalogitem_button_set_center.rb
+++ b/app/helpers/application_helper/toolbar/catalogitem_button_set_center.rb
@@ -1,0 +1,36 @@
+class ApplicationHelper::Toolbar::CatalogitemButtonSetCenter < ApplicationHelper::Toolbar::Basic
+  button_group('catalogitem_button_set_vmdb', [
+    select(
+      :catalogitem_button_set_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :ab_group_new,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Add a new Button Group'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton),
+        button(
+          :ab_button_new,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Add a new Button'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton),
+        button(
+          :ab_group_reorder,
+          'pficon pficon-edit fa-lg',
+          proc do
+            if @view_context.x_active_tree == :ab_tree
+              _('Reorder Buttons Groups')
+            else
+              _('Reorder Buttons and Groups')
+            end
+          end,
+          N_('Reorder'),
+          :klass => ApplicationHelper::Button::CatalogItemButton),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/catalogitem_buttons_center.rb
+++ b/app/helpers/application_helper/toolbar/catalogitem_buttons_center.rb
@@ -1,0 +1,33 @@
+class ApplicationHelper::Toolbar::CatalogitemButtonsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('catalogitem_button_vmdb', [
+    select(
+      :catalogitem_button_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :ab_group_edit,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit this Button Group'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+          :url_parms => "main_div"),
+        button(
+          :ab_button_new,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Add a new Button'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton),
+        button(
+          :ab_group_delete,
+          'pficon pficon-delete fa-lg',
+          t = N_('Remove this Button Group'),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+          :url_parms => "main_div",
+          :confirm   => N_("Warning: The selected Button Group will be permanently removed!")),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -10,12 +10,16 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
           :ab_group_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Button Group'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+        ),
         button(
           :ab_button_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Button'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::CatalogItemButton,
+        ),
         button(
           :catalogitem_edit,
           'pficon pficon-edit fa-lg',

--- a/app/helpers/application_helper/toolbar/servicetemplate_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplate_center.rb
@@ -5,7 +5,6 @@ class ApplicationHelper::Toolbar::ServicetemplateCenter < ApplicationHelper::Too
       'fa fa-cog fa-lg',
       t = N_('Configuration'),
       t,
-      :onwhen => "1+",
       :items  => [
         button(
           :ab_group_new,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -667,16 +667,6 @@ class ApplicationHelper::ToolbarBuilder
       when "condition_remove"
         return true if x_active_tree == :condition_tree || !role_allows?(:feature => "condition_delete")
       end
-    when "CustomButton"
-      case id
-      when "ab_button_edit", "ab_button_delete", "ab_button_simulate"
-        return !role_allows_button_manipulation if x_active_tree == :sandt_tree
-      end
-    when "CustomButtonSet"
-      case id
-      when "ab_group_edit", "ab_group_delete", "ab_button_new"
-        return !role_allows_button_manipulation if x_active_tree == :sandt_tree
-      end
     when "MiqAeClass", "MiqAeDomain", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
       case id
@@ -753,13 +743,6 @@ class ApplicationHelper::ToolbarBuilder
       when "server_delete", "role_start", "role_suspend", "promote_server", "demote_server"
         return true
       end
-    when "ServiceTemplate"
-      case id
-      when "ab_group_new", "ab_button_new"
-        return !role_allows_button_manipulation
-      when /^history_\d*/
-        return false
-      end
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
       case id
       when "configured_system_provision"
@@ -767,8 +750,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "NilClass"
       case id
-      when "ab_group_new", "ab_button_new", "ab_group_reorder"
-        return !role_allows_button_manipulation if x_active_tree == :sandt_tree
       when "log_download"
         return true if ["workers", "download_logs"].include?(@lastaction)
       when "log_collect"
@@ -792,12 +773,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     end
     false  # No reason to hide, allow the button to show
-  end
-
-  def role_allows_button_manipulation
-    %w(catalogitem_new catalogitem_edit atomic_catalogitem_new atomic_catalogitem_edit).any? do |feature|
-      role_allows?(:feature => feature)
-    end
   end
 
   # Determine if a button should be disabled

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -191,11 +191,11 @@ class ApplicationHelper::ToolbarChooser
       elsif @sb[:buttons_node]
         nodes = x_node.split('_')
         if nodes.length == 3 && nodes[2].split('-').first == "xx"
-          return "custom_button_set_center_tb"
+          return "catalogitem_button_set_center_tb"
         elsif nodes.length == 4 && nodes[3].split('-').first == "cbg"
-          return "custom_buttons_center_tb"
+          return "catalogitem_buttons_center_tb"
         else
-          return "custom_button_center_tb"
+          return "catalogitem_button_center_tb"
         end
       else
         return "servicetemplates_center_tb"

--- a/spec/helpers/application_helper/buttons/catalog_item_button_spec.rb
+++ b/spec/helpers/application_helper/buttons/catalog_item_button_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ApplicationHelper::Button::CatalogItemButton do
+  let (:session) { Hash.new }
+  before do
+    @view_context = setup_view_context_with_sandbox({})
+    allow(@view_context).to receive(:current_user).and_return(FactoryGirl.create(:user))
+    @button = described_class.new(@view_context, {}, {}, {:child_id => "ab_button_new"})
+  end
+
+  context "#role_allows_feature?" do
+    it "will be skipped" do
+      expect(@button.role_allows_feature?).to be false
+    end
+
+    it "won't be skipped" do
+      EvmSpecHelper.seed_specific_product_features("catalogitem_new")
+      feature = MiqProductFeature.find_all_by_identifier(["everything"])
+      allow(@view_context).to receive(:current_user).and_return(FactoryGirl.create(:user, :features => feature))
+      expect(@button.role_allows_feature?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Purpose is to move toolbar buttons from helper to the separate classes.
This PR contains new classes for Catalog Items (under Services/Catalogs/Catalog Items)

Links
-----
GH Issue: https://github.com/ManageIQ/manageiq/issues/6259
PivotalTracker: https://www.pivotaltracker.com/story/show/126786793
