### PR TITLE
Make CollectionConfig instances represent individual collections

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -32,7 +32,7 @@ module Api
     end
 
     def entrypoint_collections
-      collection_config.collections_with_description.sort.collect do |collection_name, description|
+      CollectionConfig.collections_with_description.sort.collect do |collection_name, description|
         {
           :name        => collection_name,
           :href        => collection_name,

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -65,9 +65,5 @@ module Api
       headers['Access-Control-Allow-Headers'] = 'origin, content-type, authorization, x-auth-token'
       headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH, OPTIONS'
     end
-
-    def collection_config
-      @collection_config ||= CollectionConfig.new
-    end
   end
 end

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -102,7 +102,7 @@ module Api
           "name"        => details[:name],
           "description" => details[:description]
         }
-        collection, method, action = collection_config.what_refers_to_feature(ident_str)
+        collection, method, action = CollectionConfig.what_refers_to_feature(ident_str)
         collections = CollectionConfig.names_for_feature(ident_str)
         res["href"] = "#{@req.api_prefix}/#{collections.first}" if collections.one?
         res["action"] = api_action_details(collection, method, action) if collection.present?

--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -103,7 +103,7 @@ module Api
           "description" => details[:description]
         }
         collection, method, action = collection_config.what_refers_to_feature(ident_str)
-        collections = collection_config.names_for_feature(ident_str)
+        collections = CollectionConfig.names_for_feature(ident_str)
         res["href"] = "#{@req.api_prefix}/#{collections.first}" if collections.one?
         res["action"] = api_action_details(collection, method, action) if collection.present?
         res["children"] = children if children.present?

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -46,7 +46,7 @@ module Api
       def add_resource(type, _id, data)
         assert_id_not_specified(data, "#{type} resource")
         klass = collection_class(type)
-        subcollection_data = collection_config.subcollections(type).each_with_object({}) do |sc, hash|
+        subcollection_data = ApiConfig.collections[type].subcollections.each_with_object({}) do |sc, hash|
           if data.key?(sc.to_s)
             hash[sc] = data[sc.to_s]
             data.delete(sc.to_s)

--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def collection_class(type)
-        @collection_klasses[type.to_sym] || collection_config.klass(type)
+        @collection_klasses[type.to_sym] || ApiConfig.collections[type].klass
       end
 
       def put_resource(type, id)
@@ -88,7 +88,7 @@ module Api
         else
           target = "#{action}_resource"
           return target if respond_to?(target)
-          collection_config.custom_actions?(type) ? "custom_action_resource" : "undefined_api_method"
+          ApiConfig.collections[type].custom_actions? ? "custom_action_resource" : "undefined_api_method"
         end
       end
 

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -62,7 +62,7 @@ module Api
               end
             end
           end
-          cspec = collection_config[type]
+          cspec = ApiConfig.collections[type]
           aspecs = gen_action_spec_for_collections(type, cspec, opts[:is_subcollection], reftype) if cspec
           add_actions(json, aspecs, reftype)
         end
@@ -187,7 +187,7 @@ module Api
       # Let's expand subcollections for objects if asked for
       #
       def expand_subcollections(json, type, resource)
-        collection_config.subcollections(type).each do |sc|
+        ApiConfig.collections[type].subcollections.each do |sc|
           target = "#{sc}_query_resource"
           next unless expand_subcollection?(sc, target)
           if Array(attribute_selection).include?(sc.to_s)
@@ -198,7 +198,7 @@ module Api
       end
 
       def expand_subcollection?(sc, target)
-        respond_to?(target) && (@req.expand?(sc) || collection_config.show?(sc))
+        respond_to?(target) && (@req.expand?(sc) || ApiConfig.collections[sc].show?)
       end
 
       #
@@ -304,7 +304,7 @@ module Api
         return unless render_actions(resource)
 
         href   = json.attributes!["href"]
-        cspec = collection_config[type]
+        cspec = ApiConfig.collections[type]
         aspecs = gen_action_spec_for_resources(cspec, opts[:is_subcollection], href, resource) if cspec
         add_actions(json, aspecs, type)
       end
@@ -318,7 +318,7 @@ module Api
       end
 
       def expand_resource_custom_actions(resource, json, type)
-        return unless render_actions(resource) && collection_config.custom_actions?(type)
+        return unless render_actions(resource) && ApiConfig.collections[type].try(:custom_actions?)
 
         href = json.attributes!["href"]
         json.actions do |js|
@@ -348,7 +348,7 @@ module Api
       # Let's expand a subcollection
       #
       def expand_subcollection(json, sc, sctype, subresources)
-        if collection_config.show_as_collection?(sc)
+        if ApiConfig.collections[sc].show_as_collection?
           copts = {
             :count            => subresources.length,
             :is_subcollection => true,
@@ -402,7 +402,7 @@ module Api
 
       def fetch_typed_subcollection_actions(method, is_subcollection)
         return unless is_subcollection
-        collection_config.typed_subcollection_action(@req.collection, @req.subcollection, method)
+        ApiConfig.collections[@req.collection].typed_subcollection_action(@req.subcollection, method)
       end
 
       def api_user_role_allows?(action_identifier)

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -96,7 +96,7 @@ module Api
 
         rclass = resource.class
         if collection_class(type) != rclass
-          matched_type = collection_config.name_for_klass(rclass)
+          matched_type = CollectionConfig.name_for_klass(rclass)
         end
         matched_type || reftype
       end

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -80,7 +80,7 @@ module Api
     private
 
     def authorize_request(typed_request_klass)
-      create_action = collection_config["requests"].collection_actions.post.detect { |a| a.name == "create" }
+      create_action = ApiConfig.collections["requests"].collection_actions.post.detect { |a| a.name == "create" }
       request_spec = create_action.identifiers.detect { |i| i.klass == typed_request_klass.name }
       raise BadRequestError, "Unsupported request class #{typed_request_klass}" if request_spec.blank?
 

--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -84,7 +84,7 @@ module InterRegionApiMethodRelay
   private
 
   def collection_for_class
-    collection_name = Api::CollectionConfig.new.name_for_klass(self)
+    collection_name = Api::CollectionConfig.name_for_klass(self)
     unless collection_name
       _log.error("No API endpoint found for class #{name}")
       raise NotImplementedError, "No API endpoint found for class #{name}"

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -90,7 +90,7 @@ module ProcessTasksMixin
     end
 
     def invoke_api_tasks(api_client, remote_options)
-      collection_name = Api::CollectionConfig.new.name_for_klass(self)
+      collection_name = Api::CollectionConfig.name_for_klass(self)
       unless collection_name
         _log.error("No API entpoint found for class #{name}")
         raise NotImplementedError

--- a/lib/api/api_config.rb
+++ b/lib/api/api_config.rb
@@ -4,5 +4,7 @@ module Api
   ApiConfig = ::Config::Options.new.tap do |o|
     o.add_source!(Rails.root.join("config/api.yml").to_s)
     o.load!
+
+    o.collections.each { |(name, c)| o.collections[name] = CollectionConfig.new(c) }
   end
 end

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -21,6 +21,12 @@ module Api
       referenced_identifiers[product_feature_name]
     end
 
+    def self.collections_with_description
+      ApiConfig.collections.each_with_object({}) do |(collection, cspec), result|
+        result[collection] = cspec[:description] if cspec[:options].include?(:collection)
+      end
+    end
+
     def self.referenced_identifiers
       @referenced_identifiers ||= @cfg.each_with_object({}) do |(collection, cspec), result|
         next unless cspec[:collection_actions].present?
@@ -99,12 +105,6 @@ module Api
 
     def klass(collection_name)
       self[collection_name][:klass].try(:constantize)
-    end
-
-    def collections_with_description
-      @cfg.each_with_object({}) do |(collection, cspec), result|
-        result[collection] = cspec[:description] if cspec[:options].include?(:collection)
-      end
     end
   end
 end

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -13,6 +13,10 @@ module Api
     end
     private_class_method :names_for_features
 
+    def self.name_for_klass(resource_klass)
+      ApiConfig.collections.detect { |_, spec| spec[:klass] == resource_klass.name }.try(:first)
+    end
+
     def initialize
       @cfg = ApiConfig.collections
     end
@@ -76,10 +80,6 @@ module Api
 
     def klass(collection_name)
       self[collection_name][:klass].try(:constantize)
-    end
-
-    def name_for_klass(resource_klass)
-      @cfg.detect { |_, spec| spec[:klass] == resource_klass.name }.try(:first)
     end
 
     def what_refers_to_feature(product_feature_name)

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -1,5 +1,18 @@
 module Api
   class CollectionConfig
+    def self.names_for_feature(product_feature_name)
+      names_for_features[product_feature_name]
+    end
+
+    def self.names_for_features
+      @names_for_features ||= ApiConfig.collections.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(collection, cspec), result|
+        ident = cspec[:identifier]
+        next unless ident
+        result[ident] << collection
+      end
+    end
+    private_class_method :names_for_features
+
     def initialize
       @cfg = ApiConfig.collections
     end
@@ -61,10 +74,6 @@ module Api
       typed_subcollection_actions(collection_name, subcollection_name).try(:fetch_path, method.to_sym)
     end
 
-    def names_for_feature(product_feature_name)
-      names_for_features[product_feature_name]
-    end
-
     def klass(collection_name)
       self[collection_name][:klass].try(:constantize)
     end
@@ -84,14 +93,6 @@ module Api
     end
 
     private
-
-    def names_for_features
-      @names_for_features ||= @cfg.each_with_object(Hash.new { |h, k| h[k] = [] }) do |(collection, cspec), result|
-        ident = cspec[:identifier]
-        next unless ident
-        result[ident] << collection
-      end
-    end
 
     def referenced_identifiers
       @referenced_identifiers ||= @cfg.each_with_object({}) do |(collection, cspec), result|

--- a/spec/lib/api/collection_config_spec.rb
+++ b/spec/lib/api/collection_config_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe Api::CollectionConfig do
-  describe "#name_for_klass" do
+  describe ".name_for_klass" do
     it "returns the corresponding name for classes managed by the API" do
-      expect(subject.name_for_klass(Vm)).to eq(:vms)
+      expect(described_class.name_for_klass(Vm)).to eq(:vms)
     end
 
     it "returns nil for classes unknown to the API" do
-      expect(subject.name_for_klass(String)).to be_nil
+      expect(described_class.name_for_klass(String)).to be_nil
     end
   end
 end

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -1,11 +1,9 @@
 describe InterRegionApiMethodRelay do
   let(:collection_name) { :test_class_collection }
-  let(:api_config)      { double("Api::CollectionConfig") }
 
   context "with a valid class definition" do
     let!(:test_class) do
-      allow(Api::CollectionConfig).to receive(:new).and_return(api_config)
-      allow(api_config).to receive(:name_for_klass).and_return(collection_name)
+      allow(Api::CollectionConfig).to receive(:name_for_klass).and_return(collection_name)
 
       Class.new do
         extend InterRegionApiMethodRelay
@@ -314,8 +312,7 @@ describe InterRegionApiMethodRelay do
       end
 
       it "raises a ArgumentError if no block is defined" do
-        allow(Api::CollectionConfig).to receive(:new).and_return(api_config)
-        allow(api_config).to receive(:name_for_klass).and_return(collection_name)
+        allow(Api::CollectionConfig).to receive(:name_for_klass).and_return(collection_name)
         expect {
           Class.new do
             extend InterRegionApiMethodRelay

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -139,9 +139,7 @@ describe ProcessTasksMixin do
       let(:api_collection)  { double("ManageIQ::API::Client collection") }
 
       before do
-        api_config = double("Api::CollectionConfig")
-        expect(Api::CollectionConfig).to receive(:new).and_return(api_config)
-        expect(api_config).to receive(:name_for_klass).and_return(collection_name)
+        expect(Api::CollectionConfig).to receive(:name_for_klass).and_return(collection_name)
         expect(api_connection).to receive(collection_name).and_return(api_collection)
       end
 


### PR DESCRIPTION
~~A WIP to extract a `Collection` class from `CollectionConfig` and move this code out of the controllers and under the `Api` namespace. This could do with better naming - more to come~~

Puts general collection config methods at the class level, and instances represent individual collections, so many of its methods will lose the `collection_name` argument, simplifying things a bit.

I first considered making two different classes and keeping the class-level stuff at the instance level, which would be a little better from an OO perspective, but I found naming confusing so tried to keep the two united in this way. Open to suggestions for improvement.

@miq-bot add-label wip, api, refactoring
