### PR TITLE
Virtual delegation subquery fix

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -279,7 +279,7 @@ module VirtualDelegates
   #   which produces the sql:
   #
   #     #select to_model[col] from to_model where to_model[to_model_col_name] = src_model_table[:src_model_id]
-  #     (SELECT "vms_ss"."name" FROM "vms" AS "vms_ss" WHERE "vms_ss"."id" = "vms"."src_template_id")
+  #     (SELECT "vms_sub"."name" FROM "vms" AS "vms_ss" WHERE "vms_ss"."id" = "vms"."src_template_id")
   #
 
   def self.select_from_alias(to_ref, col, to_model_col_name, src_model_id)
@@ -288,9 +288,9 @@ module VirtualDelegates
     # if a self join, alias the second table to a different name
     if to_table.table_name == src_model_id.relation.table_name
       # use a dup to not modify the primary table in the model
-      to_table = to_model.arel_table.dup
+      to_table = to_table.dup
       # use a table alias to not conflict with table name in the primary query
-      to_table.table_alias = "#{to_model.table_name}_ss"
+      to_table.table_alias = "#{to_table.table_name}_sub"
     end
     # to_table will give the table name (alias) when creating the fully qualified to_model_id string
     to_model_id = to_model.arel_attribute(to_model_col_name, to_table)

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -39,9 +39,9 @@ shared_examples "miq ownership" do
       it "usable as arel" do
         group_name = user.current_group.description.downcase
         sql        = <<-SQL.strip_heredoc.split("\n").join(' ')
-                       LOWER((SELECT "miq_groups_ss"."description"
-                       FROM "miq_groups" "miq_groups_ss"
-                       WHERE "miq_groups_ss"."id" = "#{described_class.table_name}"."miq_group_id")) = '#{group_name}'
+                       LOWER((SELECT "miq_groups"."description"
+                       FROM "miq_groups"
+                       WHERE "miq_groups"."id" = "#{described_class.table_name}"."miq_group_id")) = '#{group_name}'
                      SQL
         attribute  = described_class.arel_attribute(:owned_by_current_ldap_group)
         expect(stringify_arel(attribute)).to eq ["(#{sql})"]
@@ -151,9 +151,9 @@ shared_examples "miq ownership" do
       it "usable as arel" do
         userid = user.userid.downcase
         sql        = <<-SQL.strip_heredoc.split("\n").join(' ')
-                       LOWER((SELECT "users_ss"."userid"
-                       FROM "users" "users_ss"
-                       WHERE "users_ss"."id" = "#{described_class.table_name}"."evm_owner_id")) = '#{userid}'
+                       LOWER((SELECT "users"."userid"
+                       FROM "users"
+                       WHERE "users"."id" = "#{described_class.table_name}"."evm_owner_id")) = '#{userid}'
                      SQL
         attribute  = described_class.arel_attribute(:owned_by_current_user)
         expect(stringify_arel(attribute)).to eq ["(#{sql})"]


### PR DESCRIPTION
Virtual attributes form subqueries to bring back attributes.
If the subquery is a self join, an alias is assigned to the sub query.

**1. Only produce an alias for self joins** (vs all queries)

It was intended to only add a table alias when the sub query was for the same table.
Unfortunately, the comparison logic was faulty and we were generating a special alias for all queries. This is not the end of the world, but, it is best to produce the expected sql.

```diff
-if to_model.table_name == to_ref.table_name
+if to_table.table_name == src_model_id.relation.table_name
```

**2. Use `_sub` for the sub select** (vs `_ss`)

A few people asked me what `ss` stood for. `sub` seemed to make more sense.

**3. Remove duplicate parameters**

Less fields were used. A majority of the changes in this PR remove parameters that were not used and were duplicates. All of them were basically representing the `to` table.

**details:**

```ruby
VmOrTemplate.select(:id, VmOrTemplate.arel_attribute(:host_name).as("host_name")).to_a
```

before
------

```sql
SELECT "vms"."id",
       (SELECT "hosts_ss"."name"
        FROM "hosts" AS "hosts_sss"
        WHERE "hosts_ss"."id" = "vms"."host_id"
       ) AS host_name
FROM "vms"
```

after
-----

```sql
SELECT "vms"."id",
       (SELECT "hosts"."name"
        FROM "hosts"
        WHERE "hosts"."id" = "vms"."host_id"
       ) AS host_name
FROM "vms"
```
