### PR TITLE
Don't use interpolation if it's not required (ae datastore fixture files)

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb
@@ -48,7 +48,7 @@ if vm_name.blank? || vm_name == 'changeme'
   derived_name = "#{vm_name}$n{3}"
 else
   if number_of_vms_being_provisioned == 1
-    derived_name = "#{vm_name}"
+    derived_name = vm_name.to_s
   else
     derived_name = "#{vm_name}$n{3}"
   end

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
@@ -4,7 +4,7 @@
 
 # Get objects
 msg = $evm.object['reason']
-$evm.log('info', "#{msg}")
+$evm.log('info', msg.to_s)
 
 # Raise automation event: request_pending
 $evm.root["miq_request"].pending

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Cluster/Operations/Methods.class/__methods__/cluster_workload_management.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Cluster/Operations/Methods.class/__methods__/cluster_workload_management.rb
@@ -34,7 +34,7 @@ def emailresults(vm_culprit, host_culprit, host_culprit_type, host_culprit_perce
   body += "<br><br>"
   body += "Thank You,"
   body += "<br><br>"
-  body += "#{signature}"
+  body += signature.to_s
   body += "<br>"
 
   # Send email

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
@@ -4,7 +4,7 @@
 
 # Get objects
 msg = $evm.object['reason']
-$evm.log('info', "#{msg}")
+$evm.log('info', msg.to_s)
 
 # Raise automation event: request_pending
 $evm.root["miq_request"].pending

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Operations/Methods.class/__methods__/host_evacuation.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Operations/Methods.class/__methods__/host_evacuation.rb
@@ -23,7 +23,7 @@ def emailresults(vmname, current_host, target_host)
   body += "<br><br>"
   body += "Thank You,"
   body += "<br><br>"
-  body += "#{signature}"
+  body += signature.to_s
   body += "<br>"
 
   $evm.log("info", "Sending email to <#{to}> from <#{from}> subject: <#{subject}>")

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Operations/Methods.class/__methods__/vm_placement_optimization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Operations/Methods.class/__methods__/vm_placement_optimization.rb
@@ -32,7 +32,7 @@ def emailresults(vmname, target_host, vm_host, vmotion, event_type)
   body += "<br><br>"
   body += "Thank You,"
   body += "<br><br>"
-  body += "#{signature}"
+  body += signature.to_s
   body += "<br>"
 
   $evm.log("info", "Sending email to <#{to}> from <#{from}> subject: <#{subject}>")

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Naming.class/__methods__/vmname.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Naming.class/__methods__/vmname.rb
@@ -48,7 +48,7 @@ if vm_name.blank? || vm_name == 'changeme'
   derived_name = "#{vm_name}$n{3}"
 else
   if number_of_vms_being_provisioned == 1
-    derived_name = "#{vm_name}"
+    derived_name = vm_name.to_s
   else
     derived_name = "#{vm_name}$n{3}"
   end

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/ProvisionRequestApproval.class/__methods__/pending_request.rb
@@ -4,7 +4,7 @@
 
 # Get objects
 msg = $evm.object['reason']
-$evm.log('info', "#{msg}")
+$evm.log('info', msg.to_s)
 
 # Raise automation event: request_pending
 $evm.root["miq_request"].pending

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogbundleinitialization.rb
@@ -7,7 +7,7 @@
 # Important - The dialog_parser automate method has to run prior to this in order to populate the dialog information.
 #
 def log_and_update_message(level, msg, update_message = false)
-  $evm.log(level, "#{msg}")
+  $evm.log(level, msg.to_s)
   @task.message = msg if @task && (update_message || level == 'error')
 end
 
@@ -23,12 +23,12 @@ def create_tags(category, single_value, tag)
     log_and_update_message(:info, "Category #{category_name} doesn't exist, creating category")
     $evm.execute('category_create', :name         => category_name,
                                     :single_value => single_value,
-                                    :description  => "#{category}")
+                                    :description  => category.to_s)
   end
   # if the tag exists else create it
   unless $evm.execute('tag_exists?', category_name, tag_name)
     log_and_update_message(:info, "Adding new tag #{tag_name} in Category #{category_name}")
-    $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
+    $evm.execute('tag_create', category_name, :name => tag_name, :description => tag.to_s)
   end
   log_and_update_message(:info, "Processing create_tags...Complete", true)
 end
@@ -104,6 +104,6 @@ begin
 
 rescue => err
   log_and_update_message(:error, "[#{err}]\n#{err.backtrace.join("\n")}")
-  @task.finished("#{err}") if @task
+  @task.finished(err.to_s) if @task
   exit MIQ_ABORT
 end

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb
@@ -7,7 +7,7 @@
 # Important - The dialog_parser automate method has to run prior to this in order to populate the dialog information.
 #
 def log_and_update_message(level, msg, update_message = false)
-  $evm.log(level, "#{msg}")
+  $evm.log(level, msg.to_s)
   @task.message = msg if @task && (update_message || level == 'error')
 end
 
@@ -21,12 +21,12 @@ def create_tags(category, single_value, tag)
     log_and_update_message(:info, "Creating Category: {#{category_name} => #{category}}")
     $evm.execute('category_create', :name         => category_name,
                                     :single_value => single_value,
-                                    :description  => "#{category}")
+                                    :description  => category.to_s)
   end
   # if the tag exists else create it
   return if $evm.execute('tag_exists?', category_name, tag_name)
   log_and_update_message(:info, "Creating tag: {#{tag_name} => #{tag}}")
-  $evm.execute('tag_create', category_name, :name => tag_name, :description => "#{tag}")
+  $evm.execute('tag_create', category_name, :name => tag_name, :description => tag.to_s)
 end
 
 def create_category_and_tags_if_necessary(dialog_tags_hash)
@@ -258,7 +258,7 @@ begin
 
 rescue => err
   log_and_update_message(:error, "[#{err}]\n#{err.backtrace.join("\n")}")
-  @task.finished("#{err}") if @task
+  @task.finished(err.to_s) if @task
   remove_service if @service
   exit MIQ_ABORT
 end

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvisionRequestApproval.class/__methods__/pending_request.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvisionRequestApproval.class/__methods__/pending_request.rb
@@ -4,7 +4,7 @@
 
 # Get objects
 msg = $evm.object['reason']
-$evm.log('info', "#{msg}")
+$evm.log('info', msg.to_s)
 
 # Raise automation event: request_pending
 $evm.root["miq_request"].pending

--- a/db/fixtures/miq_provision_naming.rb
+++ b/db/fixtures/miq_provision_naming.rb
@@ -20,7 +20,7 @@ module MiqProvisionNaming
     #   Single VM: Pass name from dialog through without modifying
     #   Multi-VM : Append 3 digit sequence number to the end of the name from the dialog
     if number_of_vms_being_provisioned == 1
-      "#{vm_name}"
+      vm_name.to_s
     else
       "#{vm_name}$n{3}"
     end

--- a/spec/lib/miq_automation_engine/data/root_domain/root/evm/AUTOMATE.class/__methods__/root_method.rb
+++ b/spec/lib/miq_automation_engine/data/root_domain/root/evm/AUTOMATE.class/__methods__/root_method.rb
@@ -4,6 +4,6 @@ begin
             $evm.log("info", "#{@method} - Root:<$evm.root> Attributes - #{k}: #{v}")
           end
           $evm.log("info", "#{@method} - Root:<$evm.root> End Attributes")
-          $evm.log("info", "#{$evm.class.name}")
+          $evm.log("info", $evm.class.name)
           $evm.root['method_executed']  = "root"
         end

--- a/spec/lib/miq_automation_engine/data/user_domain/user/evm/AUTOMATE.class/__methods__/root_method.rb
+++ b/spec/lib/miq_automation_engine/data/user_domain/user/evm/AUTOMATE.class/__methods__/root_method.rb
@@ -4,6 +4,6 @@ begin
                 $evm.log("info", "#{@method} - Root:<$evm.root> Attributes - #{k}: #{v}")
               end
               $evm.log("info", "#{@method} - Root:<$evm.root> End Attributes")
-              $evm.log("info", "#{$evm.class.name}")
+              $evm.log("info", $evm.class.name)
               $evm.root['method_executed']  = "user"
             end


### PR DESCRIPTION
Purpose or Intent
-----------------

Follow up to #11074 and #11077, but for the ae datastore fixture code.

Interpolation syntax can be error prone so don't use it when you can just
convert to string.

Prefer `variable.to_s` over `"#{variable}"`

rubocop -a --only "Lint/StringConversionInInterpolation,Style/UnneededInterpolation" ...

cc @gmcculloug 