### PR TITLE
jasmine-core dependency - a comment about the issue

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -82,7 +82,7 @@ unless ENV['APPLIANCE']
     gem "camcorder",                    :require => false
     gem "coveralls",                    :require => false
     gem "jasmine",       "~>2.4.0",     :require => false
-    gem "jasmine-core",  "~>2.4.0",     :require => false
+    gem "jasmine-core",  "~>2.4.0",     :require => false  # force the expected version, jasmine/jasmine-gem#271
     gem "phantomjs",     "=1.9.8.0",    :require => false
     gem "rspec",         "~>3.5.0",     :require => false
     gem "test-unit",                    :require => false


### PR DESCRIPTION
Looks like the explicit dependency on jasmine-core is for keeps, since the jasmine-gem issue got closed. So adding a comment explaining why it's needed and linking [the issue](https://github.com/jasmine/jasmine-gem/issues/271#issuecomment-245447934).

(jasmine-gem depends on ~>2.4, not ~>2.4.0, meaning it brings in 2.5 when available, which breaks phantomjs)

(The line itself was introduced in https://github.com/ManageIQ/manageiq/pull/10898)