### PR TITLE
Remove process_tasks methods from provider classes

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/provider.rb
+++ b/app/models/manageiq/providers/ansible_tower/provider.rb
@@ -49,39 +49,6 @@ class ManageIQ::Providers::AnsibleTower::Provider < ::Provider
     end
   end
 
-  def self.process_tasks(options)
-    raise _("No ids given to process_tasks") if options[:ids].blank?
-    if options[:task] == "refresh_ems"
-      refresh_ems(options[:ids])
-      create_audit_event(options)
-    else
-      options[:userid] ||= "system"
-      unknown_task_exception(options)
-      invoke_tasks_queue(options)
-    end
-  end
-
-  def self.create_audit_event(options)
-    msg = "'%{task}' initiated for %{amount} %{providers}" % {
-      :task      => options[:task],
-      :amount    => options[:ids].length,
-      :providers => Dictionary.gettext('providers',
-                                       :type      => :table,
-                                       :notfound  => :titleize,
-                                       :plural    => options[:ids].length > 1,
-                                       :translate => false)}
-    AuditEvent.success(:event        => options[:task],
-                       :target_class => base_class.name,
-                       :userid       => options[:userid],
-                       :message      => msg)
-  end
-
-  def self.unknown_task_exception(options)
-    unless instance_methods.collect(&:to_s).include?(options[:task])
-      raise _("Unknown task, %{options}") % {:options => options[:task]}
-    end
-  end
-
   def self.refresh_ems(provider_ids)
     EmsRefresh.queue_refresh(Array.wrap(provider_ids).collect { |id| [base_class, id] })
   end

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -71,37 +71,6 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
     configuration_manager.zone_id = zone_id
   end
 
-  def self.process_tasks(options)
-    raise "No ids given to process_tasks" if options[:ids].blank?
-    if options[:task] == "refresh_ems"
-      refresh_ems(options[:ids])
-      create_audit_event(options)
-    else
-      options[:userid] ||= "system"
-      unknown_task_exception(options)
-      invoke_tasks_queue(options)
-    end
-  end
-
-  def self.create_audit_event(options)
-    msg = "'%{task}' initiated for %{amount} %{providers}" % {
-      :task      => options[:task],
-      :amount    => options[:ids].length,
-      :providers => Dictionary.gettext('providers',
-                                       :type      => :table,
-                                       :notfound  => :titleize,
-                                       :plural    => options[:ids].length > 1,
-                                       :translate => false)}
-    AuditEvent.success(:event        => options[:task],
-                       :target_class => base_class.name,
-                       :userid       => options[:userid],
-                       :message      => msg)
-  end
-
-  def self.unknown_task_exception(options)
-    raise "Unknown task, #{options[:task]}" unless instance_methods.collect(&:to_s).include?(options[:task])
-  end
-
   def self.refresh_ems(provider_ids)
     EmsRefresh.queue_refresh(Array.wrap(provider_ids).collect { |id| [base_class, id] })
   end


### PR DESCRIPTION
These methods are only called on the `ConfigurationManager` class ([here](https://github.com/ManageIQ/manageiq/blob/master/app/controllers/application_controller/ci_processing.rb#L1737)) and they implement them by including the `ProcessTasksMixin` ([here (foreman)](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/foreman/configuration_manager.rb#L10) and [here (ansible tower)](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/ansible_tower/configuration_manager.rb#L9))

Because of that, these methods are not needed in the provider classes.

@bdunne @Fryguy please review
Also, I don't know who to ping about the Foreman provider