### PR TITLE
Fix broken tree on automation/customization page

### DIFF
--- a/app/presenters/tree_builder_buttons.rb
+++ b/app/presenters/tree_builder_buttons.rb
@@ -55,7 +55,7 @@ class TreeBuilderButtons < TreeBuilderAeCustomization
       object.members.count
     else
       # need to show button nodes in button order that they were saved in
-      button_order = button_order? object ? object[:set_data][:button_order] : nil
+      button_order = button_order?(object) ? object[:set_data][:button_order] : nil
       objects = []
       Array(button_order).each do |bidx|
         object.members.each { |b| objects.push(b) if bidx == b.id && !objects.include?(b) }


### PR DESCRIPTION
Parentheses are important. They change meaning of things we say or write.

Previously, the object[:set_data][:button_order] was passed to button_order? method and crashed like
```
Error caught: [TypeError] no implicit conversion of Symbol into Integer
app/presenters/tree_builder_buttons.rb:49:in `[]'
app/presenters/tree_builder_buttons.rb:49:in `button_order?'
app/presenters/tree_builder_buttons.rb:60:in `x_get_tree_aset_kids'
```

Introduced in eeb1614d8c1b8b0118474fa097a1374a5dbea9d1 (#11102)

@miq-bot add_label ui, bug, automate
@miq-bot assign @martinpovolny 