### PR TITLE
Refactor code not to use div_num in report/show_schedule view

### DIFF
--- a/app/views/report/_show_schedule.html.haml
+++ b/app/views/report/_show_schedule.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_schedule_list"}
+= render :partial => "layouts/flash_msg"
 %h3= _("Schedule Info")
 .form-horizontal.static
   .form-group


### PR DESCRIPTION
Refactor code not to use div_num as part of creating DOM IDs on the fly.

Delete all use and references to div_num when invoking flash_msg partial view.