### PR TITLE
Update summary screen "label" class

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -236,7 +236,16 @@ table.table-hover tbody tr:nth-child(even).no-hover:hover td {
 
 /* summary screen formatting */
 
-table .label {display: table-cell;width: 20% !important; min-width: 200px; font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;cursor: default;color: #333; text-align: left;}
+table .label {
+  display: table-cell;
+  width: 20% !important;
+  min-width: 200px;
+  font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;
+  cursor: default;
+  color: #333;
+  text-align: left;
+  white-space: normal
+}
 
 table.table.table-selectable tbody tr.selected td {
   background-color: $link-color;


### PR DESCRIPTION
Summary screen text in the left column can be extremely long (such as on the VM Devices screen.) This PR adds word wrapping to that cell, when required.

Issue: #9518

Old
<img width="960" alt="screen shot 2016-09-08 at 4 53 57 pm" src="https://cloud.githubusercontent.com/assets/1287144/18366490/deb2dfba-75e4-11e6-8cfc-2798ad25ca81.png">

New
<img width="960" alt="screen shot 2016-09-08 at 4 52 43 pm" src="https://cloud.githubusercontent.com/assets/1287144/18366491/dec7d938-75e4-11e6-9e01-1efd19111a12.png">
