### PR TITLE
API: Allow single digit ID as a valid ID again

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -5,7 +5,7 @@ module ArRegion
 
   DEFAULT_RAILS_SEQUENCE_FACTOR = 1_000_000_000_000
   COMPRESSED_ID_SEPARATOR = 'r'.freeze
-  CID_OR_ID_MATCHER = "\\d+?#{COMPRESSED_ID_SEPARATOR}?\\d+".freeze
+  CID_OR_ID_MATCHER = "\\d+?(#{COMPRESSED_ID_SEPARATOR}\\d+)?".freeze
   RE_COMPRESSED_ID = /^(\d+)#{COMPRESSED_ID_SEPARATOR}(\d+)$/
 
   included do

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -30,6 +30,18 @@ describe "AR Regions extension" do
     expect(base_class.compressed_id?("2r5")).to be_truthy
   end
 
+  describe 'CID_OR_ID_MATCHER' do
+    subject { /^#{ArRegion::CID_OR_ID_MATCHER}$/ }
+    it { is_expected.to match('1') }
+    it { is_expected.to match('100023') }
+    it { is_expected.to match('1r23') }
+    it { is_expected.to match('10r10') }
+    it { is_expected.not_to match('hello') }
+    it { is_expected.not_to match('r1') }
+    it { is_expected.not_to match('1r') }
+    it { is_expected.not_to match('1rr1') }
+  end
+
   it ".split_id" do
     expect(base_class.split_id(5)).to eq([0, 5])
     expect(base_class.split_id(15)).to eq([1, 5])


### PR DESCRIPTION
Recently (in #11058), I made the regular expression way too strict to match URL. As a result IDs of single digit were denied.

@miq-bot add_label api, bug, darga/no
@miq-bot assign @abellotti 