### PR TITLE
update routes call

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2833,7 +2833,7 @@ Vmdb::Application.routes.draw do
     end
 
     Api::Settings.collections.each do |collection_name, collection|
-      controller collection_name, :path => collection_name do
+      controller collection_name do
         collection.verbs.each do |verb|
           root :action => API_ACTIONS[verb], :via => verb if collection.options.include?(:primary)
 


### PR DESCRIPTION
When running `reload!` from `rails/console`, a warning is displayed a few dozen times:

```
DEPRECATION WARNING: #controller with options is deprecated.
If you need to pass more options than the controller name use #scope.
(called from block (3 levels) in <top (required)> at config/routes.rb:2836)
```

This solves it.
(But may not be the right solution)

/cc @jrafanie @Fryguy @martinpovolny 