### PR TITLE
Virtual attribute accessor methods no longer getting called.

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -5,25 +5,6 @@ module Api
       super
     end
 
-    #
-    # Virtual attribute accessors
-    #
-    def fetch_service_dialogs_content(resource)
-      case @req.collection
-      when "service_templates"
-        service_template = parent_resource_obj
-      when "services"
-        service_template = parent_resource_obj.service_template
-      end
-      return resource.content if service_template.nil?
-      resource_action = service_template.resource_actions.where(:dialog_id => resource.id).first
-      if resource_action.nil?
-        raise BadRequestError,
-              "#{service_dialog_ident(resource)} is not referenced by #{service_template_ident(service_template)}"
-      end
-      resource.content(service_template, resource_action)
-    end
-
     def refresh_dialog_fields_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id
 

--- a/app/controllers/api/subcollections/service_dialogs.rb
+++ b/app/controllers/api/subcollections/service_dialogs.rb
@@ -4,6 +4,25 @@ module Api
       def service_dialogs_query_resource(object)
         object ? object.dialogs : []
       end
+
+      #
+      # Virtual attribute accessors
+      #
+      def fetch_service_dialogs_content(resource)
+        case @req.collection
+        when "service_templates"
+          service_template = parent_resource_obj
+        when "services"
+          service_template = parent_resource_obj.service_template
+        end
+        return resource.content if service_template.nil?
+        resource_action = service_template.resource_actions.where(:dialog_id => resource.id).first
+        if resource_action.nil?
+          raise BadRequestError,
+                "#{service_dialog_ident(resource)} is not referenced by #{service_template_ident(service_template)}"
+        end
+        resource.content(service_template, resource_action)
+      end
     end
   end
 end

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -87,6 +87,14 @@ describe "Service Dialogs API" do
       expect_query_result(:service_dialogs, dialogs.count, dialogs.count)
       expect_result_resources_to_include_data("resources", "label" => dialogs.pluck(:label))
     end
+
+    it "queries service dialogs content with the template and related resource action specified" do
+      expect_any_instance_of(Dialog).to receive(:content).with(template, ra1)
+
+      run_get "#{service_templates_url(template.id)}/service_dialogs/#{dialog1.id}", :attributes => "content"
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "Service Dialogs refresh dialog fields" do


### PR DESCRIPTION

With now having collection specific classes, the virtual
attribute accessor methods are no longer seen and called.
This is causing an incorrect call to content when
evaluating that virtual attribute for service dialogs.

Example call: get service_templates/1/service_dialogs --expand=resources --attributes=content

This commit simply moves the method around so it's seen by
the renderer, would need a better solution where it can
lives with the collection specific class.