### PR TITLE
Check RBAC for toolbar buttons

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -12,6 +12,14 @@ class ApplicationHelper::Button::Basic < Hash
     end
   end
 
+  def role_allows_feature?
+    # for select buttons RBAC is checked only for nested buttons
+    return true if self[:type] == :buttonSelect
+    return role_allows?(:feature => self[:child_id]) unless self[:child_id].nil?
+    return role_allows?(:feature => self[:id]) if self[:items].blank?
+    false
+  end
+
   # Return content under key such as :text or :confirm run through gettext or
   # evalated in the context of controller variables and helper methods.
   def localized(key, value = nil)
@@ -35,6 +43,7 @@ class ApplicationHelper::Button::Basic < Hash
   end
 
   def skipped?
+    return true unless role_allows_feature?
     return true if self.class.record_needed && @record.nil?
     calculate_properties
     !visible?
@@ -50,6 +59,7 @@ class ApplicationHelper::Button::Basic < Hash
     false
   end
 
+  delegate :role_allows?, :to => :@view_context
 
   class << self
     attr_reader :record_needed

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -15,9 +15,11 @@ class ApplicationHelper::Button::Basic < Hash
   def role_allows_feature?
     # for select buttons RBAC is checked only for nested buttons
     return true if self[:type] == :buttonSelect
+    # for each button in select checks RBAC, self[:child_id] represents the
+    # button id for buttons inside select
     return role_allows?(:feature => self[:child_id]) unless self[:child_id].nil?
-    return role_allows?(:feature => self[:id]) if self[:items].blank?
-    false
+    # check RBAC on separate button
+    role_allows?(:feature => self[:id])
   end
 
   # Return content under key such as :text or :confirm run through gettext or

--- a/app/helpers/application_helper/button/button_without_rback_check.rb
+++ b/app/helpers/application_helper/button/button_without_rback_check.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::ButtonWithoutRbackCheck < ApplicationHelper::Button::Basic
+  def role_allows_feature?
+    true
+  end
+end

--- a/app/helpers/application_helper/button/separator.rb
+++ b/app/helpers/application_helper/button/separator.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::Separator < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::Separator < ApplicationHelper::Button::ButtonWithoutRbackCheck
   def initialize(props)
     super(nil, nil, {}, props)
     self[:type] = :separator

--- a/app/helpers/application_helper/button/view.rb
+++ b/app/helpers/application_helper/button/view.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::View < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::View < ApplicationHelper::Button::ButtonWithoutRbackCheck
   def visible?
     # only hide gtl button if they are not in @gtl_buttons
     !@gtl_buttons || @gtl_buttons.include?(self[:id].to_s)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -251,6 +251,7 @@ class ApplicationHelper::ToolbarBuilder
       :icon      => "product product-custom-#{input[:image]} fa-lg",
       :title     => input[:description].to_s,
       :enabled   => options[:enabled],
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbackCheck,
       :url       => "button",
       :url_parms => "?id=#{record.id}&button_id=#{button_id}&cls=#{record.class}&pressed=custom_button&desc=#{button_name}"
     }

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1348,17 +1348,17 @@
     - :name: Download CSV Format
       :description: Download Report in CSV Format
       :feature_type: admin
-      :hidden: false
+      :hidden: true
       :identifier: chargeback_download_csv
     - :name: Download PDF Format
       :description: Download Report in PDF Format
       :feature_type: admin
-      :hidden: false
+      :hidden: true
       :identifier: chargeback_download_pdf
     - :name: Download Text Format
       :description: Download Report in Text Format
       :feature_type: admin
-      :hidden: false
+      :hidden: true
       :identifier: chargeback_download_text
   - :name: Rates
     :description: Rates Accordion
@@ -4741,17 +4741,17 @@
         - :name: Download CSV Format
           :description: Download Report in CSV Format
           :feature_type: admin
-          :hidden: false
+          :hidden: true
           :identifier: compare_download_csv
         - :name: Download PDF Format
           :description: Download Report in PDF Format
           :feature_type: admin
-          :hidden: false
+          :hidden: true
           :identifier: compare_download_pdf
         - :name: Download Text Format
           :description: Download Report in Text Format
           :feature_type: admin
-          :hidden: false
+          :hidden: true
           :identifier: compare_download_text
       - :name: Drift
         :description: Display Instances Drift

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1344,6 +1344,22 @@
     :description: Reports Accordion
     :feature_type: node
     :identifier: chargeback_reports
+    :children:
+    - :name: Download CSV Format
+      :description: Download Report in CSV Format
+      :feature_type: admin
+      :hidden: false
+      :identifier: chargeback_download_csv
+    - :name: Download PDF Format
+      :description: Download Report in PDF Format
+      :feature_type: admin
+      :hidden: false
+      :identifier: chargeback_download_pdf
+    - :name: Download Text Format
+      :description: Download Report in Text Format
+      :feature_type: admin
+      :hidden: false
+      :identifier: chargeback_download_text
   - :name: Rates
     :description: Rates Accordion
     :feature_type: node
@@ -3159,6 +3175,87 @@
     :feature_type: view
     :hidden: true
     :identifier: perf_reload
+  - :name: View Grid
+    :description: View Grid
+    :feature_type: admin
+    :hidden: true
+    :identifier: view_grid
+  - :name: View Tile
+    :description: View Tile
+    :feature_type: admin
+    :hidden: true
+    :identifier: view_tile
+  - :name: View List
+    :description: View List
+    :feature_type: admin
+    :hidden: true
+    :identifier: view_list
+  - :name: View Dashboard
+    :description: View Dashboard
+    :feature_type: admin
+    :hidden: true
+    :identifier: view_dashboard
+  - :name: View Summary
+    :description: View Summary
+    :feature_type: admin
+    :hidden: true
+    :identifier: view_summary
+  - :name: View Topology
+    :description: View Topology
+    :feature_type: admin
+    :hidden: true
+    :identifier: view_topology
+  - :name: Download CSV Format
+    :description: Download in CSV Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: download_csv
+  - :name: Download PDF Format
+    :description: Download in PDF Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: download_pdf
+  - :name: Download Text Format
+    :description: Download in Text Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: download_text
+  - :name: Download View
+    :description: Download View
+    :feature_type: admin
+    :hidden: true
+    :identifier: download_view
+  - :name: VM Download PDF
+    :description: VM Download PDF
+    :feature_type: admin
+    :hidden: true
+    :identifier: vm_download_pdf
+  - :name: Tree Large
+    :description: Tree Large
+    :feature_type: admin
+    :hidden: true
+    :identifier: tree_large
+  - :name: Tree Small
+    :description: Tree Small
+    :feature_type: admin
+    :hidden: true
+    :identifier: tree_small
+  - :name: Download CSV Format
+    :description: Download in CSV Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: miq_capacity_download_csv
+  - :name: Download PDF Format
+    :description: Download in PDF Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: miq_capacity_download_pdf
+  - :name: Download Text Format
+    :description: Download in Text Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: miq_capacity_download_text
+
 
 # OrchestrationStack
 - :name: Orchestration Stacks
@@ -4640,6 +4737,22 @@
         :description: Compare multiple Instances
         :feature_type: view
         :identifier: instance_compare
+        :children:
+        - :name: Download CSV Format
+          :description: Download Report in CSV Format
+          :feature_type: admin
+          :hidden: false
+          :identifier: compare_download_csv
+        - :name: Download PDF Format
+          :description: Download Report in PDF Format
+          :feature_type: admin
+          :hidden: false
+          :identifier: compare_download_pdf
+        - :name: Download Text Format
+          :description: Download Report in Text Format
+          :feature_type: admin
+          :hidden: false
+          :identifier: compare_download_text
       - :name: Drift
         :description: Display Instances Drift
         :feature_type: view

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -68,6 +68,7 @@ describe ApplicationHelper do
           :title     => CGI.escapeHTML(@button1.description.to_s),
           :text      => escaped_button1_text,
           :enabled   => true,
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbackCheck,
           :url       => "button",
           :url_parms => "?id=#{subject.id}&button_id=#{@button1.id}&cls=#{subject.class.name}&pressed=custom_button&desc=#{escaped_button1_text}"
         }
@@ -95,6 +96,7 @@ describe ApplicationHelper do
           :title     => CGI.escapeHTML(@button1.description.to_s),
           :text      => escaped_button1_text,
           :enabled   => true,
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbackCheck,
           :url       => "button",
           :url_parms => "?id=#{subject.id}&button_id=#{@button1.id}&cls=#{subject.class.name}&pressed=custom_button&desc=#{escaped_button1_text}"
         }
@@ -2133,8 +2135,8 @@ describe ApplicationHelper do
         end
       end
 
-      # This is practically a copy paste from the VMWare tests, wasted lots of time trying ot make shared example but 
-      # unfortunately it kept failing on travis while passing localy, also causing other tests to fail from totaly 
+      # This is practically a copy paste from the VMWare tests, wasted lots of time trying ot make shared example but
+      # unfortunately it kept failing on travis while passing localy, also causing other tests to fail from totaly
       # diffrent parts of the project. This is not nice but I can't spend more time on trying to figure it out.
       context "RHEV snapshot buttons" do
         before do


### PR DESCRIPTION
Purpose or Intent
-----------------

Befere we render toolbar button, we want to check RBAC. In default is button id used as RBAC feature. For specific RBAC checking you can override `check_rbac` method.

I add  features to `miq_product_features.yaml`.

For buttons for which we dont want to check RBAC i add `ButtonWithoutRbackCheck` class.
Buttons without checking: GTL buttons,  Custom Buttons, button separators. 


Note1:
This PR only changes checking RBAC before RENDERING buttons. RBAC is checked after every click on button elsewhere and i dont modify single thing about it.