### PR TITLE
[WIP] Make topology visible for rhos undercloud

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -29,6 +29,18 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     ::CloudTenant.where(:id => vms.collect(&:cloud_tenant_id).uniq)
   end
 
+  # TODO(aveselov) Added 3 empty methods here because 'entity' inside 'build_recursive_topology' calls for these methods.
+  # Work still in progress, but at least it makes a topology visible for rhos undercloud.
+
+  def load_balancers
+  end
+
+  def cloud_tenant
+  end
+
+  def security_groups
+  end
+
   def ssh_users_and_passwords
     user_auth_key, auth_key = auth_user_keypair
     user_password, password = auth_user_pwd


### PR DESCRIPTION
It temporarily fixes [this bug] (https://bugzilla.redhat.com/show_bug.cgi?id=1343553). Now the topology can be seen for undercloud provider.

![undercloud_topology](https://cloud.githubusercontent.com/assets/8054645/18433522/59afc0d8-78e8-11e6-9e73-7598818ebaba.jpg)
