### PR TITLE
Remove "typed_target" from API update paths

### DIFF
--- a/app/controllers/api/arbitration_profiles_controller.rb
+++ b/app/controllers/api/arbitration_profiles_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ArbitrationProfilesController < BaseController
-    def create_resource_arbitration_profiles(_type, _id, data)
+    def create_resource(_type, _id, data)
       validate_profile_data(data)
       attributes = build_arbitration_attributes(data)
       arbitration_profile = collection_class(:arbitration_profiles).create(attributes)
@@ -8,10 +8,10 @@ module Api
       arbitration_profile
     end
 
-    def edit_resource_arbitration_profiles(type, id, data)
+    def edit_resource(type, id, data)
       validate_profile_data(data)
       attributes = build_arbitration_attributes(data)
-      edit_resource(type, id, attributes)
+      super(type, id, attributes)
     end
 
     private

--- a/app/controllers/api/arbitration_rules_controller.rb
+++ b/app/controllers/api/arbitration_rules_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ArbitrationRulesController < BaseController
-    def create_resource_arbitration_rules(type, _id, data)
+    def create_resource(type, _id, data)
       attributes = build_rule_attributes(data)
       arbitration_rule = collection_class(type).create(attributes)
       if arbitration_rule.invalid?
@@ -10,9 +10,9 @@ module Api
       arbitration_rule
     end
 
-    def edit_resource_arbitration_rules(type, id, data)
+    def edit_resource(type, id, data)
       attributes = build_rule_attributes(data)
-      edit_resource(type, id, attributes)
+      super(type, id, attributes)
     end
 
     private

--- a/app/controllers/api/automation_requests_controller.rb
+++ b/app/controllers/api/automation_requests_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::RequestTasks
     include Subcollections::Tasks
 
-    def create_resource_automation_requests(type, _id, data)
+    def create_resource(type, _id, data)
       assert_id_not_specified(data, type)
 
       version_str = data["version"] || "1.1"
@@ -14,7 +14,7 @@ module Api
       AutomationRequest.create_from_ws(version_str, @auth_user_obj, uri_parts, parameters, requester)
     end
 
-    def approve_resource_automation_requests(type, id, data)
+    def approve_resource(type, id, data)
       raise "Must specify a reason for approving an automation request" unless data["reason"].present?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
@@ -25,7 +25,7 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def deny_resource_automation_requests(type, id, data)
+    def deny_resource(type, id, data)
       raise "Must specify a reason for denying an automation request" unless data["reason"].present?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -97,6 +97,7 @@ module Api
           raise BadRequestError, "Must specify an id for retiring a #{type} resource"
         end
       end
+      alias generic_retire_resource retire_resource
 
       def custom_action_resource(type, id, data = nil)
         action = @req.action.downcase

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -87,8 +87,6 @@ module Api
           "#{type}_#{action}_resource"
         else
           target = "#{action}_resource"
-          typed_target = "#{target}_#{type}"
-          return typed_target if respond_to?(typed_target)
           return target if respond_to?(target)
           collection_config.custom_actions?(type) ? "custom_action_resource" : "undefined_api_method"
         end

--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -7,7 +7,7 @@ module Api
       super
     end
 
-    def create_resource_blueprints(_type, _id, data)
+    def create_resource(_type, _id, data)
       attributes = data.except("bundle")
       blueprint = Blueprint.new(attributes)
       bundle = data["bundle"]
@@ -16,7 +16,7 @@ module Api
       blueprint
     end
 
-    def edit_resource_blueprints(type, id, data)
+    def edit_resource(type, id, data)
       attributes = data.except("bundle")
       blueprint = resource_search(id, type, Blueprint)
       blueprint.update!(attributes)

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -7,15 +7,15 @@ module Api
       super
     end
 
-    def edit_resource_categories(type, id, data = {})
+    def edit_resource(type, id, data = {})
       raise BaseController::Forbidden if Category.find(id).read_only?
       request_additional_attributes
-      edit_resource(type, id, data)
+      super
     end
 
-    def delete_resource_categories(type, id, data = {})
+    def delete_resource(type, id, data = {})
       raise BaseController::Forbidden if Category.find(id).read_only?
-      delete_resource(type, id, data)
+      super
     end
 
     private

--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -8,7 +8,7 @@ module Api
       end
     end
 
-    def create_resource_container_deployments(_type, _id, data)
+    def create_resource(_type, _id, data)
       deployment = ContainerDeployment.new
       deployment.create_deployment(data, @auth_user_obj)
     end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -10,7 +10,7 @@ module Api
       MiqGroup.non_tenant_groups.find(id)
     end
 
-    def create_resource_groups(_type, _id, data)
+    def create_resource(_type, _id, data)
       validate_group_data(data)
       parse_set_role(data)
       parse_set_tenant(data)
@@ -22,19 +22,19 @@ module Api
       group
     end
 
-    def edit_resource_groups(type, id, data)
+    def edit_resource(type, id, data)
       validate_group_data(data)
       parse_set_role(data)
       parse_set_tenant(data)
       group = resource_search(id, type, collection_class(:groups))
       parse_set_filters(data, :entitlement_id => group.entitlement.try(:id))
       raise Forbidden, "Cannot edit a read-only group" if group.read_only
-      edit_resource(type, id, data)
+      super
     end
 
-    def delete_resource_groups(type, id, data = {})
+    def delete_resource(type, id, data = {})
       raise Forbidden, "Cannot delete a read-only group" if MiqGroup.find(id).read_only?
-      delete_resource(type, id, data)
+      super
     end
 
     private

--- a/app/controllers/api/hosts_controller.rb
+++ b/app/controllers/api/hosts_controller.rb
@@ -8,7 +8,7 @@ module Api
     include Subcollections::PolicyProfiles
     include Subcollections::Tags
 
-    def edit_resource_hosts(type, id, data = {})
+    def edit_resource(type, id, data = {})
       credentials = data.delete(CREDENTIALS_ATTR)
       raise BadRequestError, "Cannot update non-credentials attributes of host resource" if data.any?
       resource_search(id, type, collection_class(:hosts)).tap do |host|

--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class InstancesController < BaseController
-    def terminate_resource_instances(type, id = nil, _data = nil)
+    def terminate_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for terminating a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -10,7 +10,7 @@ module Api
       end
     end
 
-    def stop_resource_instances(type, id = nil, _data = nil)
+    def stop_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for stopping a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -23,7 +23,7 @@ module Api
       end
     end
 
-    def start_resource_instances(type, id = nil, _data = nil)
+    def start_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -36,7 +36,7 @@ module Api
       end
     end
 
-    def pause_resource_instances(type, id = nil, _data = nil)
+    def pause_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for pausing a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -49,7 +49,7 @@ module Api
       end
     end
 
-    def suspend_resource_instances(type, id = nil, _data = nil)
+    def suspend_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for suspending a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -62,7 +62,7 @@ module Api
       end
     end
 
-    def shelve_resource_instances(type, id = nil, _data = nil)
+    def shelve_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for shelving a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -75,7 +75,7 @@ module Api
       end
     end
 
-    def reboot_guest_resource_instances(type, id = nil, _data = nil)
+    def reboot_guest_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for rebooting a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -88,7 +88,7 @@ module Api
       end
     end
 
-    def reset_resource_instances(type, id = nil, _data = nil)
+    def reset_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for resetting a #{type} resource" unless id
 
       api_action(type, id) do |klass|

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -8,7 +8,7 @@ module Api
       @auth_user_obj.notification_recipients.find(id)
     end
 
-    def mark_as_seen_resource_notifications(type, id = nil, _data = nil)
+    def mark_as_seen_resource(type, id = nil, _data = nil)
       api_action(type, id) do |klass|
         notification = resource_search(id, type, klass)
         action_result(notification.update_attribute(:seen, true) || false)

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -14,13 +14,13 @@ module Api
     include Subcollections::Tags
     include Subcollections::CloudNetworks
 
-    def create_resource_providers(type, _id, data = {})
+    def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)
 
       create_provider(data)
     end
 
-    def edit_resource_providers(type, id = nil, data = {})
+    def edit_resource(type, id = nil, data = {})
       raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
       raise BadRequestError, "Provider type cannot be updated" if data.key?(TYPE_ATTR)
 
@@ -28,7 +28,7 @@ module Api
       edit_provider(provider, data)
     end
 
-    def refresh_resource_providers(type, id = nil, _data = nil)
+    def refresh_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for refreshing a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -39,7 +39,7 @@ module Api
       end
     end
 
-    def delete_resource_providers(type, id = nil, _data = nil)
+    def delete_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
 
       api_action(type, id) do |klass|

--- a/app/controllers/api/provision_requests_controller.rb
+++ b/app/controllers/api/provision_requests_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::RequestTasks
     include Subcollections::Tasks
 
-    def create_resource_provision_requests(type, _id, data)
+    def create_resource(type, _id, data)
       assert_id_not_specified(data, type)
 
       version_str       = data["version"] || "1.1"
@@ -19,7 +19,7 @@ module Api
                                        additional_values, ems_custom_attrs, miq_custom_attrs)
     end
 
-    def deny_resource_provision_requests(type, id, data)
+    def deny_resource(type, id, data)
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
         provreq.deny(@auth_user, data['reason'])
@@ -29,7 +29,7 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def approve_resource_provision_requests(type, id, data)
+    def approve_resource(type, id, data)
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
         provreq.approve(@auth_user, data['reason'])

--- a/app/controllers/api/rates_controller.rb
+++ b/app/controllers/api/rates_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class RatesController < BaseController
-    def create_resource_rates(_type, _id, data = {})
+    def create_resource(_type, _id, data = {})
       rate_detail = ChargebackRateDetail.create(data)
       raise BadRequestError, "#{rate_detail.errors.full_messages.join(', ')}" unless rate_detail.valid?
       rate_detail

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -12,7 +12,7 @@ module Api
       super
     end
 
-    def run_resource_reports(_type, id, _data)
+    def run_resource(_type, id, _data)
       report = MiqReport.find(id)
       report_result = MiqReportResult.find(report.queue_generate_table)
       run_report_result(true,
@@ -32,13 +32,13 @@ module Api
       res
     end
 
-    def import_resource_reports(_type, _id, data)
+    def import_resource(_type, _id, data)
       options = data.fetch("options", {}).symbolize_keys.merge(:user => @auth_user_obj)
       result, meta = MiqReport.import_from_hash(data["report"], options)
       action_result(meta[:level] == :info, meta[:message], :result => result)
     end
 
-    def schedule_resource_reports(type, id, data)
+    def schedule_resource(type, id, data)
       api_action(type, id) do |klass|
         report = resource_search(id, type, klass)
         schedule_reports(report, type, id, data)

--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -2,7 +2,7 @@ module Api
   class RolesController < BaseController
     include Subcollections::Features
 
-    def create_resource_roles(type, _id = nil, data = {})
+    def create_resource(type, _id = nil, data = {})
       assert_id_not_specified(data, type)
 
       # Can't create a read-only role (reserved for out-of-box roles)
@@ -22,7 +22,7 @@ module Api
       raise err
     end
 
-    def edit_resource_roles(type, id = nil, data = {})
+    def edit_resource(type, id = nil, data = {})
       unless id
         raise BadRequestError, "Must specify an id for editing a #{type} resource"
       end

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -24,7 +24,7 @@ module Api
       resource.content(service_template, resource_action)
     end
 
-    def refresh_dialog_fields_resource_service_dialogs(type, id = nil, data = nil)
+    def refresh_dialog_fields_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
 
       api_action(type, id) do |klass|

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -2,19 +2,19 @@ module Api
   class ServiceOrdersController < BaseController
     include Subcollections::ServiceRequests
 
-    def create_resource_service_orders(type, id, data)
+    def create_resource(type, id, data)
       raise BadRequestError, "Can't create an ordered service order" if data["state"] == ServiceOrder::STATE_ORDERED
       service_requests = data.delete("service_requests")
       data["state"] ||= ServiceOrder::STATE_CART
       if service_requests.blank?
-        create_resource(type, id, data)
+        super
       else
         create_service_order_with_service_requests(service_requests)
         ServiceOrder.cart_for(@auth_user_obj)
       end
     end
 
-    def clear_resource_service_orders(type, id, _data)
+    def clear_resource(type, id, _data)
       service_order = resource_search(id, type, collection_class(type))
       begin
         service_order.clear
@@ -24,7 +24,7 @@ module Api
       service_order
     end
 
-    def order_resource_service_orders(type, id, _data)
+    def order_resource(type, id, _data)
       service_order = resource_search(id, type, collection_class(type))
       service_order.checkout
       service_order

--- a/app/controllers/api/service_requests_controller.rb
+++ b/app/controllers/api/service_requests_controller.rb
@@ -3,7 +3,7 @@ module Api
     include Subcollections::RequestTasks
     include Subcollections::Tasks
 
-    def approve_resource_service_requests(type, id, data)
+    def approve_resource(type, id, data)
       raise "Must specify a reason for approving a service request" unless data["reason"].present?
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)
@@ -14,7 +14,7 @@ module Api
       action_result(false, err.to_s)
     end
 
-    def deny_resource_service_requests(type, id, data)
+    def deny_resource(type, id, data)
       raise "Must specify a reason for denying a service request" unless data["reason"].present?
       api_action(type, id) do |klass|
         provreq = resource_search(id, type, klass)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -4,7 +4,7 @@ module Api
     include Subcollections::Tags
     include Subcollections::Vms
 
-    def reconfigure_resource_services(type, id = nil, data = nil)
+    def reconfigure_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
 
       api_action(type, id) do |klass|

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class TagsController < BaseController
-    def create_resource_tags(type, _id, data)
+    def create_resource(type, _id, data)
       assert_id_not_specified(data, type)
       category_data = data.delete("category") { {} }
       category = fetch_category(category_data)
@@ -17,7 +17,7 @@ module Api
       end
     end
 
-    def edit_resource_tags(type, id, data)
+    def edit_resource(type, id, data)
       klass = collection_class(type)
       tag = resource_search(id, type, klass)
       entry = Classification.find_by_tag_id(tag.id)
@@ -30,7 +30,7 @@ module Api
       entry.tag
     end
 
-    def delete_resource_tags(_type, id, _data = {})
+    def delete_resource(_type, id, _data = {})
       destroy_tag_and_classification(id)
       action_result(true, "tags id: #{id} deleting")
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/tenants_controller.rb
+++ b/app/controllers/api/tenants_controller.rb
@@ -5,7 +5,7 @@ module Api
     include Subcollections::Tags
     include Subcollections::Quotas
 
-    def create_resource_tenants(_type, _id, data)
+    def create_resource(_type, _id, data)
       bad_attrs = data_includes_invalid_attrs(data)
       if bad_attrs.present?
         raise BadRequestError,
@@ -19,13 +19,13 @@ module Api
       tenant
     end
 
-    def edit_resource_tenants(type, id, data)
+    def edit_resource(type, id, data)
       bad_attrs = data_includes_invalid_attrs(data)
       if bad_attrs.present?
         raise BadRequestError, "Attributes #{bad_attrs} should not be specified for updating a tenant resource"
       end
       parse_set_parent(data)
-      edit_resource(type, id, data)
+      super
     end
 
     private

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -20,7 +20,7 @@ module Api
       end
     end
 
-    def create_resource_users(_type, _id, data)
+    def create_resource(_type, _id, data)
       validate_user_create_data(data)
       parse_set_group(data)
       raise BadRequestError, "Must specify a valid group for creating a user" unless data["miq_groups"]
@@ -32,17 +32,17 @@ module Api
       user
     end
 
-    def edit_resource_users(type, id, data)
+    def edit_resource(type, id, data)
       (id == @auth_user_obj.id) ? validate_self_user_data(data) : validate_user_data(data)
       parse_set_group(data)
       parse_set_settings(data, resource_search(id, type, collection_class(type)))
-      edit_resource(type, id, data)
+      super
     end
 
-    def delete_resource_users(type, id = nil, data = nil)
+    def delete_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for deleting a user" unless id
       raise BadRequestError, "Cannot delete user of current request" if id.to_i == @auth_user_obj.id
-      delete_resource(type, id, data)
+      super
     end
 
     private

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -351,7 +351,7 @@ module Api
     def retire_vm(vm, id, data)
       desc = "#{vm_ident(vm)} retiring"
       desc << " on #{data['date']}" if Hash(data)['date'].present?
-      method(:retire_resource).super_method.call(:vms, id, data)
+      generic_retire_resource(:vms, id, data)
       action_result(true, desc)
     rescue => err
       action_result(false, err.to_s)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -7,7 +7,7 @@ module Api
     include Subcollections::CustomAttributes
     include Subcollections::Software
 
-    def start_resource_vms(type, id = nil, _data = nil)
+    def start_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -20,7 +20,7 @@ module Api
       end
     end
 
-    def stop_resource_vms(type, id = nil, _data = nil)
+    def stop_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for stopping a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -33,7 +33,7 @@ module Api
       end
     end
 
-    def suspend_resource_vms(type, id = nil, _data = nil)
+    def suspend_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for suspending a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -46,7 +46,7 @@ module Api
       end
     end
 
-    def pause_resource_vms(type, id = nil, _data = nil)
+    def pause_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for pausing a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -59,7 +59,7 @@ module Api
       end
     end
 
-    def shelve_resource_vms(type, id = nil, _data = nil)
+    def shelve_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for shelving a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -72,7 +72,7 @@ module Api
       end
     end
 
-    def shelve_offload_resource_vms(type, id = nil, _data = nil)
+    def shelve_offload_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for shelve-offloading a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -85,7 +85,7 @@ module Api
       end
     end
 
-    def delete_resource_vms(type, id = nil, _data = nil)
+    def delete_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for deleting a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -96,7 +96,7 @@ module Api
       end
     end
 
-    def set_owner_resource_vms(type, id = nil, data = nil)
+    def set_owner_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for setting the owner of a #{type} resource" unless id
 
       owner = data.blank? ? "" : data["owner"].strip
@@ -110,7 +110,7 @@ module Api
       end
     end
 
-    def add_lifecycle_event_resource_vms(type, id = nil, data = nil)
+    def add_lifecycle_event_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for adding a Lifecycle Event to a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -121,7 +121,7 @@ module Api
       end
     end
 
-    def scan_resource_vms(type, id = nil, _data = nil)
+    def scan_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for scanning a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -134,7 +134,7 @@ module Api
       end
     end
 
-    def add_event_resource_vms(type, id = nil, data = nil)
+    def add_event_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for adding an event to a #{type} resource" unless id
 
       data ||= {}
@@ -147,7 +147,7 @@ module Api
       end
     end
 
-    def retire_resource_vms(type, id = nil, data = nil)
+    def retire_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for retiring a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -157,7 +157,7 @@ module Api
       end
     end
 
-    def reset_resource_vms(type, id = nil, _data = nil)
+    def reset_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for resetting a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -170,7 +170,7 @@ module Api
       end
     end
 
-    def reboot_guest_resource_vms(type, id = nil, _data = nil)
+    def reboot_guest_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for rebooting a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -183,7 +183,7 @@ module Api
       end
     end
 
-    def shutdown_guest_resource_vms(type, id = nil, _data = nil)
+    def shutdown_guest_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for shutting down a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -196,7 +196,7 @@ module Api
       end
     end
 
-    def refresh_resource_vms(type, id = nil, _data = nil)
+    def refresh_resource(type, id = nil, _data = nil)
       raise BadRequestError, "Must specify an id for refreshing a #{type} resource" unless id
 
       api_action(type, id) do |klass|
@@ -206,7 +206,7 @@ module Api
       end
     end
 
-    def request_console_resource_vms(type, id = nil, data = nil)
+    def request_console_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for requesting a console for a #{type} resource" unless id
 
       # NOTE:
@@ -351,7 +351,7 @@ module Api
     def retire_vm(vm, id, data)
       desc = "#{vm_ident(vm)} retiring"
       desc << " on #{data['date']}" if Hash(data)['date'].present?
-      retire_resource(:vms, id, data)
+      method(:retire_resource).super_method.call(:vms, id, data)
       action_result(true, desc)
     rescue => err
       action_result(false, err.to_s)


### PR DESCRIPTION
Purpose or Intent
-----------------

Previously the generic API code would look for a "typed_target"
e.g. `create_resource_vms` before falling back on the generic
implementation, `create_resource`. This change makes all the specialized
methods polymorphic with the base/default implementation.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 