### PR TITLE
Typo in _rbac_group_detail.html.haml

### DIFF
--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -60,7 +60,7 @@
             - params = {:class => "product product-#{tenant.divisible ? "tenant" : "project"}"}
             - if role_allows?(:feature => "rbac_tenant_show")
               - params[:class] = "#{params[:class]} pointer"
-              - params[:onclick] = "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
+              - params[:onclick] = "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');"
               - params[:title] = tenant.divisible ? _("View this Tenant") : _("View this Project")
             %i{params}
             = h(tenant.name)


### PR DESCRIPTION
Configuration -> Access Control -> Groups -> Any group


Generated this `Error caught: [ActionView::Template::Error] undefined method `-@' for "View this Tenant":String` because of typo in haml.

@himdel please have a look, thanks :)

@miq-bot add_label ui, bug
