### PR TITLE
[DARGA] Fix NetworkTopology breadcrumbs link

### DIFF
--- a/app/controllers/network_topology_controller.rb
+++ b/app/controllers/network_topology_controller.rb
@@ -9,7 +9,9 @@ class NetworkTopologyController < ApplicationController
     # all previous navigation should not be displayed in breadcrumbs as the user could arrive from
     # any other page in the application.
     @breadcrumbs.clear if params[:id].nil?
-    drop_breadcrumb(:name => _('Topology'), :url => '')
+    drop_breadcrumb(:name => _('Topology'), :url => "/network_topology/show/#{params[:id]}")
+    @lastaction = 'show'
+    @display = @showtype = 'topology'
   end
 
   def index


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix NetworkTopology breadcrumbs link

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1371267

Cherry-pick of:
https://github.com/ManageIQ/manageiq/pull/10770

Conflicts:
	app/controllers/network_topology_controller.rb