### PR TITLE
[DARGA] Multiple fixed IP per network_port workaround

### DIFF
--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -201,7 +201,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
 
   def parse_network_port(network_port)
     uid                        = network_port.id
-    cloud_subnet_network_ports = network_port.properties.ip_configurations.map do |x|
+    cloud_subnet_network_ports = network_port.properties.ip_configurations.slice(0..0).map do |x|
       parse_cloud_subnet_network_port(x)
     end
 

--- a/app/models/manageiq/providers/openstack/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/refresh_parser.rb
@@ -212,7 +212,7 @@ module ManageIQ::Providers
 
     def parse_network_port(network_port)
       uid                        = network_port.id
-      cloud_subnet_network_ports = network_port.fixed_ips.map { |x| parse_cloud_subnet_network_port(x) }
+      cloud_subnet_network_ports = network_port.fixed_ips.slice(0..0).map { |x| parse_cloud_subnet_network_port(x) }
       device                     = find_device_object(network_port)
       security_groups            = network_port.security_groups.blank? ? [] : network_port.security_groups.map do |x|
         @data_index.fetch_path(:security_groups, x)


### PR DESCRIPTION
Purpose or Intent
-----------------
Each network_port can have multiple fixed ips from one subnet.
Our DB architecture limits that by unique index now, so we
need to limit it to 1 fixed IP per network port.

Steps for Testing/QA
--------------------
In Amazon, Azure and OpenStack, associate multiple fixed IPs to one interface. The refresh will fetch only the first one, but will not fail.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1373997
