### PR TITLE
Recompile assets when bin/update is called in production

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -32,4 +32,9 @@ Dir.chdir APP_ROOT do
     puts "\n== Resetting Automate Domains =="
     execute "bin/rake evm:automate:reset"
   end
+
+  if ENV['RAILS_ENV'] == 'production'
+    puts "\n== Recompiling assets =="
+    execute "bin/rake evm:compile_assets"
+  end
 end


### PR DESCRIPTION
Our friends at QE had their own script for updating an appliance to the latest code. However, they forgot to add `bower update` which can cause [issues](https://github.com/ManageIQ/manageiq/issues/10966#issuecomment-245671547) in the UI. This PR adds asset precompilation to the update script when called from production. This way QE can use the same `bin/update` as we do! :cake:

FYI @mfalesni 