### PR TITLE
Enable search for Middleware entities

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -793,7 +793,8 @@ module ApplicationHelper
        container_route container_project container_replicator container_image
        container_image_registry persistent_volume container_build
        ems_container vm miq_template offline retired templates
-       host service storage ems_cloud ems_cluster flavor
+       ems_middleware middleware_server middleware_domain middleware_messaging middleware_deployment
+       middleware_datasource host service storage ems_cloud ems_cluster flavor
        ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
        load_balancer
        resource_pool ems_infra ontap_storage_system ontap_storage_volume
@@ -1176,7 +1177,8 @@ module ApplicationHelper
   def show_adv_search?
     show_search = %w(availability_zone cim_base_storage_extent cloud_volume cloud_volume_snapshot container_group container_node container_service
                      container_route container_project container_replicator container_image container_image_registry
-                     persistent_volume container_build
+                     persistent_volume container_build ems_middleware middleware_server middleware_domain
+                     middleware_messaging middleware_deployment middleware_datasource
                      ems_cloud ems_cluster ems_container ems_infra flavor host miq_template offline
                      ontap_file_share ontap_logical_disk ontap_storage_system ontap_storage_volume
                      ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1281,7 +1281,8 @@ Vmdb::Application.routes.draw do
         wait_for_task
         tagging_edit
         tag_edit_form_field_changed
-      )
+      ) +
+      adv_search_post
     },
 
     :ems_network              => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1276,13 +1276,17 @@ Vmdb::Application.routes.draw do
         button
         show
         show_list
+        quick_search
+        listnav_search_selected
         tl_chooser
         update
         wait_for_task
         tagging_edit
         tag_edit_form_field_changed
       ) +
-      adv_search_post
+        adv_search_post +
+        exp_post +
+        save_post
     },
 
     :ems_network              => {


### PR DESCRIPTION
Middleware entities were lacking simple and advanced search. So to be aligned with rest of the application we have to enable this for them.

Both simple search (By name) and advanced search form works on all of these entitites:

#### Providers
![selection_065](https://cloud.githubusercontent.com/assets/3439771/18468027/78fd1336-79a2-11e6-8d04-6e279c148734.png)

#### Middleware Domains
![selection_066](https://cloud.githubusercontent.com/assets/3439771/18468068/91721718-79a2-11e6-89e9-36d1dcca9518.png)

#### Middleware Servers
![selection_067](https://cloud.githubusercontent.com/assets/3439771/18468082/a34b29f2-79a2-11e6-97c6-5a2f50a38621.png)

#### Middleware Deployments
![selection_068](https://cloud.githubusercontent.com/assets/3439771/18468098/b57218d4-79a2-11e6-8f6e-17ab5f66bda3.png)

#### Middleware Datasources
![selection_069](https://cloud.githubusercontent.com/assets/3439771/18468115/c6329d06-79a2-11e6-948b-162aa2b12ca2.png)

#### Middleware Messagings
![selection_070](https://cloud.githubusercontent.com/assets/3439771/18468120/d3133fee-79a2-11e6-87b4-071a0dd46aa9.png)

## Links

* https://github.com/ManageIQ/manageiq/issues/10600

