### PR TITLE
Added rate assigning by tags to container images

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -513,6 +513,9 @@ module UiConstants
     "vm-tags"               => PostponedTranslation.new(N_("Tagged %{tables}")) do
                                  {:tables => ui_lookup(:tables => "vm")}
                                end,
+    "container_image-tags"  => PostponedTranslation.new(N_("Tagged %{tables}")) do
+                                 {:tables => ui_lookup(:tables => "container_image")}
+                               end,
     "tenant"                => N_("Tenants")
   }
 


### PR DESCRIPTION
Needed for #10677 so we can charge rates according to image tags
![screencapture-localhost-3000-chargeback-explorer-1473095244319](https://cloud.githubusercontent.com/assets/11256940/18254248/6828e41c-73a4-11e6-802c-e7a848753424.png)

@gtanzillo Please review
cc @simon3z 

@miq-bot add_label providers/containers, chargeback