### PR TITLE
Automate - Added 2 missing System/Policy instances.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_denied.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_denied.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ServiceTemplateProvisionRequest_denied
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Service/Provisioning/Email/ServiceTemplateProvisionRequest_Denied"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_pending.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Policy.class/servicetemplateprovisionrequest_pending.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ServiceTemplateProvisionRequest_pending
+    inherits: 
+    description: 
+  fields:
+  - rel5:
+      value: "/Service/Provisioning/Email/ServiceTemplateProvisionRequest_Pending"


### PR DESCRIPTION
Denied Service requests were not generating emails so I added the instance in System Policy with the proper connection.  This will now generate the proper emails.  We don't currently support pending service requests but I added the pending Service request instance with no connection for future use.

ServiceTemplateProvisionRequest_denied and ServiceTemplateProvisionRequest_pending.

https://www.pivotaltracker.com/story/show/131760893