### PR TITLE
Truncate text in tables

### DIFF
--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -62,7 +62,8 @@
       %tr{:onclick => "miqRowClick('#{j row[:id]}', #{row_url}, #{j row_url_ajax.to_s}); return false;"}
         - row[:cells].each do |cell|
           -# double {{}} to work around hamlit issue #28
-          %td{{:onclick => (cell[:is_checkbox] || cell[:is_button]) ? "event.stopPropagation()" : false}}
+          %td{{:onclick => (cell[:is_checkbox] || cell[:is_button]) ? "event.stopPropagation()" : false,
+               :title => cell[:text]}}
             - if cell[:is_checkbox]
               = check_box_tag("check_#{row[:id]}", row[:id], false,
                 :onchange => "miqGridOnCheck(this, '#{button_div}')",
@@ -77,4 +78,4 @@
                 %i{:class => cell[:icon], :title => cell[:title]}
               - elsif cell[:image]
                 = image_tag(image_path(cell[:image]), :alt => cell[:title], :title => cell[:title])
-              = cell[:text]
+              = truncate(cell[:text], length: 30)


### PR DESCRIPTION
Text in tables sometimes gets too large, and stretches the other cells of tables in GTL views.
I would appreciate to have truncated text with full text in bubble on hover.

Before:
![screencapture-localhost-3000-miq_request-show_list-1473838290831](https://cloud.githubusercontent.com/assets/1187051/18503897/ad5aa3ce-7a5f-11e6-9b15-eddc9e0d8aae.png)

After:
![screencapture-localhost-3000-miq_request-show_list-1473838240453](https://cloud.githubusercontent.com/assets/1187051/18503908/b4e2bc62-7a5f-11e6-9312-d12ebc9fc740.png)

After (tooltip):
![screencast from 2016-09-14 09-27-19](https://cloud.githubusercontent.com/assets/1187051/18503874/849e98b4-7a5f-11e6-911c-59fcfa012b57.gif)
