### PR TITLE
Fix method which is removing duplicate records with same timestamp

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -120,7 +120,7 @@ module Metric::Helper
   end
 
   def self.remove_duplicate_timestamps(recs)
-    return recs if recs.empty? || recs.any? { |r| !r.kind_of?(Metric) || !r.kind_of?(MetricRollup) }
+    return recs if recs.empty? || !recs.all? { |r| r.kind_of?(Metric) || r.kind_of?(MetricRollup) }
 
     recs = recs.sort_by { |r| r.resource_type + r.resource_id.to_s + r.timestamp.iso8601 }
 
@@ -132,11 +132,11 @@ module Metric::Helper
         _log.warn("Multiple rows found for the same timestamp: [#{rec.timestamp}], ids: [#{rec.id}, #{last_rec.id}], resource and id: [#{rec.resource_type}:#{rec.resource_id}]")
 
         # Merge records with the same timestamp
-        last_rec.attributes.each { |a| last_rec[a] ||= rec[a] }
+        last_rec.attribute_names.each { |a| last_rec[a] ||= rec[a] }
       else
         ret << rec
+        last_rec = rec
       end
-      last_rec = rec
     end
   end
 

--- a/spec/models/metric/helper_spec.rb
+++ b/spec/models/metric/helper_spec.rb
@@ -1,0 +1,57 @@
+describe Metric::Helper do
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  describe ".remove_duplicate_timestamps" do
+    let(:host) { FactoryGirl.create(:host) }
+    let(:metric_rollup_1) do
+      FactoryGirl.create(:metric_rollup,
+                         :resource  => host,
+                         :timestamp => Time.zone.parse("2016-01-12T00:00:00.00000000"))
+    end
+
+    # duplicate of metric_rollup_1
+    let(:metric_rollup_2) do
+      FactoryGirl.create(:metric_rollup,
+                         :resource  => host,
+                         :timestamp => Time.zone.parse("2016-01-12T00:00:00.00000000"))
+    end
+
+    let(:metric_rollup_3) do
+      FactoryGirl.create(:metric_rollup,
+                         :resource  => host,
+                         :timestamp => Time.zone.parse("2016-01-12T01:00:00.00000000"))
+    end
+
+    it "returns only unique records" do
+      recs = described_class.remove_duplicate_timestamps([metric_rollup_1, metric_rollup_2, metric_rollup_3])
+      expect(recs).to match_array([metric_rollup_1, metric_rollup_3])
+    end
+
+    it "returns only unique records and merge values with the same timestamp" do
+      metric_rollup_1.cpu_usage_rate_average = nil
+      metric_rollup_1.save
+      metric_rollup_2.cpu_usage_rate_average = 500
+      metric_rollup_2.save
+
+      metric_rollup_3.timestamp = metric_rollup_1.timestamp
+      metric_rollup_3.net_usage_rate_average = 1500
+      metric_rollup_3.save
+      recs = described_class.remove_duplicate_timestamps([metric_rollup_1, metric_rollup_2, metric_rollup_3])
+
+      expect(recs.length).to eq(1)
+      expect(recs.first.cpu_usage_rate_average).to eq(500)
+      expect(recs.first.net_usage_rate_average).to eq(1500)
+    end
+
+    let(:ems_event) do
+      FactoryGirl.create(:ems_event, :timestamp => Time.zone.parse("2016-01-12T01:00:00.00000000"))
+    end
+
+    it "returns origin set of records, some input records are not MetricRollup and Metric" do
+      recs = described_class.remove_duplicate_timestamps([metric_rollup_1, metric_rollup_2, ems_event])
+      expect(recs).to match_array([metric_rollup_1, metric_rollup_2, ems_event])
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix method which is removing duplicate records with same timestamp
and resource when all records are Metric or MetricRollup
(or inherited) but guard condition did not accept such
set of records.

Second fix is that if duplicate records exist it should
merge missing values in previous records.

It looks like that origin intent was
```
return recs if recs.empty? || recs.any? { |r| !r.kind_of?(Metric) && !r.kind_of?(MetricRollup) }
```
it should not run removing algorithm when all records are not  Metric or MetricRollup(or inherited)

rewrited to more readable form
```
return recs if recs.empty? || !recs.all? { |r| r.kind_of?(Metric) || r.kind_of?(MetricRollup) }
```

This issue caused that in chargeback reporting when duplicated records are counted as well.


Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1371451 - partial fix





