### PR TITLE
Disable the Cloud Key Pair create button when no providers support that action

### DIFF
--- a/app/helpers/application_helper/button/auth_key_pair_cloud_create.rb
+++ b/app/helpers/application_helper/button/auth_key_pair_cloud_create.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Button::AuthKeyPairCloudCreate < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No cloud providers support key pair import or creation.")
+    end
+  end
+
+  def disabled?
+    # check that at least one EMS the user has access to supports
+    # creation or import of key pairs.
+    Rbac.filtered(ManageIQ::Providers::CloudManager.all).each do |ems|
+      if ems.class::AuthKeyPair.is_available?(:create_key_pair, ems)
+        return false
+      end
+    end
+    return true
+  end
+end

--- a/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb
@@ -30,7 +30,8 @@ class ApplicationHelper::Toolbar::AuthKeyPairCloudsCenter < ApplicationHelper::T
           :auth_key_pair_cloud_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Key Pair'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::AuthKeyPairCloudCreate),
         separator,
         button(
           :auth_key_pair_cloud_delete,

--- a/spec/helpers/application_helper/buttons/auth_key_pair_cloud_create_spec.rb
+++ b/spec/helpers/application_helper/buttons/auth_key_pair_cloud_create_spec.rb
@@ -1,0 +1,43 @@
+describe ApplicationHelper::Button::AuthKeyPairCloudCreate do
+  describe '#disabled?' do
+    it "when the create action is available then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      ems = object_double(ManageIQ::Providers::CloudManager.new, :class => ManageIQ::Providers::Openstack::CloudManager)
+      allow(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair).to receive(:is_available?).and_return(true)
+      allow(Rbac).to receive(:filtered).and_return([ems])
+      expect(button.disabled?).to be false
+    end
+
+    it "when the create action is unavailable then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      ems = object_double(ManageIQ::Providers::CloudManager.new, :class => ManageIQ::Providers::Openstack::CloudManager)
+      allow(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair).to receive(:is_available?).and_return(false)
+      allow(Rbac).to receive(:filtered).and_return([ems])
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when the create action is unavailable the button has the error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      ems = object_double(ManageIQ::Providers::CloudManager.new, :class => ManageIQ::Providers::Openstack::CloudManager)
+      allow(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair).to receive(:is_available?).and_return(false)
+      allow(Rbac).to receive(:filtered).and_return([ems])
+      button.calculate_properties
+      expect(button[:title]).to eq("No cloud providers support key pair import or creation.")
+    end
+
+    it "when the create action is available, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      ems = object_double(ManageIQ::Providers::CloudManager.new, :class => ManageIQ::Providers::Openstack::CloudManager)
+      allow(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair).to receive(:is_available?).and_return(true)
+      allow(Rbac).to receive(:filtered).and_return([ems])
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
If none of the configured cloud providers support importing or creating key pairs, then that button on the toolbar should be disabled instead of allowing a click through to a form that can't be filled out.

Fixes the immediate concern discussed in https://github.com/ManageIQ/manageiq/issues/11240