### PR TITLE
Containers: Download to PDF/CSV/Text - don't download deleted containers

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -116,7 +116,7 @@ class ContainerController < ApplicationController
     session.delete(:exp_parms)
     @in_a_form = false
     render :layout => "application"
-    process_show_list
+    process_show_list(:where_clause => 'containers.deleted_on IS NULL')
   end
 
   def identify_container(id = nil)


### PR DESCRIPTION
Fix BZ issue: https://bugzilla.redhat.com/show_bug.cgi?id=1369479

This commit fixes the bug by adding options to filter deleted containers on call to process_show_list, but I think the call to process_show_list (Added in PR https://github.com/ManageIQ/manageiq/pull/9073) might be obsolete, and maybe the breadcrumbs issue should be fixed differently.
process_show_list is already being called once in this method from build_accordions_and_trees with the correct filtering option, and sets session[:paged_view_search_options] for later use. the second call overrides it.

@miq-bot add_label providers/containers
@enoodle @moolitayer @simon3z  PTAL