### PR TITLE
[UI] explorer/services use ancestry vs N+1

### DIFF
--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -1,11 +1,12 @@
 class TreeBuilderServices < TreeBuilder
-  has_kids_for Service, [:x_get_tree_service_kids]
+  has_kids_for Hash,    [:x_get_tree_custom_kids]
 
   private
 
   def tree_init_options(_tree_name)
     {
       :leaf     => "Service",
+      :lazy     => false,
       :full_ids => true
     }
   end
@@ -21,16 +22,34 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    roots = Rbac.filtered(Service.roots)
-
-    # Preload the root service picture since it's called by TreeNodeBuilder#build
-    MiqPreloader.preload(roots, :picture)
-
-    count_only_or_objects(count_only, roots, "name")
+    if count_only
+      Rbac.filtered(Service.roots.where(:display => true)).size
+    else
+      all_services = Rbac.filtered(Service.where(:display => true))
+      roots = Service.arrange_nodes(all_services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
+      MiqPreloader.preload(roots.keys, :picture)
+      # array of a hash.
+      roots.map { |n, v| { n => v} }
+    end
   end
 
-  def x_get_tree_service_kids(object, count_only)
-    objects = Rbac.filtered(object.direct_service_children.select(&:display).sort_by { |o| o.name.downcase })
-    count_only_or_objects(count_only, objects, 'name')
+  # wish we didn't have to modify this.
+  # tree builder is calling into this with the hash node
+  # node_builder (via super) wants the service object
+  # converting it across
+  def x_build_single_node(object, pid, options)
+    object = object.keys.first if object.kind_of?(Hash) # assuming this is just {service -> ...}
+    super
+  end
+
+  def x_get_tree_custom_kids(object, count_only)
+    # ancestry has leaf nodes as node => {}. present? clears out the empty node
+    objects = object.values.select(&:present?)
+    if count_only
+      objects.size
+    else
+      # already sorted by name ?
+      objects.map { |n, v| { n => v} }
+    end
   end
 end


### PR DESCRIPTION
Load all the service nodes using ancestry.
Also see alternative #11171 and #11162


This requires a little hacking for the node tree, but we're able to have "walk" just return the ancestry nodes instead of the query. this is where we reduce most of the queries.

Of note, we are downloading every service into the browser. We will need to discuss limiting this.

before
------

walk each layer of the tree and look up children.
For this in particular, we took a big hit because there are no children.

after
----

load the service tree using ancestry.
use a custom node in tree builder service that allowed us to store the nodes and the children.
Besides that, use tree node walker as is.

numbers
--------


|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  22,861.8 |9,690 |  2,408.1 |    9,951 |before
|  8,993.7 |  209 |   309.0 |    6,728 |after

|ExtManagementSystem|MiqRegion|Zone|Service
|------------------:|--------:|---:|---:|
|                12 |       5 | 34 |9,481 