### PR TITLE
Filter backtrace originating from evm_spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,6 +116,9 @@ RSpec.configure do |config|
     config.backtrace_exclusion_patterns << %r{/lib\d*/ruby/[0-9]}
     config.backtrace_exclusion_patterns << %r{/gems/[0-9][^/]+/gems/}
   end
+
+  config.backtrace_exclusion_patterns << %r{/spec/spec_helper}
+  config.backtrace_exclusion_patterns << %r{/spec/support/evm_spec_helper}
 end
 
 VCR.configure do |c|


### PR DESCRIPTION
`EvmSpecHelper.clear_caches` yields to a block in which an example is
run. Should that example fail the backtrace reported by RSpec will
include the appropriate line in spec/support/evm_spec_helper, and the
line in spec/spec_helper from which it is called twice. This adds some
noise to the backtrace, making it harder to read. Adding these files to
RSpec's backtrace exclusion patterns alleviates the problem.

Before:

```
     1.2) Failure/Error: expect(response).to have_http_status(:ok)
            expected the response to have status code :ok (200) but it was :internal_server_error (500)
          # ./spec/requests/api/blueprints_spec.rb:39:in `block (3 levels) in <top (required)>'
          # ./spec/spec_helper.rb:105:in `block (3 levels) in <top (required)>'
          # ./spec/support/evm_spec_helper.rb:28:in `clear_caches'
          # ./spec/spec_helper.rb:105:in `block (2 levels) in <top (required)>'
```

After:

```
     1.2) Failure/Error: expect(response).to have_http_status(:ok)
            expected the response to have status code :ok (200) but it was :internal_server_error (500)
          # ./spec/requests/api/blueprints_spec.rb:39:in `block (3 levels) in <top (required)>'
```

@miq-bot add-label test
@miq-bot assign @Fryguy 
/cc @jrafanie 