### PR TITLE
Archived: Scope for not archived nor orphaned

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1284,8 +1284,7 @@ module VmCommon
           rec = TreeBuilder.get_model_for_prefix(@nodetype).constantize.find(from_cid(id))
           options.merge!({:association => "#{@nodetype == "az" ? "vms" : "all_vms_and_templates"}", :parent => rec})
           options[:where_clause] = MiqExpression.merge_where_clauses(
-            options[:where_clause],
-            "(NOT (#{VmOrTemplate::ARCHIVED_CONDITIONS})) AND (NOT (#{VmOrTemplate::ORPHANED_CONDITIONS}))"
+            options[:where_clause], VmOrTemplate::NOT_ARCHIVED_NOR_OPRHANED_CONDITIONS
           )
           process_show_list(options)
           model_name = @nodetype == "d" ? "Datacenter" : ui_lookup(:model => rec.class.base_class.to_s)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1855,6 +1855,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   # where.not(ORPHANED_CONDITIONS).where.not(ARCHIVED_CONDITIONS)
+  NOT_ARCHIVED_NOR_OPRHANED_CONDITIONS = "vms.ems_id IS NOT NULL".freeze
   def self.not_archived_nor_orphaned
     where.not(:ems_id => null)
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1854,6 +1854,11 @@ class VmOrTemplate < ApplicationRecord
     where(ORPHANED_CONDITIONS).to_a
   end
 
+  # where.not(ORPHANED_CONDITIONS).where.not(ARCHIVED_CONDITIONS)
+  def self.not_archived_nor_orphaned
+    where.not(:ems_id => null)
+  end
+
   # Stop certain charts from showing unless the subclass allows
   def non_generic_charts_available?
     false

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -39,9 +39,8 @@ class TreeBuilderInstances < TreeBuilder
 
   # Get AvailabilityZone children count/array
   def x_get_tree_az_kids(object, count_only)
-    objects = Rbac.filtered(object.vms.order("name"))
-    objects = objects.reject { |obj| obj.archived? || obj.orphaned? } ## TODO: turn into a scope instead of ruby
-    count_only ? objects.length : objects
+    objects = Rbac.filtered(object.vms.not_archived_nor_orphaned)
+    count_only_or_objects(count_only, objects, "name")
   end
 
   include TreeBuilderArchived


### PR DESCRIPTION
We are bringing back all vms to prune out the archived and orphaned ones.

There is a `TODO` to turn it into a scope.

This PR introduces the scope.
