### PR TITLE
Use Rails version 5.0.0.1 or higher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "ovirt-engine-sdk",               "~>4.0.0",       :require => false # Requi
 gem "ovirt_metrics",                  "~>1.3.0",       :require => false
 gem "paperclip",                      "~>4.3.0"
 gem "puma",                           "~>3.3.0"
-gem "rails",                          "~>5.0.0"
+gem "rails",                          "~>5.0.0", ">= 5.0.0.1"
 gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "recursive-open-struct",          "~>1.0.0"


### PR DESCRIPTION
Purpose or Intent
-----------------
Addresses  CVE-2016-6316

Links
-----
http://weblog.rubyonrails.org/2016/8/11/Rails-5-0-0-1-4-2-7-2-and-3-2-22-3-have-been-released/

