### PR TITLE
rake locale:update -- a rake task to run complete catalog update

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -133,6 +133,18 @@ namespace :locale do
     FileUtils.mv(attributes_file, 'config/model_attributes.rb')
   end
 
+  desc "Run store_model_attributes task in i18n environment"
+  task "run_store_model_attributes" do
+    system({"RAILS_ENV" => "i18n"}, "bundle exec rake locale:store_model_attributes")
+  end
+
+  desc "Update ManageIQ gettext catalogs"
+  task "update" => ["run_store_model_attributes", "store_dictionary_strings", "extract_yaml_strings", "gettext:find"] do
+    Dir["locale/**/*.edit.po", "locale/**/*.po.time_stamp"].each do |file|
+      File.unlink(file)
+    end
+  end
+
   desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
   task "plugin:find", :engine do |_, args|
     unless args.has_key?(:engine)


### PR DESCRIPTION
The new rake task will execute all other rake tasks leading to complete catalog update:
* extract model attribute names (this has to be run in i18n environment, which sets `config.eager_load = false` -- without this setting the attribute extraction would not be complete)
* extract strings from en.yml
* extract strings from other yaml files
* update the final catalog

In the end, the task will delete files which are not needed. Previously, we had to run all these tasks
one by one, manually.