### PR TITLE
Changed Automate import to enable system domains.

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -113,6 +113,7 @@ class MiqAeYamlImport
     domain_yaml.delete_path('object', 'attributes', 'tenant_id') unless @restore
     domain_yaml.delete_path('object', 'attributes', 'priority')
     source_from_system(domain_yaml) if domain_yaml.has_key_path?('object', 'attributes', 'system')
+    enable_system_domains(domain_yaml) if domain_yaml.has_key_path?('object', 'attributes', 'source')
   end
 
   def source_from_system(domain_yaml)
@@ -121,6 +122,13 @@ class MiqAeYamlImport
       domain_yaml.store_path('object', 'attributes', 'source', MiqAeDomain::USER_LOCKED_SOURCE)
     else
       domain_yaml.store_path('object', 'attributes', 'source', MiqAeDomain::USER_SOURCE)
+    end
+  end
+
+  def enable_system_domains(domain_yaml)
+    source = domain_yaml.fetch_path('object', 'attributes', 'source')
+    if source == MiqAeDomain::SYSTEM_SOURCE
+      domain_yaml.store_path('object', 'attributes', 'enabled', true)
     end
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -15,7 +15,7 @@ describe MiqAeDatastore do
                              'meth' => 3, 'field' => 12, 'value' => 8}
     EvmSpecHelper.local_miq_server
     @tenant = Tenant.seed
-    create_factory_data("manageiq", 0)
+    create_factory_data("manageiq", 0, MiqAeDomain::SYSTEM_SOURCE)
     setup_export_dir
     set_manageiq_values
   end
@@ -179,7 +179,7 @@ describe MiqAeDatastore do
   context "export import roundtrip" do
     context "export all domains" do
       before do
-        create_factory_data("customer", 1)
+        create_factory_data("customer", 1, MiqAeDomain::USER_SOURCE)
         set_customer_values
       end
 
@@ -245,6 +245,21 @@ describe MiqAeDatastore do
         n    = FactoryGirl.create(:miq_ae_namespace, :name => "bonus_namespace_2", :parent_id => @customer_domain.id)
         n_c1 = FactoryGirl.create(:miq_ae_class, :name => "bonus_test_class_3", :namespace_id => n.id)
         FactoryGirl.create(:miq_ae_instance, :name => "bonus_test_instance1", :class_id => n_c1.id)
+      end
+
+      it "import single user domain" do
+        options = {'yaml_file' => @yaml_file}
+        assert_single_domain_import(options, options)
+        dom = MiqAeDomain.find_by_fqname(@customer_domain.name, false)
+        expect(dom).not_to be_enabled
+      end
+
+      it "import single system domain" do
+        options = {'yaml_file' => @yaml_file}
+        @customer_domain.update_attributes(:source => MiqAeDomain::SYSTEM_SOURCE)
+        assert_single_domain_import(options, options)
+        dom = MiqAeDomain.find_by_fqname(@customer_domain.name, false)
+        expect(dom).to be_enabled
       end
 
       def assert_single_domain_import(export_options, import_options)
@@ -582,7 +597,7 @@ describe MiqAeDatastore do
 
   context 'backup and restore' do
     before do
-      create_factory_data('customer', 16)
+      create_factory_data('customer', 16, MiqAeDomain::USER_SOURCE)
       set_customer_values
     end
 
@@ -703,8 +718,8 @@ describe MiqAeDatastore do
                  'value'         => 'test_input_value')
   end
 
-  def create_factory_data(domain_name, priority)
-    domain   = FactoryGirl.create(:miq_ae_domain_enabled, :name => domain_name,                :priority => priority)
+  def create_factory_data(domain_name, priority, source = MiqAeDomain::USER_SOURCE)
+    domain   = FactoryGirl.create(:miq_ae_domain_enabled, :name => domain_name, :source => source, :priority => priority)
     n1       = FactoryGirl.create(:miq_ae_namespace, :name => "#{domain_name}_namespace_1",    :parent_id => domain.id)
     n1_c1    = FactoryGirl.create(:miq_ae_class,     :name => "#{domain_name}_test_class_1",   :namespace_id => n1.id)
     n1_1     = FactoryGirl.create(:miq_ae_namespace, :name => "#{domain_name}_namespace_1_1",  :parent_id => n1.id)


### PR DESCRIPTION
System domains should be enabled on import. 

The new provider specific system domains should be enabled on import.  Determining the priority for system domains will be handled separately.   