### PR TITLE
Suggest to use evm:db:reset, not db:reset

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -305,3 +305,7 @@ namespace :evm do
 end
 
 Rake::Task["db:migrate"].enhance(["evm:db:environmentlegacykey"])
+
+Rake::Task["db:reset"].enhance do
+  warn "Caution: You ran db:reset which resets the DB from schema.rb. You probably want to re-run all the migrations with the current ruby/rails versions, so run bin/rake evm:db:reset instead."
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
db:reset resets the database to the current schema.rb.

We as developers are probably running different branches with different migrations
and ruby/rails versions, so we most likely want to be running all the migrations over
again instead of just recreating from schema.rb.

Output when you run `bin/rake db:reset` looks like this:
```
   -> 0.0066s
-- create_table("vmdb_metrics", {:id=>:bigserial, :force=>:cascade})
   -> 0.0121s
-- create_table("vmdb_tables", {:id=>:bigserial, :force=>:cascade})
   -> 0.0075s
-- create_table("vms", {:id=>:bigserial, :force=>:cascade})
   -> 0.0519s
-- create_table("volumes", {:id=>:bigserial, :force=>:cascade})
   -> 0.0092s
-- create_table("windows_images", {:id=>:bigserial, :force=>:cascade})
   -> 0.0055s
-- create_table("zones", {:id=>:bigserial, :force=>:cascade})
   -> 0.0049s
-- add_foreign_key("notification_recipients", "notifications")
   -> 0.0029s
-- add_foreign_key("notification_recipients", "users")
   -> 0.0019s
-- add_foreign_key("notifications", "notification_types")
   -> 0.0018s
-- add_foreign_key("notifications", "users")
   -> 0.0017s
-- initialize_schema_migrations_table()
   -> 0.0044s
Caution: You ran db:reset which resets the DB from schema.rb. You probably want to re-run all the migrations with the current ruby/rails versions, so run bin/rake evm:db:reset instead.
```

