### PR TITLE
Add source column to network ports

### DIFF
--- a/db/migrate/20160912183918_add_source_to_network_ports.rb
+++ b/db/migrate/20160912183918_add_source_to_network_ports.rb
@@ -1,0 +1,5 @@
+class AddSourceToNetworkPorts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :network_ports, :source, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5299,6 +5299,7 @@ network_ports:
 - binding_host_id
 - binding_virtual_interface_type
 - extra_attributes
+- source
 network_ports_security_groups:
 - network_port_id
 - security_group_id


### PR DESCRIPTION
Adds a source column to the network_ports table, enabling us to later add port information from sources other than refresh - e.g, SSA
