### PR TITLE
Add image tag names for Containers in vim performance state.

### DIFF
--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -14,6 +14,7 @@ class VimPerformanceState < ApplicationRecord
     :parent_ems_id,
     :parent_ems_cluster_id,
     :tag_names,
+    :image_tag_names,
     :numvcpus,
     :total_cpu,
     :total_mem,
@@ -64,6 +65,7 @@ class VimPerformanceState < ApplicationRecord
     state.vm_used_disk_storage = capture_vm_disk_storage(obj, :used_disk)
     state.vm_allocated_disk_storage = capture_vm_disk_storage(obj, :allocated_disk)
     state.tag_names = capture_tag_names(obj)
+    state.image_tag_names = capture_image_tag_names(obj)
     state.host_sockets = capture_host_sockets(obj)
     state.save
 
@@ -201,6 +203,11 @@ class VimPerformanceState < ApplicationRecord
 
   def self.capture_tag_names(obj)
     obj.tag_list(:ns => "/managed").split.join("|")
+  end
+
+  def self.capture_image_tag_names(obj)
+    return '' unless obj.respond_to?(:container_image) && obj.container_image.present?
+    obj.container_image.tag_list(:ns => "/managed").split.join("|")
   end
 
   def self.capture_vm_disk_storage(obj, field)


### PR DESCRIPTION
Needed for #10677
Keep image tags in containers `vim_performance_states`

@gtanzillo\@fryguy Please review
cc @simon3z 

@miq-bot add_label providers/containers, chargeback
