### PR TITLE
Fixed issue with checking checkboxes in VAT tree when editing a group

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -292,7 +292,7 @@ function miqOnClickServerRoles(id) {
 // OnCheck handler for the belongsto tagging trees on the user edit screen
 function miqOnCheckUserFilters(node, tree_name) {
   var tree_typ = tree_name.split('_')[0];
-  var checked = Number(!node.state.selected);
+  var checked = Number(node.state.checked);
   var url = ManageIQ.tree.checkUrl + node.key + "?check=" + checked + "&tree_typ=" + tree_typ;
   miqJqueryRequest(url);
   return true;

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -168,7 +168,7 @@ function miqTreeToggleExpand(treename, expand_mode) {
 // OnCheck handler for the Protect screen
 function miqOnCheckProtect(node, _treename) {
   var ppid = node.key.split('_').pop();
-  var url = ManageIQ.tree.checkUrl + ppid + '?check=' + Number(!node.state.selected);
+  var url = ManageIQ.tree.checkUrl + ppid + '?check=' + Number(node.state.checked);
   miqJqueryRequest(url);
   return true;
 }


### PR DESCRIPTION
Instead of sending the checked state, the selected state was sent.
Configure > Configuration > Access Control > Groups > Edit a group > VMs and Templates
![screenshot from 2016-09-08 15-58-31](https://cloud.githubusercontent.com/assets/649130/18352066/1fbfc21e-75dd-11e6-9a4c-6deced3cdd11.png)

