### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+= render :partial => "layouts/flash_msg"
 - if @sb[:active_tab] == "report_info"
   - if @sb[:miq_report_id] && @miq_report
     .form-horizontal.static


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view