### PR TITLE
Fix validation flash errors in automate

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -622,7 +622,6 @@ class MiqAeClassController < ApplicationController
       rescue StandardError => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
-        flash_validation_errors(@ae_inst)
         render :update do |page|
           page << javascript_prologue
           if @sb[:row_selected]
@@ -681,7 +680,6 @@ class MiqAeClassController < ApplicationController
       rescue StandardError => bang
         add_flash(_("Error during 'add': %{message}") % {:message => bang.message}, :error)
         @in_a_form = true
-        flash_validation_errors(add_aeinst)
         render :update do |page|
           page << javascript_prologue
           page.replace("flash_msg_div_class_instances", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"})
@@ -1076,7 +1074,6 @@ class MiqAeClassController < ApplicationController
         end  # end of transaction
       rescue StandardError => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
-        flash_validation_errors(ae_class)
         session[:changed] = @changed = true
         render :update do |page|
           page << javascript_prologue
@@ -1174,7 +1171,6 @@ class MiqAeClassController < ApplicationController
         end  # end of transaction
       rescue StandardError => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
-        flash_validation_errors(ae_method)
         session[:changed] = @changed
         @changed = true
         render :update do |page|
@@ -1288,7 +1284,6 @@ class MiqAeClassController < ApplicationController
         end
       rescue StandardError => bang
         add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
-        flash_validation_errors(add_aemethod)
         @in_a_form = true
         render :update do |page|
           page << javascript_prologue

--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -13,7 +13,7 @@ class MiqAeClass < ApplicationRecord
   validates_presence_of   :name, :namespace_id
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
   validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
-                                 :message => N_("only alpha numeric and _ . - characters are allowed")
+                                 :message => N_("may contain only alphanumeric and _ . - characters")
 
   def self.find_by_fqname(fqname, args = {})
     ns, name = parse_fqname(fqname)

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -9,7 +9,7 @@ class MiqAeField < ApplicationRecord
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[\w]+\z/i,
-                                 :message => N_("only alpha numeric and _ characters are allowed")
+                                 :message => N_("may contain only alphanumeric and _ characters")
 
   validates_inclusion_of  :substitute, :in => [true, false]
 

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -9,7 +9,7 @@ class MiqAeInstance < ApplicationRecord
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
-                                 :message => N_("only alpha numeric and _ . - characters are allowed")
+                                 :message => N_("may contain only alphanumeric and _ . - characters")
 
   def self.find_by_name(name)
     where("lower(name) = ?", name.downcase).first

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -11,7 +11,7 @@ class MiqAeMethod < ApplicationRecord
   validates_presence_of   :name, :scope
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
   validates_format_of     :name, :with    => /\A[\w]+\z/i,
-                                 :message => N_("only alpha numeric and _ characters are allowed")
+                                 :message => N_("may contain only alphanumeric and _ characters")
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -14,7 +14,7 @@ class MiqAeNamespace < ApplicationRecord
 
   validates_presence_of   :name
   validates_format_of     :name, :with    => /\A[\w\.\-\$]+\z/i,
-                                 :message => N_("only alpha numeric and _ . - $ characters are allowed")
+                                 :message => N_("may contain only alphanumeric and _ . - $ characters")
   validates_uniqueness_of :name, :scope => :parent_id
 
   def self.find_by_fqname(fqname, include_classes = true)


### PR DESCRIPTION
Validation of automate model messages changed in https://github.com/ManageIQ/manageiq/pull/9527 though the resulting validation strings in the UI did not make much sense.

This PR modifies the validation messages so that the final strings look better.

Additionaly, this PR removes extraneous model validation from controller code.

Class edit error before:
![automate-before](https://cloud.githubusercontent.com/assets/6648365/18206668/fad15f9e-7127-11e6-9664-5b53b441ee73.jpg)

Class edit error after:
![automate-after](https://cloud.githubusercontent.com/assets/6648365/18434986/cd230f86-78f0-11e6-9056-44778489b740.jpg)

Similarly for automate domain, namespace, class, method, instance and field addition / modification.
