### PR TITLE
Fix DELETE for subcollection members in API

### DIFF
--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -19,6 +19,11 @@ module Api
         delete_custom_attribute(object, ca)
       end
 
+      def delete_resource_custom_attributes(parent, _type, id, data)
+        ca = find_custom_attribute(parent, id, data)
+        delete_custom_attribute(parent, ca)
+      end
+
       private
 
       def add_custom_attribute(object, data)

--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -48,6 +48,10 @@ module Api
         end
       end
 
+      def delete_resource_service_templates(_parent, type, id, data)
+        delete_resource(type, id, data)
+      end
+
       private
 
       def service_template_ident(st)

--- a/spec/requests/api/custom_attributes_spec.rb
+++ b/spec/requests/api/custom_attributes_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Custom Attributes API" do
+  it "can delete a custom attribute through its nested URI" do
+    vm = FactoryGirl.create(:vm_vmware)
+    custom_attribute = FactoryGirl.create(:custom_attribute, :resource => vm)
+    api_basic_authorize
+
+    expect do
+      run_delete("#{vms_url(vm.id)}/custom_attributes/#{custom_attribute.id}")
+    end.to change(CustomAttribute, :count).by(-1)
+
+    expect(response).to have_http_status(:no_content)
+  end
+end

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -158,5 +158,17 @@ describe "Service Templates API" do
       expect { st1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { st2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "can delete a service template through its nested URI" do
+      service_catalog = FactoryGirl.create(:service_template_catalog)
+      service_template = FactoryGirl.create(:service_template, :service_template_catalog => service_catalog)
+      api_basic_authorize action_identifier(:service_templates, :delete, :subresource_actions, :delete)
+
+      expect do
+        run_delete("#{service_catalogs_url(service_catalog.id)}/service_templates/#{service_template.id}")
+      end.to change(ServiceTemplate, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------

Some actions that support DELETE on subcollection members, i.e.:

```
DELETE
/api/service_catalogs/<service_catalog_id>/service_templates/<service_template_id>
```

were untested and failing. The cause was the
`delete_subcollection_resource` method looking for a
`delete_resource_<resource>` method which was undefined for both service
templates and custom attributes.

Note that this was part of my motivation for creating https://github.com/ManageIQ/manageiq/issues/11072

@miq-bot add-label api, bug
@miq-bot assign @abellotti 