### PR TITLE
Clear localStorage data about navigation when showing the login

### DIFF
--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -23,3 +23,5 @@
 
     :javascript
       API.logout();
+      delete localStorage['patternfly-navigation-secondary'];
+      delete localStorage['patternfly-navigation-tertiary'];


### PR DESCRIPTION
After logging in, the navbar should not be pinned in any case.

https://bugzilla.redhat.com/show_bug.cgi?id=1371227