### PR TITLE
JS global variable miq_on_load moved under ManageIQ global scope

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1,4 +1,4 @@
-/* global dialogFieldRefresh jqplot_bind_events miqBrowserDetect miqExpressionPrefill miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqValueStylePrefill performFiltering miq_after_onload */
+/* global dialogFieldRefresh jqplot_bind_events miqBrowserDetect miqExpressionPrefill miqGridCheckAll miqGridGetCheckedRows miqLoadTL miqMenu miqValueStylePrefill performFiltering */
 
 // MIQ specific JS functions
 
@@ -44,9 +44,8 @@ function miqOnLoad() {
   }
 
   // Run MIQ after onload code if present
-  // FIXME: miq_after_onload -> move under ManageIQ
-  if (typeof miq_after_onload == "string") {
-    eval(miq_after_onload);
+  if (typeof ManageIQ.afterOnload == "string") {
+    eval(ManageIQ.afterOnload);
   }
 
   // Focus on search box, if it's there and allows focus

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -2,6 +2,7 @@
 if (! window.ManageIQ) {
   window.ManageIQ = {
     actionUrl: null, // action URL used in JS function miqGridSort
+    afterOnload: null, // JS code to be evaluated after onload
     angular: {
       app: null, // angular application
       scope: null,  // helper scope, pending refactor

--- a/app/views/availability_zone/show.html.haml
+++ b/app/views/availability_zone/show.html.haml
@@ -2,7 +2,7 @@
   - if @showtype == "performance"
     = render :partial => "layouts/performance"
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
   - elsif @showtype == "download_pdf"
     = render :partial => "layouts/show_pdf"
   - else
@@ -13,6 +13,6 @@
     - elsif @showtype == "timeline"
       = render :partial => "layouts/tl_show"
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
     - else
       = render :partial => @showtype

--- a/app/views/catalog/explorer.html.haml
+++ b/app/views/catalog/explorer.html.haml
@@ -17,7 +17,7 @@
       = render :partial => "catalog/form"
       - @upload_sysprep_file = false
       :javascript
-        var miq_after_onload = "miqPrepRightCellForm('#{x_active_tree}');"
+        ManageIQ.afterOnload = "miqPrepRightCellForm('#{x_active_tree}');"
     - else
       = render :partial => "layouts/x_gtl"
 

--- a/app/views/cloud_tenant/show.html.haml
+++ b/app/views/cloud_tenant/show.html.haml
@@ -2,7 +2,7 @@
   - if @showtype == "performance"
     = render :partial => "layouts/performance"
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
   - elsif @showtype == "download_pdf"
     = render :partial => "layouts/show_pdf"
   - else
@@ -21,6 +21,6 @@
     - elsif @showtype == "timeline"
       = render :partial => "layouts/tl_show"
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{ url_for(:action => @ajax_action, :id => @record.id)}');"
     - elsif @showtype == 'main'
       = render :partial => 'main'

--- a/app/views/container/explorer.html.haml
+++ b/app/views/container/explorer.html.haml
@@ -2,11 +2,11 @@
   - if @showtype == "timeline"
     = render(:partial => "layouts/tl_show")
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
   - elsif @showtype == "performance"
     = render(:partial => "layouts/performance")
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
   - elsif TreeBuilder.get_model_for_prefix(@nodetype) == "Container"
     -# Showing a specific Service
     = render :partial => "container_show", :locals => {:controller => "container"}

--- a/app/views/container_group/show.html.haml
+++ b/app/views/container_group/show.html.haml
@@ -5,11 +5,11 @@
     - when "timeline"
         = render(:partial => "layouts/tl_show")
         :javascript
-            var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+            ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "performance"
         = render(:partial => "layouts/performance")
         :javascript
-            var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+            ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "compliance_history"
         = render :partial => "shared/views/#{@showtype}"
     - else

--- a/app/views/container_node/show.html.haml
+++ b/app/views/container_node/show.html.haml
@@ -3,11 +3,11 @@
 - elsif @showtype == "timeline"
   = render(:partial => "layouts/tl_show")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - elsif @showtype == "performance"
   = render(:partial => "layouts/performance")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - elsif @showtype == "compliance_history"
   = render :partial => "shared/views/#{@showtype}"
 - else

--- a/app/views/container_project/show.html.haml
+++ b/app/views/container_project/show.html.haml
@@ -3,10 +3,10 @@
 - elsif @showtype == "timeline"
   = render(:partial => "layouts/tl_show")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - elsif @showtype == "performance"
   = render(:partial => "layouts/performance")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/container_replicator/show.html.haml
+++ b/app/views/container_replicator/show.html.haml
@@ -3,11 +3,11 @@
 - elsif @showtype == "timeline"
     = render(:partial => "layouts/tl_show")
     :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - elsif @showtype == "performance"
     = render(:partial => "layouts/performance")
     :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - elsif @showtype == "compliance_history"
     = render :partial => "shared/views/#{@showtype}"
 - else

--- a/app/views/container_service/show.html.haml
+++ b/app/views/container_service/show.html.haml
@@ -3,7 +3,7 @@
 - elsif @showtype == "performance"
   = render(:partial => "layouts/performance")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype
 

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -137,10 +137,10 @@
   - if auto_login != false
     - if ext_auth?(:saml_enabled)
       :javascript
-        var miq_after_onload = "$('#saml_login').click()";
+        ManageIQ.afterOnload = "$('#saml_login').click()";
     - else
       :javascript
-        var miq_after_onload = "$('#sso_login').click()";
+        ManageIQ.afterOnload = "$('#sso_login').click()";
 - elsif @user_name  # If user name is pre-populated by the server, press the Login button automatically
   :javascript
-    var miq_after_onload = "$('#login').click()";
+    ManageIQ.afterOnload = "$('#login').click()";

--- a/app/views/ems_cluster/show.html.haml
+++ b/app/views/ems_cluster/show.html.haml
@@ -7,7 +7,7 @@
     - when "performance"
       = render(:partial => "layouts/performance")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "download_pdf"
       = render(:partial => "layouts/show_pdf")
     - when "details"
@@ -19,7 +19,7 @@
     - when "timeline"
       = render(:partial => "layouts/tl_show")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "dialog_provision"
       = render(:partial => "shared/dialogs/dialog_provision")
     - else

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -12,13 +12,13 @@
     - when "performance"
       = render(:partial => "layouts/performance")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "performance_summary"
       = render(:partial => "layouts/performance_summary")
     - when "timeline"
       = render(:partial => "layouts/tl_show")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "download_pdf"
       = render(:partial => "layouts/show_pdf")
     - when "dialog_provision"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -43,4 +43,4 @@
 -# if set by controller, set up to run as JS after onload is done
 - if @miq_after_onload
   :javascript
-    var miq_after_onload = '#{j @miq_after_onload}';
+    ManageIQ.afterOnload = '#{j @miq_after_onload}';

--- a/app/views/middleware_datasource/show.html.haml
+++ b/app/views/middleware_datasource/show.html.haml
@@ -1,6 +1,6 @@
 - if @showtype == "performance"
   = render(:partial => "layouts/performance")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/middleware_domain/show.html.haml
+++ b/app/views/middleware_domain/show.html.haml
@@ -3,6 +3,6 @@
 - elsif @showtype == 'performance'
   = render(:partial => 'layouts/performance')
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/middleware_messaging/show.html.haml
+++ b/app/views/middleware_messaging/show.html.haml
@@ -1,6 +1,6 @@
 - if @showtype == "performance"
   = render(:partial => "layouts/performance")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/middleware_server/show.html.haml
+++ b/app/views/middleware_server/show.html.haml
@@ -3,7 +3,7 @@
 - elsif @showtype == "performance"
   = render(:partial => "layouts/performance")
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype
 - @angular_form = true

--- a/app/views/middleware_server_group/show.html.haml
+++ b/app/views/middleware_server_group/show.html.haml
@@ -3,6 +3,6 @@
 - elsif @showtype == 'performance'
   = render(:partial => 'layouts/performance')
   :javascript
-    var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+    ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
 - else
   = render :partial => @showtype

--- a/app/views/miq_capacity/utilization.html.haml
+++ b/app/views/miq_capacity/utilization.html.haml
@@ -2,4 +2,4 @@
   = render :partial => "utilization_tabs"
 
 :javascript
-  var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action)}');"
+  ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action)}');"

--- a/app/views/miq_template/show.html.haml
+++ b/app/views/miq_template/show.html.haml
@@ -18,7 +18,7 @@
     - when "performance"
       = render :partial => "layouts/performance"
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "performance_summary"
       = render :partial => "layouts/performance_summary"
     - when "timeline"

--- a/app/views/ontap_logical_disk/show.html.haml
+++ b/app/views/ontap_logical_disk/show.html.haml
@@ -6,7 +6,7 @@
   - elsif @showtype == "performance"
     = render(:partial => "layouts/performance")
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
   - elsif @display == "show_statistics"
     = render(:partial => "layouts/show_statistics")
   - elsif @showtype == "download_pdf"

--- a/app/views/ops/_diagnostics_utilization_tab.html.haml
+++ b/app/views/ops/_diagnostics_utilization_tab.html.haml
@@ -11,4 +11,4 @@
     = render :partial => 'layouts/info_msg', :locals => {:message => msg}
   - if @ajax_action
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{url_for :action => @ajax_action, :id => @record}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for :action => @ajax_action, :id => @record}');"

--- a/app/views/ops/explorer.html.haml
+++ b/app/views/ops/explorer.html.haml
@@ -17,5 +17,5 @@
   - if @sb[:center_tb_filename].nil? || @sb[:center_tb_filename] == "blank_view_tb"
     $('#toolbar').hide();
   };
-  var miq_after_onload = "miqOpsAfterOnload();"
+  ManageIQ.afterOnload = "miqOpsAfterOnload();"
 

--- a/app/views/provider_foreman/_configuration_profile.html.haml
+++ b/app/views/provider_foreman/_configuration_profile.html.haml
@@ -9,7 +9,7 @@
       - if @sb[:active_tab] == "configured_systems"
         = render :partial => "layouts/x_gtl"
         :javascript
-          var miq_after_onload = "if (miqDomElementExists('adv_searchbox_div')) $('#adv_searchbox_div').show();"
+          ManageIQ.afterOnload = "if (miqDomElementExists('adv_searchbox_div')) $('#adv_searchbox_div').show();"
     = miq_tab_content('summary', @sb[:active_tab]) do
       - if @sb[:active_tab] == "summary"
         = render :partial => "main_configuration_profile"

--- a/app/views/provider_foreman/_inventory_group.html.haml
+++ b/app/views/provider_foreman/_inventory_group.html.haml
@@ -9,7 +9,7 @@
       - if @sb[:active_tab] == "configured_systems"
         = render :partial => "layouts/x_gtl"
         :javascript
-          var miq_after_onload = "if (miqDomElementExists('adv_searchbox_div')) $('#adv_searchbox_div').show();"
+          ManageIQ.afterOnload = "if (miqDomElementExists('adv_searchbox_div')) $('#adv_searchbox_div').show();"
     = miq_tab_content('summary', @sb[:active_tab]) do
       - if @sb[:active_tab] == "summary"
         = render :partial => "main_inventory_group"

--- a/app/views/report/explorer.html.haml
+++ b/app/views/report/explorer.html.haml
@@ -14,7 +14,7 @@
   - else
     miqTreeForceActivateNode('#{x_active_tree}', '#{x_node}')
   };
-  var miq_after_onload = "miqReportAfterOnload();"
+  ManageIQ.afterOnload = "miqReportAfterOnload();"
 
 -# Create from/to date JS vars to limit calendar starting from
 :javascript

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -17,11 +17,11 @@
   - elsif @showtype == "timeline"
     = render :partial => "layouts/tl_show"
     :javascript
-      var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
   - elsif @showtype == "performance"
     = render(:partial => "layouts/performance")
     :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+      ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
   - elsif @showtype == "dialog_provision"
     = render :partial => "shared/dialogs/dialog_provision"
   - elsif @showtype == "config"

--- a/app/views/storage/_storage_list.html.haml
+++ b/app/views/storage/_storage_list.html.haml
@@ -2,6 +2,6 @@
   - if x_node == "root" || @view
     = render :partial => 'layouts/gtl', :locals => {:action_url => "show_list"}
     :javascript
-      var miq_after_onload = "if (miqDomElementExists('adv_searchbox_div')) $('#adv_searchbox_div').show();"
+      ManageIQ.afterOnload = "if (miqDomElementExists('adv_searchbox_div')) $('#adv_searchbox_div').show();"
   - else
     = render :partial => "storage_details"

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -12,7 +12,7 @@
     - when "performance"
       = render(:partial => "layouts/performance")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - when "download_pdf"
       = render(:partial => "layouts/show_pdf")
     - when "dialog_provision"

--- a/app/views/vm_cloud/explorer.html.haml
+++ b/app/views/vm_cloud/explorer.html.haml
@@ -9,11 +9,11 @@
     - if @showtype == "performance"
       = render(:partial => "layouts/performance")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - elsif @showtype == "timeline"
       = render(:partial => "layouts/tl_show")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - else
       = render(:partial => 'vm_cloud/main', :locals => {:controller => "vm"})
 - else

--- a/app/views/vm_infra/explorer.html.haml
+++ b/app/views/vm_infra/explorer.html.haml
@@ -9,11 +9,11 @@
     - if @showtype == "performance"
       = render(:partial => "layouts/performance")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - elsif @showtype == "timeline"
       = render(:partial => "layouts/tl_show")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - else
       = render(:partial => 'vm_common/main', :locals => {:controller => "vm"})
 - elsif @upload_sysprep_file
@@ -21,7 +21,7 @@
     = render(:partial => 'miq_request/prov_edit')
     - @upload_sysprep_file = false
     :javascript
-      var miq_after_onload = "miqPrepRightCellForm('#{x_active_tree}');"
+      ManageIQ.afterOnload = "miqPrepRightCellForm('#{x_active_tree}');"
 - else
   -# Showing a list of VMs
   #main_div

--- a/app/views/vm_or_template/explorer.html.haml
+++ b/app/views/vm_or_template/explorer.html.haml
@@ -9,11 +9,11 @@
     - if @showtype == "performance"
       = render(:partial => "layouts/performance")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - elsif @showtype == "timeline"
       = render(:partial => "layouts/tl_show")
       :javascript
-        var miq_after_onload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
+        ManageIQ.afterOnload = "miqAsyncAjax('#{url_for(:action => @ajax_action, :id => @record)}');"
     - else
       = render(:partial => 'vm_common/main', :locals => {:controller => "vm"})
 - elsif @upload_sysprep_file
@@ -21,7 +21,7 @@
     = render(:partial => 'miq_request/prov_edit')
     - @upload_sysprep_file = false
     :javascript
-      var miq_after_onload = "miqPrepRightCellForm('#{x_active_tree}');"
+      ManageIQ.afterOnload = "miqPrepRightCellForm('#{x_active_tree}');"
 - else
   -# Showing a list of VMs
   #main_div

--- a/spec/views/availability_zone/show.html.haml_spec.rb
+++ b/spec/views/availability_zone/show.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "availability_zone/show.html.haml" do
   shared_examples_for "miq_before_onload JS is needed" do
     it "renders proper JS" do
-      js_string = "var miq_after_onload = \"miqAsyncAjax('/availability_zone/#{action}/#{availability_zone.id}');\""
+      js_string = "ManageIQ.afterOnload = \"miqAsyncAjax('/availability_zone/#{action}/#{availability_zone.id}');\""
       render
       expect(rendered).to include(js_string)
     end

--- a/spec/views/host/_show.html.haml_spec.rb
+++ b/spec/views/host/_show.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "host/show.html.haml" do
   shared_examples_for "miq_before_onload JS is needed" do
     it "renders proper JS" do
-      js_string = "var miq_after_onload = \"miqAsyncAjax('/host/#{action}/#{host.id}');\""
+      js_string = "ManageIQ.afterOnload = \"miqAsyncAjax('/host/#{action}/#{host.id}');\""
       render
       expect(rendered).to include(js_string)
     end

--- a/spec/views/vm/_show.html.haml_spec.rb
+++ b/spec/views/vm/_show.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe "vm/show.html.haml" do
   shared_examples_for "miq_before_onload JS is needed" do
     it "renders proper JS" do
-      js_string = "var miq_after_onload = \"miqAsyncAjax('/vm/#{action}/#{vm.id}');\""
+      js_string = "ManageIQ.afterOnload = \"miqAsyncAjax('/vm/#{action}/#{vm.id}');\""
       render
       expect(rendered).to include(js_string)
     end


### PR DESCRIPTION
Move Javascript global variable `miq_on_load` under the `ManageIQ` global variable, where all other are gathered

## Links

Parent issue: #2389
