### PR TITLE
Use is_default to filter default resource pools to fix sporadic test failure

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -190,7 +190,10 @@ class EmsCluster < ApplicationRecord
 
   # All RPs under this Cluster and all child RPs
   def all_resource_pools
-    descendants(:of_type => 'ResourcePool')[1..-1].sort_by { |r| r.name.downcase }
+    # descendants typically returns the default_rp first but sporadically it
+    # will not due to a bug in the ancestry gem, this means we cannot simply
+    # drop the first value and need to check is_default
+    descendants(:of_type => 'ResourcePool').select { |r| !r.is_default }.sort_by { |r| r.name.downcase }
   end
 
   def all_resource_pools_with_default

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -713,7 +713,10 @@ class Host < ApplicationRecord
 
   # All RPs under this Host and all child RPs
   def all_resource_pools
-    descendants(:of_type => 'ResourcePool')[1..-1].sort_by { |r| r.name.downcase }
+    # descendants typically returns the default_rp first but sporadically it
+    # will not due to a bug in the ancestry gem, this means we cannot simply
+    # drop the first value and need to check is_default
+    descendants(:of_type => 'ResourcePool').select { |r| !r.is_default }.sort_by { |r| r.name.downcase }
   end
 
   def all_resource_pools_with_default


### PR DESCRIPTION
The method [all_resource_pools](https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_cluster.rb#L192) returns all child resource pools except the default one.

This is done by returning `descendants(:of_type => 'ResourcePool')[1..-1].sort_by { |r| r.name.downcase }`.  This assumes the default resource pool is always first which was not the case in this test: https://travis-ci.org/ManageIQ/manageiq/jobs/159734435#L1176

Using select to filter out any resource pools where `is_default` is true will be more robust than relying on the location of the default resource pool in an array.

Failing test: https://travis-ci.org/ManageIQ/manageiq/jobs/159734435