### PR TITLE
Do not reload miq server in tree builder

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -300,9 +300,8 @@ class TreeBuilder
   def x_build_node(object, pid, options)    # Called with object, tree node parent id, tree options
     parents = pid.to_s.split('_')
 
-    options[:is_current] =
-        ((object.kind_of?(MiqServer) && MiqServer.my_server(true).id == object.id) ||
-         (object.kind_of?(Zone) && MiqServer.my_server(true).my_zone == object.name))
+    options[:is_current] = ((object.kind_of?(MiqServer) && MiqServer.my_server.id == object.id) ||
+                             (object.kind_of?(Zone) && MiqServer.my_server.my_zone == object.name))
 
     node = x_build_single_node(object, pid, options)
 

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -10,7 +10,7 @@ shared_examples "logs_collect" do |type|
       :active_tab       => "diagnostics_roles_servers"
     }
     controller.instance_variable_set(:@sb, sb_hash)
-    allow(MiqServer).to receive(:my_server).with(true).and_return(server)
+    allow(MiqServer).to receive(:my_server).and_return(server)
   end
 
   it "not running" do

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -20,7 +20,7 @@ describe OpsController do
         @svr1.vm_scan_storage_affinity = [@storage1]
         @svr2.vm_scan_storage_affinity = [@storage2]
         allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
-        allow(MiqServer).to receive(:my_server).with(true).and_return(OpenStruct.new('id' => 0, :name => 'name'))
+        allow(MiqServer).to receive(:my_server).and_return(OpenStruct.new('id' => 0, :name => 'name'))
 
         tree_hash = {
           :trees       => {

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2233,7 +2233,7 @@ describe ApplicationHelper do
       let(:server) { double("MiqServer", :logon_status => :ready) }
       let(:user)   { FactoryGirl.create(:user_admin) }
       before do
-        allow(MiqServer).to receive(:my_server).with(true).and_return(server)
+        allow(MiqServer).to receive(:my_server).and_return(server)
 
         @id = "miq_request_delete"
         login_as user

--- a/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
+++ b/spec/presenters/tree_builder_smartproxy_affinity_spec.rb
@@ -24,7 +24,7 @@ describe TreeBuilderSmartproxyAffinity do
       @svr2.vm_scan_storage_affinity = [@storage2]
 
       allow_any_instance_of(MiqServer).to receive_messages(:is_a_proxy? => true)
-      allow(MiqServer).to receive(:my_server).with(true).and_return(OpenStruct.new('id' => 0, :name => 'name'))
+      allow(MiqServer).to receive(:my_server).and_return(OpenStruct.new('id' => 0, :name => 'name'))
 
       @smartproxy_affinity_tree = TreeBuilderSmartproxyAffinity.new(:smartproxy_affinity,
                                                                     :smartproxy_affinity_tree,


### PR DESCRIPTION
When building trees, the current server and zone are highlighted.

Of note: the current server's id and zone do not change at runtime.

before
------
Reload my server when visiting every zone and server in the ui

after
-----

This uses the cached version of my_server.

(I'm not endorsing whether this check should even be here in the first place)