### PR TITLE
Make vApp templates orderable

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -193,7 +193,7 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
       :ems_ref     => uid,
       :name        => vapp_template.name,
       :description => vapp_template.description,
-      :orderable   => false,
+      :orderable   => true,
       :content     => content,
       # By default #save_orchestration_templates_inventory does not set the EMS
       # ID because templates are not EMS specific. We are setting the EMS

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -330,7 +330,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(@template).not_to be_nil
     expect(@template).to have_attributes(
       :ems_ref   => "vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868",
-      :orderable => false,
+      :orderable => true,
     )
 
     expect(@template.ems_id).to eq(@ems.id)


### PR DESCRIPTION
Purpose or Intent
-----------------
The initial version of the vApp template parser set `orderable` property
to false rendering templates unavailable for service dialogs. This small
patch just marks all vApp templates orderable.

@miq-bot add_label providers/vmware/cloud, enhancement