### PR TITLE
Refactor code not to use div_num as part of creating DOM IDs on the fly.

### DIFF
--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -1,7 +1,7 @@
 - url = url_for(:action => 'planning_option_changed')
 -# Div to hold the planning options
 #planning_options_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "0"}
+  = render :partial => "layouts/flash_msg"
   %h3
     = _('Reference VM Selection')
   .form.horizontal


### PR DESCRIPTION
Do not use nor reference div_num when rendering flash_msg partial view