### PR TITLE
Add Notifications Drawer and Toast Notifications List

### DIFF
--- a/app/assets/javascripts/angular_modules/module_notifications.js
+++ b/app/assets/javascripts/angular_modules/module_notifications.js
@@ -1,0 +1,2 @@
+miqHttpInject(
+  angular.module('ManageIQ.notifications', ['ui.bootstrap', 'patternfly', 'ManageIQ', 'miq.util']));

--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -1,0 +1,35 @@
+miqHttpInject(angular.module('ManageIQ.notifications')).controller('headerController', HeaderCtrl);
+
+HeaderCtrl.$inject = ['$scope', 'eventNotifications', '$timeout'];
+
+function HeaderCtrl($scope, eventNotifications, $timeout) {
+  var vm = this;
+
+  var cookieId = 'miq-notification-drawer';
+  vm.newNotifications = false;
+  vm.notificationsDrawerShown = sessionStorage.getItem(cookieId + "-shown") == 'true';
+  eventNotifications.setDrawerShown(vm.notificationsDrawerShown);
+
+  vm.toggleNotificationsList = function () {
+    vm.notificationsDrawerShown = !vm.notificationsDrawerShown;
+    sessionStorage.setItem(cookieId + "-shown", vm.notificationsDrawerShown);
+    eventNotifications.setDrawerShown(vm.notificationsDrawerShown);
+  };
+
+  var refresh = function() {
+    $timeout(function() {
+      vm.newNotifications = eventNotifications.state().unreadNotifications;
+    });
+  };
+
+  var destroy = function() {
+    eventNotifications.unregisterObserverCallback(refresh);
+  };
+
+  eventNotifications.registerObserverCallback(refresh);
+
+  $scope.$on('destroy', destroy);
+
+  refresh();
+}
+

--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -1,0 +1,135 @@
+miqHttpInject(angular.module('ManageIQ.notifications'))
+  .controller('notificationsDrawerController', NotificationsDrawerCtrl);
+
+NotificationsDrawerCtrl.$inject = ['$scope', 'eventNotifications', '$timeout'];
+
+function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
+  var vm = this;
+  var cookieId = 'miq-notification-drawer';
+  vm.notificationGroups = [];
+  vm.drawerExpanded = sessionStorage.getItem(cookieId + "-expanded") == 'true';
+  vm.notificationsDrawerShown = eventNotifications.state().drawerShown;
+
+  var watchExpanded = $scope.$watch(angular.bind(vm, function () {
+    return vm.drawerExpanded;
+  }), function () {
+    sessionStorage.setItem(cookieId + "-expanded", vm.drawerExpanded);
+  });
+
+  var addGroupWatchers = function () {
+    angular.forEach(vm.notificationGroups, function (group, index) {
+      if (group.watcher) {
+        group.watcher();
+      }
+      group.watcher = $scope.$watch(angular.bind(vm, function () {
+        return vm.notificationGroups[index];
+      }), function(newVal) {
+        sessionStorage.setItem(cookieId + "-" + newVal.notificationType + "-open", newVal.open);
+      }, true);
+    });
+  };
+
+  var clearGroupWatchers = function() {
+    angular.forEach(vm.notificationGroups, function (group) {
+      if (angular.isFunction(group.watcher)) {
+        group.watcher();
+      }
+    });
+  };
+
+  vm.markAllRead = function (group) {
+    eventNotifications.markAllRead(group);
+  };
+
+  var updatePosition = function() {
+    var hasVerticalScrollbar,
+        scrollContent = angular.element('#main-content'),
+        miqNotificationsDrawer = angular.element('#miq-notifications-drawer .drawer-pf');
+    if (scrollContent && scrollContent.length == 1 && miqNotificationsDrawer && miqNotificationsDrawer.length == 1) {
+      hasVerticalScrollbar = scrollContent[0].scrollHeight > scrollContent[0].clientHeight;
+      if (hasVerticalScrollbar) {
+        angular.element(miqNotificationsDrawer).addClass('vertical-scroll');
+      } else {
+        angular.element(miqNotificationsDrawer).removeClass('vertical-scroll');
+      }
+
+    }
+  };
+
+  var watchPositioning = function () {
+    var scrollContent = angular.element('#main-content');
+    if (scrollContent && scrollContent.length == 1) {
+      updatePosition();
+      scrollContent.off('resize', updatePosition);
+      scrollContent.on('resize', updatePosition);
+    }
+  };
+
+  var refreshNotifications = function() {
+    clearGroupWatchers();
+
+    vm.notificationGroups = eventNotifications.state().groups;
+    angular.forEach($scope.notificationGroups, function(group) {
+      group.open = sessionStorage.getItem(cookieId + "-" + group.notificationType + "-open") == 'true';
+    });
+
+    addGroupWatchers();
+  };
+
+  var refresh = function() {
+    $timeout(function() {
+      refreshNotifications();
+      vm.notificationsDrawerShown = eventNotifications.state().drawerShown;
+    });
+  };
+
+  var destroy = function() {
+    eventNotifications.unregisterObserverCallback(refresh);
+    groupsWatcher();
+    clearGroupWatchers();
+    watchExpanded();
+  };
+
+  eventNotifications.registerObserverCallback(refresh);
+
+  $scope.$on('destroy', destroy);
+
+  if (vm.notificationsDrawerShown) {
+    angular.element(document).ready(watchPositioning);
+  }
+  angular.element(window).resize(watchPositioning);
+
+  vm.customScope = {};
+
+  vm.customScope.getNotficationStatusIconClass = function(notification) {
+    var retClass = '';
+    if (notification && notification.data && notification.data.type) {
+      if (notification.data.type == 'info') {
+        retClass = "pficon pficon-info";
+      } else if ((notification.data.type == 'error') || (notification.data.type == 'danger')) {
+        retClass = "pficon pficon-error-circle-o";
+      } else if (notification.data.type == 'warning') {
+        retClass = "pficon pficon-warning-triangle-o";
+      } else if ((notification.data.type == 'success') || (notification.data.type == 'success')) {
+        retClass = "pficon pficon-ok";
+      }
+    }
+
+    return retClass;
+  };
+
+  vm.customScope.markNotificationRead = function(notification, group) {
+    eventNotifications.markRead(notification, group);
+  };
+
+  vm.customScope.clearNotification = function(notification, group) {
+    eventNotifications.clear(notification, group);
+  };
+
+  vm.customScope.clearAllNotifications = function(group) {
+    eventNotifications.clearAll(group);
+  };
+
+  refresh();
+}
+

--- a/app/assets/javascripts/controllers/notifications/toast_list_controller.js
+++ b/app/assets/javascripts/controllers/notifications/toast_list_controller.js
@@ -1,0 +1,34 @@
+miqHttpInject(angular.module('ManageIQ.notifications')).controller('toastListController', ToastListCtrl);
+
+ToastListCtrl.$inject = ['$scope', 'eventNotifications', '$timeout'];
+
+function ToastListCtrl($scope, eventNotifications, $timeout) {
+  var vm = this;
+  vm.toastNotifications = [];
+
+  vm.handleCloseToast = function (notification) {
+    eventNotifications.markRead(notification);
+    eventNotifications.dismissToast(notification);
+  };
+
+  vm.updateViewing = function (viewing, notification) {
+    eventNotifications.setViewingToast(notification, viewing)
+  };
+
+  var refresh = function() {
+    $timeout(function() {
+      vm.toastNotifications = eventNotifications.state().toastNotifications;
+    });
+  };
+
+  var destroy = function() {
+    eventNotifications.unregisterObserverCallback(refresh);
+  };
+
+  eventNotifications.registerObserverCallback(refresh);
+
+  $scope.$on('destroy', destroy);
+
+  refresh();
+}
+

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -1,0 +1,264 @@
+miqHttpInject(angular.module('ManageIQ.notifications')).service('eventNotifications', ["$timeout", function($timeout) {
+  if (!ManageIQ.angular.eventNotificationsData) {
+    ManageIQ.angular.eventNotificationsData = {
+      state: {
+        groups: [],
+        unreadNotifications: false,
+        toastNotifications: [],
+        drawerShown: false
+      },
+      toastDelay: 8 * 1000,
+      observerCallbacks: []
+    }
+  }
+
+  // psudo constants
+  this.EVENT_NOTIFICATION = 'event';
+  this.TASK_NOTIFICATION = 'task';
+
+  this.ERROR = 'danger';
+  this.WARNING = 'warning';
+  this.INFO = 'info';
+  this.SUCCESS = 'ok';
+
+  var state = ManageIQ.angular.eventNotificationsData.state;
+  var observerCallbacks = ManageIQ.angular.eventNotificationsData.observerCallbacks;
+
+  var updateUnreadCount = function(group) {
+    if (group) {
+      group.unreadCount = group.notifications.filter(function(notification) {
+        return notification.unread;
+      }).length;
+    }
+    state.unreadNotifications = state.groups.find(function(nextGroup) {
+        return nextGroup.unreadCount > 0;
+      }) !== undefined;
+  };
+
+  var notifyObservers = function(){
+    angular.forEach(observerCallbacks, function(callback){
+      callback();
+    });
+  };
+
+  this.doReset = function() {
+    state.groups.splice(0, state.groups.length);
+    state.groups.push(
+      {
+        notificationType: this.EVENT_NOTIFICATION,
+        heading: __("Events"),
+        unreadCount: 0,
+        notifications: []
+      }
+    );
+    state.groups.push(
+      {
+        notificationType: this.TASK_NOTIFICATION,
+        heading: __("Tasks"),
+        unreadCount: 0,
+        notifications: []
+      }
+    );
+    state.unreadNotifications = false;
+    state.toastNotifications = [];
+  };
+
+  this.registerObserverCallback = function(callback){
+    observerCallbacks.push(callback);
+  };
+
+  this.unregisterObserverCallback = function(callback){
+    var index = observerCallbacks.indexOf(callback);
+    if (index > -1) {
+      observerCallbacks.splice(index, 1);
+    }
+  };
+
+  this.state = function() {
+    return state;
+  };
+
+  this.setDrawerShown = function(shown) {
+    state.drawerShown = shown;
+    notifyObservers();
+  };
+
+  this.add = function(notificationType, type, message, notificationData, id) {
+    var newNotification = {
+      id: id,
+      notificationType: notificationType,
+      unread: true,
+      type: type,
+      message: message,
+      data: notificationData,
+      timeStamp: (new Date()).getTime()
+    };
+
+    var group = state.groups.find(function(notificationGroup) {
+      return notificationGroup.notificationType === notificationType;
+    });
+    if (group) {
+      if (group.notifications) {
+        group.notifications.splice(0, 0, newNotification);
+      } else {
+        group.notifications = [newNotification];
+      }
+      updateUnreadCount(group);
+    }
+    this.showToast(newNotification);
+    notifyObservers();
+  };
+
+  this.update = function(notificationType, type, message, notificationData, id, showToast) {
+    var notification;
+    var group = state.groups.find(function(notificationGroup) {
+      return notificationGroup.notificationType === notificationType;
+    });
+
+    if (group) {
+      notification = group.notifications.find(function(notification) {
+        return notification.id === id;
+      });
+
+      if (notification) {
+        if (showToast) {
+          notification.unread = true;
+        }
+        notification.type = type;
+        notification.message = message;
+        notification.data = notificationData;
+        notification.timeStamp = (new Date()).getTime();
+        updateUnreadCount(group);
+      }
+    }
+
+    if (showToast) {
+      if (!notification) {
+        notification = {
+          type: type,
+          message: message
+        };
+      }
+
+      this.showToast(notification);
+    }
+    notifyObservers();
+  };
+
+  this.markRead = function(notification, group) {
+    if (notification) {
+      notification.unread = false;
+    }
+    if (group) {
+      updateUnreadCount(group);
+    } else {
+      state.groups.forEach(function(group) {
+        updateUnreadCount(group);
+      });
+    }
+    notifyObservers();
+  };
+
+  this.markUnread = function(notification, group) {
+    if (notification) {
+      notification.unread = true;
+    }
+    if (group) {
+      updateUnreadCount(group);
+    } else {
+      state.groups.forEach(function(group) {
+        updateUnreadCount(group);
+      });
+    }
+    notifyObservers();
+  };
+
+  this.markAllRead = function(group) {
+    if (group) {
+      group.notifications.forEach(function(notification) {
+        notification.unread = false;
+      });
+      group.unreadCount = 0;
+      updateUnreadCount();
+    }
+    notifyObservers();
+  };
+
+  this.markAllUnread = function(group) {
+    if (group) {
+      group.notifications.forEach(function(notification) {
+        notification.unread = true;
+      });
+      group.unreadCount = group.notifications.length;
+      updateUnreadCount();
+      notifyObservers();
+    }
+  };
+
+  this.clear = function(notification, group) {
+    var index;
+
+    if (!group) {
+      group = state.groups.find(function(nextGroup) {
+        return notification.notificationType === nextGroup.notificationType;
+      });
+    }
+
+    if (group) {
+      index = group.notifications.indexOf(notification);
+      if (index > -1) {
+        group.notifications.splice(index, 1);
+        updateUnreadCount(group);
+        notifyObservers();
+      }
+    }
+  };
+
+  this.clearAll = function(group) {
+    if (group) {
+      group.notifications = [];
+      updateUnreadCount(group);
+      notifyObservers();
+    }
+  };
+
+  this.removeToast = function(notification) {
+    var index = state.toastNotifications.indexOf(notification);
+    if (index > -1) {
+      state.toastNotifications.splice(index, 1);
+    }
+    notifyObservers();
+  };
+
+  this.showToast = function(notification, persist) {
+    var $this = this;
+    notification.show = true;
+    state.toastNotifications.push(notification);
+    notifyObservers();
+
+    // any toast notifications with out 'danger' or 'error' status are automatically removed after a delay
+    if (persist !== true && notification.type !== 'danger' && notification.type !== 'error') {
+      notification.viewing = false;
+      $timeout(function() {
+        notification.show = false;
+        if (!notification.viewing) {
+          $this.removeToast(notification);
+        }
+      }, ManageIQ.angular.eventNotificationsData.toastDelay);
+    }
+  };
+
+  this.setViewingToast = function(notification, viewing) {
+    notification.viewing = viewing;
+    if (!viewing && !notification.show) {
+      this.removeToast(notification);
+    }
+  };
+
+  this.dismissToast = function(notification) {
+    notification.show = false;
+    this.removeToast(notification);
+  };
+
+  this.doReset();
+}]);

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -568,3 +568,17 @@ body#dashboard {
     }
   }
 }
+
+// Notifications drawer positioning
+.drawer-pf {
+  bottom: 20px;
+  position: absolute;
+  top: 60px;
+  z-index: 950;
+  .panel-body {
+    margin: 0;
+  }
+}
+.drawer-pf.vertical-scroll {
+  right: 15px;
+}

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,5 +1,5 @@
 = render :partial => 'layouts/about_modal'
-%nav.navbar.navbar-pf-vertical
+%nav.navbar.navbar-pf-vertical{'ng-controller' => "headerController as vm"}
   .navbar-header
     %button{:type => "button", :class => "navbar-toggle"}
       %span.sr-only
@@ -11,6 +11,9 @@
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
+      %li{:class => "drawer-pf-trigger dropdown"}
+        %a{:class => "nav-item-iconic drawer-pf-trigger-icon", "ng-click" => "vm.toggleNotificationsList()"}
+          %span{:title => _("Notifications"), "ng-class" => "{'fa fa-bell': vm.newNotifications, 'fa fa-bell-o': !vm.newNotifications}"}
       %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
       %li.dropdown
         %a{:class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu1",  "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "true"}
@@ -31,6 +34,11 @@
 
   = render :partial => "layouts/spinner"
   = render :partial => "layouts/lightbox_panel"
+  = render :partial => "layouts/notifications_drawer"
+  = render :partial => "layouts/toast_list"
+
+:javascript
+  miq_bootstrap('.navbar.navbar-pf-vertical', 'ManageIQ.notifications');
 
 -# if set by controller, set up to run as JS after onload is done
 - if @miq_after_onload

--- a/app/views/layouts/_notifications_drawer.html.haml
+++ b/app/views/layouts/_notifications_drawer.html.haml
@@ -1,0 +1,14 @@
+%div{"id" => "miq-notifications-drawer-container", 'ng-controller' => "notificationsDrawerController as vm"}
+  %div{"pf-notification-drawer" => "",
+       "id" => "miq-notifications-drawer",
+       "drawer-hidden" => "!vm.notificationsDrawerShown",
+       "drawer-title" => "Notifications",
+       "allow-expand" => "true",
+       "action-button-title" => "Mark All Read",
+       "action-button-callback" => "vm.markAllRead",
+       "notification-groups" => "vm.notificationGroups",
+       "heading-include" => "/static/notification_drawer/notification-heading.html",
+       "subheading-include" => "/static/notification_drawer/notification-subheading.html",
+       "notification-body-include" => "/static/notification_drawer/notification-body.html",
+       "notification-footer-include" => "/static/notification_drawer/notification-footer.html",
+       "custom-scope" => "vm.customScope"}

--- a/app/views/layouts/_toast_list.html.haml
+++ b/app/views/layouts/_toast_list.html.haml
@@ -1,0 +1,6 @@
+%div{"id" => "toast-list-container", 'ng-controller' => "toastListController as vm"}
+  %div{"pf-toast-notification-list" => "",
+       "notifications" => "vm.toastNotifications",
+       "show-close" => "true",
+       "close-callback" => "vm.handleCloseToast",
+       "update-viewing" => "vm.updateViewing"}

--- a/app/views/static/notification_drawer/notification-body.html
+++ b/app/views/static/notification_drawer/notification-body.html
@@ -1,0 +1,69 @@
+<div ng-if="!drawerExpanded" ng-click="customScope.markNotificationRead(notification, notificationGroup)">
+  <div class="dropdown pull-right dropdown-kebab-pf">
+    <button class="btn btn-link dropdown-toggle" type="button" ng-click="customScope.clearNotification(notification, notificationGroup)">
+      <span class="pficon pficon-close"></span>
+    </button>
+  </div>
+  <span class="pull-left {{customScope.getNotficationStatusIconClass(notification)}}" ng-click="customScope.markRead(notification, notificationGroup)"></span>
+  <span class="drawer-pf-notification-message notification-message"
+        ng-click="customScope.markRead(notification, notificationGroup)"
+        tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.data.message}}">
+    {{notification.data.message}}
+  </span>
+  <div ng-if="!notification.data.inProgress" class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
+    <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
+    <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+  </div>
+  <div ng-if="notification.data.inProgress" class="mini-progress clearfix">
+    <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+    <div class="mini-progress-area">
+      <div class="progress">
+        <span class="progress-bar progress-bar-info"
+              ng-style="{width: notification.data.percentComplete + '%'}" tooltip="{{notification.data.percentComplete}} + {{'% Complete'}}">
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+<div ng-if="drawerExpanded" class="container-fluid expanded-notification" ng-click="customScope.markNotificationRead(notification, notificationGroup)">
+  <div class="row">
+    <div ng-class="{'col-md-4': notificationGroup.notificationType == 'task'}" class="col-sm-6">
+      <span class="pull-left {{customScope.getNotficationStatusIconClass(notification)}}" ng-click="customScope.markRead(notification, notificationGroup)"></span>
+      <span class="drawer-pf-notification-message notification-message"
+            ng-click="customScope.markRead(notification, notificationGroup)"
+            tooltip-append-to-body="true" tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message}}">
+            {{notification.message}}
+      </span>
+    </div>
+    <div class="col-md-4 col-sm-3" ng-if="notificationGroup.notificationType == 'task'">
+      <div class="drawer-pf-notification-info expanded-info" ng-click="customScope.markRead(notification, notificationGroup)">
+        <span class="info-title">Started: </span>
+        <span class="date">{{notification.startTime | date:'MM/dd/yyyy'}}</span>
+        <span class="time">{{notification.startTime | date:'h:mm:ss a'}}</span>
+      </div>
+      <div ng-if="notification.inProgress" class="progress">
+        <div class="progress-bar progress-bar-info"
+             ng-style="{width: notification.percentComplete + '%'}" tooltip="{{notification.percentComplete}} + {{'% Complete'}}">
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4 col-sm-3" ng-if="notificationGroup.notificationType == 'task'">
+      <div class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
+        <span class="info-title">Completed: </span>
+        <span class="date">{{notification.endTime | date:'MM/dd/yyyy'}}</span>
+        <span class="time">{{notification.endTime | date:'h:mm:ss a'}}</span>
+      </div>
+    </div>
+    <div class="col-sm-6" ng-if="notificationGroup.notificationType == 'event'">
+      <div class="drawer-pf-notification-info" ng-click="customScope.markRead(notification, notificationGroup)">
+        <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
+        <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+      </div>
+      <div class="pull-right dropdown-kebab-pf">
+        <button class="btn btn-link dropdown-toggle" type="button" ng-click="customScope.clearNotification(notification, notificationGroup)">
+          <span class="pficon pficon-close"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/static/notification_drawer/notification-footer.html.haml
+++ b/app/views/static/notification_drawer/notification-footer.html.haml
@@ -1,0 +1,7 @@
+.drawer-pf-action
+  %a.btn.btn-link.btn-block{"role" => "button",
+    "ng-class" => "{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}",
+    "ng-click" => "customScope.clearAllNotifications(notificationGroup)"}
+    %span.pficon.pficon-close
+    %span
+      = _("Clear All")

--- a/app/views/static/notification_drawer/notification-heading.html
+++ b/app/views/static/notification_drawer/notification-heading.html
@@ -1,0 +1,1 @@
+<span class="heading-class">{{notificationGroup.heading}}</span>

--- a/app/views/static/notification_drawer/notification-subheading.html
+++ b/app/views/static/notification_drawer/notification-subheading.html
@@ -1,0 +1,1 @@
+<span class="subheading-class">{{notificationGroup.unreadCount}} New</span>

--- a/spec/javascripts/services/event_notifications_service_spec.js
+++ b/spec/javascripts/services/event_notifications_service_spec.js
@@ -1,0 +1,171 @@
+describe('eventNotifications', function() {
+  var testService;
+  var $scope;
+
+  beforeEach(module('ManageIQ.notifications'));
+
+  beforeEach(inject(function(eventNotifications, _$rootScope_) {
+    testService = eventNotifications;
+    $scope = _$rootScope_;
+  }));
+
+  beforeEach(function () {
+    $scope.eventsChanged = false;
+    $scope.observer = function () {
+      $scope.eventsChanged = true;
+    };
+    testService.registerObserverCallback($scope.observer);
+  });
+
+  it('should add to the notifications list and toast notifications when an event is added', function() {
+    expect(testService.state().groups.length).toBe(2);
+
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test message", {}, 1);
+    expect(testService.state().groups[0].notifications.length).toBe(1);
+  });
+
+  it('should notify observers when an event is added', function() {
+    expect($scope.eventsChanged).toBeFalsy();
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test message", {}, 1);
+    expect($scope.eventsChanged).toBeTruthy();
+  });
+
+  it('should update events', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test message", {}, 1);
+    expect(testService.state().groups[0].notifications[0].type).toBe(testService.INFO);
+    expect(testService.state().groups[0].notifications[0].message).toBe("test message");
+
+    testService.update(testService.EVENT_NOTIFICATION, testService.ERROR, "test message", {}, 1);
+    expect(testService.state().groups[0].notifications.length).toBe(1);
+    expect(testService.state().groups[0].notifications[0].type).toBe(testService.ERROR);
+    expect(testService.state().groups[0].notifications[0].message).toBe("test message");
+  });
+
+  it('should allow events to be marked as read', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test info message", {}, 1);
+    testService.add(testService.EVENT_NOTIFICATION, testService.ERROR, "test error message", {}, 2);
+    testService.add(testService.EVENT_NOTIFICATION, testService.WARNING, "test warning message", {}, 3);
+
+    expect(testService.state().groups[0].notifications.length).toBe(3);
+
+    // Pass group
+    expect(testService.state().groups[0].notifications[1].unread).toBeTruthy();
+    testService.markRead(testService.state().groups[0].notifications[1], testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications[1].unread).toBeFalsy();
+
+    // Do not pass group
+    expect(testService.state().groups[0].notifications[2].unread).toBeTruthy();
+    testService.markRead(testService.state().groups[0].notifications[2]);
+    expect(testService.state().groups[0].notifications[2].unread).toBeFalsy();
+  });
+
+  it('should allow events to be marked as unread', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test info message", {}, 1);
+    testService.add(testService.EVENT_NOTIFICATION, testService.ERROR, "test error message", {}, 2);
+    testService.add(testService.EVENT_NOTIFICATION, testService.WARNING, "test warning message", {}, 3);
+
+    expect(testService.state().groups[0].notifications.length).toBe(3);
+
+    // Pass group
+    expect(testService.state().groups[0].notifications[1].unread).toBeTruthy();
+    testService.markRead(testService.state().groups[0].notifications[1], testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications[1].unread).toBeFalsy();
+    testService.markUnread(testService.state().groups[0].notifications[1], testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications[1].unread).toBeTruthy();
+
+    // Do not pass group
+    expect(testService.state().groups[0].notifications[2].unread).toBeTruthy();
+    testService.markRead(testService.state().groups[0].notifications[2]);
+    expect(testService.state().groups[0].notifications[2].unread).toBeFalsy();
+    testService.markUnread(testService.state().groups[0].notifications[2]);
+    expect(testService.state().groups[0].notifications[2].unread).toBeTruthy();
+  });
+
+  it('should allow all events to be marked as read', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test info message", {}, 1);
+    testService.add(testService.EVENT_NOTIFICATION, testService.ERROR, "test error message", {}, 2);
+    testService.add(testService.EVENT_NOTIFICATION, testService.WARNING, "test warning message", {}, 3);
+
+    expect(testService.state().groups[0].notifications.length).toBe(3);
+    expect(testService.state().groups[0].notifications[0].unread).toBeTruthy();
+    expect(testService.state().groups[0].notifications[1].unread).toBeTruthy();
+    expect(testService.state().groups[0].notifications[2].unread).toBeTruthy();
+
+    testService.markAllRead(testService.state().groups[0]);
+
+    expect(testService.state().groups[0].notifications[0].unread).toBeFalsy();
+    expect(testService.state().groups[0].notifications[1].unread).toBeFalsy();
+    expect(testService.state().groups[0].notifications[2].unread).toBeFalsy();
+  });
+
+  it('should allow all events to be marked as unread', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test info message", {}, 1);
+    testService.add(testService.EVENT_NOTIFICATION, testService.ERROR, "test error message", {}, 2);
+    testService.add(testService.EVENT_NOTIFICATION, testService.WARNING, "test warning message", {}, 3);
+
+    expect(testService.state().groups[0].notifications.length).toBe(3);
+    expect(testService.state().groups[0].notifications[0].unread).toBeTruthy();
+    expect(testService.state().groups[0].notifications[1].unread).toBeTruthy();
+    expect(testService.state().groups[0].notifications[2].unread).toBeTruthy();
+
+    testService.markRead(testService.state().groups[0].notifications[1], testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications[1].unread).toBeFalsy();
+
+    testService.markAllUnread(testService.state().groups[0]);
+
+    expect(testService.state().groups[0].notifications[0].unread).toBeTruthy();
+    expect(testService.state().groups[0].notifications[1].unread).toBeTruthy();
+    expect(testService.state().groups[0].notifications[2].unread).toBeTruthy();
+  });
+
+  it('should allow events to be cleared', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test info message", {}, 1);
+    testService.add(testService.EVENT_NOTIFICATION, testService.ERROR, "test error message", {}, 2);
+    testService.add(testService.EVENT_NOTIFICATION, testService.WARNING, "test warning message", {}, 3);
+
+    expect(testService.state().groups[0].notifications.length).toBe(3);
+    expect(testService.state().groups[0].notifications[0].type).toBe(testService.WARNING);
+    expect(testService.state().groups[0].notifications[1].type).toBe(testService.ERROR);
+    expect(testService.state().groups[0].notifications[2].type).toBe(testService.INFO);
+
+    // Pass the group
+    testService.clear(testService.state().groups[0].notifications[1], testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications.length).toBe(2);
+    expect(testService.state().groups[0].notifications[0].type).toBe(testService.WARNING);
+    expect(testService.state().groups[0].notifications[1].type).toBe(testService.INFO);
+
+    // Do not ass the group
+    testService.clear(testService.state().groups[0].notifications[1], testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications.length).toBe(1);
+    expect(testService.state().groups[0].notifications[0].type).toBe(testService.WARNING);
+  });
+
+  it('should allow all events to be cleared', function() {
+    testService.add(testService.EVENT_NOTIFICATION, testService.INFO, "test info message", {}, 1);
+    testService.add(testService.EVENT_NOTIFICATION, testService.ERROR, "test error message", {}, 2);
+    testService.add(testService.EVENT_NOTIFICATION, testService.WARNING, "test warning message", {}, 3);
+
+    expect(testService.state().groups[0].notifications.length).toBe(3);
+
+    testService.clearAll(testService.state().groups[0]);
+    expect(testService.state().groups[0].notifications.length).toBe(0);
+  });
+
+  it('should show toast notifications', function() {
+    var notification = {message: "Test Toast", type: testService.INFO};
+    testService.showToast(notification);
+    expect(testService.state().toastNotifications.length).toBe(1);
+  });
+
+  it('should allow toast notifications to be dismissed', function() {
+    var notification = {message: "Test Toast", type: testService.INFO};
+    var notification2 = {message: "Test Toast 2", type: testService.ERROR};
+    testService.showToast(notification);
+    testService.showToast(notification2);
+    expect(testService.state().toastNotifications.length).toBe(2);
+
+    testService.dismissToast(notification);
+    expect(testService.state().toastNotifications.length).toBe(1);
+    expect(testService.state().toastNotifications[0].message).toBe("Test Toast 2");
+  });
+});


### PR DESCRIPTION
Adding a notifications drawer to provide a mechanism to show users events/tasks in the UI. Built using the Angular Patternfly directive, the drawer shows on the right side of the window above the main content. It can be opened/closed via a notifications indicator on the top nav bar.

The Toast Notifications list provides a place to show popup notifications to the user. The notifications are shown for 8 seconds for normal notifications but remain until closed for error notifications.

This PR does not cover retrieving  the notifications from the server or persisting any notification states.

Notification Drawer: 
![image](https://cloud.githubusercontent.com/assets/11633780/18181476/47228f64-7059-11e6-809c-37b44a3f2d42.png)

Toast Notifications:
![image](https://cloud.githubusercontent.com/assets/11633780/18180847/a4f17842-7056-11e6-8395-dfba333da8fe.png)


References for Patterns on Patternfly:
-------------------------------------------
> * https://www.patternfly.org/pattern-library/communication/notification-drawer/#/api
> * https://www.patternfly.org/pattern-library/communication/toast-notifications/#/api
> * http://angular-patternfly.rhcloud.com/#/api/patternfly.notification.directive:pfToastNotificationList


cc @skateman @serenamarie125 