### PR TITLE
Fix QuotaHelper for spec in darga

### DIFF
--- a/spec/automation/unit/method_validation/validate_request_spec.rb
+++ b/spec/automation/unit/method_validation/validate_request_spec.rb
@@ -1,5 +1,5 @@
 describe "Auto Approval Request Validation" do
-  include Spec::Support::QuotaHelper
+  include QuotaHelper
   let(:ws) { MiqAeEngine.instantiate("/System/Request/Call_Method?#{method}&#{args}&#{@value}", @user) }
   let(:method) do
     "namespace=/ManageIQ/Cloud/VM/Provisioning/StateMachines&class=ProvisionRequestApproval&method=validate_request"


### PR DESCRIPTION
A recent commit was made to master that namespaced a lot of the helpers in spec/support.

https://github.com/ManageIQ/manageiq/pull/10417

The one for QuotaHelper (and others) were not backported, but PRs against master still use this new namespace.  This fixes include to use the old non-namespaced module.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/10281 (backported PR)
* https://github.com/ManageIQ/manageiq/pull/10417 (`QuotaHelper` refactor)