### PR TITLE
Fix useless access modifiers(private) in lib/miq_automation_engine

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -18,7 +18,7 @@ module MiqAeEngine
       fname = File.join(AE_METHODS_DIR, path)
       raise  MiqAeException::MethodNotFound, "Method [#{aem.data}] Not Found (fname=#{fname})" unless File.exist?(fname)
       cmd = "#{aem.language} #{fname}"
-      MiqAeEngine::MiqAeMethod.invoke_external(cmd, obj.workspace)
+      invoke_external(cmd, obj.workspace)
     end
 
     def self.invoke_builtin(aem, obj, inputs)
@@ -90,6 +90,7 @@ module MiqAeEngine
       end
       process_ruby_method_results(rc, msg)
     end
+    private_class_method :invoke_external
 
     MIQ_OK    = 0
     MIQ_WARN  = 4

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -67,8 +67,6 @@ module MiqAeEngine
       nil
     end
 
-    private
-
     def self.invoke_external(cmd, workspace, serialize_workspace = false)
       ws = nil
 
@@ -101,6 +99,7 @@ module MiqAeEngine
     def self.open_transactions_threshold
       @open_transactions_threshold ||= Rails.env.test? ? 1 : 0
     end
+    private_class_method :open_transactions_threshold
 
     def self.verbose_rc(rc)
       case rc
@@ -111,6 +110,7 @@ module MiqAeEngine
       else                "Unknown RC: [#{rc}]"
       end
     end
+    private_class_method :verbose_rc
 
     def self.run_ruby_method(*code)
       ActiveRecord::Base.connection_pool.release_connection
@@ -122,6 +122,7 @@ module MiqAeEngine
         end
       end
     end
+    private_class_method :run_ruby_method
 
     def self.process_ruby_method_results(rc, msg)
       case rc
@@ -138,6 +139,7 @@ module MiqAeEngine
       end
       rc
     end
+    private_class_method :process_ruby_method_results
 
     def self.ruby_method_runnable?(aem)
       return false if aem.data.blank?
@@ -146,6 +148,7 @@ module MiqAeEngine
 
       true
     end
+    private_class_method :ruby_method_runnable?
 
     def self.invoke_inline_ruby(aem, obj, inputs)
       if ruby_method_runnable?(aem)
@@ -158,6 +161,7 @@ module MiqAeEngine
         end
       end
     end
+    private_class_method :invoke_inline_ruby
 
     def self.run_method(cmd)
       require 'open4'
@@ -190,6 +194,7 @@ module MiqAeEngine
       end
       return rc, msg
     end
+    private_class_method :run_method
 
     def self.cleanup(method_pid, threads)
       if method_pid
@@ -203,5 +208,6 @@ module MiqAeEngine
       end
       threads.each(&:exit)
     end
+    private_class_method :cleanup
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -6,7 +6,7 @@ module MiqAeEngine
     include UuidMixin
 
     def self.evmget(token, uri)
-      MiqAeWorkspace.workspace_from_token(token).evmget(uri)
+      workspace_from_token(token).evmget(uri)
     end
 
     def evmget(uri)
@@ -14,7 +14,7 @@ module MiqAeEngine
     end
 
     def self.evmset(token, uri, value)
-      MiqAeWorkspace.workspace_from_token(token).evmset(uri, value)
+      workspace_from_token(token).evmset(uri, value)
     end
 
     def evmset(uri, value)
@@ -25,13 +25,12 @@ module MiqAeEngine
       end
     end
 
-    private
-
     def self.workspace_from_token(token)
       ws = MiqAeWorkspace.find_by_guid(token)
       raise MiqAeException::WorkspaceNotFound, "Workspace Not Found for token=[#{token}]" if ws.nil?
       ws
     end
+    private_class_method(:workspace_from_token)
   end
 
   class MiqAeWorkspaceRuntime

--- a/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
@@ -147,17 +147,17 @@ module MiqAeMethodService
       MiqAeServiceModelBase.wrap_results(AutomationRequest.create_request(options, user, auto_approve))
     end
 
-    private
-
     def self.service_now_drb_undumped
       _log.info "Entered"
       [SnsHash, SnsArray].each { |klass| drb_undumped(klass) }
     end
+    private_class_method :service_now_drb_undumped
 
     def self.drb_undumped(klass)
       _log.info "Entered: klass=#{klass.name}"
       klass.include(DRbUndumped) unless klass.ancestors.include?(DRbUndumped)
     end
+    private_class_method :drb_undumped
 
     def self.ar_method
       yield
@@ -168,6 +168,7 @@ module MiqAeMethodService
     ensure
       ActiveRecord::Base.connection_pool.release_connection rescue nil
     end
+    private_class_method :ar_method
 
     def self.service_now_task_service(service, server, username, password, *params)
       log_prefix = "[#{service.underscore}]"
@@ -194,5 +195,6 @@ module MiqAeMethodService
         raise
       end
     end
+    private_class_method :service_now_task_service
   end
 end

--- a/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
@@ -1,5 +1,5 @@
 describe MiqAeEngine::MiqAeMethod do
-  context ".invoke_inline_ruby" do
+  context ".invoke_inline_ruby(private)" do
     it "writes to the logger immediately" do
       script = <<-EOS
         puts 'Hi from puts'
@@ -58,7 +58,7 @@ describe MiqAeEngine::MiqAeMethod do
       expect($miq_ae_logger).to receive(:info).with("<AEMethod [fqname]> Ending").ordered
       expect($miq_ae_logger).to receive(:info).with("Method exited with rc=MIQ_OK").ordered
 
-      expect(described_class.invoke_inline_ruby(aem, obj, inputs)).to eq(0)
+      expect(described_class.send(:invoke_inline_ruby, aem, obj, inputs)).to eq(0)
 
       expect(logger_stub.expected_messages).to eq([])
     end


### PR DESCRIPTION
Purpose or Intent
-----------------
private for class methods doesn't work.  These class methods following the private keyword are still public.  You need to either use private_class_method or move the methods to private instance methods on the singleton class.  The attached are changes for lib/miq_automation_engine.  

You probably want to review each commit one by one and append `?w=1` to the URL so you can skip whitespace changes, like `https://github.com/ManageIQ/manageiq/commit/032491f7e4456582fdaf29ee4b56a3040bd05d32?w=1`

Found using `rubocop --only UselessAccessModifier`

Links
-----
> * Follow up to #10960