### PR TITLE
Automate - Retirement - Allow VM's with unknown power state to retire.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_check_pre_retirement.rb
@@ -5,22 +5,24 @@
 
 # Get vm from root object
 vm = $evm.root['vm']
+ems = vm.ext_management_system if vm
 
-if vm
-  power_state = vm.attributes['power_state']
-  ems = vm.ext_management_system
-  $evm.log('info', "Instance:<#{vm.name}> on EMS:<#{ems.try(:name)} has Power State:<#{power_state}>")
+if vm.nil? || ems.nil?
+  $evm.log('info', "Skipping check pre retirement for Instance:<#{vm.try(:name)}> on EMS:<#{ems.try(:name)}>")
+  exit MIQ_OK
+end
 
-  # If VM is powered off or this instance is running on an instance store
-  if %w(off suspended terminated).include?(power_state) || vm.hardware.root_device_type == "instance-store"
-    # Bump State
-    $evm.root['ae_result'] = 'ok'
-  elsif power_state == "never"
-    # If never then this VM is a template so exit the retirement state machine
-    $evm.root['ae_result'] = 'error'
-  else
-    vm.refresh
-    $evm.root['ae_result']         = 'retry'
-    $evm.root['ae_retry_interval'] = '60.seconds'
-  end
+power_state = vm.power_state
+$evm.log('info', "Instance:<#{vm.name}> on EMS:<#{ems.name}> has Power State:<#{power_state}>")
+# If VM is powered off, suspended, terminated, unknown or this instance is running on an instance store exit
+if %w(off suspended terminated unknown).include?(power_state) || vm.hardware.root_device_type == "instance-store"
+  # Bump State
+  $evm.root['ae_result'] = 'ok'
+elsif power_state == "never"
+  # If never then this VM is a template so exit the retirement state machine
+  $evm.root['ae_result'] = 'error'
+else
+  vm.refresh
+  $evm.root['ae_result']         = 'retry'
+  $evm.root['ae_retry_interval'] = '60.seconds'
 end

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
@@ -4,21 +4,23 @@
 
 # Get vm from root object
 vm = $evm.root['vm']
+ems = vm.ext_management_system if vm
 
-if vm
-  power_state = vm.power_state
-  ems = vm.ext_management_system
-  $evm.log('info', "Instance:<#{vm.name}> on EMS:<#{ems.try(:name)} has Power State:<#{power_state}>")
+if vm.nil? || ems.nil?
+  $evm.log('info', "Skipping check pre retirement for Instance:<#{vm.try(:name)}> on EMS:<#{ems.try(:name)}>")
+  exit MIQ_OK
+end
 
-  # If VM is powered off or suspended exit
-  if %w(off suspended).include?(power_state)
-    # Bump State
-    $evm.root['ae_result'] = 'ok'
-  elsif power_state == "never"
-    # If never then this VM is a template so exit the retirement state machine
-    $evm.root['ae_result'] = 'error'
-  else
-    $evm.root['ae_result'] = 'retry'
-    $evm.root['ae_retry_interval'] = '60.seconds'
-  end
+power_state = vm.power_state
+$evm.log('info', "Instance:<#{vm.name}> on EMS:<#{ems.name}> has Power State:<#{power_state}>")
+# If VM is powered off, suspended or unknown exit
+if %w(off suspended unknown).include?(power_state)
+  # Bump State
+  $evm.root['ae_result'] = 'ok'
+elsif power_state == "never"
+  # If never then this VM is a template so exit the retirement state machine
+  $evm.root['ae_result'] = 'error'
+else
+  $evm.root['ae_result'] = 'retry'
+  $evm.root['ae_retry_interval'] = '60.seconds'
 end

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_pre_retirement.rb
@@ -4,22 +4,25 @@
 
 # Get vm from root object
 vm = $evm.root['vm']
+ems = vm.ext_management_system if vm
 
-if vm
-  power_state = vm.attributes['power_state']
-  ems = vm.ext_management_system
-  $evm.log('info', "VM:<#{vm.name}> on provider:<#{ems.try(:name)} has Power State:<#{power_state}>")
+if vm.nil? || ems.nil?
+  $evm.log('info', "Skipping check pre retirement for VM:<#{vm.try(:name)}> on EMS:<#{ems.try(:name)}>")
+  exit MIQ_OK
+end
 
-  # If VM is powered off or suspended exit
+power_state = vm.power_state
+$evm.log('info', "VM:<#{vm.name}> on Provider:<#{ems.name}> has Power State:<#{power_state}>")
 
-  if %w(off suspended).include?(power_state)
-    # Bump State
-    $evm.root['ae_result'] = 'ok'
-  elsif power_state == "never"
-    # If never then this VM is a template so exit the retirement state machine
-    $evm.root['ae_result'] = 'error'
-  else
-    $evm.root['ae_result']     = 'retry'
-    $evm.root['ae_retry_interval'] = '60.seconds'
-  end
+# If VM is powered off or suspended exit
+
+if %w(off suspended unknown).include?(power_state)
+  # Bump State
+  $evm.root['ae_result'] = 'ok'
+elsif power_state == "never"
+  # If never then this VM is a template so exit the retirement state machine
+  $evm.root['ae_result'] = 'error'
+else
+  $evm.root['ae_result'] = 'retry'
+  $evm.root['ae_retry_interval'] = '60.seconds'
 end

--- a/spec/automation/unit/method_validation/amazon_check_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/amazon_check_pre_retirement_spec.rb
@@ -2,7 +2,7 @@ describe "amazon_check_pre_retirement Method Validation" do
   before(:each) do
     @zone = FactoryGirl.create(:zone)
     @user = FactoryGirl.create(:user_with_group)
-    @ems  = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
     @ebs_hardware = FactoryGirl.create(:hardware, :bitness             => 64,
                                                   :virtualization_type => 'paravirtual',
                                                   :root_device_type    => 'ebs')
@@ -36,5 +36,13 @@ describe "amazon_check_pre_retirement Method Validation" do
     ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
     expect(ws.root['ae_result']).to eq('ok')
     expect(ws.root['vm'].power_state).to eq('off')
+  end
+
+  it "returns 'ok' for ebs instance with unknown power state" do
+    @vm.hardware = @ebs_hardware
+    @vm.update_attributes(:raw_power_state => "unknown")
+    ws = MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
+    expect(ws.root['ae_result']).to eq('ok')
+    expect(ws.root['vm'].power_state).to eq('terminated')
   end
 end

--- a/spec/automation/unit/method_validation/check_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/check_pre_retirement_spec.rb
@@ -1,34 +1,83 @@
 describe "check_pre_retirement Method Validation" do
-  before(:each) { @vm = FactoryGirl.create(:vm_microsoft) }
-  after(:each) { @vm.destroy }
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:zone) { FactoryGirl.create(:zone) }
 
-  let(:user) do
-    FactoryGirl.create(:user_with_group)
+  context "Infrastructure" do
+    let(:ems) { FactoryGirl.create(:ems_microsoft, :zone => zone) }
+    let(:vm) do
+      FactoryGirl.create(:vm_microsoft,
+                         :raw_power_state => "PowerOff",
+                         :ems_id          => ems.id)
+    end
+    let(:ws) do
+      MiqAeEngine.instantiate("/Infrastructure/VM/Retirement/StateMachines/Methods/CheckPreRetirement?" \
+                              "Vm::vm=#{vm.id}#microsoft", user)
+    end
+
+    it "returns 'ok' for a vm in powered_off state" do
+      expect(ws.root['vm'].power_state).to eq("off")
+      expect(ws.root['ae_result']).to eq("ok")
+    end
+
+    it "errors for a template" do
+      vm.update_attribute(:template, true)
+
+      expect(vm.state).to eq("never")
+      expect { ws }.to raise_error(MiqAeException::ServiceNotFound)
+    end
+
+    it "retries for a vm in powered_on state" do
+      vm.update_attribute(:raw_power_state, "Running")
+
+      expect(ws.root['ae_result']).to eq("retry")
+      expect(ws.root['vm'].power_state).to eq("on")
+    end
+
+    it "returns 'ok' for a vm in unknown state" do
+      vm.update_attribute(:raw_power_state, "unknown")
+
+      expect(ws.root['vm'].power_state).to eq("unknown")
+      expect(ws.root['ae_result']).to eq("ok")
+    end
   end
 
-  let(:ws) do
-    MiqAeEngine.instantiate("/Infrastructure/VM/Retirement/StateMachines/Methods/CheckPreRetirement?" \
-                            "Vm::vm=#{@vm.id}#microsoft", user)
-  end
+  context "Cloud" do
+    let(:ems) { FactoryGirl.create(:ems_google, :zone => zone) }
+    let(:vm)  do
+      FactoryGirl.create(:vm_google,
+                         :raw_power_state => "stopping",
+                         :ems_id          => ems.id)
+    end
 
-  it "returns 'ok' for a vm in powered_off state" do
-    @vm.update_attribute(:raw_power_state, "PowerOff")
+    let(:ws) do
+      MiqAeEngine.instantiate("/Cloud/VM/Retirement/StateMachines/Methods/CheckPreRetirement?" \
+                              "Vm::vm=#{vm.id}#google", user)
+    end
 
-    expect(ws.root['vm'].power_state).to eq("off")
-    expect(ws.root['ae_result']).to eq("ok")
-  end
+    it "returns 'ok' for a instance in powered_off state" do
+      expect(ws.root['vm'].power_state).to eq("off")
+      expect(ws.root['ae_result']).to eq("ok")
+    end
 
-  it "errors for a template" do
-    @vm.update_attribute(:template, true)
-    expect(@vm.state).to eq("never")
+    it "retries for an instance in powered_on state" do
+      vm.update_attribute(:raw_power_state, "Running")
 
-    expect { ws }.to raise_error(MiqAeException::ServiceNotFound)
-  end
+      expect(ws.root['ae_result']).to eq("retry")
+      expect(ws.root['vm'].power_state).to eq("on")
+    end
 
-  it "retries for a vm in powered_on state" do
-    @vm.update_attribute(:raw_power_state, "Running")
+    it "returns 'ok' for an instance in unknown state" do
+      vm.update_attribute(:raw_power_state, "unknown")
 
-    expect(ws.root['ae_result']).to eq("retry")
-    expect(ws.root['vm'].power_state).to eq("on")
+      expect(ws.root['vm'].power_state).to eq("unknown")
+      expect(ws.root['ae_result']).to eq("ok")
+    end
+
+    it "returns 'ok' for an instance with no ems" do
+      vm.update_attribute(:ems_id, nil)
+
+      expect(ws.root['vm'].power_state).to eq("off")
+      expect(ws.root['ae_result']).to be_nil
+    end
   end
 end


### PR DESCRIPTION
This change in the retirement process will allow VM's with an unknown power state to proceed past the check_pre_retirement automate method to the next state. That should allow retirement to fall through and retire even if there is no ems.

Modified check_pre_retirement and amazon_check_pre_retirement methods to continue if power state is unknown or if ems is nil.

Added a test for ems nil and ems.try in log messages was removed.

https://www.pivotaltracker.com/story/show/130661861