### PR TITLE
Tree builder misc performance fixes

### DIFF
--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -38,17 +38,16 @@ class TreeBuilderConfigurationManager < TreeBuilder
   end
 
   def x_get_tree_cmat_kids(object, count_only)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ManageIQ::Providers::ConfigurationManager::InventoryGroup.where(:ems_id => object[:id]),
-                                        :match_via_descendants => ConfiguredSystem), "name")
+    count_only_or_objects_filtered(count_only,
+                                   ManageIQ::Providers::ConfigurationManager::InventoryGroup.where(:ems_id => object[:id]),
+                                   "name", :match_via_descendants => ConfiguredSystem)
   end
 
   def x_get_tree_cmf_kids(object, count_only)
     assigned_configuration_profile_objs =
-      count_only_or_objects(count_only,
-                            Rbac.filtered(ConfigurationProfile.where(:manager_id => object[:id]),
-                                          :match_via_descendants => ConfiguredSystem),
-                            "name")
+      count_only_or_objects_filtered(count_only,
+                                     ConfigurationProfile.where(:manager_id => object[:id]),
+                                     "name", :match_via_descendants => ConfiguredSystem)
     unassigned_configuration_profile_objs =
       fetch_unassigned_configuration_profile_objects(count_only, object[:id])
 
@@ -75,28 +74,24 @@ class TreeBuilderConfigurationManager < TreeBuilder
   end
 
   def x_get_tree_cpf_kids(object, count_only)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ConfiguredSystem.where(:configuration_profile_id => object[:id],
-                                                               :manager_id               => object[:manager_id]),
-                                        :match_via_descendants => ConfiguredSystem),
-                          "hostname")
+    count_only_or_objects_filtered(count_only,
+                                   ConfiguredSystem.where(:configuration_profile_id => object[:id],
+                                                          :manager_id               => object[:manager_id]),
+                                   "hostname", :match_via_descendants => ConfiguredSystem)
   end
 
   def x_get_tree_igf_kids(object, count_only)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ConfiguredSystem.where(:inventory_root_group_id=> object[:id]),
-                                        :match_via_descendants => ConfiguredSystem),
-                          "hostname")
+    count_only_or_objects_filtered(count_only,
+                                   ConfiguredSystem.where(:inventory_root_group_id=> object[:id]),
+                                   "hostname", :match_via_descendants => ConfiguredSystem)
   end
 
   def x_get_tree_custom_kids(object_hash, count_only, _options)
     objects =
       case object_hash[:id]
-      when "fr" then Rbac.filtered(ManageIQ::Providers::Foreman::ConfigurationManager.order("lower(name)"),
-                                   :match_via_descendants => ConfiguredSystem)
-      when "at" then Rbac.filtered(ManageIQ::Providers::AnsibleTower::ConfigurationManager.order("lower(name)"),
-                                   :match_via_descendants => ConfiguredSystem)
+      when "fr" then ManageIQ::Providers::Foreman::ConfigurationManager
+      when "at" then ManageIQ::Providers::AnsibleTower::ConfigurationManager
       end
-    count_only_or_objects(count_only, objects, "name")
+    count_only_or_objects_filtered(count_only, objects, "name", :match_via_descendants => ConfiguredSystem)
   end
 end

--- a/app/presenters/tree_builder_configuration_manager.rb
+++ b/app/presenters/tree_builder_configuration_manager.rb
@@ -54,6 +54,7 @@ class TreeBuilderConfigurationManager < TreeBuilder
     assigned_configuration_profile_objs + unassigned_configuration_profile_objs
   end
 
+  # Note: a lot of logic / queries to determine if should display menu item
   def fetch_unassigned_configuration_profile_objects(count_only, configuration_manager_id)
     unprovisioned_configured_systems = ConfiguredSystem.where(:configuration_profile_id => nil,
                                                               :manager_id               => configuration_manager_id)
@@ -64,13 +65,8 @@ class TreeBuilderConfigurationManager < TreeBuilder
       unassigned_configuration_profile =
         [ConfigurationProfile.new(:name       => "Unassigned Profiles Group|#{unassigned_id}",
                                   :manager_id => configuration_manager_id)]
-      unassigned_configuration_profile_objs = count_only_or_objects(count_only, unassigned_configuration_profile)
     end
-
-    if unassigned_configuration_profile_objs.nil?
-      count_only ? unassigned_configuration_profile_objs = 0 : unassigned_configuration_profile_objs = []
-    end
-    unassigned_configuration_profile_objs
+    count_only_or_objects(count_only, unassigned_configuration_profile || [])
   end
 
   def x_get_tree_cpf_kids(object, count_only)

--- a/app/presenters/tree_builder_configuration_manager_configured_systems.rb
+++ b/app/presenters/tree_builder_configuration_manager_configured_systems.rb
@@ -43,8 +43,7 @@ class TreeBuilderConfigurationManagerConfiguredSystems < TreeBuilder
   end
 
   def x_get_tree_custom_kids(object, count_only, options)
-    objects = x_get_search_results(object, options[:leaf])
-    count_only ? objects.length : objects
+    count_only_or_objects(count_only, x_get_search_results(object, options[:leaf]))
   end
 
   def x_get_search_results(object, leaf)

--- a/app/presenters/tree_builder_containers_filter.rb
+++ b/app/presenters/tree_builder_containers_filter.rb
@@ -31,6 +31,6 @@ class TreeBuilderContainersFilter < TreeBuilder
   def x_get_tree_custom_kids(object, count_only, options)
     return count_only ? 0 : [] if object[:id] != "global"
     objects = MiqSearch.where(:db => options[:leaf]).visible_to_all
-    count_only ? objects.length : objects.sort_by { |a| a.description.downcase }
+    count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -29,7 +29,7 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def x_get_tree_ems_kids(object, count_only)
-    objects = Rbac.filtered(object.miq_templates.order("name"))
-    count_only ? objects.length : objects
+    objects = Rbac.filtered(object.miq_templates)
+    count_only_or_objects(count_only, objects, "name")
   end
 end

--- a/app/presenters/tree_builder_images.rb
+++ b/app/presenters/tree_builder_images.rb
@@ -23,13 +23,11 @@ class TreeBuilderImages < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(EmsCloud.order("lower(name)"), :match_via_descendants => TemplateCloud) +
-              x_get_tree_arch_orph_nodes("Images")
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => TemplateCloud) +
+      count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Images"))
   end
 
   def x_get_tree_ems_kids(object, count_only)
-    objects = Rbac.filtered(object.miq_templates)
-    count_only_or_objects(count_only, objects, "name")
+    count_only_or_objects_filtered(count_only, object.miq_templates, "name")
   end
 end

--- a/app/presenters/tree_builder_instances.rb
+++ b/app/presenters/tree_builder_instances.rb
@@ -24,20 +24,17 @@ class TreeBuilderInstances < TreeBuilder
   end
 
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(EmsCloud.order("lower(name)"), :match_via_descendants => VmCloud) +
-              x_get_tree_arch_orph_nodes("Instances")
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects_filtered(count_only, EmsCloud, "name", :match_via_descendants => VmCloud) +
+      count_only_or_objects(count_only, x_get_tree_arch_orph_nodes("Instances"))
   end
 
   def x_get_tree_ems_kids(object, count_only)
-    objects = Rbac.filtered(object.availability_zones.order("name")) +
-              Rbac.filtered(object.vms.where(:availability_zone_id => nil).order("name"))
-    count_only ? objects.length : objects
+    count_only_or_objects_filtered(count_only, object.availability_zones, "name") +
+      count_only_or_objects_filtered(object.vms.where(:availability_zone_id => nil), "name")
   end
 
   # Get AvailabilityZone children count/array
   def x_get_tree_az_kids(object, count_only)
-    objects = Rbac.filtered(object.vms.not_archived_nor_orphaned)
-    count_only_or_objects(count_only, objects, "name")
+    count_only_or_objects_filtered(count_only, object.vms.not_archived_nor_orphaned, "name")
   end
 end

--- a/app/presenters/tree_builder_ops_vmdb.rb
+++ b/app/presenters/tree_builder_ops_vmdb.rb
@@ -21,13 +21,13 @@ class TreeBuilderOpsVmdb < TreeBuilderOps
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = Rbac.filtered(VmdbDatabase.my_database.evm_tables).sort { |a, b| a.name.downcase <=> b.name.downcase }
-    # storing table names and their id in hash so they can be used ot build links on summary screen in top 5 boxes
+    objects = Rbac.filtered(VmdbDatabase.my_database.evm_tables).to_a
+    # storing table names and their id in hash so they can be used to build links on summary screen in top 5 boxes
     @sb[:vmdb_tables] = {}
     objects.each do |o|
       @sb[:vmdb_tables][o.name] = o.id
     end
-    count_only ? objects.length : objects
+    count_only_or_objects(count_only, objects, "name")
   end
 
   # Handle custom tree nodes (object is a Hash)

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -48,7 +48,6 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
       "otazu" => OrchestrationTemplateAzure,
       "otvnf" => OrchestrationTemplateVnfd
     }
-    objects = Rbac.filtered(classes[object[:id]].where(["orderable=?", true])).sort_by { |o| o.name.downcase }
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects_filtered(count_only, classes[object[:id]].where(["orderable=?", true]), "name")
   end
 end

--- a/app/presenters/tree_builder_orchestration_templates.rb
+++ b/app/presenters/tree_builder_orchestration_templates.rb
@@ -38,7 +38,7 @@ class TreeBuilderOrchestrationTemplates < TreeBuilder
        :image => "orchestration_template_vnfd",
        :tip   => _("VNF Templates")}
     ]
-    count_only ? children.length : children
+    count_only_or_objects(count_only, children)
   end
 
   def x_get_tree_custom_kids(object, count_only, _options)

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -21,7 +21,7 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
     items = PxeImageType.all
     if count_only
       # add +1 for customization spec folder thats used to show system templates
-      items.length + 1
+      items.size + 1
     else
       objects = []
       objects.push(:id    => "xx-system",

--- a/app/presenters/tree_builder_pxe_customization_templates.rb
+++ b/app/presenters/tree_builder_pxe_customization_templates.rb
@@ -45,12 +45,12 @@ class TreeBuilderPxeCustomizationTemplates < TreeBuilder
     if nodes[1] == "system" || nodes[2] == "system"
       # root node was clicked or if folder node was clicked
       # System templates
-      objects = CustomizationTemplate.where(:pxe_image_type_id => nil)
+      pxe_img_id = nil
     else
       # root node was clicked or if folder node was clicked
-      pxe_img = PxeImageType.find_by_id(from_cid(get_pxe_image_id(nodes)))
-      objects = CustomizationTemplate.where(:pxe_image_type_id => pxe_img.id)
+      pxe_img_id = from_cid(get_pxe_image_id(nodes))
     end
+    objects = CustomizationTemplate.where(:pxe_image_type_id => pxe_img_id)
     count_only_or_objects(count_only, objects, "name")
   end
 end

--- a/app/presenters/tree_builder_report_dashboards.rb
+++ b/app/presenters/tree_builder_report_dashboards.rb
@@ -55,6 +55,6 @@ class TreeBuilderReportDashboards < TreeBuilder
     else
       objects = copy_array(widgetsets.to_a)
     end
-    count_only ? objects.count : objects.sort_by { |a| a.name.to_s.downcase }
+    count_only_or_objects(count_only, objects, :name)
   end
 end

--- a/app/presenters/tree_builder_storage.rb
+++ b/app/presenters/tree_builder_storage.rb
@@ -26,6 +26,6 @@ class TreeBuilderStorage < TreeBuilder
   def x_get_tree_custom_kids(object, count_only, options)
     return count_only ? 0 : [] if object[:id] != "global"
     objects = MiqSearch.where(:db => options[:leaf]).visible_to_all
-    count_only ? objects.length : objects.sort_by { |a| a.description.downcase }
+    count_only_or_objects(count_only, objects, "description")
   end
 end


### PR DESCRIPTION
In the tree builders, we sometimes follow a pattern where we add active record results. This will download all records even when we want a simple `count(*)`. For archived, #10919 got us ~5% speed improvement, but it really depends upon the number of archived records.

Martin, could you let me know the best way to test these / divide this PR up?
This was focused on the pattern we discussed.

```ruby
# before
objects = Vm.all_orphans + MiqTemplate.all_orphans
count_only_or_objects(count_only, objects)

# after
count_only_or_objects(count_only, Vm.all_orphans) +
  count_only_or_objects(count_only, MiqTemplate.all_orphans)
```

There is also an rbac version of this method which reads shorter, but is currently no real performance boost.

```ruby
# before
count_only_or_objects(count_only,  Rbac.filtered(Vm.all_orphans))

# after
count_only_or_objects_filtered(count_only,  Vm.all_orphans)
```

We often want to sort these results, which we are doing in ruby. Some of our examples also do that in the database.

```ruby
# before
count_only_or_objects(count_only, Vm.all_orphans.order("lower(name)")
# before 2
count_only_or_objects(count_only, Vm.all_orphans).sort_by { |r| r.name.to_s.downcase }

# after
count_only_or_objects(count_only, Vm.all_orphans, "name")
```

/cc @ZitaNemeckova 