### PR TITLE
Add support to prompt for a day of the month number.

### DIFF
--- a/gems/pending/appliance_console/prompts.rb
+++ b/gems/pending/appliance_console/prompts.rb
@@ -94,8 +94,12 @@ module ApplianceConsole
       ask_for_integer(prompt, (0..23))
     end
 
-    def ask_for_day_number(prompt)
+    def ask_for_week_day_number(prompt)
       ask_for_integer(prompt, (0..6))
+    end
+
+    def ask_for_month_day_number(prompt)
+      ask_for_integer(prompt, (1..31))
     end
 
     def ask_for_many(prompt, collective = nil, default = nil, max_length = 255, max_count = 6)

--- a/gems/pending/spec/appliance_console/prompts_spec.rb
+++ b/gems/pending/spec/appliance_console/prompts_spec.rb
@@ -508,23 +508,39 @@ describe ApplianceConsole::Prompts do
     end
   end
 
-  describe "#ask_for_day_number" do
+  describe "#ask_for_week_day_number" do
     it "supports 0 as Sunday" do
       say "0"
-      expect(subject.ask_for_day_number("prompt")).to eq(0)
+      expect(subject.ask_for_week_day_number("prompt")).to eq(0)
     end
 
     it "should only accept an integer" do
       error = "Please provide an integer"
       say %w(no words 2)
-      expect(subject.ask_for_day_number("prompt")).to eq(2)
+      expect(subject.ask_for_week_day_number("prompt")).to eq(2)
       expect_heard ["Enter the prompt: ", error, prompt + error, prompt]
     end
 
     it "should ensure valid response" do
       error = "Your answer isn't within the expected range (included in 0..6)."
       say %w(99 9 2)
-      expect(subject.ask_for_day_number("prompt")).to eq(2)
+      expect(subject.ask_for_week_day_number("prompt")).to eq(2)
+      expect_heard ["Enter the prompt: ", error, prompt + error, prompt]
+    end
+  end
+
+  describe "#ask_for_month_day_number" do
+    it "should only accept an integer" do
+      error = "Please provide an integer"
+      say %w(no words 2)
+      expect(subject.ask_for_month_day_number("prompt")).to eq(2)
+      expect_heard ["Enter the prompt: ", error, prompt + error, prompt]
+    end
+
+    it "should ensure valid response" do
+      error = "Your answer isn't within the expected range (included in 1..31)."
+      say %w(0 32 30)
+      expect(subject.ask_for_month_day_number("prompt")).to eq(30)
       expect_heard ["Enter the prompt: ", error, prompt + error, prompt]
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
This PR adds support for prompting for a month day number in addition to the existing
week day number. 

This is a supporting PR for:

* https://www.pivotaltracker.com/n/projects/1608513/stories/128645799

