### PR TITLE
Use the rails bin/setup template for cleaning logs/tmp

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -59,8 +59,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  execute "find log/ -type 'f' | xargs rm"
-  execute "rm -rf tmp/cache"
+  execute 'bin/rails log:clear tmp:clear'
 
   if options[:do_tests]
     puts "\n== Preparing tests =="


### PR DESCRIPTION
Fixes an issue introduced in #10883 where bin/setup would delete log/.gitkeep.

The existing "remove logs and tmp/cache" came before rails 5 here:
27cf8815769fc3fc4772

It was subsequently extracted in Rails to rake tasks, see below.

Let's go back to what Rails ships with and remove our custom stuff.

The current 5.0.0.1 bin/setup example is here:
https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/generators/rails/app/templates/bin/setup#L29

The log:clear does this:
https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/tasks/log.rake#L10-L14

The tmp:clear does this:
https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/tasks/tmp.rake#L3