### PR TITLE
Fix dev reload issues when Vmdb::Settings.reload! is called.

### DIFF
--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -67,11 +67,11 @@ module Vmdb
       # we do not fail in cases where the database is not yet created, not yet
       # available, or has not yet been seeded.
       def my_server
-        resource_queryable? ? MiqServer.my_server(true) : nil
+        resource_queryable? ? ::MiqServer.my_server(true) : nil
       end
 
       def resource_queryable?
-        database_connectivity? && SettingsChange.table_exists?
+        database_connectivity? && ::SettingsChange.table_exists?
       end
 
       def database_connectivity?


### PR DESCRIPTION
When the global Vmdb::Settings object is created it maintains references
to instances of Vmdb::Settings::DatabaseSource.  In the recent changes
in #10886 the calls to dynamically load MiqServer.my_server were moved
into the DatabaseSource class.  Unfortunately, since we maintain a
reference to that class, when the my_server method is called after a
code reload, it tries to find the missing constant for SettingsChange.
As it walks the tree to find it, it starts at
Vmdb::Settings::DatabaseSource, which now is in the "bad" state, and
giving the error:

    [ArgumentError] A copy of Vmdb::Settings::DatabaseSource has been removed from the module tree but is still active!

The fix in this commit prefixes those calls with `::`, bypassing that
lookup at the Vmdb::Settings::DatabaseSource level, and making it start
at the top-level namespace.

In console, a failing recipe is

    reload! && Settings.reload!

Fixes #10978