### PR TITLE
User feedback for quick search results

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1031,6 +1031,11 @@ class ApplicationController < ActionController::Base
     else
       @title = new_bc [:name] # Set the title to be the new breadcrumb
     end
+
+    # Modify user feedback for quick searches when not found
+    unless @search_text.blank?
+      @title += _(" (Names with \"%{search_text}\")") % {:search_text => @search_text}
+    end
   end
 
   def handle_invalid_session(timed_out = nil)


### PR DESCRIPTION
Give visual feedback cue to users when filtered quick search results are not found.

Display user search text string for not found condition. 

To test/verify, click on Compute => Infrastructure => Providers, enter search text string in the Search text box, press Enter.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1365232

![provider not found quick search results](https://cloud.githubusercontent.com/assets/552686/18220089/8617239a-7123-11e6-8d13-1f50c22c08f5.png)
