### PR TITLE
Formalize event for ConfiguredSystem been provisioned

### DIFF
--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -200,3 +200,7 @@ containerreplicator_compliance_check,Replicator Compliance Check,Default,complia
 containerreplicator_compliance_passed,Replicator Compliance Passed,Default,compliance
 containerreplicator_compliance_failed,Replicator Compliance Failed,Default,compliance
 
+#
+# Configuration
+#
+configured_system_provisioned,System Provisioned by Configuration Manager,Default,vm_process


### PR DESCRIPTION
Without proper MiqEventDefinition, the `configured_system_provisioned` event is never created, and it only logs:

```
WARN -- : MIQ(MiqEvent.raise_evm_event) Event configured_system_provisioned [...] was not raised: configured_system_provisioned is not defined in MiqEventDefinition
INFO -- : MIQ(MiqEvent.raise_evm_event) Alert for Event [configured_system_provisioned]
```

@miq-bot add_label bug, event, automate, providers/foreman
