### PR TITLE
[DARGA] Bump the expected report count

### DIFF
--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 132)
+    include_examples(".seed called multiple times", 134)
   end
 end


### PR DESCRIPTION
Purpose or Intent
-----------------
The cherry-picked merged commit from below didn't include the bump of the report
counts as described below, so we need to manually bump it, just like we did
in #11119.

---------------------
PR #10262 increased the count from 137 to 139.
But it's merge commit: 4a9a81e02167be2a32, doesn't include this change!

That's because PR #10962 already did the exact same change in merge
commit: 7cf2bfe679fcfe

Now that both PRs are merged but only one bumped the number, we need to fix it
for the other PR.