### PR TITLE
[UI] VM Explorer: Speed up rbac when no vm in tree

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -334,7 +334,7 @@ module RelationshipMixin
     options = args.extract_options!
     rel = relationship(:raise_on_multiple => true)
     return {} if rel.nil?  # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
-    Relationship.filter_arranged_rels_by_resource_type(rel.descendants.arrange, options)
+    Relationship.filter_by_resource_type(rel.descendants, options).arrange
   end
 
   # Returns the descendant class/id pairs arranged in a tree
@@ -377,7 +377,7 @@ module RelationshipMixin
     options = args.extract_options!
     rel = relationship(:raise_on_multiple => true)
     return {relationship_for_isolated_root => {}} if rel.nil?
-    Relationship.filter_arranged_rels_by_resource_type(rel.subtree.arrange, options)
+    Relationship.filter_by_resource_type(rel.subtree, options).arrange
   end
 
   # Returns the subtree class/id pairs arranged in a tree
@@ -482,7 +482,7 @@ module RelationshipMixin
     root_id = relationship.try(:root_id)
     return {relationship_for_isolated_root => {}} if root_id.nil?
     rels = Relationship.subtree_of(root_id).arrange
-    Relationship.filter_arranged_rels_by_resource_type(rels, options)
+    Relationship.filter_by_resource_type(Relationship.subtree_of(root_id), options).arrange
   end
 
   # Returns the class/id pairs in the tree from the root arranged in a tree

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -96,6 +96,8 @@ class Relationship < ApplicationRecord
     end
   end
 
+  # This prunes a tree already in memory
+  # may be faster to prune the tree before creating the tree
   def self.filter_arranged_rels_by_resource_type(relationships, options)
     of_type = options[:of_type].to_miq_a
     except_type = options[:except_type].to_miq_a

--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -8,18 +8,22 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
 
   def relationship_tree
     # TODO: Do more to pre-prune the tree.
-    # - Use :of_type to limit the types of objects
     # - Perhaps only get the folders, then prune those based on RBAC and let
     #   the UI still do the lazy loading of individual folders.  This can be
     #   possibly done by querying the relationship tree only, and then only
     #   converting the folders to real objects.  For the VMs we only need ids,
     #   so taking them from the relationship records can cut down on the huge
     #   VM query.
-    tree = root.subtree_arranged
+
+    # TODO: Zita: please change next 2 lines
+    display_vms = User.current_user.settings.fetch_path(:display, :display_vms)
+    display_vms = true if display_vms.nil?
+
+    tree = root.subtree_arranged(display_vms ? {} : {:except_type => VmOrTemplate})
 
     prune_non_vandt_folders(tree)
     reparent_hidden_folders(tree)
-    prune_rbac(tree)
+    prune_rbac(tree, display_vms)
     sort_tree(tree)
 
     tree
@@ -50,25 +54,43 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
     end
   end
 
-  def prune_rbac(tree)
-    allowed_vm_ids = Set.new(Rbac.filtered(@root_ems.vms).pluck(:id))
-
-    prune_filtered_vms(tree, allowed_vm_ids)
-    prune_empty_folders(tree)
-  end
-
-  def prune_filtered_vms(tree, allowed_vm_ids)
-    tree.reject! do |object, children|
-      prune_filtered_vms(children, allowed_vm_ids)
-      object.kind_of?(VmOrTemplate) && !allowed_vm_ids.include?(object.id)
+  def prune_rbac(tree, display_vms)
+    if display_vms
+      allowed_vm_ids = Set.new(Rbac.filtered(@root_ems.vms).pluck(:id))
+      prune_folders_via_vms(tree, allowed_vm_ids)
+    else
+      allowed_vms = Rbac.filtered(@root_ems.vms) # this is a sub-query
+      vm_relations = Relationship.where(:resource     => allowed_vms,
+                                        :relationship => "ems_metadata")
+                                 .select(:ancestry).distinct # bigger sub-query
+                                 .map(&:parent_id)
+      allowed_folder_ids = Relationship.where(:id => vm_relations).pluck(:resource_id)
+      prune_folders_via_folders(tree, allowed_folder_ids)
     end
   end
 
-  def prune_empty_folders(tree)
+  def prune_folders_via_vms(tree, allowed_vm_ids)
     tree.reject! do |object, children|
-      prune_empty_folders(children)
-      object.kind_of?(EmsFolder) && children.empty?
+      prune_folders_via_vms(children, allowed_vm_ids)
+      if object.kind_of?(VmOrTemplate)
+        !allowed_vm_ids.include?(object.id)
+      elsif object.kind_of?(EmsFolder)
+        children.empty?
+      end
     end
+  end
+
+  def prune_folders_via_folders(tree, allowed_folder_ids)
+    has_sub_folders = false
+    tree.select! do |object, children|
+      has_sub_sub_folders = prune_folders_via_folders(children, allowed_folder_ids)
+
+      next(true) unless object.kind_of?(EmsFolder)
+      keep_folder = has_sub_sub_folders || allowed_folder_ids.include?(object.id)
+      has_sub_folders = true if keep_folder
+      keep_folder
+    end
+    has_sub_folders
   end
 
   # Datacenters will sort before normal folders via the sort_tree method

--- a/spec/presenters/tree_builder_vms_and_templates_spec.rb
+++ b/spec/presenters/tree_builder_vms_and_templates_spec.rb
@@ -1,22 +1,69 @@
 describe TreeBuilderVmsAndTemplates do
-  before do
-    ems     = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone))
-    folder  = FactoryGirl.create(:ems_folder, :ext_management_system => ems)
-    subfolder1 = FactoryGirl.create(:ems_folder)
+  let(:ems) { FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone)) }
+  let(:folder) { FactoryGirl.create(:ems_folder, :ext_management_system => ems) }
+  let(:subfolder1) { FactoryGirl.create(:ems_folder) }
+
+  let(:tree) do
     subfolder2 = FactoryGirl.create(:ems_folder)
     subfolder3 = FactoryGirl.create(:datacenter)
 
+    ems.with_relationship_type("ems_metadata") { ems.add_child(folder) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder1) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder2) }
     folder.with_relationship_type("ems_metadata") { folder.add_child(subfolder3) }
 
-    @vandt_tree = TreeBuilderVmsAndTemplates.new(ems, {})
-    @tree = {ems => {folder => {subfolder1 => {}, subfolder2 => {}, subfolder3 => {}}}}
+    {ems => {folder => {subfolder1 => {}, subfolder2 => {}, subfolder3 => {}}}}
   end
 
-  context "#sort_tree" do
+  describe "#sort_tree" do
     it "making sure sort_tree was successful for mixed ems_folder types" do
-      expect { @vandt_tree.send(:sort_tree, @tree) }.not_to raise_error
+      builder = TreeBuilderVmsAndTemplates.new(ems)
+      expect { builder.send(:sort_tree, tree) }.not_to raise_error
+    end
+  end
+
+  describe "#tree" do
+    it "returns vms with display_vms=true" do
+      EvmSpecHelper.local_miq_server
+      User.current_user = FactoryGirl.create(:user, :settings => {:display => {:display_vms => true}})
+      tree
+      vms = FactoryGirl.create_list(:vm_vmware, 2, :ext_management_system => ems)
+      subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
+
+      tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
+      expect(tree_v[:title]).to eq(ems.name)
+      expect(tree_v[:children].size).to eq(1)
+
+      folders_v = tree_v[:children].first
+      expect(folders_v[:title]).to match folder.name
+      expect(folders_v[:children].size).to eq(1)
+
+      subfolders_v = folders_v[:children].detect { |f| f[:title] == subfolder1.name }
+      expect(subfolders_v).to be_present
+      expect(subfolders_v[:children].size).to eq(2)
+
+      ems_vs = subfolders_v[:children]
+      expect(ems_vs.map { |e| e[:title] }).to match_array(vms.map(&:name))
+    end
+
+    it "returns no vms with display_vms=false" do
+      EvmSpecHelper.local_miq_server
+      User.current_user = FactoryGirl.create(:user, :settings => {:display => {:display_vms => false}})
+      tree
+      vms = FactoryGirl.create_list(:vm_vmware, 2, :ext_management_system => ems)
+      subfolder1.with_relationship_type("ems_metadata") { vms.each { |vm| subfolder1.add_child(vm) } }
+
+      tree_v = TreeBuilderVmsAndTemplates.new(ems).tree
+      expect(tree_v[:title]).to eq(ems.name)
+      expect(tree_v[:children].size).to eq(1)
+
+      folders_v = tree_v[:children].first
+      expect(folders_v[:title]).to match folder.name
+      expect(folders_v[:children].size).to eq(1) # would be 3 if we did not prune
+
+      subfolders_v = folders_v[:children].detect { |f| f[:title] == subfolder1.name }
+      expect(subfolders_v).to be_present
+      expect(subfolders_v[:children]).to be_blank # no vms in the tree
     end
   end
 end


### PR DESCRIPTION
The user interface is introduced by #11387 - but this is no longer blocked by the PR.

This PR gives the customer a setting to not display VMs in the navbar.

![explorer without vms](https://cloud.githubusercontent.com/assets/1930/18327645/8182d334-7519-11e6-8f89-af77ca9351f6.png)

The orange square shows that there are no longer expanders for the bottom level. But each level can be selected to show the VMs in the right hand paginated view.

~~@Fryguy pointed out, this no longer prunes folders that may contain unseen vms. It does not make them accessible, but makes the folders visible. Self service seeing too many folders is the only feature justification that resonates, but I'm not the business owner. Pulling back every VM is a big memory/time hit, but if that is what is needed...~~ now showing records

Numbers
------

I added an estimate for #11387 - it prunes the vms so they are not serialized / sent to the client. Wanted to show this so you could gauge how much time is spent in serialization vs queries

|        ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  21,056.1 |  135 |  5,587.9 |   68,426 |before
|  11,335.9 |  131 |  5,072.4 |   68,422 |estimated #11387 
|   3,272.1 |  132 |  2,271.3 |    5,765 |after
| 84% | 2% | 59% | 92%

|VmOrTemplate|Host|Storage|ExtManagementSystem|MiqRegion|Zone|
|-----------:|---:|------:|------------------:|--------:|---:|
|      23,023 |3,244 |  3,825 |                12 |       5 | 34 |
