### PR TITLE
Rails scripts for setting a server's zone and configuration settings from a command line

### DIFF
--- a/tools/change_server_zone.rb
+++ b/tools/change_server_zone.rb
@@ -2,7 +2,7 @@
 require File.expand_path("../config/environment", __dir__)
 
 if ARGV.empty?
-  puts "USAGE: #{__FILE__} server_id zone_name"
+  puts "USAGE: #{__FILE__} serverid zone_name"
   exit 0
 end
 

--- a/tools/change_server_zone.rb
+++ b/tools/change_server_zone.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path("../config/environment", __dir__)
+
 if ARGV.empty?
   puts "USAGE: #{__FILE__} server_id zone_name"
   exit 0

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -1,0 +1,37 @@
+if ARGV.empty?
+  puts "USAGE: #{__FILE__} server_id settings_path_separated_by_a_/ value [settings_path_separated_by_a_/ value]"
+  exit 0
+end
+
+server_id = ARGV[0]
+new_settings = ARGV[1..-1]
+
+server = MiqServer.where(:id => server_id).take
+unless server
+  puts "Unable to find server with id [#{server_id}]"
+  exit 1
+end
+
+settings = server.get_config("vmdb")
+
+new_settings.each_slice(2) do |k, v|
+  path = settings.config
+  keys = k.split("/")
+  key = keys.pop.to_sym
+  keys.each { |p| path = path[p.to_sym] }
+
+  puts "Setting [#{k}], old value: [#{path[key]}], new value: [#{v}]"
+  path[key] = v
+end
+
+valid, errors = VMDB::Config::Validator.new(settings).validate
+unless valid
+  puts "ERROR: Configuration is invalid:"
+  errors.each { |k, v| puts "\t#{k}: #{v}" }
+  exit 1
+end
+
+server.set_config(settings)
+server.save!
+
+puts "Done"

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -1,5 +1,10 @@
+#!/usr/bin/env ruby
+require File.expand_path("../config/environment", __dir__)
+
 if ARGV.empty?
-  puts "USAGE: #{__FILE__} server_id settings_path_separated_by_a_/ value [settings_path_separated_by_a_/ value]"
+  puts "USAGE:   #{__FILE__} server_id settings_path_separated_by_a_/ value [settings_path_separated_by_a_/ value]"
+  puts "Example: #{__FILE__} 2 smtp/authentication plain smtp/host gt123"
+
   exit 0
 end
 

--- a/tools/configure_server_zone.rb
+++ b/tools/configure_server_zone.rb
@@ -1,0 +1,29 @@
+if ARGV.empty?
+  puts "USAGE: #{__FILE__} server_id zone_name"
+  exit 0
+end
+
+server_id, zone_name = ARGV
+
+server = MiqServer.where(:id => server_id).take
+unless server
+  puts "Unable to find server with id [#{server_id}]"
+  exit 1
+end
+
+zone = Zone.where(:name => zone_name).take
+unless zone
+  puts "Unable to find zone with name [#{zone_name}]"
+  exit 1
+end
+
+server.zone = zone
+server.save!
+
+settings = server.get_config("vmdb")
+settings.config[:server][:zone] = zone.name
+server.set_config(settings)
+
+server.save!
+
+puts "Configured server [#{server.id}] to be in zone [#{zone.name}]"


### PR DESCRIPTION
These tools enable automation of server configuration in environments that have many appliances
- tools/configure_server_zone.rb - Updates the zone of a specific server. The zone must exist.
- tools/configure_server_settings.rb - Generic script updating VMDB configuration settings of a specific server.
