### PR TITLE
Archived vms roots

### DIFF
--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -8,4 +8,11 @@ module TreeBuilderArchived
     objects = Rbac.filtered(klass.send(method))
     count_only ? objects.length : objects
   end
+
+  def x_get_tree_arch_orph_nodes(model_name)
+    [
+      {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived #{model_name}")},
+      {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned #{model_name}")}
+    ]
+  end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -1,6 +1,8 @@
 class TreeBuilderImages < TreeBuilder
   has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
 
+  include TreeBuilderArchived
+
   def tree_init_options(_tree_name)
     {
       :leaf => "ManageIQ::Providers::CloudManager::Template"
@@ -22,11 +24,8 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(EmsCloud.order("lower(name)"), :match_via_descendants => TemplateCloud)
-    objects += [
-      {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived Images")},
-      {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned Images")}
-    ]
+    objects = Rbac.filtered(EmsCloud.order("lower(name)"), :match_via_descendants => TemplateCloud) +
+              x_get_tree_arch_orph_nodes("Images")
     count_only_or_objects(count_only, objects)
   end
 
@@ -34,6 +33,4 @@ class TreeBuilderImages < TreeBuilder
     objects = Rbac.filtered(object.miq_templates.order("name"))
     count_only ? objects.length : objects
   end
-
-  include TreeBuilderArchived
 end

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -2,6 +2,8 @@ class TreeBuilderInstances < TreeBuilder
   has_kids_for AvailabilityZone, [:x_get_tree_az_kids]
   has_kids_for ExtManagementSystem, [:x_get_tree_ems_kids]
 
+  include TreeBuilderArchived
+
   def tree_init_options(_tree_name)
     {
       :leaf => 'VmCloud'
@@ -23,11 +25,8 @@ class TreeBuilderInstances < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(EmsCloud.order("lower(name)"), :match_via_descendants => VmCloud)
-    objects += [
-      {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived Instances")},
-      {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned Instances")}
-    ]
+    objects = Rbac.filtered(EmsCloud.order("lower(name)"), :match_via_descendants => VmCloud) +
+              x_get_tree_arch_orph_nodes("Instances")
     count_only_or_objects(count_only, objects)
   end
 
@@ -42,6 +41,4 @@ class TreeBuilderInstances < TreeBuilder
     objects = Rbac.filtered(object.vms.not_archived_nor_orphaned)
     count_only_or_objects(count_only, objects, "name")
   end
-
-  include TreeBuilderArchived
 end

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -25,11 +25,8 @@ class TreeBuilderVandt < TreeBuilder
       objects.length + 2
     else
       objects = objects.to_a
-      objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options.dup).tree }
-      objects + [
-        {:id => "arch", :text => _("<Archived>"), :image => "currentstate-archived", :tip => _("Archived VMs and Templates")},
-        {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned VMs and Templates")}
-      ]
+      objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options.dup).tree } +
+        x_get_tree_arch_orph_nodes("VMs and Templates")
     end
   end
 

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -1,4 +1,6 @@
 class TreeBuilderVandt < TreeBuilder
+  include TreeBuilderArchived
+
   def tree_init_options(_tree_name)
     {:leaf => 'VmOrTemplate'}
   end
@@ -29,19 +31,6 @@ class TreeBuilderVandt < TreeBuilder
         {:id => "orph", :text => _("<Orphaned>"), :image => "currentstate-orphaned", :tip => _("Orphaned VMs and Templates")}
       ]
     end
-  end
-
-  # Handle custom tree nodes (object is a Hash)
-  def x_get_tree_custom_kids(object, count_only, _options)
-    objects = case object[:id]
-              when "orph" # Orphaned
-                Rbac.filtered(VmInfra.all_orphaned) +
-                Rbac.filtered(TemplateInfra.all_orphaned)
-              when "arch" # Archived
-                Rbac.filtered(VmInfra.all_archived) +
-                Rbac.filtered(TemplateInfra.all_archived)
-              end
-    count_only_or_objects(count_only, objects, "name")
   end
 
   def x_get_child_nodes(id)


### PR DESCRIPTION
- We have a common module that implements `x_get_tree_custom_kids`, but reimplement it in another place. Just merge the two.
- We generate the root nodes for archived and orphans in 3 different places, move this to the common module.

This should have no visible change