### PR TITLE
Setting default entry points for a new non-generic catalog items.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -157,7 +157,8 @@ class CatalogController < ApplicationController
       set_form_vars
       @edit[:new][:st_prov_type] = params[:st_prov_type] if params[:st_prov_type]
       @edit[:new][:service_type] = "atomic"
-      default_entry_point(@edit[:new][:st_prov_type]) if params[:st_prov_type].start_with?('generic')
+      default_entry_point(@edit[:new][:st_prov_type],
+                          @edit[:new][:service_type])
       @edit[:rec_id] = @record ? @record.id : nil
       @tabactive = @edit[:new][:current_tab_key]
     end
@@ -1425,12 +1426,12 @@ class CatalogController < ApplicationController
     end
   end
 
-  def default_entry_point(prov_type)
+  def default_entry_point(prov_type, service_type)
     edit_new = @edit[:new]
     klass = class_service_template(prov_type)
-    edit_new[:fqname] = klass.default_provisioning_entry_point
-    edit_new[:retire_fqname] = klass.default_retirement_entry_point if klass.respond_to?(:default_retirement_entry_point)
-    edit_new[:reconfigure_fqname] = klass.default_reconfiguration_entry_point if klass.respond_to?(:default_reconfiguration_entry_point)
+    edit_new[:fqname] = klass.default_provisioning_entry_point(service_type)
+    edit_new[:retire_fqname] = klass.default_retirement_entry_point
+    edit_new[:reconfigure_fqname] = klass.default_reconfiguration_entry_point
   end
 
   def get_form_vars

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -47,7 +47,7 @@ class Blueprint < ApplicationRecord
         :service_type => 'composite'
       )
       add_catalog_items(new_bundle, options[:service_templates]) if options.key?(:service_templates)
-      add_entry_points(new_bundle, options[:entry_points], options[:service_dialog])
+      add_entry_points(new_bundle, options[:entry_points], options[:service_dialog], new_bundle[:service_type])
       new_bundle.service_template_catalog = options[:service_catalog]
 
       new_bundle.save!
@@ -175,9 +175,9 @@ class Blueprint < ApplicationRecord
     remove_catalog_items(the_bundle, existing_items - catalog_items)
   end
 
-  def add_entry_points(new_bundle, entry_points, dialog)
+  def add_entry_points(new_bundle, entry_points, dialog, service_type)
     entry_points ||= {
-      'Provision'  => ServiceTemplate.default_provisioning_entry_point,
+      'Provision'  => ServiceTemplate.default_provisioning_entry_point(service_type),
       'Retirement' => ServiceTemplate.default_retirement_entry_point
     }
 

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -242,12 +242,20 @@ class ServiceTemplate < ApplicationRecord
     service.save
   end
 
-  def self.default_provisioning_entry_point
-    '/Service/Provisioning/StateMachines/ServiceProvision_Template/default'
+  def self.default_provisioning_entry_point(service_type)
+    if service_type == 'atomic'
+      '/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization'
+    else
+      '/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogBundleInitialization'
+    end
   end
 
   def self.default_retirement_entry_point
-    '/Service/Retirement/StateMachines/ServiceRetirement/default'
+    '/Service/Retirement/StateMachines/ServiceRetirement/Default'
+  end
+
+  def self.default_reconfiguration_entry_point
+    nil
   end
 
   def template_valid?

--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -16,8 +16,8 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
     []
   end
 
-  def self.default_provisioning_entry_point
-    '/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision/default'
+  def self.default_provisioning_entry_point(_service_type)
+    '/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision/provision_from_bundle'
   end
 
   def self.default_reconfiguration_entry_point

--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -13,8 +13,8 @@ class ServiceTemplateOrchestration < ServiceTemplate
     []
   end
 
-  def self.default_provisioning_entry_point
-    '/Cloud/Orchestration/Provisioning/StateMachines/Provision/default'
+  def self.default_provisioning_entry_point(_service_type)
+    '/Cloud/Orchestration/Provisioning/StateMachines/Provision/CatalogItemInitization'
   end
 
   def self.default_reconfiguration_entry_point

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -135,7 +135,7 @@ describe Blueprint do
       expect(bundle.dialogs.first).to eq(dialog)
 
       prov = bundle.resource_actions.find_by(:action => 'Provision')
-      expect(prov.ae_uri).to eq(ServiceTemplate.default_provisioning_entry_point)
+      expect(prov.ae_uri).to eq(ServiceTemplate.default_provisioning_entry_point(bundle['service_type']))
 
       retire = bundle.resource_actions.find_by(:action => 'Retirement')
       expect(retire.ae_uri).to eq(ServiceTemplate.default_retirement_entry_point)


### PR DESCRIPTION
Purpose or Intent
-----------------
As a response to BZ I enabled setting default entry points for a new vendor based catalog items. I also created a new method `def self.default_reconfiguration_entry_point` in ServiceTemplate model, but I am not sure what this method should return. So it returns `nil` for now. 

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1331877

@miq-bot add_labels automate, ui
Cc @gmcculloug 
