### PR TITLE
Introduce delete API for notifications

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -578,14 +578,16 @@
     :description: User's past notifications
     :options:
     - :collection
-    :verbs: *gp
+    :verbs: *gpd
     :klass: NotificationRecipient
     :collection_actions:
       :post:
       - :name: mark_as_seen
+      - :name: delete
     :resource_actions:
       :post:
       - :name: mark_as_seen
+      - :name: delete
   :pictures:
     :description: Pictures
     :options:


### PR DESCRIPTION
Not much to write about, simple API for deleting Notifications. Anyone can delete his/her own notifications.

Mr @skateman, the delete of multiple items works like this
```
POST /api/notifications
{
  "action" : "delete",
  "resources" : [
     "href" : "https://skateman.hu:3000/api/notifications/10001",
     "href" : "https://skateman.hu:3000/api/notifications/10002"
   ]
}
```

@miq-bot add_label api, enhancement
@miq-bot assign @abellotti 
