### PR TITLE
Automate - Retirement - Allow archived/orphaned VM's to retire.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method removes the VM from the provider
+# Description: This method removes the Instance from the provider
 #
 
 # Get vm from root object
@@ -9,22 +9,25 @@ tag = "retire_full"
 
 removal_type = $evm.inputs['removal_type'].downcase
 $evm.set_state_var('vm_removed_from_provider', false)
+ems = vm.ext_management_system if vm
 
-if vm
-  ems = vm.ext_management_system
-  case removal_type
-  when "remove_from_disk"
-    if vm.miq_provision || vm.tagged_with?(category, tag)
-      $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.try(:name)}>")
-      vm.remove_from_disk(false)
-      $evm.set_state_var('vm_removed_from_provider', true)
-    end
-  when "unregister"
-    $evm.log('info', "Unregistering VM:<#{vm.name}> from provider:<#{ems.try(:name)}")
-    vm.unregister
+if vm.nil? || ems.nil?
+  $evm.log('info', "Skipping remove from provider for Instance:<#{vm.try(:name)}> on provider:<#{ems.try(:name)}>")
+  exit MIQ_OK
+end
+
+case removal_type
+when "remove_from_disk"
+  if vm.miq_provision || vm.tagged_with?(category, tag)
+    $evm.log('info', "Removing Instance:<#{vm.name}> from provider:<#{ems.name}>")
+    vm.remove_from_disk(false)
     $evm.set_state_var('vm_removed_from_provider', true)
-  else
-    $evm.log('info', "Unknown retirement type for VM:<#{vm.name}> from provider:<#{ems.try(:name)}")
-    exit MIQ_ABORT
   end
+when "unregister"
+  $evm.log('info', "Unregistering Instance:<#{vm.name}> from provider:<#{ems.name}>")
+  vm.unregister
+  $evm.set_state_var('vm_removed_from_provider', true)
+else
+  $evm.log('info', "Unknown retirement type for VM:<#{vm.name}> from provider:<#{ems.name}>")
+  exit MIQ_ABORT
 end

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -9,22 +9,25 @@ tag = "retire_full"
 
 removal_type = $evm.inputs['removal_type'].downcase
 $evm.set_state_var('vm_removed_from_provider', false)
+ems = vm.ext_management_system if vm
 
-if vm
-  ems = vm.ext_management_system
-  case removal_type
-  when "remove_from_disk"
-    if vm.miq_provision || vm.tagged_with?(category, tag)
-      $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.try(:name)}>")
-      vm.remove_from_disk(false)
-      $evm.set_state_var('vm_removed_from_provider', true)
-    end
-  when "unregister"
-    $evm.log('info', "Unregistering VM:<#{vm.name}> from provider:<#{ems.try(:name)}")
-    vm.unregister
+if vm.nil? || ems.nil?
+  $evm.log('info', "Skipping remove from provider for VM:<#{vm.try(:name)}> on provider:<#{ems.try(:name)}>")
+  exit MIQ_OK
+end
+
+case removal_type
+when "remove_from_disk"
+  if vm.miq_provision || vm.tagged_with?(category, tag)
+    $evm.log('info', "Removing VM:<#{vm.name}> from provider:<#{ems.name}>")
+    vm.remove_from_disk(false)
     $evm.set_state_var('vm_removed_from_provider', true)
-  else
-    $evm.log('info', "Unknown retirement type for VM:<#{vm.name}> from provider:<#{ems.try(:name)}")
-    exit MIQ_ABORT
   end
+when "unregister"
+  $evm.log('info', "Unregistering VM:<#{vm.name}> from provider:<#{ems.name}>")
+  vm.unregister
+  $evm.set_state_var('vm_removed_from_provider', true)
+else
+  $evm.log('info', "Unknown retirement type for VM:<#{vm.name}> from provider:<#{ems.name}>")
+  exit MIQ_ABORT
 end


### PR DESCRIPTION
This change in the retirement process will allow archived/orphaned VM's to proceed past the remove_from_provider and check_removed_from_provider automate methods to the next state.   That should allow retirement to fall through and retire/remove the vm from the vmdb even if there is no ems.

Modified remove_from_provider retirement method to continue if there is no ems.

Added a test for ems nil and ems.try in log messages was removed.

https://www.pivotaltracker.com/story/show/130210033