### PR TITLE
Skip asset pipeline resolution for for Service nodes in TreeNodeBuilder#node_icon

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -138,7 +138,7 @@ class TreeNodeBuilder
     when PxeImageType         then generic_node(object.name, "pxeimagetype.png")
     when PxeServer            then generic_node(object.name, "pxeserver.png")
     when ScanItemSet          then generic_node(object.name, "scan_item_set.png")
-    when Service              then generic_node(object.name, object.picture ? "../../../pictures/#{object.picture.basename}" : "service.png")
+    when Service              then generic_node(object.name, object.picture ? "/pictures/#{object.picture.basename}" : "service.png")
     when ServiceResource      then generic_node(object.resource_name, object.resource_type == "VmOrTemplate" ? "vm.png" : "service_template.png")
     when ServerRole           then server_role_node(object)
     when ServiceTemplate      then service_template_node
@@ -186,7 +186,11 @@ class TreeNodeBuilder
   end
 
   def node_icon(icon)
-    ActionController::Base.helpers.image_path("100/#{icon}")
+    if icon.start_with?("/")
+      icon
+    else
+      ActionController::Base.helpers.image_path("100/#{icon}")
+    end
   end
 
   def generic_node(text, image, tip = nil)


### PR DESCRIPTION
_**Note to a future review/observer**:  This PR has had a bit of "developer discovery" since originally being open, and the PR description is "false" in a lot of ways.  For historical context, I have left this description as originally written (minus this addition), so reading the comments is required to further understand the use case of this PR._

Purpose or Intent
-----------------
Speed up rendering of large trees with many nodes (10k+) by memoizing the result from `TreeNodeBuilder#node_icon` to avoid expensive lookups.


Overview
--------

I would like to open this overview with an image in regards to my knowledge regarding Sprocket's internals:

![No seriously... not a clue](http://i0.kym-cdn.com/photos/images/facebook/000/234/739/fa5.jpg)
> _Fig(1):  @NickLaMuro in his natural development env.  Photo courtesy of **Bill Ney the Science Guy**_


To better explain, I am "pretty sure"™ that asset digests should not change unless the code base is updated or the restarted, but I am not sure.  If I am wrong, then we really should consider `request_store` for this.

What I mean by "asset digest" is the following:

```ruby
irb> ActionController::Base.helpers.image_path '100/x.png'
30 seconds later for some reason...
=> "/assets/100/x-7b70a6351d2b6bf24c61ef6768858a6a35e78f9b4228d9df1c98154cfdd6c1a1.png"
```
> _Fig(2): Seriously... why did this take so long..._

For those unaware about the `-7b70a6351...` non-sense following the "x", this is a browser cache busting mechanism that updates when the HTML is rendered after a server is restarted to bust any caching the browser may have done with that asset.  This "should", as far as I can tell, not change during the course of the process's lifecycle.  If it did, it means an invalid link to an image could be created and would cause a broken link in the browser.


Technical Notes
---------------
Calling `ActionController::Base.helpers.image_path` seems to be causing a directory scan for each node in the tree.  On large trees, this accounts for a significant CPU churn when resolving the assets.  Here is a truncation of a stackprof output as an example:

```
==================================
  Mode: wall(1000)
  Samples: 49798 (1.48% miss rate)
  GC: 7636 (15.33%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     12432  (25.0%)       12320  (24.7%)     block in Sprockets::Resolve#dirname_matches
      3898   (7.8%)        3898   (7.8%)     Puma::Single#run
      2710   (5.4%)        1675   (3.4%)     ActiveRecord::LazyAttributeHash#[]
      6069  (12.2%)        1667   (3.3%)     #<Module:0x007fd8a11403a8>.accumulate_descendants
```
> _Fig(3):  Think of all the cat gifs that could have been rendered in those wasted CPU cycles..._

The `100` directory allow has 600 images in it, so that means (somewhere in the stacktrace) we are looping over all the items in the directory to find a match, sometimes to get `x.png` (alphabetically, pretty far down the list).  This seems to be done on almost all nodes, even though the `100` dir is static, meaning this isn't going to change no matter how many times we render it.

By memoizing this on to the class, we can save this look up on future requests, and even within the same request.  This digest for this image should not change while the current unless there is an app update (as far as I can tell), so storing it until the server is restarted should be reasonable, and a hash of 600 items shouldn't be too big of a memory footprint.

Here are some quick before and after metrics for total request time on `/vm_infra/explorer` on a 10k+ node tree (these requests were made right after an app restart):

```
Before:
  request_01: 50505.778ms
  request_02: 42697.014ms
  request_03: 43752.757ms

After
  request_01: 34255.921ms
  request_02: 27997.403ms
  request_03: 29105.170ms
```
> _Fig(4):  `ms = milli-cats per/sec`.  True story_

The `mutex` is there just as a safeguard incase there would be a Thread Saftey issue between multiple `ui_worker` threads accessing that class variable.

As stated before, if the memory issues are a concern, or if the way we restart UI workers would cause this variable to remained cached after the digest has changed, we could consider using `request_store` as an alternative and only maintain this list for the life of the request, which should still cause a noticable gain in performance on large trees.


Notes on the Sprocket's cache
-----------------------------
Sprockets already has a cache of it's own, that I thought I could use, but this is a cache for the generated assets that weren't pre-compiled, and not storing the memoizing the digest of assets and expiring that as needed.


Links
-----
* https://github.com/steveklabnik/request_store