### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/miq_capacity/_planning_report.html.haml
+++ b/app/views/miq_capacity/_planning_report.html.haml
@@ -1,5 +1,5 @@
 #planning_report_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "3"}
+  = render :partial => "layouts/flash_msg"
 
   - if @perf_record && @sb[:planning] && @sb[:planning][:rpt]
 


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view