### PR TITLE
Pass floating ip object to association to deal with special cases

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -64,7 +64,7 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
 
     if floating_ip
       _log.info("Associating floating IP address [#{floating_ip.address}] to #{for_destination}")
-      associate_floating_ip(floating_ip.address)
+      associate_floating_ip(floating_ip)
     end
 
     signal :post_create_destination

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/configuration.rb
@@ -1,7 +1,8 @@
 module ManageIQ::Providers::Openstack::CloudManager::Provision::Configuration
   def associate_floating_ip(ip_address)
+    # TODO(lsmola) this should be moved to FloatingIp model
     destination.with_provider_object do |instance|
-      instance.associate_address(ip_address)
+      instance.associate_address(ip_address.address)
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Pass floating ip object to association to deal with special
cases, e.g. amazon needs to send different info the ip.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1373438

Fixes issue:
https://github.com/ManageIQ/manageiq/issues/10586