### PR TITLE
Allow bring VM out of retirement from detail page

### DIFF
--- a/app/helpers/application_helper/button/vm_retire.rb
+++ b/app/helpers/application_helper/button/vm_retire.rb
@@ -1,15 +1,11 @@
 class ApplicationHelper::Button::VmRetire < ApplicationHelper::Button::Basic
   needs_record
 
-  def calculate_properties
-    self[:enabled] = !(self[:title] = N_("VM is already retired") if disabled?)
-  end
-
   def visible?
     @record.supports_retire?
   end
 
   def disabled?
-    @record.retired
+    false
   end
 end

--- a/app/helpers/application_helper/button/vm_retire_now.rb
+++ b/app/helpers/application_helper/button/vm_retire_now.rb
@@ -1,0 +1,16 @@
+class ApplicationHelper::Button::VmRetireNow < ApplicationHelper::Button::Basic
+  needs_record
+
+  def calculate_properties
+    super
+    self[:title] = N_("VM is already retired") if disabled?
+  end
+
+  def visible?
+    @record.supports_retire?
+  end
+
+  def disabled?
+    @record.retired
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -138,7 +138,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           t = N_('Retire this VM'),
           t,
           :confirm => N_("Retire this VM?"),
-          :klass => ApplicationHelper::Button::VmRetire),
+          :klass => ApplicationHelper::Button::VmRetireNow),
       ]
     ),
   ])

--- a/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_now_spec.rb
@@ -1,0 +1,52 @@
+describe ApplicationHelper::Button::VmRetireNow do
+  describe '#visible?' do
+    context "when record is retireable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:supports_retire?).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "when record is not retiretable" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:supports_retire?).and_return(false)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "when record has an error message" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:retired).and_return(true)
+      end
+
+      it "disables the button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+      end
+    end
+  end
+
+  describe "#calculate_properties" do
+    context "when record is retired" do
+      before do
+        @record = FactoryGirl.create(:vm_vmware)
+        allow(@record).to receive(:retired).and_return(true)
+      end
+
+      it "sets the error message for disabled button" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.calculate_properties
+        expect(button[:title]).to eq("VM is already retired")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/vm_retire_spec.rb
+++ b/spec/helpers/application_helper/buttons/vm_retire_spec.rb
@@ -20,32 +20,16 @@ describe ApplicationHelper::Button::VmRetire do
   end
 
   describe '#disabled?' do
-    context "when record has an error message" do
+    context "button should not be disabled" do
       before do
         @record = FactoryGirl.create(:vm_vmware)
         allow(@record).to receive(:retired).and_return(true)
       end
 
-      it "disables the button" do
+      it "does not disable the button" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        expect(button.disabled?).to be_truthy
-      end
-    end
-  end
-
-  describe "#calculate_properties" do
-    context "when record is retired" do
-      before do
-        @record = FactoryGirl.create(:vm_vmware)
-        allow(@record).to receive(:retired).and_return(true)
-      end
-
-      it "sets the error message for disabled button" do
-        view_context = setup_view_context_with_sandbox({})
-        button = described_class.new(view_context, {}, {'record' => @record}, {})
-        button.calculate_properties
-        expect(button[:title]).to eq("VM is already retired")
+        expect(button.disabled?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
According to [BZ ticket](https://bugzilla.redhat.com/show_bug.cgi?id=1306471), the button *Set Retirement Date* should be enabled for retired VMs.

This BZ fixes the issue by adding new class for the button instead of the one shared with *Retire this VM* button.

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1306471


Steps for Testing/QA
--------------------
1) Retire VM
2) Open VM's detail page

![screencast from 2016-09-09 17-18-13](https://cloud.githubusercontent.com/assets/1187051/18392267/75685e2c-76b1-11e6-9914-e01d464b76e8.gif)