### PR TITLE
Fix chargeback rates read identfiers for API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -773,7 +773,7 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: chargeback_rates_show_list
+        :identifier: chargeback_rates
       :post:
       - :name: create
         :identifier: chargeback_rates_new
@@ -784,7 +784,7 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: chargeback_rates_show
+        :identifier: chargeback_rates
       :post:
       - :name: edit
         :identifier: chargeback_rates_edit


### PR DESCRIPTION
Purpose or Intent
-----------------

GETs to the chargeback rates API was resulting in a forbidden request
even for admins because the rates read actions were referencing some
identifiers which did not exist. The only available identifier is the
top level `chargeback_rates`, which these have been changed to.

@miq-bot add-label darga/yes, api, bug
@miq-bot assign @abellotti 