### PR TITLE
Remove custom routing from API base controller

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -108,25 +108,5 @@ module Api
 
     before_action :parse_api_request, :log_api_request, :validate_api_request
     after_action :log_api_response
-
-    def redirect_api_request(method)
-      target_method = "#{method}_#{@req.collection || "entrypoint"}"
-      return send(target_method) if respond_to?(target_method)
-      target_method = "#{method}_generic"
-      return send(target_method) if respond_to?(target_method)
-      api_error_type(:not_found, "Unknown resource specified")
-    end
-
-    def show    # GET
-      redirect_api_request(:show)
-    end
-
-    def update  # POST, PUT, PATCH
-      redirect_api_request(:update)
-    end
-
-    def destroy # DELETE
-      redirect_api_request(:destroy)
-    end
   end
 end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -5,7 +5,7 @@ module Api
       # Primary Methods
       #
 
-      def show_generic
+      def show
         validate_api_action
         if @req.subcollection
           render_collection_type @req.subcollection.to_sym, @req.s_id, true
@@ -14,7 +14,7 @@ module Api
         end
       end
 
-      def update_generic
+      def update
         validate_api_action
         if @req.subcollection
           render_normal_update @req.collection.to_sym, update_collection(@req.subcollection.to_sym, @req.s_id, true)
@@ -23,7 +23,7 @@ module Api
         end
       end
 
-      def destroy_generic
+      def destroy
         validate_api_action
         if @req.subcollection
           delete_subcollection_resource @req.subcollection.to_sym, @req.s_id


### PR DESCRIPTION
Purpose or Intent
-----------------

Now that all API controllers respond to `#show`, `#update` and
`#destroy` which all do the appropriate thing for their corresponding
resource, we don't need the custom routing in the base controller.

@miq-bot assign @abellotti 
@miq-bot add-label api, refactoring

/cc @jrafanie :fire: :scissors: :fire: 