### PR TITLE
Remove cfme repos from MiqDatabase model

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -32,11 +32,23 @@ class MiqDatabase < ApplicationRecord
   end
 
   def self.registration_default_value_for_update_repo_name
-    "cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms"
+    names = Settings.product.default_update_repo_names
+    return names.join(" ") if names
   end
 
   def update_repo_names
-    update_repo_name.split
+    Settings.product.update_repo_names
+  end
+
+  def update_repo_name
+    names = Settings.product.update_repo_names
+    return names.join(" ") if names
+  end
+
+  def update_repo_name=(repos)
+    return unless repos
+    hash = {:product => {:update_repo_names => repos.split}}
+    Vmdb::Settings.save!(MiqRegion.my_region, hash)
   end
 
   def self.seed

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -47,6 +47,7 @@ class MiqDatabase < ApplicationRecord
     return unless repos
     hash = {:product => {:update_repo_names => repos.split}}
     Vmdb::Settings.save!(MiqRegion.my_region, hash)
+    Settings.reload!
   end
 
   def self.seed

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -32,17 +32,15 @@ class MiqDatabase < ApplicationRecord
   end
 
   def self.registration_default_value_for_update_repo_name
-    names = Settings.product.default_update_repo_names
-    return names.join(" ") if names
+    Vmdb::Settings.template_settings.product.update_repo_names.to_a.join(" ")
   end
 
   def update_repo_names
-    Settings.product.update_repo_names
+    Settings.product.update_repo_names.to_a
   end
 
   def update_repo_name
-    names = Settings.product.update_repo_names
-    return names.join(" ") if names
+    update_repo_names.join(" ")
   end
 
   def update_repo_name=(repos)

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -14,7 +14,7 @@ class MiqDatabase < ApplicationRecord
   encrypt_column  :csrf_secret_token
   encrypt_column  :session_secret_token
 
-  validates_presence_of :session_secret_token, :csrf_secret_token, :update_repo_name
+  validates_presence_of :session_secret_token, :csrf_secret_token
 
   default_values REGISTRATION_DEFAULT_VALUES
 

--- a/db/migrate/20160913195129_move_repo_data_from_database_to_settings.rb
+++ b/db/migrate/20160913195129_move_repo_data_from_database_to_settings.rb
@@ -1,0 +1,43 @@
+class MoveRepoDataFromDatabaseToSettings < ActiveRecord::Migration[5.0]
+  class MiqRegion < ActiveRecord::Base; end
+  class MiqDatabase < ActiveRecord::Base; end
+  class SettingsChange < ActiveRecord::Base
+    serialize :value
+  end
+
+  SETTING_KEY = "/product/update_repo_names".freeze
+
+  def up
+    db = MiqDatabase.first
+    return unless db && my_region
+
+    say_with_time("Moving repo information from miq_databases to Settings") do
+      repos = db.update_repo_name.split
+      SettingsChange.create!(settings_hash.merge(:value => repos))
+    end
+  end
+
+  def down
+    return unless my_region
+    change = SettingsChange.where(settings_hash).first
+    return unless change
+
+    say_with_time("Moving repo information from Settings to miq_databases") do
+      db = MiqDatabase.first
+      db.update_attributes!(:update_repo_name => change.value.join(" ")) if db
+      change.delete
+    end
+  end
+
+  def my_region
+    MiqRegion.find_by_region(ApplicationRecord.my_region_number)
+  end
+
+  def settings_hash
+    {
+      :resource_type => "MiqRegion",
+      :resource_id   => my_region.id,
+      :key           => SETTING_KEY
+    }
+  end
+end

--- a/db/migrate/20160913195130_remove_update_repo_name_from_miq_databases.rb
+++ b/db/migrate/20160913195130_remove_update_repo_name_from_miq_databases.rb
@@ -1,0 +1,5 @@
+class RemoveUpdateRepoNameFromMiqDatabases < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :miq_databases, :update_repo_name, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4888,7 +4888,6 @@ miq_databases:
 - postgres_update_available
 - session_secret_token
 - csrf_secret_token
-- update_repo_name
 - registration_organization_display_name
 miq_dialogs:
 - id

--- a/spec/migrations/20160913195129_move_repo_data_from_database_to_settings_spec.rb
+++ b/spec/migrations/20160913195129_move_repo_data_from_database_to_settings_spec.rb
@@ -1,0 +1,59 @@
+require_migration
+
+describe MoveRepoDataFromDatabaseToSettings do
+  let(:region_stub)   { migration_stub(:MiqRegion) }
+  let(:database_stub) { migration_stub(:MiqDatabase) }
+  let(:settings_stub) { migration_stub(:SettingsChange) }
+
+  let(:region_number) { ApplicationRecord.my_region_number }
+  let(:region)        { region_stub.find_by_region(region_number) }
+  let(:repo_string)   { "my-repo my-other-repo" }
+  let(:repo_list)     { %w(my-repo my-other-repo) }
+
+  before do
+    region_id = ApplicationRecord.region_to_range(region_number).first
+    region_stub.create(:id => region_id, :region => region_number)
+  end
+
+  migration_context :up do
+    it "moves the data from miq_databases to the settings" do
+      database_attrs = {
+        :session_secret_token => SecureRandom.hex(64),
+        :csrf_secret_token    => SecureRandom.hex(64),
+        :update_repo_name     => repo_string
+      }
+      database_stub.create!(database_attrs)
+
+      migrate
+
+      setting_change = settings_stub.where(
+        :key           => described_class::SETTING_KEY,
+        :resource_id   => region.id,
+        :resource_type => MiqRegion
+      ).first
+      expect(setting_change.value).to eq(repo_list)
+    end
+  end
+
+  migration_context :down do
+    it "moves the data from the settings to miq_databases" do
+      database_attrs = {
+        :session_secret_token => SecureRandom.hex(64),
+        :csrf_secret_token    => SecureRandom.hex(64),
+        :update_repo_name     => nil
+      }
+      db = database_stub.create!(database_attrs)
+      settings_stub.create!(
+        :key           => described_class::SETTING_KEY,
+        :value         => repo_list,
+        :resource_id   => region.id,
+        :resource_type => MiqRegion
+      )
+
+      migrate
+
+      db.reload
+      expect(db.update_repo_name).to eq(repo_string)
+    end
+  end
+end

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -1,4 +1,8 @@
 describe MiqDatabase do
+  before do
+    FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)
+  end
+
   context ".seed" do
     include_examples ".seed called multiple times"
 

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -1,6 +1,54 @@
 describe MiqDatabase do
-  before do
+  let(:db) { described_class.seed }
+
+  let!(:region) do
     FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)
+  end
+
+  context ".registration_default_value_for_update_repo_name" do
+    it "returns an empty array if the setting is not set" do
+      expect(described_class.registration_default_value_for_update_repo_name).to eq("")
+    end
+
+    it "returns the template repos as a string when the setting is set" do
+      stub_template_settings(:product => {:update_repo_names => %w(repo-1 repo-2)})
+      stub_settings(:product => {:update_repo_names => %w(repo-3 repo-4)})
+
+      expect(described_class.registration_default_value_for_update_repo_name).to eq("repo-1 repo-2")
+    end
+  end
+
+  context "#update_repo_names" do
+    it "returns an empty array by default" do
+      expect(db.update_repo_names).to eq([])
+    end
+
+    it "returns the repos as an array when the setting is set" do
+      repo_names = %w(repo-1 repo-2)
+      stub_settings(:product => {:update_repo_names => repo_names})
+
+      expect(db.update_repo_names).to eq(repo_names)
+    end
+  end
+
+  context "#update_repo_name" do
+    it "returns an empty string by default" do
+      expect(db.update_repo_name).to eq("")
+    end
+
+    it "returns the repos as a string when the setting is set" do
+      repo_names = %w(repo-1 repo-2)
+      stub_settings(:product => {:update_repo_names => repo_names})
+
+      expect(db.update_repo_name).to eq("repo-1 repo-2")
+    end
+  end
+
+  context "#update_repo_name=" do
+    it "sets the update repo names in the setting hash" do
+      db.update_repo_name = "repo-1 repo-2"
+      expect(Vmdb::Settings.for_resource(region).product.update_repo_names).to eq(%w(repo-1 repo-2))
+    end
   end
 
   context ".seed" do
@@ -11,7 +59,6 @@ describe MiqDatabase do
         db = MiqDatabase.seed
         expect(db.csrf_secret_token_encrypted).to be_encrypted
         expect(db.session_secret_token_encrypted).to be_encrypted
-        expect(db.update_repo_name).to eq("cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         expect(db.registration_type).to eq("sm_hosted")
         expect(db.registration_server).to eq("subscription.rhn.redhat.com")
       end
@@ -20,21 +67,18 @@ describe MiqDatabase do
         it "will seed nil values" do
           FactoryGirl.build(:miq_database,
                             :csrf_secret_token    => nil,
-                            :session_secret_token => nil,
-                            :update_repo_name     => nil
+                            :session_secret_token => nil
                            ).save(:validate => false)
 
           db = MiqDatabase.seed
           expect(db.csrf_secret_token_encrypted).to be_encrypted
           expect(db.session_secret_token_encrypted).to be_encrypted
-          expect(db.update_repo_name).to eq("cf-me-5.6-for-rhel-7-rpms rhel-server-rhscl-7-rpms")
         end
 
         it "will not change existing values" do
           FactoryGirl.create(:miq_database,
                              :csrf_secret_token    => "abc",
-                             :session_secret_token => "def",
-                             :update_repo_name     => "ghi"
+                             :session_secret_token => "def"
                             )
           csrf, session, update_repo = MiqDatabase.all.collect { |db| [db.csrf_secret_token, db.session_secret_token, db.update_repo_name] }.first
 

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -4,6 +4,11 @@ def stub_settings(hash)
   allow(Vmdb::Settings).to receive(:for_resource) { settings }
 end
 
+def stub_template_settings(hash)
+  settings = Config::Options.new.merge!(hash)
+  allow(Vmdb::Settings).to receive(:template_settings) { settings }
+end
+
 def stub_local_settings(my_server)
   stub_const("Settings", Vmdb::Settings.for_resource(my_server))
 end


### PR DESCRIPTION
This PR removes the default value for the cfme yum repos out of the MiqDatabase model. This will remove the need for PRs like https://github.com/ManageIQ/manageiq/pull/11224 and https://github.com/ManageIQ/manageiq/pull/9526 every time we cut a cfme release.

This also allows us to drop the `update_repo_name` column in the `miq_databases` table and move the information to the config settings which are more easily productized.

@miq-bot add_label enhancement, core, darga/no
@Fryguy @gtanzillo please review