### PR TITLE
Use more specific jQuery selector in git click handlers

### DIFF
--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -208,6 +208,10 @@ var Automate = {
     });
   },
 
+  setUpDefaultGitBranchOrTagValue: function() {
+    $('.git-branch-or-tag').val($('select.git-branches').val());
+  },
+
   setUpGitRefreshClickHandlers: function() {
     $('.git-branch-or-tag-select').on('change', function(event) {
       event.preventDefault();

--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -214,20 +214,20 @@ var Automate = {
       if ($(event.currentTarget).val() === "Branch") {
         $('.git-branch-group').show();
         $('.git-tag-group').hide();
-        $('.git-branch-or-tag').val($('.git-branches select').val());
+        $('.git-branch-or-tag').val($('select.git-branches').val());
       } else if ($(event.currentTarget).val() === "Tag") {
         $('.git-branch-group').hide();
         $('.git-tag-group').show();
-        $('.git-branch-or-tag').val($('.git-tags select').val());
+        $('.git-branch-or-tag').val($('select.git-tags').val());
       }
     });
 
-    $('.git-branches').on('change', function(event) {
-      $('.git-branch-or-tag').val($('.git-branches select').val());
+    $('select.git-branches').on('change', function(event) {
+      $('.git-branch-or-tag').val($('select.git-branches').val());
     });
 
-    $('.git-tags').on('change', function(event) {
-      $('.git-branch-or-tag').val($('.git-tags select').val());
+    $('select.git-tags').on('change', function(event) {
+      $('.git-branch-or-tag').val($('select.git-tags').val());
     });
   }
 };

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -31,6 +31,6 @@
 
     Automate.setUpGitRefreshClickHandlers();
 
-    $('.git-branch-or-tag').val($('.git-branches').val());
+    $('.git-branch-or-tag').val($('select.git-branches').val());
     miqButtons('show');
   });

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -30,7 +30,7 @@
     miqInitSelectPicker();
 
     Automate.setUpGitRefreshClickHandlers();
+    Automate.setUpDefaultGitBranchOrTagValue();
 
-    $('.git-branch-or-tag').val($('select.git-branches').val());
     miqButtons('show');
   });

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -1,0 +1,90 @@
+describe('Automate', function() {
+  describe('#setUpGitRefreshClickHandlers', function() {
+    beforeEach(function() {
+      var html = '';
+      html += '<select class="git-branch-or-tag-select">';
+      html += '  <option value="Branch">Branch</option>';
+      html += '  <option value="Tag">Tag</option>';
+      html += '</select>';
+      html += '<div class="git-branch-group"></div>';
+      html += '<div class="git-tag-group"></div>';
+      html += '<input type="hidden" class="git-branch-or-tag"></input>';
+      html += '<select class="git-branches">';
+      html += '  <option value="1">Branch 1</option>';
+      html += '  <option value="2" selected="selected">Branch 2</option>';
+      html += '</select>';
+      html += '<select class="git-tags">';
+      html += '  <option value="1" selected="selected">Tag 1</option>';
+      html += '  <option value="2">Tag 2</option>';
+      html += '</select>';
+      html += '<div class="git-branches"></div>';
+      html += '<div class="git-tags"></div>';
+      html += '';
+      setFixtures(html);
+
+      Automate.setUpGitRefreshClickHandlers();
+    });
+
+    describe('when the git-branch-or-select field changes', function() {
+      describe('when "Branch" is selected', function() {
+        beforeEach(function() {
+          $('.git-branch-or-tag-select').val("Branch");
+          $('.git-branch-or-tag-select').change();
+        });
+
+        it('shows the git-branch-group', function() {
+          expect($('.git-branch-group')).toBeVisible();
+        });
+
+        it('hides the git-tag-group', function() {
+          expect($('.git-tag-group')).toBeHidden();
+        });
+
+        it('copies the value of the git-branches select into the hidden field', function() {
+          expect($('.git-branch-or-tag').val()).toEqual("2");
+        });
+      });
+
+      describe('when "Tag" is selected', function() {
+        beforeEach(function() {
+          $('.git-branch-or-tag-select').val("Tag");
+          $('.git-branch-or-tag-select').change();
+        });
+
+        it('hides the git-branch-group', function() {
+          expect($('.git-branch-group')).toBeHidden();
+        });
+
+        it('shows the git-tag-group', function() {
+          expect($('.git-tag-group')).toBeVisible();
+        });
+
+        it('copies the value of the git-tag select into the hidden field', function() {
+          expect($('.git-branch-or-tag').val()).toEqual("1");
+        });
+      });
+    });
+
+    describe('when the select.git-branches field changes', function() {
+      beforeEach(function() {
+        $('select.git-branches').val("1");
+        $('select.git-branches').change();
+      });
+
+      it('copies the value of the git-branches select into the hidden field', function() {
+        expect($('.git-branch-or-tag').val()).toEqual("1");
+      });
+    });
+
+    describe('when the select.git-tags field changes', function() {
+      beforeEach(function() {
+        $('select.git-tags').val("2");
+        $('select.git-tags').change();
+      });
+
+      it('copies the value of the git-tags select into the hidden field', function() {
+        expect($('.git-branch-or-tag').val()).toEqual("2");
+      });
+    });
+  });
+});

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -3,13 +3,14 @@ describe('Automate', function() {
     beforeEach(function() {
       var html = '';
       html += '<input type="hidden" class="git-branch-or-tag"></input>';
-      html += '<select class="git-branches">';
+      html += '<select class="git-branches selectpicker">';
       html += '  <option value="1">Branch 1</option>';
       html += '  <option value="2" selected="selected">Branch 2</option>';
       html += '</select>';
-      html += '<div class="git-branches"></div>';
       html += '';
       setFixtures(html);
+
+      miqInitSelectPicker();
     });
 
     it('ensures the selected value from the branches select tag is set on the hidden input', function() {
@@ -29,18 +30,18 @@ describe('Automate', function() {
       html += '<div class="git-branch-group"></div>';
       html += '<div class="git-tag-group"></div>';
       html += '<input type="hidden" class="git-branch-or-tag"></input>';
-      html += '<select class="git-branches">';
+      html += '<select class="git-branches selectpicker">';
       html += '  <option value="1">Branch 1</option>';
       html += '  <option value="2" selected="selected">Branch 2</option>';
       html += '</select>';
-      html += '<select class="git-tags">';
+      html += '<select class="git-tags selectpicker">';
       html += '  <option value="1" selected="selected">Tag 1</option>';
       html += '  <option value="2">Tag 2</option>';
       html += '</select>';
-      html += '<div class="git-branches"></div>';
-      html += '<div class="git-tags"></div>';
       html += '';
       setFixtures(html);
+
+      miqInitSelectPicker();
 
       Automate.setUpGitRefreshClickHandlers();
     });

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -1,4 +1,24 @@
 describe('Automate', function() {
+  describe('#setUpDefaultGitBranchOrTagValue', function() {
+    beforeEach(function() {
+      var html = '';
+      html += '<input type="hidden" class="git-branch-or-tag"></input>';
+      html += '<select class="git-branches">';
+      html += '  <option value="1">Branch 1</option>';
+      html += '  <option value="2" selected="selected">Branch 2</option>';
+      html += '</select>';
+      html += '<div class="git-branches"></div>';
+      html += '';
+      setFixtures(html);
+    });
+
+    it('ensures the selected value from the branches select tag is set on the hidden input', function() {
+      expect($('.git-branch-or-tag').val()).toEqual('');
+      Automate.setUpDefaultGitBranchOrTagValue();
+      expect($('.git-branch-or-tag').val()).toEqual('2');
+    });
+  });
+
   describe('#setUpGitRefreshClickHandlers', function() {
     beforeEach(function() {
       var html = '';


### PR DESCRIPTION
This should fix a few issues. The first is, in the haml, using the correct selector ensures that we pull the value from the `select` html element, as Patternfly adds a `div` with the same class. This allows us to submit the refresh with default values and it not to break.

Similarly, when changing one of those select elements, two 'change' events were firing, because there were two elements with the same class name. Using the specific selector should ensure only one event is fired.

@himdel @Ladas Please ensure this fixes the issues you were seeing.

Related to discussion on #11113 

@gmcculloug Not sure if you want to review or not, but since you're the assignee on the other one I figured I'd tag you here.