### PR TITLE
Add api client to process tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem "websocket-driver",               "~>0.6.3"
 
 # Modified gems (forked on Github)
 gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "https://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
+gem "manageiq-api-client",                         :require => false, :git => "https://github.com/ManageIQ/manageiq-api-client.git", :branch => "master"
 gem "query_relation",                              :require => false, :git => "https://github.com/ManageIQ/query_relation.git", :branch => "master"
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 gem "ziya",                           "=2.3.0",    :require => false, :git => "https://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1909,7 +1909,7 @@ module ApplicationController::CiProcessing
       objs, _objs_out_reg = filter_ids_in_region(objs, "Service")
       klass = Service
     when "VmOrTemplate"
-      objs, _objs_out_reg = filter_ids_in_region(objs, "VM") unless VmOrTemplate::POWER_OPS.include?(task)
+      objs, _objs_out_reg = filter_ids_in_region(objs, "VM") unless VmOrTemplate::REMOTE_REGION_TASKS.include?(task)
       klass = Vm
     end
 

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -86,8 +86,11 @@ module ProcessTasksMixin
       end
     end
 
-    # Best guess at how the classes map to API collections and how the tasks map to actions
-    # Override as needed
+    # Override as needed to handle differences between API actions and method names
+    def action_for_task(task)
+      task
+    end
+
     def invoke_api_tasks(api_client, remote_options)
       collection = Api.model_to_collection(name)
       unless collection
@@ -95,10 +98,11 @@ module ProcessTasksMixin
         raise NotImplementedError
       end
 
+      action = action_for_task(remote_options[:task])
       remote_options[:ids].each do |id|
         obj = api_client.send(collection).search(:filter => ["id=#{id}"]).first
-        _log.info("Invoking task #{remote_options[:task]} on collection #{collection} - object #{obj.id}")
-        # obj.send(task)
+        _log.info("Invoking task #{action} on collection #{collection} - object #{obj.id}")
+        # obj.send(action_for_task(action))
       end
     end
 

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -119,7 +119,7 @@ module ProcessTasksMixin
       hostname = MiqRegion.find_by_region(region).remote_ws_address
       if hostname.nil?
         $log.error("An error occurred while invoking remote tasks...The remote region [#{region}] does not have a web service address.")
-        return
+        raise "Failed to establish API connection to region #{region}"
       end
 
       ManageIQ::API::Client.new(

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -1,5 +1,3 @@
-require 'manageiq-api-client'
-
 module ProcessTasksMixin
   extend ActiveSupport::Concern
 
@@ -121,6 +119,8 @@ module ProcessTasksMixin
         $log.error("An error occurred while invoking remote tasks...The remote region [#{region}] does not have a web service address.")
         raise "Failed to establish API connection to region #{region}"
       end
+
+      require 'manageiq-api-client'
 
       ManageIQ::API::Client.new(
         :url      => "https://#{hostname}",

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -103,7 +103,7 @@ module ProcessTasksMixin
 
       if resource_ids.present?
         resource_ids.each do |id|
-          obj = collection.where(:id => id).first
+          obj = collection.find(id)
           _log.info("Invoking task #{action} on collection #{collection_name}, object #{obj.id}, with args #{post_args}")
           obj.send(action, post_args)
         end

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -89,7 +89,7 @@ module ProcessTasksMixin
     # Best guess at how the classes map to API collections and how the tasks map to actions
     # Override as needed
     def invoke_api_tasks(api_client, remote_options)
-      collection = base_class.table_name
+      collection = Api.model_to_collection(self.class)
 
       remote_options[:ids].each do |id|
         obj = api_client.send(collection).search(:filter => ["id=#{id}"]).first

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -128,6 +128,7 @@ module ProcessTasksMixin
         :ssl      => {:verify => false}
       )
     end
+    private :api_client_connection_for_region
 
     # default: invoked by task, can be overridden
     def task_invoked_by(_options)

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -98,15 +98,16 @@ module ProcessTasksMixin
         raise NotImplementedError
       end
 
-      collection = api_client.send(collection_name)
-      action     = action_for_task(remote_options[:task])
-      post_args  = remote_options[:args]
+      collection   = api_client.send(collection_name)
+      action       = action_for_task(remote_options[:task])
+      post_args    = remote_options[:args] || {}
+      resource_ids = remote_options[:ids]
 
-      if remote_options[:ids].present?
+      if resource_ids.present?
         resource_ids.each do |id|
-          obj = collection.search(:filter => ["id=#{id}"]).first
+          obj = collection.search(:first, :where => {:id => id})
           _log.info("Invoking task #{action} on collection #{collection_name}, object #{obj.id}, with args #{post_args}")
-          obj.send(action_for_task(action, post_args))
+          obj.send(action, post_args)
         end
       else
         _log.info("Invoking task #{action} on collection #{collection_name}, with args #{post_args}")

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -99,10 +99,17 @@ module ProcessTasksMixin
       end
 
       action = action_for_task(remote_options[:task])
-      remote_options[:ids].each do |id|
-        obj = api_client.send(collection).search(:filter => ["id=#{id}"]).first
-        _log.info("Invoking task #{action} on collection #{collection} - object #{obj.id}")
-        # obj.send(action_for_task(action))
+      post_args = remote_options[:args]
+
+      if remote_options[:ids].present?
+        resource_ids.each do |id|
+          obj = api_client.send(collection).search(:filter => ["id=#{id}"]).first
+          _log.info("Invoking task #{action} on collection #{collection}, object #{obj.id}, with args #{post_args}")
+          # obj.send(action_for_task(action, post_args))
+        end
+      else
+        _log.info("Invoking task #{action} on collection #{collection}, with args #{post_args}")
+        # api_client.send(collection).send(action, post_args)
       end
     end
 

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -92,24 +92,25 @@ module ProcessTasksMixin
     end
 
     def invoke_api_tasks(api_client, remote_options)
-      collection = Api.model_to_collection(name)
-      unless collection
+      collection_name = Api.model_to_collection(name)
+      unless collection_name
         _log.error("No API entpoint found for class #{name}")
         raise NotImplementedError
       end
 
-      action = action_for_task(remote_options[:task])
-      post_args = remote_options[:args]
+      collection = api_client.send(collection_name)
+      action     = action_for_task(remote_options[:task])
+      post_args  = remote_options[:args]
 
       if remote_options[:ids].present?
         resource_ids.each do |id|
-          obj = api_client.send(collection).search(:filter => ["id=#{id}"]).first
-          _log.info("Invoking task #{action} on collection #{collection}, object #{obj.id}, with args #{post_args}")
-          # obj.send(action_for_task(action, post_args))
+          obj = collection.search(:filter => ["id=#{id}"]).first
+          _log.info("Invoking task #{action} on collection #{collection_name}, object #{obj.id}, with args #{post_args}")
+          obj.send(action_for_task(action, post_args))
         end
       else
-        _log.info("Invoking task #{action} on collection #{collection}, with args #{post_args}")
-        # api_client.send(collection).send(action, post_args)
+        _log.info("Invoking task #{action} on collection #{collection_name}, with args #{post_args}")
+        collection.send(action, post_args)
       end
     end
 

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -92,7 +92,7 @@ module ProcessTasksMixin
     end
 
     def invoke_api_tasks(api_client, remote_options)
-      collection_name = Api.model_to_collection(name)
+      collection_name = Api::CollectionConfig.new.name_for_klass(self)
       unless collection_name
         _log.error("No API entpoint found for class #{name}")
         raise NotImplementedError

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -105,7 +105,7 @@ module ProcessTasksMixin
 
       if resource_ids.present?
         resource_ids.each do |id|
-          obj = collection.search(:first, :where => {:id => id})
+          obj = collection.where(:id => id).first
           _log.info("Invoking task #{action} on collection #{collection_name}, object #{obj.id}, with args #{post_args}")
           obj.send(action, post_args)
         end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -52,6 +52,7 @@ class VmOrTemplate < ApplicationRecord
   }
 
   POWER_OPS = %w(start stop suspend reset shutdown_guest standby_guest reboot_guest)
+  REMOTE_REGION_TASKS = POWER_OPS + %w(retire_now)
 
   validates_presence_of     :name, :location
   validates                 :vendor, :inclusion => {:in => VENDOR_TYPES.keys}
@@ -467,6 +468,15 @@ class VmOrTemplate < ApplicationRecord
       :role         => role,
       :expires_on   => POWER_OPS.include?(options[:task]) ? powerops_expiration : nil
     )
+  end
+
+  def self.action_for_task(task)
+    case task
+    when "retire_now"
+      "retire"
+    else
+      task
+    end
   end
 
   def scan_data_current?

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -90,6 +90,8 @@ describe ProcessTasksMixin do
       end
 
       it "calls invoke_api_tasks with the api connection and options" do
+        require "manageiq-api-client"
+
         expect(MiqRegion).to receive(:api_system_auth_token_for_region)
           .with(ApplicationRecord.my_region_number, request_user).and_return(region_auth_token)
 

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -129,11 +129,11 @@ describe ProcessTasksMixin do
     it "requeues if the server does not have an address" do
       test_class.invoke_tasks_remote(test_options)
 
-      message = MiqQueue.first
-
-      expect(message.class_name).to eq(test_class.name)
-      expect(message.method_name).to eq("invoke_tasks_remote")
-      expect(message.args).to eq([test_options])
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => test_class.name,
+        :method_name => "invoke_tasks_remote",
+        :args        => [test_options]
+      )
     end
   end
 
@@ -144,8 +144,8 @@ describe ProcessTasksMixin do
 
     context "with a valid class name" do
       let(:collection_name) { :test_class_collection }
-      let(:api_connection)    { double("ManageIQ::API::Client connection") }
-      let(:api_collection)    { double("ManageIQ::API::Client collection") }
+      let(:api_connection)  { double("ManageIQ::API::Client connection") }
+      let(:api_collection)  { double("ManageIQ::API::Client collection") }
 
       before do
         api_config = double("Api::CollectionConfig")

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -180,8 +180,8 @@ describe ProcessTasksMixin do
         let(:resource1)     { double("resource1", :id => 1) }
 
         before do
-          expect(api_collection).to receive(:where).with(:id => 0).and_return([resource0])
-          expect(api_collection).to receive(:where).with(:id => 1).and_return([resource1])
+          expect(api_collection).to receive(:find).with(0).and_return(resource0)
+          expect(api_collection).to receive(:find).with(1).and_return(resource1)
         end
 
         it "executes the task on each resource" do

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -146,7 +146,9 @@ describe ProcessTasksMixin do
       let(:api_collection)    { double("ManageIQ::API::Client collection") }
 
       before do
-        expect(Api).to receive(:model_to_collection).and_return(collection_name)
+        api_config = double("Api::CollectionConfig")
+        expect(Api::CollectionConfig).to receive(:new).and_return(api_config)
+        expect(api_config).to receive(:name_for_klass).and_return(collection_name)
         expect(api_connection).to receive(collection_name).and_return(api_collection)
       end
 


### PR DESCRIPTION
This PR adds the [manageiq-api-client gem](https://github.com/ManageIQ/manageiq-api-client) to the application and makes use of it to execute API requests for changes requested of a remote region from a global region.

This is implemented in the `ProcessTasksMixin` which already has logic for splitting tasks by local/remote regions.

This mixin is currently in use by `VmOrTemplate` and we intend to expand that use to any model that wants it's requests to be routed to remote regions via the REST API.

@miq-bot add_label wip, core, enhancement, darga/no
/cc @bdunne @abellotti @gtanzillo 

https://www.pivotaltracker.com/epic/show/2561187