### PR TITLE
Fix Tenant quota's name attribute to use quota_name

### DIFF
--- a/app/views/ops/_tenant_quota_form.html.haml
+++ b/app/views/ops/_tenant_quota_form.html.haml
@@ -31,7 +31,7 @@
             %td
               %input.form-control{"type"        => "text",
                                   "id"          => "id_{{quota_name}}",
-                                  "name"        => "value",
+                                  "name"        => "id_{{quota_name}}",
                                   "ng-model"    => "quota_obj.value",
                                   "ng-required" => "quota_obj.enforced",
                                   "ng-disabled" => "!quota_obj.enforced",


### PR DESCRIPTION
Set the name attribute of an input text field HTML element in the Tenant Quota form to the same value as id attribute (that's commonly used in all NG forms in the application)

Fix requested by @akarol 