### PR TITLE
No longer select 'Discovered virtual machine' as a default folder

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -64,9 +64,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
 
     host_dc = dest_host.parent_datacenter || dest_host.ems_cluster.parent_datacenter
 
-    # Pick 'Discovered virtual machine' or its parent folder in the destination datacenter
-    vm_folder = "#{host_dc.folder_path}/vm"
-    find_folder("#{vm_folder}/Discovered virtual machine", host_dc) || find_folder(vm_folder, host_dc)
+    # Pick the parent folder in the destination datacenter
+    find_folder("#{host_dc.folder_path}/vm", host_dc)
   end
 
   def find_folder(folder_path, datacenter)

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -147,14 +147,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           FactoryGirl.create(:ems_folder, :name => 'vm', :ems_id => @ems.id).tap { |v| v.parent = dc }
         end
 
-        let(:discovered_vm_folder) do
-          FactoryGirl.create(:ems_folder, :name => 'Discovered virtual machine', :ems_id => @ems.id).tap { |f| f.parent = vm_folder }
-        end
-
-        let(:discovered_vm_folder_nested) do
-          FactoryGirl.create(:ems_folder, :name => 'Discovered virtual machine', :ems_id => @ems.id).tap { |f| f.parent = vm_folder_nested }
-        end
-
         let(:dest_host_nested) do
           FactoryGirl.create(:host_vmware, :ext_management_system => @ems).tap { |h| h.parent = dc_nested }
         end
@@ -168,18 +160,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           expect(@vm_prov.dest_folder).to eq(user_folder)
         end
 
-        it "uses 'Discoverd virtual machine' folder in destination host" do
-          discovered_vm_folder
-          @vm_prov.options[:dest_host] = [dest_host.id, dest_host.name]
-          expect(@vm_prov.dest_folder).to eq(discovered_vm_folder)
-        end
-
-        it "uses a nested 'Discovered virtual machine' folder in destination host" do
-          discovered_vm_folder_nested
+        it "correctly locates a nested folder in destination host" do
           @vm_prov.options[:dest_host] = [dest_host_nested.id, dest_host_nested.name]
           parent_datacenter = dest_host_nested.parent_datacenter
           expect(parent_datacenter.folder_path).to eq("Datacenters/nested/testing/#{parent_datacenter.name}")
-          expect(@vm_prov.dest_folder).to eq(discovered_vm_folder_nested)
         end
 
         it "uses vm folder in destination host" do


### PR DESCRIPTION
Purpose or Intent
-----------------
> No longer default to the `Discovered virtual machine` folder when provisioning VMWare VM's.
>


Links
-----
> * https://www.pivotaltracker.com/story/show/130055823


Steps for Testing/QA
--------------------
> Provision a VM from a dialog with `:placement_auto` set to true.
> The VM will now show up off the root folder for the parent datacenter as opposed to the `Discovered virtual machine` folder.