### PR TITLE
Api should return http:404 when URL has trailing garbage

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -231,6 +231,10 @@ module Api
         service_request.each { |key, value| workflow.set_value(key, value) } if service_request.present?
         workflow
       end
+
+      def validate_id(id, klass)
+        raise NotFound, "Invalid #{klass} id #{id} specified" unless id.kind_of?(Integer) || id =~ /\A\d+\z/
+      end
     end
   end
 end

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -1,6 +1,8 @@
 module Api
   class BaseController
     module Parser
+      include CompressedIds
+
       def parse_api_request
         @req = RequestAdapter.new(request, params)
       end
@@ -97,7 +99,7 @@ module Api
       end
 
       def href_id(href, collection)
-        href.match(%r{^.*/#{collection}/([0-9r]+)$}) && Regexp.last_match(1) if href.present?
+        href.match(%r{^.*/#{collection}/(#{CID_OR_ID_MATCHER})$}) && Regexp.last_match(1) if href.present?
       end
 
       def parse_by_attr(resource, type, attr_list)

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -55,7 +55,7 @@ module Api
 
         def c_id
           id = @params[:c_id] || c_path_parts[1]
-          id =~ /\A[0-9]/ ? from_cid(id) : id
+          cid?(id) ? from_cid(id) : id
         end
 
         def subcollection
@@ -63,7 +63,8 @@ module Api
         end
 
         def s_id
-          from_cid(@params[:s_id] || c_path_parts[3])
+          id = @params[:s_id] || c_path_parts[3]
+          cid?(id) ? from_cid(id) : id
         end
 
         def expand?(what)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -178,6 +178,7 @@ module Api
       private
 
       def resource_search(id, type, klass)
+        validate_id(id, klass)
         target = respond_to?("find_#{type}") ? public_send("find_#{type}", id) : klass.find(id)
         res = Rbac.filtered_object(target, :user => @auth_user_obj, :class => klass)
         raise Forbidden, "Access to the resource #{type}/#{id} is forbidden" unless res

--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class ServiceOrdersController < BaseController
     include Subcollections::ServiceRequests
+    USER_CART_ID = 'cart'.freeze
 
     def create_resource_service_orders(type, id, data)
       raise BadRequestError, "Can't create an ordered service order" if data["state"] == ServiceOrder::STATE_ORDERED
@@ -30,8 +31,12 @@ module Api
       service_order
     end
 
+    def validate_id(id, klass)
+      id == USER_CART_ID || super(id, klass)
+    end
+
     def find_service_orders(id)
-      if id == "cart"
+      if id == USER_CART_ID
         ServiceOrder.cart_for(@auth_user_obj)
       else
         ServiceOrder.find_for_user(@auth_user_obj, id)

--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -43,7 +43,7 @@ module Api
         return klass.find_by_guid(guid) if guid.present?
 
         href = data["href"]
-        href.match(%r{^.*/#{collection}/[0-9r]+$}) ? klass.find(from_cid(href.split('/').last)) : {}
+        href.match(%r{^.*/#{collection}/#{CID_OR_ID_MATCHER}$}) ? klass.find(from_cid(href.split('/').last)) : {}
       end
 
       def policy_subcollection_action(ctype, policy)

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -85,7 +85,7 @@ module Api
 
       def parse_tag_from_href(data)
         href = data["href"]
-        tag  = if href && href.match(%r{^.*/tags/[0-9r]+$})
+        tag  = if href && href.match(%r{^.*/tags/#{CID_OR_ID_MATCHER}$})
                  klass = collection_class(:tags)
                  klass.find(from_cid(href.split('/').last))
                end

--- a/app/controllers/mixins/compressed_ids.rb
+++ b/app/controllers/mixins/compressed_ids.rb
@@ -1,7 +1,7 @@
 module CompressedIds
   CID_OR_ID_MATCHER = ArRegion::CID_OR_ID_MATCHER
   #
-  # Methods to convert record id (id, fixnum, 12000000000056) to/from compressed id (cid, string, "12c56")
+  # Methods to convert record id (id, fixnum, 12000000000056) to/from compressed id (cid, string, "12r56")
   #   for use in UI controls (i.e. tree node ids, pulldown list items, etc)
   #
 

--- a/app/controllers/mixins/compressed_ids.rb
+++ b/app/controllers/mixins/compressed_ids.rb
@@ -1,4 +1,5 @@
 module CompressedIds
+  CID_OR_ID_MATCHER = ArRegion::CID_OR_ID_MATCHER
   #
   # Methods to convert record id (id, fixnum, 12000000000056) to/from compressed id (cid, string, "12c56")
   #   for use in UI controls (i.e. tree node ids, pulldown list items, etc)

--- a/app/controllers/mixins/compressed_ids.rb
+++ b/app/controllers/mixins/compressed_ids.rb
@@ -11,4 +11,8 @@ module CompressedIds
   def from_cid(cid)
     ApplicationRecord.uncompress_id(cid)
   end
+
+  def cid?(cid)
+    ApplicationRecord.compressed_id?(cid)
+  end
 end

--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -4,6 +4,9 @@ module ArRegion
   extend ActiveSupport::Concern
 
   DEFAULT_RAILS_SEQUENCE_FACTOR = 1_000_000_000_000
+  COMPRESSED_ID_SEPARATOR = 'r'.freeze
+  CID_OR_ID_MATCHER = "\\d+?#{COMPRESSED_ID_SEPARATOR}?\\d+".freeze
+  RE_COMPRESSED_ID = /^(\d+)#{COMPRESSED_ID_SEPARATOR}(\d+)$/
 
   included do
     cache_with_timeout(:id_to_miq_region) { Hash.new }
@@ -93,8 +96,6 @@ module ArRegion
     # ID compression
     #
 
-    COMPRESSED_ID_SEPARATOR = 'r'
-    RE_COMPRESSED_ID = /^(\d+)#{COMPRESSED_ID_SEPARATOR}(\d+)$/
     def compressed_id?(id)
       id.to_s =~ RE_COMPRESSED_ID
     end

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -62,6 +62,15 @@ describe "Queries API" do
 
       expect_single_resource_query("id" => vm1.id, "href" => vm1_url, "guid" => vm1.guid)
     end
+
+    it 'returns 404 on url with trailing garbage' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+      vm1   # create resource
+
+      run_get vm1_url + 'garbage'
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "Query subcollections" do
@@ -104,6 +113,13 @@ describe "Queries API" do
       expect_result_resources_to_include_keys("resources", %w(id href))
       expect_result_resources_to_include_hrefs("resources", :vm1_accounts_url_list)
       expect_result_resources_to_include_data("resources", "id" => [acct1.id, acct2.id])
+    end
+
+    it 'returns 404 on url with trailing garbage' do
+      api_basic_authorize
+
+      run_get acct1_url + 'garbage'
+      expect(response).to have_http_status(:not_found)
     end
   end
 


### PR DESCRIPTION
Purpose or Intent
-----------------
Return 404 Not Found on URL like `/api/vms/123garbage`.

There are two parts to this pr.
 - First we ensure that we don't drop the garbage in `RequestAdapter`.
 - Second we ensure we push numeric to `ActiveRecord.find`

The `ActiveRecord.find` seems to be running `to_i` and dropping any garbage.

Fixes #11030.

@miq-bot add_label api, bug, darga/no
@miq-bot assign @abellotti 