### PR TITLE
bin/setup and bin/update: Use as much from the rails template

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -55,13 +55,13 @@ chdir APP_ROOT do
     # it invokes the db:setup rake task which creates the db from the
     # schema (and seeds it), but doesn't run through migrations.
     puts "\n== Preparing database =="
-    system! "bin/rake db:create"
+    system! "bin/rails db:create"
 
     puts "\n== Migrating database =="
-    system! "bin/rake db:migrate"
+    system! "bin/rails db:migrate"
 
     puts "\n== Seeding database =="
-    system! "bin/rake db:seed GOOD_MIGRATIONS=skip"
+    system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
   end
 
   puts "\n== Removing old logs and tempfiles =="
@@ -69,7 +69,7 @@ chdir APP_ROOT do
 
   if options[:do_tests]
     puts "\n== Preparing tests =="
-    system! "bin/rake test:vmdb:setup"
+    system! "bin/rails test:vmdb:setup"
   end
   bower_thread.join
   puts "Done running `bower update`."

--- a/bin/setup
+++ b/bin/setup
@@ -1,16 +1,8 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'optparse'
-require 'English'
-
-def execute(cmd)
-  system(cmd)
-  result = $CHILD_STATUS
-  unless result.success?
-    puts "ERROR: Command failed: #{cmd}"
-    exit result.exitstatus
-  end
-end
+require 'fileutils'
+include FileUtils
 
 options = {:do_tests => true, :do_db => true}
 OptionParser.new do |opts|
@@ -30,46 +22,51 @@ end.parse!
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
-Dir.chdir APP_ROOT do
-  puts "== Installing dependencies =="
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
 
+chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file.
+
+  puts '== Installing dependencies =='
   # Run bower in a thread and continue to do the non-js stuff
   puts "Updating bower assets in parallel..."
   bower_thread = Thread.new do
-    execute "bower install --allow-root -F --silent --config.analytics=false"
+    system! "bower install --allow-root -F --silent --config.analytics=false"
   end
-
-  execute "gem install bundler --conservative"
-  execute "bundle check || bundle install"
+  system! 'gem install bundler --conservative'
+  system('bundle check') || system!('bundle install')
 
   puts "\n== Copying sample files =="
   unless File.exist?("config/database.yml")
-    execute "cp config/database.pg.yml config/database.yml"
+    system! "cp config/database.pg.yml config/database.yml"
   end
   unless File.exist?("config/cable.yml")
-    execute "cp config/cable.yml.sample config/cable.yml"
+    system! "cp config/cable.yml.sample config/cable.yml"
   end
   unless File.exist?("certs/v2_key")
-    execute "cp certs/v2_key.dev certs/v2_key"
+    system! "cp certs/v2_key.dev certs/v2_key"
   end
 
   if options[:do_db]
     puts "\n== Preparing database =="
-    execute "bin/rake db:create"
+    system! "bin/rake db:create"
 
     puts "\n== Migrating database =="
-    execute "bin/rake db:migrate"
+    system! "bin/rake db:migrate"
 
     puts "\n== Seeding database =="
-    execute "bin/rake db:seed GOOD_MIGRATIONS=skip"
+    system! "bin/rake db:seed GOOD_MIGRATIONS=skip"
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  execute 'bin/rails log:clear tmp:clear'
+  system! 'bin/rails log:clear tmp:clear'
 
   if options[:do_tests]
     puts "\n== Preparing tests =="
-    execute "bin/rake test:vmdb:setup"
+    system! "bin/rake test:vmdb:setup"
   end
   bower_thread.join
   puts "Done running `bower update`."

--- a/bin/setup
+++ b/bin/setup
@@ -64,13 +64,14 @@ chdir APP_ROOT do
     system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
   end
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
-
   if options[:do_tests]
     puts "\n== Preparing tests =="
     system! "bin/rails test:vmdb:setup"
   end
+
   bower_thread.join
   puts "Done running `bower update`."
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! 'bin/rails log:clear tmp:clear'
 end

--- a/bin/setup
+++ b/bin/setup
@@ -51,6 +51,9 @@ chdir APP_ROOT do
   end
 
   if options[:do_db]
+    # Note, we deviate from the default rails db:setup here because
+    # it invokes the db:setup rake task which creates the db from the
+    # schema (and seeds it), but doesn't run through migrations.
     puts "\n== Preparing database =="
     system! "bin/rake db:create"
 

--- a/bin/update
+++ b/bin/update
@@ -50,4 +50,7 @@ chdir APP_ROOT do
     puts "\n== Recompiling assets =="
     system! "bin/rake evm:compile_assets"
   end
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! 'bin/rake log:clear tmp:clear'
 end

--- a/bin/update
+++ b/bin/update
@@ -1,42 +1,40 @@
 #!/usr/bin/env ruby
 require 'pathname'
-require 'English'
+require 'fileutils'
+include FileUtils
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
-def execute(cmd)
-  system(cmd)
-  result = $CHILD_STATUS
-  unless result.success?
-    puts "ERROR: Command failed: #{cmd}"
-    exit result.exitstatus
-  end
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-Dir.chdir APP_ROOT do
-  puts "== Installing dependencies =="
+chdir APP_ROOT do
+  # This script is a way to update your development environment automatically.
+  # Add necessary update steps to this file.
 
+  puts '== Installing dependencies =='
   # Run bower in a thread and continue to do the non-js stuff
   puts "Updating bower assets in parallel..."
   bower_thread = Thread.new do
-    execute "bower update --allow-root -F --silent --config.analytics=false"
+    system! "bower update --allow-root -F --silent --config.analytics=false"
   end
+  system! 'gem install bundler --conservative'
+  system! 'bundle update'
 
-  execute "bundle update"
-
-  puts "\n== Migrating database =="
-  execute "bin/rake db:migrate"
+  puts "\n== Updating database =="
+  system! 'bin/rake db:migrate'
 
   puts "\n== Seeding database =="
-  execute "bin/rake db:seed GOOD_MIGRATIONS=skip"
+  system! "bin/rake db:seed GOOD_MIGRATIONS=skip"
 
   puts "\n== Resetting tests =="
-  execute "bin/rake test:vmdb:setup"
+  system! "bin/rake test:vmdb:setup"
 
   unless ENV["SKIP_AUTOMATE_RESET"]
     puts "\n== Resetting Automate Domains =="
-    execute "bin/rake evm:automate:reset"
+    system! "bin/rake evm:automate:reset"
   end
 
   # Make sure bower is done before compiling assets
@@ -45,6 +43,6 @@ Dir.chdir APP_ROOT do
 
   if ENV['RAILS_ENV'] == 'production'
     puts "\n== Recompiling assets =="
-    execute "bin/rake evm:compile_assets"
+    system! "bin/rake evm:compile_assets"
   end
 end

--- a/bin/update
+++ b/bin/update
@@ -29,17 +29,17 @@ chdir APP_ROOT do
   system! 'bundle update'
 
   puts "\n== Updating database =="
-  system! 'bin/rake db:migrate'
+  system! 'bin/rails db:migrate'
 
   puts "\n== Seeding database =="
-  system! "bin/rake db:seed GOOD_MIGRATIONS=skip"
+  system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
 
   puts "\n== Resetting tests =="
-  system! "bin/rake test:vmdb:setup"
+  system! "bin/rails test:vmdb:setup"
 
   unless ENV["SKIP_AUTOMATE_RESET"]
     puts "\n== Resetting Automate Domains =="
-    system! "bin/rake evm:automate:reset"
+    system! "bin/rails evm:automate:reset"
   end
 
   # Make sure bower is done before compiling assets
@@ -48,9 +48,9 @@ chdir APP_ROOT do
 
   if ENV['RAILS_ENV'] == 'production'
     puts "\n== Recompiling assets =="
-    system! "bin/rake evm:compile_assets"
+    system! "bin/rails evm:compile_assets"
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rake log:clear tmp:clear'
+  system! 'bin/rails log:clear tmp:clear'
 end

--- a/bin/update
+++ b/bin/update
@@ -21,6 +21,11 @@ chdir APP_ROOT do
     system! "bower update --allow-root -F --silent --config.analytics=false"
   end
   system! 'gem install bundler --conservative'
+
+  # TODO: This unlocks your dependencies and installs all updates.
+  # From: https://github.com/ManageIQ/manageiq/pull/11137
+  # It should be system('bundle check') || system!('bundle install').
+  # If we need a "reset all the things" script, we should call it bin/reset.
   system! 'bundle update'
 
   puts "\n== Updating database =="


### PR DESCRIPTION
### Synopsis:

Our bin/setup and bin/rails were added before rails 5.  Subsequently, the rails bin/setup and bin/update templates have changed so we should try to move back to how rails does it.

* use `system!` from the rails version and remove our very similar `execute` method
* rails command now wraps rake tasks, so convert `bin/rake` to `bin/rails`
* Clear the logs and cache after running all the things.

The 5.0.0.1 template for [bin/update is here](https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/generators/rails/app/templates/bin/update) and [bin/setup is here](https://github.com/rails/rails/blob/v5.0.0.1/railties/lib/rails/generators/rails/app/templates/bin/setup)
