### PR TITLE
Do not allow to copy "Administrator" user

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -34,6 +34,14 @@ module OpsController::OpsRbac
   end
 
   def rbac_user_copy
+    user = User.find(from_cid(params[:miq_grid_checks]))
+    if rbac_user_copy_restriction?(user)
+      rbac_restricted_user_copy_flash(user)
+    end
+    if @flash_array
+      javascript_flash
+      return
+    end
     assert_privileges("rbac_user_copy")
     rbac_edit_reset('copy', 'user', User)
   end
@@ -559,12 +567,20 @@ module OpsController::OpsRbac
     ["admin", session[:userid]].include?(user.userid)
   end
 
+  def rbac_user_copy_restriction?(user)
+    user.super_admin_user?
+  end
+
   def rbac_restricted_user_delete_flash(user)
-    if user.userid == "admin"
+    if user.super_admin_user?
       add_flash(_("Default %{model} \"%{name}\" cannot be deleted") % {:model => ui_lookup(:model => "User"), :name => user.name}, :error)
     elsif user.userid == session[:userid]
       add_flash(_("Current %{model} \"%{name}\" cannot be deleted") % {:model => ui_lookup(:model => "User"), :name => user.name}, :error)
     end
+  end
+
+  def rbac_restricted_user_copy_flash(user)
+    add_flash(_("Default %{model} \"%{name}\" cannot be copied") % {:model => ui_lookup(:model => "User"), :name => user.name}, :error)
   end
 
   def rbac_edit_tags_reset(tagging)


### PR DESCRIPTION
Purpose or Intent
-----------------
According to the [code in toolbar_builder.rb](https://github.com/ManageIQ/manageiq/blob/master/app/helpers/application_helper/toolbar_builder.rb#L1206) the *Administrator* user should not be allowed to be copied.

Steps for Testing/QA
--------------------
1) Go to Configuration
2) Access Control
3) Users
4) Check *Administrator* user
5) In *Configuration* select the button *Copy the selected User to a new User*

After the change it does not take you to the form, but displays the error flash message

![screencast from 2016-09-09 17-28-11](https://cloud.githubusercontent.com/assets/1187051/18392647/d802465a-76b2-11e6-8303-3d2f9d4adb04.gif)