### PR TITLE
Fixed tertiary pin icon in the vertical navigation

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -568,7 +568,7 @@ body#dashboard {
 
 /* end toolbar styling */
 
-.secondary-collapse-toggle-pf {
+.secondary-collapse-toggle-pf, .tertiary-collapse-toggle-pf {
   &:before {
     content: '\f08d';
   }


### PR DESCRIPTION
**Before:**
![screenshot from 2016-09-15 15-50-51](https://cloud.githubusercontent.com/assets/649130/18552327/3ad7786a-7b5c-11e6-88fa-9540afdd2f5f.png)

**After:**
![screenshot from 2016-09-15 15-49-37](https://cloud.githubusercontent.com/assets/649130/18552334/3fd0d1e0-7b5c-11e6-9204-de7b62c7c20b.png)
