### PR TITLE
[WIP] Add assignee and severity to miq_alert_statuses

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -1,4 +1,5 @@
 class MiqAlertStatus < ApplicationRecord
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
+  belongs_to :miq_user
 end

--- a/db/migrate/20160907071240_extend_miq_alert_statuses.rb
+++ b/db/migrate/20160907071240_extend_miq_alert_statuses.rb
@@ -1,0 +1,6 @@
+class ExtendMiqAlertStatuses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_alert_statuses, :user_id, :bigint
+    add_column :miq_alert_statuses, :severity, :string
+  end
+end


### PR DESCRIPTION
Extending miq_alert_statuses with data needed for notification management. 
- The assignee, a user, is someone currently working to resolve the problem represented by the alert status. 
- The severity represents the gravity of the alert status.
- Still working on how to represent life cycle: on going  vs resolved. Will probably go for a resolves column that holds the id of a different alert statuses resolved by this alert status.
