### PR TITLE
Upgrade config gem to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "ancestry",                       "~>2.1.0",       :require => false
 gem "ansible_tower_client",           "~>0.3.2",       :require => false
 gem "aws-sdk",                        "~>2.2.19",      :require => false
 gem "color",                          "~>1.8"
+gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
 gem "draper",                         "~>3.0.0.pre1"
 gem "default_value_for",              "~>3.0.2"
@@ -67,8 +68,6 @@ gem "uglifier",                       "~>2.7.1",       :require => false
 gem "websocket-driver",               "~>0.6.3"
 
 # Modified gems (forked on Github)
-gem "config",                         "~>1.1.0",                      :git => "git://github.com/ManageIQ/config.git", :branch => "overwrite_arrays"
-gem "deep_merge",                     "~>1.0.1",                      :git => "git://github.com/ManageIQ/deep_merge.git", :branch => "overwrite_arrays"
 gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "git://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
 gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"


### PR DESCRIPTION
config v1.3.0 now has support for overwriting Arrays, so we no longer
need to track the specific branch.

See also https://github.com/railsconfig/config/pull/137

@jrafanie or @kbrock Please review.

@chessbyte I'd like to bring this back to darga so we don't have to keep our fork around, but that's up to you.