### PR TITLE
remove warnings for bundler over git

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -3,6 +3,9 @@ set -v
 echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
 travis_retry gem install bundler -v ">= 1.11.1"
 
+# use more secure means to connect to github for gems
+git config url."https://github.com".insteadOf git://github.com
+
 if [[ -n "${GEM}" ]] ; then
   cd gems/${GEM}
 else


### PR DESCRIPTION
Sorry, continuation of #11175

Per nick's suggestion, I'm attempting to tell travis to just use the https protocol.

Alternative would be to change all our git clone urls

-----

copied for posterity

remove the warning from travis tests [[ref]](https://travis-ci.org/ManageIQ/manageiq/jobs/159124160#L784):

```
git source `git://github.com/ManageIQ/manageiq-providers-amazon` uses the `git` protocol,
which transmits data without encryption. Disable this warning with
`bundle config git.allow_insecure true`, or switch to the `https` protocol
to keep your data secure.
```