### PR TITLE
Removes 'Middleware ' prefix from sub-elements of 'Middleware'.

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -139,11 +139,16 @@ module Menu
       def middleware_menu_section
         Menu::Section.new(:mdl, N_("Middleware"), 'fa product-middleware fa-2x', [
           Menu::Item.new('ems_middleware', N_('Providers'), 'ems_middleware', {:feature => 'ems_middleware_show_list'}, '/ems_middleware'),
-          Menu::Item.new('middleware_domain', deferred_ui_lookup(:tables => 'middleware_domains'), 'middleware_domain', {:feature => 'middleware_domain_show_list'}, '/middleware_domain'),
-          Menu::Item.new('middleware_server', deferred_ui_lookup(:tables => 'middleware_server'), 'middleware_server', {:feature => 'middleware_server_show_list'}, '/middleware_server'),
-          Menu::Item.new('middleware_deployment', deferred_ui_lookup(:tables => 'middleware_deployment'), 'middleware_deployment', {:feature => 'middleware_deployment_show_list'}, '/middleware_deployment'),
-          Menu::Item.new('middleware_datasource', deferred_ui_lookup(:tables => 'middleware_datasource'), 'middleware_datasource', {:feature => 'middleware_datasource_show_list'}, '/middleware_datasource'),
-          Menu::Item.new('middleware_messaging', deferred_ui_lookup(:tables => 'middleware_messaging'), 'middleware_messaging', {:feature => 'middleware_messaging_show_list'}, '/middleware_messaging'),
+          Menu::Item.new('middleware_domain', N_('Domains'), 'middleware_domain',
+                         {:feature => 'middleware_domain_show_list'}, '/middleware_domain'),
+          Menu::Item.new('middleware_server', N_('Servers'), 'middleware_server',
+                         {:feature => 'middleware_server_show_list'}, '/middleware_server'),
+          Menu::Item.new('middleware_deployment', N_('Deployments'), 'middleware_deployment',
+                         {:feature => 'middleware_deployment_show_list'}, '/middleware_deployment'),
+          Menu::Item.new('middleware_datasource', N_('Datasources'), 'middleware_datasource',
+                         {:feature => 'middleware_datasource_show_list'}, '/middleware_datasource'),
+          Menu::Item.new('middleware_messaging', N_('Messagings'), 'middleware_messaging',
+                         {:feature => 'middleware_messaging_show_list'}, '/middleware_messaging'),
           Menu::Item.new('middleware_topology', N_('Topology'), 'middleware_topology', {:feature => 'middleware_topology', :any => true}, '/middleware_topology')
 
         ])


### PR DESCRIPTION

![screenshot from 2016-09-13 01-11-17](https://cloud.githubusercontent.com/assets/3845764/18463494/42c349ae-7950-11e6-951a-b73149b4f2ef.png)


Fixes #11118