### PR TITLE
Rename dropdown options in Planning page

### DIFF
--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -7,11 +7,11 @@
   .form.horizontal
     .form-group
       - options = [["<#{_('Choose')}>"],
-        [_("By Infrastructure Providers"), "ems"],
+        [_("By Providers"), "ems"],
         [_("By Clusters / Deployment Roles"), "cluster"],
         [_("By Host"), "host"],
         [_("By Filter"), "filter"],
-        [_("All VMs"), "all"],]
+        [_("All VMs/Instances"), "all"],]
       = select_tag("filter_typ",
                     options_for_select(options, @sb[:planning][:options][:filter_typ]),
                     :disabled              => @sb[:planning][:options][:vm_mode] == :manual,


### PR DESCRIPTION
Purpose or Intent
-----------------
Selecting 'By Infrastructure Providers' is showing all the providers(cloud and infra) so it's renamed to - 'By Providers'.
Selecting 'All VMs' is showing all VMs and Templates so it's renamed to 'All VMs/Instances'.

Links
-----

https://bugzilla.redhat.com/show_bug.cgi?id=1371261