### PR TITLE
Refactor API request helpers a bit

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -57,7 +57,7 @@ describe "Authentication API" do
     it "test basic authentication with incorrect group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => "bogus_group"}
+      run_get entrypoint_url, :headers => {"HTTP_X_MIQ_GROUP" => "bogus_group"}
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -65,7 +65,7 @@ describe "Authentication API" do
     it "test basic authentication with a primary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => group1.description}
+      run_get entrypoint_url, :headers => {"HTTP_X_MIQ_GROUP" => group1.description}
 
       expect(response).to have_http_status(:ok)
     end
@@ -73,7 +73,7 @@ describe "Authentication API" do
     it "test basic authentication with a secondary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => group2.description}
+      run_get entrypoint_url, :headers => {"HTTP_X_MIQ_GROUP" => group2.description}
 
       expect(response).to have_http_status(:ok)
     end
@@ -91,7 +91,7 @@ describe "Authentication API" do
     it "basic authentication with a secondary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => group2.description}
+      run_get entrypoint_url, :headers => {"HTTP_X_MIQ_GROUP" => group2.description}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -134,7 +134,7 @@ describe "Authentication API" do
     end
 
     it "authentication using a bad token" do
-      run_get entrypoint_url, :headers => {"auth_token" => "badtoken"}
+      run_get entrypoint_url, :headers => {"HTTP_X_AUTH_TOKEN" => "badtoken"}
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -149,7 +149,7 @@ describe "Authentication API" do
 
       auth_token = response.parsed_body["auth_token"]
 
-      run_get entrypoint_url, :headers => {"auth_token" => auth_token}
+      run_get entrypoint_url, :headers => {"HTTP_X_AUTH_TOKEN" => auth_token}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -171,7 +171,7 @@ describe "Authentication API" do
       expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
 
       expect_any_instance_of(TokenManager).to receive(:reset_token).with(auth_token)
-      run_get entrypoint_url, :headers => {"auth_token" => auth_token}
+      run_get entrypoint_url, :headers => {"HTTP_X_AUTH_TOKEN" => auth_token}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -214,7 +214,7 @@ describe "Authentication API" do
       auth_token = response.parsed_body["auth_token"]
 
       expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
-      run_delete auth_url, "auth_token" => auth_token
+      run_delete auth_url, "HTTP_X_AUTH_TOKEN" => auth_token
     end
 
     context 'Tokens for Web Sockets' do
@@ -232,7 +232,7 @@ describe "Authentication API" do
         run_get auth_url, :requester_type => 'ws'
         ws_token = response.parsed_body["auth_token"]
 
-        run_get entrypoint_url, :headers => {'auth_token' => ws_token}
+        run_get entrypoint_url, :headers => {"HTTP_X_AUTH_TOKEN" => ws_token}
 
         expect(response).to have_http_status(:unauthorized)
       end
@@ -248,7 +248,7 @@ describe "Authentication API" do
 
     it "authentication using a bad token" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => "badtoken"}
+              :headers => {"HTTP_X_MIQ_TOKEN" => "badtoken"}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -258,7 +258,7 @@ describe "Authentication API" do
 
     it "authentication using a token with a bad server guid" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken("bad_server_guid", api_config(:user), Time.now.utc)}
+              :headers => {"HTTP_X_MIQ_TOKEN" => systoken("bad_server_guid", api_config(:user), Time.now.utc)}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -268,7 +268,7 @@ describe "Authentication API" do
 
     it "authentication using a token with bad user" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken(MiqServer.first.guid, "bad_user_id", Time.now.utc)}
+              :headers => {"HTTP_X_MIQ_TOKEN" => systoken(MiqServer.first.guid, "bad_user_id", Time.now.utc)}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -278,7 +278,7 @@ describe "Authentication API" do
 
     it "authentication using a token with an old timestamp" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)}
+              :headers => {"HTTP_X_MIQ_TOKEN" => systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -288,7 +288,7 @@ describe "Authentication API" do
 
     it "authentication using a valid token succeeds" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)}
+              :headers => {"HTTP_X_MIQ_TOKEN" => systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -74,7 +74,7 @@ describe "Logging" do
 
       expect_log_requests(log_request_expectations)
 
-      run_get entrypoint_url, :headers => {"miq_token" => miq_token}
+      run_get entrypoint_url, :headers => {"HTTP_X_MIQ_TOKEN" => miq_token}
     end
   end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -19,15 +19,15 @@ module ApiSpecHelper
   end
 
   def run_post(url, body = {}, headers = {})
-    post url, :headers => request_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
+    post url, :params => body.to_json, :headers => request_headers.merge(headers)
   end
 
   def run_put(url, body = {}, headers = {})
-    put url, :headers => request_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
+    put url, :params => body.to_json, :headers => request_headers.merge(headers)
   end
 
   def run_patch(url, body = {}, headers = {})
-    patch url, :headers => request_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
+    patch url, :params => body.to_json, :headers => request_headers.merge(headers)
   end
 
   def run_delete(url, headers = {})

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -6,35 +6,34 @@ require 'bcrypt'
 require 'json'
 
 module ApiSpecHelper
-  DEF_HEADERS = {
-    "Content-Type" => "application/json",
-    "Accept"       => "application/json"
-  }
-
-  def update_headers(headers)
-    headers.merge!("HTTP_AUTHORIZATION" => @http_authorization) if @http_authorization
-    headers.merge(DEF_HEADERS)
+  def default_headers
+    headers = {
+      "Content-Type" => "application/json",
+      "Accept"       => "application/json"
+    }
+    headers["HTTP_AUTHORIZATION"] = @http_authorization if @http_authorization
+    headers
   end
 
   def run_get(url, options = {})
     headers = options.delete(:headers) || {}
-    get url, :params => options, :headers => update_headers(headers)
+    get url, :params => options, :headers => default_headers.merge(headers)
   end
 
   def run_post(url, body = {}, headers = {})
-    post url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
+    post url, :headers => default_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
   end
 
   def run_put(url, body = {}, headers = {})
-    put url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
+    put url, :headers => default_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
   end
 
   def run_patch(url, body = {}, headers = {})
-    patch url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
+    patch url, :headers => default_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
   end
 
   def run_delete(url, headers = {})
-    delete url, :headers => update_headers(headers)
+    delete url, :headers => default_headers.merge(headers)
   end
 
   def resources_include_suffix?(resources, key, suffix)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -6,24 +6,12 @@ require 'bcrypt'
 require 'json'
 
 module ApiSpecHelper
-  HEADER_ALIASES = {
-    "auth_token" => "HTTP_X_AUTH_TOKEN",
-    "miq_token"  => "HTTP_X_MIQ_TOKEN",
-    "miq_group"  => "HTTP_X_MIQ_GROUP"
-  }
-
   DEF_HEADERS = {
     "Content-Type" => "application/json",
     "Accept"       => "application/json"
   }
 
   def update_headers(headers)
-    HEADER_ALIASES.keys.each do |k|
-      if headers.key?(k)
-        headers[HEADER_ALIASES[k]] = headers[k]
-        headers.delete(k)
-      end
-    end
     headers.merge!("HTTP_AUTHORIZATION" => @http_authorization) if @http_authorization
     headers.merge(DEF_HEADERS)
   end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -6,34 +6,32 @@ require 'bcrypt'
 require 'json'
 
 module ApiSpecHelper
-  def default_headers
-    headers = {
+  def request_headers
+    @request_headers ||= {
       "Content-Type" => "application/json",
       "Accept"       => "application/json"
     }
-    headers["HTTP_AUTHORIZATION"] = @http_authorization if @http_authorization
-    headers
   end
 
   def run_get(url, options = {})
     headers = options.delete(:headers) || {}
-    get url, :params => options, :headers => default_headers.merge(headers)
+    get url, :params => options, :headers => request_headers.merge(headers)
   end
 
   def run_post(url, body = {}, headers = {})
-    post url, :headers => default_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
+    post url, :headers => request_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
   end
 
   def run_put(url, body = {}, headers = {})
-    put url, :headers => default_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
+    put url, :headers => request_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
   end
 
   def run_patch(url, body = {}, headers = {})
-    patch url, :headers => default_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
+    patch url, :headers => request_headers.merge(headers).merge('RAW_POST_DATA' => body.to_json)
   end
 
   def run_delete(url, headers = {})
-    delete url, :headers => default_headers.merge(headers)
+    delete url, :headers => request_headers.merge(headers)
   end
 
   def resources_include_suffix?(resources, key, suffix)
@@ -98,7 +96,7 @@ module ApiSpecHelper
   end
 
   def basic_authorize(user, password)
-    @http_authorization = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
+    request_headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
   end
 
   def update_user_role(role, *identifiers)

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -18,7 +18,7 @@ module ApiSpecHelper
 
   def run_get(url, options = {})
     headers = options.delete(:headers) || {}
-    get url, :params => options.stringify_keys, :headers => update_headers(headers)
+    get url, :params => options, :headers => update_headers(headers)
   end
 
   def run_post(url, body = {}, headers = {})


### PR DESCRIPTION
Makes a few changes to simplify/delete:

* Remove the header aliases - they obscure intent
* Integration tests, unlike controller tests, don't provide a way to set headers outside of the calling of a request helper (e.g. `get`, `post`, etc..), apart from the one `accept` accessor (grr). As an alternative, I've provided `request_headers`, which is stored and can be appended to before the request is made, which simplifies the logic that was handling the default headers
* The resulting `run_<method>` methods are now a fairly thin wrapper around the ones that Rails provides, and could even be removed with a little :sparkles:, but I'll leave that for a future PR

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 

:fire: :scissors: :fire: