### PR TITLE
Add new Azure events

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/networksecuritygroups_write_endrequest.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/networksecuritygroups_write_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: networkSecurityGroups_write_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/subscriptions_resourcegroups_endrequest.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/subscriptions_resourcegroups_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: subscriptions_resourceGroups_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/virtualmachines_capture_endrequest.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/virtualmachines_capture_endrequest.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: virtualMachines_capture_EndRequest
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
Add EMS events for Azure provider.

The creation of the following within an Azure provider will trigger an EMS refresh, allowing their use within Provisioning Dialogs:

Private images (virtualMachines_capture_EndRequest)
Security Groups (networkSecurityGroups_write_EndRequest)
Resource Groups (subscriptions_resourceGroups_EndRequest)
