### PR TITLE
[VirtualDelegates] add Host delegates

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -116,7 +116,7 @@ class Host < ApplicationRecord
 
   virtual_column :os_image_name,                :type => :string,      :uses => [:operating_system, :hardware]
   virtual_column :platform,                     :type => :string,      :uses => [:operating_system, :hardware]
-  virtual_column :v_owning_cluster,             :type => :string,      :uses => :ems_cluster
+  virtual_delegate :v_owning_cluster, :to => "ems_cluster.name", :allow_nil => true, :default => ""
   virtual_column :v_owning_datacenter,          :type => :string,      :uses => :all_relationships
   virtual_column :v_owning_folder,              :type => :string,      :uses => :all_relationships
   virtual_column :total_vcpus,                  :type => :integer,     :uses => :cpu_total_cores
@@ -1501,12 +1501,7 @@ class Host < ApplicationRecord
     end
   end
 
-  # Virtual columns for owning cluster, folder and datacenter
-  def v_owning_cluster
-    o = owning_cluster
-    o ? o.name : ""
-  end
-
+  # Virtual columns for folder and datacenter
   def v_owning_folder
     o = owning_folder
     o ? o.name : ""

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -140,7 +140,7 @@ class Host < ApplicationRecord
   virtual_column :enabled_run_level_5_services, :type => :string_set,  :uses => :host_services
   virtual_column :enabled_run_level_6_services, :type => :string_set,  :uses => :host_services
   virtual_column :last_scan_on,                 :type => :time,        :uses => :last_drift_state_timestamp
-  virtual_column :v_annotation,                 :type => :string,      :uses => :hardware
+  virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true
   virtual_column :vmm_vendor_display,           :type => :string
   virtual_column :ipmi_enabled,                 :type => :boolean
 
@@ -191,10 +191,6 @@ class Host < ApplicationRecord
 
   def authentication_check_role
     'smartstate'
-  end
-
-  def v_annotation
-    hardware.try(:annotation)
   end
 
   def my_zone

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -408,4 +408,16 @@ describe Host do
       expect(h.v_annotation).to eq("the annotation")
     end
   end
+
+  describe "#v_owning_cluster" do
+    it "handles nil" do
+      h = FactoryGirl.build(:host)
+      expect(h.v_owning_cluster).to eq("")
+    end
+
+    it "delegates" do
+      h = FactoryGirl.build(:host, :ems_cluster => FactoryGirl.build(:ems_cluster, :name => "the cluster"))
+      expect(h.v_owning_cluster).to eq("the cluster")
+    end
+  end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -420,4 +420,54 @@ describe Host do
       expect(h.v_owning_cluster).to eq("the cluster")
     end
   end
+
+  describe "#ram_size" do
+    it "handles nil" do
+      h = FactoryGirl.build(:host)
+      expect(h.ram_size).to eq(0)
+    end
+
+    it "delegates" do
+      h = FactoryGirl.build(:host, :hardware => FactoryGirl.build(:hardware, :memory_mb => 100))
+      expect(h.ram_size).to eq(100)
+    end
+  end
+
+  describe "#cpu_total_cores", "#total_vcpus" do
+    it "handles nil" do
+      h = FactoryGirl.build(:host)
+      expect(h.cpu_total_cores).to eq(0)
+      expect(h.total_vcpus).to eq(0)
+    end
+
+    it "delegates" do
+      h = FactoryGirl.build(:host, :hardware => FactoryGirl.build(:hardware, :cpu_total_cores => 4))
+      expect(h.cpu_total_cores).to eq(4)
+      expect(h.total_vcpus).to eq(4)
+    end
+  end
+
+  describe "#num_cpu" do
+    it "handles nil" do
+      h = FactoryGirl.build(:host)
+      expect(h.num_cpu).to eq(0)
+    end
+
+    it "delegates" do
+      h = FactoryGirl.build(:host, :hardware => FactoryGirl.build(:hardware, :cpu_sockets => 3))
+      expect(h.num_cpu).to eq(3)
+    end
+  end
+
+  describe "#cpu_cores_per_socket" do
+    it "handles nil" do
+      h = FactoryGirl.build(:host)
+      expect(h.cpu_cores_per_socket).to eq(0)
+    end
+
+    it "delegates" do
+      h = FactoryGirl.build(:host, :hardware => FactoryGirl.build(:hardware, :cpu_cores_per_socket => 4))
+      expect(h.cpu_cores_per_socket).to eq(4)
+    end
+  end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -396,4 +396,16 @@ describe Host do
       expect(Host.attribute_supported_by_sql?(:v_total_miq_templates)).to be true
     end
   end
+
+  describe "#v_annotation" do
+    it "handles nil" do
+      h = FactoryGirl.build(:host)
+      expect(h.v_annotation).to be_nil
+    end
+
+    it "delegates" do
+      h = FactoryGirl.build(:host, :hardware => FactoryGirl.build(:hardware, :annotation => "the annotation"))
+      expect(h.v_annotation).to eq("the annotation")
+    end
+  end
 end


### PR DESCRIPTION
`Hosts` has a number of `virtual_attribute` values that in truth are just a column from another table.

This properly defines them so the query can be formed without requiring all the data to be downloaded to be processed.

For a few, the value returned is strange. Took liberty to make value more consistent. I feel the foreign object being `nil` or it being present but having a nil field value are the same and should return the same value. Most of our fields exhibit this behavior.

- `annotation`, `ram_size`, `total_vcpus` are the same.
- `v_owning_cluster`, `num_cpu`, `cpu_total_cores`, and `cpu_cores_per_socket` now only return `""` or the value.

---
Example showing changes for `v_owning_cluster` but it is the same for all the fields:

context|before|after
---|---|---
`owning_cluster.nil?`|`""`|`""`
`owning_cluster.name.nil?`|**`nil`**|**`""`**
`owning_cluster.name.present?`|value|value
