### PR TITLE
Update ui-components to 0.0.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,7 @@
     "qs": "^0.3.10",
     "rxjs": "^4.1.0",
     "rx-angular": "rx.angular#^1.1.3",
-    "manageiq-ui-components": "~0.0.6"
+    "manageiq-ui-components": "~0.0.7"
   },
   "resolutions": {
     "moment": ">=2.9.0",


### PR DESCRIPTION
Fixing [view toolbars](https://github.com/ManageIQ/ui-components/pull/17) after the move to patternfly 3.10 - without this, all the view toolbar items are blue, all the time, as of ManageIQ/manageiq#11020.

Cc @martinpovolny 