### PR TITLE
[UI] Hierarchical TreeBuilder: explorer/services use ancestry vs N+1

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -293,27 +293,54 @@ class TreeBuilder
     [{:key => 'root', :children => child_nodes, :expand => true}]
   end
 
+  # determine if this is an ancestry node, and return the approperiate object
+  #
+  # @param object [Hash,Array,Object] object that is possibly an ancestry node
+  # @returns [Object, Hash] The object of interest from this ancestry tree, and the children
+  #
+  # Ancestry trees are of the form:
+  #
+  #   {Object => {Object1 => {}, Object2 => {Object2a => {}}}}
+  #
+  # Since `build_tree` and x_build_node uses enumeration, it comes in as:
+  #   [Object, {Object1 => {}, Object2 => {Object2a => {}}}]
+  #
+  def object_from_ancestry(object)
+    if object.kind_of?(Array) && object.size == 2 && object[1].kind_of?(Hash)
+      obj = object.first
+      children = object.last
+      [obj, children]
+    else
+      [object, nil]
+    end
+  end
+
   def x_get_tree_objects(parent, options, count_only, parents)
     children_or_count = parent.nil? ? x_get_tree_roots(count_only, options) : x_get_tree_kids(parent, count_only, options, parents)
     children_or_count || (count_only ? 0 : [])
   end
 
-  # Return a tree node for the passed in object
-  def x_build_node(object, pid, options)    # Called with object, tree node parent id, tree options
+  # @param object the current node object (or an ancestry tree hash)
+  # @param pid [String|Nil] parent id root nodes are nil
+  # @param options [Hash] tree options
+  # @returns [Hash] display hash for this node and all children
+  def x_build_node(object, pid, options)
     parents = pid.to_s.split('_')
 
     options[:is_current] = ((object.kind_of?(MiqServer) && MiqServer.my_server.id == object.id) ||
                              (object.kind_of?(Zone) && MiqServer.my_server.my_zone == object.name))
 
+    object, ancestry_kids = object_from_ancestry(object)
     node = x_build_single_node(object, pid, options)
 
     # Process the node's children
     node[:expand] = Array(@tree_state.x_tree(@name)[:open_nodes]).include?(node[:key]) || !!options[:open_all] || node[:expand]
-    if object[:load_children] ||
+    if ancestry_kids ||
+       object[:load_children] ||
        node[:expand] ||
        @options[:lazy] == false
 
-      kids = x_get_tree_objects(object, options, false, parents).map do |o|
+      kids = (ancestry_kids || x_get_tree_objects(object, options, false, parents)).map do |o|
         x_build_node(o, node[:key], options)
       end
       node[:children] = kids unless kids.empty?

--- a/app/presenters/tree_builder_services.rb
+++ b/app/presenters/tree_builder_services.rb
@@ -1,5 +1,5 @@
 class TreeBuilderServices < TreeBuilder
-  has_kids_for Service, [:x_get_tree_service_kids]
+  # Services are returned in a tree - kids are discovered automatically
 
   private
 
@@ -21,16 +21,12 @@ class TreeBuilderServices < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    roots = Rbac.filtered(Service.roots)
-
-    # Preload the root service picture since it's called by TreeNodeBuilder#build
-    MiqPreloader.preload(roots, :picture)
-
-    count_only_or_objects(count_only, roots, "name")
-  end
-
-  def x_get_tree_service_kids(object, count_only)
-    objects = Rbac.filtered(object.direct_service_children.select(&:display).sort_by { |o| o.name.downcase })
-    count_only_or_objects(count_only, objects, 'name')
+    all_services = Rbac.filtered(Service.where(:display => true))
+    if count_only
+      all_services.size
+    else
+      MiqPreloader.preload(all_services.to_a, :picture)
+      Service.arrange_nodes(all_services.sort_by { |n| [n.ancestry.to_s, n.name.downcase] })
+    end
   end
 end

--- a/spec/presenters/tree_builder_services_spec.rb
+++ b/spec/presenters/tree_builder_services_spec.rb
@@ -4,13 +4,17 @@ describe TreeBuilderServices do
   it "generates tree" do
     create_deep_tree
 
-    expect(root_nodes).to eq([@service])
-    expect(kid_nodes(@service)).to match_array([@service_c1, @service_c2])
-    expect(kid_nodes(@service_c1)).to match_array([@service_c11, @service_c12])
-    expect(kid_nodes(@service_c12)).to match_array([@service_c121])
-    expect(kid_nodes(@service_c11)).to be_blank
-    expect(kid_nodes(@service_c121)).to be_blank
-    expect(kid_nodes(@service_c2)).to be_blank
+    expect(root_nodes).to eq(
+      @service => {
+        @service_c1 => {
+          @service_c11 => {},
+          @service_c12 => {
+            @service_c121 => {}
+          }
+        },
+        @service_c2 => {}
+      }
+    )
   end
 
   private


### PR DESCRIPTION
Overview
---------

The tree builder builds a hierarchical tree of nodes which are converted into a ui tree.

Most of the times, fetching each layer in the tree is a unique operation. e.g.: Give me all the vms in an ems.
But sometimes it makes more sense to fetch multiple layers in a single query. e.g. Give me all the levels of folders for this Host. Or give me the hierarchy of all the Services

**IMPORTANT:** This does not preload everything into memory. This is performing fewer queries AND bringing back fewer rows.

Details
-------

~~Alternative implementation of #11166~~

This PR lets a tree builder operation return multiple layers. It doesn't need to return all layers, just the layers that make sense in a single operation.

It is most useful when a model uses ancestry and has a built in way to return multiple layers.

before
------

Walk each layer of the tree and look up children. This is worse than an N+1. Because the query is performed at each node of each layer. (I call it the `parent_id` pattern)

Even if we lazy expand the tree, we still need to count the number of nodes of the next layer of the tree. A deep tree will have the most queries. But a flat tree is frustrating because of the extra `count(*)` queries for every node.

after
----

Fetch all services in 1 query. Return a hash showing parents and children.
Do not count children at each level because we already know all the children.

numbers
--------

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  21,611.5 |9,690 |  2,325.7 |    9,951 |before
|  8,557.9 |  210 |   293.3 |    6,728 |after


|ExtManagementSystem|MiqRegion|Zone|Service
|------------------:|--------:|---:|---:|
|                12 |       5 | 34 |9,481 