### PR TITLE
Fix javascript for Automate git import

### DIFF
--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -214,20 +214,20 @@ var Automate = {
       if ($(event.currentTarget).val() === "Branch") {
         $('.git-branch-group').show();
         $('.git-tag-group').hide();
-        $('.git-branch-or-tag').val($('.git-branches').val());
-      } else {
+        $('.git-branch-or-tag').val($('.git-branches select').val());
+      } else if ($(event.currentTarget).val() === "Tag") {
         $('.git-branch-group').hide();
         $('.git-tag-group').show();
-        $('.git-branch-or-tag').val($('.git-tags').val());
+        $('.git-branch-or-tag').val($('.git-tags select').val());
       }
     });
 
     $('.git-branches').on('change', function(event) {
-      $('.git-branch-or-tag').val($(event.currentTarget).val());
+      $('.git-branch-or-tag').val($('.git-branches select').val());
     });
 
     $('.git-tags').on('change', function(event) {
-      $('.git-branch-or-tag').val($(event.currentTarget).val());
+      $('.git-branch-or-tag').val($('.git-tags select').val());
     });
   }
 };


### PR DESCRIPTION
Purpose or Intent
-----------------

Fix javascript for Automate git import. 2 errors were fixed

1. This method is invoked twice on click:
https://github.com/Ladas/manageiq/blob/e940b7a793d2d1c858f88b67d76a2cbb5f90d000/app/assets/javascripts/automate_import_export.js#L213-L213

in second pass $(event.currentTarget).val() is "", causing that
only Tag selectbox was being shown.

2. $('.git-branches').val() does not really return anything.
To access the selectboxes' selected value, we need to do
$('.git-branches select').val()

---
note, all 3 OnChange methods are invoked twice and each time, the
$(event.currentTarget).val() is blank. This should be also fixed.

Steps for Testing/QA
--------------------
Without this after typing down git repo and submit, we can pick only tag. But even submitting that leads to loading circle of infinity, cause no data were send.