### PR TITLE
Add GUID validation for certain Azure fields in Cloud Provider screen

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //= require angular-ui-bootstrap
 //= require angular-ui-bootstrap-tpls
 //= require angular-sanitize
+//= require angular.validators
 //= require moment
 //= require moment-strftime/build/moment-strftime.min
 //= require moment-timezone
@@ -82,3 +83,4 @@
 // Bower packages
 //= require manageiq-ui-components/dist/js/ui-components
 //= require rx-angular/dist/rx.angular
+

--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -2,6 +2,7 @@ ManageIQ.angular.app = angular.module('ManageIQ', [
   'ui.bootstrap',
   'patternfly',
   'frapontillo.bootstrap-switch',
+  'angular.validators',
   'miq.api'
 ]);
 miqHttpInject(ManageIQ.angular.app);

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -15,7 +15,7 @@
 - cancel_password_change ||= _("Cancel password change")
 - verify_title_off       ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - ng_show_userid         ||= true
-- guid_regex             ||= ""
+- guid_regex             ||= false
 
 %div{"ng-controller" => "CredentialsController"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
@@ -23,23 +23,24 @@
       %label.col-md-2.control-label{"for" => "#{prefix}_userid"}
         = userid_label
       .col-md-4
-        %input.form-control{"type"                    => "text",
-                            "id"                      => "#{prefix}_userid",
-                            "ng-required"             => "#{ng_reqd_userid}",
-                            "ng-disabled"             => userid_disabled,
-                            "name"                    => "#{prefix}_userid",
-                            "ng-model"                => "#{ng_model}.#{prefix}_userid",
-                            "checkchange"             => "",
-                            "ng-trim"                 => false,
-                            "ng-pattern"              => guid_regex,
-                            "detect_spaces"           => "",
-                            "prefix"                  => "#{prefix}",
-                            "reset-validation-status" => "#{prefix}_auth_status"}
+        - hash_for_userid = {"type"                    => "text",
+                             "id"                      => "#{prefix}_userid",
+                             "ng-required"             => "#{ng_reqd_userid}",
+                             "ng-disabled"             => userid_disabled,
+                             "name"                    => "#{prefix}_userid",
+                             "ng-model"                => "#{ng_model}.#{prefix}_userid",
+                             "checkchange"             => "",
+                             "ng-trim"                 => false,
+                             "detect_spaces"           => "",
+                             "prefix"                  => "#{prefix}",
+                             "reset-validation-status" => "#{prefix}_auth_status"}
+        - hash_for_userid['is-uuid'] = 4 if guid_regex
+        %input.form-control{hash_for_userid}
         %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.required"}
           = _("Required")
         %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.detectedSpaces"}
           = _("Spaces are prohibited")
-        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.pattern"}
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.isUuid"}
           = _("Invalid input format, please enter a GUID")
         .note
           {{note}}

--- a/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
+++ b/app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml
@@ -15,6 +15,7 @@
 - cancel_password_change ||= _("Cancel password change")
 - verify_title_off       ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - ng_show_userid         ||= true
+- guid_regex             ||= ""
 
 %div{"ng-controller" => "CredentialsController"}
   %div{"ng-show" => "#{ng_show} && #{ng_show_userid}"}
@@ -30,6 +31,7 @@
                             "ng-model"                => "#{ng_model}.#{prefix}_userid",
                             "checkchange"             => "",
                             "ng-trim"                 => false,
+                            "ng-pattern"              => guid_regex,
                             "detect_spaces"           => "",
                             "prefix"                  => "#{prefix}",
                             "reset-validation-status" => "#{prefix}_auth_status"}
@@ -37,6 +39,8 @@
           = _("Required")
         %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.detectedSpaces"}
           = _("Spaces are prohibited")
+        %span.help-block{"ng-show" => "angularForm.#{prefix}_userid.$error.pattern"}
+          = _("Invalid input format, please enter a GUID")
         .note
           {{note}}
 

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -81,12 +81,12 @@
                             "ng-model"                => "emsCommonModel.azure_tenant_id",
                             "required"                => "",
                             "checkchange"             => "",
-                            "ng-pattern"              => "/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/",
+                            "is-uuid"                 => 4,
                             "prefix"                  => "default",
                             "reset-validation-status" => "default_auth_status"}
         %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.required"}
           = _("Required")
-        %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.pattern"}
+        %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.isUuid"}
           = _("Invalid input format, please enter a GUID")
 
     .form-group{"ng-class" => "{'has-error': angularForm.subscription.$invalid}", "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
@@ -99,9 +99,9 @@
                             "ng-model"                => "emsCommonModel.subscription",
                             "checkchange"             => "",
                             "prefix"                  => "default",
-                            "ng-pattern"              => "/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/",
+                            "is-uuid"                 => 4,
                             "reset-validation-status" => "default_auth_status"}
-        %span.help-block{"ng-show" => "angularForm.subscription.$error.pattern"}
+        %span.help-block{"ng-show" => "angularForm.subscription.$error.isUuid"}
           = _("Invalid input format, please enter a GUID")
 
     .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -225,7 +225,7 @@
                               :validate_url           => @ems.id ? "update" : "create",
                               :id                     => @ems.id || "new",
                               :basic_info_needed      => true,
-                              :guid_regex             => "/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/",
+                              :guid_regex             => true,
                               :userid_label           => _("Client ID"),
                               :password_label         => _("Client Key"),
                               :verify_label           => _("Confirm Client Key"),

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -81,10 +81,13 @@
                             "ng-model"                => "emsCommonModel.azure_tenant_id",
                             "required"                => "",
                             "checkchange"             => "",
+                            "ng-pattern"              => "/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/",
                             "prefix"                  => "default",
                             "reset-validation-status" => "default_auth_status"}
         %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.required"}
           = _("Required")
+        %span.help-block{"ng-show" => "angularForm.azure_tenant_id.$error.pattern"}
+          = _("Invalid input format, please enter a GUID")
 
     .form-group{"ng-class" => "{'has-error': angularForm.subscription.$invalid}", "ng-if" => "emsCommonModel.emstype != '' && emsCommonModel.emstype == 'azure'"}
       %label.col-md-2.control-label{"for" => "ems_subscription"}
@@ -96,7 +99,10 @@
                             "ng-model"                => "emsCommonModel.subscription",
                             "checkchange"             => "",
                             "prefix"                  => "default",
+                            "ng-pattern"              => "/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/",
                             "reset-validation-status" => "default_auth_status"}
+        %span.help-block{"ng-show" => "angularForm.subscription.$error.pattern"}
+          = _("Invalid input format, please enter a GUID")
 
     .form-group{"ng-class" => "{'has-error': angularForm.api_version.$invalid}", "ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
       %label.col-md-2.control-label{"for" => "ems_api_version"}
@@ -219,6 +225,7 @@
                               :validate_url           => @ems.id ? "update" : "create",
                               :id                     => @ems.id || "new",
                               :basic_info_needed      => true,
+                              :guid_regex             => "/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/",
                               :userid_label           => _("Client ID"),
                               :password_label         => _("Client Key"),
                               :verify_label           => _("Confirm Client Key"),

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "angular-mocks": "^1.5.3",
     "angular-patternfly-sass": "3.10.0",
     "angular-sanitize": "^1.5.3",
+    "angular.validators": "^4.4.2",
     "bootstrap-filestyle": "^1.2.1",
     "bootstrap-hover-dropdown": "^2.0.11",
     "jquery.observe_field": "himdel/jquery.observe_field#^0.1.0",


### PR DESCRIPTION
Added a new bower package `angular.validators` that offers validation directives for many input types -- UUID being one of them and needed for this PR.

https://libraries.io/bower/angular.validators

This validation was added for `Tenant ID`, `Subscription ID` and `Client ID` fields.

Screenshot (Validation in action)
![screen shot 2016-09-12 at 3 25 05 pm](https://cloud.githubusercontent.com/assets/1538216/18455164/2746c65e-78fd-11e6-97b9-5882b1208210.png)




