### PR TITLE
Remove the unique validation on time_profiles description column

### DIFF
--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -3,8 +3,6 @@ class TimeProfile < ApplicationRecord
   ALL_HOURS = (0...24).to_a.freeze
   DEFAULT_TZ = "UTC"
 
-  validates_uniqueness_of :description
-
   serialize :profile
   default_value_for :days,  ALL_DAYS
   default_value_for :hours, ALL_HOURS


### PR DESCRIPTION
The validation was causing an issue with seeding and determining the default time profile.

If a user changes the timezone of the original seeded time profile, it is no longer recognized as the default because the timezone is not UTC. This causes us to attempt to seed a new time profile which could conflict by description.

https://bugzilla.redhat.com/show_bug.cgi?id=1368192
@miq-bot add_label bug, core

@gtanzillo please review