### PR TITLE
Update PR template with some styling changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,15 @@
-Purpose or Intent
------------------
-> Describe the rationale and use case for this pull request.  Provide any background, examples, and images that provide further information to accurately describe what it is that you are adding to the repo.  Add subsections as necessary to organize and feel free to link and reference other PRs as necessary, but also include them in the links section below as a quick reference.
-> 
-> Guidelines:
->   * Keep Pull Request titles short and to the point, ideally under 72 characters
->   * Provide as much context/info in the description as necessary to get the reviewer up to the same domain knowledge level as yourself
->   * Keep code changes as short and implementing a single feature/bug fix/refactoring when possible
+Describe the rationale and use case for this pull request.  Provide any background, examples, and images that provide further information to accurately describe what it is that you are adding to the repo.  Add subsections as necessary to organize and feel free to link and reference other PRs as necessary, but also include them in the links section below as a quick reference.
 
+Guidelines:
+* Keep Pull Request titles short and to the point, ideally under 72 characters
+* Provide as much context/info in the description as necessary to get the reviewer up to the same domain knowledge level as yourself
+* Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
 
-Links
------
-> * http://documentation.for/library/that/I/am/adding
-> * [PR relevant issue or pull_request](#123)
+## Links [Optional]
 
+* http://documentation.for/library/that/I/am/adding
+* [PR relevant issue or pull_request](#123)
 
-Steps for Testing/QA
---------------------
-> [Optional] If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.
+## Steps for Testing/QA [Optional]
+
+If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.


### PR DESCRIPTION
The main point of the change here is to remove the inline quoting as part of the template.  The reason is that people think that that quoting is part of how they are supposed to do it and you get a big wall of quoted text, which makes it very hard for me to read/review, particularly because the text is gray on white.

Compare:

![manageiq 2016-09-09 16-42-13](https://cloud.githubusercontent.com/assets/52120/18402218/70893174-76ac-11e6-937b-7ffbafdfaf6d.png)

to

![manageiq 2016-09-09 16-43-42](https://cloud.githubusercontent.com/assets/52120/18402262/9fbacc64-76ac-11e6-83d2-2ef7f8e0db80.png)

---

I also changed the markdown styling a bit (using `##` vs `------------`) so that it takes up less space, and removed the Purpose or Intent titling, because it's not necessary.

@NickLaMuro @chessbyte Please review.
