### PR TITLE
SCVMM - Set CPU sockets and cores per socket

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -314,18 +314,21 @@ module ManageIQ::Providers::Microsoft
     end
 
     def process_vm_hardware(vm)
-      p = vm[:Properties][:Props]
+      p    = vm[:Properties][:Props]
+      cpus = p[:CPUCount]
 
       {
-        :cpu_total_cores    => p[:CPUCount],
-        :guest_os           => p[:OperatingSystem][:Props][:Name],
-        :guest_os_full_name => p[:OperatingSystem][:Props][:Name],
-        :memory_mb          => normalize_blank_property_num(p[:Memory]),
-        :cpu_type           => normalize_blank_property_str(p[:CPUType]),
-        :disks              => process_disks(p),
-        :networks           => process_hostname_and_ip(vm),
-        :guest_devices      => process_vm_guest_devices(vm),
-        :bios               => p[:BiosGuid]
+        :cpu_sockets          => cpus,
+        :cpu_cores_per_socket => 1,
+        :cpu_total_cores      => cpus,
+        :guest_os             => p[:OperatingSystem][:Props][:Name],
+        :guest_os_full_name   => p[:OperatingSystem][:Props][:Name],
+        :memory_mb            => normalize_blank_property_num(p[:Memory]),
+        :cpu_type             => normalize_blank_property_str(p[:CPUType]),
+        :disks                => process_disks(p),
+        :networks             => process_hostname_and_ip(vm),
+        :guest_devices        => process_vm_guest_devices(vm),
+        :bios                 => p[:BiosGuid]
       }
     end
 

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -192,12 +192,14 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     expect(v.snapshots.size).to eq(1)
 
     expect(v.hardware).to have_attributes(
-      :guest_os           => "Unknown",
-      :guest_os_full_name => "Unknown",
-      :bios               => "2c67139b-76e1-40fd-896f-407ee9efc447",
-      :cpu_total_cores    => 1,
-      :annotation         => nil,
-      :memory_mb          => 512
+      :guest_os             => "Unknown",
+      :guest_os_full_name   => "Unknown",
+      :bios                 => "2c67139b-76e1-40fd-896f-407ee9efc447",
+      :cpu_total_cores      => 1,
+      :cpu_sockets          => 1,
+      :cpu_cores_per_socket => 1,
+      :annotation           => nil,
+      :memory_mb            => 512
     )
 
     expect(v.hardware.disks.size).to eq(1)


### PR DESCRIPTION
Although the number of CPUs allocated to a VM is collected, 2 additional properties, ```cpu_cores_per_socket``` and ```cpu_sockets``` are not. These property values are required during VM provisioning when the quotas and limits placed on a user or user group are being checked. 

## Links

https://bugzilla.redhat.com/show_bug.cgi?id=1364381
## Steps for Testing/QA

1. Add an SCVMM provider
2. Enforce the tenant quota
3. Provision a VM requesting a higher quota than the enforced quota

**Actual results:**
Requested value is always shown as zero.

**Expected results:**
Requested value should be displayed.

