### PR TITLE
Mounted ActionCable as a Rails route in development

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2861,6 +2861,7 @@ Vmdb::Application.routes.draw do
   match "/auth/:provider/callback" => "sessions#create", :via => :get
 
   if Rails.env.development? && defined?(Rails::Server)
+    mount ActionCable.server => '/ws/notifications'
     mount WebsocketServer.new(:logger => Logger.new(STDOUT)) => '/ws'
   end
   # rubocop:enable MultilineOperationIndentation


### PR DESCRIPTION
Before it was proxied through the WebsocketServer rack proxy.

There is an issue with code-reloading when a premanent WebSocket connection is present.
It's not sure that this will fix the issue but this was my first guess.

Resolves #11095 