### PR TITLE
[WIP] Add load balancer service type ui

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -138,6 +138,7 @@ class CatalogController < ApplicationController
       "amazon"                => "Amazon",
       "azure"                 => "Azure",
       "generic"               => "Generic",
+      "generic_load_balancer" => "LoadBalancer",
       "generic_orchestration" => "Orchestration",
       "generic_ansible_tower" => "AnsibleTower",
       "google"                => "Google",
@@ -917,6 +918,7 @@ class CatalogController < ApplicationController
       ServiceTemplate.find_by_id(@edit[:rec_id]) :
       class_service_template(@edit[:new][:st_prov_type]).new
     common_st_record_vars(st)
+    add_load_balancer_template_vars(st) if st.kind_of?(ServiceTemplateLoadBalancer)
     add_orchestration_template_vars(st) if st.kind_of?(ServiceTemplateOrchestration)
     add_ansible_tower_job_template_vars(st) if st.kind_of?(ServiceTemplateAnsibleTower)
     st.service_type = "atomic"
@@ -1314,6 +1316,7 @@ class CatalogController < ApplicationController
     @edit[:new][:available_catalogs] = @edit[:new][:available_catalogs].sort
     available_orchestration_templates if @record.kind_of?(ServiceTemplateOrchestration)
     available_ansible_tower_managers if @record.kind_of?(ServiceTemplateAnsibleTower)
+    available_load_balancer_managers if @record.kind_of?(ServiceTemplateLoadBalancer)
 
     # initialize fqnames
     @edit[:new][:fqname] = @edit[:new][:reconfigure_fqname] = @edit[:new][:retire_fqname] = ""
@@ -1452,8 +1455,20 @@ class CatalogController < ApplicationController
     @edit[:new][:long_description] = params[:long_description] if params[:long_description]
     @edit[:new][:long_description] = @edit[:new][:long_description].to_s + "..." if params[:transOne]
 
+    get_form_vars_load_balancer if @edit[:new][:st_prov_type] == 'generic_load_balancer'
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
     get_form_vars_ansible_tower if @edit[:new][:st_prov_type] == 'generic_ansible_tower'
+  end
+
+  def get_form_vars_load_balancer
+    available_load_balancer_managers
+    if params[:manager_id]
+      if params[:manager_id] == ""
+        @edit[:new][:manager_id] = nil
+      else
+        @edit[:new][:manager_id] = params[:manager_id]
+      end
+    end
   end
 
   def get_form_vars_orchestration
@@ -1492,6 +1507,12 @@ class CatalogController < ApplicationController
     template_type.eligible_managers.collect { |m| [m.name, m.id] }.sort
   end
 
+  def available_load_balancer_managers
+    @edit[:new][:available_managers] =
+      ManageIQ::Providers::NetworkManager.all.collect { |t| [t.name, t.id] }.sort
+    @edit[:new][:manager_id] = @record.try(:load_balancer_manager).try(:id)
+  end
+
   def available_orchestration_managers(template_id)
     @edit[:new][:available_managers] = OrchestrationTemplate.find_by_id(template_id)
                                        .eligible_managers
@@ -1519,6 +1540,11 @@ class CatalogController < ApplicationController
     @edit[:new][:template_id] = @record.job_template.try(:id)
     @edit[:new][:manager_id] = @record.job_template.try(:manager).try(:id)
     available_ansible_tower_job_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
+  end
+
+  def add_load_balancer_template_vars(st)
+    st.load_balancer_manager  = @edit[:new][:manager_id].nil? ?
+      nil : ExtManagementSystem.find_by_id(@edit[:new][:manager_id])
   end
 
   def add_orchestration_template_vars(st)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1463,11 +1463,7 @@ class CatalogController < ApplicationController
   def get_form_vars_load_balancer
     available_load_balancer_managers
     if params[:manager_id]
-      if params[:manager_id] == ""
-        @edit[:new][:manager_id] = nil
-      else
-        @edit[:new][:manager_id] = params[:manager_id]
-      end
+      @edit[:new][:manager_id] = (params[:manager_id] == "") ? nil : params[:manager_id]
     end
   end
 

--- a/app/helpers/load_balancer_helper/textual_summary.rb
+++ b/app/helpers/load_balancer_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module LoadBalancerHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(parent_ems_cloud ems_network cloud_tenant instances)
+    %i(parent_ems_cloud ems_network service cloud_tenant instances)
   end
 
   #
@@ -40,6 +40,19 @@ module LoadBalancerHelper::TextualSummary
 
   def textual_parent_ems_cloud
     @record.ext_management_system.try(:parent_manager)
+  end
+
+  def textual_service
+    h = {:label => _("Service"), :image => "service"}
+    service = @record.service
+    if service.nil?
+      h[:value] = _("None")
+    else
+      h[:value] = service.name
+      h[:title] = _("Show this Service")
+      h[:link]  = url_for(:controller => 'service', :action => 'show', :id => service)
+    end
+    h
   end
 
   def textual_cloud_tenant

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -21,7 +21,7 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(catalog_item parent_service orchestration_stack job)
+    %i(catalog_item parent_service orchestration_stack job load_balancer)
   end
 
   def textual_group_miq_custom_attributes
@@ -107,6 +107,10 @@ module ServiceHelper::TextualSummary
       :title => _("Show this Service's Job"),
       :link  => url_for(:controller => 'configuration_job', :action => 'show', :id => job.id)
     } if job
+  end
+
+  def textual_load_balancer
+    @record.try(:load_balancer)
   end
 
   def textual_owner

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -68,6 +68,18 @@
                             :class                => "selectpicker")
               :javascript
                 miqSelectPickerEvent('generic_subtype', '#{url}')
+    - if @edit[:new][:st_prov_type] == "generic_load_balancer"
+      - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
+      .form-group
+        %label.col-md-2.control-label
+          = _('Provider')
+        .col-md-8
+          = select_tag('manager_id',
+                       options_for_select(opts, @edit[:new][:manager_id]),
+                       "data-miq_sparkle_on" => true,
+                       :class               => "selectpicker")
+          :javascript
+            miqSelectPickerEvent('manager_id', '#{url}')
     - if @edit[:new][:st_prov_type] == "generic_orchestration"
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
       .form-group

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -43,6 +43,18 @@
               = _('Subtype')
             .col-md-8
               = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@record[:generic_subtype]])
+        - if @record.prov_type == "generic_load_balancer"
+          .form-group
+            %label.col-md-2.control-label
+              = _('Load Balancer')
+            .col-md-8
+              = h(@record.try(:load_balancer).try(:name))
+          - if @record.load_balancer_manager
+            .form-group
+              %label.col-md-2.control-label
+                = _('Provider')
+              .col-md-8
+                = h(@record.load_balancer_manager.name)
         - if @record.prov_type == "generic_orchestration"
           .form-group
             %label.col-md-2.control-label

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3908,6 +3908,14 @@
       :description: Edit Tags of Load Balancer
       :feature_type: control
       :identifier: load_balancer_tag
+    - :name: Retire Load Balancer
+      :description: Retire Load Balancer
+      :feature_type: control
+      :identifier: load_balancer_retire_now
+    - :name: Set Retirement Date
+      :description: Set Retirement Date
+      :feature_type: control
+      :identifier: load_balancer_retire
 
 # ContainerGroup
 - :name: Pods

--- a/product/dialogs/service_dialogs/load_balancer_amazon.yml
+++ b/product/dialogs/service_dialogs/load_balancer_amazon.yml
@@ -1,0 +1,781 @@
+---
+- description: 
+  buttons: submit,cancel
+  label: load_balancer_amazon
+  dialog_tabs:
+  - description: 
+    display: edit
+    label: Load Balancer
+    display_method: 
+    display_method_options: 
+    position: 0
+    dialog_groups:
+    - description: 
+      display: edit
+      label: Basic Configuration
+      display_method: 
+      display_method_options: 
+      position: 0
+      dialog_fields:
+      - name: load_balancer_name
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Name
+        position: 0
+        validator_type: regex
+        validator_rule: "[A-Za-z0-9-]"
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+    - description: ''
+      display: edit
+      label: Create LB inside
+      display_method: 
+      display_method_options: 
+      position: 1
+      dialog_fields:
+      - name: cloud_network
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values:
+        - - 
+          - EC2-classic
+        values_method: 
+        values_method_options: {}
+        options:
+          :sort_by: :value
+        label: VPC/EC2-classic
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: true
+        trigger_auto_refresh: true
+        visible: true
+        type: DialogFieldDropDownList
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/LoadBalancer/Operations/Amazon
+          ae_class: Methods
+          ae_instance: Available_CloudNetworks
+          ae_message: 
+          ae_attributes: {}
+      - name: cloud_subnets
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values:
+        - - 
+          - "-- select a subnet from a list --"
+        values_method: 
+        values_method_options: {}
+        options:
+          :sort_by: :value
+        label: Subnet
+        position: 1
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: true
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldDropDownList
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/LoadBalancer/Operations/Amazon
+          ae_class: Methods
+          ae_instance: Available_CloudSubnets
+          ae_message: 
+          ae_attributes: {}
+  - description: 
+    display: edit
+    label: Listener Configuration
+    display_method: 
+    display_method_options: 
+    position: 1
+    dialog_groups:
+    - description: 
+      display: edit
+      label: Listener
+      display_method: 
+      display_method_options: 
+      position: 0
+      dialog_fields:
+      - name: load_balancer_listeners_0_load_balancer_port
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Load Balancer Port
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_listeners_0_load_balancer_protocol
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Load Balancer Protocol
+        position: 1
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_listeners_0_instance_port
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Instance Port
+        position: 2
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_listeners_0_instance_protocol
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Instance Protocol
+        position: 3
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+    - description: 
+      display: edit
+      label: Optional Listener 1
+      display_method: 
+      display_method_options: 
+      position: 1
+      dialog_fields:
+      - name: load_balancer_listeners_1_load_balancer_port
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Load Balancer Port
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_listeners_1_load_balancer_protocol
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Load Balancer Protocol
+        position: 1
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_listeners_1_instance_port
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Instance Port
+        position: 2
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_listeners_1_instance_protocol
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Instance Protocol
+        position: 3
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+  - description: 
+    display: edit
+    label: Health Check
+    display_method: 
+    display_method_options: 
+    position: 2
+    dialog_groups:
+    - description: 
+      display: edit
+      label: Health Check
+      display_method: 
+      display_method_options: 
+      position: 0
+      dialog_fields:
+      - name: load_balancer_health_checks_target
+        description: Write target in format HTTP:80 or HTTP:80/index.html
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Target
+        position: 0
+        validator_type: regex
+        validator_rule: "^(\\w+)\\:(\\d+)\\/?(.*?)$"
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_health_checks_interval
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Interval
+        position: 1
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_health_checks_timeout
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: timeout
+        position: 2
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_health_checks_unhealthy_threshold
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Unhealthy Threshold
+        position: 3
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+      - name: load_balancer_health_checks_healthy_threshold
+        description: 
+        data_type: 
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: true
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values: 
+        values_method: 
+        values_method_options: {}
+        options:
+          :protected: false
+        label: Healthy Threshold
+        position: 4
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: false
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: 
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldTextBox
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: 
+          ae_class: 
+          ae_instance: 
+          ae_message: 
+          ae_attributes: {}
+  - description: 
+    display: edit
+    label: Security
+    display_method: 
+    display_method_options: 
+    position: 3
+    dialog_groups:
+    - description: 
+      display: edit
+      label: Security Groups
+      display_method: 
+      display_method_options: 
+      position: 0
+      dialog_fields:
+      - name: security_groups
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values:
+        - - 
+          - "-- select a security_group from a list --"
+        values_method: 
+        values_method_options: {}
+        options:
+          :sort_by: :value
+        label: Security Groups
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: true
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldDropDownList
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/LoadBalancer/Operations/Amazon
+          ae_class: Methods
+          ae_instance: Available_SecurityGroups
+          ae_message: 
+          ae_attributes: {}
+  - description: 
+    display: edit
+    label: Add EC2 instances
+    display_method: 
+    display_method_options: 
+    position: 4
+    dialog_groups:
+    - description: 
+      display: edit
+      label: Instances
+      display_method: 
+      display_method_options: 
+      position: 0
+      dialog_fields:
+      - name: vms
+        description: 
+        data_type: string
+        notes: 
+        notes_display: 
+        display: edit
+        display_method: 
+        display_method_options: {}
+        required: false
+        required_method: 
+        required_method_options: {}
+        default_value: 
+        values:
+        - - 
+          - "-- select a Vms from a list --"
+        values_method: 
+        values_method_options: {}
+        options:
+          :sort_by: :value
+        label: Instances
+        position: 0
+        validator_type: 
+        validator_rule: 
+        reconfigurable: 
+        dynamic: true
+        show_refresh_button: 
+        load_values_on_init: 
+        read_only: false
+        auto_refresh: true
+        trigger_auto_refresh: 
+        visible: true
+        type: DialogFieldDropDownList
+        resource_action:
+          action: 
+          resource_type: DialogField
+          ae_namespace: Cloud/LoadBalancer/Operations/Amazon
+          ae_class: Methods
+          ae_instance: Available_Vms
+          ae_message: 
+          ae_attributes: {}


### PR DESCRIPTION
## Purpose or Intent

UI for a Load Balancer Service Type
## Steps for Testing/QA

Creating Catalog item with type Load Balancer, with default automate and provoded defaul dialog should allow us to Provision a Load Balancer in Amazon

---

depends on:
https://github.com/ManageIQ/manageiq/pull/10975
https://github.com/ManageIQ/manageiq/pull/10974
https://github.com/ManageIQ/manageiq/pull/10972
https://github.com/ManageIQ/manageiq/pull/10971
https://github.com/ManageIQ/manageiq/pull/10970
https://github.com/ManageIQ/manageiq-providers-amazon/pull/40
https://github.com/ManageIQ/manageiq/pull/10270
