### PR TITLE
remove explicit declaration of supports_not

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -2,11 +2,6 @@ module ManageIQ::Providers
   class BaseManager < ExtManagementSystem
     require_nested :Refresher
 
-    include SupportsFeatureMixin
-    supports_not :provisioning # via automate
-    supports_not :regions      # as in ManageIQ::Providers::<Type>::Regions
-    supports_not :smartstate_analysis
-
     def self.metrics_collector_queue_name
       self::MetricsCollectorWorker.default_queue_name
     end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -39,9 +39,6 @@ module ManageIQ::Providers
     include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
 
-    supports_not :discovery
-    supports_not :cloud_tenant_mapping
-
     # Development helper method for Rails console for opening a browser to the EMS.
     #
     # This method is NOT meant to be called from production code.

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -3,8 +3,6 @@ class MiqTemplate < VmOrTemplate
 
   include_concern 'Operations'
 
-  supports_not :provisioning
-
   def self.base_model
     MiqTemplate
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -32,10 +32,6 @@ class VmOrTemplate < ApplicationRecord
 
   include AvailabilityMixin
 
-  supports_not :retire
-  supports_not :associate_floating_ip
-  supports_not :disassociate_floating_ip
-
   has_many :ems_custom_attributes, -> { where(:source => 'VC') }, :as => :resource, :dependent => :destroy,
            :class_name => "CustomAttribute"
   has_many :counterparts, :as => :counterpart, :class_name => "ConfiguredSystem", :dependent => :nullify
@@ -132,8 +128,6 @@ class VmOrTemplate < ApplicationRecord
   belongs_to                :tenant
 
   acts_as_miq_taggable
-
-  supports_not :resize
 
   virtual_column :is_evm_appliance,                     :type => :boolean,    :uses => :miq_server
   virtual_column :os_image_name,                        :type => :string,     :uses => [:operating_system, :hardware]

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -1,11 +1,4 @@
 module VmOrTemplate::Operations::Relocation
-  extend ActiveSupport::Concern
-
-  included do
-    supports_not :live_migrate, :reason => N_("Operation not supported.")
-    supports_not :evacuate, :reason => N_("Operation not supported.")
-  end
-
   def raw_live_migrate(_options = nil)
     raise NotImplementedError, _("raw_live_migrate must be implemented in a subclass")
   end

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -8,13 +8,6 @@ require 'blackbox/VmBlackBox'
 module VmOrTemplate::Scanning
   extend ActiveSupport::Concern
 
-  # Smartstate Analysis is unsupported by default.
-  # Subclasses need to override this method if they support SSA.
-  included do
-    supports_not :smartstate_analysis,
-                 :reason => N_("Operation not supported.")
-  end
-
   # Call the VmScan Job and raise a "request" event
   def scan(userid = "system", options = {})
     # Check if there are any current scan jobs already waiting to run


### PR DESCRIPTION
as of 478f749f9036cd429ae2bb18d393b083fb7a2b3c every known feature is unsupported by default, so no need to explicitly make it unsupported

@miq-bot add_label refactoring, pluggable providers

@blomquisg @gauravaradhye pls review