### PR TITLE
Use proper relationship to present cluster information

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -216,7 +216,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_cluster
-    cluster = @record.host.try(:ems_cluster)
+    cluster = @record.try(:ems_cluster)
     return nil if cluster.nil?
     h = {:label => title_for_cluster, :image => "ems_cluster", :value => (cluster.nil? ? _("None") : cluster.name)}
     if cluster && role_allows?(:feature => "ems_cluster_show")


### PR DESCRIPTION
When a vm is not running there is no relationship between a vm and a host and as a result cluster information is not presented in vm details. In Rhev this relationship is only available when a vm is running on specific host.

This PR fixes:
https://bugzilla.redhat.com/1373826