### PR TITLE
Replaced validate_reboot_guest by supports_reboot_guest

### DIFF
--- a/app/controllers/api/instances_controller.rb
+++ b/app/controllers/api/instances_controller.rb
@@ -140,8 +140,12 @@ module Api
     end
 
     def validate_instance_for_action(instance, action)
-      validation = instance.send("validate_#{action}")
-      action_result(validation[:available], validation[:message].to_s)
+      if instance.respond_to?("supports_#{action}?")
+        action_result(instance.public_send("supports_#{action}?"), instance.unsupported_reason(action.to_sym))
+      else
+        validation = instance.send("validate_#{action}")
+        action_result(validation[:available], validation[:message].to_s)
+      end
     end
 
     def suspend_instance(instance)

--- a/app/controllers/api/vms_controller.rb
+++ b/app/controllers/api/vms_controller.rb
@@ -235,8 +235,12 @@ module Api
     end
 
     def validate_vm_for_action(vm, action)
-      validation = vm.send("validate_#{action}")
-      action_result(validation[:available], validation[:message].to_s)
+      if vm.respond_to?("supports_#{action}?")
+        action_result(vm.public_send("supports_#{action}?"), vm.unsupported_reason(action.to_sym))
+      else
+        validation = vm.send("validate_#{action}")
+        action_result(validation[:available], validation[:message].to_s)
+      end
     end
 
     def validate_vm_for_remote_console(vm, protocol = nil)

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations.rb
@@ -1,4 +1,6 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations
+  extend ActiveSupport::Concern
+
   include_concern 'Guest'
   include_concern 'Power'
 

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/guest.rb
@@ -1,6 +1,11 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Guest
-  def validate_reboot_guest
-    validate_vm_control_powered_on
+  extend ActiveSupport::Concern
+
+  included do
+    supports :reboot_guest do
+      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+    end
   end
 
   def raw_reboot_guest

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
@@ -1,5 +1,6 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations
   extend ActiveSupport::Concern
+
   include_concern 'Guest'
   include_concern 'Power'
   include_concern 'Relocation'

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
@@ -1,6 +1,11 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Guest
-  def validate_reboot_guest
-    validate_vm_control_powered_on
+  extend ActiveSupport::Concern
+
+  included do
+    supports :reboot_guest do
+      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+    end
   end
 
   def validate_reset

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations.rb
@@ -1,3 +1,5 @@
 module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations
+  extend ActiveSupport::Concern
+
   include_concern 'Guest'
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -1,17 +1,22 @@
 module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
+  extend ActiveSupport::Concern
+
+  included do
+    supports :reboot_guest do
+      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+    end
+  end
+
   def validate_shutdown_guest
     msg = validate_vm_control
     return {:available => msg[0], :message => msg[1]} unless msg.nil?
-    return {:available => true,   :message => ''}     if tools_status && tools_status == 'toolsNotInstalled'
-    return {:available => true,   :message => nil}    if current_state == 'on'
-    {:available => false,  :message => 'The VM is not powered on'}
+    return {:available => true, :message => ''} if tools_status && tools_status == 'toolsNotInstalled'
+    return {:available => true, :message => nil} if current_state == 'on'
+    {:available => false, :message => 'The VM is not powered on'}
   end
 
   def validate_standby_guest
-    validate_vm_control_powered_on
-  end
-
-  def validate_reboot_guest
     validate_vm_control_powered_on
   end
 

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -27,10 +27,6 @@ module MiqTemplate::Operations
     validate_invalid_for_template(_("Standby Guest Operation"))
   end
 
-  def validate_reboot_guest
-    validate_invalid_for_template(_("Reboot Guest Operation"))
-  end
-
   def validate_reset
     validate_invalid_for_template(_("Reset Operation"))
   end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -72,6 +72,7 @@ module SupportsFeatureMixin
     :live_migrate             => 'Live Migration',
     :migrate                  => 'Migration',
     :provisioning             => 'Provisioning',
+    :reboot_guest             => 'Reboot Guest Operation',
     :reconfigure              => 'Reconfiguration',
     :regions                  => 'Regions of a Provider',
     :resize                   => 'Resizing',
@@ -96,7 +97,7 @@ module SupportsFeatureMixin
   end
 
   def self.reason_or_default(reason)
-    reason.present? ? reason : _("Feature not supported")
+    reason.present? ? reason : _("Feature not available/supported")
   end
 
   # query instance for the reason why the feature is unsupported

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -7,10 +7,6 @@ module Vm::Operations::Guest
     validate_unsupported("Standby Guest Operation")
   end
 
-  def validate_reboot_guest
-    validate_unsupported("Reboot Guest Operation")
-  end
-
   def validate_reset
     validate_unsupported("Reset Guest Operation")
   end

--- a/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
+++ b/spec/helpers/application_helper/buttons/generic_feature_button_with_disable_spec.rb
@@ -5,7 +5,11 @@ describe ApplicationHelper::Button::GenericFeatureButtonWithDisable do
       context "when vm supports feature #{feature}" do
         before do
           @record = FactoryGirl.create(:vm_vmware)
-          allow(@record).to receive(:is_available?).with(feature).and_return(true)
+          if @record.respond_to?("supports_#{feature}?")
+            allow(@record).to receive("supports_#{feature}?").and_return(true)
+          else
+            allow(@record).to receive(:is_available?).with(feature).and_return(true)
+          end
         end
 
         it "will not be skipped for this vm" do

--- a/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
+++ b/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb
@@ -1,30 +1,51 @@
 shared_examples_for "Vm operation is available when not powered on" do
   it "when powered on" do
     vm.update_attributes(:raw_power_state => power_state_on)
-    expect(vm.is_available?(state)).to be_falsey
+    if vm.respond_to?("supports_#{state}?")
+      expect(vm.public_send("supports_#{state}?")).to be_falsey
+    else
+      expect(vm.is_available?(state)).to be_falsey
+    end
   end
 
   it "when not powered on" do
     vm.update_attributes(:raw_power_state => power_state_suspended)
-    expect(vm.is_available?(state)).to be_truthy
+    if vm.respond_to?("supports_#{state}?")
+      expect(vm.public_send("supports_#{state}?")).to be_truthy
+    else
+      expect(vm.is_available?(state)).to be_truthy
+    end
   end
 end
 
 shared_examples_for "Vm operation is available when powered on" do
   it "when powered on" do
     vm.update_attributes(:raw_power_state => power_state_on)
-    expect(vm.is_available?(state)).to be_truthy
+    if vm.respond_to?("supports_#{state}?")
+      expect(vm.public_send("supports_#{state}?")).to be_truthy
+    else
+      expect(vm.is_available?(state)).to be_truthy
+    end
   end
 
   it "when not powered on" do
     vm.update_attributes(:raw_power_state => power_state_suspended)
-    expect(vm.is_available?(state)).to be_falsey
+    if vm.respond_to?("supports_#{state}?")
+      expect(vm.public_send("supports_#{state}?")).to be_falsey
+    else
+      expect(vm.is_available?(state)).to be_falsey
+    end
   end
 end
 
 shared_examples_for "Vm operation is not available" do
   it "is not available" do
-    expect(vm.is_available?(state)).to be_falsey
-    expect(vm.is_available_now_error_message(state)).to include("not available")
+    if vm.respond_to?("supports_#{state}?")
+      expect(vm.public_send("supports_#{state}?")).to be_falsey
+      expect(vm.unsupported_reason(state.to_sym)).to include("not available")
+    else
+      expect(vm.is_available?(state)).to be_falsey
+      expect(vm.is_available_now_error_message(state)).to include("not available")
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
To use SupportsFeatureMixin instead of AvailabilityMixin, removed instances of validate_reboot_guest method and added supports_rebot_guest method. Changed common methods to check whether given instance supports "supports_*" calls, and call methods accordingly. 

