### PR TITLE
Supports feature default reason

### DIFF
--- a/app/helpers/application_helper/button/vm_instance_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_scan.rb
@@ -14,8 +14,7 @@ class ApplicationHelper::Button::VmInstanceScan < ApplicationHelper::Button::Bas
 
   def visible?
     return true if @display == "instances"
-    (@record.supports_smartstate_analysis? || @record.unsupported_reason(:smartstate_analysis)) &&
-     @record.has_proxy?
+    @record.supports_smartstate_analysis? && @record.has_proxy?
   end
 
   def disabled?

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -30,11 +30,8 @@ module SupportsFeatureMixin
   #   Post.new(featured: true).supports_archive?   # => false
   #
   # To get a reason why a feature is unsupported use the +unsupported_reason+ method
-  # Note: Because providing a reason for an unsupported feature is optional, you should
-  #       not rely on checking the reason to be nil for a feature to be unsupported.
-  #       You have to use +supports_feature?+
   #
-  #   Post.unsupported_reason(:publish)                     # => nil
+  #   Post.unsupported_reason(:publish)                     # => "Feature not supported"
   #   Post.unsupported_reason(:fake)                        # => "We keep it real"
   #   Post.new(featured: true).unsupported_reason(:archive) # => "Its too good"
   #
@@ -89,6 +86,10 @@ module SupportsFeatureMixin
     end
   end
 
+  def self.reason_or_default(reason)
+    reason.present? ? reason : _("Feature not supported")
+  end
+
   # query instance for the reason why the feature is unsupported
   def unsupported_reason(feature)
     SupportsFeatureMixin.guard_queryable_feature(feature)
@@ -106,9 +107,9 @@ module SupportsFeatureMixin
 
   # used inside a +supports+ block to add a reason why the feature is not supported
   # just adding a reason will make the feature unsupported
-  def unsupported_reason_add(feature, reason)
+  def unsupported_reason_add(feature, reason = nil)
     SupportsFeatureMixin.guard_queryable_feature(feature)
-    unsupported[feature] = reason
+    unsupported[feature] = SupportsFeatureMixin.reason_or_default(reason)
   end
 
   def unsupported
@@ -119,20 +120,20 @@ module SupportsFeatureMixin
     # This is the DSL used a class level to define what is supported
     def supports(feature, &block)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      send(:define_supports_methods, feature, true, &block)
+      define_supports_feature_methods(feature, &block)
     end
 
     # supports_not does not take a block, because its never supported
     # and not conditionally supported
     def supports_not(feature, reason: nil)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      send(:define_supports_methods, feature, false, reason)
+      define_supports_feature_methods(feature, :is_supported => false, :reason => reason)
     end
 
     # query the class if the feature is supported or not
     def supports?(feature)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      send("supports_#{feature}?")
+      public_send("supports_#{feature}?")
     end
 
     # query the class for the reason why something is unsupported
@@ -150,13 +151,13 @@ module SupportsFeatureMixin
       @unsupported ||= Concurrent::Hash.new
     end
 
-    # use this for making an instance not support a feature
-    def unsupported_reason_add(feature, reason)
+    # use this for making a class not support a feature
+    def unsupported_reason_add(feature, reason = nil)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      unsupported[feature] = reason
+      unsupported[feature] = SupportsFeatureMixin.reason_or_default(reason)
     end
 
-    def define_supports_methods(feature, is_supported, reason = nil, &block)
+    def define_supports_feature_methods(feature, is_supported: true, reason: nil, &block)
       method_name = "supports_#{feature}?"
 
       # defines the method on the instance
@@ -165,7 +166,7 @@ module SupportsFeatureMixin
         if block_given?
           instance_eval(&block)
         else
-          unsupported[feature] = reason unless is_supported
+          unsupported_reason_add(feature, reason) unless is_supported
         end
         !unsupported.key?(feature)
       end
@@ -174,7 +175,7 @@ module SupportsFeatureMixin
       define_singleton_method(method_name) do
         unsupported.delete(feature)
         # TODO: durandom - make reason evaluate in class context, to e.g. include the name of a subclass (.to_proc?)
-        unsupported[feature] = reason unless is_supported
+        unsupported_reason_add(feature, reason) unless is_supported
         !unsupported.key?(feature)
       end
     end

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -121,12 +121,12 @@ describe SupportsFeatureMixin do
       expect(Post.new.supports_delete?).to be false
     end
 
-    it "#unsupported_reason(:feature) returns no reason" do
-      expect(Post.new.unsupported_reason(:delete)).to be_nil
+    it "#unsupported_reason(:feature) returns some default reason" do
+      expect(Post.new.unsupported_reason(:delete)).not_to be_blank
     end
 
     it ".unsupported_reason(:feature) returns no reason" do
-      expect(Post.unsupported_reason(:delete)).to be_nil
+      expect(Post.unsupported_reason(:delete)).not_to be_blank
     end
   end
 


### PR DESCRIPTION
Otherwise it could return nil or an empty string

In case you would (wrongly) rely on the reason that is returned and check for it to be present it could lead to a false positive.

And it's better to always return a reason :)

@miq-bot add_label wip, pluggable providers, darga/no