### PR TITLE
dont remove .gitkeep when running bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -59,7 +59,7 @@ Dir.chdir APP_ROOT do
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  execute "find log/ -type 'f' | xargs rm"
+  execute "find log/ -not -name .gitkeep -type 'f' | xargs rm"
   execute "rm -rf tmp/cache"
 
   if options[:do_tests]


### PR DESCRIPTION
when running `bin/setup` it now also removes `log/.gitkeep` which can accidentally slip into a commit.

This was introduced here:
https://github.com/ManageIQ/manageiq/pull/10883

@miq-bot add_labels bug
@miq-bot assign Fryguy 

cc @fbladilo 