### PR TITLE
Api for refreshing automate domain from git

### DIFF
--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -14,7 +14,7 @@ module Api
 
     def git_refresh_resource(type, id = nil, data = nil)
       api_action(type, id) do |klass|
-        unless MiqRegion.my_region.role_active?("git_owner")
+        unless GitBasedDomainImportService.available?
           return action_result(false, 'Please enable the git owner role in order to import git repositories')
         end
         domain = resource_search(id, type, klass)

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -201,7 +201,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
 
     if git_url.blank?
       add_flash(_("Please provide a valid git URL"), :error)
-    elsif !MiqRegion.my_region.role_active?("git_owner")
+    elsif !GitBasedDomainImportService.available?
       add_flash(_("Please enable the git owner role in order to import git repositories"), :error)
     else
       if GitRepository.exists?(:url => git_url)

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -675,7 +675,7 @@ class ApplicationHelper::ToolbarBuilder
       when "miq_ae_instance_copy", "miq_ae_method_copy"
         return false unless editable_domain?(@record)
       when "miq_ae_git_refresh"
-        return true unless git_enabled?(@record) && MiqRegion.my_region.role_active?("git_owner")
+        return true unless git_enabled?(@record) && GitBasedDomainImportService.available?
       else
         return true unless editable_domain?(@record)
       end

--- a/app/helpers/miq_ae_tools_helper.rb
+++ b/app/helpers/miq_ae_tools_helper.rb
@@ -1,6 +1,6 @@
 module MiqAeToolsHelper
   def git_import_button_enabled?
-    MiqRegion.my_region.role_active?("git_owner")
+    GitBasedDomainImportService.available?
   end
 
   def git_import_submit_help

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -17,4 +17,8 @@ class GitBasedDomainImportService
     domain = MiqAeDomain.import_git_repo(options)
     domain.update_attribute(:enabled, true)
   end
+
+  def self.available?
+    MiqRegion.my_region.role_active?("git_owner")
+  end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -52,7 +52,7 @@
     :options:
     - :arbitrary_resource_path
     - :collection
-    :verbs: *g
+    :verbs: *gp
     :klass: MiqAeDomain
     :collection_actions:
       :get:
@@ -62,6 +62,9 @@
       :get:
       - :name: read
         :identifier: miq_ae_domain_view
+      :post:
+      - :name: git_refresh
+        :identifier: miq_ae_git_refresh
   :automation_requests:
     :description: Automation Requests
     :options:

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -2,16 +2,16 @@
 # REST API Request Tests - /api/automate
 #
 describe "Automate API" do
-  before(:each) do
-    MiqAeDatastore.reset
-    FactoryGirl.create(:miq_ae_domain, :name => "ManageIQ", :tenant_id => @group.tenant.id)
-    FactoryGirl.create(:miq_ae_domain, :name => "Custom",   :tenant_id => @group.tenant.id)
-    system_class = FactoryGirl.create(:miq_ae_class, :name => "System", :namespace => "Custom")
-    FactoryGirl.create(:miq_ae_field, :name    => "on_entry", :class_id => system_class.id,
-                                      :aetype  => "state",    :datatype => "string")
-  end
-
   context "Automate Queries" do
+    before(:each) do
+      MiqAeDatastore.reset
+      FactoryGirl.create(:miq_ae_domain, :name => "ManageIQ", :tenant_id => @group.tenant.id)
+      FactoryGirl.create(:miq_ae_domain, :name => "Custom",   :tenant_id => @group.tenant.id)
+      system_class = FactoryGirl.create(:miq_ae_class, :name => "System", :namespace => "Custom")
+      FactoryGirl.create(:miq_ae_field, :name    => "on_entry", :class_id => system_class.id,
+                                        :aetype  => "state",    :datatype => "string")
+    end
+
     it "returns domains by default" do
       api_basic_authorize action_identifier(:automate, :read, :collection_actions, :get)
 

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -98,7 +98,7 @@ describe "Automate API" do
 
     it 'fails to refresh git when the region misses git_owner role' do
       api_basic_authorize action_identifier(:automate, :git_refresh)
-      expect(MiqRegion).to receive(:my_region).and_return(double(:role_active? => false))
+      expect(GitBasedDomainImportService).to receive(:available?).and_return(false)
 
       run_post(automate_url(git_domain.id), gen_request(:git_refresh))
       expect_single_action_result(:success => false,
@@ -108,7 +108,7 @@ describe "Automate API" do
     context 'with proper git_owner role' do
       let(:non_git_domain) { FactoryGirl.create(:miq_ae_domain) }
       before do
-        expect(MiqRegion).to receive(:my_region).and_return(double(:role_active? => true))
+        expect(GitBasedDomainImportService).to receive(:available?).and_return(true)
       end
 
       it 'fails to refresh when domain did not originate from git' do


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610125/stories/121850447

Previously
>As per discussion in #9517, we want to introduce API for git_repository actions only on top of existing API for automate. The problem is that we don't have API for automate yet.
>
>  WIP
> Publishing this pr early to get early comments.
> 
> My plans is to all CRUD actions for MiqAeDomain while on this. Also, the create action should creation from git_repository.

@miq-bot add_label api, enhancement, automate, darga/no, wip
@miq-bot assign @abellotti 