### PR TITLE
Remove a `N+1` on `/services/explorer` for large flat trees when fetching non-existent children

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -23,6 +23,16 @@ class TreeBuilderServices < TreeBuilder
   def x_get_tree_roots(count_only, _options)
     roots = Rbac.filtered(Service.roots)
 
+    # Define array of roots with children
+    coalesce_func = Arel::Nodes::NamedFunction.new(
+      "COALESCE",
+      [Service.arel_table[:ancestry], Arel::Nodes::SqlLiteral.new("'0'")]
+    ).as('bigint')
+    cast_as_bigint_func = Arel::Nodes::NamedFunction.new("CAST", [coalesce_func])
+    @root_nodes_with_kids = Service.where.not(:ancestry => nil)
+                                   .where(cast_as_bigint_func.eq(Service.arel_table.project(:id)))
+                                   .pluck(:id)
+
     # Preload the root service picture since it's called by TreeNodeBuilder#build
     MiqPreloader.preload(roots, :picture)
 
@@ -30,6 +40,9 @@ class TreeBuilderServices < TreeBuilder
   end
 
   def x_get_tree_service_kids(object, count_only)
+    # Skip getting children if there are no children for a root node
+    return unless object.ancestry || @root_nodes_with_kids.index(object.id)
+
     objects = Rbac.filtered(object.direct_service_children.select(&:display).sort_by { |o| o.name.downcase })
     count_only_or_objects(count_only, objects, 'name')
   end


### PR DESCRIPTION
Purpose or Intent
-----------------
Removes an `N+1` on flat service trees.  Effects are much more noticeable where `N` is large (~ 10k)


Overview
--------
This is there query that is added:

```sql
SELECT "services"."id"
FROM "services"
WHERE "services"."ancestry" IS NULL
  AND CAST(coalesce("services"."ancestry") AS bigint) IN (SELECT id FROM services);
```

Which basically returns an array of ids that have children.  This can then be used to determine if `x_get_tree_service_kids` should even be executed on each of the children.


Metrics
-------
_**Note**:  These metrics were taken against `/service/explorer/s-XXXXXXXXXXXX`, and not `/service/explorer`, so the queries and rows returned are inflated because it loads both the tree and the some extra data_ 

**Before**

|   ms | queries |    rows |
| ---: |    ---: |    ---: |
| ~50k |  17,157 |  77,764 |


**After**

|   ms | queries |    rows |
| ---: |    ---: |    ---: |
| ~43k |   7,677 |  77,764 |


Links
-----
* This is similar to https://github.com/ManageIQ/manageiq/pull/11046, but doesn't remove existing functionality of the tree (improving the algorithm v.s. reducing the algorithm's scope).
* Alternative (and faster) solution:  https://github.com/ManageIQ/manageiq/pull/11166
  - We will probably got with #11166 since it is faster and less data in the long run.  Leaving this PR open for now for comparison.