### PR TITLE
Increase coverage for MiqExpression#to_ruby

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -624,6 +624,24 @@ describe MiqExpression do
   end
 
   describe "#to_ruby" do
+    it "generates the SQL for a < expression" do
+      actual = described_class.new("<" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_ruby
+      expected = "<value ref=vm, type=integer>/virtual/hardware/cpu_sockets</value> < 2"
+      expect(actual).to eq(expected)
+    end
+
+    it "generates the SQL for a <= expression" do
+      actual = described_class.new("<=" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_ruby
+      expected = "<value ref=vm, type=integer>/virtual/hardware/cpu_sockets</value> <= 2"
+      expect(actual).to eq(expected)
+    end
+
+    it "generates the SQL for a != expression" do
+      actual = described_class.new("!=" => {"field" => "Vm-name", "value" => "foo"}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> != \"foo\""
+      expect(actual).to eq(expected)
+    end
+
     it "detects value empty array" do
       exp = MiqExpression.new("INCLUDES" => {"field" => "Vm-name", "value" => "[]"})
       expect(exp.to_ruby).to eq("<value ref=vm, type=string>/virtual/name</value> =~ /\\[\\]/")


### PR DESCRIPTION
Purpose or Intent
-----------------
Expanding the case statement in `#to_ruby` reveals that we lack coverage
for the <, <= and != operators, so adding these specs.

@miq-bot add-label test
@miq-bot assign @gtanzillo 