### PR TITLE
Clean up Api::BaseController a bit

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,9 +2,9 @@ module Api
   class ApiController < Api::BaseController
     def index
       res = {
-        :name        => @name,
-        :description => @description,
-        :version     => @version,
+        :name        => Settings.base.name,
+        :description => Settings.base.description,
+        :version     => Settings.base.version,
         :versions    => entrypoint_versions,
         :settings    => user_settings,
         :identity    => auth_identity,

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -18,7 +18,7 @@ module Api
     private
 
     def entrypoint_versions
-      version_config[:definitions].select(&:ident).collect do |version_specification|
+      Settings.version.definitions.select(&:ident).collect do |version_specification|
         {
           :name => version_specification[:name],
           :href => "#{@req.api_prefix}/#{version_specification[:ident]}"

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,13 @@ module Api
   Initializer.new.go
 
   class BaseController < ApplicationController
+    TAG_NAMESPACE = "/managed"
+
+    #
+    # Attributes used for identification
+    #
+    ID_ATTRS = %w(href id)
+
     #
     # Support for REST API
     #
@@ -56,13 +63,6 @@ module Api
     #
     respond_to :json
     rescue_from_api_errors
-
-    TAG_NAMESPACE = "/managed"
-
-    #
-    # Attributes used for identification
-    #
-    ID_ATTRS = %w(href id)
 
     def collection_config
       @collection_config ||= CollectionConfig.new

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,12 +5,12 @@ module Api
   Initializer.new.go
 
   class BaseController < ApplicationController
-    TAG_NAMESPACE = "/managed"
+    TAG_NAMESPACE = "/managed".freeze
 
     #
     # Attributes used for identification
     #
-    ID_ATTRS = %w(href id)
+    ID_ATTRS = %w(href id).freeze
 
     include_concern 'Parameters'
     include_concern 'Parser'

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,22 +19,6 @@ module Api
       headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
     end
 
-    # Order *Must* be from most generic to most specific
-    ERROR_MAPPING = {
-      StandardError                  => :internal_server_error,
-      NoMethodError                  => :internal_server_error,
-      ActiveRecord::RecordNotFound   => :not_found,
-      ActiveRecord::StatementInvalid => :bad_request,
-      JSON::ParserError              => :bad_request,
-      MultiJson::LoadError           => :bad_request,
-      MiqException::MiqEVMLoginError => :unauthorized,
-      AuthenticationError            => :unauthorized,
-      Forbidden                      => :forbidden,
-      BadRequestError                => :bad_request,
-      NotFound                       => :not_found,
-      UnsupportedMediaTypeError      => :unsupported_media_type
-    }
-
     #
     # Support for REST API
     #

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -48,6 +48,12 @@ module Api
     before_action :validate_response_format, :except => [:destroy]
     after_action :log_api_response
 
+    #
+    # Api Controller Hooks
+    #
+    respond_to :json
+    rescue_from_api_errors
+
     def handle_options_request
       head(:ok)
     end
@@ -57,12 +63,6 @@ module Api
       headers['Access-Control-Allow-Headers'] = 'origin, content-type, authorization, x-auth-token'
       headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
     end
-
-    #
-    # Api Controller Hooks
-    #
-    respond_to :json
-    rescue_from_api_errors
 
     def collection_config
       @collection_config ||= CollectionConfig.new

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,12 +8,6 @@ module Api
     skip_before_action :get_global_session_data
     skip_after_action :set_global_session_data
 
-    class AuthenticationError < StandardError; end
-    class Forbidden < StandardError; end
-    class BadRequestError < StandardError; end
-    class NotFound < StandardError; end
-    class UnsupportedMediaTypeError < StandardError; end
-
     def handle_options_request
       head(:ok)
     end
@@ -27,18 +21,18 @@ module Api
 
     # Order *Must* be from most generic to most specific
     ERROR_MAPPING = {
-      StandardError                             => :internal_server_error,
-      NoMethodError                             => :internal_server_error,
-      ActiveRecord::RecordNotFound              => :not_found,
-      ActiveRecord::StatementInvalid            => :bad_request,
-      JSON::ParserError                         => :bad_request,
-      MultiJson::LoadError                      => :bad_request,
-      MiqException::MiqEVMLoginError            => :unauthorized,
-      BaseController::AuthenticationError       => :unauthorized,
-      BaseController::Forbidden                 => :forbidden,
-      BaseController::BadRequestError           => :bad_request,
-      BaseController::NotFound                  => :not_found,
-      BaseController::UnsupportedMediaTypeError => :unsupported_media_type
+      StandardError                  => :internal_server_error,
+      NoMethodError                  => :internal_server_error,
+      ActiveRecord::RecordNotFound   => :not_found,
+      ActiveRecord::StatementInvalid => :bad_request,
+      JSON::ParserError              => :bad_request,
+      MultiJson::LoadError           => :bad_request,
+      MiqException::MiqEVMLoginError => :unauthorized,
+      AuthenticationError            => :unauthorized,
+      Forbidden                      => :forbidden,
+      BadRequestError                => :bad_request,
+      NotFound                       => :not_found,
+      UnsupportedMediaTypeError      => :unsupported_media_type
     }
 
     #

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -86,10 +86,6 @@ module Api
                          :only => [:show, :update, :destroy, :handle_options_request, :options]
     end
 
-    def version_config
-      Settings.version
-    end
-
     def collection_config
       @collection_config ||= CollectionConfig.new
     end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -86,25 +86,12 @@ module Api
                          :only => [:show, :update, :destroy, :handle_options_request, :options]
     end
 
-    def base_config
-      Settings.base
-    end
-
     def version_config
       Settings.version
     end
 
     def collection_config
       @collection_config ||= CollectionConfig.new
-    end
-
-    def initialize
-      @module          = base_config[:module]
-      @name            = base_config[:name]
-      @description     = base_config[:description]
-      @version         = base_config[:version]
-      @prefix          = "/#{@module}"
-      @api_config      = VMDB::Config.new("vmdb").config[@module.to_sym] || {}
     end
 
     before_action :parse_api_request, :log_api_request, :validate_api_request

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -52,6 +52,14 @@ module Api
       head(:ok)
     end
 
+    private
+
+    def validate_response_format
+      accept = request.headers["Accept"]
+      return if accept.blank? || accept.include?("json") || accept.include?("*/*")
+      raise UnsupportedMediaTypeError, "Invalid Response Format #{accept} requested"
+    end
+
     def set_access_control_headers
       headers['Access-Control-Allow-Origin'] = '*'
       headers['Access-Control-Allow-Headers'] = 'origin, content-type, authorization, x-auth-token'
@@ -60,14 +68,6 @@ module Api
 
     def collection_config
       @collection_config ||= CollectionConfig.new
-    end
-
-    private
-
-    def validate_response_format
-      accept = request.headers["Accept"]
-      return if accept.blank? || accept.include?("json") || accept.include?("*/*")
-      raise UnsupportedMediaTypeError, "Invalid Response Format #{accept} requested"
     end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -12,9 +12,6 @@ module Api
     #
     ID_ATTRS = %w(href id)
 
-    #
-    # Support for REST API
-    #
     include_concern 'Parameters'
     include_concern 'Parser'
     include_concern 'Manager'
@@ -48,9 +45,6 @@ module Api
     before_action :validate_response_format, :except => [:destroy]
     after_action :log_api_response
 
-    #
-    # Api Controller Hooks
-    #
     respond_to :json
     rescue_from_api_errors
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,23 @@ module Api
   Initializer.new.go
 
   class BaseController < ApplicationController
+    #
+    # Support for REST API
+    #
+    include_concern 'Parameters'
+    include_concern 'Parser'
+    include_concern 'Manager'
+    include_concern 'Action'
+    include_concern 'Logger'
+    include_concern 'ErrorHandler'
+    include_concern 'Normalizer'
+    include_concern 'Renderer'
+    include_concern 'Results'
+    include_concern 'Generic'
+    include_concern 'Authentication'
+    include CompressedIds
+    extend ErrorHandler::ClassMethods
+
     skip_before_action :get_global_session_data
     skip_after_action :set_global_session_data
 
@@ -20,24 +37,8 @@ module Api
     end
 
     #
-    # Support for REST API
-    #
-    include_concern 'Parameters'
-    include_concern 'Parser'
-    include_concern 'Manager'
-    include_concern 'Action'
-    include_concern 'Logger'
-    include_concern 'ErrorHandler'
-    include_concern 'Normalizer'
-    include_concern 'Renderer'
-    include_concern 'Results'
-    include_concern 'Generic'
-    include_concern 'Authentication'
-
-    #
     # Api Controller Hooks
     #
-    extend ErrorHandler::ClassMethods
     respond_to :json
     rescue_from_api_errors
     prepend_before_action :require_api_user_or_token, :except => [:handle_options_request]

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -53,12 +53,7 @@ module Api
     include_concern 'Normalizer'
     include_concern 'Renderer'
     include_concern 'Results'
-
-    #
-    # Support for API Collections
-    #
     include_concern 'Generic'
-
     include_concern 'Authentication'
 
     #

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -14,7 +14,7 @@ module Api
         else
           authenticate_options = {
             :require_user => true,
-            :timeout      => api_config.authentication_timeout.to_i_with_method
+            :timeout      => ::Settings.api.authentication_timeout.to_i_with_method
           }
 
           if (user = authenticate_with_http_basic { |u, p| User.authenticate(u, p, request, authenticate_options) })
@@ -28,10 +28,6 @@ module Api
           end
         end
         log_api_auth
-      end
-
-      def api_config
-        ::Settings[Settings.base.module.to_sym]
       end
 
       def auth_identity

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -31,7 +31,7 @@ module Api
       end
 
       def api_config
-        @api_config ||= VMDB::Config.new("vmdb").config[Settings.base.module.to_sym] || {}
+        ::Settings[Settings.base.module.to_sym]
       end
 
       def auth_identity

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -14,7 +14,7 @@ module Api
         else
           authenticate_options = {
             :require_user => true,
-            :timeout      => @api_config[:authentication_timeout].to_i_with_method
+            :timeout      => api_config.authentication_timeout.to_i_with_method
           }
 
           if (user = authenticate_with_http_basic { |u, p| User.authenticate(u, p, request, authenticate_options) })
@@ -28,6 +28,10 @@ module Api
           end
         end
         log_api_auth
+      end
+
+      def api_config
+        @api_config ||= VMDB::Config.new("vmdb").config[Settings.base.module.to_sym] || {}
       end
 
       def auth_identity

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -11,9 +11,9 @@ module Api
         MultiJson::LoadError           => :bad_request,
         MiqException::MiqEVMLoginError => :unauthorized,
         AuthenticationError            => :unauthorized,
-        Forbidden                      => :forbidden,
+        ForbiddenError                 => :forbidden,
         BadRequestError                => :bad_request,
-        NotFound                       => :not_found,
+        NotFoundError                  => :not_found,
         UnsupportedMediaTypeError      => :unsupported_media_type
       }
 

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -1,6 +1,22 @@
 module Api
   class BaseController
     module ErrorHandler
+      # Order *Must* be from most generic to most specific
+      ERROR_MAPPING = {
+        StandardError                  => :internal_server_error,
+        NoMethodError                  => :internal_server_error,
+        ActiveRecord::RecordNotFound   => :not_found,
+        ActiveRecord::StatementInvalid => :bad_request,
+        JSON::ParserError              => :bad_request,
+        MultiJson::LoadError           => :bad_request,
+        MiqException::MiqEVMLoginError => :unauthorized,
+        AuthenticationError            => :unauthorized,
+        Forbidden                      => :forbidden,
+        BadRequestError                => :bad_request,
+        NotFound                       => :not_found,
+        UnsupportedMediaTypeError      => :unsupported_media_type
+      }
+
       #
       # Class Methods
       #

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -15,7 +15,7 @@ module Api
         BadRequestError                => :bad_request,
         NotFoundError                  => :not_found,
         UnsupportedMediaTypeError      => :unsupported_media_type
-      }
+      }.freeze
 
       #
       # Class Methods

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -246,7 +246,7 @@ module Api
       end
 
       def validate_id(id, klass)
-        raise NotFound, "Invalid #{klass} id #{id} specified" unless id.kind_of?(Integer) || id =~ /\A\d+\z/
+        raise NotFoundError, "Invalid #{klass} id #{id} specified" unless id.kind_of?(Integer) || id =~ /\A\d+\z/
       end
     end
   end

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -65,7 +65,7 @@ module Api
         method = api_get_method_name(caller.first, __method__)
         log_prefix = "MIQ(#{self.class.name}.#{method})"
 
-        $api_log.error("#{log_prefix} #{@name} Error")
+        $api_log.error("#{log_prefix} #{Settings.base.name} Error")
         msg.split("\n").each { |l| $api_log.error("#{log_prefix} #{l}") }
       end
 

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -72,11 +72,15 @@ module Api
       def parse_href(href)
         if href
           path = href.match(/^http/) ? URI.parse(href).path.sub(/\/*$/, '') : href
-          path = "#{@prefix}/#{path}" unless path.match(@prefix)
+          path = "#{prefix}/#{path}" unless path.match(prefix)
           path = path.sub(/\/*$/, '')
           return href_collection_id(path)
         end
         [nil, nil]
+      end
+
+      def prefix
+        @prefix ||= "/#{Settings.base.module}"
       end
 
       def href_collection_id(path)

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -223,7 +223,7 @@ module Api
         action_hash = fetch_action_hash(aspec, method_name, action_name)
         raise BadRequestError, "Disabled action #{action_name}" if action_hash[:disabled]
         unless api_user_role_allows?(action_hash[:identifier])
-          raise Forbidden, "Use of the #{action_name} action is forbidden"
+          raise ForbiddenError, "Use of the #{action_name} action is forbidden"
         end
       end
 
@@ -250,7 +250,9 @@ module Api
 
         if action_hash.present?
           raise BadRequestError, "Disabled Action #{aname} for the #{cname} #{type} specified" if action_hash[:disabled]
-          raise Forbidden, "Use of Action #{aname} is forbidden" unless api_user_role_allows?(action_hash[:identifier])
+          unless api_user_role_allows?(action_hash[:identifier])
+            raise ForbiddenError, "Use of Action #{aname} is forbidden"
+          end
         end
 
         validate_post_api_action_as_subcollection(cname, mname, aname)
@@ -298,7 +300,7 @@ module Api
         raise BadRequestError, "Disabled Action #{aname} for the #{cname} sub-collection" if action_hash[:disabled]
 
         unless api_user_role_allows?(action_hash[:identifier])
-          raise Forbidden, "Use of Action #{aname} for the #{cname} sub-collection is forbidden"
+          raise ForbiddenError, "Use of Action #{aname} for the #{cname} sub-collection is forbidden"
         end
       end
 

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -13,7 +13,7 @@ module Api
         # API Version Validation
         if @req.version
           vname = @req.version
-          unless version_config[:definitions].collect { |vent| vent[:name] }.include?(vname)
+          unless Settings.version.definitions.collect { |vent| vent[:name] }.include?(vname)
             raise BadRequestError, "Unsupported API Version #{vname} specified"
           end
         end
@@ -85,7 +85,7 @@ module Api
 
       def href_collection_id(path)
         path_array = path.split('/')
-        cidx = path_array[2] && path_array[2].match(version_config[:regex]) ? 3 : 2
+        cidx = path_array[2] && path_array[2].match(Settings.version.regex) ? 3 : 2
 
         collection, c_id    = path_array[cidx..cidx + 1]
         subcollection, s_id = path_array[cidx + 2..cidx + 3]

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -72,15 +72,11 @@ module Api
       def parse_href(href)
         if href
           path = href.match(/^http/) ? URI.parse(href).path.sub(/\/*$/, '') : href
-          path = "#{prefix}/#{path}" unless path.match(prefix)
+          path = "/api/#{path}" unless path.match("/api")
           path = path.sub(/\/*$/, '')
           return href_collection_id(path)
         end
         [nil, nil]
-      end
-
-      def prefix
-        @prefix ||= "/#{Settings.base.module}"
       end
 
       def href_collection_id(path)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -170,7 +170,7 @@ module Api
         validate_id(id, klass)
         target = respond_to?("find_#{type}") ? public_send("find_#{type}", id) : klass.find(id)
         res = Rbac.filtered_object(target, :user => @auth_user_obj, :class => klass)
-        raise Forbidden, "Access to the resource #{type}/#{id} is forbidden" unless res
+        raise ForbiddenError, "Access to the resource #{type}/#{id} is forbidden" unless res
         res
       end
 

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -5,12 +5,12 @@ module Api
     before_action :set_additional_attributes, :only => [:show, :update]
 
     def edit_resource(type, id, data = {})
-      raise Forbidden if Category.find(id).read_only?
+      raise ForbiddenError if Category.find(id).read_only?
       super
     end
 
     def delete_resource(type, id, data = {})
-      raise Forbidden if Category.find(id).read_only?
+      raise ForbiddenError if Category.find(id).read_only?
       super
     end
 

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -5,12 +5,12 @@ module Api
     before_action :set_additional_attributes, :only => [:show, :update]
 
     def edit_resource(type, id, data = {})
-      raise BaseController::Forbidden if Category.find(id).read_only?
+      raise Forbidden if Category.find(id).read_only?
       super
     end
 
     def delete_resource(type, id, data = {})
-      raise BaseController::Forbidden if Category.find(id).read_only?
+      raise Forbidden if Category.find(id).read_only?
       super
     end
 

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -28,12 +28,12 @@ module Api
       parse_set_tenant(data)
       group = resource_search(id, type, collection_class(:groups))
       parse_set_filters(data, :entitlement_id => group.entitlement.try(:id))
-      raise Forbidden, "Cannot edit a read-only group" if group.read_only
+      raise ForbiddenError, "Cannot edit a read-only group" if group.read_only
       super
     end
 
     def delete_resource(type, id, data = {})
-      raise Forbidden, "Cannot delete a read-only group" if MiqGroup.find(id).read_only?
+      raise ForbiddenError, "Cannot delete a read-only group" if MiqGroup.find(id).read_only?
       super
     end
 

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -4,7 +4,7 @@ module Api
       category = @req.c_id
       selected_sections =
         if category
-          raise NotFound, "Settings category #{category} not found" unless exposed_settings.include?(category)
+          raise NotFoundError, "Settings category #{category} not found" unless exposed_settings.include?(category)
           category
         else
           exposed_settings

--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -72,7 +72,7 @@ module Api
 
       def new_custom_attribute(data)
         name = data["name"].to_s.strip
-        raise Api::BaseController::BadRequestError, "Must specify a name for a custom attribute to be added" if name.blank?
+        raise BadRequestError, "Must specify a name for a custom attribute to be added" if name.blank?
         CustomAttribute.new(:name    => name,
                             :value   => data["value"],
                             :source  => data["source"].blank? ? "EVM" : data["source"],

--- a/app/controllers/api/subcollections/service_templates.rb
+++ b/app/controllers/api/subcollections/service_templates.rb
@@ -7,7 +7,7 @@ module Api
       end
 
       def service_templates_assign_resource(object, type, id = nil, _data = nil)
-        raise Api::BaseController::BadRequestError, "Must specify an id for Assigning a #{type} resource" unless id
+        raise BadRequestError, "Must specify an id for Assigning a #{type} resource" unless id
 
         service_template_subcollection_action(type, id) do |st|
           api_log_info("Assigning #{service_template_ident(st)}")
@@ -17,7 +17,7 @@ module Api
       end
 
       def service_templates_unassign_resource(object, type, id = nil, _data = nil)
-        raise Api::BaseController::BadRequestError, "Must specify an id for Unassigning a #{type} resource" unless id
+        raise BadRequestError, "Must specify an id for Unassigning a #{type} resource" unless id
 
         service_template_subcollection_action(type, id) do |st|
           api_log_info("Unassigning #{service_template_ident(st)}")
@@ -33,13 +33,13 @@ module Api
         request_result = workflow.submit_request
         errors = request_result[:errors]
         if errors.present?
-          raise Api::BaseController::BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
+          raise BadRequestError, "Failed to order #{service_template_ident(service_template)} - #{errors.join(", ")}"
         end
         request_result[:request]
       end
 
       def service_templates_refresh_dialog_fields_resource(object, type, id = nil, data = nil)
-        raise Api::BaseController::BadRequestError, "Must specify an id for Refreshing dialog fields of a #{type} resource" unless id
+        raise BadRequestError, "Must specify an id for Refreshing dialog fields of a #{type} resource" unless id
 
         service_template_subcollection_action(type, id) do |st|
           api_log_info("Refreshing dialog fields for #{service_template_ident(st)}")

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,0 +1,7 @@
+module Api
+  class AuthenticationError < StandardError; end
+  class Forbidden < StandardError; end
+  class BadRequestError < StandardError; end
+  class NotFound < StandardError; end
+  class UnsupportedMediaTypeError < StandardError; end
+end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,7 +1,8 @@
 module Api
-  class AuthenticationError < StandardError; end
-  class Forbidden < StandardError; end
-  class BadRequestError < StandardError; end
-  class NotFound < StandardError; end
-  class UnsupportedMediaTypeError < StandardError; end
+  ApiError = Class.new(StandardError)
+  AuthenticationError = Class.new(ApiError)
+  Forbidden = Class.new(ApiError)
+  BadRequestError = Class.new(ApiError)
+  NotFound = Class.new(ApiError)
+  UnsupportedMediaTypeError = Class.new(ApiError)
 end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,8 +1,8 @@
 module Api
   ApiError = Class.new(StandardError)
   AuthenticationError = Class.new(ApiError)
-  Forbidden = Class.new(ApiError)
+  ForbiddenError = Class.new(ApiError)
   BadRequestError = Class.new(ApiError)
-  NotFound = Class.new(ApiError)
+  NotFoundError = Class.new(ApiError)
   UnsupportedMediaTypeError = Class.new(ApiError)
 end


### PR DESCRIPTION
Purpose or Intent
-----------------

There's a few things going on here - I'll definitely split this PR up if it's too much. Basically a combination of:

* Removes the patching of `#initialize` - probably not a best practice 
* Move and consolidate like things for better organization
* Move some other things so they don't have to be fully qualified
~~* Eliminates `ApplicationController` from the inheritance chain, so that we don't have to skip its callbacks, or prepend any of ours. We don't skip all the callbacks but I can't see that we need any of them - but would appreciate a second pair of eyes to look over this closely.~~

EDIT: I've removed the last change as it had far-reaching consequences beyond the scope of this PR

Probably best viewed as individual commits.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 
