### PR TITLE
Make Subscription ID field mandatory in Azure discovery

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1176,8 +1176,8 @@ module ApplicationController::CiProcessing
         @azure_tenant_id = params[:azure_tenant_id] if params[:azure_tenant_id]
         @subscription = params[:subscription] if params[:subscription]
 
-        if @client_id == "" || @client_key == "" || @azure_tenant_id == ""
-          add_flash(_("Client ID, Client Key and Azure Tenant ID are required"), :error)
+        if @client_id == "" || @client_key == "" || @azure_tenant_id == "" || @subscription == ""
+          add_flash(_("Client ID, Client Key, Azure Tenant ID and Subscription ID are required"), :error)
           render :action => 'discover'
           return
         end


### PR DESCRIPTION
This is a follow-up PR for https://github.com/ManageIQ/manageiq/pull/10531

Subscription ID field which was optional before is now mandatory.
<img width="1183" alt="screen shot 2016-09-08 at 10 07 17 am" src="https://cloud.githubusercontent.com/assets/1538216/18359354/6cd119b0-75ae-11e6-9c21-40a1b56cf75a.png">
