### PR TITLE
Automate - Added Google pre and post provisioning.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/__class__.yaml
@@ -211,3 +211,43 @@ object:
       on_error: 
       max_retries: 
       max_time: 
+  - field:
+      aetype: relationship
+      name: google_rel1
+      display_name: 
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: google
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: google_meth1
+      display_name: 
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: google
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/postprovision.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/postprovision.yaml
@@ -14,3 +14,5 @@ object:
       value: openstack_PostProvision
   - azure_meth1:
       value: PostProvision
+  - google_meth1:
+      value: PostProvision

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods.class/preprovision.yaml
@@ -14,3 +14,5 @@ object:
       value: openstack_PreProvision
   - azure_meth1:
       value: PreProvision
+  - google_meth1:
+      value: PreProvision


### PR DESCRIPTION
Added relationship and method fields for Google.

Configured Google for generic pre and post provisioning methods.

http://talk.manageiq.org/t/azure-and-amazon-vm-post-provisioning/1691

https://bugzilla.redhat.com/show_bug.cgi?id=1375225