### PR TITLE
Add 'Choose' to Cloud Volume's form dropdown

### DIFF
--- a/app/views/cloud_volume/new.html.haml
+++ b/app/views/cloud_volume/new.html.haml
@@ -31,7 +31,7 @@
         = _('Cloud Tenant')
       .col-md-8
         = select_tag("cloud_tenant_id",
-                      options_for_select(@cloud_tenant_choices.sort),
+          options_for_select([["<#{_('Choose')}>", nil]] + @cloud_tenant_choices.sort),
                       "ng-model"                    => "cloudVolumeModel.cloud_tenant_id",
                       "required"                    => "",
                       :miqrequired                  => true,


### PR DESCRIPTION
Purpose or Intent
-----------------
Add missing default option to "Cloud Tenant" dropdown in new Cloud Volume form.

Links
-----

https://bugzilla.redhat.com/show_bug.cgi?id=1362143