### PR TITLE
Added rounding for Memory/CPU ratios in Cluster textual helper

### DIFF
--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -106,13 +106,14 @@ module EmsClusterHelper::TextualSummary
     {:label => _("Total Configured Memory"),
      :value => _("%{number} (Virtual to Real Ratio: %{ratio})") %
        {:number => number_to_human_size(@record.aggregate_vm_memory.megabytes, :precision => 2),
-        :ratio  => @record.v_ram_vr_ratio}}
+        :ratio  => @record.v_ram_vr_ratio.round(2)}}
   end
 
   def textual_aggregate_vm_cpus
     {:label => _("Total Configured CPUs"),
      :value => _("%{number} (Virtual to Real Ratio: %{ratio})") %
-       {:number => number_with_delimiter(@record.aggregate_vm_cpus), :ratio => @record.v_cpu_vr_ratio}}
+       {:number => number_with_delimiter(@record.aggregate_vm_cpus),
+        :ratio  => @record.v_cpu_vr_ratio.round(2)}}
   end
 
   def textual_ems


### PR DESCRIPTION
Purpose or Intent
-----------------
Rounding fixes long float values

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1365664