### PR TITLE
Takes new_resource_group when resource_group is blank

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/orchestration_service_option_converter.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers
     def stack_create_options
       {
         :parameters     => stack_parameters,
-        :resource_group => @dialog_options['dialog_resource_group'] || @dialog_options['dialog_new_resource_group'],
+        :resource_group => @dialog_options['dialog_resource_group'].presence || @dialog_options['dialog_new_resource_group'],
         :mode           => @dialog_options['dialog_deploy_mode']
       }
     end

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/orchestration_service_option_converter_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack/orchestration_service_option_converter_spec.rb
@@ -1,0 +1,21 @@
+describe ManageIQ::Providers::Azure::CloudManager::OrchestrationServiceOptionConverter do
+  subject { ManageIQ::Providers::Azure::CloudManager::OrchestrationServiceOptionConverter.new(dialog_options) }
+
+  describe "#create_stack_options" do
+    context "both resource_group and new_resource_group exist" do
+      let(:dialog_options) { {'dialog_resource_group' => 'abc', 'dialog_new_resource_group' => 'xyz'} }
+
+      it "prefers resource_group over new_resource_group" do
+        expect(subject.stack_create_options).to have_attributes(:resource_group => 'abc')
+      end
+    end
+
+    context "resource_group is blank" do
+      let(:dialog_options) { {'dialog_resource_group' => '', 'dialog_new_resource_group' => 'xyz'} }
+
+      it "takes new_resource_group" do
+        expect(subject.stack_create_options).to have_attributes(:resource_group => 'xyz')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Purpose or Intent
-----------------
In SSUI if user select <New_resource_group> the option value is `nil`. When it is passed to backend through REST Api, it gets converted to `""`.

The fix is to test blankness of `resource_group` option and pick `new_resource_group` option accordingly.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1374398

Steps for Testing/QA
--------------------
https://bugzilla.redhat.com/show_bug.cgi?id=1374398