### PR TITLE
Remove User.admin scope

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,6 @@ class User < ApplicationRecord
   has_many   :unseen_notifications, :through => :unseen_notification_recipients, :source => :notification
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
-  scope      :admin, -> { where(:userid => "admin") }
   scope      :superadmins, lambda {
     joins(:miq_groups => :miq_user_role).where(:miq_user_roles => {:name => MiqUserRole::SUPER_ADMIN_ROLE_NAME })
   }


### PR DESCRIPTION
I haven't found anyone using this. Also, it is questionable, whether this is useful as it uses 'admin' username, while there might be other people with superadmin role.

Note, we have recently introduced more powerful scope in #11186

@miq-bot add_label core, refactoring, darga/no
@miq-bot assign @gtanzillo 