### PR TITLE
Save Authentication status on a Save

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -455,38 +455,18 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       .then(function success(data) {
         $scope.$apply(function() {
           if(data.level == "error") {
-            if ($scope.authType === "default") {
-              $scope.emsCommonModel.default_auth_status = false;
-            } else if ($scope.authType === "amqp") {
-              $scope.emsCommonModel.amqp_auth_status = false;
-            } else if ($scope.authType === "service_account") {
-              $scope.emsCommonModel.service_account_auth_status = false;
-            } else if ($scope.authType === "metrics") {
-              $scope.emsCommonModel.metrics_auth_status = false;
-            } else if ($scope.authType === "ssh_keypair") {
-              $scope.emsCommonModel.ssh_keypair_auth_status = false;
-            } else if ($scope.authType === "hawkular") {
-              $scope.emsCommonModel.hawkular_auth_status = false;
-            }
+            $scope.updateAuthStatus(false);
           } else {
-            if ($scope.authType === "default") {
-              $scope.emsCommonModel.default_auth_status = true;
-            } else if ($scope.authType === "amqp") {
-              $scope.emsCommonModel.amqp_auth_status = true;
-            } else if ($scope.authType === "service_account") {
-              $scope.emsCommonModel.service_account_auth_status = true;
-            } else if ($scope.authType === "metrics") {
-              $scope.emsCommonModel.metrics_auth_status = true;
-            } else if ($scope.authType === "ssh_keypair") {
-              $scope.emsCommonModel.ssh_keypair_auth_status = true;
-            } else if ($scope.authType === "hawkular") {
-              $scope.emsCommonModel.hawkular_auth_status = true;
-            }
+            $scope.updateAuthStatus(true);
           }
           miqService.miqFlash(data.level, data.message);
           miqSparkleOff();
         });
       });
+  };
+
+  $scope.updateAuthStatus = function(updatedValue) {
+    $scope.angularForm[$scope.authType + '_auth_status'].$setViewValue(updatedValue);
   };
 
   $scope.radioSelectionChanged = function() {

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -42,6 +42,8 @@ module Mixins
                  :name  => update_ems.name}
         construct_edit_for_audit(update_ems)
         AuditEvent.success(build_saved_audit(update_ems, @edit))
+        update_ems.authentication_check_types_queue(update_ems.authentication_for_summary.pluck(:authtype),
+                                                    :save => true)
         ems_path = ems_path(update_ems, :flash_msg => flash)
         javascript_redirect ems_path
       else


### PR DESCRIPTION
If there is a "Validation Required" status being displayed in the Edit Provider form, it indicates that the Authentication status went from Valid to Invalid since the last time the Provider record was saved. At this point, the user has the option to reinstate the Authentication Status of the Provider in question either by -- 
(a) clicking the `Re-check Authentication Status` button or 
(b) by revalidating the credentials in the Edit Provider form and saving the form.

Option (b) was not quite working as expected and has been fixed in this PR.

https://bugzilla.redhat.com/show_bug.cgi?id=1374865

