### PR TITLE
Switch.ports always 0 for Distributed Virtual Switches

### DIFF
--- a/app/models/ems_refresh/vc_updates.rb
+++ b/app/models/ems_refresh/vc_updates.rb
@@ -181,6 +181,7 @@ module EmsRefresh::VcUpdates
       "MOR",
       "config.uplinkPortgroup",
       "config.defaultPortConfig",
+      "config.numPorts",
       "summary.name",
       "summary.uuid",
       "summary.host",

--- a/gems/pending/VMwareWebService/VimPropMaps.rb
+++ b/gems/pending/VMwareWebService/VimPropMaps.rb
@@ -377,6 +377,7 @@ module VimPropMaps
       :props    => [
         'config.uplinkPortgroup',
         'config.defaultPortConfig',
+        'config.numPorts',
         'summary.name',
         'summary.uuid',
         'summary.host',
@@ -527,6 +528,7 @@ module VimPropMaps
       :props    => [
         'config.uplinkPortgroup',
         'config.defaultPortConfig',
+        'config.numPorts',
         'summary.name',
         'summary.uuid',
         'summary.host',

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -409,7 +409,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(dvswitch).to have_attributes(
       :uid_ems           => 'dvs-119',
       :name              => 'DC1_DVS',
-      :ports             => 0,
+      :ports             => 26,
       :allow_promiscuous => nil,
       :forged_transmits  => nil,
       :mac_changes       => nil,

--- a/spec/tools/vim_data/miq_vim_inventory/dvSwitchesByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dvSwitchesByMor.yml
@@ -8,6 +8,10 @@
     MOR: *1
     config: !ruby/hash-with-ivars:VimHash
       elements:
+        numPorts: !ruby/string:VimString
+          str: '26'
+          xsiType: :SOAP::SOAPInt
+          vimType:
         uplinkPortgroup: !ruby/array:VimArray
           internal:
           - !ruby/string:VimString


### PR DESCRIPTION
The number of ports for a distributed switch was always 0 due to the property not being in the VimPropMap.

The value is set here https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb#L458 which is correct to the SDK but the value was being filtered out before being returned.

* https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.DistributedVirtualSwitch.ConfigInfo.html

Before:
```
Switch.where(:shared => true).collect {|s| s.ports}
=> [0, 0, 0]
```

After:
```
Switch.where(:shared => true).collect {|s| s.ports}
=> [26, 12, 16]
```