### PR TITLE
Make resources related to a published blueprint readonly

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -16,6 +16,13 @@ class Blueprint < ApplicationRecord
     status == 'published'
   end
 
+  def readonly?
+    return true if super
+
+    # with this implementation we still allow to modify status.
+    published? unless status_changed?
+  end
+
   # The new blueprint is saved before returning
   def deep_copy(new_attributes = {})
     self.class.transaction do

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -26,6 +26,14 @@ class Dialog < ApplicationRecord
     end
   end
 
+  def readonly?
+    return true if super
+    resource_actions.each do |action|
+      return true if action.readonly?
+    end
+    false
+  end
+
   def each_dialog_field(&block)
     dialog_fields.each(&block)
   end

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -4,6 +4,11 @@ class ResourceAction < ApplicationRecord
 
   serialize  :ae_attributes, Hash
 
+  def readonly?
+    return true if super
+    resource.readonly? if resource.kind_of?(ServiceTemplate)
+  end
+
   def automate_queue_hash(target, override_attrs, user)
     if target.nil?
       override_values = {}

--- a/app/models/service_resource.rb
+++ b/app/models/service_resource.rb
@@ -12,6 +12,12 @@ class ServiceResource < ApplicationRecord
   virtual_column :resource_name,        :type => :string
   virtual_column :resource_description, :type => :string
 
+  def readonly?
+    return true if super
+
+    service_template.try(:readonly?)
+  end
+
   def resource_name
     virtual_column_resource_value(:name).to_s
   end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -45,6 +45,11 @@ class ServiceTemplate < ApplicationRecord
   virtual_has_one :custom_actions, :class_name => "Hash"
   virtual_has_one :custom_action_buttons, :class_name => "Array"
 
+  def readonly?
+    return true if super
+    blueprint.try(:published?)
+  end
+
   def children
     service_templates
   end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -88,7 +88,8 @@ describe Dialog do
     end
 
     it "destroy with resource_action association" do
-      resource_action = FactoryGirl.create(:resource_action, :action => "Provision", :dialog => @dialog)
+      FactoryGirl.create(:resource_action, :action => "Provision", :dialog => @dialog)
+      @dialog.reload
       expect { @dialog.destroy }
         .to raise_error(RuntimeError, /Dialog cannot be deleted.*connected to other components/)
       expect(Dialog.count).to eq(1)


### PR DESCRIPTION
Purpose or Intent
-----------------
Once a blueprint is published, all related resources should be readonly. 

The implementation overrides `ActiveRecord`'s `readonly?` method, relying it to throw errors when any attribute is attempted to be modified.

Resources that have been studied in this PR include 

- Blueprint
- ServiceTemplate
- Dialog
- ResourceAction
- ServiceResource

Resources to be further reviewed and addressed in followup PRs include
- Tag
- CustomButton
- CustomButtonGroup 

Links
-----
https://www.pivotaltracker.com/story/show/129940811


Steps for Testing/QA
--------------------