### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -1,6 +1,6 @@
 - url = url_for(:action => 'planning_option_changed')
 #planning_summary_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+  = render :partial => "layouts/flash_msg"
   - if @perf_record
     %h3= _('Display Options')
     %dl.dl-horizontal


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view