### PR TITLE
Enable server-push using ActionCable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ bin/*
 # config/
 config/apache
 config/database.yml*
+config/cable.yml
 config/vmdb.yml.db
 
 config/initializers/*.local.rb

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 
 # Unmodified gems
 gem "activerecord-session_store",     "~>1.0.0"
+gem "actioncable",                    "~>5.0.0"
 gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.1.0",       :require => false
@@ -90,6 +91,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "lodash-rails",                 "~>3.10.0"
   gem "patternfly-sass",              "~>3.9.0"
   gem "sass-rails"
+  gem "coffee-rails"
 
   # Modified gems (forked on Github)
   gem "jquery-rjs",                   "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require moment-timezone
 //= require sprintf
 //= require numeral
+//= require cable
 //= require miq_api
 //= require rxjs/dist/rx.all
 //= require miq_angular_application

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,0 +1,23 @@
+//= require action_cable
+
+var miqInitNotifications = function () {
+  var cable = ActionCable.createConsumer('/ws/notifications');
+
+  var notifications = cable.subscriptions.create("NotificationChannel", {
+    connected: function () {
+      console.log("Cable client connected!");
+    },
+    disconnected: function () {
+      var _this = this;
+      // Try to request a new ws_token if disconnected, reconnecting will happen automatically
+      API.ws_init().then(null, function () {
+        console.warn("Unable to retrieve a valid ws_token!");
+        // Disconnect permanently if the ws_token cannot be fetched
+        _this.consumer.connection.close({ allowReconnect: false })
+      });
+    },
+    received: function (data) {
+      console.log("Cable message received:", data);
+    }
+  });
+}

--- a/app/assets/javascripts/miq_api.js
+++ b/app/assets/javascripts/miq_api.js
@@ -72,11 +72,16 @@
     });
   };
 
+  API.ws_destroy = function() {
+    document.cookie = 'ws_token=; path=/ws/notifications; Max-Age=0;'
+  };
+
   API.logout = function() {
     if (sessionStorage.miq_token) {
       API.delete('/api/auth');
     }
 
+    API.ws_destroy();
     delete sessionStorage.miq_token;
   };
 
@@ -92,6 +97,13 @@
     return function() {
       clearInterval(id);
     };
+  };
+
+  API.ws_init = function() {
+    return API.get('/api/auth?requester_type=ws').then(function(response) {
+      API.ws_destroy();
+      document.cookie = 'ws_token=' + response.auth_token + '; path=/ws/notifications';
+    });
   };
 
   window.API = API;

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -822,6 +822,9 @@ function miqAjaxAuth(url) {
 
   API.login(credentials.login, credentials.password)
   .then(function() {
+    return API.ws_init();
+  })
+  .then(function() {
     // API login ok, now do the normal one
     miqJqueryRequest(url || '/dashboard/authenticate', {
       beforeSend: true,

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,21 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+
+    def find_verified_user
+      return reject_unauthorized_connection unless cookies[:ws_token]
+      userid = TokenManager.new('ws').token_get_info(cookies[:ws_token], :userid)
+      if current_user = User.find_by(:userid => userid)
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
+  end
+end

--- a/app/channels/notification_channel.rb
+++ b/app/channels/notification_channel.rb
@@ -1,0 +1,9 @@
+class NotificationChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "notifications_#{current_user.id}" if current_user
+  end
+
+  def unsubscribed
+    # TODO: Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,14 @@ class ApplicationController < ActionController::Base
   before_action :get_global_session_data, :except => [:resize_layout, :window_sizes, :authenticate]
   before_action :set_user_time_zone, :except => [:window_sizes]
   before_action :set_gettext_locale, :except => [:window_sizes]
+  before_action :allow_websocket
   after_action :set_global_session_data, :except => [:resize_layout, :window_sizes]
+
+  def allow_websocket
+    proto = request.ssl? ? 'wss' : 'ws'
+    override_content_security_policy_directives(:connect_src => ["'self'", "#{proto}://#{request.env['HTTP_HOST']}"])
+  end
+  private :allow_websocket
 
   def reset_toolbar
     @toolbars = {}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -44,6 +44,7 @@
         ManageIQ.browser = "#{j browser_info(:name_ui)}";
         ManageIQ.controller = "#{j controller_name}";
         API.autorenew();
+        miqInitNotifications();
 
     - id = %w(configuration policy).include?(@layout) ? @config_tab : @layout
     %body{:id => id, :onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}

--- a/bin/setup
+++ b/bin/setup
@@ -40,6 +40,9 @@ Dir.chdir APP_ROOT do
   unless File.exist?("config/database.yml")
     execute "cp config/database.pg.yml config/database.yml"
   end
+  unless File.exist?("config/cable.yml")
+    execute "cp config/cable.yml.sample config/cable.yml"
+  end
   unless File.exist?("certs/v2_key")
     execute "cp certs/v2_key.dev certs/v2_key"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require 'action_view/railtie'
 require 'action_mailer/railtie'
 require 'active_job/railtie'
 require 'sprockets/railtie'
+require 'action_cable/engine'
 
 if defined?(Bundler)
   Bundler.require(*Rails.groups(:assets => %w(development test)), :ui_dependencies)

--- a/config/cable.yml.sample
+++ b/config/cable.yml.sample
@@ -1,0 +1,8 @@
+production:
+  adapter: postgresql
+
+development:
+  adapter: postgresql
+
+test:
+  adapter: postgresql

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -39,10 +39,14 @@ class WebsocketServer
 
   def call(env)
     if WebSocket::Driver.websocket?(env)
-      exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
-      return not_found if exp.nil?
 
-      init_proxy(env, exp[1])
+      if env['REQUEST_URI'] =~ %r{^/ws/notifications}
+        ActionCable.server.call(env)
+      else
+        exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
+        return not_found if exp.nil?
+        init_proxy(env, exp[1])
+      end
 
       [-1, {}, []]
     else


### PR DESCRIPTION
This PR enables server-push in ManageIQ using ActionCable. The plan is to use it for asynchronous notifications displayed in the form of PatternFly toasts. This PR just implements a PoC solution, where the notifications are logged into the browser's JS console.

For testing it is necessary to run run `cp config/cable.yml.sample config/cable.yml` or re-run `bin/setup`. Then log in to the Web UI and open the browser's JavaScript console. Notifications can be emitted using a rails console in the following form:
```ruby
ActionCable.server.broadcast("notifications_#{user_id}", message)
```
Where `user_id` is the numerical database ID of the logged in user and the `message` is an instance of a `Hash` object. 