### PR TITLE
Add filters bar to Availability Zones and Flavors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1157,14 +1157,14 @@ module ApplicationHelper
 
   def render_listnav_filename
     if @lastaction == "show_list" && !session[:menu_click] &&
-      %w(auth_key_pair_cloud cloud_object_store_container cloud_object_store_object cloud_volume cloud_volume_snapshot
-         container_node container_service ems_container container_group ems_cloud ems_cluster container_route
-         container_project container_replicator container_image container_image_registry container_build
-         ems_infra host miq_template offline orchestration_stack persistent_volume ems_middleware
-         middleware_server middleware_deployment middleware_datasource middleware_domain middleware_server_group
-         middleware_messaging ems_network security_group floating_ip cloud_subnet network_router network_port
-         cloud_network resource_pool retired service storage templates vm
-         configuration_job).include?(@layout) && !@in_a_form
+       %w(auth_key_pair_cloud availability_zone cloud_object_store_container cloud_object_store_object cloud_tenant
+          cloud_volume cloud_volume_snapshot container_node container_service ems_container container_group ems_cloud
+          ems_cluster container_route container_project container_replicator container_image container_image_registry
+          container_build ems_infra flavor host miq_template offline orchestration_stack persistent_volume
+          ems_middleware middleware_server middleware_deployment middleware_datasource middleware_domain
+          middleware_server_group middleware_messaging ems_network security_group floating_ip cloud_subnet
+          network_router network_port cloud_network resource_pool retired service storage templates vm
+          configuration_job).include?(@layout) && !@in_a_form
       "show_list"
     elsif @compare
       "compare_sections"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,7 @@ Vmdb::Application.routes.draw do
                compare_get,
       :post => %w(
         button
+        listnav_search_selected
         quick_search
         sections_field_changed
         show
@@ -174,7 +175,7 @@ Vmdb::Application.routes.draw do
         tag_edit_form_field_changed
         tl_chooser
         wait_for_task
-      ) + adv_search_post + compare_post + exp_post + perf_post
+      ) + adv_search_post + compare_post + exp_post + perf_post + save_post
     },
 
     :catalog                  => {
@@ -344,6 +345,7 @@ Vmdb::Application.routes.draw do
                compare_get,
       :post => %w(
         button
+        listnav_search_selected
         protect
         quick_search
         sections_field_changed
@@ -353,7 +355,7 @@ Vmdb::Application.routes.draw do
         tag_edit_form_field_changed
         update
       ) +
-               compare_post + adv_search_post + exp_post
+               compare_post + adv_search_post + exp_post + save_post
     },
 
     :cloud_object_store_object => {
@@ -1524,6 +1526,7 @@ Vmdb::Application.routes.draw do
                compare_get,
       :post => %w(
         button
+        listnav_search_selected
         quick_search
         sections_field_changed
         show
@@ -1533,7 +1536,8 @@ Vmdb::Application.routes.draw do
       ) +
                adv_search_post +
                compare_post +
-               exp_post
+               exp_post +
+               save_post
     },
 
     :host                     => {


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1361607

Add missing filters bar to Availability Zones, Flavors
and also to Tenants, when reaching Compute -> Clouds ->
Availability Zones/Flavors/Tenants.

Before
![screenshot from 2016-09-07 15-46-16](https://cloud.githubusercontent.com/assets/13417815/18314224/63919808-7512-11e6-9a0a-73c2150c438e.png)

After
![screenshot from 2016-09-07 15-47-05](https://cloud.githubusercontent.com/assets/13417815/18314230/68d55cbe-7512-11e6-9890-79b069271a04.png)
