### PR TITLE
Fix chargeback rate assignments' title

### DIFF
--- a/app/views/chargeback/_assignments_list.html.haml
+++ b/app/views/chargeback/_assignments_list.html.haml
@@ -9,7 +9,7 @@
       %td{:title => _("Edit Compute Rate Assignments")}
         = _('Compute')
     %tr{:onclick => remote_function(:url => {:action => 'tree_select', :id => "xx-Storage"})}
-      %td.narrow{:title => _("Edit Compute Rate Assignments")}
+      %td.narrow{:title => _("Edit Storage Rate Assignments")}
         %i.fa-2x.fa.fa-hdd-o
-      %td{:title => _("Edit Compute Rate Assignments")}
+      %td{:title => _("Edit Storage Rate Assignments")}
         = _('Storage')


### PR DESCRIPTION
Purpose or Intent
-----------------
At chargeback rate assignments page, both compute and storage's title is "Edit Compute Rate Assignments"