### PR TITLE
Publish Blueprint API

### DIFF
--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -25,6 +25,12 @@ module Api
       blueprint
     end
 
+    def publish_resource(type, id, data)
+      blueprint = resource_search(id, type, Blueprint)
+      blueprint.publish(data['bundle_name'])
+      blueprint
+    end
+
     private
 
     def create_bundle(blueprint, bundle)

--- a/config/api.yml
+++ b/config/api.yml
@@ -108,6 +108,8 @@
         :identifier: blueprint_edit
       - :name: delete
         :identifier: blueprint_delete
+      - :name: publish
+        :identifier: blueprint_publish
       :delete:
       - :name: delete
         :identifier: blueprint_delete
@@ -120,6 +122,8 @@
         :identifier: blueprint_edit
       - :name: delete
         :identifier: blueprint_delete
+      - :name: publish
+        :identifier: blueprint_publish
       :delete:
       - :name: delete
         :identifier: blueprint_delete

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5481,3 +5481,7 @@
       :description: Remove Blueprint
       :feature_type: admin
       :identifier: blueprint_delete
+    - :name: Publish
+      :description: Publish Blueprint
+      :feature_type: admin
+      :identifier: blueprint_publish


### PR DESCRIPTION
Adds ability to publish one or multiple blueprints

**POST /api/blueprints/:id**
```
{ "action": "publish" }
```

**POST /api/blueprints**
```
{
  "action": "publish",
  "resources": [
    { "id": 1 },
    { "id": 2 }
  ]
}
```

@miq-bot add_label api, service broker, enhancement, darga/no 