### PR TITLE
Retirement - use datetime instead of date - migration

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -276,6 +276,7 @@ module ApplicationController::CiProcessing
         if params[:retire_date].blank?
           t = nil
           w = nil
+
           if session[:retire_items].length == 1
             flash = _("Retirement date removed")
           else
@@ -284,10 +285,12 @@ module ApplicationController::CiProcessing
         else
           t = params[:retire_date].in_time_zone
           w = params[:retire_warn].to_i
+
+          ts = t.strftime("%x %R %Z")
           if session[:retire_items].length == 1
-            flash = _("Retirement date set to %{date}") % {:date => t}
+            flash = _("Retirement date set to %{date}") % {:date => ts}
           else
-            flash = _("Retirement dates set to %{date}") % {:date => t}
+            flash = _("Retirement dates set to %{date}") % {:date => ts}
           end
         end
         kls.retire(session[:retire_items], :date => t, :warn => w) # Call the model to retire the VM(s)

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -282,7 +282,7 @@ module ApplicationController::CiProcessing
             flash = _("Retirement dates removed")
           end
         else
-          t = params[:retire_date]
+          t = params[:retire_date].in_time_zone
           w = params[:retire_warn].to_i
           if session[:retire_items].length == 1
             flash = _("Retirement date set to %{date}") % {:date => t}

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -285,9 +285,9 @@ module ApplicationController::CiProcessing
           t = params[:retire_date]
           w = params[:retire_warn].to_i
           if session[:retire_items].length == 1
-            flash = _("Retirement date set to %{date}") % {:date => params[:retire_date]}
+            flash = _("Retirement date set to %{date}") % {:date => t}
           else
-            flash = _("Retirement dates set to %{date}") % {:date => params[:retire_date]}
+            flash = _("Retirement dates set to %{date}") % {:date => t}
           end
         end
         kls.retire(session[:retire_items], :date => t, :warn => w) # Call the model to retire the VM(s)

--- a/app/helpers/orchestration_stack_helper/textual_summary.rb
+++ b/app/helpers/orchestration_stack_helper/textual_summary.rb
@@ -37,7 +37,7 @@ module OrchestrationStackHelper::TextualSummary
   def textual_retirement_date
     {:label => _("Retirement Date"),
      :image => "retirement",
-     :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.to_time.strftime("%x"))}
+     :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.strftime("%x %R %Z"))}
   end
 
   def textual_service

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -65,7 +65,7 @@ module ServiceHelper::TextualSummary
   def textual_retirement_date
     {:label => _("Retirement Date"),
      :image => "retirement",
-     :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.to_time.strftime("%x"))}
+     :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.strftime("%x %R %Z"))}
   end
 
   def textual_retirement_state

--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -194,7 +194,7 @@ module VmHelper::TextualSummary
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
     {:label => _("Retirement Date"),
      :image => "retirement",
-     :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.to_time.strftime("%x"))}
+     :value => (@record.retires_on.nil? ? _("Never") : @record.retires_on.strftime("%x %R %Z"))}
   end
 
   def textual_retirement_state

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -573,7 +573,7 @@ class MiqAction < ApplicationRecord
     target = inputs[:synchronous] ? VmOrTemplate : rec.class
     invoke_or_queue(
       inputs[:synchronous], __method__, "ems_operations", rec.my_zone, target, 'retire',
-      [[rec], :date => Time.now.utc - 1.day],
+      [[rec], :date => Time.zone.now - 1.day],
       "VM Retire for VM [#{rec.name}]")
   end
 

--- a/app/models/miq_provision/retirement.rb
+++ b/app/models/miq_provision/retirement.rb
@@ -1,10 +1,13 @@
 module MiqProvision::Retirement
   def set_retirement(vm)
     retire_date = nil
+
     retirement = get_option(:retirement).to_i
-    retire_date = (Time.now.utc + retirement).to_date unless retirement == 0
+    retire_date = (Time.now.utc + retirement) unless retirement == 0
+
     retirement_time = get_option(:retirement_time)
-    retire_date = retirement_time.to_date unless retirement_time.nil?
+    retire_date = retirement_time unless retirement_time.nil?
+
     unless retire_date.nil?
       _log.info("#{vm.class.base_model.name}:[#{vm.name}] set to retire on [#{retire_date}]")
       vm.retires_on = retire_date

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -28,28 +28,25 @@ module RetirementMixin
   end
 
   def retirement_warning_due?
-    retirement_warn && retires_on && retirement_warn.days.from_now.to_date >= retires_on.to_date
+    retirement_warn && retires_on && retirement_warn.days.from_now >= retires_on
   end
 
   def retirement_due?
-    retires_on && (Date.today >= retires_on_date)
+    retires_on && (Time.zone.now >= retires_on)
   end
 
   def retires_on=(timestamp)
     return if retires_on == timestamp
 
-    if timestamp.nil? || (timestamp.to_date > Time.zone.today)
+    if timestamp.nil? || (timestamp > Time.zone.now)
       self.retired = false
       _log.warn("Resetting retirement state from #{retirement_state}") unless retirement_state.nil?
       self.retirement_state = nil
     end
+
     self.retirement_last_warn = nil # Reset so that a new warning can be sent out when the time is right
     self[:retires_on] = timestamp
     self.retirement_requester = nil
-  end
-
-  def retires_on_date
-    retires_on.nil? ? nil : retires_on.to_date
   end
 
   def extend_retires_on(days, date = Time.zone.today)
@@ -134,8 +131,8 @@ module RetirementMixin
   def finish_retirement
     raise _("%{name} already retired") % {:name => name} if retired?
     $log.info("Finishing Retirement for [#{name}]")
-    update_attributes(:retires_on => Date.today, :retired => true, :retirement_state => "retired")
-    message = "#{self.class.base_model.name}: [#{name}], Retires On Date: [#{retires_on}], has been retired"
+    update_attributes(:retires_on => Time.zone.now, :retired => true, :retirement_state => "retired")
+    message = "#{self.class.base_model.name}: [#{name}], Retires On: [#{retires_on}], has been retired"
     $log.info("Calling audit event for: #{message} ")
     raise_audit_event(retired_event_name, message)
     $log.info("Called audit event for: #{message} ")

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -64,7 +64,7 @@ module RetirementMixin
 
     if options.key?(:date)
       date = nil
-      date = options[:date].to_date unless options[:date].nil?
+      date = options[:date].in_time_zone unless options[:date].nil?
       self.retires_on = date
 
       if date

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -68,7 +68,7 @@ module RetirementMixin
       self.retires_on = date
 
       if date
-        message += " is scheduled to retire on date: [#{retires_on_date}]"
+        message += " is scheduled to retire on: [#{retires_on}]"
       else
         message += " is no longer scheduled to retire"
       end
@@ -115,7 +115,7 @@ module RetirementMixin
   def retire_now(requester = nil)
     if retired
       return if retired_validated?
-      _log.info("#{retirement_object_title}: [#{name}], Retires On Date: [#{retires_on_date}], was previously retired, but currently #{retired_invalid_reason}")
+      _log.info("#{retirement_object_title}: [#{name}], Retires On: [#{retires_on}], was previously retired, but currently #{retired_invalid_reason}")
     else
       update_attributes(:retirement_requester => requester)
       event_name = "request_#{retirement_event_prefix}_retire"

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -68,7 +68,7 @@ module RetirementMixin
       self.retires_on = date
 
       if date
-        message += " is scheduled to retire on: [#{retires_on}]"
+        message += " is scheduled to retire on: [#{retires_on.strftime("%x %R %Z")}]"
       else
         message += " is no longer scheduled to retire"
       end
@@ -115,7 +115,7 @@ module RetirementMixin
   def retire_now(requester = nil)
     if retired
       return if retired_validated?
-      _log.info("#{retirement_object_title}: [#{name}], Retires On: [#{retires_on}], was previously retired, but currently #{retired_invalid_reason}")
+      _log.info("#{retirement_object_title}: [#{name}], Retires On: [#{retires_on.strftime("%x %R %Z")}], was previously retired, but currently #{retired_invalid_reason}")
     else
       update_attributes(:retirement_requester => requester)
       event_name = "request_#{retirement_event_prefix}_retire"
@@ -132,7 +132,7 @@ module RetirementMixin
     raise _("%{name} already retired") % {:name => name} if retired?
     $log.info("Finishing Retirement for [#{name}]")
     update_attributes(:retires_on => Time.zone.now, :retired => true, :retirement_state => "retired")
-    message = "#{self.class.base_model.name}: [#{name}], Retires On: [#{retires_on}], has been retired"
+    message = "#{self.class.base_model.name}: [#{name}], Retires On: [#{retires_on.strftime("%x %R %Z")}], has been retired"
     $log.info("Calling audit event for: #{message} ")
     raise_audit_event(retired_event_name, message)
     $log.info("Called audit event for: #{message} ")

--- a/db/migrate/20160912160750_change_retires_on_to_datetime.rb
+++ b/db/migrate/20160912160750_change_retires_on_to_datetime.rb
@@ -3,19 +3,13 @@ class ChangeRetiresOnToDatetime < ActiveRecord::Migration[5.0]
     change_column :vms, :retires_on, :datetime
     change_column :services, :retires_on, :datetime
     change_column :orchestration_stacks, :retires_on, :datetime
-
-    change_column :vms, :retirement_last_warn, :datetime
-    change_column :services, :retirement_last_warn, :datetime
-    change_column :orchestration_stacks, :retirement_last_warn, :datetime
+    change_column :load_balancers, :retires_on, :datetime
   end
 
   def down
     change_column :vms, :retires_on, :date
     change_column :services, :retires_on, :date
     change_column :orchestration_stacks, :retires_on, :date
-
-    change_column :vms, :retirement_last_warn, :date
-    change_column :services, :retirement_last_warn, :date
-    change_column :orchestration_stacks, :retirement_last_warn, :date
+    change_column :load_balancers, :retires_on, :date
   end
 end

--- a/db/migrate/20160912160750_change_retires_on_to_datetime.rb
+++ b/db/migrate/20160912160750_change_retires_on_to_datetime.rb
@@ -1,0 +1,21 @@
+class ChangeRetiresOnToDatetime < ActiveRecord::Migration[5.0]
+  def up
+    change_column :vms, :retires_on, :datetime
+    change_column :services, :retires_on, :datetime
+    change_column :orchestration_stacks, :retires_on, :datetime
+
+    change_column :vms, :retirement_last_warn, :datetime
+    change_column :services, :retirement_last_warn, :datetime
+    change_column :orchestration_stacks, :retirement_last_warn, :datetime
+  end
+
+  def down
+    change_column :vms, :retires_on, :date
+    change_column :services, :retires_on, :date
+    change_column :orchestration_stacks, :retires_on, :date
+
+    change_column :vms, :retirement_last_warn, :date
+    change_column :services, :retirement_last_warn, :date
+    change_column :orchestration_stacks, :retirement_last_warn, :date
+  end
+end

--- a/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
+++ b/spec/helpers/orchestration_stack_helper/textual_summary_spec.rb
@@ -10,9 +10,9 @@ describe OrchestrationStackHelper::TextualSummary do
       expect(textual_retirement_date[:value]).to eq("Never")
     end
 
-    it "with :retires_on returns date in %x format" do
-      @record.retires_on = Date.new(2015, 11, 01)
-      expect(textual_retirement_date[:value]).to eq("11/01/15")
+    it "with :retires_on returns date in %x %R %Z format" do
+      @record.retires_on = Date.new(2015, 11, 01).in_time_zone('UTC')
+      expect(textual_retirement_date[:value]).to eq("11/01/15 00:00 UTC")
     end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_spec.rb
@@ -162,7 +162,7 @@ EOF
       service_service.finish_retirement
 
       expect(service_service.retired).to be_truthy
-      expect(service_service.retires_on).to eq(Date.today)
+      expect(service_service.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)
       expect(service_service.retirement_state).to eq("retired")
     end
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_vm_spec.rb
@@ -124,7 +124,7 @@ module MiqAeServiceVmSpec
       service_vm.finish_retirement
 
       expect(service_vm.retired).to be_truthy
-      expect(service_vm.retires_on).to eq(Date.today)
+      expect(service_vm.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)
       expect(service_vm.retirement_state).to eq("retired")
     end
 

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -92,11 +92,6 @@ RSpec.describe MiqExpression::Field do
   end
 
   describe "#date?" do
-    it "returns true for fields of column type :date" do
-      field = described_class.new(Vm, [], "retires_on")
-      expect(field).to be_date
-    end
-
     it "returns false for fields of column type other than :date" do
       field = described_class.new(Vm, [], "name")
       expect(field).not_to be_date

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -201,13 +201,13 @@ describe MiqExpression do
       it "generates the SQL for an AFTER expression" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for a BEFORE expression" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-10 00:00:00'")
       end
 
       it "generates the SQL for an AFTER expression with date/time" do
@@ -224,19 +224,19 @@ describe MiqExpression do
       it "generates the SQL for an IS expression" do
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" = '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-10 00:00:00' AND '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for a FROM expression" do
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-09' AND '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-09 00:00:00' AND '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for a FROM expression with MM/DD/YYYY dates" do
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-09' AND '2011-01-10'")
+        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-09 00:00:00' AND '2011-01-10 23:59:59.999999'")
       end
 
       it "generates the SQL for a FROM expression with date/time" do
@@ -263,32 +263,32 @@ describe MiqExpression do
         it "generates the SQL for a AFTER expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("AFTER" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" > '2011-01-11'))
+          expect(sql).to eq(%q("vms"."retires_on" > '2011-01-11 16:59:59.999999'))
         end
 
         it "generates the SQL for a BEFORE expression with a value of 'Yesterday' for a date field" do
           exp =  described_class.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" < '2011-01-11'))
+          expect(sql).to eq(%q("vms"."retires_on" < '2011-01-10 17:00:00'))
         end
 
         it "generates the SQL for an IS expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-11' AND '2011-01-11'))
+          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-10 17:00:00' AND '2011-01-11 16:59:59.999999'))
         end
 
         it "generates the SQL for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
           exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
           sql, * = exp.to_sql("Asia/Jakarta")
-          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-11' AND '2011-01-12'))
+          expect(sql).to eq(%q("vms"."retires_on" BETWEEN '2011-01-10 17:00:00' AND '2011-01-12 16:59:59.999999'))
         end
       end
 
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-09'")
+        expect(sql).to eq("\"vms\".\"retires_on\" > '2011-01-09 23:59:59.999999'")
       end
 
       it "generates the SQL for an AFTER expression with an 'n Days Ago' value for a datetime field" do
@@ -300,7 +300,7 @@ describe MiqExpression do
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a date field" do
         exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-09'")
+        expect(sql).to eq("\"vms\".\"retires_on\" < '2011-01-09 00:00:00'")
       end
 
       it "generates the SQL for a BEFORE expression with an 'n Days Ago' value for a datetime field" do
@@ -318,7 +318,7 @@ describe MiqExpression do
       it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a date field" do
         exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-03' AND '2011-01-09'")
+        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-03 00:00:00' AND '2011-01-09 23:59:59.999999'")
       end
 
       it "generates the SQL for a FROM expression with a 'Last Week'/'Last Week' value for a datetime field" do
@@ -336,13 +336,13 @@ describe MiqExpression do
       it "generates the SQL for an IS expression with a 'Today' value for a date field" do
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-11' AND '2011-01-11'")
+        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-11 00:00:00' AND '2011-01-11 23:59:59.999999'")
       end
 
       it "generates the SQL for an IS expression with an 'n Hours Ago' value for a date field" do
         exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
         sql, * = exp.to_sql
-        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-11' AND '2011-01-11'")
+        expect(sql).to eq("\"vms\".\"retires_on\" BETWEEN '2011-01-11 14:00:00' AND '2011-01-11 14:59:59.999999'")
       end
 
       it "generates the SQL for an IS expression with an 'n Hours Ago' value for a datetime field" do
@@ -978,12 +978,12 @@ describe MiqExpression do
       context "static dates and times with no timezone" do
         it "generates the ruby for an AFTER expression with date value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-10T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T00:00:00Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
@@ -993,7 +993,7 @@ describe MiqExpression do
 
         it "generates the ruby for a IS expression with date value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-10T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a IS expression with datetime value" do
@@ -1003,12 +1003,12 @@ describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-09T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-09T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a FROM expression with datetime values" do
@@ -1027,12 +1027,12 @@ describe MiqExpression do
 
         it "generates the ruby for a AFTER expression with date value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-11T04:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T05:00:00Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
@@ -1047,12 +1047,12 @@ describe MiqExpression do
 
         it "generates the ruby for a IS expression wtih date value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-10T05:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T04:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-09T05:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T04:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a FROM expression with datetime values" do
@@ -1074,32 +1074,32 @@ describe MiqExpression do
         it "generates the SQL for a AFTER expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("AFTER" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-11T16:59:59Z'.to_time(:utc)")
         end
 
         it "generates the RUBY for a BEFORE expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-10T17:00:00Z'.to_time(:utc)")
         end
 
         it "generates the RUBY for an IS expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-10T17:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T16:59:59Z'.to_time(:utc)")
         end
 
         it "generates the RUBY for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
           exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-12'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-10T17:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-12T16:59:59Z'.to_time(:utc)")
         end
       end
 
       context "relative dates with no time zone" do
         it "generates the ruby for an AFTER expression with date value of n Days Ago" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time > '2011-01-09T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for an AFTER expression with datetime value of n Days ago" do
@@ -1109,7 +1109,7 @@ describe MiqExpression do
 
         it "generates the ruby for a BEFORE expression with date value of n Days Ago" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time < '2011-01-09T00:00:00Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a BEFORE expression with datetime value of n Days Ago" do
@@ -1124,7 +1124,7 @@ describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last Week" do
@@ -1144,17 +1144,17 @@ describe MiqExpression do
 
         it "generates the ruby for an IS expression with date value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-03T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-09T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a IS expression with date value of Today" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-11T00:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T23:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for an IS expression with date value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a IS expression with datetime value of n Hours Ago" do
@@ -1173,7 +1173,7 @@ describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last Week" do
@@ -1193,17 +1193,17 @@ describe MiqExpression do
 
         it "generates the ruby for an IS expression with date value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-03T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-10T09:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for an IS expression with date value of Today" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-11T10:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-12T09:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for an IS expression with date value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_time >= '2011-01-11T14:00:00Z'.to_time(:utc) && val.to_time <= '2011-01-11T14:59:59Z'.to_time(:utc)")
         end
 
         it "generates the ruby for an IS expression with datetime value of n Hours Ago" do

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -978,12 +978,12 @@ describe MiqExpression do
       context "static dates and times with no timezone" do
         it "generates the ruby for an AFTER expression with date value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
@@ -993,7 +993,7 @@ describe MiqExpression do
 
         it "generates the ruby for a IS expression with date value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a IS expression with datetime value" do
@@ -1003,12 +1003,12 @@ describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["01/09/2011", "01/10/2011"]})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a FROM expression with datetime values" do
@@ -1027,12 +1027,12 @@ describe MiqExpression do
 
         it "generates the ruby for a AFTER expression with date value" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a BEFORE expression with date value" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a AFTER expression with datetime value" do
@@ -1047,12 +1047,12 @@ describe MiqExpression do
 
         it "generates the ruby for a IS expression wtih date value" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date == '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a FROM expression with date values" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["2011-01-09", "2011-01-10"]})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-09'.to_date && val.to_date <= '2011-01-10'.to_date")
         end
 
         it "generates the ruby for a FROM expression with datetime values" do
@@ -1074,32 +1074,32 @@ describe MiqExpression do
         it "generates the SQL for a AFTER expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("AFTER" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for a BEFORE expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for an IS expression with a value of 'Yesterday' for a date field" do
           exp = described_class.new("IS" => {"field" => "Vm-retires_on", "value" => "Yesterday"})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the RUBY for a FROM expression with a value of 'Yesterday'/'Today' for a date field" do
           exp = described_class.new("FROM" => {"field" => "Vm-retires_on", "value" => %w(Yesterday Today)})
           ruby, * = exp.to_ruby("Asia/Jakarta")
-          expect(ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-12'.to_date")
+          expect(ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-12'.to_date")
         end
       end
 
       context "relative dates with no time zone" do
         it "generates the ruby for an AFTER expression with date value of n Days Ago" do
           exp = MiqExpression.new("AFTER" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date > '2011-01-09'.to_date")
         end
 
         it "generates the ruby for an AFTER expression with datetime value of n Days ago" do
@@ -1109,7 +1109,7 @@ describe MiqExpression do
 
         it "generates the ruby for a BEFORE expression with date value of n Days Ago" do
           exp = MiqExpression.new("BEFORE" => {"field" => "Vm-retires_on", "value" => "2 Days Ago"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date < '2011-01-09'.to_date")
         end
 
         it "generates the ruby for a BEFORE expression with datetime value of n Days Ago" do
@@ -1124,7 +1124,7 @@ describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last Week" do
@@ -1144,17 +1144,17 @@ describe MiqExpression do
 
         it "generates the ruby for an IS expression with date value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
         end
 
         it "generates the ruby for a IS expression with date value of Today" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the ruby for an IS expression with date value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the ruby for a IS expression with datetime value of n Hours Ago" do
@@ -1173,7 +1173,7 @@ describe MiqExpression do
 
         it "generates the ruby for a FROM expression with date values of Last Week" do
           exp = MiqExpression.new("FROM" => {"field" => "Vm-retires_on", "value" => ["Last Week", "Last Week"]})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
         end
 
         it "generates the ruby for a FROM expression with datetime values of Last Week" do
@@ -1193,17 +1193,17 @@ describe MiqExpression do
 
         it "generates the ruby for an IS expression with date value of Last Week" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Last Week"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-03'.to_date && val.to_date <= '2011-01-09'.to_date")
         end
 
         it "generates the ruby for an IS expression with date value of Today" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "Today"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the ruby for an IS expression with date value of n Hours Ago" do
           exp = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=date>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
+          expect(exp.to_ruby(tz)).to eq("val=<value ref=vm, type=datetime>/virtual/retires_on</value>; !val.nil? && val.to_date >= '2011-01-11'.to_date && val.to_date <= '2011-01-11'.to_date")
         end
 
         it "generates the ruby for an IS expression with datetime value of n Hours Ago" do

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -467,15 +467,6 @@ describe MiqExpression do
           expect(result).to contain_exactly(vm2, vm3)
         end
 
-        it "finds the correct instances for an IS expression with a date field and 'n Hours Ago" do
-          _vm1 = FactoryGirl.create(:vm_vmware, :retires_on => Time.zone.yesterday)
-          vm2 = FactoryGirl.create(:vm_vmware, :retires_on => Time.zone.today)
-          _vm3 = FactoryGirl.create(:vm_vmware, :retires_on => Time.zone.tomorrow)
-          filter = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "3 Hours Ago"})
-          result = Vm.where(filter.to_sql.first)
-          expect(result).to eq([vm2])
-        end
-
         it "finds the correct instances for an IS expression with 'Last Month'" do
           _vm1 = FactoryGirl.create(:vm_vmware, :last_scan_on => (1.month.ago.beginning_of_month - 1.day).end_of_day)
           vm2 = FactoryGirl.create(:vm_vmware, :last_scan_on => 1.month.ago.beginning_of_month)
@@ -552,9 +543,9 @@ describe MiqExpression do
 
         it "finds the correct instances for a FROM expression with a date field and timezone" do
           timezone = "Eastern Time (US & Canada)"
-          _vm1 = FactoryGirl.create(:vm_vmware, :retires_on => "2011-01-09")
-          vm2 = FactoryGirl.create(:vm_vmware, :retires_on => "2011-01-10")
-          _vm3 = FactoryGirl.create(:vm_vmware, :retires_on => "2011-01-11")
+          _vm1 = FactoryGirl.create(:vm_vmware, :retires_on => "2011-01-09T23:59:59Z")
+          vm2 = FactoryGirl.create(:vm_vmware, :retires_on => "2011-01-10T06:30:00Z")
+          _vm3 = FactoryGirl.create(:vm_vmware, :retires_on => "2011-01-11T08:00:00Z")
           filter = MiqExpression.new("IS" => {"field" => "Vm-retires_on", "value" => "2011-01-10"})
           result = Vm.where(filter.to_sql(timezone).first)
           expect(result).to eq([vm2])

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -109,7 +109,7 @@ describe MiqProvision do
       context "sets retirement" do
         it "with :retirement option" do
           options[:retirement] = retirement = 2.days.to_i
-          retires_on           = (Time.now.utc + retirement).to_date
+          retires_on           = Time.now.utc + retirement
           task.update_attributes(:options => options)
 
           expect(task).to receive(:mark_as_completed)
@@ -127,7 +127,7 @@ describe MiqProvision do
           options[:retirement]      = 2.days.to_i
           options[:retirement_time] = retirement_time = Time.now.utc + 3.days  # This setting overrides the :retirement setting
           options[:retirement_warn] = retirement_warn_days.days.to_i
-          retires_on                = retirement_time.to_date
+          retires_on                = retirement_time
           task.update_attributes(:options => options)
 
           expect(task).to receive(:mark_as_completed)
@@ -135,7 +135,7 @@ describe MiqProvision do
           task.signal(:post_create_destination)
 
           expect(task.destination.retires_on).to eq(retires_on)
-          expect(vm.reload.retires_on).to        eq(retires_on)
+          expect(vm.reload.retires_on).to        be_between(retires_on - 1.second, retires_on + 1.second)
           expect(vm.retirement_warn).to          eq(retirement_warn_days)
           expect(vm.retired).to                  be_falsey
         end

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -116,8 +116,8 @@ describe MiqProvision do
 
           task.signal(:post_create_destination)
 
-          expect(task.destination.retires_on).to eq(retires_on)
-          expect(vm.reload.retires_on).to        eq(retires_on)
+          expect(task.destination.retires_on).to be_between(retires_on - 1.second, retires_on + 1.second)
+          expect(vm.reload.retires_on).to        be_between(retires_on - 1.second, retires_on + 1.second)
           expect(vm.retirement_warn).to          eq(0)
           expect(vm.retired).to                  be_falsey
         end

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -76,7 +76,7 @@ describe "Service Retirement Management" do
     @stack.finish_retirement
     @stack.reload
     expect(@stack.retired).to be_truthy
-    expect(@stack.retires_on).to eq(Date.today)
+    expect(@stack.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)
     expect(@stack.retirement_state).to eq("retired")
   end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -105,7 +105,7 @@ describe "Service Retirement Management" do
     @service.finish_retirement
     @service.reload
     expect(@service.retired).to be_truthy
-    expect(@service.retires_on).to eq(Date.today)
+    expect(@service.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)
     expect(@service.retirement_state).to eq("retired")
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -74,7 +74,7 @@ describe "VM Retirement Management" do
     @vm.reload
 
     expect(@vm.retired).to eq(true)
-    expect(@vm.retires_on).to eq(Date.today)
+    expect(@vm.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)
     expect(@vm.retirement_state).to eq("retired")
   end
 

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -131,7 +131,7 @@ describe "Services API" do
 
   describe "Services retirement" do
     def format_retirement_date(time)
-      time.strftime("%Y-%m-%d")
+      time.in_time_zone('UTC').strftime("%Y-%m-%dT%H:%M:%SZ")
     end
 
     it "rejects requests without appropriate role" do

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -947,8 +947,8 @@ describe "Vms API" do
 
     it "in the future" do
       api_basic_authorize action_identifier(:vms, :retire)
-      date = 2.weeks.from_now.to_date
-      run_post(vm_url, gen_request(:retire, :date => date.strftime("%m/%d/%Y")))
+      date = 2.weeks.from_now
+      run_post(vm_url, gen_request(:retire, :date => date.iso8601))
 
       expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => :vm_url)
     end


### PR DESCRIPTION
This was originally a part of https://github.com/ManageIQ/manageiq/pull/7471, splitting off the backend part for easier review/merge..

This changes the `retires_on` field from `:date` to `:datetime` - the idea is that we will change the UI to let the user pick a specific point in time (including timezone) for the machine to retire, instead of a rather vague "that day +- 23.5 hours" (yay timezones!).

(`retirement_last_warn` already IS a datetime)

https://bugzilla.redhat.com/show_bug.cgi?id=1316632

---

UI changes are limited to adding time and time zone info to the messages and summaries...

![retire flash](https://cloud.githubusercontent.com/assets/289743/18584662/d00bddcc-7c01-11e6-80a0-335e53c1ab28.png)
![retire summary](https://cloud.githubusercontent.com/assets/289743/18584663/d11b4eaa-7c01-11e6-9fe0-c38c84e5f9dc.png)
