### PR TITLE
Fix the Configuration Management Provider Refresh when selected from the Explorer tree

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1716,15 +1716,15 @@ module ApplicationController::CiProcessing
         add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:table => controller_name)}, :error)
       else
         items.push(params[:id])
-        @single_delete = true if method == 'destroy' && !flash_errors?
       end
     else
       items = find_checked_items
-      if items.empty?
-        add_flash(_("No providers were selected for %{task}") % {:task  => display_name}, :error)
-      else
-        process_cfgmgr(items, method) unless items.empty? && !flash_errors?
-      end
+    end
+
+    if items.empty?
+      add_flash(_("No providers were selected for %{task}") % {:task  => display_name}, :error)
+    else
+      process_cfgmgr(items, method) unless items.empty? && !flash_errors?
     end
   end
 

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -232,6 +232,19 @@ describe ProviderForemanController do
       expect(response.status).to eq(200)
       expect(assigns(:flash_array).first[:message]).to include("Refresh Provider initiated for 1 provider (Foreman)")
     end
+
+    it "refreshes the provider when the configuration manager id is supplied" do
+      allow(controller).to receive(:replace_right_cell)
+      post :refresh, :params => { :id => @config_mgr.id }
+      expect(assigns(:flash_array).first[:message]).to include("Refresh Provider initiated for 1 provider")
+    end
+
+    it "it refreshes a provider when the configuration manager id is selected from a grid/tile" do
+      allow(controller).to receive(:replace_right_cell)
+      post :refresh, :params => { "check_#{ApplicationRecord.compress_id(@config_mgr.id)}"  => "1",
+                                  "check_#{ApplicationRecord.compress_id(@config_mgr2.id)}" => "1" }
+      expect(assigns(:flash_array).first[:message]).to include("Refresh Provider initiated for 2 providers")
+    end
   end
 
   context "#delete" do


### PR DESCRIPTION
Purpose or Intent
----------------
The Configuration Management Provider Refresh does not start when the provider is selected from the explorer tree.
