### PR TITLE
Notification export details for creating urls

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -30,10 +30,9 @@ class Notification < ApplicationRecord
   end
 
   def text_bindings
-    h = {}
-    h[:initiator] = { :text => initiator.name } if initiator
-    h[:subject] = { :text => subject.name } if subject
-    h[:cause] = { :text => cause.name } if cause
-    h
+    [:initiator, :subject, :cause].each_with_object({}) do |key, result|
+      value = public_send(key)
+      result[key] = { :text => value.name } if value
+    end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -32,7 +32,13 @@ class Notification < ApplicationRecord
   def text_bindings
     [:initiator, :subject, :cause].each_with_object({}) do |key, result|
       value = public_send(key)
-      result[key] = { :text => value.name } if value
+      result[key] = {
+        :link => {
+          :id    => value.id,
+          :model => value.class.name,
+        },
+        :text => value.name
+      } if value
     end
   end
 end


### PR DESCRIPTION
We want to have links from NotificationDrawer to affected entities where applicable. Examples:
 * When user receives notification that his/her request was denied, we want to link to that request from the NotificationDrawer.
 * When vm is freshly provisioned we want to have link to that specific vm.
The link needs to be composed on the client side. Different link will be needed for SSUI, different link will be needed for traditional UI.

For traditional UI, we don't have restful routes for resources, but we will be able to introduce a controller, that will redirect to other pages. Something like: `/restful_redirect?model=Request&id=100000000012`.

/cc @skateman

@miq-bot add_label core, enhancement, darga/no
@miq-bot assign @gtanzillo 