### PR TITLE
Don't use interpolation if it's not required (core backend files)

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -106,7 +106,7 @@ module Authenticator
 
           unless identity
             msg = "Authentication failed for userid #{username}, unable to find user object in #{self.class.proper_name}"
-            _log.warn("#{msg}")
+            _log.warn(msg)
             AuditEvent.failure(audit.merge(:message => msg))
             task.error(msg)
             task.state_finished
@@ -122,7 +122,7 @@ module Authenticator
           if matching_groups.empty?
             msg = "Authentication failed for userid #{user.userid}, unable to match user's group membership to an EVM role"
             AuditEvent.failure(audit.merge(:message => msg))
-            _log.warn("#{msg}")
+            _log.warn(msg)
             task.error(msg)
             task.state_finished
             user.save! unless user.new_record?

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -143,7 +143,7 @@ class Chargeback < ActsAsArModel
     when "monthly"
       s_ts = ts.beginning_of_month
       e_ts = ts.end_of_month
-      [s_ts, e_ts, "#{s_ts.strftime("%b %Y")}"]
+      [s_ts, e_ts, s_ts.strftime("%b %Y")]
     else
       raise _("interval '%{interval}' is not supported") % {:interval => interval}
     end

--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -27,11 +27,11 @@ class CloudNetwork < ApplicationRecord
 
   # Define all getters and setters for extra_attributes related virtual columns
   %i(maximum_transmission_unit port_security_enabled).each do |action|
-	  define_method("#{action.to_s}=") do |value|
+	  define_method("#{action}=") do |value|
       extra_attributes_save(action, value)
     end
 
-    define_method("#{action.to_s}") do
+    define_method(action) do
       extra_attributes_load(action)
     end
   end

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -30,11 +30,11 @@ class CloudSubnet < ApplicationRecord
 
   # Define all getters and setters for extra_attributes related virtual columns
   %i(allocation_pools host_routes ip_version subnetpool_id).each do |action|
-    define_method("#{action.to_s}=") do |value|
+    define_method("#{action}=") do |value|
       extra_attributes_save(action, value)
     end
 
-    define_method("#{action.to_s}") do
+    define_method(action) do
       extra_attributes_load(action)
     end
   end

--- a/app/models/file_depot_ftp.rb
+++ b/app/models/file_depot_ftp.rb
@@ -20,7 +20,7 @@ class FileDepotFtp < FileDepot
         upload(file.local_file, destination_file)
       rescue => err
         msg = "Error '#{err.message.chomp}', writing to FTP: [#{uri}], Username: [#{authentication_userid}]"
-        _log.error("#{msg}")
+        _log.error(msg)
         raise _("Error '%{message}', writing to FTP: [%{uri}], Username: [%{id}]") % {:message => err.message.chomp,
                                                                                       :uri     => uri,
                                                                                       :id      => authentication_userid}

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -70,7 +70,7 @@ class Hardware < ApplicationRecord
       begin
         parent.hardware.send("m_#{e.name}", parent, e, deletes) if parent.hardware.respond_to?("m_#{e.name}")
       rescue => err
-        _log.warn "#{err}"
+        _log.warn err.to_s
       end
     end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -355,7 +355,7 @@ class Host < ApplicationRecord
       data  = event.attributes["full_data"]
       prevented = data.fetch_path(:policy, :prevented) if data
     end
-    prevented ? _log.info("#{event.attributes["message"]}") : send(*action)
+    prevented ? _log.info((event.attributes["message"]).to_s) : send(*action)
   end
 
   def ipmi_power_on
@@ -809,7 +809,7 @@ class Host < ApplicationRecord
     rescue Net::SSH::HostKeyMismatch
       raise # Re-raise the error so the UI can prompt the user to allow the keys to be reset.
     rescue Exception => err
-      _log.warn("#{err.inspect}")
+      _log.warn(err.inspect)
       raise MiqException::MiqHostError, _("Unexpected response returned from system, see log for details")
     else
       true

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -130,7 +130,7 @@ class Job < ApplicationRecord
 
   def process_error(*args)
     message, status = args
-    _log.error "#{message}"
+    _log.error message.to_s
     set_status(message, status, 1)
   end
 
@@ -183,7 +183,7 @@ class Job < ApplicationRecord
           job.timeout!
         end
     rescue Exception
-      _log.error("#{$!}")
+      _log.error($!.to_s)
     end
   end
 

--- a/app/models/lifecycle_event.rb
+++ b/app/models/lifecycle_event.rb
@@ -4,7 +4,7 @@ class LifecycleEvent < ApplicationRecord
   include UuidMixin
 
   def self.create_event(vm, event_hash)
-    _log.debug("#{event_hash.inspect}")
+    _log.debug(event_hash.inspect)
 
     # Update the location if not provided by getting the value from the vm
     event_hash[:location] = vm.path if event_hash[:location].blank? && !vm.blank?

--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -44,7 +44,7 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
 
     status_message = "completed; post provision work queued" if clone_status
     message = "Clone of #{clone_direction} is #{status_message}"
-    _log.info("#{message}")
+    _log.info(message)
     update_and_notify_parent(:message => message)
 
     if clone_status

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers
       "cpu_usage_rate_average"     => {
         :counter_key           => "cpu_usage_rate_average",
         :instance              => "",
-        :capture_interval      => "#{INTERVAL}",
+        :capture_interval      => INTERVAL.to_s,
         :precision             => 1,
         :rollup                => "average",
         :unit_key              => "percent",
@@ -20,7 +20,7 @@ module ManageIQ::Providers
       "mem_usage_absolute_average" => {
         :counter_key           => "mem_usage_absolute_average",
         :instance              => "",
-        :capture_interval      => "#{INTERVAL}",
+        :capture_interval      => INTERVAL.to_s,
         :precision             => 1,
         :rollup                => "average",
         :unit_key              => "percent",
@@ -29,7 +29,7 @@ module ManageIQ::Providers
       "net_usage_rate_average" => {
         :counter_key           => "net_usage_rate_average",
         :instance              => "",
-        :capture_interval      => "#{INTERVAL}",
+        :capture_interval      => INTERVAL.to_s,
         :precision             => 2,
         :rollup                => "average",
         :unit_key              => "datagramspersecond",

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -120,17 +120,17 @@ module ManageIQ::Providers
       begin
         with_provider_connection(:use_broker => false, :auth_type => auth_type) {}
       rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH
-        _log.warn("#{$!.inspect}")
+        _log.warn($!.inspect)
         raise MiqException::MiqUnreachableError, $!.message
       rescue Handsoap::Fault
-        _log.warn("#{$!.inspect}")
+        _log.warn($!.inspect)
         if $!.respond_to?(:reason)
           raise MiqException::MiqInvalidCredentialsError, $!.reason if $!.reason =~ /Authorize Exception|incorrect user name or password/
           raise $!.reason
         end
         raise $!.message
       rescue Exception
-        _log.warn("#{$!.inspect}")
+        _log.warn($!.inspect)
         raise "Unexpected response returned from #{ui_lookup(:table => "ext_management_systems")}, see log for details"
       end
 

--- a/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/host_esx.rb
@@ -118,14 +118,14 @@ class ManageIQ::Providers::Vmware::InfraManager::HostEsx < ManageIQ::Providers::
     rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH => err
       raise MiqException::MiqUnreachableError, err.message
     rescue Handsoap::Fault => err
-      _log.warn("#{err.inspect}")
+      _log.warn(err.inspect)
       if err.respond_to?(:reason)
         raise MiqException::MiqInvalidCredentialsError, err.reason if err.reason =~ /Authorize Exception|incorrect user name or password/
         raise err.reason
       end
       raise err.message
     rescue Exception => err
-      _log.warn("#{err.inspect}")
+      _log.warn(err.inspect)
       raise "Unexpected response returned from system, see log for details"
     else
       true

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -74,7 +74,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
       _log.info "#{property} was set to #{value} (#{value.class})"
       obj.send("#{property}=", value)
     else
-      value = obj.send("#{property}")
+      value = obj.send(property.to_s)
       if value.nil?
         _log.info "#{property} was NOT set due to nil"
       else

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/customization.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/customization.rb
@@ -242,7 +242,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Customization
       end
       obj.send("#{property}=", pwd_hash)
     else
-      value = obj.send("#{property}")
+      value = obj.send(property.to_s)
       if value.nil?
         _log.info "#{pwd_type} password was NOT set"
       else

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
 
     status_message = "completed; post provision work queued" if clone_status
     message = "Clone of #{clone_direction} is #{status_message}"
-    _log.info("#{message}")
+    _log.info(message.to_s)
     update_and_notify_parent(:message => message)
 
     if clone_status

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1625,7 +1625,7 @@ module ManageIQ::Providers
 
           # Process each Firewall Rule
           data['rule'].each do |rule|
-            rule_string = rule['endPort'].nil? ? "#{rule['port']}" : "#{rule['port']}-#{rule['endPort']}"
+            rule_string = rule['endPort'].nil? ? rule['port'].to_s : "#{rule['port']}-#{rule['endPort']}"
             rule_string << " (#{rule['protocol']}-#{rule['direction']})"
             result << {
               :name          => "#{data['key']} #{rule_string}",

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -206,7 +206,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
       _log.info "#{property} was set to #{value} (#{value.class})"
       obj.send("#{property}=", value)
     else
-      value = obj.send("#{property}")
+      value = obj.send(property.to_s)
       if value.nil?
         _log.info "#{property} was NOT set due to nil"
       else

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -257,7 +257,7 @@ class MiqAction < ApplicationRecord
         # ${Object.method}
         if what == "object"
           if method == "type"
-            subst = "#{rec.class}"
+            subst = rec.class.to_s
           elsif method == "ems" && rec.respond_to?(:ext_management_system)
             ems = rec.ext_management_system
             subst = "vCenter #{ems.hostname}/#{ems.ipaddress}" unless ems.nil?

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -539,7 +539,7 @@ class MiqAlert < ApplicationRecord
     begin
       result = MiqAeEvent.eval_alert_expression(target, aevent)
     rescue => err
-      _log.error("#{err.message}")
+      _log.error(err.message)
       result = false
     end
     result

--- a/app/models/miq_provision/automate.rb
+++ b/app/models/miq_provision/automate.rb
@@ -144,7 +144,7 @@ module MiqProvision::Automate
           :deliver_on  => Time.now.utc + interval
         )
         message = "Request [#{ae_message}] has been re-queued for processing in #{interval} seconds"
-        _log.info("#{message}")
+        _log.info(message)
         update_and_notify_parent(:state => "queued", :status => "Ok", :message => message)
         return false
       end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -122,7 +122,7 @@ class MiqQueue < ApplicationRecord
     end
 
     msg = MiqQueue.create!(options)
-    _log.info("#{MiqQueue.format_full_log_msg(msg)}")
+    _log.info(MiqQueue.format_full_log_msg(msg))
     msg
   end
 

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -40,7 +40,7 @@ module MiqReport::ImportExport
         rep = MiqReport.new(report)
         result = {:message => "Imported Report: [#{report["name"]}]", :level => :info, :status => :add}
       end
-      _log.info("#{msg}")
+      _log.info(msg)
 
       if options[:save] && result[:status].in?([:add, :update])
         rep.save!

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -198,7 +198,7 @@ class MiqRequest < ApplicationRecord
       execute
     rescue => err
       _log.error("#{err.message}, attempting to execute request: [#{description}]")
-      _log.error("#{err.backtrace.join("\n")}")
+      _log.error(err.backtrace.join("\n"))
     end
 
     true

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -186,7 +186,7 @@ class MiqRequestTask < ApplicationRecord
 
     begin
       message = "#{request_class::TASK_DESCRIPTION} initiated"
-      _log.info("#{message}")
+      _log.info(message)
       update_and_notify_parent(:message => message)
 
       # Process the request

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -890,7 +890,7 @@ class MiqRequestWorkflow
 
   def get_ems_folders(folder, dh = {}, full_path = "")
     if folder.evm_object_class == :EmsFolder && !folder.hidden
-      full_path += full_path.blank? ? "#{folder.name}" : " / #{folder.name}"
+      full_path += full_path.blank? ? folder.name.to_s : " / #{folder.name}"
       dh[folder.id] = full_path unless folder.type == "Datacenter"
     end
 
@@ -906,7 +906,7 @@ class MiqRequestWorkflow
     if node.kind_of?(XmlHash::Element)
       folder = node.attributes[:object]
       if node.name == :ResourcePool
-        full_path += full_path.blank? ? "#{folder.name}" : " / #{folder.name}"
+        full_path += full_path.blank? ? folder.name.to_s : " / #{folder.name}"
         dh[folder.id] = full_path
       end
     end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -520,7 +520,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
         end
       rescue Exception => err
         msg = "Error adjusting schedules: #{err.message}"
-        _log.error("#{msg}")
+        _log.error(msg)
         _log.log_backtrace(err)
         do_exit("#{msg}. Restarting.", 1)
       end
@@ -549,7 +549,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       rescue ActiveRecord::StatementInvalid, SystemExit
         raise
       rescue Exception => err
-        _log.error("#{err.message}")
+        _log.error(err.message)
         _log.log_backtrace(err)
       end
       Thread.pass

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -118,7 +118,7 @@ class MiqServer < ApplicationRecord
     MiqEvent.raise_evm_event(self, "evm_server_start")
 
     msg = "Server starting in #{self.class.startup_mode} mode."
-    _log.info("#{msg}")
+    _log.info(msg)
     puts "** #{msg}"
 
     starting_server_record
@@ -265,7 +265,7 @@ class MiqServer < ApplicationRecord
     unless self.is_deleteable?
       msg = @error_message
       @error_message = nil
-      _log.error("#{msg}")
+      _log.error(msg)
       raise _(msg)
     end
   end
@@ -354,7 +354,7 @@ class MiqServer < ApplicationRecord
     # A SystemExit would be caught below, so we need to explicitly rescue/raise.
     raise
   rescue Exception => err
-    _log.error("#{err.message}")
+    _log.error(err.message)
     _log.log_backtrace(err)
 
     begin

--- a/app/models/miq_smis_agent.rb
+++ b/app/models/miq_smis_agent.rb
@@ -125,11 +125,10 @@ class MiqSmisAgent < StorageManager
       # this seems to be due to some strange interaction between WBEM and Rails.
       # This is only a problem in the verify failure case.
       #
-      _log.warn("#{$!.inspect}")
+      _log.warn($!.inspect)
       raise $!.message
     rescue Exception
-      _log.warn("#{$!.inspect}")
-      # $log.info $!.backtrace.join("\n")
+      _log.warn($!.inspect)
       raise _("Unexpected response returned from %{table}, see log for details") %
               {:table => ui_lookup(:table => "ext_management_systems")}
     else
@@ -159,7 +158,7 @@ class MiqSmisAgent < StorageManager
         agent.connect
         agent.update_stats
       rescue Exception => err
-        _log.warn "#{err}"
+        _log.warn err.to_s
         $log.warn err.backtrace.join("\n")
         next
       ensure
@@ -175,7 +174,7 @@ class MiqSmisAgent < StorageManager
       begin
         spRn = @conn.GetInstance(me.obj_name, :LocalNamespacePath => me.namespace, :PropertyList => ['HealthState', 'OperationalStatus'])
       rescue Exception => err
-        _log.error "#{err}"
+        _log.error err.to_s
         _log.error "obj_name: #{me.obj_name}"
         next
       end
@@ -206,7 +205,7 @@ class MiqSmisAgent < StorageManager
         agent.connect
         agent.update_status
       rescue Exception => err
-        _log.warn "#{err}"
+        _log.warn err.to_s
         $log.warn err.backtrace.join("\n")
         next
       ensure

--- a/app/models/mixins/ontap_metrics_rollup_mixin.rb
+++ b/app/models/mixins/ontap_metrics_rollup_mixin.rb
@@ -124,7 +124,7 @@ module OntapMetricsRollupMixin
   end
 
   def hourly_rollup(rollup_time, metric_list)
-    _log.info "#{rollup_time}"
+    _log.info rollup_time.to_s
     self.statistic_time = rollup_time
     self.rollup_type  = "hourly"
 
@@ -181,7 +181,7 @@ module OntapMetricsRollupMixin
   end
 
   def daily_rollup(rollup_time, time_profile, metric_list)
-    _log.info "#{rollup_time}"
+    _log.info rollup_time.to_s
     self.statistic_time = rollup_time
     self.time_profile = time_profile
     self.rollup_type  = "daily"

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -95,7 +95,7 @@ module RetirementMixin
 
   def raise_retire_audit_event(message)
     event_name = "#{retirement_event_prefix}_scheduled_to_retire"
-    _log.info("#{message}")
+    _log.info(message.to_s)
     raise_audit_event(event_name, message)
   end
 

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -357,7 +357,7 @@ module ScanningMixin
         end
       end
     rescue => syncErr
-      _log.error "#{syncErr}"
+      _log.error syncErr.to_s
       _log.debug { syncErr.backtrace.join("\n") }
     ensure
       if bb

--- a/app/models/netapp_rcu.rb
+++ b/app/models/netapp_rcu.rb
@@ -212,7 +212,7 @@ class NetappRcu < StorageManager
     $log.error hserr.backtrace.join("\n")
     raise
   rescue => err
-    _log.error "#{err}"
+    _log.error err.to_s
     $log.error err.backtrace.join("\n")
     raise
   end

--- a/app/models/netapp_remote_service.rb
+++ b/app/models/netapp_remote_service.rb
@@ -235,7 +235,7 @@ class NetappRemoteService < StorageManager
         agent.connect
         agent.update_metrics(statistic_time)
       rescue Exception => err
-        _log.warn "#{err}"
+        _log.warn err.to_s
         $log.warn err.backtrace.join("\n")
         next
       ensure
@@ -257,7 +257,7 @@ class NetappRemoteService < StorageManager
       begin
         agent.rollup_hourly_metrics(rollup_time)
       rescue Exception => err
-        _log.warn "#{err}"
+        _log.warn err.to_s
         $log.warn err.backtrace.join("\n")
         next
       ensure
@@ -295,7 +295,7 @@ class NetappRemoteService < StorageManager
       begin
         agent.rollup_daily_metrics(rollup_time, time_profile)
       rescue Exception => err
-        _log.warn "#{err}"
+        _log.warn err.to_s
         $log.warn err.backtrace.join("\n")
         next
       ensure
@@ -531,10 +531,10 @@ class NetappRemoteService < StorageManager
       volume_list_info
       disconnect
     rescue NetAppManageability::Error, NameError, Errno::ETIMEDOUT, Errno::ENETUNREACH
-      _log.warn("#{$!.inspect}")
+      _log.warn($!.inspect)
       raise $!.message
     rescue Exception
-      _log.warn("#{$!.inspect}")
+      _log.warn($!.inspect)
       raise _("Unexpected response returned from %{table}, see log for details") %
               {:table => ui_lookup(:table => "storage_managers")}
     else

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -51,11 +51,11 @@ class NetworkPort < ApplicationRecord
   # Define all getters and setters for extra_attributes related virtual columns
   %i(binding_virtual_interface_details binding_virtual_nic_type binding_profile extra_dhcp_opts
      allowed_address_pairs fixed_ips).each do |action|
-	  define_method("#{action.to_s}=") do |value|
+	  define_method("#{action}=") do |value|
       extra_attributes_save(action, value)
     end
 
-    define_method("#{action.to_s}") do
+    define_method(action) do
       extra_attributes_load(action)
     end
   end

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -29,11 +29,11 @@ class NetworkRouter < ApplicationRecord
 
   # Define all getters and setters for extra_attributes related virtual columns
   %i(external_gateway_info distributed routes high_availability).each do |action|
-    define_method("#{action.to_s}=") do |value|
+    define_method("#{action}=") do |value|
       extra_attributes_save(action, value)
     end
 
-    define_method("#{action.to_s}") do
+    define_method(action) do
       extra_attributes_load(action)
     end
   end

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -23,9 +23,9 @@ class RssFeed < ApplicationRecord
 
     options = {
       :feed => {
-        :title       => "#{title}",
+        :title       => title.to_s,
         :link        => "#{host_url}#{link}",
-        :description => "#{description}"
+        :description => description.to_s
       },
       :item => {
         :title       => proc { |rec| RssFeed.eval_item_attr(self.options[:item_title], rec) },

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -81,12 +81,12 @@ class ServiceTemplateProvisionTask < MiqRequestTask
   def do_request
     if miq_request_tasks.size.zero?
       message = "Service does not have children processes"
-      _log.info("#{message}")
+      _log.info(message)
       update_and_notify_parent(:state => 'provisioned', :message => message)
     else
       miq_request_tasks.each(&:deliver_to_automate)
       message = "Service Provision started"
-      _log.info("#{message}")
+      _log.info(message)
       update_and_notify_parent(:message => message)
       queue_post_provision
     end

--- a/app/models/snia_file_share.rb
+++ b/app/models/snia_file_share.rb
@@ -263,7 +263,7 @@ class SniaFileShare < MiqCimInstance
   def queue_create_datastore(ds_name, hosts)
     unless /^[a-zA-Z0-9\-]+$/ =~ ds_name
       message          = "#{ds_name} is not valid"
-      _log.error("#{message}")
+      _log.error(message)
       errors.add("name", message)
       return false
     end
@@ -272,7 +272,7 @@ class SniaFileShare < MiqCimInstance
     nrs       = storage_system.storage_managers.first
     if nrs.nil?
       message   = "No available manager entry for NetApp filer: #{evm_display_name}"
-      _log.error("#{message}")
+      _log.error(message)
       errors.add("netapp_filer", message)
       return false
     end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -272,7 +272,7 @@ class Storage < ApplicationRecord
     end
 
     if scan_complete?(miq_task)
-      _log.info "#{scan_complete_message(miq_task)}"
+      _log.info scan_complete_message(miq_task).to_s
       return
     end
 
@@ -540,7 +540,7 @@ class Storage < ApplicationRecord
     hosts = active_hosts_with_authentication_status_ok_in_zone(MiqServer.my_zone)
     if hosts.empty?
       message = "There are no active Hosts with valid credentials connected to Storage: [#{name}] in Zone: [#{MiqServer.my_zone}]."
-      _log.warn "#{message}"
+      _log.warn message
       raise MiqException::MiqUnreachableStorage,
             _("There are no active Hosts with valid credentials connected to Storage: [%{name}] in Zone: [%{zone}].") %
               {:name => name, :zone => MiqServer.my_zone}

--- a/app/models/storage_manager.rb
+++ b/app/models/storage_manager.rb
@@ -125,7 +125,7 @@ class StorageManager < ApplicationRecord
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_OK"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_OK)
     rescue Exception => err
-      _log.error "#{err}"
+      _log.error err.to_s
       $log.error err.backtrace.join("\n")
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_FAILED"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_FAILED)
@@ -162,7 +162,7 @@ class StorageManager < ApplicationRecord
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_OK"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_OK)
     rescue Exception => err
-      _log.error "#{err}"
+      _log.error err.to_s
       $log.error err.backtrace.join("\n")
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_FAILED"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_FAILED)
@@ -211,7 +211,7 @@ class StorageManager < ApplicationRecord
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_OK"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_OK)
     rescue Exception => err
-      _log.error "#{err}"
+      _log.error err.to_s
       $log.error err.backtrace.join("\n")
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_FAILED"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_FAILED)
@@ -243,7 +243,7 @@ class StorageManager < ApplicationRecord
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_OK"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_OK)
     rescue Exception => err
-      _log.error "#{err}"
+      _log.error err.to_s
       $log.error err.backtrace.join("\n")
       _log.info "zone = #{zoneId} - STORAGE_UPDATE_FAILED"
       agent.update_attribute(:last_update_status, STORAGE_UPDATE_FAILED)

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -65,7 +65,7 @@ class Vm < VmOrTemplate
     pl = {}
     check = validate_collect_running_processes
     unless check[:message].nil?
-      _log.warn "#{check[:message]}"
+      _log.warn check[:message].to_s
       return pl
     end
 
@@ -79,7 +79,7 @@ class Vm < VmOrTemplate
           wmi = WMIHelper.connectServer(ipaddr, *cred)
           pl = MiqProcess.process_list_all(wmi) unless wmi.nil?
         rescue => wmi_err
-          _log.warn "#{wmi_err}"
+          _log.warn wmi_err.to_s
         end
         _log.info "Running processes for VM:[#{id}:#{name}]  Count:[#{pl.length}]"
       end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -353,7 +353,7 @@ class VmOrTemplate < ApplicationRecord
       data  = event.attributes["full_data"]
       prevented = data.fetch_path(:policy, :prevented) if data
     end
-    prevented ? _log.info("#{event.attributes["message"]}") : send(*action)
+    prevented ? _log.info(event.attributes["message"].to_s) : send(*action)
   end
 
   def enforce_policy(event, inputs = {}, options = {})

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -134,7 +134,7 @@ class VmScan < Job
             when :smartProxy, :skipped then "Request to log snapshot user event with EMS timed out."
             else "Request to create snapshot timed out"
             end
-      _log.error("#{msg}")
+      _log.error(msg)
       signal(:abort, msg, "error")
     end
   end
@@ -177,12 +177,12 @@ class VmScan < Job
       vm.scan_metadata(options[:categories], "taskid" => jobid, "host" => host, "args" => [YAML.dump(scan_args)])
     rescue Timeout::Error
       message = "timed out attempting to scan, aborting"
-      _log.error("#{message}")
+      _log.error(message)
       signal(:abort, message, "error")
       return
     rescue => message
-      _log.error("#{message}")
-      _log.error("#{message.backtrace.join("\n")}")
+      _log.error(message.to_s)
+      _log.error(message.backtrace.join("\n"))
       signal(:abort, message.message, "error")
     end
 
@@ -246,11 +246,11 @@ class VmScan < Job
             delete_snapshot(mor)
           end
         rescue => err
-          _log.error("#{err}")
+          _log.error(err.to_s)
           return
         rescue Timeout::Error
           msg = "Request to delete snapshot timed out"
-          _log.error("#{msg}")
+          _log.error(msg)
         end
 
         unless options[:snapshot] == :smartProxy
@@ -281,11 +281,11 @@ class VmScan < Job
                       )
     rescue Timeout::Error
       message = "timed out attempting to synchronize, aborting"
-      _log.error("#{message}")
+      _log.error(message)
       signal(:abort, message, "error")
       return
     rescue => message
-      _log.error("#{message}")
+      _log.error(message.to_s)
       signal(:abort, message.message, "error")
       return
     end
@@ -325,7 +325,7 @@ class VmScan < Job
           end
           unless request_docs.empty? || (request_docs.length != all_docs.length)
             message = "scan operation yielded no data. aborting"
-            _log.error("#{message}")
+            _log.error(message)
             signal(:abort, message, "error")
           else
             _log.info("sending :finish")
@@ -395,7 +395,7 @@ class VmScan < Job
                   {:table => ui_lookup(:table => "ext_management_systems")}
         end
       rescue => err
-        _log.error("#{err.message}")
+        _log.error(err.message)
         _log.debug err.backtrace.join("\n")
       end
     else

--- a/app/models/vm_synchronize.rb
+++ b/app/models/vm_synchronize.rb
@@ -23,11 +23,11 @@ class VmSynchronize < Job
       vm.sync_metadata(options[:categories], "taskid" => jobid, "host" => host)
     rescue Timeout::Error
       message = "timed out attempting to synchronize, aborting"
-      _log.error("#{message}")
+      _log.error(message)
       signal(:abort, message, "error")
       return
     rescue => message
-      _log.error("#{message}")
+      _log.error(message.to_s)
       signal(:abort, message.message, "error")
     end
 
@@ -59,7 +59,7 @@ class VmSynchronize < Job
           end
           unless request_docs.empty? || (request_docs.length != all_docs.length)
             message = "synchronize operation yielded no data. aborting"
-            _log.error("#{message}")
+            _log.error(message)
             signal(:abort, message, "error")
           else
             _log.info("sending :finish")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2824,7 +2824,7 @@ Vmdb::Application.routes.draw do
   controller_routes.each do |controller_name, controller_actions|
     # Default route with no action to controller's index action
     unless [:ems_cloud, :ems_infra, :ems_container, :ems_middleware].include?(controller_name)
-      match "#{controller_name}", :controller => controller_name, :action => :index, :via => :get
+      match controller_name.to_s, :controller => controller_name, :action => :index, :via => :get
     end
 
     # One-by-one get/post routes for defined controllers

--- a/gems/pending/RcuWebService/RcuService.rb
+++ b/gems/pending/RcuWebService/RcuService.rb
@@ -114,12 +114,12 @@ class RcuService < Handsoap::Service
       obj.each do |k, v|
         if v.kind_of? Array
           v.each do |av|
-            node.add "#{k}" do |i|
+            node.add k.to_s do |i|
               marshalObj(i, av)
             end
           end
         else
-          node.add "#{k}" do |i|
+          node.add k.to_s do |i|
             marshalObj(i, v)
           end
         end

--- a/gems/pending/VixDiskLib/VixDiskLibServer.rb
+++ b/gems/pending/VixDiskLib/VixDiskLibServer.rb
@@ -53,7 +53,7 @@ class VDDKFactory
   end
 
   def shut_down_service(msg)
-    $vim_log.info "#{msg}"
+    $vim_log.info msg.to_s
     VdlWrapper.__exit__ if @started
     @running = true
     $vim_log.info "VdlWrapper.__exit__ finished"
@@ -108,7 +108,7 @@ begin
   # Now write the URI used back to the parent (client) process to let it know which port was selected.
   #
   IO.open(3, 'w') do |uri_writer|
-    uri_writer.write "#{uri_used}"
+    uri_writer.write uri_used.to_s
   end
 
   proc_reader = IO.open(4, 'r')

--- a/gems/pending/fs/MiqFS/modules/Ext4.rb
+++ b/gems/pending/fs/MiqFS/modules/Ext4.rb
@@ -226,7 +226,7 @@ module Ext4
       dirObj = ifs_getDir(dir, miqfs)
       dirEnt = dirObj.nil? ? nil : dirObj.findEntry(fname)
     rescue RuntimeError => err
-      $log.error "#{err.message}" if $log
+      $log.error err.message.to_s if $log
       dirEnt = nil
     end
 

--- a/gems/pending/metadata/ScanProfile/modules/VmScanItemNteventlog.rb
+++ b/gems/pending/metadata/ScanProfile/modules/VmScanItemNteventlog.rb
@@ -19,7 +19,7 @@ module VmScanItemNteventlog
             ntevent = Win32EventLog.new(vm.rootTrees[0])
             ntevent.readAllLogs(d['content'])
           rescue MiqException::NtEventLogFormat
-            $log.warn "#{$!}"
+            $log.warn $!.to_s
           rescue => err
             $log.error "Win32EventLog: #{err}"
             $log.error err.backtrace.join("\n")

--- a/gems/pending/metadata/util/win32/ms-registry.rb
+++ b/gems/pending/metadata/util/win32/ms-registry.rb
@@ -209,7 +209,7 @@ class MSRegHive
     if nkHash[:type_display] == :SUB
       level += 1
       if fqName.nil?
-        fqName = "#{nkHash[:keyname].chomp}"
+        fqName = nkHash[:keyname].chomp
       else
         fqName += "\\#{nkHash[:keyname].chomp}"
       end

--- a/gems/pending/spec/util/postgres_admin_spec.rb
+++ b/gems/pending/spec/util/postgres_admin_spec.rb
@@ -15,7 +15,7 @@ describe PostgresAdmin do
      %w(template_directory APPLIANCE_TEMPLATE_DIRECTORY /some/path      true),
 
     ].each do |method, var, value, pathname_required|
-      it "#{method}" do
+      it method.to_s do
         ENV[var] = value
         result = described_class.public_send(method)
         if pathname_required

--- a/gems/pending/util/win32/miq-powershell.rb
+++ b/gems/pending/util/win32/miq-powershell.rb
@@ -78,7 +78,7 @@ module MiqPowerShell
     node = xml.find_first("//*/Property[@Name=\"Message\"]") if node.nil? || node.text.to_s.strip.empty?
     err_msg << "#{node.text} " unless node.nil?
     node = xml.find_first("//*/Property[@Name=\"PositionMessage\"]")
-    err_msg << "#{node.text}" unless node.nil?
+    err_msg << node.text.to_s unless node.nil?
     raise err_msg
   end
 

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -58,7 +58,7 @@ class EvmDatabaseOps
         _log.info("[#{db_opts[:dbname]}] with database size: [#{db_size} bytes], free space at [#{db_opts[:local_file]}]: [#{free_space} bytes]")
       else
         msg = "Destination location: [#{db_opts[:local_file]}], does not have enough free disk space: [#{free_space} bytes] for database of size: [#{db_size} bytes]"
-        _log.warn("#{msg}")
+        _log.warn(msg)
         MiqEvent.raise_evm_event_queue(MiqServer.my_server, "evm_server_db_backup_low_space", :event_details => msg)
         raise MiqException::MiqDatabaseBackupInsufficientSpace, msg
       end

--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -4,14 +4,14 @@ module RequireNested
     return if const_defined?(name, false)
 
     filename = "#{self}::#{name}".underscore
-    filename = "#{name}".underscore if self == Object
+    filename = name.to_s.underscore if self == Object
     if Rails.application.config.cache_classes
       autoload name, filename
     else
       require_dependency filename
     end
 
-    if ActiveSupport::Dependencies.search_for_file("#{name}".underscore) && self != Object
+    if ActiveSupport::Dependencies.search_for_file(name.to_s.underscore) && self != Object
       Object.require_nested name
     end
   end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -119,7 +119,7 @@ module MiqAeEngine
 
       if ws.nil? || ws.root.nil?
         message = "Error delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate: Empty Workspace"
-        _log.error("#{message}")
+        _log.error(message)
         return nil
       end
 
@@ -138,12 +138,12 @@ module MiqAeEngine
           options[:ae_state_previous] = YAML.dump(ws.current_state_info) unless ws.current_state_info.empty?
 
           message = "Requeuing #{options.inspect} for object [#{object_name}] with state [#{options[:state]}] to Automate for delivery in [#{ae_retry_interval}] seconds"
-          _log.info("#{message}")
+          _log.info(message)
           deliver_queue(options, :deliver_on => deliver_on)
         else
           if ae_result.casecmp('error').zero?
             message = "Error delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate: #{ws.root['ae_message']}"
-            _log.error("#{message}")
+            _log.error(message)
           end
           MiqAeEvent.process_result(ae_result, automate_attrs) if options[:instance_name].to_s.casecmp('EVENT').zero?
         end
@@ -152,7 +152,7 @@ module MiqAeEngine
       return ws
     rescue MiqAeException::Error => err
       message = "Error delivering #{automate_attrs.inspect} for object [#{object_name}] with state [#{state}] to Automate: #{err.message}"
-      _log.error("#{message}")
+      _log.error(message)
     ensure
       vmdb_object.after_ae_delivery(ae_result.to_s.downcase) if vmdb_object.respond_to?(:after_ae_delivery)
     end
@@ -212,7 +212,7 @@ module MiqAeEngine
 
   def self.create_automation_attribute_key(object, attr_name = nil)
     klass_name  = create_automation_attribute_class_name(object)
-    return "#{klass_name}" if automation_attribute_is_array?(klass_name)
+    return klass_name.to_s if automation_attribute_is_array?(klass_name)
     attr_name ||= create_automation_attribute_name(object)
     "#{klass_name}::#{attr_name}"
   end

--- a/lib/miq_automation_engine/models/miq_ae_method_yaml.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method_yaml.rb
@@ -10,7 +10,7 @@ class MiqAeMethodYaml
   def define_instance_variables
     @ae_method_obj['object']['attributes'].each do |k, v|
       instance_variable_set("@#{k}", v)
-      singleton_class.class_eval { attr_accessor "#{k}" }
+      singleton_class.class_eval { attr_accessor k.to_s }
       send("#{k}=", v)
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
@@ -121,7 +121,7 @@ module MiqAeMethodService
       $log.error hserr.backtrace.join("\n")
       raise
     rescue => err
-      _log.error "#{err}"
+      _log.error err.to_s
       $log.error err.backtrace.join("\n")
       raise
     end

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_mixin.rb
@@ -57,7 +57,7 @@ module MiqAeServiceMiqProvisionMixin
   end
 
   def set_vlan(vlan)
-    set_option(:vlan, ["#{vlan}", "#{vlan}"])
+    set_option(:vlan, [vlan.to_s, vlan.to_s])
   end
 
   def get_folder_paths

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -45,7 +45,7 @@ module ReportFormatter
     # report building methods
     def build_document_header
       super
-      type = c3_convert_type("#{mri.graph[:type]}")
+      type = c3_convert_type(mri.graph[:type].to_s)
       mri.chart = {
         :miqChart => type,
         :data     => {:columns => [], :names => {}},

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -192,7 +192,7 @@ module ReportFormatter
       output << "</table>"
 
       if mri.filter_summary
-        output << "#{mri.filter_summary}"
+        output << mri.filter_summary.to_s
       end
 
       #     output << "<div class='clr'></div>"

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -1,4 +1,4 @@
-$:.push("#{File.dirname(__FILE__)}")
+$:.push(File.dirname(__FILE__))
 require 'evm_application'
 
 namespace :evm do

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -90,7 +90,7 @@ module VMDB
           return start_time, end_time
         end
       rescue Exception => e
-        _log.error "#{e}"
+        _log.error e.to_s
         return []
       end
     end

--- a/lib/xmldata_helper.rb
+++ b/lib/xmldata_helper.rb
@@ -14,7 +14,7 @@ class XmlData < ActiveRecord::Base
     _log.info "request received from ems id: #{emsId}"
     handler = EventXmlHandler.new
     Document.parse_stream(data, handler)
-    $log.debug "#{handler.result.inspect}"
+    $log.debug handler.result.inspect
 
     handler.result.each { |event| eval "VmwareEmsEvent.#{event[:type]}(event)" }
   end

--- a/spec/automation/unit/method_validation/available_flavors_spec.rb
+++ b/spec/automation/unit/method_validation/available_flavors_spec.rb
@@ -7,7 +7,7 @@ describe "Available_Flavors Method Validation" do
 
   context "workspace has no service template" do
     it "provides only default value to the flavor list" do
-      ws = MiqAeEngine.instantiate("#{@ins}", user)
+      ws = MiqAeEngine.instantiate(@ins.to_s, user)
       expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end

--- a/spec/automation/unit/method_validation/available_images_spec.rb
+++ b/spec/automation/unit/method_validation/available_images_spec.rb
@@ -7,7 +7,7 @@ describe "Available_Images Method Validation" do
 
   context "workspace has no service template" do
     it "provides only default value to the image list" do
-      ws = MiqAeEngine.instantiate("#{@ins}", user)
+      ws = MiqAeEngine.instantiate(@ins.to_s, user)
       expect(ws.root["values"]).to eq(nil => default_desc)
       expect(ws.root["default_value"]).to be_nil
     end

--- a/spec/automation/unit/method_validation/available_resource_groups_spec.rb
+++ b/spec/automation/unit/method_validation/available_resource_groups_spec.rb
@@ -7,7 +7,7 @@ describe "Available_Resource_Groups Method Validation" do
 
   context "workspace has no service template" do
     it "provides only default value to the resource group list" do
-      ws = MiqAeEngine.instantiate("#{@ins}", user)
+      ws = MiqAeEngine.instantiate(@ins.to_s, user)
       expect(ws.root["values"]).to eq(nil => default_desc)
     end
   end

--- a/spec/automation/unit/method_validation/available_tenants_spec.rb
+++ b/spec/automation/unit/method_validation/available_tenants_spec.rb
@@ -6,7 +6,7 @@ describe "Available_Tenants Method Validation" do
 
   context "workspace has no service template" do
     it "provides only default value to the tenant list" do
-      ws = MiqAeEngine.instantiate("#{@ins}", user)
+      ws = MiqAeEngine.instantiate(@ins.to_s, user)
       expect(ws.root["values"]).to eq(nil => "<default>")
     end
   end

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -63,7 +63,7 @@ describe MiqAeEngine::MiqAeObject do
   end
 
   it "#process_args_as_attributes with a hash with an object reference" do
-    result = @miq_obj.process_args_as_attributes("VmOrTemplate::vm" => "#{@vm.id}")
+    result = @miq_obj.process_args_as_attributes("VmOrTemplate::vm" => @vm.id.to_s)
     expect(result["vm_id"]).to eq(@vm.id.to_s)
     expect(result["vm"]).to be_kind_of(MiqAeMethodService::MiqAeServiceVmOrTemplate)
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
@@ -35,7 +35,7 @@ module MiqAeServiceManageIQ_Providers_CloudManager_ProvisionSpec
           end
 
           %w(template clone_to_vm).each do |provision_type|
-            it "#{provision_type}" do
+            it provision_type.to_s do
               @miq_provision.update_attributes(:provision_type => provision_type)
               expect(ae_svc_prov.target_type).to eq('vm')
             end

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -11,8 +11,8 @@ describe AutomationRequest do
     @ae_var1     = "vvvv"
     @ae_var2     = "wwww"
     @ae_var3     = "xxxx"
-    @uri_parts   = {'instance' => "#{@ae_instance}", 'message' => "#{@ae_message}"}
-    @parameters  = {'var1' => "#{@ae_var1}", 'var2' => "#{@ae_var2}", 'var3' => "#{@ae_var3}"}
+    @uri_parts   = {'instance' => @ae_instance.to_s, 'message' => @ae_message.to_s}
+    @parameters  = {'var1' => @ae_var1.to_s, 'var2' => @ae_var2.to_s, 'var3' => @ae_var3.to_s}
   end
 
   it ".request_task_class" do
@@ -42,7 +42,7 @@ describe AutomationRequest do
       user_name = 'oleg'
 
       expect do
-        AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name" => "#{user_name}")
+        AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name" => user_name.to_s)
       end.to raise_error(ActiveRecord::RecordNotFound)
 
     end
@@ -50,7 +50,7 @@ describe AutomationRequest do
     it "with requester string overriding userid who is in the database" do
       ar = AutomationRequest.create_from_ws(@version, admin,
                                             @uri_parts, @parameters,
-                                            "user_name" => "#{@approver.userid}")
+                                            "user_name" => @approver.userid.to_s)
       expect(ar).to be_kind_of(AutomationRequest)
 
       expect(ar).to eq(AutomationRequest.first)
@@ -70,7 +70,7 @@ describe AutomationRequest do
     it "with requester string overriding userid AND auto_approval" do
       ar = AutomationRequest.create_from_ws(@version, admin,
                                             @uri_parts, @parameters,
-                                            "user_name" => "#{@approver.userid}", 'auto_approve' => 'true')
+                                            "user_name" => @approver.userid.to_s, 'auto_approve' => 'true')
       expect(ar).to be_kind_of(AutomationRequest)
 
       expect(ar).to eq(AutomationRequest.first)
@@ -155,10 +155,10 @@ describe AutomationRequest do
     end
 
     def deliver(zone_name)
-      parameters = {'miq_zone' => "#{zone_name}",
-                    'var1'     => "#{@ae_var1}",
-                    'var2'     => "#{@ae_var2}",
-                    'var3'     => "#{@ae_var3}"}
+      parameters = {'miq_zone' => zone_name.to_s,
+                    'var1'     => @ae_var1.to_s,
+                    'var2'     => @ae_var2.to_s,
+                    'var3'     => @ae_var3.to_s}
       AutomationRequest.create_from_ws(@version, @approver, @uri_parts, parameters, 'auto_approve' => 'true')
       MiqQueue.find_by(:method_name => "create_request_tasks").deliver
     end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -271,7 +271,7 @@ describe ExtManagementSystem do
 
     %w(total_vms_on total_vms_off total_vms_unknown total_vms_never total_vms_suspended).each do |vcol|
       it "should have virtual column #{vcol} " do
-        expect(described_class).to have_virtual_column "#{vcol}", :integer
+        expect(described_class).to have_virtual_column vcol.to_s, :integer
       end
     end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -21,7 +21,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
 
   it "will perform a full refresh on k8s" do
     2.times do # Run twice to verify that a second run with existing data does not change anything
-      VCR.use_cassette("#{described_class.name.underscore}") do # , :record => :new_episodes) do
+      VCR.use_cassette(described_class.name.underscore) do # , :record => :new_episodes) do
         EmsRefresh.refresh(@ems)
       end
       @ems.reload

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   it "will perform a full refresh on openshift" do
     2.times do
       @ems.reload
-      VCR.use_cassette("#{described_class.name.underscore}",
+      VCR.use_cassette(described_class.name.underscore,
                        :match_requests_on => [:path,]) do # , :record => :new_episodes) do
         EmsRefresh.refresh(@ems)
       end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -182,7 +182,7 @@ describe MiqGroup do
 
     %w(allocated_memory allocated_vcpu allocated_storage provisioned_storage).each do |vcol|
       it "should have virtual column #{vcol} " do
-        expect(described_class).to have_virtual_column "#{vcol}", :integer
+        expect(described_class).to have_virtual_column vcol.to_s, :integer
       end
     end
 

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -59,7 +59,7 @@ describe MiqProvisionWorkflow do
         it "should encrypt fields" do
           password_input = "secret"
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test', 'root_password' => password_input.to_s},
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test', 'root_password' => password_input.dup}, # dup because it's mutated
             {'owner_email' => 'admin'}, {'owner_first_name' => 'test'},
             {'owner_last_name' => 'test'}, nil, nil, nil, nil)
 

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -59,7 +59,7 @@ describe MiqProvisionWorkflow do
         it "should encrypt fields" do
           password_input = "secret"
           request = ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.from_ws(
-            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test', 'root_password' => "#{password_input}"},
+            "1.1", admin, {'name' => 'template'}, {'vm_name' => 'spec_test', 'root_password' => password_input.to_s},
             {'owner_email' => 'admin'}, {'owner_first_name' => 'test'},
             {'owner_last_name' => 'test'}, nil, nil, nil, nil)
 

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -21,7 +21,7 @@ shared_examples "custom_report_with_custom_attributes" do |base_report, custom_a
       :rpt_type  => "Custom",
       :db        => base_report == "Host" ? "Host" : "ManageIQ::Providers::InfraManager::Vm",
       :cols      => %w(name),
-      :include   => {"#{custom_attributes_field}" => {"columns" => %w(name value)}},
+      :include   => {custom_attributes_field.to_s => {"columns" => %w(name value)}},
       :col_order => %w(miq_custom_attributes.name miq_custom_attributes.value name),
       :headers   => ["EVM Custom Attribute Name", "EVM Custom Attribute Value", "Name"],
       :order     => "Ascending",

--- a/spec/models/sysprep_file_spec.rb
+++ b/spec/models/sysprep_file_spec.rb
@@ -8,7 +8,7 @@ describe SysprepFile do
 
   context "valid inputs" do
     ["INI", "XML"].each do |type|
-      context "#{type}" do
+      context type.to_s do
         it("allows string")    { expect(described_class.new(send("good_#{type.downcase}"))).to be_kind_of(SysprepFile) }
         it("allows IO stream") { expect(described_class.new(StringIO.new(send("good_#{type.downcase}")))).to be_kind_of(SysprepFile) }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -323,7 +323,7 @@ describe User do
 
     %w(allocated_memory allocated_vcpu allocated_storage provisioned_storage).each do |vcol|
       it "should have virtual column #{vcol} " do
-        expect(described_class).to have_virtual_column "#{vcol}", :integer
+        expect(described_class).to have_virtual_column vcol.to_s, :integer
       end
     end
   end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -392,7 +392,7 @@ describe VmOrTemplate do
     [:template_vmware, :vm_vmware].each do |vm_or_template|
       let(:instance) { FactoryGirl.create(vm_or_template) }
 
-      it "#{vm_or_template.to_s.classify}" do
+      it vm_or_template.to_s.classify do
         expect(EmsRefresh).to receive(:queue_refresh).with([[VmOrTemplate, instance.id]])
 
         instance.class.refresh_ems(instance.id)


### PR DESCRIPTION
Purpose or Intent
-----------------

Follow up to #11074, but for the core backend ruby files

Interpolation syntax can be error prone so don't use it when you can just
convert to string.

Prefer `variable.to_s` over `"#{variable}"`

Also, some places we use Array#join which returns a String already:
`"#{rate_detail.errors.full_messages.join(', ')}"`
Becomes:

`rate_detail.errors.full_messages.join(', ')`

Also, some places already created a message string but then wanted to interpolate
it for good measure:

```diff
msg = "Authentication failed for userid #{username}, unable to find user object in #{self.class.proper_name}"
-            _log.warn("#{msg}")
+            _log.warn(msg)
```

rubocop -a --only "Lint/StringConversionInInterpolation,Style/UnneededInterpolation" ...