### PR TITLE
Display confirmation message when kicking off DB garbage collection

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -415,11 +415,7 @@ module OpsController::Diagnostics
     else
       add_flash(_("Database Garbage Collection successfully initiated"))
     end
-    render :update do |page|
-      page << javascript_prologue
-      page.replace("flash_msg_divdatabase", :partial => "layouts/flash_msg", :locals => {:div_num => "database"})
-      page << "miqSparkle(false);"
-    end
+    render_flash
   end
 
   # to delete orphaned records for user that was delete from db

--- a/app/views/ops/_diagnostics_database_tab.html.haml
+++ b/app/views/ops/_diagnostics_database_tab.html.haml
@@ -6,6 +6,7 @@
                               'data-db-backup-form-field-changed-url' => "/#{controller_name}/db_backup_form_field_changed/",
                               'data-submit-url'                       => "/#{controller_name}/db_backup/"}
   - if @sb[:active_tab] == "diagnostics_database"
+    = render :partial => "layouts/flash_msg"
     %h3
       = _("Basic Info")
   .form-group
@@ -36,9 +37,6 @@
   %hr/
   %h3
     = _("Run a Database Backup Now")
-  - if @sb[:active_tab] == "diagnostics_database"
-    -# created div with different name so database validation flash message can be shown in it's own box
-    = render :partial => "layouts/flash_msg"
   %hr
   %h3
     = _("Backup Schedules")
@@ -118,7 +116,7 @@
           - submit = button_tag(_("Submit"), :class => "btn btn-primary", :alt => caption)
 
           = link_to(submit, {:action => 'db_gc_collection'},
-            "data-miq_sparkle_on" => true,
+            "data-miq_sparkle_off" => true,
             :confirm              => _("Are you sure you want to Run Database Garbage Collection Now?"),
             :remote               => true,
             'data-method'         => :post,


### PR DESCRIPTION
Display confirmation message when Database Garbage Collection task is manually initiated via Submit button.

Moved flash message display box higher up the page for better visibility and to match rest of the application for both Diagnostics actions on the page (same partial view code): Backup and Garbage Collection.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1364100

Screen shots for both DB Garbage Collection action and DB Backup posted below:
![db garbage collection flash message](https://cloud.githubusercontent.com/assets/552686/18769619/afab860e-80e3-11e6-8bb2-ec865c93bd9c.png)

![db backup flash message](https://cloud.githubusercontent.com/assets/552686/18769631/c02256a2-80e3-11e6-9820-d83a69c007be.png)
