### PR TITLE
Fix the issue that unconditional compliance check history isn't shown.

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -183,6 +183,8 @@ class MiqPolicy < ApplicationRecord
     plist.each do|p|
       logger.info("MIQ(policy-enforce_policy): Resolving policy [#{p.description}]...")
       if p.conditions.empty?
+        always_condition = {"id" => nil, "description" => "always", "result" => "allow"}
+        result[:details].push(p.attributes.merge("result" => true, "conditions" => [always_condition]))
         succeeded.push(p)
         next
       end


### PR DESCRIPTION
Purpose or Intent
-----------------
Fix the issue that compliance check history isn't shown if compliance policy is unconditional.
A compliance detail record is required to display the compliance check history.
Create a compliance detail record with always condition for unconditional compliance policy.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1369488

cc @gmcculloug @gtanzillo 