### PR TITLE
Bootstrap Treeview updated to PatterFly's v2.1.0 fork

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -49,10 +49,12 @@
     "qs": "^0.3.10",
     "rxjs": "^4.1.0",
     "rx-angular": "rx.angular#^1.1.3",
-    "manageiq-ui-components": "~0.0.7"
+    "manageiq-ui-components": "~0.0.7",
+    "patternfly-bootstrap-treeview": "~2.1.0"
   },
   "resolutions": {
     "moment": ">=2.9.0",
-    "d3": "~3.5.0"
+    "d3": "~3.5.0",
+    "patternfly-bootstrap-treeview": "~2.1.0"
   }
 }


### PR DESCRIPTION
Will be unnecessary when it will be [updated](https://github.com/patternfly/patternfly/pull/465) in the next PatternFly version. Fixes #11142 #11143 and the performance issues discovered by @NickLaMuro.

/cc @kbrock 