### PR TITLE
Display notifications in the drawer using the API

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1684,3 +1684,11 @@ function miqUncompressedId(id) {
 }
 
 function queryParam(name) { return QS(window.location.href).get(name); }
+
+function miqFormatNotification(text, bindings) {
+  var str = __(text);
+  _.each(bindings, function (value, key) {
+    str = str.replace(new RegExp('%{' + key + '}', 'g'), value.text);
+  });
+  return str;
+}

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -450,4 +450,25 @@ describe('miq_application.js', function() {
       expect(miqUncompressedId('999r123456789012')).toEqual('999123456789012');
     });
   });
+
+  describe('miqFormatNotification', function () {
+    context('single placeholder', function () {
+      it('replaces placeholders with bindings', function () {
+        expect(miqFormatNotification('¯\_%{dude}_/¯', {dude: { text: '(ツ)' }})).toEqual('¯\_(ツ)_/¯');
+      });
+    });
+
+    context('multiple placeholders', function () {
+      it('replaces placeholders with bindings', function () {
+        expect(miqFormatNotification('%{dude}︵ %{table}', {dude: { text: '(╯°□°）╯' }, table: {text: '┻━┻'}})).toEqual('(╯°□°）╯︵ ┻━┻');
+      });
+    });
+
+    context('same placeholder multiple times', function () {
+      it('replaces placeholders with bindings', function () {
+        expect(miqFormatNotification('( %{eye}▽%{eye})/', {eye: { text: 'ﾟ' }})).toEqual('( ﾟ▽ﾟ)/');
+      });
+    });
+  });
 });
+


### PR DESCRIPTION
Continuing the work on #10955 by consuming #10696 and #11268:
* [x] Fetching notifications 
* [x] Marking a notification as read
* [x] Mark all notifications as read
* [x] Remove a notification
* [x] Remove all notifications

![screenshot from 2016-09-15 16-26-28](https://cloud.githubusercontent.com/assets/649130/18553563/30b1fc20-7b61-11e6-81c8-eb1274489d5e.png)

Creating a notification from the `rails console`:
```ruby
Notification.create(:type => :vm_powered_on, :subject => Vm.first)
```