### PR TITLE
Fix useless access modifiers(private) in lib 

### DIFF
--- a/lib/charting.rb
+++ b/lib/charting.rb
@@ -23,8 +23,6 @@ class Charting
     @instance ||= new
   end
 
-  private
-
   def self.new
     self == Charting ? detect_available_plugin.new : super
   end

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -123,8 +123,6 @@ class EvmDatabaseOps
     PostgresAdmin.start(DEFAULT_OPTS)
   end
 
-  private
-
   def self.upload(connect_opts, local_file, destination_file)
     MiqGenericMountSession.in_depot_session(connect_opts) { |session| session.upload(local_file, destination_file) }
     destination_file
@@ -139,4 +137,5 @@ class EvmDatabaseOps
     time_suffix  = Time.now.utc.strftime("%Y%m%d_%H%M%S")
     "#{BACKUP_TMP_FILE}_#{time_suffix}"
   end
+  private_class_method :backup_file_name
 end

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -47,8 +47,6 @@ module MiqEnvironment
       "rails"
     end
 
-    private
-
     def self.supports_command?(cmd)
       return false unless EVM_KNOWN_COMMANDS.include?(cmd)
       require "runcmd"

--- a/lib/pdf_generator.rb
+++ b/lib/pdf_generator.rb
@@ -29,11 +29,10 @@ class PdfGenerator
     self.class.available?
   end
 
-  private
-
   def self.detect_available_generator
     self.subclasses.detect(&:available?) || NullPdfGenerator
   end
+  private_class_method :detect_available_generator
 
   def self.sanitize_html(html_string)
     # strip out bad attachment_fu URLs
@@ -41,11 +40,13 @@ class PdfGenerator
     html_string.gsub('.com:/', '.com/')
       .gsub(/src=["'](\S+)\?\d*["']/i, 'src="\1"')
   end
+  private_class_method :sanitize_html
 
   def self.stylesheet_file_path(stylesheet)
     # Determine path relative to Rails.public_path
     "/../app/assets/stylesheets/#{stylesheet}.css"
   end
+  private_class_method :stylesheet_file_path
 end
 
 # Dynamically load all plugins

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -107,8 +107,6 @@ module Vmdb
       end
     end
 
-    private
-
     def self.get_build
       build_file = File.join(File.expand_path(Rails.root), "BUILD")
 
@@ -122,6 +120,7 @@ module Vmdb
 
       build
     end
+    private_class_method :get_build
 
     def self.get_network
       retVal = {}
@@ -135,6 +134,7 @@ module Vmdb
 
       retVal
     end
+    private_class_method :get_network
 
     def self.installed_rpms
       File.open(log_dir.join("package_list_rpm.txt"), "a") do |file|
@@ -144,6 +144,7 @@ module Vmdb
         end
       end
     end
+    private_class_method :installed_rpms
 
     def self.installed_gems
       File.open(log_dir.join("gem_list.txt"), "a") do |file|
@@ -151,10 +152,12 @@ module Vmdb
         file.puts `gem list`
       end
     end
+    private_class_method :installed_gems
 
     def self.log_dir
       Pathname.new("/var/www/miq/vmdb/log")
     end
+    private_class_method :log_dir
 
     def self.init_diagnostics
       @diags ||= [
@@ -172,5 +175,6 @@ module Vmdb
         {:cmd => -> { installed_rpms },                                               :msg => "Installed RPMs" },
       ]
     end
+    private_class_method :init_diagnostics
   end
 end

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -123,8 +123,6 @@ module VMDB
       zfile
     end
 
-    private
-
     # TODO: Make a class out of this so we don't have to pass around the zip.
     def self.add_zip_entry(zip, file_path, zfile)
       entry = zip_entry_from_path(file_path)
@@ -138,6 +136,7 @@ module VMDB
       end
       return entry, mtime
     end
+    private_class_method :add_zip_entry
 
     def self.zip_entry_from_path(path)
       rails_root_directories = Rails.root.to_s.split("/")
@@ -145,6 +144,7 @@ module VMDB
       entry = within_rails_root ? Pathname.new(path).relative_path_from(Rails.root).to_s : "ROOT#{path}"
       entry
     end
+    private_class_method :zip_entry_from_path
 
     def self.find_timestamp(handle)
       handle
@@ -154,5 +154,6 @@ module VMDB
         .reject(&:nil?)
         .first
     end
+    private_class_method :find_timestamp
   end
 end

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -89,7 +89,7 @@ describe VMDB::Util do
 
     def self.assert_zip_entry_from_path(expected_entry, path)
       it "#{path} => #{expected_entry}" do
-        expect(described_class.zip_entry_from_path(path)).to eq(expected_entry)
+        expect(described_class.send(:zip_entry_from_path, path)).to eq(expected_entry)
       end
     end
 
@@ -101,7 +101,7 @@ describe VMDB::Util do
     assert_zip_entry_from_path("GUID", "/var/www/miq/vmdb/GUID")
   end
 
-  it ".add_zip_entry" do
+  it ".add_zip_entry(private)" do
     require 'zip/zipfilesystem'
     file  = "/var/log/messages.log"
     entry = "ROOT/var/log/messages.log"
@@ -115,7 +115,7 @@ describe VMDB::Util do
     expect(zip).to receive(:add).with(zip_entry, file)
     zip_file = double
 
-    expect(described_class.add_zip_entry(zip, file, zip_file)).to eq([entry, mtime])
+    expect(described_class.send(:add_zip_entry, zip, file, zip_file)).to eq([entry, mtime])
   end
 
   it ".get_evm_log_for_date" do


### PR DESCRIPTION
Purpose or Intent
-----------------
private for class methods doesn't work.  These class methods following the private keyword are still public.  You need to either use private_class_method or move the methods to private instance methods on the singleton class.  The attached are changes for the rest of lib.  

You probably want to review each commit one by one and append `?w=1` to the URL so you can skip whitespace changes, like `https://github.com/ManageIQ/manageiq/commit/af1a1a2c64d3defe46b62c9569ebeb5a3832bece?w=1`

Found using `rubocop --only UselessAccessModifier`

Links
-----
> * Follow up to #10960 and #11031 
