### PR TITLE
rubocop issues: tree_builder_utilization.rb

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -764,10 +764,14 @@ class MiqCapacityController < ApplicationController
     selected_node = x_node(name)
     if type == :bottlenecks
       @right_cell_text = _("Bottlenecks Summary")
-      @bottlenecks_tree = TreeBuilderUtilization.new(name, type, @sb, true, selected_node)
+      @bottlenecks_tree = TreeBuilderUtilization.new(
+        name, type, @sb, true, :selected_node => selected_node
+      )
     else
       @right_cell_text = _("Utilization Summary")
-      @utilization_tree = TreeBuilderUtilization.new(name, type, @sb, true, selected_node)
+      @utilization_tree = TreeBuilderUtilization.new(
+        name, type, @sb, true, :selected_node => selected_node
+      )
     end
   end
 

--- a/app/presenters/tree_builder_utilization.rb
+++ b/app/presenters/tree_builder_utilization.rb
@@ -4,8 +4,8 @@ class TreeBuilderUtilization < TreeBuilderRegion
   has_kids_for EmsFolder, [:x_get_tree_folder_kids, :type]
   has_kids_for EmsCluster, [:x_get_tree_cluster_kids]
 
-  def initialize(name, type, sandbox, build = true, selected_node)
-    @selected_node = selected_node
+  def initialize(name, type, sandbox, build = true, **params)
+    @selected_node = params[:selected_node]
     super(name, type, sandbox, build)
   end
 
@@ -26,7 +26,7 @@ class TreeBuilderUtilization < TreeBuilderRegion
       icon  = :enterprise
     else
       title = _("CFME Region: %{region_description} [%{region}]") %
-                {:region_description => MiqRegion.my_region.description, :region => MiqRegion.my_region.region}
+              {:region_description => MiqRegion.my_region.description, :region => MiqRegion.my_region.region}
       icon  = :miq_region
     end
     [title, title, icon]
@@ -104,7 +104,7 @@ class TreeBuilderUtilization < TreeBuilderRegion
   end
 
   def x_get_tree_cluster_kids(object, count_only)
-    objects =  rbac_filtered_sorted_objects(object.hosts, "name")
+    objects = rbac_filtered_sorted_objects(object.hosts, "name")
     # FIXME: is the condition below ever false?
     unless [:bottlenecks, :utilization].include?(@type)
       objects += rbac_filtered_sorted_objects(object.resource_pools, "name")


### PR DESCRIPTION
== app/presenters/tree_builder_utilization.rb ==
    C:  7: 39: Optional arguments should appear at the end of the argument
    list.
    C: 29: 17: Align the operands of an expression in an assignment spanning
    multiple lines.
    R: 63:  3: Assignment Branch Condition size for
    x_get_tree_vandt_datacenter_kids is too high. [15.52/15]
    R: 78:  3: Assignment Branch Condition size for
    x_get_tree_handc_datacenter_kids is too high. [18.14/15]
    C:107: 13: Operator = should be surrounded by a single space.
    C:107: 14: Unnecessary spacing detected.