### PR TITLE
Don't use interpolation if it's not required (ui/api)

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -58,7 +58,7 @@ module Api
         Jbuilder.new do |json|
           json.ignore_nil!
           [:name, :count, :subcount].each do |opt_name|
-            json.set! "#{opt_name}", opts[opt_name] if opts[opt_name]
+            json.set! opt_name.to_s, opts[opt_name] if opts[opt_name]
           end
           json.resources resources.collect do |resource|
             if opts[:expand_resources]

--- a/app/controllers/api/rates_controller.rb
+++ b/app/controllers/api/rates_controller.rb
@@ -2,7 +2,7 @@ module Api
   class RatesController < BaseController
     def create_resource_rates(_type, _id, data = {})
       rate_detail = ChargebackRateDetail.create(data)
-      raise BadRequestError, "#{rate_detail.errors.full_messages.join(', ')}" unless rate_detail.valid?
+      raise BadRequestError, rate_detail.errors.full_messages.join(', ') unless rate_detail.valid?
       rate_detail
     end
   end

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -23,7 +23,7 @@ module Api
 
       def tags_create_resource(parent, _type, _id, data)
         entry = parent.add_entry(data)
-        raise BadRequestError, "#{entry.errors.full_messages.join(', ')}" unless entry.valid?
+        raise BadRequestError, entry.errors.full_messages.join(', ') unless entry.valid?
         entry.tag
       rescue => err
         raise BadRequestError, "Could not create a new tag - #{err}"

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -10,7 +10,7 @@ module Api
       end
       begin
         entry = category.add_entry(data)
-        raise BadRequestError, "#{entry.errors.full_messages.join(', ')}" unless entry.valid?
+        raise BadRequestError, entry.errors.full_messages.join(', ') unless entry.valid?
         entry.tag
       rescue => err
         raise BadRequestError, "Could not create a new tag - #{err}"

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -116,7 +116,7 @@ module ApplicationController::Buttons
         page.replace("ab_form", :partial => "shared/buttons/ab_form")
       end
       if params[:visibility_typ]
-        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => "#{@custom_button.id || "new"}", :action => "automate_button_field_changed"})
+        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@custom_button.id.to_s || "new"), :action => "automate_button_field_changed"})
       end
       unless params[:target_class]
         @changed = (@edit[:new] != @edit[:current])

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -676,7 +676,7 @@ module ApplicationController::CiProcessing
       replace_right_cell if @orig_action == "x_history"
     else
       if role_allows?(:feature => "vm_right_size")
-        javascript_redirect :controller => "#{rec_cls}", :action => 'right_size', :id => recs[0], :escape => false # redirect to build the ownership screen
+        javascript_redirect :controller => rec_cls.to_s, :action => 'right_size', :id => recs[0], :escape => false # redirect to build the ownership screen
       else
         head :ok
       end
@@ -1469,7 +1469,7 @@ module ApplicationController::CiProcessing
       @refresh_partial = "vm_common/reconfigure"
     else
       if role_allows?(:feature => "vm_reconfigure")
-        javascript_redirect :controller => "#{rec_cls}", :action => 'reconfigure', :req_id => @request_id, :rec_ids => @reconfigure_items, :escape => false # redirect to build the ownership screen
+        javascript_redirect :controller => rec_cls.to_s, :action => 'reconfigure', :req_id => @request_id, :rec_ids => @reconfigure_items, :escape => false # redirect to build the ownership screen
       else
         head :ok
       end

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -1023,8 +1023,8 @@ module ApplicationController::Compare
       :indent     => 0,
       :parent     => nil,
       :section    => true,
-      :exp_id     => "#{section[:name]}",
-      :_collapsed => collapsed_state("#{section[:name]}")
+      :exp_id     => section[:name].to_s,
+      :_collapsed => collapsed_state(section[:name].to_s)
     }
     row.merge!(drift_section_data_cols(view, section))
     @section_parent_id = @rows.length
@@ -1172,7 +1172,7 @@ module ApplicationController::Compare
 
   def drift_record_field_compressed(view, section, record, field)
     basval = ""
-    row = {:col0 => "#{field[:header]}"}
+    row = {:col0 => field[:header].to_s}
 
     view.ids.each_with_index do |id, idx|
       match_condition = view.results[view.ids[0]][section[:name]][record].nil? &&
@@ -1181,7 +1181,7 @@ module ApplicationController::Compare
       if !view.results[id][section[:name]][record].nil? && # Record exists
          !view.results[id][section[:name]][record][field[:name]].nil?      # Field exists
 
-        val = "#{view.results[id][section[:name]][record][field[:name]][:_value_]}"
+        val = view.results[id][section[:name]][record][field[:name]][:_value_].to_s
         row.merge!(drift_record_field_exists_compressed(idx, match_condition, val))
       else
         val = view.results[id][section[:name]].include?(record) ? "Found" : "Missing"
@@ -1193,7 +1193,7 @@ module ApplicationController::Compare
   end
 
   def drift_record_field_expanded(view, section, record, field)
-    row = {:col0 => "#{field[:header]}"}
+    row = {:col0 => field[:header].to_s}
 
     view.ids.each_with_index do |id, idx|
       if !view.results[id][section[:name]][record].nil? && !view.results[id][section[:name]][record][field[:name]].nil?
@@ -1203,7 +1203,7 @@ module ApplicationController::Compare
                           view.results[view.ids[idx - 1]][section[:name]][record][field[:name]][:_value_].to_s ==
                           view.results[id][section[:name]][record][field[:name]][:_value_].to_s
 
-        val = "#{view.results[id][section[:name]][record][field[:name]][:_value_]}"
+        val = view.results[id][section[:name]][record][field[:name]][:_value_].to_s
         row.merge!(drift_record_field_exists_expanded(idx, match_condition, val))
       else
         match_condition = !view.results[view.ids[0]][section[:name]][record].nil? &&
@@ -1294,9 +1294,9 @@ module ApplicationController::Compare
   end
 
   def drift_add_section_field_compressed(view, section, field)
-    row = {:col0 => "#{field[:header]}"}
+    row = {:col0 => field[:header].to_s}
     view.ids.each_with_index do |id, idx|
-      val = "#{view.results[id][section[:name]][field[:name]][:_value_]}"
+      val = view.results[id][section[:name]][field[:name]][:_value_].to_s
       if !view.results[id][section[:name]][field[:name]].nil? && idx == 0     # On base object
         row.merge!(drift_add_same_image(idx, val))
       elsif !view.results[id][section[:name]].nil? && !view.results[id][section[:name]][field[:name]].nil?
@@ -1318,17 +1318,17 @@ module ApplicationController::Compare
     row = {:col0 => field[:header]}
     view.ids.each_with_index do |id, idx|
       if !view.results[id][section[:name]][field[:name]].nil? && idx == 0       # On base object
-        col = "#{view.results[id][section[:name]][field[:name]][:_value_]}"
+        col = view.results[id][section[:name]][field[:name]][:_value_].to_s
         img_bkg = "cell-stripe"
         row.merge!(drift_add_txt_col(idx, col, img_bkg))
       elsif !view.results[id][section[:name]].nil? && !view.results[id][section[:name]][field[:name]].nil?
         if view.results[id][section[:name]][field[:name]][:_match_]
-          col = "#{view.results[id][section[:name]][field[:name]][:_value_]}"
+          col = view.results[id][section[:name]][field[:name]][:_value_].to_s
           img_bkg = "cell-bkg-plain-no-shade"
           row.merge!(drift_add_txt_col(idx, col, img_bkg))
         else
           @same = false
-          col = "#{view.results[id][section[:name]][field[:name]][:_value_]}"
+          col = view.results[id][section[:name]][field[:name]][:_value_].to_s
           img_bkg = "cell-bkg-plain-mark-txt-no-shade"
           row.merge!(drift_add_txt_col(idx, col, img_bkg))
         end
@@ -1584,8 +1584,8 @@ module ApplicationController::Compare
       :indent     => 0,
       :parent     => nil,
       :section    => true,
-      :exp_id     => "#{section[:name]}",
-      :_collapsed => collapsed_state("#{section[:name]}")
+      :exp_id     => section[:name].to_s,
+      :_collapsed => collapsed_state(section[:name].to_s)
     }
     row.merge!(compare_section_data_cols(view, section, records))
 

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -548,7 +548,7 @@ module ApplicationController::MiqRequestMethods
     @edit[:wf].get_dialog_order.each do |d|
       @edit[:wf].get_all_fields(d, false).each do |_f, field|
         unless field[:error].blank?
-          @error_div ||= "#{d}"
+          @error_div ||= d.to_s
           add_flash(field[:error], :error)
         end
       end
@@ -560,7 +560,7 @@ module ApplicationController::MiqRequestMethods
       @edit[:wf].get_all_fields(d, false).each do |_f, field|
         @edit[:wf].validate(@edit[:new])
         unless field[:error].nil?
-          @error_div ||= "#{d}"
+          @error_div ||= d.to_s
           add_flash(field[:error], :error)
         end
       end
@@ -748,8 +748,8 @@ module ApplicationController::MiqRequestMethods
     if @options[:schedule_time]
       @options[:schedule_time] = format_timezone(@options[:schedule_time], Time.zone, "raw")
       @options[:start_date] = "#{@options[:schedule_time].month}/#{@options[:schedule_time].day}/#{@options[:schedule_time].year}"  # Set the start date
-      @options[:start_hour] = "#{@options[:schedule_time].hour}"
-      @options[:start_min] = "#{@options[:schedule_time].min}"
+      @options[:start_hour] = @options[:schedule_time].hour.to_s
+      @options[:start_min] = @options[:schedule_time].min.to_s
     end
     drop_breadcrumb(:name => @miq_request.description.to_s.split(' submitted')[0], :url => "/miq_request/show/#{@miq_request.id}")
     if @miq_request.workflow_class
@@ -812,8 +812,8 @@ module ApplicationController::MiqRequestMethods
         @edit[:new][:schedule_time] = format_timezone(@edit[:new][:schedule_time], Time.zone, "raw")
         @edit[:new][:start_date] = "#{@edit[:new][:schedule_time].month}/#{@edit[:new][:schedule_time].day}/#{@edit[:new][:schedule_time].year}" # Set the start date
         if params[:id]
-          @edit[:new][:start_hour] = "#{@edit[:new][:schedule_time].hour}"
-          @edit[:new][:start_min] = "#{@edit[:new][:schedule_time].min}"
+          @edit[:new][:start_hour] = @edit[:new][:schedule_time].hour.to_s
+          @edit[:new][:start_min] = @edit[:new][:schedule_time].min.to_s
         else
           @edit[:new][:start_hour] = "00"
           @edit[:new][:start_min] = "00"

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -155,7 +155,7 @@ module ApplicationController::ReportDownloads
     @report_only = true
     @showtype    = @display
     run_time     = Time.now
-    klass        = ui_lookup(:model => "#{@record.class}")
+    klass        = ui_lookup(:model => @record.class.name)
 
     @options = {
       :page_layout => "portrait",

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -102,11 +102,11 @@ class ChargebackController < ApplicationController
     assert_privileges(params[:pressed]) if params[:pressed]
     case params[:button]
     when "cancel"
-      add_flash("#{params[:id] ?
+      add_flash((params[:id] ?
         _("Edit of %{model} \"%{name}\" was cancelled by the user") %
           {:model => ui_lookup(:model => "ChargebackRate"), :name => session[:edit][:new][:description]} :
         _("Add of new %{model} was cancelled by the user") %
-          {:model => ui_lookup(:model => "ChargebackRate")}}")
+          {:model => ui_lookup(:model => "ChargebackRate")}).to_s)
       get_node_info(x_node)
       @edit = session[:edit] = nil  # clean out the saved info
       session[:changed] =  false

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -187,7 +187,7 @@ class DashboardController < ApplicationController
           :id    => w.id,
           :type  => :button,
           :text  => w.title,
-          :image => "#{image}",
+          :image => image.to_s,
           :title => tip
         }
       end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -967,7 +967,7 @@ module EmsCommon
          :models => ui_lookup(:tables => @table_name)})
       AuditEvent.success(:userid => session[:userid], :event => "#{@table_name}_#{task}",
           :message => _("'%{task}' successfully initiated for %{table}") %
-            {:task => task, :table => pluralize(emss.length, "#{ui_lookup(:tables => @table_name)}")},
+            {:task => task, :table => pluralize(emss.length, ui_lookup(:tables => @table_name).to_s)},
           :target_class => model.to_s)
     elsif task == "destroy"
       model.where(:id => emss).order("lower(name)").each do |ems|

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -295,7 +295,7 @@ class HostController < ApplicationController
       begin
         verify_host.verify_credentials(params[:type])
       rescue StandardError => bang
-        add_flash("#{bang}", :error)
+        add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
       end
@@ -418,7 +418,7 @@ class HostController < ApplicationController
         end
         return
       rescue StandardError => bang
-        add_flash("#{bang}", :error)
+        add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
       end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -444,8 +444,8 @@ class MiqAeClassController < ApplicationController
       end
       srow = root.add_element("row", "id" => "#{cls}-#{to_cid(kids.id)}", "style" => "border-bottom: 1px solid #CCCCCC;color:black; text-align: center")
       srow.add_element("cell").text = "0" # Checkbox column unchecked
-      srow.add_element("cell", "image" => "blank.png", "title" => "#{cls}", "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = REXML::CData.new("<ul class='icons list-unstyled'><li><span class='#{glyphicon}' alt='#{cls}' title='#{cls}'></span></li></ul>")
-      srow.add_element("cell", "image" => "blank.png", "title" => "#{rec_name}", "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = rec_name
+      srow.add_element("cell", "image" => "blank.png", "title" => cls.to_s, "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = REXML::CData.new("<ul class='icons list-unstyled'><li><span class='#{glyphicon}' alt='#{cls}' title='#{cls}'></span></li></ul>")
+      srow.add_element("cell", "image" => "blank.png", "title" => rec_name.to_s, "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = rec_name
     end
     xml.to_s
   end
@@ -1743,14 +1743,14 @@ class MiqAeClassController < ApplicationController
       res = @edit[:typ].copy(options)
     rescue StandardError => bang
       add_flash(_("Error during '%{record} copy': %{error_message}") %
-        {:record => ui_lookup(:model => "#{@edit[:typ]}"), :error_message => bang.message}, :error)
+        {:record => ui_lookup(:model => @edit[:typ].to_s), :error_message => bang.message}, :error)
       render :update do |page|
         page << javascript_prologue
         page.replace("flash_msg_div_copy", :partial => "layouts/flash_msg", :locals  => {:div_num => "_copy"})
       end
     else
       model = @edit[:selected_items].count > 1 ? :models : :model
-      add_flash(_("Copy selected %{record} was saved") % {:record => ui_lookup(model => "#{@edit[:typ]}")})
+      add_flash(_("Copy selected %{record} was saved") % {:record => ui_lookup(model => @edit[:typ].to_s)})
       @record = res.kind_of?(Array) ? @edit[:typ].find_by_id(res.first) : res
       self.x_node = "#{TreeBuilder.get_prefix_for_model(@edit[:typ])}-#{to_cid(@record.id)}"
       @in_a_form = @changed = session[:changed] = false
@@ -1775,7 +1775,7 @@ class MiqAeClassController < ApplicationController
     @record = session[:edit][:typ].find_by_id(session[:edit][:rec_id])
     model = @edit[:selected_items].count > 1 ? :models : :model
     @sb[:action] = session[:edit] = nil # clean out the saved info
-    add_flash(_("Copy %{record} was cancelled by the user") % {:record => ui_lookup(model => "#{@edit[:typ]}")})
+    add_flash(_("Copy %{record} was cancelled by the user") % {:record => ui_lookup(model => @edit[:typ].to_s)})
     @in_a_form = false
     replace_right_cell
   end

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -525,13 +525,13 @@ module MiqAeCustomizationController::Dialogs
       page << javascript_for_miq_button_visibility(changed)
 
       # replace select tag of default values
-      url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || "new"}")
+      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id.to_s || "new"))
       none =  [['<None>', nil]]
       values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]
       page << "$('#field_default_value').next('.bootstrap-select').remove();"
       page.replace("field_default_value",
-                   :text => "#{select_tag('field_default_value', options_for_select(values, selected), 'data-miq_observe' => {:interval => '.5', :url => url}.to_json)}")
+                   :text => select_tag('field_default_value', options_for_select(values, selected), 'data-miq_observe' => {:interval => '.5', :url => url}.to_json).to_s)
       page << "$('#field_default_value').selectpicker();"
     end
   end
@@ -565,7 +565,7 @@ module MiqAeCustomizationController::Dialogs
       page << javascript_for_miq_button_visibility(changed)
 
       # replace select tag of default values
-      url = url_for(:action => 'dialog_form_field_changed', :id => "#{@record.id || "new"}")
+      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id.to_s || "new"))
       none =  [['<None>', nil]]
       values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]
@@ -785,7 +785,7 @@ module MiqAeCustomizationController::Dialogs
 
     base_node = TreeNodeBuilder.generic_tree_node(
       "root",
-      "#{@edit[:new][:label] || _('[New Dialog]')}",
+      (@edit[:new][:label].to_s || _('[New Dialog]')),
       "dialog.png",
       @edit[:new][:description] || @edit[:new][:label],
       :expand => true

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -293,7 +293,7 @@ class MiqRequestController < ApplicationController
   def prov_load_tab
     if @options && @options[:current_tab_key] == :purpose # Need to build again for purpose tab
       fld = @options[:wf].kind_of?(MiqHostProvisionWorkflow) ? "tag_ids" : "vm_tags"
-      build_tags_tree(@options[:wf], @options["#{fld}".to_sym], false)
+      build_tags_tree(@options[:wf], @options[fld.to_s.to_sym], false)
     end
     # need to build host list view, to display on show screen
     @options[:host_sortdir] = "ASC"

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -347,7 +347,7 @@ class MiqTaskController < ApplicationController
 
     cond = add_to_condition(cond, *build_query_for_state(opts)) if opts[:state_choice] != "all"
 
-    cond[0] = "#{cond[0].join(" AND ")}"
+    cond[0] = cond[0].join(" AND ")
     cond.flatten
   end
 

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -167,12 +167,12 @@ class OpsController < ApplicationController
       @scan = @edit[:scan]
       case params[:tab].split("_")[0]
       when "new"
-        redirect_to(:action => "ap_new", :tab => params[:tab], :id => "#{@scan.id || "new"}")
+        redirect_to(:action => "ap_new", :tab => params[:tab], :id => (@scan.id.to_s || "new"))
       when "edit"
-        redirect_to(:action => "ap_edit", :tab => params[:tab], :id => "#{@scan.id || "new"}")
+        redirect_to(:action => "ap_edit", :tab => params[:tab], :id => (@scan.id.to_s || "new"))
       else
         @sb[:miq_tab] = "new#{params[:tab]}"
-        redirect_to(:action => "ap_edit", :tab => "edit#{params[:tab]}", :id => "#{@scan.id || "new"}")
+        redirect_to(:action => "ap_edit", :tab => "edit#{params[:tab]}", :id => (@scan.id.to_s || "new"))
       end
     else
       @sb[:active_tab] = params[:tab_id] || new_tab_id
@@ -456,7 +456,7 @@ class OpsController < ApplicationController
     existing_node = nil                     # Init var
 
     parent_rec = VmdbTableEvm.find_by_id(@record.vmdb_table_id)
-    parents = [parent_rec, {:id => "#{@record.vmdb_table_id}"}]
+    parents = [parent_rec, {:id => @record.vmdb_table_id.to_s}]
     # Go up thru the parents and find the highest level unopened, mark all as opened along the way
     # Skip if no parents or parent already open
     unless parents.empty? || x_tree[:open_nodes].include?(x_build_node_id(parents.last))

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -37,7 +37,7 @@ module OpsController::Settings::AnalysisProfiles
         @file = [] if @file.nil?
         @file_stats = {}
         for i in 0...a[:definition]["stats"].length
-          @file_stats["#{a[:definition]["stats"][i]["target"]}"] = a[:definition]["stats"][i]["content"] ? a[:definition]["stats"][i]["content"] : false
+          @file_stats[a[:definition]["stats"][i]["target"].to_s] = a[:definition]["stats"][i]["content"] ? a[:definition]["stats"][i]["content"] : false
           @file.push(a[:definition]["stats"][i]["target"])
         end
       when "registry"

--- a/app/controllers/ops_controller/settings/ldap.rb
+++ b/app/controllers/ops_controller/settings/ldap.rb
@@ -143,7 +143,7 @@ module OpsController::Settings::Ldap
       begin
         ldap_server.verify_credentials
       rescue StandardError => bang
-        add_flash("#{bang}", :error)
+        add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
       end

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -65,7 +65,7 @@ module OpsController::Settings::Zones
     begin
       zone.destroy
     rescue StandardError => bang
-      add_flash("#{bang}", :error)
+      add_flash(bang.to_s, :error)
       zone.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
       self.x_node = "z-#{zone.id}"
       get_node_info(x_node)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -806,7 +806,7 @@ class ReportController < ApplicationController
       presenter.replace(:flash_msg_div_menu_list, r[:partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}]) if @flash_array
       if @refresh_div
         presenter.hide(:flash_msg_div_menu_list)
-        presenter.replace("#{@refresh_div}", r[:partial => @refresh_partial, :locals => {:action_url => "menu_update"}])
+        presenter.replace(@refresh_div.to_s, r[:partial => @refresh_partial, :locals => {:action_url => "menu_update"}])
         presenter.hide(:menu_div1)
         if params[:pressed] == "commit"
           presenter.show(:menu_div3).hide(:menu_div2)

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -423,7 +423,7 @@ module ReportController::Dashboards
                 when "menu"
                   "fa fa-share-square-o"
                 end
-        @widgets_options.push([w.title, w.id, {"data-icon" => "#{image}"}])
+        @widgets_options.push([w.title, w.id, {"data-icon" => image.to_s}])
       end
     end
     @widgets_options

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -293,9 +293,9 @@ module ReportController::Reports::Editor
       4.times { |i| end_array.push(["#{pluralize(i + 1, "week")} ago", (i + 1).weeks.to_s]) }
       5.times { |i| end_array.push(["#{pluralize(i + 2, "month")} ago", (i + 1).months.to_s]) }
       start_array = []
-      6.times { |i| start_array.push(["#{pluralize(i + 1, "day")}", (i + 1).days.to_s]) }
-      4.times { |i| start_array.push(["#{pluralize(i + 1, "week")}", (i + 1).weeks.to_s]) }
-      5.times { |i| start_array.push(["#{pluralize(i + 2, "month")}", (i + 1).months.to_s]) }
+      6.times { |i| start_array.push([pluralize(i + 1, "day").to_s, (i + 1).days.to_s]) }
+      4.times { |i| start_array.push([pluralize(i + 1, "week").to_s, (i + 1).weeks.to_s]) }
+      5.times { |i| start_array.push([pluralize(i + 2, "month").to_s, (i + 1).months.to_s]) }
       @edit[:new][:perf_end] ||= "0"
       @edit[:new][:perf_start] ||= 1.day.to_s
     when "daily"
@@ -306,9 +306,9 @@ module ReportController::Reports::Editor
       3.times  { |i| end_array.push(["#{pluralize((i + 1), "week")} ago", ((i + 1).weeks - 1.day).to_s]) }
       6.times  { |i| end_array.push(["#{pluralize((i + 1), "month")} ago", ((i + 1).months - 1.day).to_s]) }
       start_array = []
-      5.times  { |i| start_array.push(["#{pluralize(i + 2, "day")}", (i + 2).days.to_s]) }
-      3.times  { |i| start_array.push(["#{pluralize((i + 1), "week")}", (i + 1).weeks.to_s]) }
-      11.times { |i| start_array.push(["#{pluralize((i + 1), "month")}", (i + 1).months.to_s]) }
+      5.times  { |i| start_array.push([pluralize(i + 2, "day").to_s, (i + 2).days.to_s]) }
+      3.times  { |i| start_array.push([pluralize((i + 1), "week").to_s, (i + 1).weeks.to_s]) }
+      11.times { |i| start_array.push([pluralize((i + 1), "month").to_s, (i + 1).months.to_s]) }
       start_array.push(["1 year", 1.year.to_i.to_s])  # For some reason, 1.year is a float, so use to_i to get rid of decimals
       @edit[:new][:perf_end] ||= "0"
       @edit[:new][:perf_start] ||= 2.days.to_s

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -144,7 +144,7 @@ module ReportController::Widgets
       end
 
       if params[:visibility_typ]
-        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => "#{@widget.id || "new"}", :action => "widget_form_field_changed"})
+        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@widget.id.to_s || "new"), :action => "widget_form_field_changed"})
       end
 
       javascript_for_timer_type(params[:timer_typ]).each { |js| page << js }

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -114,7 +114,7 @@ class StorageManagerController < ApplicationController
       begin
         verify_sm.verify_credentials
       rescue StandardError => bang
-        add_flash("#{bang}", :error)
+        add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
       end
@@ -201,7 +201,7 @@ class StorageManagerController < ApplicationController
       begin
         verify_sm.verify_credentials
       rescue StandardError => bang
-        add_flash("#{bang}", :error)
+        add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
       end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1151,7 +1151,7 @@ module VmCommon
     existing_node = nil                     # Init var
 
     if record.orphaned? || record.archived?
-      parents = [{:type => "x", :id => "#{record.orphaned ? "orph" : "arch"}"}]
+      parents = [{:type => "x", :id => (record.orphaned ? "orph" : "arch")}]
     else
       if x_active_tree == :instances_tree
         parents = record.kind_of?(ManageIQ::Providers::CloudManager::Vm) && record.availability_zone ? [record.availability_zone] : [record.ext_management_system]
@@ -1224,7 +1224,7 @@ module VmCommon
           @breadcrumbs.clear
           drop_breadcrumb({:name => breadcrumb_name(model), :url => "/#{controller_name}/explorer"}, false)
         end
-        @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => "#{ui_lookup(:model => model && model != "VmOrTemplate" ? model : TreeBuilder.get_model_for_prefix(@nodetype))}"}
+        @right_cell_text = _("%{model} \"%{name}\"") % {:name => @record.name, :model => (ui_lookup(:model => model && model != "VmOrTemplate" ? model : TreeBuilder.get_model_for_prefix(@nodetype))).to_s}
       end
     else      # Get list of child VMs of this node
       options = {:model => model}
@@ -1273,7 +1273,7 @@ module VmCommon
                              end
         else
           rec = TreeBuilder.get_model_for_prefix(@nodetype).constantize.find(from_cid(id))
-          options.merge!({:association => "#{@nodetype == "az" ? "vms" : "all_vms_and_templates"}", :parent => rec})
+          options.merge!({:association => (@nodetype == "az" ? "vms" : "all_vms_and_templates"), :parent => rec})
           options[:where_clause] = MiqExpression.merge_where_clauses(
             options[:where_clause], VmOrTemplate::NOT_ARCHIVED_NOR_OPRHANED_CONDITIONS
           )

--- a/app/helpers/charting_helper.rb
+++ b/app/helpers/charting_helper.rb
@@ -6,14 +6,14 @@ module ChartingHelper
                          :action     => options[:action] || 'render_chart',
                          :width      => options[:width],
                          :height     => options[:height],
-                         :rand       => "#{rand(999_999_999)}"),
+                         :rand       => rand(999_999_999)).to_s,
                  options.slice(:id, :bgcolor, :width, :height))
     when :jqplot
       jqplot_remote(url_for(:controller => a_controller,
                             :action     => options[:action] || 'render_chart',
                             :width      => options[:width],
                             :height     => options[:height],
-                            :rand       => "#{rand(999_999_999)}"),
+                            :rand       => rand(999_999_999)).to_s,
                     options.slice(:id, :bgcolor, :width, :height))
     when :c3
       c3chart_remote(url_for(:controller => a_controller,

--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -102,7 +102,7 @@ module ContainerGroupHelper::TextualSummary
     {
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
       :image => "vendor-#{lives_on_ems.image_name}",
-      :value => "#{@record.container_node.lives_on.name}",
+      :value => @record.container_node.lives_on.name.to_s,
       :link  => url_for(
         :action     => 'show',
         :controller => 'vm_or_template',

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -79,7 +79,7 @@ module ContainerNodeHelper::TextualSummary
     {
       :label => _("Underlying %{name}") % {:name => lives_on_entity_name},
       :image => "vendor-#{lives_on_ems.image_name}",
-      :value => "#{@record.lives_on.name}",
+      :value => @record.lives_on.name.to_s,
       :link  => url_for(
         :action     => 'show',
         :controller => 'vm_or_template',

--- a/app/helpers/ems_cluster_helper/textual_summary.rb
+++ b/app/helpers/ems_cluster_helper/textual_summary.rb
@@ -86,7 +86,7 @@ module EmsClusterHelper::TextualSummary
   end
 
   def textual_aggregate_cpu_speed
-    {:label => _("Total CPU Resources"), :value => "#{mhz_to_human_size(@record.aggregate_cpu_speed)}"}
+    {:label => _("Total CPU Resources"), :value => mhz_to_human_size(@record.aggregate_cpu_speed).to_s}
   end
 
   def textual_aggregate_memory

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -111,11 +111,11 @@ module HostHelper::TextualSummary
   end
 
   def textual_ipaddress
-    {:label => _("IP Address"), :value => "#{@record.ipaddress}"}
+    {:label => _("IP Address"), :value => @record.ipaddress.to_s}
   end
 
   def textual_ipmi_ipaddress
-    {:label => _("IPMI IP Address"), :value => "#{@record.ipmi_address}"}
+    {:label => _("IPMI IP Address"), :value => @record.ipmi_address.to_s}
   end
 
   def textual_custom_1

--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -43,7 +43,7 @@ module MiddlewareServerHelper::TextualSummary
      {
          :label      => "Underlying #{lives_on_entity_name}",
          :image      => "vendor-#{lives_on_ems.image_name}",
-         :value      => "#{@record.lives_on.name}",
+         :value      => @record.lives_on.name.to_s,
          :link       => url_for(
            :action     => 'show',
            :controller => 'vm_or_template',

--- a/app/helpers/pxe_helper/textual_summary.rb
+++ b/app/helpers/pxe_helper/textual_summary.rb
@@ -5,31 +5,31 @@ module PxeHelper::TextualSummary
   end
 
   def textual_uri_prefix
-    {:label => _("URI Prefix"), :value => "#{@ps.uri_prefix}"}
+    {:label => _("URI Prefix"), :value => @ps.uri_prefix.to_s}
   end
 
   def textual_uri
-    {:label => _("URI"), :value => "#{@ps.uri}"}
+    {:label => _("URI"), :value => @ps.uri.to_s}
   end
 
   def textual_access_url
-    {:label => _("Access URL"), :value => "#{@ps.access_url}"}
+    {:label => _("Access URL"), :value => @ps.access_url.to_s}
   end
 
   def textual_pxe_directory
-    {:label => _("PXE Directory"), :value => "#{@ps.pxe_directory}"}
+    {:label => _("PXE Directory"), :value => @ps.pxe_directory.to_s}
   end
 
   def textual_windows_images_directory
-    {:label => _("Windows Images Directory"), :value => "#{@ps.windows_images_directory}"}
+    {:label => _("Windows Images Directory"), :value => @ps.windows_images_directory.to_s}
   end
 
   def textual_customization_directory
-    {:label => _("Customization Directory"), :value => "#{@ps.customization_directory}"}
+    {:label => _("Customization Directory"), :value => @ps.customization_directory.to_s}
   end
 
   def textual_last_refreshed_on
-    {:label => _("Last Refreshed On"), :value => "#{@ps.last_refresh_on}"}
+    {:label => _("Last Refreshed On"), :value => @ps.last_refresh_on.to_s}
   end
 
   def textual_group_pxe_image_menus
@@ -37,7 +37,7 @@ module PxeHelper::TextualSummary
   end
 
   def textual_filename
-    {:label => _("Filename"), :value => "#{@ps.pxe_menus[0].file_name}"}
+    {:label => _("Filename"), :value => @ps.pxe_menus[0].file_name.to_s}
   end
 
   def textual_pxe_img_basicinfo
@@ -45,19 +45,19 @@ module PxeHelper::TextualSummary
   end
 
   def textual_pxe_img_name
-    {:label => _("Name"), :value => "#{@img.name}"}
+    {:label => _("Name"), :value => @img.name.to_s}
   end
 
   def textual_pxe_img_description
-    {:label => _("Description"), :value => "#{@img.description}"}
+    {:label => _("Description"), :value => @img.description.to_s}
   end
 
   def textual_pxe_img_type
-    {:label => _("Type"), :value => @img.pxe_image_type ? "#{@img.pxe_image_type.name}" : ""}
+    {:label => _("Type"), :value => @img.pxe_image_type ? @img.pxe_image_type.name.to_s : ""}
   end
 
   def textual_pxe_img_kernel
-    {:label => _("Kernel"), :value => "#{@img.kernel}"}
+    {:label => _("Kernel"), :value => @img.kernel.to_s}
   end
 
   def textual_pxe_img_win_boot_env
@@ -69,15 +69,15 @@ module PxeHelper::TextualSummary
   end
 
   def textual_win_img_name
-    {:label => _("Name"), :value => "#{@wimg.name}"}
+    {:label => _("Name"), :value => @wimg.name.to_s}
   end
 
   def textual_win_img_description
-    {:label => _("Description"), :value => "#{@wimg.description}"}
+    {:label => _("Description"), :value => @wimg.description.to_s}
   end
 
   def textual_win_img_type
-    {:label => _("Type"), :value => @wimg.pxe_image_type ? "#{@wimg.pxe_image_type.name}" : ""}
+    {:label => _("Type"), :value => @wimg.pxe_image_type ? @wimg.pxe_image_type.name.to_s : ""}
   end
 
   def textual_win_img_path
@@ -101,7 +101,7 @@ module PxeHelper::TextualSummary
   end
 
   def textual_template_img_type
-    {:label => _("Image Type"), :value => @ct.pxe_image_type ? "#{@ct.pxe_image_type.name}" : ""}
+    {:label => _("Image Type"), :value => @ct.pxe_image_type ? @ct.pxe_image_type.name.to_s : ""}
   end
 
   def textual_template_type

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -172,7 +172,7 @@ class TreeBuilder
   end
 
   def locals_for_render
-    @locals_for_render.update(:select_node => "#{@tree_state.x_node(@name)}")
+    @locals_for_render.update(:select_node => @tree_state.x_node(@name).to_s)
   end
 
   def reload!

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -48,7 +48,7 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
       @tree_state.x_tree(@name)[:open_nodes].push("xx-#{to_cid(object.id.to_s)}") unless @tree_state.x_tree(@name)[:open_nodes].include?("xx-#{to_cid(object.id.to_s)}")
       [
         {
-          :id            => "#{to_cid(object.id.to_s)}",
+          :id            => to_cid(object.id.to_s).to_s,
           :text          => _("Indexes"),
           :image         => "folder",
           :tip           => _("Indexes"),

--- a/app/presenters/tree_builder_report_reports.rb
+++ b/app/presenters/tree_builder_report_reports.rb
@@ -28,9 +28,9 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
     objects = []
     @rpt_menu.each_with_index do |r, i|
       objects.push(
-        :id    => "#{i}",
+        :id    => i.to_s,
         :text  => r[0],
-        :image => "#{@grp_title == r[0] ? 'blue_folder' : 'folder'}",
+        :image => (@grp_title == r[0] ? 'blue_folder' : 'folder'),
         :tip   => r[0]
       )
       # load next level of folders when building the tree
@@ -47,7 +47,7 @@ class TreeBuilderReportReports < TreeBuilderReportReportsClass
         objects.push(
           :id    => "#{nodes.last.split('-').last}-#{i}",
           :text  => r[0],
-          :image => "#{@grp_title == @rpt_menu[nodes.last.to_i][0] ? 'blue_folder' : 'folder'}",
+          :image => (@grp_title == @rpt_menu[nodes.last.to_i][0] ? 'blue_folder' : 'folder'),
           :tip   => r[0]
         )
       end

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -328,7 +328,7 @@ describe HostController do
                               :ext_management_system => FactoryGirl.create(:ems_openstack_infra),
                               :storage               => FactoryGirl.create(:storage)
                              )
-      controller.instance_variable_set(:@_params, :miq_grid_checks => "#{vm.id}")
+      controller.instance_variable_set(:@_params, :miq_grid_checks => vm.id.to_s)
       expect(controller).to receive(:process_objects)
       controller.send(:vm_button_operation, 'scan', "Smartstate Analysis")
     end

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -15,7 +15,7 @@ describe MiqAeCustomizationController do
 
         controller.instance_variable_set(:@sb,
                                          :trees       => {
-                                           :dlg_tree => {:active_node => "#{dialog.id}"}
+                                           :dlg_tree => {:active_node => dialog.id.to_s}
                                          },
                                          :active_tree => :dlg_tree)
         session[:settings] = {:display   => {:locale => 'default'}}

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -11,7 +11,7 @@ describe ServiceController do
       controller.instance_variable_set(:@record, svc)
       controller.instance_variable_set(:@sb,
                                        :trees       => {
-                                         :svcs_tree => {:active_node => "#{svc.id}"}
+                                         :svcs_tree => {:active_node => svc.id.to_s}
                                        },
                                        :active_tree => :svcs_tree
                                       )

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -80,7 +80,7 @@ describe StorageController do
         command = button.split('_', 2)[1]
         allow_any_instance_of(Host).to receive(:is_available?).with(command).and_return(true)
 
-        controller.instance_variable_set(:@_params, :pressed => button, :miq_grid_checks => "#{host.id}")
+        controller.instance_variable_set(:@_params, :pressed => button, :miq_grid_checks => host.id.to_s)
         controller.instance_variable_set(:@lastaction, "show_list")
         allow(controller).to receive(:show_list)
         expect(controller).to receive(:render)

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "reports API" do
     expect_result_resources_to_include_hrefs(
       "resources",
       [
-        "#{results_url(result.id)}"
+        results_url(result.id).to_s
       ]
     )
     expect(response).to have_http_status(:ok)
@@ -161,7 +161,7 @@ RSpec.describe "reports API" do
 
       expect do
         api_basic_authorize action_identifier(:reports, :run)
-        run_post "#{reports_url(report.id)}", :action => "run"
+        run_post reports_url(report.id).to_s, :action => "run"
       end.to change(MiqReportResult, :count).by(1)
       expect_single_action_result(
         :href    => reports_url(report.id),
@@ -268,7 +268,7 @@ RSpec.describe "reports API" do
 
       expect do
         api_basic_authorize
-        run_post "#{reports_url(report.id)}", :action => "run"
+        run_post reports_url(report.id).to_s, :action => "run"
       end.not_to change(MiqReportResult, :count)
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
Purpose or Intent
-----------------

Interpolation syntax can be error prone so don't use it when you can just convert to string.

Prefer `variable.to_s` over `"#{variable}"`

Also, some places we use Array#join which returns a String already:

`"#{rate_detail.errors.full_messages.join(', ')}"`
 Becomes:

 `rate_detail.errors.full_messages.join(', ')`

rubocop -a --only "Lint/StringConversionInInterpolation,Style/UnneededInterpolation" app/controllers app/presenters app/helpers spec/controllers spec/requests