### PR TITLE
Install dependencies in threads

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -32,9 +32,14 @@ APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
 Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
+
+  # Run bower in a thread and continue to do the non-js stuff
+  bower_thread = Thread.new do
+    execute "bower install --allow-root -F --config.analytics=false"
+  end
+
   execute "gem install bundler --conservative"
   execute "bundle check || bundle install"
-  execute "bower install --allow-root -F --config.analytics=false"
 
   puts "\n== Copying sample files =="
   unless File.exist?("config/database.yml")
@@ -66,4 +71,5 @@ Dir.chdir APP_ROOT do
     puts "\n== Preparing tests =="
     execute "bin/rake test:vmdb:setup"
   end
+  bower_thread.join
 end

--- a/bin/update
+++ b/bin/update
@@ -16,8 +16,13 @@ end
 
 Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
+
+  # Run bower in a thread and continue to do the non-js stuff
+  bower_thread = Thread.new do
+    execute "bower update --allow-root -F --config.analytics=false"
+  end
+
   execute "bundle update"
-  execute "bower update --allow-root -F --config.analytics=false"
 
   puts "\n== Migrating database =="
   execute "bin/rake db:migrate"
@@ -32,6 +37,9 @@ Dir.chdir APP_ROOT do
     puts "\n== Resetting Automate Domains =="
     execute "bin/rake evm:automate:reset"
   end
+
+  # Make sure bower is done before compiling assets
+  bower_thread.join
 
   if ENV['RAILS_ENV'] == 'production'
     puts "\n== Recompiling assets =="


### PR DESCRIPTION
Purpose or Intent
-----------------

Doing bundler and bower at the same time for initial setup saves ~50 seconds
(2:09 before, 1:22 after).  Note, we can actually do all the ruby stuff while bower is running so locally, the database is all setup by the time bower is done.

**Before**

```
bin/setup  91.90s user 28.87s system 93% cpu 2:09.38 total
bin/setup  91.14s user 28.47s system 80% cpu 2:28.04 total
```

**After**

```
bin/setup  58.28s user 20.73s system 103% cpu 1:16.53 total
bin/setup  66.03s user 20.73s system 104% cpu 1:22.94 total
```

**Script**

```
rm -rf vendor/assets/bower_components ~/.cache/bower Gemfile.lock
time bin/setup
```

Followup to #11137 and #11157 

Additionally, doing this for `bin/update` saves time if there are updated dependencies.
