### PR TITLE
Update openSCAP results styling

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -242,7 +242,6 @@ table .label {
   min-width: 200px;
   font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;
   cursor: default;
-  color: #333;
   text-align: left;
   white-space: normal
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -903,6 +903,10 @@ class ApplicationController < ActionController::Base
           celltext = Dictionary.gettext(row[col], :type => :model, :notfound => :titleize)
         when 'approval_state'
           celltext = _(PROV_STATES[row[col]])
+        when "result"
+          new_row[:cells] << {:span => result_span_class(row[col]), :text => row[col].titleize}
+        when "severity"
+          new_row[:cells] << {:span => severity_span_class(row[col]), :text => row[col].titleize}
         when 'state'
           celltext = row[col].titleize
         when 'hardware.bitness'
@@ -915,7 +919,7 @@ class ApplicationController < ActionController::Base
           celltext = format_col_for_display(view, row, col, celltz || tz)
         end
 
-        new_row[:cells] << {:text => celltext}
+        new_row[:cells] << {:text => celltext} if celltext
       end
 
       if @row_button # Show a button in the last col
@@ -927,6 +931,28 @@ class ApplicationController < ActionController::Base
     end
 
     root
+  end
+
+  def result_span_class(value)
+    case value.downcase
+    when "pass"
+      "label label-success"
+    when "fail"
+      "label label-danger"
+    else
+      "label label-primary"
+    end
+  end
+
+  def severity_span_class(value)
+    case value.downcase
+    when "high"
+      "label label-danger"
+    when "medium"
+      "label label-warning"
+    else
+      "label label-primary"
+    end
   end
 
   def calculate_pct_img(val)

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -72,6 +72,9 @@
                                       :title   => cell[:title],
                                       :alt     => cell[:title]}
                 = cell[:text]
+            - elsif cell[:span]
+              %span{:class => "#{cell[:span]}"}
+                = cell[:text]
             - else
               - if cell[:icon]
                 %i{:class => cell[:icon], :title => cell[:title]}


### PR DESCRIPTION
Update OpenSCAP results styling using Patternfly Label to display severity level and pass/fail status.

https://www.pivotaltracker.com/n/projects/1613907/stories/130217447
https://bugzilla.redhat.com/show_bug.cgi?id=1342787

Old
![screen shot 2016-09-15 at 10 06 42 am](https://cloud.githubusercontent.com/assets/1287144/18553220/a8c91b64-7b2d-11e6-8d88-fce48cfba783.png)

New
![screen shot 2016-09-15 at 10 05 01 am](https://cloud.githubusercontent.com/assets/1287144/18553221/a8d99142-7b2d-11e6-8470-f9fed916496c.png)