### PR TITLE
Added model tags as columns to Chargeback reports

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1661,7 +1661,7 @@ module ReportController::Reports::Editor
       f_len = fields.length
       for f_idx in 1..f_len # Go thru fields in reverse
         f_key = fields[f_len - f_idx].last
-        next if f_key.ends_with?(*CHARGEBACK_ALLOWED_FIELD_SUFFIXES)
+        next if f_key.ends_with?(*CHARGEBACK_ALLOWED_FIELD_SUFFIXES) || f_key.include?('managed')
         headers.delete(f_key)
         col_formats.delete(f_key)
         fields.delete_at(f_len - f_idx)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -185,4 +185,8 @@ class Chargeback < ActsAsArModel
   def self.db_is_chargeback?(db)
     db && db.present? && db.safe_constantize < Chargeback
   end
+
+  def self.report_tag_field
+    "tag_name"
+  end
 end # class Chargeback

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -42,20 +42,20 @@ class ChargebackContainerProject < Chargeback
     project_id = options[:entity_id]
     filter_tag = options[:tag]
 
-    @project_ids = if filter_tag.present?
-                     # Get all ids of tagged projects
-                     ContainerProject.find_tagged_with(:all => filter_tag, :ns => "*").pluck(:id)
-                   elsif provider_id == "all"
-                     ContainerProject.all.pluck(:id)
-                   elsif provider_id.present? && project_id == "all"
-                     ContainerProject.where('ems_id = ? or old_ems_id = ?', provider_id, provider_id).pluck(:id)
-                   elsif project_id.present?
-                     [project_id.to_i]
-                   elsif project_id.nil? && provider_id.nil? && filter_tag.nil?
-                     raise "must provide option :entity_id, provider_id or tag"
-                   end
+    @projects = if filter_tag.present?
+                  # Get all ids of tagged projects
+                  ContainerProject.find_tagged_with(:all => filter_tag, :ns => "*")
+                elsif provider_id == "all"
+                  ContainerProject.all
+                elsif provider_id.present? && project_id == "all"
+                  ContainerProject.where('ems_id = ? or old_ems_id = ?', provider_id, provider_id)
+                elsif project_id.present?
+                  ContainerProject.where(:id => project_id)
+                elsif project_id.nil? && provider_id.nil? && filter_tag.nil?
+                  raise "must provide option :entity_id, provider_id or tag"
+                end
 
-    return [[]] if @project_ids.empty?
+    return [[]] if @projects.empty?
 
     if @options[:groupby_tag]
       @tag_hash = Classification.hash_all_by_type_and_name[@options[:groupby_tag]][:entry]
@@ -89,15 +89,11 @@ class ChargebackContainerProject < Chargeback
   end
 
   def self.where_clause(records, _options)
-    records.where(:resource_type => ContainerProject.name, :resource_id => @project_ids)
+    records.where(:resource_type => ContainerProject.name, :resource_id => @projects.select(:id))
   end
 
   def self.report_name_field
     "project_name"
-  end
-
-  def self.report_tag_field
-    "tag_name"
   end
 
   def self.report_col_options
@@ -113,5 +109,9 @@ class ChargebackContainerProject < Chargeback
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}
     }
+  end
+
+  def tags
+    ContainerProject.includes(:tags).find_by_ems_ref(project_uid).try(:tags).to_a
   end
 end # class Chargeback

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -5,6 +5,7 @@ class ChargebackVm < Chargeback
     :interval_name            => :string,
     :display_range            => :string,
     :vm_name                  => :string,
+    :vm_uid                   => :string,
     :owner_name               => :string,
     :provider_name            => :string,
     :provider_uid             => :string,
@@ -89,8 +90,13 @@ class ChargebackVm < Chargeback
     key = "#{perf.resource_id}_#{ts_key}"
     @vm_owners[perf.resource_id] ||= perf.resource.evm_owner_name
 
-    extra_fields = {"vm_name" => perf.resource_name, "owner_name" => @vm_owners[perf.resource_id],
-                    "provider_name" => perf.parent_ems.try(:name), "provider_uid" => perf.parent_ems.try(:guid) }
+    extra_fields = {
+      "vm_name"       => perf.resource_name,
+      "vm_uid"        => perf.resource.ems_ref,
+      "owner_name"    => @vm_owners[perf.resource_id],
+      "provider_name" => perf.parent_ems.try(:name),
+      "provider_uid"  => perf.parent_ems.try(:guid)
+    }
 
     [key, extra_fields]
   end
@@ -107,10 +113,6 @@ class ChargebackVm < Chargeback
 
   def self.report_name_field
     "vm_name"
-  end
-
-  def self.report_tag_field
-    "tag_name"
   end
 
   def self.report_col_options
@@ -148,5 +150,9 @@ class ChargebackVm < Chargeback
       "storage_used_metric"      => {:grouping => [:total]},
       "total_cost"               => {:grouping => [:total]}
     }
+  end
+
+  def tags
+    Vm.includes(:tags).find_by_ems_ref(vm_uid).try(:tags).to_a
   end
 end # class Chargeback

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -250,6 +250,7 @@ class MiqExpression
     'VmOrTemplate'                                => 'vm',
     'ManageIQ::Providers::CloudManager::Vm'       => 'vm',
     'ManageIQ::Providers::InfraManager::Vm'       => 'vm',
+    'ContainerProject'                            => 'container_project'
   }
   EXCLUDE_FROM_RELATS = {
     "ManageIQ::Providers::CloudManager" => ["hosts", "ems_clusters", "resource_pools"]
@@ -1212,8 +1213,10 @@ class MiqExpression
       @reporting_available_fields[model.to_s] ||= {}
       @reporting_available_fields[model.to_s][interval.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true, :interval => interval)
     elsif Chargeback.db_is_chargeback?(model)
+      cb_model = Chargeback.report_cb_model(model)
       @reporting_available_fields[model.to_s] ||=
-        MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) }
+        MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) } +
+        MiqExpression.tag_details(cb_model, model, {})
     else
       @reporting_available_fields[model.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true)
     end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -11,7 +11,7 @@ describe ChargebackVm do
 
     @admin = FactoryGirl.create(:user_admin)
 
-    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => @admin)
+    @vm1 = FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => @admin, :ems_ref => "ems_ref")
     @vm1.tag_with(@tag.name, :ns => '*')
 
     @host1   = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
@@ -592,7 +592,7 @@ describe ChargebackVm do
 
       extra_fields = ChargebackVm.get_keys_and_extra_fields(metric_rollup, timestamp_key)
       expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => @ems.name,
-                         "provider_uid" => @ems.guid}
+                         "provider_uid" => @ems.guid, "vm_uid" => "ems_ref"}
 
       expect("#{metric_rollup.resource_id}_#{timestamp_key}").to eq(extra_fields.first)
       expect(extra_fields.second).to eq(expected_fields)
@@ -610,7 +610,7 @@ describe ChargebackVm do
 
       extra_fields = ChargebackVm.get_keys_and_extra_fields(metric_rollup_without_ems, timestamp_key)
       expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => nil,
-                         "provider_uid" => nil}
+                         "provider_uid" => nil, "vm_uid" => "ems_ref"}
 
       expect("#{metric_rollup.resource_id}_#{timestamp_key}").to eq(extra_fields.first)
       expect(extra_fields.second).to eq(expected_fields)


### PR DESCRIPTION
Add ContainerProject tags to chargeback reports

![screencapture-localhost-3000-report-explorer-1472740215704](https://cloud.githubusercontent.com/assets/11256940/18171273/0f472bfc-706a-11e6-9838-82d718bf5650.png)
![screencapture-localhost-3000-report-report_only-1472740321663](https://cloud.githubusercontent.com/assets/11256940/18171274/0fefdc8e-706a-11e6-98a1-53f0b9f94bd2.png)

** important note: The tag that is filled out in the column is the tag that applies to the project when the report was made and not the one that was applied at the time

@gtanzillo Please review
cc @simon3z 

@miq-bot add_label providers/containers, chargeback
