### PR TITLE
Some future notifications will be only useful for superadmins

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -2,10 +2,11 @@ class NotificationType < ApplicationRecord
   AUDIENCE_USER = 'user'.freeze
   AUDIENCE_TENANT = 'tenant'.freeze
   AUDIENCE_GLOBAL = 'global'.freeze
+  AUDIENCE_SUPERADMIN = 'superadmin'.freeze
   has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
-  validates :audience, :inclusion => { :in => [AUDIENCE_USER, AUDIENCE_TENANT, AUDIENCE_GLOBAL] }
+  validates :audience, :inclusion => { :in => [AUDIENCE_USER, AUDIENCE_TENANT, AUDIENCE_GLOBAL, AUDIENCE_SUPERADMIN] }
 
   def subscriber_ids(subject, initiator)
     case audience
@@ -15,6 +16,8 @@ class NotificationType < ApplicationRecord
       [initiator.id]
     when AUDIENCE_TENANT
       subject.tenant.user_ids
+    when AUDIENCE_SUPERADMIN
+      User.superadmins.pluck(:id)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,9 @@ class User < ApplicationRecord
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
   scope      :admin, -> { where(:userid => "admin") }
+  scope      :superadmins, lambda {
+    joins(:miq_groups => :miq_user_role).where(:miq_user_roles => {:name => MiqUserRole::SUPER_ADMIN_ROLE_NAME })
+  }
 
   virtual_has_many :active_vms, :class_name => "VmOrTemplate"
 


### PR DESCRIPTION
Some notifications will be useful only for superadmins. Let's introduce new audience class for them.

Example of such notification may be MiqEvents about disk space usage. But, any event_type=evm_server_* can be useful for admins to see.

@miq-bot add_label enhancement, core, darga/no
@miq-bot assign @gtanzillo 