### PR TITLE
Fix minor typo in spec

### DIFF
--- a/spec/models/arbitration_setting_spec.rb
+++ b/spec/models/arbitration_setting_spec.rb
@@ -9,7 +9,7 @@ describe ArbitrationSetting do
 
       context 'seeding again' do
         it 'should not create new records' do
-          expect { ArbitrationSetting.count }.not_to change(ArbitrationSetting, :count)
+          expect { ArbitrationSetting.seed }.not_to change(ArbitrationSetting, :count)
         end
       end
     end


### PR DESCRIPTION
Fix minor typo in spec. It renders this specific test ineffective.

@miq-bot add_label test, bug, darga/no
