### PR TITLE
Database changes to support mapping Flavors to Cloud Tenants

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -22,6 +22,8 @@ class CloudTenant < ApplicationRecord
   has_many   :cloud_object_store_containers
   has_many   :cloud_object_store_objects
   has_many   :cloud_resource_quotas
+  has_many   :cloud_tenant_flavors, :dependent => :destroy
+  has_many   :flavors, :through => :cloud_tenant_flavors
 
   alias_method :direct_cloud_networks, :cloud_networks
 

--- a/app/models/cloud_tenant_flavor.rb
+++ b/app/models/cloud_tenant_flavor.rb
@@ -1,0 +1,4 @@
+class CloudTenantFlavor < ApplicationRecord
+  belongs_to :cloud_tenant
+  belongs_to :flavor
+end

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -6,7 +6,8 @@ class Flavor < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   has_many   :vms
-  has_and_belongs_to_many :cloud_tenants
+  has_many   :cloud_tenant_flavors, :dependent => :destroy
+  has_many   :cloud_tenants, :through => :cloud_tenant_flavors
 
   virtual_total :total_vms, :vms
 

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -6,6 +6,7 @@ class Flavor < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   has_many   :vms
+  has_and_belongs_to_many :cloud_tenants
 
   virtual_total :total_vms, :vms
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -4,4 +4,9 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
                           :join_table              => "cloud_tenants_vms",
                           :association_foreign_key => "vm_id",
                           :class_name              => "ManageIQ::Providers::Openstack::CloudManager::Template"
+  has_and_belongs_to_many :flavors,
+                          :foreign_key             => "cloud_tenant_id",
+                          :join_table              => "cloud_tenants_flavors",
+                          :association_foreign_key => "flavor_id",
+                          :class_name              => "ManageIQ::Providers::Openstack::CloudManager::Flavor"
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -4,9 +4,4 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
                           :join_table              => "cloud_tenants_vms",
                           :association_foreign_key => "vm_id",
                           :class_name              => "ManageIQ::Providers::Openstack::CloudManager::Template"
-  has_and_belongs_to_many :flavors,
-                          :foreign_key             => "cloud_tenant_id",
-                          :join_table              => "cloud_tenants_flavors",
-                          :association_foreign_key => "flavor_id",
-                          :class_name              => "ManageIQ::Providers::Openstack::CloudManager::Flavor"
 end

--- a/db/migrate/20160820003340_add_flavor_multi_tenant_relationship.rb
+++ b/db/migrate/20160820003340_add_flavor_multi_tenant_relationship.rb
@@ -1,10 +1,10 @@
 class AddFlavorMultiTenantRelationship < ActiveRecord::Migration[5.0]
   def change
-    create_table :cloud_tenants_flavors do |t|
+    create_table :cloud_tenant_flavors do |t|
       t.column :cloud_tenant_id, :bigint
       t.column :flavor_id, :bigint
     end
     add_column :flavors, :publicly_available, :boolean
-    add_index :cloud_tenants_flavors, [:cloud_tenant_id, :flavor_id], :unique => true
+    add_index :cloud_tenant_flavors, [:cloud_tenant_id, :flavor_id], :unique => true
   end
 end

--- a/db/migrate/20160820003340_add_flavor_multi_tenant_relationship.rb
+++ b/db/migrate/20160820003340_add_flavor_multi_tenant_relationship.rb
@@ -1,0 +1,10 @@
+class AddFlavorMultiTenantRelationship < ActiveRecord::Migration[5.0]
+  def change
+    create_table :cloud_tenants_flavors do |t|
+      t.column :cloud_tenant_id, :bigint
+      t.column :flavor_id, :bigint
+    end
+    add_column :flavors, :publicly_available, :boolean
+    add_index :cloud_tenants_flavors, [:cloud_tenant_id, :flavor_id], :unique => true
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -367,6 +367,10 @@ cloud_tenants:
 - updated_at
 - type
 - parent_id
+cloud_tenants_flavors:
+- id
+- cloud_tenant_id
+- flavor_id
 cloud_tenants_vms:
 - cloud_tenant_id
 - vm_id
@@ -1267,6 +1271,7 @@ flavors:
 - ephemeral_disk_count
 - root_disk_size
 - swap_disk_size
+- publicly_available
 floating_ips:
 - id
 - type

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -356,6 +356,10 @@ cloud_subnets_network_ports:
 - cloud_subnet_id
 - network_port_id
 - address
+cloud_tenant_flavors:
+- id
+- cloud_tenant_id
+- flavor_id
 cloud_tenants:
 - id
 - name
@@ -367,10 +371,6 @@ cloud_tenants:
 - updated_at
 - type
 - parent_id
-cloud_tenants_flavors:
-- id
-- cloud_tenant_id
-- flavor_id
 cloud_tenants_vms:
 - cloud_tenant_id
 - vm_id


### PR DESCRIPTION
This is the DB changes to support https://github.com/ManageIQ/manageiq/pull/10680, pulled out into their own PR to make it easier to review and merge.