### PR TITLE
TreeBuilder use settings not config. and use sql where

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -363,10 +363,6 @@ class TreeBuilder
     open_nodes.push(id) unless open_nodes.include?(id)
   end
 
-  def get_vmdb_config
-    @vmdb_config ||= VMDB::Config.new("vmdb").config
-  end
-
   # Tree node prefixes for generic explorers
   X_TREE_NODE_PREFIXES = {
     "a"   => "MiqAction",

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -37,15 +37,10 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   def x_get_tree_custom_kids(object, count_only, _options)
     case object[:id]
     when "l"
-      count_only_or_objects(count_only, LdapRegion.all, "name.to_s")
+      count_only_or_objects(count_only, LdapRegion.all, "name")
     when "msc"
-      objects = []
-      MiqSchedule.where("prod_default != 'system' or prod_default is null").to_a.sort do |a, b|
-        a.name.downcase <=> b.name.downcase
-      end.each do |z|
-        objects.push(z) if z.adhoc.nil?
-      end
-      count_only_or_objects(count_only, objects)
+      objects = MiqSchedule.where("(prod_default != 'system' or prod_default is null) AND adhoc is null")
+      count_only_or_objects(count_only, objects, "name")
     when "sis"
       count_only_or_objects(count_only, ScanItemSet.all, "name")
     when "z"

--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -26,7 +26,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
       {:id => "sis", :text => _("Analysis Profiles"), :image => "scan_item_set", :tip => _("Analysis Profiles")},
       {:id => "z", :text => _("Zones"), :image => "zone", :tip => _("Zones")}
     ]
-    if get_vmdb_config[:product][:new_ldap]
+    if Settings.product.new_ldap
       objects.push(:id => "l", :text => _("LDAP"), :image => "ldap", :tip => _("LDAP"))
     end
     objects.push(:id => "msc", :text => _("Schedules"), :image => "miq_schedule", :tip => _("Schedules"))


### PR DESCRIPTION
Making a pass through tree builders to not bring back all records.

1. We prefer `Settings` over `VMDB::Config.new`. I changed the only spot I could find under `app/presenters/`.
2. Instead of bringing back all schedules to then filter in ruby on `!adhoc.nil?`, this moves that to the query. This then becomes a standard tree builder accessor. now, in building the collapsed tree, it will not have to download all the nodes to the server to count them.

I put both of these commits together because it will be easier to test.
/cc @ZitaNemeckova let me know if changes like this conflict with what you are doing