### PR TITLE
VmOrTemplateInfra to represent Infra specific Vms/Templates

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1241,9 +1241,10 @@ module VmCommon
     else      # Get list of child VMs of this node
       options = {:model => model}
       if x_node == "root"
-        # TODO: potential to move this into a model with a scope built into it
-        options[:where_clause] =
-          ["vms.type IN (?)", ManageIQ::Providers::InfraManager::Vm.subclasses.collect(&:name) + ManageIQ::Providers::InfraManager::Template.subclasses.collect(&:name)] if x_active_tree == :vandt_tree
+        if x_active_tree == :vandt_tree
+          klass = ManageIQ::Providers::InfraManager::VmOrTemplate
+          options[:where_clause] = ["vms.type IN (?)", klass.vm_descendants.collect(&:name)]
+        end
         process_show_list(options)  # Get all VMs & Templates
         # :model=>ui_lookup(:models=>"VmOrTemplate"))
         # TODO: Change ui_lookup/dictionary to handle VmOrTemplate, returning VMs And Templates
@@ -1254,8 +1255,10 @@ module VmCommon
                            end
       else
         if TreeBuilder.get_model_for_prefix(@nodetype) == "Hash"
-          options[:where_clause] =
-            ["vms.type IN (?)", ManageIQ::Providers::InfraManager::Vm.subclasses.collect(&:name) + ManageIQ::Providers::InfraManager::Template.subclasses.collect(&:name)] if x_active_tree == :vandt_tree
+          if x_active_tree == :vandt_tree
+            klass = ManageIQ::Providers::InfraManager::VmOrTemplate
+            options[:where_clause] = ["vms.type IN (?)", klass.vm_descendants.collect(&:name)]
+          end
           if id == "orph"
             options[:where_clause] = MiqExpression.merge_where_clauses(options[:where_clause], VmOrTemplate::ORPHANED_CONDITIONS)
             process_show_list(options)

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -7,6 +7,7 @@ module ManageIQ::Providers
     require_nested :ProvisionWorkflow
     require_nested :Vm
     require_nested :OrchestrationStack
+    require_nested :VmOrTemplate
 
     class << model_name
       define_method(:route_key) { "ems_clouds" }

--- a/app/models/manageiq/providers/cloud_manager/vm_or_template.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm_or_template.rb
@@ -1,0 +1,15 @@
+class ManageIQ::Providers::CloudManager::VmOrTemplate < ActsAsArScope
+  class << self
+    delegate :all_orphaned, :all_archived, :to => :aar_scope
+    delegate :klass, :to => :aar_scope, :prefix => true
+  end
+
+  def self.aar_scope
+    ::VmOrTemplate.where(:type => vm_descendants)
+  end
+
+  def self.vm_descendants
+    ManageIQ::Providers::CloudManager::Vm.descendants +
+      ManageIQ::Providers::CloudManager::Template.descendants
+  end
+end

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers
     require_nested :Template
     require_nested :ProvisionWorkflow
     require_nested :Vm
+    require_nested :VmOrTemplate
 
     include AvailabilityMixin
 

--- a/app/models/manageiq/providers/infra_manager/vm_or_template.rb
+++ b/app/models/manageiq/providers/infra_manager/vm_or_template.rb
@@ -1,0 +1,15 @@
+class ManageIQ::Providers::InfraManager::VmOrTemplate < ActsAsArScope
+  class << self
+    delegate :all_orphaned, :all_archived, :to => :aar_scope
+    delegate :klass, :to => :aar_scope, :prefix => true
+  end
+
+  def self.aar_scope
+    ::VmOrTemplate.where(:type => vm_descendants)
+  end
+
+  def self.vm_descendants
+    ManageIQ::Providers::InfraManager::Vm.descendants +
+      ManageIQ::Providers::InfraManager::Template.descendants
+  end
+end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1843,15 +1843,15 @@ class VmOrTemplate < ApplicationRecord
   end
 
   # Return all archived VMs
-  ARCHIVED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NULL"
+  ARCHIVED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NULL".freeze
   def self.all_archived
-    where(ARCHIVED_CONDITIONS).to_a
+    where(ARCHIVED_CONDITIONS)
   end
 
   # Return all orphaned VMs
-  ORPHANED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NOT NULL"
+  ORPHANED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NOT NULL".freeze
   def self.all_orphaned
-    where(ORPHANED_CONDITIONS).to_a
+    where(ORPHANED_CONDITIONS)
   end
 
   # where.not(ORPHANED_CONDITIONS).where.not(ARCHIVED_CONDITIONS)

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -321,6 +321,10 @@ class TreeBuilder
     end
   end
 
+  def count_only_or_objects_filtered(count_only, objects, sort_by = nil, options = {}, &block)
+    count_only_or_objects(count_only, Rbac.filtered(objects, options), sort_by, &block)
+  end
+
   def assert_type(actual, expected)
     raise "#{self.class}: expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
   end

--- a/app/presenters/tree_builder_archived.rb
+++ b/app/presenters/tree_builder_archived.rb
@@ -1,12 +1,11 @@
 module TreeBuilderArchived
   def x_get_tree_custom_kids(object, count_only, options)
     klass  = Object.const_get(options[:leaf])
-    method = case object[:id]
-             when "orph" then :all_orphaned
-             when "arch" then :all_archived
-             end
-    objects = Rbac.filtered(klass.send(method))
-    count_only ? objects.length : objects
+    objects = case object[:id]
+              when "orph" then klass.all_orphaned
+              when "arch" then klass.all_archived
+              end
+    count_only_or_objects_filtered(count_only, objects)
   end
 
   def x_get_tree_arch_orph_nodes(model_name)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -19,15 +19,11 @@ class TreeBuilderVandt < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, options)
-    objects = Rbac.filtered(EmsInfra.order("lower(name)"), :match_via_descendants => VmOrTemplate)
+    objects = count_only_or_objects_filtered(count_only, EmsInfra, "name", :match_via_descendants => VmOrTemplate)
+    objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options.dup).tree } unless count_only
+    root_nodes = count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("VMs and Templates"))
 
-    if count_only
-      objects.length + 2
-    else
-      objects = objects.to_a
-      objects.collect! { |o| TreeBuilderVmsAndTemplates.new(o, options.dup).tree } +
-        x_get_tree_arch_orph_nodes("VMs and Templates")
-    end
+    objects + root_nodes
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_vandt.rb
+++ b/app/presenters/tree_builder_vandt.rb
@@ -30,6 +30,16 @@ class TreeBuilderVandt < TreeBuilder
     end
   end
 
+  # Handle custom tree nodes (object is a Hash)
+  def x_get_tree_custom_kids(object, count_only, _options)
+    klass = ManageIQ::Providers::InfraManager::VmOrTemplate
+    objects = case object[:id]
+              when "orph" then klass.all_orphaned
+              when "arch" then klass.all_archived
+              end
+    count_only_or_objects_filtered(count_only, objects, "name")
+  end
+
   def x_get_child_nodes(id)
     model, _, prefix = self.class.extract_node_model_and_id(id)
     model == "Hash" ? super : find_child_recursive(x_get_tree_roots(false, {}), id)

--- a/spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb
@@ -1,0 +1,28 @@
+describe ManageIQ::Providers::CloudManager::VmOrTemplate do
+  describe "#all" do
+    it "scopes" do
+      vm = FactoryGirl.create(:vm_openstack)
+      t  = FactoryGirl.create(:template_openstack)
+      FactoryGirl.create(:vm_vmware)
+      FactoryGirl.create(:template_vmware)
+
+      expect(described_class.all).to match_array([vm, t])
+    end
+  end
+
+  describe "#all_archived" do
+    it "scopes" do
+      ems = FactoryGirl.create(:ems_openstack)
+      vm = FactoryGirl.create(:vm_openstack)
+      t  = FactoryGirl.create(:template_openstack)
+      # non archived
+      FactoryGirl.create(:vm_openstack, :ext_management_system => ems)
+      FactoryGirl.create(:template_openstack, :ext_management_system => ems)
+      # non cloud
+      FactoryGirl.create(:vm_vmware)
+      FactoryGirl.create(:template_vmware)
+
+      expect(described_class.all_archived).to match_array([vm, t])
+    end
+  end
+end

--- a/spec/models/manageiq/providers/infra_manager/vm_or_template_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/vm_or_template_spec.rb
@@ -1,0 +1,28 @@
+describe ManageIQ::Providers::InfraManager::VmOrTemplate do
+  describe "#all" do
+    it "scopes" do
+      vm = FactoryGirl.create(:vm_vmware)
+      t  = FactoryGirl.create(:template_vmware)
+      FactoryGirl.create(:vm_openstack)
+      FactoryGirl.create(:template_openstack)
+
+      expect(described_class.all).to match_array([vm, t])
+    end
+  end
+
+  describe "#all_archived" do
+    it "scopes" do
+      ems = FactoryGirl.create(:ems_vmware)
+      vm = FactoryGirl.create(:vm_vmware)
+      t  = FactoryGirl.create(:template_vmware)
+      # non archived
+      FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+      FactoryGirl.create(:template_vmware, :ext_management_system => ems)
+      # non infra
+      FactoryGirl.create(:vm_openstack)
+      FactoryGirl.create(:template_openstack)
+
+      expect(described_class.all_archived).to match_array([vm, t])
+    end
+  end
+end


### PR DESCRIPTION
Followup to #10919 

Before
-------

We were downloading all archived records twice. Once to count them and the other for rbac purposes.

In #10919 I had moved `all_orphaned` over to the generic implementation, but doesn't properly scope the archived and orphaned vms that display on this page.

After
-----

We are performing a single query to count or download records.
We are no longer sorting in the database.
We are bringing back fewer orphaned and archived records. (performing a count instead of bringing back all the records twice)

numbers
---------

`/vm_infra/explorer` production mode.
As admin user, 1 ems, 1 zone, 3k active VMs, 3k orphaned VMs

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  3,132.8 |   38 | 1,267.2 |   18,680 |before
|  2,853.9 |   36 |   680.8 |   12,680 |after
| 9%         | 5%   | 46%      |  32% | improvement

The discrepancy is downloading all the orphaned records 2 times. First time to get a count, and the second time to rbac filter them.