### PR TITLE
Emit Notification on lifecycle events and on request approvals

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -24,4 +24,12 @@ class EventStream < ApplicationRecord
   belongs_to :container_node
 
   belongs_to :middleware_server, :foreign_key => :middleware_server_id
+
+  after_commit :emit_notifications, :on => :create
+
+  def emit_notifications
+    Notification.emit_for_event(self)
+  rescue => err
+    _log.log_backtrace(err)
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -18,8 +18,8 @@ class Notification < ApplicationRecord
   end
 
   def self.emit_for_event(event)
+    return unless NotificationType.names.include?(event.event_type)
     type = NotificationType.find_by_name(event.event_type)
-    return unless type
     Notification.create(:notification_type => type, :subject => event.target)
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -17,6 +17,12 @@ class Notification < ApplicationRecord
     self.notification_type = NotificationType.find_by_name!(typ)
   end
 
+  def self.emit_for_event(event)
+    type = NotificationType.find_by_name(event.event_type)
+    return unless type
+    Notification.create(:notification_type => type, :subject => event.target)
+  end
+
   def to_h
     {
       :level      => notification_type.level,

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -21,6 +21,10 @@ class NotificationType < ApplicationRecord
     end
   end
 
+  def self.names
+    @names ||= Set.new(pluck(:name))
+  end
+
   def self.seed
     seed_data.each do |t|
       rec = find_by_name(t[:name])

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -1,11 +1,36 @@
 ---
-- :name: vm_powered_off
-  :message: Virtual Machine %{subject} has been powered off
-  :expires_in: 24.hours
+- :name: host_provisioned
+  :message: Host %{subject} has been provisioned.
+  :expires_in: 7.days
   :level: :success
   :audience: tenant
-- :name: vm_powered_on
-  :message: Virtual Machine %{subject} has been powered on
-  :expires_in: 24.hours
+- :name: service_provisioned
+  :message: Service %{subject} has been provisioned.
+  :expires_in: 7.days
   :level: :success
+  :audience: tenant
+- :name: service_retired
+  :message: Service %{subject} has been retired.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
+- :name: vm_provisioned
+  :message: Virtual Machine %{subject} has been provisioned.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
+- :name: vm_retired
+  :message: Virtual Machine %{subject} has been retired.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
+- :name: request_approved
+  :message: Request %{subject} has been approved.
+  :expires_in: 14.days
+  :level: :success
+  :audience: tenant
+- :name: request_denied
+  :message: Request %{subject} has been denied.
+  :expires_in: 14.days
+  :level: :warning
   :audience: tenant

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -6,7 +6,7 @@ describe Notification, :type => :model do
   describe '.emit' do
     context 'successful' do
       let(:vm) { FactoryGirl.create(:vm, :tenant => tenant) }
-      let(:notification_type) { :vm_powered_on }
+      let(:notification_type) { :vm_provisioned }
 
       subject { Notification.create(:type => notification_type, :subject => vm) }
 


### PR DESCRIPTION
## Summary
This pr brings in notifications on life cycle events like
 * service/vm/host being provisioned
 * service/vm being retired
 * MiqRequest (provisioning) being approved or denied

https://www.pivotaltracker.com/n/projects/1608513/stories/128407995

## Details
I spent good time investigating how various events work currently. Perhaps, it is worth to share my thoughts, so excuse my verbosity.

### Problem description
Notifications are hard. :point_up: It is fairly easy for us to flood the users with plethora of notifications, it will be much more difficult to build a system that sends only targeted, useful and contextful messages. Two problems arise here: 
    
 * **(A) For users stuff happens in context**: Ours EventStream oftentimes lacks context. An event either tells that something had happened, or that some(body/thing) has requested it to happen. For a notification to be useful, it is required to combine both. In a nutshell, we need to put an EmsEvent into context of preceding MiqEvent (if exists). Chances are that Control and Automate will benefit from this as well.
    
 * **(B) Users may want to customize conditions upon which the notification is emitted** We already have MiqAlert subsystem to emit e-mails (or any MiqAction in general) upon event. MiqAlert offers great customization for users. It would be waste not to re-use MiqAlert for emiting notification. However, notifications will need more customization than MiqAlert offers now. (1) Upon some conditions users will be interested in notification, othertimes they won't. The conditions won't be easy to define in a generic way. (2) A state machine may be needed to notify users about complex background tasks.

Fortunately, we don't need to handle all the problems at once. We can start introduce notifications that we have enough context for, adding the more difficult later.

### Where to hook Notifications
Basically, I saw three options where to hook notifications.
1. Any time, when something specific happens -> emit notification.
2. Any time an event is raised/processed, -> emit a notification
3. Make a notification special MiqAction of MiqAlert

The 1. would require modification of many places and automate scripts, and still it would leave a lot of notification missing. This would make notifications totally isolated from events subsystem. However, there is not much of a benefit. If the notification exists about something, perhaps an event should exists as well. 

The third options seems superior, however the second is good enough for start. There will be multiple changes needed to MiqAlert before we can use it to emit notification. Additionally, the problem **(A)** needs to be resolved before amending MiqAlert otherwise it just doubles the scope of work.

Option 2. seems to be good enough to start with. And let's adopt 3. later.

@miq-bot add_label enhancement, events, core, darga/no
/cc @gtanzillo @gmcculloug @lfu @skateman 
