### PR TITLE
Comment out SubnetTopologyService from SubnetTopologyController

### DIFF
--- a/app/controllers/subnet_topology_controller.rb
+++ b/app/controllers/subnet_topology_controller.rb
@@ -1,4 +1,4 @@
 class SubnetTopologyController < TopologyController
   @layout = "subnet_topology"
-  @service_class = SubnetTopologyService
+  # @service_class = SubnetTopologyService
 end


### PR DESCRIPTION
The class `SubnetTopologyService` isn't defined anywhere and this line would cause parsing
error for gettext model attribute extraction task:

```
$ be rake locale:run_store_model_attributes
writing model translations to: manageiq/locale/model_attributes.rb
[Error] Attribute extraction failed. Removing incomplete file (locale/model_attributes.rb)
rake aborted!
NameError: uninitialized constant SubnetTopologyController::SubnetTopologyService
app/controllers/subnet_topology_controller.rb:3:in `<class:SubnetTopologyController>'
app/controllers/subnet_topology_controller.rb:1:in `<top (required)>'
lib/tasks/locale.rake:131:in `block (2 levels) in <top (required)>'
.rbenv/versions/2.3.1/bin/bundle:23:in `load'
.rbenv/versions/2.3.1/bin/bundle:23:in `<main>'
Tasks: TOP => gettext:store_model_attributes
(See full trace by running task with --trace)

```