### PR TITLE
Flag for allowing cloud tenant mapping feature for provider

### DIFF
--- a/db/migrate/20160915160023_add_tenant_mapping_enabled_to_ext_management_systems.rb
+++ b/db/migrate/20160915160023_add_tenant_mapping_enabled_to_ext_management_systems.rb
@@ -1,0 +1,5 @@
+class AddTenantMappingEnabledToExtManagementSystems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ext_management_systems, :tenant_mapping_enabled, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -1226,6 +1226,7 @@ ext_management_systems:
 - last_metrics_error
 - last_metrics_update_date
 - last_metrics_success_date
+- tenant_mapping_enabled
 file_depots:
 - id
 - name


### PR DESCRIPTION
- flag will be used for enabling/disabling syncing CloudTenants
   with Tenants in Miq
- at this moment especially for OpenStack CloudManager


@miq-bot assign @gtanzillo 