### PR TITLE
Log warn for entities with a default value

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb
@@ -16,7 +16,7 @@ module ManageIQ
               h[entity[:name].singularize] = client.send("get_#{entity[:name]}")
             rescue KubeException => e
               raise e if entity[:default].nil?
-              $log.error("Unexpected Exception during refresh: #{e}")
+              $log.warn("Unexpected Exception during refresh: #{e}")
               h[entity[:name].singularize] = entity[:default]
             end
           end


### PR DESCRIPTION
Context: For specific container entities where we expect problems during refresh we ignore the error and continue with the refresh. An example is component_statuses that we have no permissions to read from k8s with our recommended service account.

Warning for this is more adequate since we expect this to fail in most cases.
We have seen this in several bug reports where it might hide the real problem.

Steps for Testing/QA
--------------------
Execute refresh, you should see the following in the log with WARN and not ERROR 
WARN -- : Unexpected Exception during refresh: HTTP status code 403, User "system:serviceaccount:management-infra:management-admin" cannot list all componentstatuses in the cluster
