### PR TITLE
Make validate_api_action a controller callback

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class AuthController < BaseController
+    skip_before_action :validate_api_action
+
     def show
       requester_type = fetch_and_validate_requester_type
       token_service = Environment.user_token_service

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -106,7 +106,7 @@ module Api
       @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
     end
 
-    before_action :parse_api_request, :log_api_request, :validate_api_request
+    before_action :parse_api_request, :log_api_request, :validate_api_request, :validate_api_action
     after_action :log_api_response
   end
 end

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -6,7 +6,6 @@ module Api
       #
 
       def show
-        validate_api_action
         if @req.subcollection
           render_collection_type @req.subcollection.to_sym, @req.s_id, true
         else
@@ -15,7 +14,6 @@ module Api
       end
 
       def update
-        validate_api_action
         if @req.subcollection
           render_normal_update @req.collection.to_sym, update_collection(@req.subcollection.to_sym, @req.s_id, true)
         else
@@ -24,7 +22,6 @@ module Api
       end
 
       def destroy
-        validate_api_action
         if @req.subcollection
           delete_subcollection_resource @req.subcollection.to_sym, @req.s_id
         else

--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -1,7 +1,6 @@
 module Api
   class ContainerDeploymentsController < BaseController
     def show
-      validate_api_action
       if @req.c_id == "container_deployment_data"
         render_resource :container_deployments, :data => ContainerDeploymentService.new.all_data
       else

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -1,7 +1,6 @@
 module Api
   class SettingsController < BaseController
     def show
-      validate_api_action
       category = @req.c_id
       selected_sections =
         if category

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,6 +3,8 @@ module Api
     INVALID_USER_ATTRS = %w(id href current_group_id settings).freeze # Cannot update other people's settings
     INVALID_SELF_USER_ATTRS = %w(id href current_group_id).freeze
 
+    skip_before_action :validate_api_action, :only => :update
+
     def update
       aname = @req.action
       if aname == "edit" && !api_user_role_allows?(aname) && update_target_is_api_user?
@@ -13,6 +15,7 @@ module Api
         end
         render_normal_update :users, update_collection(:users, @req.c_id)
       else
+        validate_api_action
         super
       end
     end


### PR DESCRIPTION
Purpose or Intent
-----------------

DRY's up the API controller code by making this method a callback that's
invoked before each action. Turning it off has to be done explicitly
with `skip_before_action`, which I've done in a couple of places here to
preserve the existing behavior.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 