### PR TITLE
rubocop issues: tree_builder_report_schedules.rb

### DIFF
--- a/app/presenters/tree_builder_report_schedules.rb
+++ b/app/presenters/tree_builder_report_schedules.rb
@@ -1,7 +1,7 @@
 class TreeBuilderReportSchedules < TreeBuilder
   private
 
-  def tree_init_options(tree_name)
+  def tree_init_options(_tree_name)
     {
       :leaf     => 'Schedules',
       :full_ids => true
@@ -19,12 +19,12 @@ class TreeBuilderReportSchedules < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    if User.current_user.current_group.miq_user_role.name.split('-').last == 'super_administrator'
-      # Super admins see all report schedules
-      objects = MiqSchedule.where(:towhat => 'MiqReport')
-    else
-      objects = MiqSchedule.where(:towhat => 'MiqReport', :userid => User.current_user.userid)
-    end
+    objects = if User.current_user.current_group.miq_user_role.name.split('-').last == 'super_administrator'
+                # Super admins see all report schedules
+                MiqSchedule.where(:towhat => 'MiqReport')
+              else
+                MiqSchedule.where(:towhat => 'MiqReport', :userid => User.current_user.userid)
+              end
     count_only_or_objects(count_only, objects.sort_by { |o| o.name.downcase }, 'name')
   end
 end


### PR DESCRIPTION
== app/presenters/tree_builder_report_schedules.rb ==
    W:  4: 25: Unused method argument - tree_name. If it's necessary, use _
    or _tree_name as an argument name to indicate that it won't be used. You
    can also write as tree_init_options(*) if you want the method to accept
    any arguments but don't care about them.
    C: 25:  5: Use the return of the conditional for variable assignment and
    comparison.