### PR TITLE
API: Allow compressed IDs in service_template_href and resource { "id" }

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -93,9 +93,14 @@ module Api
         return nil if resource.blank?
 
         href_id = href_id(resource["href"], collection)
-        return href_id if href_id.present?
-
-        resource["id"].kind_of?(Integer) ? resource["id"] : nil
+        case
+        when href_id.present?
+          href_id
+        when resource["id"].kind_of?(Integer)
+          resource["id"]
+        when cid?(resource["id"])
+          from_cid(resource["id"])
+        end
       end
 
       def href_id(href, collection)

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -93,13 +93,15 @@ module Api
         return nil if resource.blank?
 
         href_id = href_id(resource["href"], collection)
-        return from_cid(href_id) if href_id.present?
+        return href_id if href_id.present?
 
         resource["id"].kind_of?(Integer) ? resource["id"] : nil
       end
 
       def href_id(href, collection)
-        href.match(%r{^.*/#{collection}/(#{CID_OR_ID_MATCHER})$}) && Regexp.last_match(1) if href.present?
+        if href.present? && href.match(%r{^.*/#{collection}/(#{CID_OR_ID_MATCHER})$})
+          from_cid(Regexp.last_match(1))
+        end
       end
 
       def parse_by_attr(resource, type, attr_list)


### PR DESCRIPTION
 This fixes `href_id` and `parse_id` methods to allways decompress ids.

The sooner we convert compressed ID to ID the better. When we delay the conversion, we may find that there are too many places that can get cid.

As a result we get support of compressed ids for `service_template_href` and jsons like:
```
{
  "action" : ...,
  "resource" : {
     "id" : "1r23"
   }
}
```

@miq-bot add_label api, enhancement, darga/no
@miq-bot assign @abellotti 
