### PR TITLE
Fixed double-scrollbar issue in accordions

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1540,7 +1540,7 @@ function miqWidgetToolbarClick(_e) {
 
 function miqInitAccordions() {
   var height = $('#left_div').height() - $('#toolbar').outerHeight();
-  var panel = $('.panel-heading').outerHeight();
+  var panel = $('#left_div .panel-heading').outerHeight();
   var count = $('#accordion:visible > .panel .panel-body').length;
   $('#accordion:visible > .panel .panel-body').each(function (_k, v) {
     $(v).css('max-height', (height - count * panel) + 'px');

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -587,3 +587,10 @@ body#dashboard {
 .drawer-pf.vertical-scroll {
   right: 15px;
 }
+
+// Panel in sidebar doesn't need bottom margin
+.sidebar-pf-left {
+  .panel-group {
+    margin-bottom: 0px;
+  }
+}


### PR DESCRIPTION
The notification drawer uses the same `panel-heading` CSS class as the accordions and the jQuery selector in `miqInitAccordions()` wasn't specific enough to skip these new panels.

**Before:**
![screenshot from 2016-09-09 17-30-31](https://cloud.githubusercontent.com/assets/649130/18392841/a019a868-76b3-11e6-9b1b-59dd3434eff4.png)

**After:**
![screenshot from 2016-09-09 17-29-59](https://cloud.githubusercontent.com/assets/649130/18392851/a7c85aaa-76b3-11e6-9b61-dbbe1469e58c.png)

