### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -1,5 +1,4 @@
 - @angular_form = true
-- div_num ||= ""
 
 %form.form-horizontal#form_div{:name                                 => "angularForm",
                                'ng-controller'                       => "logCollectionFormController",
@@ -8,7 +7,7 @@
                                'data-save-url'                       => "/#{controller_name}/log_depot_edit/",
                                'data-log-protocol-changed-url'       => "/#{controller_name}/log_protocol_changed/",
                                :novalidate                           => 1}
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => div_num}
+  = render :partial => "layouts/flash_msg"
 
   %h3
     = _("Editing Log Depot Settings for %{class}: %{display}") % {:class   => Dictionary.gettext(@record.class.name,


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view