### PR TITLE
Minor: Remove unnecesarry false in a condition context

### DIFF
--- a/app/models/miq_widget/report_content.rb
+++ b/app/models/miq_widget/report_content.rb
@@ -19,7 +19,7 @@ class MiqWidget::ReportContent < MiqWidget::ContentGeneration
     tz ||= user_or_group.get_timezone if user_or_group.respond_to?(:get_timezone)
 
     body = user_or_group.with_a_timezone(tz) do
-      if report.rpt_options.fetch_path(:summary, :hide_detail_rows) || false
+      if report.rpt_options.fetch_path(:summary, :hide_detail_rows)
         report.rpt_options[:group_limit] = row_count
         report.build_html_rows.join
       else


### PR DESCRIPTION
In condition context whatever is converted to boolean. Similarly, the operand before `||` operator is evaluated as a boolean. Thus, `if whatever || false` is equal to `if whatever`.

This got there by refactoring, previously we assigned value of `whatever || false` to a variable.

@miq-bot add_label core, reporting, refactoring
@miq-bot assign @gtanzillo 

