### PR TITLE
Add CloudTenant mapping to QUERYABLE_FEATURES in SupportsFeatureMixin

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -57,6 +57,7 @@ module SupportsFeatureMixin
   QUERYABLE_FEATURES = {
     :associate_floating_ip    => 'Associate a Floating IP',
     :control                  => 'Basic control operations', # FIXME: this is just a internal helper and should be refactored
+    :cloud_tenant_mapping     => 'CloudTenant mapping',
     :delete                   => 'Deletion',
     :disassociate_floating_ip => 'Disassociate a Floating IP',
     :discovery                => 'Discovery of Managers for a Provider',


### PR DESCRIPTION
using SupportsFeatureMixin was added here for cloud tenant mapping
https://github.com/ManageIQ/manageiq/pull/10761 but before merging this 
there was introduced QUERYABLE_FEATURES https://github.com/ManageIQ/manageiq/pull/10917
and it caused failing CI

cc @durandom 

@miq-bot assign  @gtanzillo 

