### PR TITLE
Move include for AutomationHelper

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_browser_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_browser_spec.rb
@@ -1,7 +1,8 @@
-include AutomationSpecHelper
 module MiqAeBrowserSpec
   include MiqAeEngine
   describe MiqAeBrowser do
+    include Spec::Support::AutomationHelper
+
     before(:each) do
       MiqAeDatastore.reset
       @composition_fields = { "title" => { :aetype => "attribute", :datatype => "string" } }


### PR DESCRIPTION
This addresses the `uninitialized constant AutomationSpecHelper` error that currently happens when running tests.

**Potentially relevant links:**
* https://github.com/ManageIQ/manageiq/commit/239a406dc347b1876ea4e0a2362ac105a072bf2b
* https://github.com/ManageIQ/manageiq/commit/9e7b18da32c9bab8306b8a7c601313971786865d#diff-93830fa29d616f7c87903d08b5b1b29aR56
* https://github.com/ManageIQ/manageiq/pull/11165
* https://github.com/ManageIQ/manageiq/pull/10281