### PR TITLE
Add new registy elements to Analysis Profiles fix

### DIFF
--- a/app/views/ops/_ap_form_registry.html.haml
+++ b/app/views/ops/_ap_form_registry.html.haml
@@ -1,4 +1,7 @@
 %fieldset
+  - scan_id = "#{@scan.id || 'new'}"
+  - url = url_for(:action => 'ap_edit',
+                  :id     => scan_id)
   %h3= _("Registry Entry")
   %table.table.table-striped.table-bordered.table-hover
     %thead
@@ -19,9 +22,13 @@
       - else
         %tr#new_tr
           %td
-            = image_submit_tag(image_path('toolbars/import.png'),
-              :class => "rollover small",
-              :name => "accept", :alt => _("Add this entry"), :title => _("Add this entry"), :item_type => "registry", :id => "#{@scan.id || "new"}")
+            %button.btn.btn-default{:title => _("Add this entry"),
+              "data-submit"         => 'ap_form_div',
+              "data-miq_sparkle_on" => true,
+              :remote               => true,
+              "data-method"         => :post,
+              'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
+              %i.pficon.pficon-import.fa-lg
           %td
             = _("HKLM")
           %td


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix adding new registry elements to Analysis Profiles. Changing image to button icon.
Not really sure if i choose right icon, @epwinchell look at this please

Before:
![image-3](https://cloud.githubusercontent.com/assets/9535558/18310530/2f501ad2-74ff-11e6-8e1f-9fb9292e1245.png)

After:
![firefox_screenshot_2016-09-07t11-31-44 287z](https://cloud.githubusercontent.com/assets/9535558/18310570/73c21652-74ff-11e6-81bc-f867015778fa.png)
![firefox_screenshot_2016-09-07t11-33-57 118z](https://cloud.githubusercontent.com/assets/9535558/18310620/c26cd09e-74ff-11e6-869b-0cab4209f5e6.png)




https://bugzilla.redhat.com/show_bug.cgi?id=1364520