### PR TITLE
Base StaticController on ActionController::Base, not ApplicationController

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,6 @@
 # used to serve static angular templates from under app/views/static/
 
-class StaticController < ApplicationController
+class StaticController < ActionController::Base
   # hide_action is gone in Rails, but high_voltage is still using it.
   # https://github.com/thoughtbot/high_voltage/pull/214
   def self.hide_action(*)


### PR DESCRIPTION
StaticController serves only to serve static html templates for angular, via the `/static/*` route...

Previously it would inherit from `ApplicationController` making it load & save the session, etc.

Changing to inherit from `ActionController::Base`, which should prevent /static accesses from breaking the session.

(The problem got exposed because https://github.com/ManageIQ/manageiq/pull/10955 downloads a few static templates on full page reload, causing the original request to get its session overwritten)

Closes #11060, Closes #11063, Closes #11059, Closes #11104