### PR TITLE
Fix literal string in interpolation

### DIFF
--- a/lib/resource_feeder/test/atom_feed_test.rb
+++ b/lib/resource_feeder/test/atom_feed_test.rb
@@ -23,7 +23,7 @@ class AtomFeedTest < MiniTest::Unit::TestCase
       assert_select 'entry', 5 do
         assert_select 'title', :text => 'feed title (title)'
         assert_select "content[type='html']", '&lt;p&gt;feed description (description)&lt;/p&gt;'
-        assert_select 'id', "tag:#{request.host_with_port},#{@records.first.created_at.xmlschema}:#{'http://example.com/posts/1'}"
+        assert_select 'id', "tag:#{request.host_with_port},#{@records.first.created_at.xmlschema}:http://example.com/posts/1"
         assert_select 'published', @records.first.created_at.xmlschema
         assert_select 'updated', @records.first.created_at.xmlschema
         assert_select 'link' do

--- a/spec/presenters/tree_builder_node_datacenter_spec.rb
+++ b/spec/presenters/tree_builder_node_datacenter_spec.rb
@@ -35,12 +35,12 @@ describe TreeNodeBuilder do
     it 'is blue folder when type is :vat' do
       object = FactoryGirl.build(:ems_folder)
       node = TreeNodeBuilderDatacenter.build(object, nil, {:type => :vat})
-      expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/#{"blue_folder.png"}"))
+      expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/blue_folder.png"))
     end
     it 'is normal folder when type is not :vat' do
       object = FactoryGirl.build(:ems_folder)
       node = TreeNodeBuilderDatacenter.build(object, nil, {})
-      expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/#{"folder.png"}"))
+      expect(node[:icon]).to eq(ActionController::Base.helpers.image_path("100/folder.png"))
     end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------

Quick rubocop fix seen while doing other things:
`rubocop -a --only Lint/LiteralInInterpolation`