### PR TITLE
[WIP] [UI] Explorer: skip counting for expanding ui trees

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -257,10 +257,8 @@ class TreeBuilder
         x_build_node(o, node[:key], options)
       end
       node[:children] = kids unless kids.empty?
-    else
-      if x_get_tree_objects(object, options, true, parents) > 0
-        node[:isLazy] = true  # set child flag if children exist
-      end
+    elsif !Settings.ui.tree.count_lazy_nodes || x_get_tree_objects(object, options, true, parents) > 0
+      node[:isLazy] = true
     end
     node
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1184,6 +1184,8 @@
     :purge_window_size: 1000
 :ui:
   :mark_translated_strings: false
+  :tree:
+    :count_lazy_nodes: true
 :webservices:
   :consume_protocol: https
   :contactwith: ipaddress


### PR DESCRIPTION
pulled out of #11003

**blocked:** code working, blocked on business decision

We're running a number of queries to decide if we should display an "expand" arrow widget next to a lazy load tree entry.

With this PR, it gives admins the ability to take the hit for counting the records in the lazy trees, or improving performance and always displaying the expand arrows. Possibly even when there are no records to display.

At minimum, this saves 2 queries for the vm explorer.
For other cases that have a non optimized count mechanism, it saves downloading quite a few rows.
(before recent PR, this saved downloading all archived and orphans on vm explorer - 3k rows in my example) For other screens, it will be large as well. All depending upon the customer's data set of course.
## before

It is smart and doesn't display expand arrows
## after

It is dumb and always displays expand bars. It hides them if the user clicks on them

~~/cc @martinpovolny not sure the key namespace and if you want to try this route~~ came up with a solution
