### PR TITLE
Add VMware cloud orchestration stack operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     "~>0.3.0",       :require => false
-gem "fog-vcloud-director",            "~>0.1.5",       :require => false
+gem "fog-vcloud-director",            "~>0.1.6",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_stack.rb
@@ -1,6 +1,32 @@
 class ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
   require_nested :Status
 
+  def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
+    orchestration_manager.with_provider_connection do |service|
+      create_options = {:stack_name => stack_name, :template => template.ems_ref}.merge(options)
+
+      service.instantiate_template(create_options)
+    end
+  rescue => err
+    _log.error "stack=[#{stack_name}], error: #{err}"
+    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+  end
+
+  def raw_delete_stack
+    ext_management_system.with_provider_connection do |service|
+      raw_stack = service.vapps.get_single_vapp(ems_ref)
+      raise MiqException::MiqOrchestrationStackNotExistError, "#{name} does not exist on #{ems.name}" unless raw_stack
+
+      # First, undeploy the vApp (power off).
+      raw_stack.undeploy
+      # Then delete it.
+      raw_stack.destroy
+    end
+  rescue => err
+    _log.error "stack=[#{name}], error: #{err}"
+    raise MiqException::MiqOrchestrationDeleteError, err.to_s, err.backtrace
+  end
+
   def raw_status
     ems = ext_management_system
     ems.with_provider_connection do |service|

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -2,8 +2,4 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
   def self.eligible_manager_types
     [ManageIQ::Providers::Vmware::CloudManager]
   end
-
-  def self.stack_type
-    "VMware vApp"
-  end
 end

--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -38,4 +38,9 @@ FactoryGirl.define do
           :class  => "OrchestrationTemplateAzure" do
     content File.read(Rails.root.join('spec/fixtures/orchestration_templates/azure_parameters.json'))
   end
+
+  factory :orchestration_template_vmware_cloud,
+          :parent => :orchestration_template,
+          :class  => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate" do
+  end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
@@ -1,5 +1,6 @@
 describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_vmware_cloud) }
+  let(:template) { FactoryGirl.create(:orchestration_template_vmware_cloud) }
   let(:orchestration_stack) do
     FactoryGirl.create(:orchestration_stack_vmware_cloud,
                        :ext_management_system => ems,
@@ -11,15 +12,55 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack do
 
   let(:raw_stacks) do
     double.tap do |stacks|
-      handle = double
-      allow(handle).to receive(:vapps).and_return(stacks)
-      allow(ems).to receive(:connect).and_return(handle)
       allow(stacks).to receive(:get_single_vapp).with(orchestration_stack.ems_ref).and_return(the_raw_stack)
     end
   end
 
+  let(:orchestration_service) do
+    double.tap do |service|
+      allow(service).to receive(:vapps).and_return(raw_stacks)
+      allow(service).to receive(:instantiate_template).and_return(the_raw_stack.id)
+    end
+  end
+
   before do
-    raw_stacks
+    allow(ems).to receive(:connect).and_return(orchestration_service)
+  end
+
+  describe 'stack operations' do
+    context ".create_stack" do
+      let(:the_new_stack) { double }
+      let(:stack_option) { {:vdc_id => 'vdc_id'} }
+
+      it 'creates a stack' do
+        stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
+        expect(stack.class).to eq(described_class)
+        expect(stack.name).to eq('mystack')
+        expect(stack.ems_ref).to eq(the_raw_stack.id)
+      end
+
+      it 'catches error from provider' do
+        expect(orchestration_service).to receive(:instantiate_template).and_raise('bad request')
+
+        expect do
+          ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, {})
+        end.to raise_error(MiqException::MiqOrchestrationProvisionError)
+      end
+    end
+
+    context '#delete_stack' do
+      it 'deletes the stack' do
+        expect(the_raw_stack).to receive(:undeploy)
+        expect(the_raw_stack).to receive(:destroy)
+        orchestration_stack.delete_stack
+      end
+
+      it 'catches errors from provider' do
+        expect(the_raw_stack).to receive(:undeploy)
+        expect(the_raw_stack).to receive(:destroy).and_raise('bad_request')
+        expect { orchestration_stack.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
+      end
+    end
   end
 
   describe 'stack status' do


### PR DESCRIPTION
Purpose or Intent
-----------------
This patch extends the orchestration stack of the VMware cloud manager
with the support for provisioning a new stack from a template and delete
an existing one. In VMware, the orchestration stack is represented by a
vApp, while its template, stored in a catalog, is a vApp template.

The refresh parser is responsible for parsing these templates into
`orchestration_templates` table. However, due to the way vApps are
instantiated in VMware cloud, this patch does not use the content of the
template, but rather just uses it's ID to request provisioning.

Corresponding tests are provided using mocks in a similar way as other
providers do it.

Links
-----
> * [Add orchestration stack status support for VMware Cloud](#10556)


Steps for Testing/QA
--------------------
Although the patch provides an automated test with mocks, we also used
the following procedure to test this patch.

```ruby
# Get the corresponding EMS
ems = ExtManagementSystem.first
# Find the orchestration template (should be already in the DB due
# to refresh_parser)
template = OrchestrationTemplate.find(3)
# Specify the VMware vApp instantiation options
options = { :vdc_id => "0ede26a2-58c8-4494-821a-a216b149b865", :deploy => true, :powerOn => true }

# Request the provisioning of the vApp.
ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'ems_test', template, options)
```

Once the vApp is up and running, it should be picked up by the refresh
parser as an orchestration stack, so

```ruby
# Get the corresponding stack
stack = OrchestrationStack.find(8)
# Request removal
stack.delete_stack
```

@miq-bot add_label providers/vmware/cloud, enhancement, gem changes, wip