### PR TITLE
Fixed lazy-loading issue when selecting items on Clouds/Instances

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -141,7 +141,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
     miqAddNodeChildren(data.addNodes.activeTree,
                        data.addNodes.key,
                        data.addNodes.osf,
-                       data.addNodes.children);
+                       data.addNodes.nodes);
   }
 
 

--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -20,6 +20,9 @@ function miqOnCheckHandler(node) {
 
 function miqAddNodeChildren(treename, key, selected_node, children) {
   var node = miqTreeFindNodeByKey(treename, key);
+  if (node.lazyLoad) {
+    node.lazyLoad = false;
+  }
   miqTreeObject(treename).addNode(children, node);
   miqTreeActivateNodeSilently(treename, selected_node);
 }

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1344,7 +1344,7 @@ module VmCommon
          @record && # Showing a record
          !@in_a_form && # Not in a form
          x_active_tree.to_s !~ /_filter_tree$/ # Not in a filter tree; FIXME: create some property on trees for this
-        add_nodes = open_parent_nodes(@record) # Open the parent nodes of selected record, if not open
+        add_nodes = TreeBuilder.convert_bs_tree(open_parent_nodes(@record)).first # Open the parent nodes of selected record, if not open
       end
     end
 

--- a/app/presenters/explorer_presenter.rb
+++ b/app/presenters/explorer_presenter.rb
@@ -221,7 +221,7 @@ class ExplorerPresenter
       :activeTree => @options[:active_tree],
       :key        => @options[:add_nodes][:key],
       :osf        => @options[:osf_node],
-      :children   => @options[:add_nodes][:children],
+      :nodes      => @options[:add_nodes][:nodes],
       :remove     => !!@options[:remove_nodes],
     } if @options[:add_nodes]
 


### PR DESCRIPTION
When selecting an item on the right side, the loaded nodes are not converted from their old format and therefore not displayed:
![screenshot from 2016-09-15 14-48-03](https://cloud.githubusercontent.com/assets/649130/18550318/805ba9b4-7b53-11e6-8b76-19dae3709872.png)

Also when clicking on the parent node's expand button, the lazyLoad kicks in and loads the nodes properly, but with padding:
![screenshot from 2016-09-15 14-49-50](https://cloud.githubusercontent.com/assets/649130/18550390/e6a5fdf0-7b53-11e6-9eef-54d4092c03b7.png)

After applying this PR both issues are fixed:
![screenshot from 2016-09-15 14-56-43](https://cloud.githubusercontent.com/assets/649130/18550534/a597c0a4-7b54-11e6-8fd9-f69b79bf7b94.png)

