### PR TITLE
Fix storing virtual custom attributes with "."

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1255,7 +1255,8 @@ module ReportController::Reports::Editor
         @edit[:new][:sortby2].split("__").first :
         @edit[:new][:sortby2]
 
-    if field.include?(".")                            # Has a period, so it's an include
+    # Has a period, so it's an include
+    if field.include?(".") && !field.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
       tables = field.split("-")[0].split(".")[1..-1]  # Get the list of tables from before the hyphen
       inc_hash = rpt.include                          # Start at the main hash
       tables.each_with_index do |table, idx|

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -46,6 +46,25 @@ describe ReportController do
         allow(controller).to receive(:build_edit_screen) # Don't actually build the edit screen
       end
 
+      describe "#add_field_to_col_order" do
+        let(:miq_report)               { FactoryGirl.create(:miq_report, :cols => [], :col_order => []) }
+        let(:base_model)               { "Vm" }
+        let(:virtual_custom_attribute) { "virtual_custom_attribute_kubernetes.io/hostname" }
+
+        before do
+          @edit = assigns(:edit)
+          @edit[:new][:sortby1] = S1 # Set an initial sort by col
+          @edit[:new][:sortby2] = S2 # Set no second sort col
+          @edit[:new][:pivot] = ReportController::PivotOptions.new
+          controller.instance_variable_set(:@edit, @edit)
+        end
+
+        it "fills report by passed column" do
+          controller.send(:add_field_to_col_order, miq_report, "#{base_model}-#{virtual_custom_attribute}")
+          expect(miq_report.cols.first).to eq(virtual_custom_attribute)
+        end
+      end
+
       context "handle report fields" do
         it "sets pdf page size" do
           ps = "US-Legal"


### PR DESCRIPTION
Fix storing report with custom attributes which contains "." 

## Links [Optional]

https://github.com/ManageIQ/manageiq/pull/11112
https://github.com/ManageIQ/manageiq/issues/10482 [related]

## Steps for Testing/QA [Optional]

1. Create new Report 
2. Add custom attribute which contains "."
3. Save and confirm
