### PR TITLE
Cleanup subclass check to use operators over .subclasses

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1485,9 +1485,8 @@ class CatalogController < ApplicationController
   end
 
   def available_orchestration_managers_for_template_type(template_type)
-    return [] unless OrchestrationTemplate.subclasses.collect(&:name).include?(template_type.to_s)
-
-    template_type = template_type.constantize if template_type.kind_of?(String)
+    template_type = template_type.to_s.safe_constantize
+    return [] unless template_type && template_type < OrchestrationTemplate
 
     template_type.eligible_managers.collect { |m| [m.name, m.id] }.sort
   end


### PR DESCRIPTION
Minor refactoring in the UI for OrchestrationTemplates where we check if something is subclass.  It's preferable to use class operators for this kind of thing than doing lookups on `.subclasses`. This is technically a bug as well, since it should have been looking at `.descendants`, but we happen to only have first level descendants at this point anyway, so it didn't really matter.

@bzwei Please review.

cc @kbrock 
