### PR TITLE
Fix Middleware Operation timeout parameter fetch

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -175,13 +175,13 @@ module ManageIQ::Providers
       run_generic_operation(:Shutdown, ems_ref, :restart => true)
     end
 
-    def shutdown_middleware_server(ems_ref, _params)
-      timeout = 10 # we default to 10s until we get the UI params. params.fetch ':timeout'
+    def shutdown_middleware_server(ems_ref, params)
+      timeout = params[:timeout] || 0
       run_generic_operation(:Shutdown, ems_ref, :restart => false, :timeout => timeout)
     end
 
     def suspend_middleware_server(ems_ref, params)
-      timeout = params[':timeout'] || 0
+      timeout = params[:timeout] || 0
       run_generic_operation(:Suspend, ems_ref, :timeout => timeout)
     end
 


### PR DESCRIPTION
Also implement it to shutdown_middleware_server as it wasn't using the
parameter at all, using a hardcoded value of 10.

Fixes #10968