### PR TITLE
Relax RSpec req to 3.5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ unless ENV["APPLIANCE"]
   group :development, :test do
     gem "good_migrations"
     gem "parallel_tests"
-    gem "rspec-rails",      "~>3.5.0"
+    gem "rspec-rails",      "~>3.5"
   end
 end
 


### PR DESCRIPTION
Allows installation of latest bug fixes (like 3.5.3 which was just released)

@miq-bot add_labels core, test