### PR TITLE
Prevent bin/setup from deleting the log/.gitkeep file

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -59,7 +59,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  execute "find log/ -type 'f' | xargs rm"
+  execute "find log/ -type 'f' ! -name '.gitkeep' | xargs rm"
   execute "rm -rf tmp/cache"
 
   if options[:do_tests]


### PR DESCRIPTION
Purpose or Intent
-----------------
Recently `bin/setup` was changed to use find to remove all files in the `log/` directory, but that includes the file `.gitkeep` which is used to allow the empty `log/` directory to be tracked by git.

```
$ bin/setup
$ git status
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	deleted:    log/.gitkeep
```

Steps for Testing/QA
--------------------
Run `bin/setup` and check if the `log/.gitkeep` file is removed
