### PR TITLE
Update ::Button::OrchestrationTemplateEditRemove methods

### DIFF
--- a/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
+++ b/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
@@ -1,15 +1,18 @@
 class ApplicationHelper::Button::OrchestrationTemplateEditRemove < ApplicationHelper::Button::Basic
+  needs_record
+
+  def disabled?
+    @record.in_use?
+  end
+
   def calculate_properties
     super
-    if @view_context.x_active_tree == :ot_tree && @record
-      if @record.in_use?
-        self[:enabled] = false
-        self[:title] = if self[:id] =~ /_edit$/
-                         N_('Orchestration Templates that are in use cannot be edited')
-                       else
-                         N_('Orchestration Templates that are in use cannot be removed')
-                       end
-      end
+    if disabled?
+      self[:title] = if self[:id] =~ /_edit$/
+                       N_('Orchestration Templates that are in use cannot be edited')
+                     else
+                       N_('Orchestration Templates that are in use cannot be removed')
+                     end
     end
   end
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -812,8 +812,6 @@ class ApplicationHelper::ToolbarBuilder
       else
         return !role_allows?(:feature => id)
       end
-    when "OrchestrationTemplate", "OrchestrationTemplateCfn", "OrchestrationTemplateHot", "OrchestrationTemplateAzure", "OrchestrationTemplateVnfd"
-      return true unless role_allows?(:feature => id)
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
       case id
       when "configured_system_provision"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1129,11 +1129,6 @@ class ApplicationHelper::ToolbarBuilder
       when "orchestration_stack_retire_now"
         return N_("Orchestration Stack is already retired") if @record.retired == true
       end
-    when "OrchestrationTemplateCfn", "OrchestrationTemplateHot", "OrchestrationTemplateAzure", "OrchestrationTemplateVnfd"
-      case id
-      when "orchestration_template_remove"
-        return N_("Read-only Orchestration Template cannot be deleted") if @record.in_use?
-      end
     when "Service"
       case id
       when "service_retire_now"


### PR DESCRIPTION
Purpose or Intent
-----------------
Updated already defined button class, used in Services/Catalogs/listnav 'Orchestration Templates'.

1st commit - Method ```calculate_properties``` in ```::Button::Basic``` class is calling the ```disabled?``` so let the setting of the enable flag there, just call ```disabled?``` defined in the class. Also remove the code from ```build_toolbar_disable_button``` in toolbar_builder.rb (that's the main goal of the refactoring).
```if @view_context.x_active_tree == :ot_tree && @record``` is not needed as I found the buttons of the class generated in ```ot_tree``` only. ```@record``` is checked before the ```calculate_properties``` method call.

2nd commit - role_allows? will be solved in https://github.com/ManageIQ/manageiq/pull/10942

Marking the PR as WIP as it needs to have solved PR mentioned above.

Links
-----
Parent issue: https://github.com/ManageIQ/manageiq/issues/6259