### PR TITLE
Fixed length checking issue

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -787,11 +787,7 @@ function miqCheckMaxLength(obj) {
     obj.value = obj.value.substring(0, ml);
   }
   if (counter) {
-    if (ManageIQ.browser != 'Explorer') {
-      $('#' + counter)[0].textContent = obj.value.length;
-    } else {
-      $('#' + counter).innerText = obj.value.length;
-    }
+    $('#' + counter).text(obj.value.length);
   }
 }
 

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -48,13 +48,15 @@
     .form-group
       %label.col-md-2.control-label{:valign => "top"}
         = field_hash[:description]
+        - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
         - if field_hash[:description] == "Provision on"
           (#{get_timezone_abbr(current_user)})
         - if @edit && @edit[:new] && [:vm_description].include?(field)
+          %br
           (
           %span#description_count
             = @edit[:new][:vm_description] ? @edit[:new][:vm_description].length : 0
-          \/ #{field_hash[:max_length]})
+          \/ #{len} )
         - if @edit && field_hash[:required] && field_hash[:display] == :edit
           *
       -# Text fields
@@ -84,14 +86,13 @@
                                    "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             - elsif [:request_notes, :vm_description].include?(field)
               = text_area_tag(field_id, options[field],
-                              :maxlength                  => field_hash[:max_length],
+                              :maxlength                  => len,
                               :class                      => "form-control",
                               :size                       => "25x4",
                               :counter                    => "description_count",
                               "data-miq_check_max_length" => true,
                               "data-miq_observe"          => {:interval => '.5', :url => url}.to_json)
             - else
-              - len =  field_hash[:max_length] ? field_hash[:max_length] : MAX_NAME_LEN
               = text_field_tag(field_id, options[field],
                                :maxlength         => len,
                                :class             => "form-control",


### PR DESCRIPTION
I've ran into issue while provisioning VM. When I started typing to the textarea, the issue notification appeared.

![screencapture-localhost-3000-vm_infra-explorer-1473074876643](https://cloud.githubusercontent.com/assets/1187051/18247066/5f356210-7370-11e6-95c7-35fc21007d82.png)

After fixing issue from JS side, I've noticed, that text length is checked, but there is no max length set, so in the PR I'm fixing two kinds of problem:

- content of `$('#' + counter)[0]` that was `undefined`, and was causing JS error
- making sure that `:maxlength` is always set.

I'm not sure, what is the proper maxlength for textareas in *Provision VM* page though. `MAX_NAME_LEN` constant allows `255` characters.

@h-kataria @dclarizio do you have any idea, if this solution is correct? 

Steps for Testing/QA
--------------------
Try to fill *Notes* while provisioning VMs. There should be no error in JS console

