### PR TITLE
Adds UI to create/update/delete OpenStack cloud tenants

### DIFF
--- a/app/assets/javascripts/controllers/cloud_tenant/cloud_tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_tenant/cloud_tenant_form_controller.js
@@ -1,0 +1,51 @@
+ManageIQ.angular.app.controller('cloudTenantFormController', ['$http', '$scope', 'cloudTenantFormId', 'miqService', function($http, $scope, cloudTenantFormId, miqService) {
+  $scope.cloudTenantModel = { name: '' };
+  $scope.formId = cloudTenantFormId;
+  $scope.afterGet = false;
+  $scope.modelCopy = angular.copy( $scope.cloudTenantModel );
+  $scope.model = "cloudTenantModel";
+
+  ManageIQ.angular.scope = $scope;
+
+  if (cloudTenantFormId == 'new') {
+    $scope.cloudTenantModel.name = "";
+  } else {
+    miqService.sparkleOn();
+
+    $http.get('/cloud_tenant/cloud_tenant_form_fields/' + cloudTenantFormId).success(function(data) {
+      $scope.afterGet = true;
+      $scope.cloudTenantModel.name = data.name;
+
+      $scope.modelCopy = angular.copy( $scope.cloudTenantModel );
+      miqService.sparkleOff();
+    });
+  }
+
+  $scope.addClicked = function() {
+    miqService.sparkleOn();
+    var url = 'create/new' + '?button=add';
+    miqService.miqAjaxButton(url, true);
+  };
+
+  $scope.cancelClicked = function() {
+    miqService.sparkleOn();
+    if (cloudTenantFormId == 'new') {
+      var url = '/cloud_tenant/create/new' + '?button=cancel';
+    } else {
+      var url = '/cloud_tenant/update/' + cloudTenantFormId + '?button=cancel';
+    }
+    miqService.miqAjaxButton(url);
+  };
+
+  $scope.saveClicked = function() {
+    miqService.sparkleOn();
+    var url = '/cloud_tenant/update/' + cloudTenantFormId + '?button=save';
+    miqService.miqAjaxButton(url, true);
+  };
+
+  $scope.resetClicked = function() {
+    $scope.cloudTenantModel = angular.copy( $scope.modelCopy );
+    $scope.angularForm.$setPristine(true);
+    miqService.miqFlash("warn", "All changes have been reset");
+  };
+}]);

--- a/app/assets/javascripts/controllers/cloud_tenant/cloud_tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_tenant/cloud_tenant_form_controller.js
@@ -21,14 +21,7 @@ ManageIQ.angular.app.controller('cloudTenantFormController', ['$http', '$scope',
     });
   }
 
-  $scope.addClicked = function() {
-    miqService.sparkleOn();
-    var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);
-  };
-
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     if (cloudTenantFormId == 'new') {
       var url = '/cloud_tenant/create/new' + '?button=cancel';
     } else {
@@ -38,9 +31,12 @@ ManageIQ.angular.app.controller('cloudTenantFormController', ['$http', '$scope',
   };
 
   $scope.saveClicked = function() {
-    miqService.sparkleOn();
+    if (cloudTenantFormId == 'new') {
+      var url = 'create/new' + '?button=add';
+    } else {
     var url = '/cloud_tenant/update/' + cloudTenantFormId + '?button=save';
-    miqService.miqAjaxButton(url, true);
+    }
+    miqService.miqAjaxButton(url, $scope.cloudTenantModel, { complete: false });
   };
 
   $scope.resetClicked = function() {

--- a/app/controllers/cloud_tenant_controller.rb
+++ b/app/controllers/cloud_tenant_controller.rb
@@ -34,6 +34,16 @@ class CloudTenantController < ApplicationController
         @refresh_partial = "layouts/gtl"
         show
       end
+    elsif params[:pressed] == "cloud_tenant_new"
+      javascript_redirect :action => "new"
+      return
+    elsif params[:pressed] == "cloud_tenant_edit"
+      javascript_redirect :action => "edit", :id => params[:id]
+      return
+    elsif params[:pressed] == 'cloud_tenant_delete'
+      delete_cloud_tenants
+      render_flash
+      return
     elsif params[:pressed] == "custom_button"
       custom_buttons
       # custom button screen, so return, let custom_buttons method handle everything
@@ -51,7 +61,197 @@ class CloudTenantController < ApplicationController
     process_show_list
   end
 
+  def new
+    assert_privileges("cloud_tenant_new")
+    @tenant = CloudTenant.new
+    @in_a_form = true
+    @ems_choices = {}
+    ManageIQ::Providers::Openstack::CloudManager.all.each { |ems|
+      @ems_choices[ems.name] = ems.id
+      # keystone v3 allows for hierarchical tenants
+      if ems.api_version == "v3"
+        ems.cloud_tenants.each { |ems_cloud_tenant|
+          tenant_choice_name = ems.name + " (" + ems_cloud_tenant.name + ")"
+          tenant_choice_id = ems.id.to_s + ":" + ems_cloud_tenant.id.to_s
+          @ems_choices[tenant_choice_name] = tenant_choice_id
+        }
+      end
+    }
+    drop_breadcrumb(
+      :name => _("Add New %{model}") % {:model => ui_lookup(:table => 'cloud_tenant')},
+      :url  => "/cloud_tenant/new"
+    )
+  end
+
+  def create
+    assert_privileges("cloud_tenant_new")
+    case params[:button]
+    when "cancel"
+      javascript_redirect :action => 'show_list',
+                          :flash_msg => _("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:table => 'cloud_tenant')}
+
+    when "add"
+      @tenant = CloudTenant.new
+      options = form_params
+      ems = find_by_id_filtered(ExtManagementSystem, options[:ems_id])
+      options.delete(:ems_id)
+      begin
+        CloudTenant.create_cloud_tenant(ems, options)
+        add_flash(_("Creating %{tenant} \"%{tenant_name}\"") % {
+                    :tenant      => ui_lookup(:table => 'cloud_tenant'),
+                    :tenant_name => options[:name]})
+      rescue => ex
+        add_flash(_("Unable to create %{tenant} \"%{tenant_name}\": %{details}") % {
+                    :tenant      => ui_lookup(:table => 'cloud_tenant'),
+                    :tenant_name => options[:name],
+                    :details     => ex}, :error)
+      end
+      @breadcrumbs.pop if @breadcrumbs
+      session[:flash_msgs] = @flash_array.dup if @flash_array
+      javascript_redirect :action => "show_list"
+    end
+  end
+
+  def edit
+    assert_privileges("cloud_tenant_edit")
+    @tenant = find_by_id_filtered(CloudTenant, params[:id])
+    @in_a_form = true
+    drop_breadcrumb(
+      :name => _("Edit %{model} \"%{name}\"") % {:model => ui_lookup(:table => 'cloud_tenant'), :name => @tenant.name},
+      :url  => "/cloud_tenant/edit/#{@tenant.id}"
+    )
+  end
+
+  def update
+    assert_privileges("cloud_tenant_edit")
+    @tenant = find_by_id_filtered(CloudTenant, params[:id])
+
+    case params[:button]
+    when "cancel"
+      cancel_action(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {
+        :model => ui_lookup(:table => 'cloud_tenant'),
+        :name  => @tenant.name
+      })
+
+    when "save"
+      options = form_params
+      begin
+        @tenant.update_cloud_tenant(options)
+        add_flash(_("Updating %{model} \"%{name}\"") % {
+                    :model => ui_lookup(:table => 'cloud_tenant'),
+                    :name  => @tenant.name
+                  })
+      rescue => ex
+        add_flash(_("Unable to update %{model} \"%{name}\": %{details}") % {
+                    :model   => ui_lookup(:table => 'cloud_tenant'),
+                    :name    => @tenant.name,
+                    :details => ex
+                  }, :error)
+      end
+      @breadcrumbs.pop if @breadcrumbs
+      session[:edit] = nil
+      session[:flash_msgs] = @flash_array.dup if @flash_array
+      javascript_redirect :action => "show", :id => @tenant.id
+    end
+  end
+
+  def cloud_tenant_form_fields
+    assert_privileges("cloud_tenant_edit")
+    tenant = find_by_id_filtered(CloudTenant, params[:id])
+    render :json => {
+      :name => tenant.name
+    }
+  end
+
+  def delete_cloud_tenants
+    assert_privileges("cloud_tenant_delete")
+
+    tenants = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "cloud_tenant")
+                find_checked_items
+              else
+                [params[:id]]
+              end
+
+    if tenants.empty?
+      add_flash(_("No %{models} were selected for deletion.") % {
+        :models => ui_lookup(:tables => "cloud_tenant")
+      }, :error)
+    end
+
+    tenants_to_delete = []
+    tenants.each do |tenant_id|
+      tenant = CloudTenant.find_by_id(tenant_id)
+      if tenant.nil?
+        add_flash(_("%{model} no longer exists.") % {:model => ui_lookup(:table => "cloud_tenant")}, :error)
+      elsif !tenant.vms.empty?
+        add_flash(_("%{model} \"%{name}\" cannot be removed because it is attached to one or more %{instances}") % {
+          :model     => ui_lookup(:table => 'cloud_tenant'),
+          :name      => tenant.name,
+          :instances => ui_lookup(:tables => 'vm_cloud')}, :warning)
+      else
+        tenants_to_delete.push(tenant)
+      end
+    end
+    process_cloud_tenants(tenants_to_delete, "destroy") unless tenants_to_delete.empty?
+
+    # refresh the list if applicable
+    if @lastaction == "show_list"
+      show_list
+      @refresh_partial = "layouts/gtl"
+    elsif @lastaction == "show" && @layout == "cloud_tenant"
+      @single_delete = true unless flash_errors?
+      if @flash_array.nil?
+        add_flash(_("The selected %{model} was deleted") % {:model => ui_lookup(:table => "cloud_tenant")})
+      end
+    end
+  end
+
+  def cancel_action(message)
+    session[:edit] = nil
+    @breadcrumbs.pop if @breadcrumbs
+    javascript_redirect :action    => @lastaction,
+                        :id        => @tenant.id,
+                        :display   => session[:cloud_tenant_display],
+                        :flash_msg => message
+  end
+
   private
+
+  def form_params
+    options = {}
+    options[:name] = params[:name] if params[:name]
+    if params[:ems_id]
+      ems_id_array = params[:ems_id].split(":")
+      options[:ems_id] = ems_id_array[0]
+      if ems_id_array.length > 1
+        parent_id = find_by_id_filtered(CloudTenant, ems_id_array[1]).ems_ref
+        options[:parent_id] = parent_id
+      end
+    end
+    options
+  end
+
+  # dispatches tasks to multiple tenants
+  def process_cloud_tenants(tenants, task)
+    return if tenants.empty?
+
+    if task == "destroy"
+      tenants.each do |tenant|
+        audit = {
+          :event        => "cloud_tenant_record_delete_initiateed",
+          :message      => "[#{tenant.name}] Record delete initiated",
+          :target_id    => tenant.id,
+          :target_class => "CloudTenant",
+          :userid       => session[:userid]
+        }
+        AuditEvent.success(audit)
+        tenant.delete_cloud_tenant
+      end
+      add_flash(n_("Delete initiated for %{number} Cloud Tenant.",
+                   "Delete initiated for %{number} Cloud Tenants.",
+                   tenants.length) % {:number => tenants.length})
+    end
+  end
 
   def render_button_partial(pfx)
     if @flash_array && params[:pressed] == "#{@table_name}_delete" && @single_delete

--- a/app/helpers/application_helper/toolbar/cloud_tenant_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_tenant_center.rb
@@ -1,4 +1,24 @@
 class ApplicationHelper::Toolbar::CloudTenantCenter < ApplicationHelper::Toolbar::Basic
+  button_group('cloud_tenant_vmdb', [
+    select(
+      :cloud_tenant_vmdb_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :cloud_tenant_edit,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit Cloud Tenant'),
+          t),
+        button(
+          :cloud_tenant_delete,
+          'pficon pficon-edit fa-lg',
+          t = N_('Delete Cloud Tenant'),
+          t),
+      ]
+    ),
+  ])
   button_group('cloud_tenant_policy', [
     select(
       :cloud_tenant_policy_choice,

--- a/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_tenants_center.rb
@@ -1,4 +1,19 @@
 class ApplicationHelper::Toolbar::CloudTenantsCenter < ApplicationHelper::Toolbar::Basic
+  button_group('cloud_tenant_vmdb', [
+    select(
+      :cloud_tenant_vmdb_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :cloud_tenant_new,
+          'pficon pficon-edit fa-lg',
+          t = N_('Create Cloud Tenant'),
+          t)
+      ]
+    ),
+  ])
   button_group('cloud_tenant_policy', [
     select(
       :cloud_tenant_policy_choice,

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -33,6 +33,43 @@ class CloudTenant < ApplicationRecord
 
   virtual_total :total_vms, :vms
 
+  def self.class_by_ems(ext_management_system)
+    ext_management_system && ext_management_system.class::CloudTenant
+  end
+
+  def self.create_cloud_tenant(ext_management_system, options = {})
+    raise ArgumentError, _("ext_management_system cannot be nil") if ext_management_system.nil?
+
+    klass = class_by_ems(ext_management_system)
+
+    created_cloud_tenant = klass.raw_create_cloud_tenant(ext_management_system, options)
+
+    klass.create(
+      :name                  => created_cloud_tenant[:name],
+      :ems_ref               => created_cloud_tenant[:ems_ref],
+      :ext_management_system => ext_management_system)
+  end
+
+  def self.raw_create_cloud_tenant(_ext_management_system, _options = {})
+    raise NotImplementedError, _("raw_create_cloud_tenant must be implemented in a subclass")
+  end
+
+  def update_cloud_tenant(options = {})
+    raw_update_cloud_tenant(options)
+  end
+
+  def raw_update_cloud_tenant(_options = {})
+    raise NotImplementedError, _("raw_update_cloud_tenant must be implemented in a subclass")
+  end
+
+  def delete_cloud_tenant
+    raw_delete_cloud_tenant
+  end
+
+  def raw_delete_cloud_tenant
+    raise NotImplementedError, _("raw_delete_cloud_tenant must be implemented in a subclass")
+  end
+
   def all_cloud_networks
     direct_cloud_networks + shared_cloud_networks
   end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -126,5 +126,9 @@ module ManageIQ::Providers
 
       ems_tenant.update_attributes!(:name => ems_tenant_name, :description => ems_tenant_name)
     end
+
+    def create_cloud_tenant(options)
+      CloudTenant.create_cloud_tenant(self, options)
+    end
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -11,4 +11,44 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
   def all_private_networks
     private_networks + (try(:ext_management_system).try(:private_networks).try(:where, :shared => true) || [])
   end
+
+  def self.raw_create_cloud_tenant(ext_management_system, options)
+    tenant = nil
+    ext_management_system.with_provider_connection(connection_options) do |service|
+      tenant = service.create_tenant(options)
+    end
+    {:ems_ref => tenant.id, :name => options[:name]}
+  rescue => e
+    _log.error "tenant=[#{options[:name]}], error: #{e}"
+    raise MiqException::MiqCloudTenantCreateError, e.to_s, e.backtrace
+  end
+
+  def raw_update_cloud_tenant(options)
+    ext_management_system.with_provider_connection(connection_options) do |service|
+      service.update_tenant(ems_ref, options)
+    end
+  rescue => e
+    _log.error "tenant=[#{name}], error: #{e}"
+    raise MiqException::MiqCloudTenantUpdateError, e.to_s, e.backtrace
+  end
+
+  def raw_delete_cloud_tenant
+    ext_management_system.with_provider_connection(connection_options) do |service|
+      service.delete_tenant(ems_ref)
+    end
+  rescue => e
+    _log.error "tenant=[#{name}], error: #{e}"
+    raise MiqException::MiqCloudTenantDeleteError, e.to_s, e.backtrace
+  end
+
+  private
+
+  def self.connection_options
+    connection_options = {:service => "Identity", :openstack_endpoint_type => 'adminURL'}
+    connection_options
+  end
+
+  def connection_options
+    self.class.connection_options
+  end
 end

--- a/app/views/cloud_tenant/edit.html.haml
+++ b/app/views/cloud_tenant/edit.html.haml
@@ -1,0 +1,37 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudTenantFormController"}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Edit Cloud Tenant')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Tenant Name')
+      .col-md-8
+        %input.form-control{:type          => "text",
+                            :name          => "name",
+                            'ng-model'     => "cloudTenantModel.name",
+                            'ng-maxlength' => 128,
+                            :miqrequired   => false,
+                            :checkchange   => true}
+
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          = button_tag(_("Save"),
+                       :class        => "btn btn-primary",
+                       "ng-click"    => "saveClicked()",
+                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
+                       "ng-class"    => "{ disabled: cloudTenantForm.$pristine || angularForm.$invalid}")
+          = button_tag(_("Reset"),
+                       :class        => "btn btn-primary",
+                       "ng-click"    => "resetClicked()",
+                       "ng-disabled" => "angularForm.$pristine",
+                       "ng-class"    => "{ disabled: cloudTenantForm.$pristine}")
+          = button_tag(_("Cancel"),
+                        :class     => "btn btn-default",
+                        "ng-click" => "cancelClicked()")
+
+:javascript
+  ManageIQ.angular.app.value('cloudTenantFormId', '#{@tenant.id}');
+  miq_bootstrap(jQuery('#form_div'));

--- a/app/views/cloud_tenant/edit.html.haml
+++ b/app/views/cloud_tenant/edit.html.haml
@@ -18,19 +18,7 @@
     %tr
       %td{:align => 'right'}
         #buttons_on
-          = button_tag(_("Save"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "saveClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{ disabled: cloudTenantForm.$pristine || angularForm.$invalid}")
-          = button_tag(_("Reset"),
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "resetClicked()",
-                       "ng-disabled" => "angularForm.$pristine",
-                       "ng-class"    => "{ disabled: cloudTenantForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelClicked()")
+          = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudTenantFormId', '#{@tenant.id}');

--- a/app/views/cloud_tenant/new.html.haml
+++ b/app/views/cloud_tenant/new.html.haml
@@ -1,0 +1,56 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudTenantFormController"}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Basic Information')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Cloud Provider')
+      .col-md-8
+        = select_tag("ems_id",
+          options_for_select([["<#{_('Choose')}>", nil]] + @ems_choices.sort),
+                      "ng-model"                    => "cloudTenantModel.ems_id",
+                      "required"                    => "",
+                      :miqrequired                  => true,
+                      :checkchange                  => true,
+                      "selectpicker-for-select-tag" => "")
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Tenant Name')
+      .col-md-8
+        %input.form-control{:type          => "text",
+                            :name          => "name",
+                            'ng-model'     => "cloudTenantModel.name",
+                            'ng-maxlength' => 128,
+                            :miqrequired   => true,
+                            :checkchange   => true}
+
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          - if @tenant.id.nil?
+            = button_tag(_("Add"),
+                         :class        => "btn btn-primary",
+                         "ng-class"    => "{ disabled: angularForm.$invalid}",
+                         "ng-disabled" => "angularForm.$invalid",
+                         "ng-click"    => "addClicked()")
+          - else
+            = button_tag(_("Save"),
+                         :class        => "btn btn-primary",
+                         "ng-click"    => "saveClicked()",
+                         "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
+                         "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
+            = button_tag(_("Reset"),
+                         :class        => "btn btn-primary",
+                         "ng-click"    => "resetClicked()",
+                         "ng-disabled" => "angularForm.$pristine",
+                         "ng-class"    => "{ disabled: angularForm.$pristine}")
+          = button_tag(_("Cancel"),
+                        :class     => "btn btn-default",
+                        "ng-click" => "cancelClicked()")
+
+:javascript
+  ManageIQ.angular.app.value('cloudTenantFormId', '#{@tenant.id || "new"}');
+  miq_bootstrap('#form_div');

--- a/app/views/cloud_tenant/new.html.haml
+++ b/app/views/cloud_tenant/new.html.haml
@@ -30,26 +30,7 @@
     %tr
       %td{:align => 'right'}
         #buttons_on
-          - if @tenant.id.nil?
-            = button_tag(_("Add"),
-                         :class        => "btn btn-primary",
-                         "ng-class"    => "{ disabled: angularForm.$invalid}",
-                         "ng-disabled" => "angularForm.$invalid",
-                         "ng-click"    => "addClicked()")
-          - else
-            = button_tag(_("Save"),
-                         :class        => "btn btn-primary",
-                         "ng-click"    => "saveClicked()",
-                         "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                         "ng-class"    => "{ disabled: angularForm.$pristine || angularForm.$invalid}")
-            = button_tag(_("Reset"),
-                         :class        => "btn btn-primary",
-                         "ng-click"    => "resetClicked()",
-                         "ng-disabled" => "angularForm.$pristine",
-                         "ng-class"    => "{ disabled: angularForm.$pristine}")
-          = button_tag(_("Cancel"),
-                        :class     => "btn btn-default",
-                        "ng-click" => "cancelClicked()")
+          = render :partial => "layouts/angular/x_edit_buttons_angular"
 
 :javascript
   ManageIQ.angular.app.value('cloudTenantFormId', '#{@tenant.id || "new"}');

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -83,7 +83,7 @@
             - {:manegeiq_providers_cloudmanager => ["ems_cloud_show_list",                    _('Cloud Providers')],
                :availabilityzone                => ["availability_zone_show_list",            _('Availability Zones')],
                :hostaggregate                   => ["host_aggregate_show_list",               _('Host Aggregates')],
-               :cloudtenat                      => ["cloud_tenant_show_list",                 _('Tenants')],
+               :cloudtenant                     => ["cloud_tenant_show_list",                 _('Tenants')],
                :flavor                          => ["flavor_show_list",                       _('Flavors')],
                :manageiq_providers_cloudmanager_vm       => [["instances_accord",
                                                               "instances_filter_accord"], _('Instances')],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -357,9 +357,11 @@ Vmdb::Application.routes.draw do
 
     :cloud_tenant             => {
       :get => %w(
+        cloud_tenant_form_fields
         download_data
         edit
         index
+        new
         protect
         show
         show_list
@@ -369,6 +371,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         listnav_search_selected
+        create
         protect
         quick_search
         sections_field_changed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -380,6 +380,7 @@ Vmdb::Application.routes.draw do
         tagging_edit
         tag_edit_form_field_changed
         update
+        wait_for_task
       ) +
                compare_post + adv_search_post + exp_post + save_post
     },

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -620,6 +620,23 @@
       :description: Edit Tags of Tenants
       :feature_type: control
       :identifier: cloud_tenant_tag
+  - :name: Modify
+    :description: Modify Tenants
+    :feature_type: admin
+    :identifier: cloud_tenant_admin
+    :children:
+    - :name: Add
+      :description: Add a Tenant
+      :feature_type: admin
+      :identifier: cloud_tenant_new
+    - :name: Edit
+      :description: Edit a Tenant
+      :feature_type: admin
+      :identifier: cloud_tenant_edit
+    - :name: Remove
+      :description: Remove Tenants
+      :feature_type: admin
+      :identifier: cloud_tenant_delete
 
 # CloudVolume
 - :name: Cloud Volumes

--- a/gems/pending/openstack/openstack_handle/identity_delegate.rb
+++ b/gems/pending/openstack/openstack_handle/identity_delegate.rb
@@ -50,5 +50,73 @@ module OpenstackHandle
       vtenants.load(body['tenants'])
       vtenants
     end
+
+    def create_tenant(options)
+      if respond_to?(:projects)
+        # Check if keystone v3 method projects is available, if not fall back to v2
+        create_tenant_v3(options)
+      else
+        create_tenant_v2(options)
+      end
+    end
+
+    def create_tenant_v3(options)
+      project = projects.create({:domain_id => @os_handle.domain_id}.merge(options))
+      admin_role = roles.all.detect { |x| x.name == 'admin' }
+      user = users.all(:domain_id => @os_handle.domain_id).detect { |x| x.name == @os_handle.username }
+      project.grant_role_to_user(admin_role.id, user.id)
+      project
+    end
+
+    def create_tenant_v2(options)
+      tenant = tenants.create(options)
+      admin_role = roles.all.detect { |x| x.name == 'admin' }
+      user = users.all.detect { |x| x.name == @os_handle.username }
+      tenant.grant_user_role(user.id, admin_role.id)
+      tenant
+    end
+
+    def update_tenant(tenant_id, options)
+      if respond_to?(:projects)
+        # Check if keystone v3 method projects is available, if not fall back to v2
+        update_tenant_v3(tenant_id, options)
+      else
+        update_tenant_v2(tenant_id, options)
+      end
+    end
+
+    def update_tenant_v3(tenant_id, options)
+      project = projects.all(:domain_id => @os_handle.domain_id,
+                             :user_id => current_user_id).detect {
+        |x| x.id == tenant_id
+      }
+      project.update(options)
+    end
+
+    def update_tenant_v2(tenant_id, options)
+      tenant = tenants.find_by_id(tenant_id)
+      tenant.update(options)
+    end
+
+    def delete_tenant(tenant_id)
+      if respond_to?(:projects)
+        # Check if keystone v3 method projects is available, if not fall back to v2
+        delete_tenant_v3(tenant_id)
+      else
+        delete_tenant_v2(tenant_id)
+      end
+    end
+
+    def delete_tenant_v3(tenant_id)
+      project = projects.all(:domain_id => @os_handle.domain_id,
+                             :user_id => current_user_id).detect {
+        |x| x.id == tenant_id
+      }
+      project.destroy
+    end
+
+    def delete_tenant_v2(tenant_id)
+      tenants.destroy(tenant_id)
+    end
   end
 end

--- a/gems/pending/util/miq-exception.rb
+++ b/gems/pending/util/miq-exception.rb
@@ -120,6 +120,10 @@ module MiqException
   class MiqSubnetUpdateError < Error; end
   class MiqSubnetDeleteError < Error; end
 
+  class MiqCloudTenantCreateError < Error; end
+  class MiqCloudTenantUpdateError < Error; end
+  class MiqCloudTenantDeleteError < Error; end
+
   class MiqOpenstackRequiredServiceMissing < Error; end
   class MiqOpenstackKeystoneServiceMissing < MiqOpenstackRequiredServiceMissing; end
   class MiqOpenstackNovaServiceMissing < MiqOpenstackRequiredServiceMissing; end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_cloud_tenant.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_cloud_tenant.rb
@@ -8,5 +8,8 @@ module MiqAeMethodService
     expose :miq_templates,         :association => true
     expose :floating_ips,          :association => true
     expose :cloud_resource_quotas, :association => true
+
+    expose :raw_update_cloud_tenant
+    expose :raw_delete_cloud_tenant
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager.rb
@@ -13,5 +13,9 @@ module MiqAeMethodService
     expose :cloud_resource_quotas,  :association => true
     expose :orchestration_stacks,   :association => true
     expose :host_aggregates,        :association => true
+
+    def create_cloud_tenant(create_options, options = {})
+      sync_or_async_ems_operation(options[:sync], "create_cloud_tenant", [create_options])
+    end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_tenant_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_cloud_tenant_spec.rb
@@ -31,5 +31,13 @@ module MiqAeServiceCloudTenantSpec
     it "#cloud_resource_quotas" do
       expect(described_class.instance_methods).to include(:cloud_resource_quotas)
     end
+
+    it "#raw_update_cloud_tenant" do
+      expect(described_class.instance_methods).to include(:raw_update_cloud_tenant)
+    end
+
+    it "#raw_delete_cloud_tenant" do
+      expect(described_class.instance_methods).to include(:raw_delete_cloud_tenant)
+    end
   end
 end


### PR DESCRIPTION
This PR adds a UI to create/update/delete OpenStack cloud tenants. 

**Steps for Testing/QA**

Create
1. Go to Clouds > Tenants and select "Create Cloud Tenant" under "Configuration".
2. Fill out the cloud tenant creation form and submit.
3. You will be redirected to the list of cloud tenants.  Your new cloud tenant should appear there.