### PR TITLE
Fix useless access modifiers on the app directory

### DIFF
--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -99,6 +99,4 @@ module OpsController::Settings::Upload
     @sb[:show_button] = (@sb[:good] && @sb[:good] > 0)
     redirect_to :action => 'explorer', :flash_msg => msg, :flash_error => err, :no_refresh => true
   end
-
-  private
 end

--- a/app/helpers/number_helper.rb
+++ b/app/helpers/number_helper.rb
@@ -69,8 +69,6 @@ module NumberHelper
     nil
   end
 
-  private
-
   def self.handling_negatives(number)
     return nil if number.nil?
     number = Float(number)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresher.rb
@@ -257,9 +257,6 @@ module ManageIQ::Providers
       #
       # Inventory refresh for Reconfigure VM Task event
       #
-
-      public
-
       def self.reconfig_refresh(vm)
         new([vm]).reconfig_refresh
       end

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -107,8 +107,6 @@ module Metric::Capture
     MiqAlert.target_needs_realtime_capture?(target)
   end
 
-  private
-
   #
   # Capture entry points
   #
@@ -128,6 +126,7 @@ module Metric::Capture
       _log.info(msg)
     end
   end
+  private_class_method :perf_capture_health_check
 
   def self.calc_targets_by_rollup_parent(targets)
     # Collect realtime targets and group them by their rollup parent, e.g. {"EmsCluster:4"=>[Host:4], "EmsCluster:5"=>[Host:1, Host:2]}
@@ -147,6 +146,7 @@ module Metric::Capture
     end
     targets_by_rollup_parent
   end
+  private_class_method :calc_targets_by_rollup_parent
 
   def self.calc_tasks_by_rollup_parent(targets_by_rollup_parent)
     task_end_time           = Time.now.utc.iso8601
@@ -180,6 +180,7 @@ module Metric::Capture
 
     tasks_by_rollup_parent
   end
+  private_class_method :calc_tasks_by_rollup_parent
 
   def self.calc_target_options(zone, targets, targets_by_rollup_parent, tasks_by_rollup_parent)
     targets.each_with_object({}) do |target, all_options|
@@ -200,6 +201,7 @@ module Metric::Capture
       all_options[target] = options
     end
   end
+  private_class_method :calc_target_options
 
   def self.queue_captures(targets, target_options)
     # Queue the captures for each target
@@ -216,6 +218,7 @@ module Metric::Capture
       end
     end
   end
+  private_class_method :queue_captures
 
   def self.perf_target_to_interval_name(target)
     case target
@@ -224,6 +227,7 @@ module Metric::Capture
     when Storage then                                  "hourly"
     end
   end
+  private_class_method :perf_target_to_interval_name
 
   def self.minutes_ago(value)
     if value.kind_of?(Fixnum) # Default unit is minutes
@@ -234,4 +238,5 @@ module Metric::Capture
       value.to_i_with_method.seconds.ago.utc
     end
   end
+  private_class_method :minutes_ago
 end

--- a/app/models/miq_snmp.rb
+++ b/app/models/miq_snmp.rb
@@ -100,8 +100,6 @@ class MiqSnmp
     AVAILABLE_TYPES_HASH.keys
   end
 
-  private
-
   def self.create_var_bind_list(object_list, base = nil)
     vars = []
     object_list.each do |tuple|
@@ -114,6 +112,7 @@ class MiqSnmp
     end
     vars
   end
+  private_class_method :create_var_bind_list
 
   def self.subst_oid(oid, base = nil)
     oid = oid.strip
@@ -144,12 +143,15 @@ class MiqSnmp
 
     oid
   end
+  private_class_method :subst_oid
 
   def self.system_uptime
     (Time.now.utc - MiqServer.my_server.started_on.utc) * 100
   end
+  private_class_method :system_uptime
 
   def self.agent_address
     VMDB::Config.new("vmdb").get(:server, :host)
   end
+  private_class_method :agent_address
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -503,8 +503,6 @@ class MiqWorker < ApplicationRecord
     {:guid => guid}
   end
 
-  protected
-
   def self.normalized_type
     @normalized_type ||= if parent == Object
                            name.sub(/^Miq/, '').underscore
@@ -521,4 +519,5 @@ class MiqWorker < ApplicationRecord
     delta = worker_settings[:nice_delta]
     delta.kind_of?(Integer) ? delta.to_s : "+10"
   end
+  private_class_method :nice_increment
 end

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -94,8 +94,6 @@ class Snapshot < ApplicationRecord
     !self.recently_created?
   end
 
-  private
-
   def self.xml_to_hashes(xmlNode, vm_or_template_id)
     return nil unless MiqXml.isXmlElement?(xmlNode)
 
@@ -158,12 +156,14 @@ class Snapshot < ApplicationRecord
 
     all_nh
   end
+  private_class_method :xml_to_hashes
 
   def self.add_snapshot_size_for_ems(parentObj, hashes)
     ss_props = {}
     hashes.each { |h| ss_props[normalize_ss_uid(h[:uid])] = {:total_size => h[:total_size]} }
     parentObj.snapshots.each { |s| s.update_attributes(ss_props[normalize_ss_uid(s[:uid])]) unless ss_props[normalize_ss_uid(s[:uid])].nil? }
   end
+  private_class_method :add_snapshot_size_for_ems
 
   # If the snapshot uid looks like a iso8601 time (2009-09-25T20:11:14.299742Z) drop off the microseconds so
   # we don't skip linking up data because of a format change.  (IE 2009-09-25T20:11:14.000000Z to 2009-09-25T20:11:14.299742Z)
@@ -171,4 +171,5 @@ class Snapshot < ApplicationRecord
     return uid[0, 20] if !uid.nil? && uid.length == 27 && uid[-1, 1] == 'Z'
     uid
   end
+  private_class_method :normalize_ss_uid
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,16 +225,6 @@ class User < ApplicationRecord
     in_my_region.find_by_userid("admin")
   end
 
-  private
-
-  def self.seed_file_name
-    @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")
-  end
-
-  def self.seed_data
-    File.exist?(seed_file_name) ? YAML.load_file(seed_file_name) : []
-  end
-
   def self.seed
     seed_data.each do |user_attributes|
       user_id = user_attributes[:userid]
@@ -286,4 +276,14 @@ class User < ApplicationRecord
   def self.with_current_user_groups
     current_user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
   end
+
+  def self.seed_file_name
+    @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")
+  end
+  private_class_method :seed_file_name
+
+  def self.seed_data
+    File.exist?(seed_file_name) ? YAML.load_file(seed_file_name) : []
+  end
+  private_class_method :seed_data
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,24 +225,6 @@ class User < ApplicationRecord
     in_my_region.find_by_userid("admin")
   end
 
-  def self.seed
-    seed_data.each do |user_attributes|
-      user_id = user_attributes[:userid]
-      next if in_my_region.find_by_userid(user_id)
-      log_attrs = user_attributes.slice(:name, :userid, :group)
-      _log.info("Creating user with parameters #{log_attrs.inspect}")
-
-      group_description = user_attributes.delete(:group)
-      group = MiqGroup.in_my_region.find_by_description(group_description)
-
-      _log.info("Creating #{user_id} user...")
-      user = create(user_attributes)
-      user.miq_groups = [group] if group
-      user.save
-      _log.info("Creating #{user_id} user... Complete")
-    end
-  end
-
   def self.current_tenant
     current_user.try(:current_tenant)
   end
@@ -275,6 +257,24 @@ class User < ApplicationRecord
 
   def self.with_current_user_groups
     current_user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
+  end
+
+  def self.seed
+    seed_data.each do |user_attributes|
+      user_id = user_attributes[:userid]
+      next if in_my_region.find_by_userid(user_id)
+      log_attrs = user_attributes.slice(:name, :userid, :group)
+      _log.info("Creating user with parameters #{log_attrs.inspect}")
+
+      group_description = user_attributes.delete(:group)
+      group = MiqGroup.in_my_region.find_by_description(group_description)
+
+      _log.info("Creating #{user_id} user...")
+      user = create(user_attributes)
+      user.miq_groups = [group] if group
+      user.save
+      _log.info("Creating #{user_id} user... Complete")
+    end
   end
 
   def self.seed_file_name

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -63,7 +63,7 @@ describe Metric::Capture do
       expect(Metric::Capture._log).to receive(:info).with(/2 "realtime" captures on the queue.*oldest:.*recent:/)
       expect(Metric::Capture._log).to receive(:info).with(/0 "hourly" captures on the queue/)
       expect(Metric::Capture._log).to receive(:info).with(/0 "historical" captures on the queue/)
-      described_class.perf_capture_health_check(miq_server.zone)
+      described_class.send(:perf_capture_health_check, miq_server.zone)
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------

Fix usage of private/public/protected where it's useless on the app directory.  This is:

* where it's either superfluous and unneeded (public when all things are public already)
* where the intent was to make private class methods but you can't using the `private` method
* where the intent was wrong and we luckily weren't correctly creating private class methods

`rubocop --only UselessAccessModifier`

Please review commit by commit

cc @Fryguy @chrisarcand @bdunne 