### PR TITLE
[WIP] Support special characters in reporting of Custom Attributes

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -118,14 +118,31 @@ class MiqReport < ApplicationRecord
     }
   end
 
+  # example
+  # converts  "Host.hardware.disks-filename" to
+  # ["Host", "hardware", "disk", "filename"]
+  def self.parse_column(column)
+    prefix = CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX
+    column, column_without_relations = column.split("-#{prefix}") if column.include?(prefix)
+
+    parts = column.split(".")
+
+    if column.include?(prefix)
+      parts.push("#{prefix}#{column_without_relations}")
+    end
+
+    parts[-1] = parts.last.split("-").first # Strip off field name from last element
+
+    parts
+  end
+
   def self.display_filter_details(cols, mode)
     # mode => :field || :tag
     # Only return cols from has_many sub-tables
     return [] if cols.nil?
     cols.inject([]) do |r, c|
       # eg. c = ["Host.Hardware.Disks : File Name", "Host.hardware.disks-filename"]
-      parts = c.last.split(".")
-      parts[-1] = parts.last.split("-").first # Strip off field name from last element
+      parts = parse_column(c.last)
 
       if parts.last == "managed"
         next(r) unless mode == :tag

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -188,8 +188,13 @@ module ActsAsTaggable
 
   def vtag_list(options = {})
     ns = Tag.get_namespace(options)
+    origin_ns = ns
+
+    prefix = CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX
+    ns, attribute_without_prefix = ns.split(prefix) if origin_ns.include?(prefix)
 
     predicate = ns.split("/")[2..-1] # throw away /virtual
+    predicate.push("#{prefix}#{attribute_without_prefix}") if origin_ns.include?(prefix)
 
     # p "ns: [#{ns}]"
     # p "predicate: [#{predicate.inspect}]"

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1005,13 +1005,26 @@ class MiqExpression
   # convert "MiqGroup.vms.host-disconnected" to
   # ["MiqGroup", ["vms", "host", "disconnected"]]
   def self.model_and_attributes_from(attribute_with_model)
+    origin_attribute_with_model = attribute_with_model
+
+    prefix = CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX
+
+    if origin_attribute_with_model.include?(prefix)
+      attribute_with_model, virtual_custom_attribute_without_prefix = attribute_with_model.split(prefix)
+    end
+
     # replace model path ".", column name "-" with "/"
     model, *values = attribute_with_model.to_s.gsub(/[\.-]/, "/").split("/")
+
+    if origin_attribute_with_model.include?(prefix)
+      values.push("#{prefix}#{virtual_custom_attribute_without_prefix}")
+    end
+
     [model, values]
   end
 
   def self.value2tag(attribute_with_model, val = nil)
-    model, *values = model_and_attributes_from(attribute_with_model)
+    model, values = model_and_attributes_from(attribute_with_model)
 
     case values.first
     when "user_tag"

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1001,8 +1001,17 @@ class MiqExpression
     tag
   end
 
-  def self.value2tag(tag, val = nil)
-    model, *values = tag.to_s.gsub(/[\.-]/, "/").split("/") # replace model path ".", column name "-" with "/"
+  # example:
+  # convert "MiqGroup.vms.host-disconnected" to
+  # ["MiqGroup", ["vms", "host", "disconnected"]]
+  def self.model_and_attributes_from(attribute_with_model)
+    # replace model path ".", column name "-" with "/"
+    model, *values = attribute_with_model.to_s.gsub(/[\.-]/, "/").split("/")
+    [model, values]
+  end
+
+  def self.value2tag(attribute_with_model, val = nil)
+    model, *values = model_and_attributes_from(attribute_with_model)
 
     case values.first
     when "user_tag"

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -2,14 +2,19 @@ class MiqExpression::Field
   FIELD_REGEX = /
 (?<model_name>([[:upper:]][[:alnum:]]*(::)?)+)
 \.?(?<associations>[a-z_\.]+)*
--(?<column>[a-z]+(_[[:alnum:]]+)*)
+-
+(?:
+  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}.*)|
+  (?<column>[a-z]+(_[[:alnum:]]+)*)
+)
 /x
 
   ParseError = Class.new(StandardError)
 
   def self.parse(field)
     match = FIELD_REGEX.match(field) or raise ParseError, field
-    new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:column])
+    column = match[:virtual_custom_column] || match[:column]
+    new(match[:model_name].constantize, match[:associations].to_s.split("."), column)
   end
 
   attr_reader :model, :associations, :column

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -81,16 +81,16 @@ describe MiqReport do
 
   context "report with virtual dynamic custom attributes" do
     let(:options)              { {:targets_hash => true, :userid => "admin"} }
-    let(:custom_column_key_1)  { 'ATTR_Name_1' }
-    let(:custom_column_key_2)  { 'ATTR_Name_2' }
+    let(:custom_column_key_1)  { 'kubernetes.io/hostname' }
+    let(:custom_column_key_2)  { 'manageiq.org' }
     let(:custom_column_key_3)  { 'ATTR_Name_3' }
     let(:custom_column_value)  { 'value1' }
     let(:user)                 { FactoryGirl.create(:user_with_group) }
     let(:ems)                  { FactoryGirl.create(:ems_vmware) }
     let!(:vm_1)                { FactoryGirl.create(:vm_vmware) }
     let!(:vm_2)                { FactoryGirl.create(:vm_vmware, :retired => false, :ext_management_system => ems) }
-    let(:virtual_column_key_1) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}ATTR_Name_1" }
-    let(:virtual_column_key_2) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}ATTR_Name_2" }
+    let(:virtual_column_key_1) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}kubernetes.io/hostname" }
+    let(:virtual_column_key_2) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}manageiq.org" }
     let(:virtual_column_key_3) { "#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}ATTR_Name_3" }
     let(:miq_task)             { FactoryGirl.create(:miq_task) }
 
@@ -111,9 +111,9 @@ describe MiqReport do
       MiqReport.new(
         :name => "Custom VM report", :title => "Custom VM report", :rpt_group => "Custom", :rpt_type => "Custom",
         :db        => "ManageIQ::Providers::InfraManager::Vm",
-        :cols      => %w(name virtual_custom_attribute_ATTR_Name_1 virtual_custom_attribute_ATTR_Name_2),
+        :cols      => %w(name virtual_custom_attribute_kubernetes.io/hostname virtual_custom_attribute_manageiq.org),
         :include   => {:custom_attributes => {}},
-        :col_order => %w(name virtual_custom_attribute_ATTR_Name_1 virtual_custom_attribute_ATTR_Name_2),
+        :col_order => %w(name virtual_custom_attribute_kubernetes.io/hostname virtual_custom_attribute_manageiq.org),
         :headers   => ["Name", custom_column_key_1, custom_column_key_1],
         :order     => "Ascending"
       )
@@ -151,6 +151,7 @@ describe MiqReport do
       end
 
       expected_results = ["name" => vm_1.name, virtual_column_key_1 => custom_column_value, virtual_column_key_2 => nil]
+
       expect(report_result).to match_array(expected_results)
     end
 


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/10482 point 1
## Purpose

Reporting with custom attributes was broken when CustomAttribute#name contains some special characters as "." or "/". 

This PR is fixing in UI : clicking on filter tab in report definition and in report generation.

The common thread is basically that we have couple method which processing(and expecting) attributes (defined report) with form (for example)
`Vm.hosts.disks-name`
and when we have virtual custom attribute it has form
`Vm.virtual_custom_attribute_manage.org/kurbenetes` so it is failing in some parsing method.

So I found such parsing methods and I added here some "IFs" for handling virtual custom attributes (https://github.com/ManageIQ/manageiq/pull/11112/commits/794b9867a959744e3f90d672a5995e22afd90a9a, https://github.com/ManageIQ/manageiq/pull/11112/commits/84a855deaea7462d9aa8a8b852fe0a608de86105,  https://github.com/ManageIQ/manageiq/pull/11112/commits/69c85ee66970688a90834da759532acdfa06c1b0)

I needed to change also regex in MiqExpression::Field to parse it, and I solved by prefix(https://github.com/ManageIQ/manageiq/pull/11112/commits/6fbce18e993364777ff0c885876f4a6ccddbfb1f).

1)  At this moment I am allowing to have basically "whatever" in name of custom attribute and I didn't any issue with it maybe we should limited it. ? 

2) If we will limited it how I should tackle with custom attributes which contains forbidden characters ? (Don't display it at all ? )

cc @imtayadeway 
@miq-bot assign @gtanzillo 

fyi @cben @alongoldboim 
