### PR TITLE
Clean up API routes a bit

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2802,9 +2802,7 @@ Vmdb::Application.routes.draw do
     Api::Settings.collections.each do |collection_name, collection|
       controller collection_name, :path => collection_name do
         collection.verbs.each do |verb|
-          if collection.options.include?(:primary)
-            root :action => API_ACTIONS[verb], :via => verb
-          end
+          root :action => API_ACTIONS[verb], :via => verb if collection.options.include?(:primary)
 
           next unless collection.options.include?(:collection)
 
@@ -2817,9 +2815,7 @@ Vmdb::Application.routes.draw do
 
         Array(collection.subcollections).each do |subcollection_name|
           Api::Settings.collections[subcollection_name].verbs.each do |verb|
-            match("/:c_id/#{subcollection_name}(/:s_id)",
-                  :action => API_ACTIONS[verb],
-                  :via => verb)
+            match("/:c_id/#{subcollection_name}(/:s_id)", :action => API_ACTIONS[verb], :via => verb)
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2799,30 +2799,26 @@ Vmdb::Application.routes.draw do
       }.freeze
     end
 
-    def action_for_collection(verb)
-      API_ACTIONS[verb]
-    end
-
     Api::Settings.collections.each do |collection_name, collection|
       controller collection_name, :path => collection_name do
         collection.verbs.each do |verb|
           if collection.options.include?(:primary)
-            root :action => action_for_collection(verb), :via => verb
+            root :action => API_ACTIONS[verb], :via => verb
           end
 
           next unless collection.options.include?(:collection)
 
           if collection.options.include?(:arbitrary_resource_path)
-            match "(/*c_suffix)", :action => action_for_collection(verb), :via => verb
+            match "(/*c_suffix)", :action => API_ACTIONS[verb], :via => verb
           else
-            match "(/:c_id)", :action => action_for_collection(verb), :via => verb
+            match "(/:c_id)", :action => API_ACTIONS[verb], :via => verb
           end
         end
 
         Array(collection.subcollections).each do |subcollection_name|
           Api::Settings.collections[subcollection_name].verbs.each do |verb|
             match("/:c_id/#{subcollection_name}(/:s_id)",
-                  :action => action_for_collection(verb),
+                  :action => API_ACTIONS[verb],
                   :via => verb)
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2803,30 +2803,26 @@ Vmdb::Application.routes.draw do
       "#{collection_name}##{API_ACTIONS[verb]}"
     end
 
-    def create_api_route(verb, url, action)
-      public_send(verb, url, :to => action)
-    end
-
     Api::Settings.collections.each do |collection_name, collection|
       collection.verbs.each do |verb|
         if collection.options.include?(:primary)
-          create_api_route(verb, collection_name, action_for_collection(collection_name, verb))
+          match(collection_name, :to => action_for_collection(collection_name, verb), :via => verb)
         end
 
         next unless collection.options.include?(:collection)
 
         if collection.options.include?(:arbitrary_resource_path)
-          create_api_route(verb, "#{collection_name}(/*c_suffix)", action_for_collection(collection_name, verb))
+          match "#{collection_name}/(*c_suffix)", :to => action_for_collection(collection_name, verb), :via => verb
         else
-          create_api_route(verb, "#{collection_name}(/:c_id)", action_for_collection(collection_name, verb))
+          match "#{collection_name}(/:c_id)", :to => action_for_collection(collection_name, verb), :via => verb
         end
       end
 
       Array(collection.subcollections).each do |subcollection_name|
         Api::Settings.collections[subcollection_name].verbs.each do |verb|
-          create_api_route(verb,
-                           "#{collection_name}/:c_id/#{subcollection_name}(/:s_id)",
-                           action_for_collection(collection_name, verb))
+          match("#{collection_name}/:c_id/#{subcollection_name}(/:s_id)",
+                :to => action_for_collection(collection_name, verb),
+                :via => verb)
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2799,30 +2799,32 @@ Vmdb::Application.routes.draw do
       }.freeze
     end
 
-    def action_for_collection(collection_name, verb)
-      "#{collection_name}##{API_ACTIONS[verb]}"
+    def action_for_collection(verb)
+      API_ACTIONS[verb]
     end
 
     Api::Settings.collections.each do |collection_name, collection|
-      collection.verbs.each do |verb|
-        if collection.options.include?(:primary)
-          match(collection_name, :to => action_for_collection(collection_name, verb), :via => verb)
+      controller collection_name, :path => collection_name do
+        collection.verbs.each do |verb|
+          if collection.options.include?(:primary)
+            root :action => action_for_collection(verb), :via => verb
+          end
+
+          next unless collection.options.include?(:collection)
+
+          if collection.options.include?(:arbitrary_resource_path)
+            match "(/*c_suffix)", :action => action_for_collection(verb), :via => verb
+          else
+            match "(/:c_id)", :action => action_for_collection(verb), :via => verb
+          end
         end
 
-        next unless collection.options.include?(:collection)
-
-        if collection.options.include?(:arbitrary_resource_path)
-          match "#{collection_name}/(*c_suffix)", :to => action_for_collection(collection_name, verb), :via => verb
-        else
-          match "#{collection_name}(/:c_id)", :to => action_for_collection(collection_name, verb), :via => verb
-        end
-      end
-
-      Array(collection.subcollections).each do |subcollection_name|
-        Api::Settings.collections[subcollection_name].verbs.each do |verb|
-          match("#{collection_name}/:c_id/#{subcollection_name}(/:s_id)",
-                :to => action_for_collection(collection_name, verb),
-                :via => verb)
+        Array(collection.subcollections).each do |subcollection_name|
+          Api::Settings.collections[subcollection_name].verbs.each do |verb|
+            match("/:c_id/#{subcollection_name}(/:s_id)",
+                  :action => action_for_collection(verb),
+                  :via => verb)
+          end
         end
       end
     end


### PR DESCRIPTION
* By preferring `match` to `public_send`, we can eliminate `create_api_route`
* Further, by using a `controller` block we can eliminate the need for `action_for_collection`
* Allows for a few multiliners to be collapsed, resulting in a smaller, more readable block of code
* Probably best viewed as individual commits

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 
:scissors: :fire: :toilet: 