### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/miq_capacity/_utilization_summary.html.haml
+++ b/app/views/miq_capacity/_utilization_summary.html.haml
@@ -1,5 +1,5 @@
 #utilization_summary_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+  = render :partial => "layouts/flash_msg"
   - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "summ"}
     = render(:partial => "layouts/perf_charts",


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view