### PR TITLE
Updating validation when creating or editing a provider's endpoint.

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -309,7 +309,9 @@ class ExtManagementSystem < ApplicationRecord
       connection.delete(:authentication)
     else
       unless connection[:authentication].key?(:role)
-        connection[:authentication][:role] ||= "default"
+        endpoint_role = connection[:endpoint][:role]
+        authentication_role = endpoint_role == "default" ? default_authentication_type.to_s : endpoint_role
+        connection[:authentication][:role] ||= authentication_role
       end
     end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -196,17 +196,43 @@ describe ExtManagementSystem do
     end
   end
 
-  context "with multiple endpoints using default authtype" do
+  context "with multiple endpoints using explicit authtype" do
     let(:ems) do
       FactoryGirl.build(:ems_openshift,
                         :connection_configurations => [{:endpoint       => {:role     => "default",
                                                                             :hostname => "openshift.example.org"},
                                                         :authentication => {:role     => "bearer",
+                                                                            :auth_key => "SomeSecret"}},
+                                                       {:endpoint       => {:role     => "hawkular",
+                                                                            :hostname => "openshift.example.org"},
+                                                        :authentication => {:role     => "hawkular",
                                                                             :auth_key => "SomeSecret"}}])
     end
 
     it "will contain the bearer authentication as default" do
       expect(ems.connection_configuration_by_role("default").authentication.authtype).to eq("bearer")
+    end
+    it "will contain the hawkular authentication as hawkular" do
+      expect(ems.connection_configuration_by_role("hawkular").authentication.authtype).to eq("hawkular")
+    end
+  end
+
+  context "with multiple endpoints using implicit default authtype" do
+    let(:ems) do
+      FactoryGirl.build(:ems_openshift,
+                        :connection_configurations => [{:endpoint       => {:role     => "default",
+                                                                            :hostname => "openshift.example.org"},
+                                                        :authentication => {:auth_key => "SomeSecret"}},
+                                                       {:endpoint       => {:role     => "hawkular",
+                                                                            :hostname => "openshift.example.org"},
+                                                        :authentication => {:auth_key => "SomeSecret"}}])
+    end
+
+    it "will contain the default authentication (bearer) for default endpoint" do
+      expect(ems.connection_configuration_by_role("default").authentication.authtype).to eq("bearer")
+    end
+    it "will contain the hawkular authentication for the hawkular endpoint" do
+      expect(ems.connection_configuration_by_role("hawkular").authentication.authtype).to eq("hawkular")
     end
   end
 


### PR DESCRIPTION
**Description**
A regression was created when introducing multiple provider endpoints to the providers API.
The function for updating authentications did not re-authenticate when changing
an endpoint or an authentication. This commit updates the authentication in this cases.

**Issue**
https://github.com/ManageIQ/manageiq/issues/7256