### PR TITLE
[DARGA] Add missing policy buttons to Network Manager Relationship pages

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -342,35 +342,39 @@ module EmsCommon
     params[:display] = @display if ["vms", "hosts", "storages", "instances", "images"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
-    if params[:pressed].starts_with?("vm_", # Handle buttons from sub-items screen
-                                     "miq_template_",
+    # Handle buttons from sub-items screen
+    if params[:pressed].starts_with?("ems_cluster_",
                                      "guest_",
+                                     "host_",
                                      "image_",
                                      "instance_",
+                                     "miq_template_",
                                      "storage_",
-                                     "ems_cluster_",
-                                     "host_")
+                                     "vm_")
 
-      scanhosts if params[:pressed] == "host_scan"
-      analyze_check_compliance_hosts if params[:pressed] == "host_analyze_check_compliance"
-      check_compliance_hosts if params[:pressed] == "host_check_compliance"
-      refreshhosts if params[:pressed] == "host_refresh"
-      tag(Host) if params[:pressed] == "host_tag"
-      assign_policies(Host) if params[:pressed] == "host_protect"
-      deletehosts if params[:pressed] == "host_delete"
-      comparemiq if params[:pressed] == "host_compare"
-      edit_record  if params[:pressed] == "host_edit"
-
-      scanclusters if params[:pressed] == "ems_cluster_scan"
-      tag(EmsCluster) if params[:pressed] == "ems_cluster_tag"
-      assign_policies(EmsCluster) if params[:pressed] == "ems_cluster_protect"
-      deleteclusters if params[:pressed] == "ems_cluster_delete"
-      comparemiq if params[:pressed] == "ems_cluster_compare"
-
-      scanstorage if params[:pressed] == "storage_scan"
-      refreshstorage if params[:pressed] == "storage_refresh"
-      tag(Storage) if params[:pressed] == "storage_tag"
-      deletestorages if params[:pressed] == "storage_delete"
+      case params[:pressed]
+      # Clusters
+      when "ems_cluster_compare"              then comparemiq
+      when "ems_cluster_delete"               then deleteclusters
+      when "ems_cluster_protect"              then assign_policies(EmsCluster)
+      when "ems_cluster_scan"                 then scanclusters
+      when "ems_cluster_tag"                  then tag(EmsCluster)
+      # Hosts
+      when "host_analyze_check_compliance"    then analyze_check_compliance_hosts
+      when "host_check_compliance"            then check_compliance_hosts
+      when "host_compare"                     then comparemiq
+      when "host_delete"                      then deletehosts
+      when "host_edit"                        then edit_record
+      when "host_protect"                     then assign_policies(Host)
+      when "host_refresh"                     then refreshhosts
+      when "host_scan"                        then scanhosts
+      when "host_tag"                         then tag(Host)
+      # Storages
+      when "storage_delete"                   then deletestorages
+      when "storage_refresh"                  then refreshstorage
+      when "storage_scan"                     then scanstorage
+      when "storage_tag"                      then tag(Storage)
+      end
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])
       # Handle Host power buttons

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -343,12 +343,25 @@ module EmsCommon
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
     # Handle buttons from sub-items screen
-    if params[:pressed].starts_with?("ems_cluster_",
+    if params[:pressed].starts_with?("availability_zone_",
+                                     "cloud_network_",
+                                     "cloud_object_store_container_",
+                                     "cloud_subnet_",
+                                     "cloud_tenant_",
+                                     "cloud_volume_",
+                                     "ems_cluster_",
+                                     "flavor_",
+                                     "floating_ip_",
                                      "guest_",
                                      "host_",
                                      "image_",
                                      "instance_",
+                                     "load_balancer_",
                                      "miq_template_",
+                                     "network_port_",
+                                     "network_router_",
+                                     "orchestration_stack_",
+                                     "security_group_",
                                      "storage_",
                                      "vm_")
 
@@ -374,6 +387,20 @@ module EmsCommon
       when "storage_refresh"                  then refreshstorage
       when "storage_scan"                     then scanstorage
       when "storage_tag"                      then tag(Storage)
+      # Edit Tags for Network Manager Relationship pages
+      when "availability_zone_tag"            then tag(AvailabilityZone)
+      when "cloud_network_tag"                then tag(CloudNetwork)
+      when "cloud_object_store_container_tag" then tag(CloudObjectStoreContainer)
+      when "cloud_subnet_tag"                 then tag(CloudSubnet)
+      when "cloud_tenant_tag"                 then tag(CloudTenant)
+      when "cloud_volume_tag"                 then tag(CloudVolume)
+      when "flavor_tag"                       then tag(Flavor)
+      when "floating_ip_tag"                  then tag(FloatingIp)
+      when "load_balancer_tag"                then tag(LoadBalancer)
+      when "network_port_tag"                 then tag(NetworkPort)
+      when "network_router_tag"               then tag(NetworkRouter)
+      when "orchestration_stack_tag"          then tag(OrchestrationStack)
+      when "security_group_tag"               then tag(SecurityGroup)
       end
 
       pfx = pfx_for_vm_button_pressed(params[:pressed])

--- a/app/controllers/mixins/generic_button_mixin.rb
+++ b/app/controllers/mixins/generic_button_mixin.rb
@@ -6,7 +6,8 @@ module Mixins
       params[:display] = @display if %w(images instances).include?(@display) # Were we displaying vms/hosts/storages
       params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
 
-      if params[:pressed].starts_with?("image_", # Handle buttons from sub-items screen
+      # Handle buttons from sub-items screen
+      if params[:pressed].starts_with?("image_",
                                        "instance_")
 
         pfx = pfx_for_vm_button_pressed(params[:pressed])
@@ -25,10 +26,18 @@ module Mixins
           @refresh_partial = "layouts/gtl"
           show # Handle VMs buttons
         end
-      else
-        tag(self.class.model) if params[:pressed] == "#{self.class.table_name}_tag"
-        return if ["#{self.class.table_name}_tag"].include?(params[:pressed]) &&
-                  @flash_array.nil? # Tag screen showing, so return
+      elsif params[:pressed].ends_with?("_tag")
+        case params[:pressed]
+        when "#{self.class.table_name}_tag" then tag(self.class.model)
+        when "cloud_subnet_tag"             then tag(CloudSubnet)
+        when "floating_ip_tag"              then tag(FloatingIp)
+        when "load_balancer_tag"            then tag(LoadBalancer)
+        when "network_port_tag"             then tag(NetworkPort)
+        when "network_router_tag"           then tag(NetworkRouter)
+        when "security_group_tag"           then tag(SecurityGroup)
+        end
+
+        return if @flash_array.nil?
       end
 
       check_if_button_is_implemented

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -433,31 +433,25 @@ class ApplicationHelper::ToolbarChooser
   def center_toolbar_filename_classic
     # Original non vmx view code follows
     # toolbar buttons on sub-screens
-    if ((@lastaction == "show" && @view) ||
-        (@lastaction == "show" && @display != "main")) &&
-       !@layout.starts_with?("miq_request")
+    to_display = %w(ems_clusters hosts resource_pools storages)
+    to_display_center = %w(stack_orchestration_template topology)
+    if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"
         return "vm_infras_center_tb"
-      elsif @display == "ems_clusters"
-        return "ems_clusters_center_tb"
-      elsif @display == "hosts"
-        return "hosts_center_tb"
       elsif @display == "images"
         return "template_clouds_center_tb"
       elsif @display == "instances"
         return "vm_clouds_center_tb"
       elsif @display == "miq_templates"
         return "template_infras_center_tb"
-      elsif @display == "resource_pools"
-        return "resource_pools_center_tb"
-      elsif @display == "storages"
-        return "storages_center_tb"
-      elsif @display == "stack_orchestration_template"
-        return "stack_orchestration_template_center"
       elsif (@layout == "vm" || @layout == "host") && @display == "performance"
         return "#{@explorer ? "x_" : ""}vm_performance_tb"
       elsif @display == "dashboard"
         return "#{@layout}_center_tb"
+      elsif to_display.include?(@display)
+        return "#{@display}_center_tb"
+      elsif to_display_center.include?(@display)
+        return "#{@display}_center"
       end
     elsif @lastaction == "compare_miq" || @lastaction == "compare_compress"
       return "compare_center_tb"

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -433,7 +433,9 @@ class ApplicationHelper::ToolbarChooser
   def center_toolbar_filename_classic
     # Original non vmx view code follows
     # toolbar buttons on sub-screens
-    to_display = %w(ems_clusters hosts resource_pools storages)
+    to_display = %w(availability_zones cloud_networks cloud_object_store_containers cloud_subnets
+                    cloud_tenants cloud_volumes ems_clusters flavors floating_ips hosts load_balancers
+                    network_ports network_routers orchestration_stacks resource_pools security_groups storages)
     to_display_center = %w(stack_orchestration_template topology)
     if @lastaction == 'show' && (@view || @display != 'main') && !@layout.starts_with?("miq_request")
       if @display == "vms" || @display == "all_vms"


### PR DESCRIPTION
Backport of #10584 
(cherry picked from commit 35bfb21)
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1347223

Refactor ems_common.rb controller in app/controllers and toolbar_chooser.rb 
in app/helpers/application_helper and add missing policy buttons to some 
of the Network Manager Relationship pages to enable tagging more items
at once when managing a cloud provider in Compute -> Clouds -> Provider.
Fix policy buttons on some of the Network Managers pages to enable
tagging when reaching Networks -> Providers/Networks/Subnets/etc.

Before:
![screenshot from 2016-08-22 16-02-33](https://cloud.githubusercontent.com/assets/13417815/17857433/022c4f28-6882-11e6-9201-fe0ea83e816c.png)

After:
![screenshot from 2016-08-22 15-57-48](https://cloud.githubusercontent.com/assets/13417815/17857422/fafec190-6881-11e6-9759-0b69654e01b9.png)