### PR TITLE
Removed unnecessary RBAC checking for toolbar buttons

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -444,8 +444,6 @@ class ApplicationHelper::ToolbarBuilder
       else
         false
       end
-    else
-      !role_allows?(:feature => id)
     end
   end
 
@@ -660,8 +658,6 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Condition"
       case id
-      when "condition_edit"
-        return true unless role_allows?(:feature => "condition_edit")
       when "condition_copy"
         return true if x_active_tree != :condition_tree || !role_allows?(:feature => "condition_new")
       when "condition_delete"
@@ -681,13 +677,6 @@ class ApplicationHelper::ToolbarBuilder
       when "ab_group_edit", "ab_group_delete", "ab_button_new"
         return !role_allows_button_manipulation if x_active_tree == :sandt_tree
       end
-    when "MiqAction"
-      case id
-      when "action_edit"
-        return true unless role_allows?(:feature => "action_edit")
-      when "action_delete"
-        return true unless role_allows?(:feature => "action_delete")
-      end
     when "MiqAeClass", "MiqAeDomain", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
       case id
@@ -705,22 +694,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless git_enabled?(@record) && MiqRegion.my_region.role_active?("git_owner")
       else
         return true unless editable_domain?(@record)
-      end
-    when "MiqAlert"
-      case id
-      when "alert_copy"
-        return true unless role_allows?(:feature => "alert_copy")
-      when "alert_edit"
-        return true unless role_allows?(:feature => "alert_edit")
-      when "alert_delete"
-        return true unless role_allows?(:feature => "alert_delete")
-      end
-    when "MiqAlertSet"
-      case id
-      when "alert_profile_edit"
-        return true unless role_allows?(:feature => "alert_profile_edit")
-      when "alert_profile_delete"
-        return true unless role_allows?(:feature => "alert_profile_delete")
       end
     when "MiqEventDefinition"
       case id
@@ -742,13 +715,6 @@ class ApplicationHelper::ToolbarBuilder
       when "policy_delete"
         return true if !role_allows?(:feature => "policy_delete") ||
                        x_active_tree != :policy_tree
-      end
-    when "MiqPolicySet"
-      case id
-      when "profile_edit"
-        return true unless role_allows?(:feature => "profile_edit")
-      when "profile_delete"
-        return true unless role_allows?(:feature => "profile_delete")
       end
     when "MiqRequest"
       # Don't hide certain buttons on AutomationRequest screen
@@ -809,11 +775,7 @@ class ApplicationHelper::ToolbarBuilder
         return !role_allows_button_manipulation
       when /^history_\d*/
         return false
-      else
-        return !role_allows?(:feature => id)
       end
-    when "OrchestrationTemplate", "OrchestrationTemplateCfn", "OrchestrationTemplateHot", "OrchestrationTemplateAzure", "OrchestrationTemplateVnfd"
-      return true unless role_allows?(:feature => id)
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
       case id
       when "configured_system_provision"
@@ -823,14 +785,6 @@ class ApplicationHelper::ToolbarBuilder
       case id
       when "ab_group_new", "ab_button_new", "ab_group_reorder"
         return !role_allows_button_manipulation if x_active_tree == :sandt_tree
-      when "action_new"
-        return true unless role_allows?(:feature => "action_new")
-      when "alert_profile_new"
-        return true unless role_allows?(:feature => "alert_profile_new")
-      when "alert_new"
-        return true unless role_allows?(:feature => "alert_new")
-      when "condition_new"
-        return true unless role_allows?(:feature => "condition_new")
       when "log_download"
         return true if ["workers", "download_logs"].include?(@lastaction)
       when "log_collect"
@@ -839,10 +793,6 @@ class ApplicationHelper::ToolbarBuilder
         return true if ["workers", "download_logs"].include?(@lastaction)
       when "logdepot_edit"
         return true if ["workers", "evm_logs", "audit_logs"].include?(@lastaction)
-      when "policy_new"
-        return true unless role_allows?(:feature => "policy_new")
-      when "profile_new"
-        return true unless role_allows?(:feature => "profile_new")
       when "processmanager_restart"
         return true if ["download_logs", "evm_logs", "audit_logs"].include?(@lastaction)
       when "refresh_workers"
@@ -855,8 +805,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @report
       when "timeline_txt"
         return true unless @report
-      else
-        return !role_allows?(:feature => id)
       end
     end
     false  # No reason to hide, allow the button to show

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -955,25 +955,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when with MiqAlert" do
-      before do
-        @record = MiqAlert.new
-        @layout = "miq_policy"
-      end
-
-      it "alert_copy don't hide if RBAC allows" do
-        stub_user(:features => :all)
-        @id = "alert_copy"
-        expect(subject).to be_falsey
-      end
-
-      it "alert_copy hide if RBAC denies" do
-        stub_user(:features => :none)
-        @id = "alert_copy"
-        expect(subject).to be_truthy
-      end
-    end
-
     context "when with MiqServer" do
       before do
         @record = MiqServer.new


### PR DESCRIPTION
# Continuation of #10942
Purpose or Intent
-----------------

In PR #10942, @PanSpagetka is changing the RBAC checking for all buttons, that means we don't need to check `role_allows?(:feature => id)` again in `toolbar_builder.rb`



Links
-----
#10942 
https://www.pivotaltracker.com/story/show/126783831
https://www.pivotaltracker.com/story/show/126783921
https://www.pivotaltracker.com/story/show/126784153
https://www.pivotaltracker.com/story/show/126782877

@PanSpagetka @martinpovolny @jzigmund

