### PR TITLE
Added ActiveRecord callback for ActionCable notification broadcasting

### DIFF
--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -7,11 +7,12 @@ describe Notification, :type => :model do
       let!(:user) { FactoryGirl.create(:user_with_group, :tenant => tenant) }
       let(:notification_type) { :vm_powered_on }
 
+      subject { Notification.create(:type => notification_type, :subject => vm) }
+
       it 'creates a new notification along with recipients' do
-        n = Notification.create(:type => notification_type, :subject => vm)
-        expect(n.notification_type.name).to eq(notification_type.to_s)
-        expect(n.subject).to eq(vm)
-        expect(n.recipients).to match_array([user])
+        expect(subject.notification_type.name).to eq(notification_type.to_s)
+        expect(subject.subject).to eq(vm)
+        expect(subject.recipients).to match_array([user])
         expect(user.notifications.count).to eq(1)
         expect(user.unseen_notifications.count).to eq(1)
       end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -16,6 +16,11 @@ describe Notification, :type => :model do
         expect(user.notifications.count).to eq(1)
         expect(user.unseen_notifications.count).to eq(1)
       end
+
+      it 'broadcasts the message through ActionCable' do
+        expect_any_instance_of(ActionCable::Server::Base).to receive(:broadcast)
+        subject # force the creation of the db object
+      end
     end
   end
 end

--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -9,6 +9,7 @@ else
   echo "1" > REGION
   cp certs/v2_key.dev certs/v2_key
   cp config/database.pg.yml config/database.yml
+  cp config/cable.yml.sample config/cable.yml
   psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
   export BUNDLE_WITHOUT=development
 fi


### PR DESCRIPTION
Creates an `after_commit :on => create` callback for sending the notifications through the WebSocket channel. Related to: #10623 #10874 #10965

For testing it is necessary to run run `cp config/cable.yml.sample config/cable.yml` or re-run `bin/setup`. Then log in to the Web UI and open the browser's JavaScript console. Notifications can be emitted using a rails console in the following form:
```ruby
Notification.create(:type => :vm_powered_on, :subject => Vm.first)
```
