### PR TITLE
Console proxy level 2

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -20,24 +20,26 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
             "#{protocol} remote console requires the vm to be running.") if options[:check_if_running] && state != "on"
     end
 
-    def remote_console_acquire_ticket(userid, console_type)
+    def remote_console_acquire_ticket(userid, originating_server, console_type)
       validate_remote_console_acquire_ticket(console_type)
 
       parsed_ticket = Nokogiri::XML(provider_object.ticket)
       display = provider_object.attributes[:display]
 
-      SystemConsole.where(:vm_id => id).each(&:destroy)
-      # TODO: non-blocking SSL support in the proxy
-      SystemConsole.create!(
+      SystemConsole.force_vm_invalid_token(id)
+
+      console_args = {
         :user       => User.find_by(:userid => userid),
         :vm_id      => id,
-        :host_name  => display[:address],
-        :port       => display[:secure_port] || display[:port],
-        :ssl        => display[:secure_port].present?,
         :protocol   => display[:type],
         :secret     => parsed_ticket.xpath('action/ticket/value')[0].text,
-        :url_secret => SecureRandom.hex
-      ).connection_params
+        :url_secret => SecureRandom.hex,
+        :ssl        => display[:secure_port].present?
+      }
+      host_address = display[:address],
+      host_port    = display[:secure_port] || display[:port]
+
+      SystemConsole.launch_proxy_if_is_local(console_args, originating_server, host_address, host_port)
     end
 
     def remote_console_acquire_ticket_queue(protocol, userid)
@@ -53,7 +55,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
         :priority    => MiqQueue::HIGH_PRIORITY,
         :role        => 'ems_operations',
         :zone        => my_zone,
-        :args        => [userid, protocol]
+        :args        => [userid, MiqServer.my_server.id, protocol]
       }
 
       MiqTask.generic_action_with_callback(task_opts, queue_opts)

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -39,7 +39,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
       host_address = display[:address],
       host_port    = display[:secure_port] || display[:port]
 
-      SystemConsole.launch_proxy_if_is_local(console_args, originating_server, host_address, host_port)
+      SystemConsole.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
     end
 
     def remote_console_acquire_ticket_queue(protocol, userid)

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -12,8 +12,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
     raise(MiqException::RemoteConsoleNotSupportedError, "#{protocol} remote console requires the vm to be running.") if options[:check_if_running] && state != "on"
   end
 
-  def remote_console_acquire_ticket(userid, protocol)
-    send("remote_console_#{protocol.to_s.downcase}_acquire_ticket", userid)
+  def remote_console_acquire_ticket(userid, protocol, originating_server)
+    send("remote_console_#{protocol.to_s.downcase}_acquire_ticket", userid, originating_server)
   end
 
   def remote_console_acquire_ticket_queue(protocol, userid)
@@ -29,7 +29,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
       :zone        => my_zone,
-      :args        => [userid, protocol]
+      :args        => [userid, protocol, MiqServer.my_server.id]
     }
 
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
@@ -62,11 +62,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   #
   # VNC
   #
-  def remote_console_html5_acquire_ticket(userid)
-    remote_console_vnc_acquire_ticket(userid)
+  def remote_console_html5_acquire_ticket(userid, originating_server)
+    remote_console_vnc_acquire_ticket(userid, originating_server)
   end
 
-  def remote_console_vnc_acquire_ticket(userid)
+  def is_local?(originating_server)
+    # MiqServer.my_server.id == originating_server
+    false
+  end
+
+  def remote_console_vnc_acquire_ticket(userid, originating_server)
     validate_remote_console_acquire_ticket("vnc")
 
     password     = SecureRandom.base64[0, 8] # Random password from the Base64 character set
@@ -89,16 +94,39 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
     end
     update_attributes(:vnc_port => host_port)
 
-    SystemConsole.where(:vm_id => id).each(&:destroy)
-    SystemConsole.create!(
-      :user       => User.find_by(:userid => userid),
-      :vm_id      => id,
-      :host_name  => host.address,
-      :port       => host_port,
-      :ssl        => false,
-      :protocol   => 'vnc',
-      :secret     => password,
-      :url_secret => SecureRandom.hex
-    ).connection_params
+    SystemConsole.force_vm_invalid_token(id)
+
+    console_args = {
+        :user       => User.find_by(:userid => userid),
+        :vm_id      => id,
+        :ssl        => false,
+        :protocol   => 'vnc',
+        :secret     => password,
+        :url_secret => SecureRandom.hex
+    }
+
+    _log.info "Originating server: #{originating_server}, local server: #{MiqServer.my_server.id}"
+    if is_local?(originating_server)
+      console_args.update(
+        :host_name  => host.address,
+        :port       => host_port,
+      )
+    else
+      SystemConsole.cleanup_proxy_processes
+      proxy_address, proxy_port, proxy_pid = SystemConsole.launch_proxy(host.address, host_port)
+      return nil if proxy_address.nil?
+
+      _log.info "Proxy server started: #{proxy_address}:#{proxy_port} <--> #{host.address}:#{host_port}"
+      _log.info "Proxy process PID: #{proxy_pid}"
+
+      console_args.update(
+        :host_name    => proxy_address,
+        :port         => proxy_port,
+        :proxy_status => 'proxy_running',
+        :proxy_pid    => proxy_pid
+      )
+    end
+
+    SystemConsole.create!(console_args).connection_params
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -101,6 +101,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
     }
     host_address = host.address
 
-    SystemConsole.launch_proxy_if_is_local(console_args, originating_server, host_address, host_port)
+    SystemConsole.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
   end
 end

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -13,4 +13,78 @@ class SystemConsole < ApplicationRecord
       :proto  => protocol
     }
   end
+
+  def destroy_or_mark
+    if proxy_pid.nil?
+      destroy
+      return
+    end
+    update(:proxy_status => 'websocket_closed')
+    self.cleanup_proxy_processes
+  end
+
+  def self.allocate_port
+    port_range_start = ::Settings.server.proxy_port.try(:start) || 6000
+    port_range_end   = ::Settings.server.proxy_port.try(:end) || 7000
+
+    used_ports = SystemConsole.where.not(:proxy_pid => nil).where(:host_name => local_address).order(:port).pluck(:port)
+
+    (port_range_start..port_range_end).each do |port_number|
+      return port_number if used_ports[0].nil? || used_ports[0] > port_number
+      used_ports.shift if used_ports[0] == port_number
+    end
+    nil
+  end
+
+  def self.local_address
+    MiqServer.my_server.ipaddress.blank? ? local_address_fallback : MiqServer.my_server.ipaddress
+    #'10.40.5.140'
+  end
+
+  def self.local_address_fallback
+    require 'socket'
+    Socket.ip_address_list.collect(&:ip_address).reject { |address| address == '127.0.0.1' }.first
+  end
+
+  def self.launch_proxy(remote_address, remote_port)
+    local_port = allocate_port
+
+    if local_port.nil?
+      _log.error("No unused ports for proxy.")
+      return nil
+    end
+
+    command = '/usr/bin/socat', "TCP-LISTEN:#{local_port},fork", "TCP:#{remote_address}:#{remote_port}"
+    _log.info("Running socat proxy command: #{command.join(' ')}")
+
+    pid = spawn(*command)
+    Process.detach(pid)
+
+    return [local_address, local_port, pid]
+  end
+
+  def self.kill_proxy_process(pid)
+    system('/usr/bin/kill', pid)
+  end
+
+  def self.cleanup_proxy_processes
+    SystemConsole.where.not(:proxy_pid => nil).
+      where( :host_name    => local_address) do |console|
+      next unless %w(websocket_closed ticket_invalid).include?(console.proxy_status)
+
+      kill_proxy_process(console.proxy_pid)
+      console.destroy
+    end
+  end
+
+  def self.force_vm_invalid_token(vm_id)
+    SystemConsole.where(:vm_id => vm_id).each do |console|
+      if console.proxy_pid.nil?
+        console.destroy
+        next
+      else
+        console.update(:vm_id => :nil, :proxy_status => 'ticket_invalid')
+      end
+    end
+  end
 end

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -92,7 +92,7 @@ class SystemConsole < ApplicationRecord
     MiqServer.my_server.id == originating_server.to_i
   end
 
-  def self.launch_proxy_if_is_local(console_args, originating_server, host_address, host_port)
+  def self.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
     _log.info "Originating server: #{originating_server}, local server: #{MiqServer.my_server.id}"
     if SystemConsole.is_local?(originating_server)
       console_args.update(

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -89,7 +89,7 @@ class SystemConsole < ApplicationRecord
   end
 
   def self.is_local?(originating_server)
-    MiqServer.my_server.id == originating_server
+    MiqServer.my_server.id == originating_server.to_i
   end
 
   def self.launch_proxy_if_is_local(console_args, originating_server, host_address, host_port)

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -20,7 +20,7 @@ class SystemConsole < ApplicationRecord
       return
     end
     update(:proxy_status => 'websocket_closed')
-    self.cleanup_proxy_processes
+    SystemConsole.cleanup_proxy_processes
   end
 
   def self.allocate_port

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -58,6 +58,25 @@
       "note": "Temporarily skipped, found in new brakeman version"
     },
     {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "921b9f7b353a4de1033addb95d4a7c7efb090a7e60f8acb350ec8c7aea6e84ff",
+      "message": "Possible command injection",
+      "file": "app/models/system_console.rb",
+      "line": 60,
+      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "spawn(*[\"/usr/bin/socat\", \"TCP-LISTEN:#{local_port},fork\", \"TCP:#{remote_address}:#{remote_port}\"])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SystemConsole",
+        "method": "SystemConsole.launch_proxy"
+      },
+      "user_input": "remote_address",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "b7c5d0a1acf9b6e1d8241cc62f61ddde1dd9f6e1b871b9bd99982135465d1f24",
@@ -77,6 +96,6 @@
       "note": "Temporarily skipped, found in new brakeman version"
     }
   ],
-  "updated": "2016-08-29 12:33:49 -0500",
-  "brakeman_version": "3.3.5"
+  "updated": "2016-10-11 14:14:13 +0200",
+  "brakeman_version": "3.4.0"
 }

--- a/lib/websocket_proxy.rb
+++ b/lib/websocket_proxy.rb
@@ -48,7 +48,10 @@ class WebsocketProxy
   end
 
   def cleanup
-    @console.destroy unless @console.destroyed?
+    # FIXME:
+    # if @console.proxy_pid.present?
+    #   need to kill proxy process on the ems_operations appliance...
+    @console.destroy_or_mark unless @console.destroyed?
     @sock.close if @sock && !@sock.closed?
     @ws.close if @ws && !@ws.closed?
   end


### PR DESCRIPTION
Single level proxying for consoles.

Workflow:
---
If the console ticket request is being processed on a `ems_operations` role, it will check if the request is originated on the same appliance. If it, no change is done to the existing console workflow.

However if the request originated on a different appliance we conclude that proxying is needed. In that case we:
 1. get the ticket from the provide as before
 1. run a `socat` proxy that will forward connections to a local port to the remote hypervisor's VNC or SPICE endpoint.
 1. put the local port and appliance address to the `SystemConsole` table instead of the data from the ticket.
 1. run a cleanup process for unneeded proxy processes

Model changes:
---
Adding `proxy_pid` to hold PID of proxy process (`socat`)
Adding `proxy_status` to hold status of the proxy:
 1. null if there's no proxying
 1. "running" if proxy is running
 1. "websocket_opened" if the websocket connection is opened
 1. "websocket_closed" if the websocket connection is closed
3 means that the proxy process in `proxy_pid` is to be killed.

Unneeded proxy processes are found by the `ems_operations` role and killed. Such `SystemConsole` records have a `proxy_pid`, have `proxy_status = 2` and have `host_address` equal this appliances `MiqServer.my_server.ipaddress`.

Websocket worker will set `proxy_status` to 2 if there's a `proxy_pid` when the connection is closed.

## TODO:
  * `ipaddress` fallback or configurable?
  * ~~port range configurable?~~ (test)

Testing
---
appliance one:
```
appliance_console_cli --region 0 --internal --force-key -p smartvm
systemctl restart evmserverd
```

appliance two:
```
appliance_console_cli --hostname 10.16.7.80 --dbname vmdb_production --username root --password smartvm --fetch-key 10.16.7.80 -a smartvm
systemctl restart evmserverd
```

Single appliance usecase can be testing by accessing the first apliance and using the remote console.
Proxy usecase testing:
 1. setup 2 appliances as above
 1. remove roles "provider operations" from the first appliance
 1. try the console on the first appliance
 1. now it should NOT work ;-) and that's a check that it's properly setup
 1. install 'socat' on the 2nd apliance and 
 1. either open ports 6000-7000 or turn off the firewall
 1. try the console on the first appliance and now it should work
 
You should see records with `proxy_pid` filled in in the `system_consoles` table. You should see `socat` processes running on the 2nd appliance. And the console should work.
