### PR TITLE
[WIP] Seed the primordial classes, not all of them

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,4 @@
 #
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Emanuel', :city => cities.first)
-EvmDatabase.seed
+EvmDatabase.seed_primordial


### PR DESCRIPTION
Purpose or Intent
-----------------
Discovered while playing in #11137.

`db:seed` is for populating the base database tables needed to boot
the rails server.  `seed_primordial` seeds only the base (primordial) classes.
A normal rake evm:start (evmserver) will do the full seed.

If anything blows up after this change, the missing seeds should be added to
primordial classes:
https://github.com/ManageIQ/manageiq/blob/b1cc742a339b0bb3d766fb84ca7137a69d925faa/lib/evm_database.rb#L6-L20

This saves ~7 seconds (~40%) from rake db:seed.
Note: rake db:seed is called from both bin/setup and bin/update.

Note2: the primordial class VmdbDatabase is not really required but the UI fails
without it.  We really need to remove that from primordial as it's very slow.

**Before**

```
12:46:42 ~/Code/manageiq (seed_primordial_in_db_seeds) (2.3.1) + time bin/rake db:seed
bin/rake db:seed  14.05s user 2.33s system 86% cpu 18.857 total
```

**After**

```
12:47:15 ~/Code/manageiq (seed_primordial_in_db_seeds) (2.3.1) + time bin/rake db:seed
bin/rake db:seed  7.85s user 1.85s system 85% cpu 11.340 total
```