### PR TITLE
Change labels in middleware topology

### DIFF
--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -12,7 +12,7 @@
             %circle{:r => "17"}
             %image{:height => "20", :width => "20", :x => "-10", :y => "-10", "xlink:href" => image_path('/assets/svg/vendor-wildfly.svg')}
         %label
-          = _("Middleware Servers")
+          = _("Servers")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDeployment"}
         %svg.kube-topology
           %g.MiddlewareDeployment{:transform => "translate(21, 21)"}
@@ -20,7 +20,7 @@
             -# product-report
             %text{:x => "0", :y => "8", :class => "product-report glyph"} &#xE603;
         %label
-          = _("Middleware Deployments")
+          = _("Deployments")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareDatasource"}
         %svg.kube-topology
           %g.MiddlewareDatasource{:transform => "translate(21, 21)"}
@@ -28,7 +28,7 @@
             -# fa-database
             %text{:x => "0", :y => "6", :class => "fa fa-database glyph"} &#xF1C0;
         %label
-          = _("Middleware Datasources")
+          = _("Datasources")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareMessaging"}
         %svg.kube-topology
           %g.MiddlewareMessaging{:transform => "translate(21, 21)"}
@@ -36,7 +36,7 @@
             -# fa-exchange (placeholder)
             %text{:x => "0", :y => "6", :class => "fa fa-exchange glyph"} &#xF0EC;
         %label
-          = _("Message Destinations")
+          = _("Messaging")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Vm"}
         %svg.kube-topology
           %g.EntityLegend.Infra
@@ -51,14 +51,14 @@
             %circle{:r => "17"}
             %text{:x => "0", :y => "6", :class => "fa fa-sitemap glyph"} &#xF0E8;
         %label
-          = _("Middleware Domains")
+          = _("Domains")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServerGroup"}
         %svg.kube-topology
           %g.MiddlewareServerGroup{:transform => "translate(21, 21)"}
             %circle{:r => "17"}
             %text{:x => "0", :y => "8", :class => "fa fa-th glyph"} &#xF00A;
         %label
-          = _("Middleware Server Groups")
+          = _("Server Groups")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}


### PR DESCRIPTION

![screenshot from 2016-09-13 22-14-39](https://cloud.githubusercontent.com/assets/3845764/18498861/a39224ee-79ff-11e6-8b4b-9e01716b1718.png)



- Drop Middleware prefix.
- Refer to servers as EAP.

Depends on PR #10892 (because one entity was added there and is also renamed)
Fixes #10910
