### PR TITLE
Environment variable for serving static files

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,7 @@ Vmdb::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = !!ENV['RAILS_SERVE_STATIC']
 
   # Compress JavaScripts and CSS
   config.assets.compress = true


### PR DESCRIPTION
I run performance numbers in production mode.

I'm constantly editing `environments/production.rb` to enable static file serving.

This adds `$RAILS_SERVE_STATIC` to make this easier.
It defaults to off