### PR TITLE
[DARGA] Show non-tenant groups in Set Ownership group dropdown

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -88,7 +88,7 @@ module ApplicationController::CiProcessing
     # need to do this only if 1 vm is selected and miq_group has been set for it
     group = record.miq_group if @edit[:ownership_items].length == 1
     @edit[:new][:group] = group ? group.id.to_s : nil
-    rbac_filtered_objects(MiqGroup).each { |g| @groups[g.description] = g.id.to_s }
+    rbac_filtered_objects(MiqGroup.non_tenant_groups).each { |g| @groups[g.description] = g.id.to_s }
 
     @edit[:new][:user] = @edit[:new][:group] = DONT_CHANGE_OWNER if @edit[:ownership_items].length > 1
 

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -199,12 +199,12 @@ describe ApplicationController do
       @edit = {:ownership_items => [@vm_or_template.id], :klass => VmOrTemplate, :new => {:user => nil}}
     end
 
-    it "lists all groups when (admin user is logged)" do
+    it "lists all non-tenant groups when (admin user is logged)" do
       login_as(admin_user)
       controller.instance_variable_set(:@edit, @edit)
       controller.ownership_build_screen
       groups = controller.instance_variable_get(:@groups)
-      expect(groups.count).to eq(MiqGroup.count)
+      expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
     end
 
     it "lists all users when (admin user is logged)" do
@@ -222,15 +222,6 @@ describe ApplicationController do
       users = controller.instance_variable_get(:@users)
       expected_ids = [great_grand_child_tenant.user_ids, grand_child_tenant.user_ids].flatten
       expect(expected_ids).to match_array(users.values(&:id).map(&:to_i))
-    end
-
-    it "lists all groups that are related to descendants tenats strategy" do
-      login_as(grand_child_user)
-      controller.instance_variable_set(:@edit, @edit)
-      controller.ownership_build_screen
-      groups = controller.instance_variable_get(:@groups)
-      expected_ids = [great_grand_child_tenant.miq_group_ids, grand_child_tenant.miq_group_ids].flatten
-      expect(expected_ids).to match_array(groups.values(&:id).map(&:to_i))
     end
   end
 end


### PR DESCRIPTION
When setting the ownership of a Cloud Instance, the group drop down should only contain non-tenant groups.  This PR resolves a Darga merge conflict in #10720.

https://bugzilla.redhat.com/show_bug.cgi?id=1374695
