### PR TITLE
Ownership mixin use delegation

### DIFF
--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -66,17 +66,77 @@ shared_examples "miq ownership" do
       end
     end
 
+    describe ".evm_owner_name" do
+      before { User.current_user = user }
+
+      context "when has a user" do
+        it "returns userid" do
+          column = "evm_owner_name"
+          query  = described_class.where(:name => 'user_owned')
+          expect(virtual_column_sql_value(query, column)).to eq(user.name)
+        end
+      end
+
+      context "when has no user" do
+        it "returns no description" do
+          column = "evm_owner_name"
+          query  = described_class.where(:name => 'no_group')
+          expect(virtual_column_sql_value(query, column)).to be_nil
+        end
+      end
+    end
+
+    describe ".evm_owner_userid" do
+      before { User.current_user = user }
+
+      context "when has a user" do
+        it "returns userid" do
+          column = "evm_owner_userid"
+          query  = described_class.where(:name => 'user_owned')
+          expect(virtual_column_sql_value(query, column)).to eq(user.userid)
+        end
+      end
+
+      context "when has no user" do
+        it "returns no description" do
+          column = "evm_owner_userid"
+          query  = described_class.where(:name => 'no_group')
+          expect(virtual_column_sql_value(query, column)).to be_nil
+        end
+      end
+    end
+
+    describe ".evm_owner_email" do
+      before { User.current_user = user }
+
+      context "when has a user" do
+        it "returns userid" do
+          column = "evm_owner_email"
+          query  = described_class.where(:name => 'user_owned')
+          expect(virtual_column_sql_value(query, column)).to eq(user.email)
+        end
+      end
+
+      context "when has no user" do
+        it "returns no description" do
+          column = "evm_owner_email"
+          query  = described_class.where(:name => 'no_group')
+          expect(virtual_column_sql_value(query, column)).to be_nil
+        end
+      end
+    end
+
     describe ".owned_by_current_user" do
       before { User.current_user = user }
       it "usable as arel" do
         userid = user.userid.downcase
         sql        = <<-SQL.strip_heredoc.split("\n").join(' ')
-                       SELECT (LOWER("users"."userid") = '#{userid}')
-                       FROM "users"
-                       WHERE "users"."id" = "#{described_class.table_name}"."evm_owner_id"
+                       LOWER((SELECT "users_ss"."userid"
+                       FROM "users" "users_ss"
+                       WHERE "users_ss"."id" = "#{described_class.table_name}"."evm_owner_id")) = '#{userid}'
                      SQL
         attribute  = described_class.arel_attribute(:owned_by_current_user)
-        expect(stringify_arel(attribute)).to eq ["((#{sql}))"]
+        expect(stringify_arel(attribute)).to eq ["(#{sql})"]
       end
 
       context "when owned by the current user" do


### PR DESCRIPTION
~~blocked on: #11300~~
Decided to move forward without that PR.
Either merge that PR or this PR.

When we implemented #10704 We did not have a number of PRs merged around delegation.
Now that delegation is merged, use it to simplify this query (and act as a good demonstration)

When we introduce a `virtual_delegation`, we are able to embed the attribute in a query, so when it is in a filter, we get tremendous benefits.

We were using virtual attributes with arel before this change. But the change simplifies the code we need to support

details
-------

The sql generated is only slightly different, the `LOWER` moved, but is the same besides.
The difference being that we can now use the delegated fields in queries.

/cc @NickLaMuro We already test these fields. Do you think these tests are overkill? Or are there tests you want me to add?