### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -5,7 +5,7 @@
   :javascript
     ManageIQ.calendar.calDateFrom = null;
     ManageIQ.calendar.calDateTo = new Date();
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "cu_repair"}
+  = render :partial => "layouts/flash_msg"
 
   %h3= _("Collection Options")
   .form-horizontal


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view