### PR TITLE
Fix bug in SmartProxy Affinity tree

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -572,8 +572,7 @@ module OpsController::Settings::Common
     server_id, child = id.split('__')
 
     if server_id.include?('svr')
-      server_id.sub!('svr-', '')
-      from_cid(server_id)
+      server_id = from_cid(server_id.sub('svr-', ''))
     else
       server_id.sub!('xx-', '')
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
Configuration -> Settings -> any Zone -> SmartProxy Affinity -> select any server in a tree

When server was selected there was a `Error caught: [NoMethodError] undefined method 'each_value' for nil:NilClass` message in console. This fixes it.

Closes #10911

@skateman please have a look, thanks :)
@miq_bot add_label ui, bug