### PR TITLE
Fix unreachable code by removing it or commenting it out

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -619,7 +619,6 @@ class VmOrTemplate < ApplicationRecord
                     # local
                     else
                       raise _("path, '%{path}', is malformed") % {:path => path}
-                      path
                     end
     return storage_name, (relative_path.empty? ? "/" : relative_path)
   end

--- a/gems/pending/disk/modules/QcowDisk.rb
+++ b/gems/pending/disk/modules/QcowDisk.rb
@@ -487,7 +487,10 @@ module QcowDisk
       case partial_header['version']
       when 1
         raise "QCOW Version 1 is not supported"
-        QCOW_HEADER_V1.decode(file_handle.read(SIZEOF_QCOW_HEADER_V1))
+
+        # Commented out for now to avoid unreachable code
+        #
+        # QCOW_HEADER_V1.decode(file_handle.read(SIZEOF_QCOW_HEADER_V1))
       when 2
         h = QCOW_HEADER_V2.decode(file_handle.read(SIZEOF_QCOW_HEADER_V2))
         # TODO: Handle Encryption

--- a/gems/pending/fs/MiqFS/modules/Ext3.rb
+++ b/gems/pending/fs/MiqFS/modules/Ext3.rb
@@ -237,18 +237,21 @@ module Ext3
   # Create a directory entry.
   def ifs_putFile(p, miqfs = nil)
     raise "Write functionality is not yet supported on Ext3."
-    # If this is being called from a FileObject instance, then MiqFS owns contained instance members.
-    # If this is being called from an Ext3 module method, then self owns contained instance members.
-    miqfs = self if miqfs.nil?
 
-    # Preprocess path.
-    p = unnormalizePath(p)
-    dir, fil = File.split(p)
+    # Commented out for now to avoid unreachable code
+    #
+    # # If this is being called from a FileObject instance, then MiqFS owns contained instance members.
+    # # If this is being called from an Ext3 module method, then self owns contained instance members.
+    # miqfs = self if miqfs.nil?
 
-    # Parent directory must exist.
-    dirObj = ifs_getDir(dir, miqfs)
-    return nil if dir.nil?
-    dirObj.createFile(fil)
+    # # Preprocess path.
+    # p = unnormalizePath(p)
+    # dir, fil = File.split(p)
+
+    # # Parent directory must exist.
+    # dirObj = ifs_getDir(dir, miqfs)
+    # return nil if dir.nil?
+    # dirObj.createFile(fil)
   end
 
   # Return a Directory object for a path.

--- a/gems/pending/fs/MiqFS/modules/Ext4.rb
+++ b/gems/pending/fs/MiqFS/modules/Ext4.rb
@@ -236,18 +236,21 @@ module Ext4
   # Create a directory entry.
   def ifs_putFile(p, miqfs = nil)
     raise "Write functionality is not yet supported on Ext4."
-    # If this is being called from a FileObject instance, then MiqFS owns contained instance members.
-    # If this is being called from an Ext4 module method, then self owns contained instance members.
-    miqfs = self if miqfs.nil?
 
-    # Preprocess path.
-    p = unnormalizePath(p)
-    dir, fil = File.split(p)
+    # Commented out for now to avoid unreachable code
+    #
+    # # If this is being called from a FileObject instance, then MiqFS owns contained instance members.
+    # # If this is being called from an Ext4 module method, then self owns contained instance members.
+    # miqfs = self if miqfs.nil?
 
-    # Parent directory must exist.
-    dirObj = ifs_getDir(dir, miqfs)
-    return nil if dir.nil?
-    dirObj.createFile(fil)
+    # # Preprocess path.
+    # p = unnormalizePath(p)
+    # dir, fil = File.split(p)
+
+    # # Parent directory must exist.
+    # dirObj = ifs_getDir(dir, miqfs)
+    # return nil if dir.nil?
+    # dirObj.createFile(fil)
   end
 
   # Return a Directory object for a path.

--- a/gems/pending/fs/MiqFS/modules/ReiserFS.rb
+++ b/gems/pending/fs/MiqFS/modules/ReiserFS.rb
@@ -248,18 +248,21 @@ module ReiserFS
   # Create a directory entry.
   def ifs_putFile(p, miqfs = nil)
     raise "Write functionality is not yet supported on ReiserFS."
-    # If this is being called from a FileObject instance, then MiqFS owns contained instance members.
-    # If this is being called from an ReiserFS module method, then self owns contained instance members.
-    miqfs = self if miqfs.nil?
 
-    # Preprocess path.
-    p = unnormalizePath(p)
-    dir, fil = File.split(p)
+    # Commented out for now to avoid unreachable code
+    #
+    # # If this is being called from a FileObject instance, then MiqFS owns contained instance members.
+    # # If this is being called from an ReiserFS module method, then self owns contained instance members.
+    # miqfs = self if miqfs.nil?
 
-    # Parent directory must exist.
-    dirObj = ifs_getDir(dir, miqfs)
-    return nil if dir.nil?
-    dirObj.createFile(fil)
+    # # Preprocess path.
+    # p = unnormalizePath(p)
+    # dir, fil = File.split(p)
+
+    # # Parent directory must exist.
+    # dirObj = ifs_getDir(dir, miqfs)
+    # return nil if dir.nil?
+    # dirObj.createFile(fil)
   end
 
   # Return a Directory object for a path.

--- a/gems/pending/fs/ext3/file_data.rb
+++ b/gems/pending/fs/ext3/file_data.rb
@@ -59,7 +59,10 @@ module Ext3
 
     def write(buf, _len = buf.length)
       raise "Ext3::FileData.write: Write functionality is not yet supported on Ext3."
-      @dirty = true
+
+      # Commented out for now to avoid unreachable code
+      #
+      # @dirty = true
     end
 
     private


### PR DESCRIPTION
Purpose or Intent
-----------------

I'd prefer to just remove all unreachable code but some have expressed the desire
to keep the example code around.  Therefore, where appropriate, I commented it
out for now since it silences the cop and doesn't remove the example code.

Note, I believe we can whitelist each of these using a comment:
`# rubocop:disable Lint/UnreachableCode`

But, that implies that the current code is correct and we're just saying "ignore"
it.  Clearly, unreachable code is wrong so let's not pretend this previously
active but unreachable code is correct.

rubocop --only "Lint/UnreachableCode"