### PR TITLE
remove warnings for bundler over git

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -3,6 +3,9 @@ set -v
 echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
 travis_retry gem install bundler -v ">= 1.11.1"
 
+# disable warnings for git based gems over git:// protocol
+bundle config git.allow_insecure true
+
 if [[ -n "${GEM}" ]] ; then
   cd gems/${GEM}
 else


### PR DESCRIPTION
remove the warning from travis tests [[ref]](https://travis-ci.org/ManageIQ/manageiq/jobs/159124160#L784):

```
git source `git://github.com/ManageIQ/manageiq-providers-amazon` uses the `git` protocol,
which transmits data without encryption. Disable this warning with
`bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```