### PR TITLE
[DARGA] Add back a space char. Otherwise one gets "-4 days ago".

### DIFF
--- a/app/helpers/ems_cloud_helper/textual_summary.rb
+++ b/app/helpers/ems_cloud_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module EmsCloudHelper::TextualSummary
+  include TextualMixins::TextualRefreshStatus
   #
   # Groups
   #
@@ -148,20 +149,6 @@ module EmsCloudHelper::TextualSummary
        :value => auth[:status] || _("None"),
        :title => auth[:status_details]}
     end
-  end
-
-  def textual_refresh_status
-    last_refresh_status = @ems.last_refresh_status.titleize
-    if @ems.last_refresh_date
-      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << " - #{last_refresh_date} Ago"
-    end
-    {
-      :label => _("Last Refresh"),
-      :value => [{:value => last_refresh_status},
-                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
-      :title => @ems.last_refresh_error
-    }
   end
 
   def textual_zone

--- a/app/helpers/ems_container_helper/textual_summary.rb
+++ b/app/helpers/ems_container_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module EmsContainerHelper::TextualSummary
+  include TextualMixins::TextualRefreshStatus
   #
   # Groups
   #
@@ -94,20 +95,6 @@ module EmsContainerHelper::TextualSummary
 
   def textual_zone
     {:label => _("Managed by Zone"), :image => "zone", :value => @ems.zone.name}
-  end
-
-  def textual_refresh_status
-    last_refresh_status = @ems.last_refresh_status.titleize
-    if @ems.last_refresh_date
-      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << " - #{last_refresh_date} Ago"
-    end
-    {
-      :label => _("Last Refresh"),
-      :value => [{:value => last_refresh_status},
-                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
-      :title => @ems.last_refresh_error
-    }
   end
 
   def textual_topology

--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module EmsInfraHelper::TextualSummary
+  include TextualMixins::TextualRefreshStatus
   #
   # Groups
   #
@@ -182,20 +183,6 @@ module EmsInfraHelper::TextualSummary
     return nil unless @ems.respond_to?(:orchestration_stacks)
 
     @ems.orchestration_stacks
-  end
-
-  def textual_refresh_status
-    last_refresh_status = @ems.last_refresh_status.titleize
-    if @ems.last_refresh_date
-      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << " - #{last_refresh_date} Ago"
-    end
-    {
-      :label => _("Last Refresh"),
-      :value => [{:value => last_refresh_status},
-                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
-      :title => @ems.last_refresh_error
-    }
   end
 
   def textual_zone

--- a/app/helpers/ems_middleware_helper/textual_summary.rb
+++ b/app/helpers/ems_middleware_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module EmsMiddlewareHelper::TextualSummary
+  include TextualMixins::TextualRefreshStatus
   #
   # Groups
   #
@@ -19,20 +20,6 @@ module EmsMiddlewareHelper::TextualSummary
 
   def textual_group_smart_management
     %i(tags)
-  end
-
-  def textual_refresh_status
-    last_refresh_status = @ems.last_refresh_status.titleize
-    if @ems.last_refresh_date
-      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << " - #{last_refresh_date} Ago"
-    end
-    {
-      :label => _('Last Refresh'),
-      :value => [{:value => last_refresh_status},
-                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
-      :title => @ems.last_refresh_error
-    }
   end
 
   def textual_group_topology

--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -1,4 +1,5 @@
 module EmsNetworkHelper::TextualSummary
+  include TextualMixins::TextualRefreshStatus
   #
   # Groups
   #
@@ -107,20 +108,6 @@ module EmsNetworkHelper::TextualSummary
        :value => auth[:status] || _("None"),
        :title => auth[:status_details]}
     end
-  end
-
-  def textual_refresh_status
-    last_refresh_status = @ems.last_refresh_status.titleize
-    if @ems.last_refresh_date
-      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << _(" -%{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
-    end
-    {
-      :label => _("Last Refresh"),
-      :value => [{:value => last_refresh_status},
-                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
-      :title => @ems.last_refresh_error
-    }
   end
 
   def textual_topology

--- a/app/helpers/textual_mixins/textual_refresh_status.rb
+++ b/app/helpers/textual_mixins/textual_refresh_status.rb
@@ -1,0 +1,15 @@
+module TextualMixins::TextualRefreshStatus
+  def textual_refresh_status
+    last_refresh_status = @ems.last_refresh_status.titleize
+    if @ems.last_refresh_date
+      last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
+      last_refresh_status << " - #{last_refresh_date} Ago"
+    end
+    {
+      :label => _("Last Refresh"),
+      :value => [{:value => last_refresh_status},
+                 {:value => @ems.last_refresh_error.try(:truncate, 120)}],
+      :title => @ems.last_refresh_error
+    }
+  end
+end

--- a/app/helpers/textual_mixins/textual_refresh_status.rb
+++ b/app/helpers/textual_mixins/textual_refresh_status.rb
@@ -3,7 +3,7 @@ module TextualMixins::TextualRefreshStatus
     last_refresh_status = @ems.last_refresh_status.titleize
     if @ems.last_refresh_date
       last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << " - #{last_refresh_date} Ago"
+      last_refresh_status << _(" -%{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
     end
     {
       :label => _("Last Refresh"),

--- a/app/helpers/textual_mixins/textual_refresh_status.rb
+++ b/app/helpers/textual_mixins/textual_refresh_status.rb
@@ -3,7 +3,7 @@ module TextualMixins::TextualRefreshStatus
     last_refresh_status = @ems.last_refresh_status.titleize
     if @ems.last_refresh_date
       last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << _(" -%{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
+      last_refresh_status << _(" - %{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
     end
     {
       :label => _("Last Refresh"),


### PR DESCRIPTION
Reaction on https://github.com/ManageIQ/manageiq/pull/10165#issuecomment-243943208

This PR (except the commit f38efb19f) also brings two commits that introduced the `TextualRefreshStatus` mixin:
 * 5f0bb1871
 * f65310b73

@miq-bot add_label ui, bug, darga/yes

hmm, the "darga/yes" label is redundant here, right?

@miq-bot assign chessbyte