### PR TITLE
Fix hawkular provider refresh issue due to new resource type naming

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -91,18 +91,20 @@ module ManageIQ::Providers
           return os_resources.first
         end
 
+        $mw_log.warn "Found no OS resources for resource type #{os.path}"
         nil
       end
     end
 
     def os_for(feed)
       with_provider_connection do |connection|
-        resources = connection.inventory.list_resource_types(hawk_escape_id(feed))
-        oses = resources.select { |item| item.id == 'Operating System' }
-        unless oses.nil? || oses.empty?
-          return oses.first
+        resource_types = connection.inventory.list_resource_types(hawk_escape_id(feed))
+        os_types = resource_types.select { |item| item.id.include? 'Operating System' }
+        unless os_types.nil? || os_types.empty?
+          return os_types.first
         end
 
+        $mw_log.warn "Found no OS resource types for feed #{feed}"
         nil
       end
     end


### PR DESCRIPTION
The hawkular-agent-defined operating system resource types may no longer be identified with Id  equals 'Operating System'.  Instead, the more unique Ids are guaranteed only to contain the 'Operating System' substring.  This PR is required for use with hawkular server version 0.0.11 and later.  It is backward compatible with earlier server versions.

The PR also adds some middleware specific logging that would have helped immensely in finding this issue.

Links
-----
> * https://issues.jboss.org/browse/HWKAGENT-133

@miq-bot add-label providers/hawkular,bug

@abonas please review and fast track as this is required for services 0.0.11 compatibility.