### PR TITLE
Do not include ae/git methods to every page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,6 @@ module ApplicationHelper
   include_concern 'PageLayouts'
   include_concern 'FormTags'
   include_concern 'Tasks'
-  include_concern 'AutomateImportExport'
   include Sandbox
   include CompressedIds
   include JsHelper

--- a/app/helpers/miq_ae_tools_helper.rb
+++ b/app/helpers/miq_ae_tools_helper.rb
@@ -1,4 +1,4 @@
-module ApplicationHelper::AutomateImportExport
+module MiqAeToolsHelper
   def git_import_button_enabled?
     MiqRegion.my_region.role_active?("git_owner")
   end

--- a/app/helpers/miq_ae_tools_helper.rb
+++ b/app/helpers/miq_ae_tools_helper.rb
@@ -4,7 +4,7 @@ module MiqAeToolsHelper
   end
 
   def git_import_submit_help
-    unless MiqRegion.my_region.role_active?("git_owner")
+    unless git_import_button_enabled?
       content_tag(
         :i,
         "",

--- a/spec/helpers/miq_ae_tools_spec.rb
+++ b/spec/helpers/miq_ae_tools_spec.rb
@@ -1,4 +1,4 @@
-describe ApplicationHelper::AutomateImportExport do
+describe MiqAeToolsHelper do
   describe "#git_import_button_enabled?" do
     let(:my_region) { double("MiqRegion") }
 


### PR DESCRIPTION
Previously we included these methods to every page through ApplicationHelper. While this is fairly minor issue, it is unnecessary waste. Let's introduce separate helper for miq_ae_tools.

@miq-bot add_label ui, refactoring, darga/no
@miq-bot assign @martinpovolny 