### PR TITLE
Remove incorrect usage of ui lookup(:ui_title => ...)

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -33,18 +33,8 @@ class ProviderForemanController < ApplicationController
     end
   end
 
-  def self.model_to_cs_name(provmodel)
-    if provmodel.include?("ManageIQ::Providers::AnsibleTower")
-      ui_lookup(:ui_title => 'Ansible Tower Job Template')
-    end
-  end
-
   def model_to_name(provmodel)
     ProviderForemanController.model_to_name(provmodel)
-  end
-
-  def model_to_cs_name(provmodel)
-    ProviderForemanController.model_to_cs_name(provmodel)
   end
 
   def model_to_type_name(provmodel)
@@ -723,7 +713,7 @@ class ProviderForemanController < ApplicationController
     @listicon = "configuration_script"
     if x_active_tree == :configuration_scripts_tree
       options = {:model => model.to_s}
-      @right_cell_text = _("All %{title}") % {:title => model_to_cs_name(model)}
+      @right_cell_text = _("All Ansible Tower Job Templates")
       process_show_list(options)
     end
   end

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -661,7 +661,7 @@ class StorageController < ApplicationController
   end
 
   def breadcrumb_name(_model)
-    "#{ui_lookup(:ui_title => 'storage')} #{ui_lookup(:model => 'Storage')}"
+    _("Datastores")
   end
 
   def tagging_explorer_controller?


### PR DESCRIPTION
* In `ProviderForemanController` we're passing just an arbitrary string to `ui_lookup()`, its
usage here makes no sense.

* `"#{ui_lookup(:ui_title => 'storage')} #{ui_lookup(:model => 'Storage')}"` would
return just `"storage Datastore"` which makes no sense.