### PR TITLE
javascript_redirect refactor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -623,7 +623,12 @@ class ApplicationController < ActionController::Base
       else
         redirect_to_action = lastaction
       end
-      javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
+      js_args = {:action        => redirect_to_action,
+                 :id            => params[:id],
+                 :escape        => false,
+                 :load_edit_err => true
+      }
+      javascript_redirect(javascript_process_redirect_args(js_args))
     else
       redirect_to :action => lastaction, :id => params[:id], :escape => false
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -623,14 +623,7 @@ class ApplicationController < ActionController::Base
       else
         redirect_to_action = lastaction
       end
-
-      # there's no model for ResourceController - defaulting to traditional routing
-      model = self.class.model rescue nil
-      if model && restful_routed?(model)
-        javascript_redirect polymorphic_path(model.find(params[:id]), :escape => false, :load_edit_err => true)
-      else
-        javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
-      end
+      javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true
     else
       redirect_to :action => lastaction, :id => params[:id], :escape => false
     end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -304,8 +304,13 @@ module EmsCommon
     _model = model
     flash = _("Edit of %{model} \"%{name}\" was cancelled by the user") %
             {:model => ui_lookup(:model => _model.to_s), :name => @ems.name}
-    javascript_redirect :action => @lastaction, :id => @ems.id, :display => session[:ems_display],
-                        :flash_msg => flash, :record => @ems
+    js_args = {:action    => @lastaction,
+               :id        => @ems.id,
+               :display   => session[:ems_display],
+               :flash_msg => flash,
+               :record    => @ems
+    }
+    javascript_redirect(javascript_process_redirect_args(js_args))
   end
   private :update_button_cancel
 
@@ -323,7 +328,8 @@ module EmsCommon
               {:model => ui_lookup(:model => model.to_s), :name => update_ems.name}
       AuditEvent.success(build_saved_audit(update_ems, @edit))
       session[:edit] = nil  # clean out the saved info
-      javascript_redirect :action => 'show', :id => @ems.id.to_s, :flash_msg => flash, :record => @ems
+      js_args = {:action => 'show', :id => @ems.id.to_s, :flash_msg => flash, :record => @ems}
+      javascript_redirect(javascript_process_redirect_args(js_args))
       return
     else
       @edit[:errors].each { |msg| add_flash(msg, :error) }

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -304,13 +304,8 @@ module EmsCommon
     _model = model
     flash = _("Edit of %{model} \"%{name}\" was cancelled by the user") %
             {:model => ui_lookup(:model => _model.to_s), :name => @ems.name}
-    if restful_routed?(model)
-      javascript_redirect polymorphic_path(model.find(params[:id]), :escape => false, :load_edit_err => true,
-                                           :flash_msg => flash)
-    else
-      javascript_redirect :action => @lastaction, :id => @ems.id, :display => session[:ems_display],
-                          :flash_msg => flash
-    end
+    javascript_redirect :action => @lastaction, :id => @ems.id, :display => session[:ems_display],
+                        :flash_msg => flash, :record => @ems
   end
   private :update_button_cancel
 
@@ -328,11 +323,7 @@ module EmsCommon
               {:model => ui_lookup(:model => model.to_s), :name => update_ems.name}
       AuditEvent.success(build_saved_audit(update_ems, @edit))
       session[:edit] = nil  # clean out the saved info
-      if restful_routed?(model)
-        javascript_redirect polymorphic_path(model.find(params[:id]), :flash_msg => flash)
-      else
-        javascript_redirect :action => 'show', :id => @ems.id.to_s, :flash_msg => flash
-      end
+      javascript_redirect :action => 'show', :id => @ems.id.to_s, :flash_msg => flash, :record => @ems
       return
     else
       @edit[:errors].each { |msg| add_flash(msg, :error) }

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -21,11 +21,12 @@ module Mixins
       flash_msg = _("Edit of %{model} \"%{name}\" was cancelled by the user") %
                   {:model => ui_lookup(:model => model_name),
                    :name  => update_ems.name}
-      javascript_redirect :action    => @lastaction,
-                          :id        => update_ems.id,
-                          :display   => session[:ems_display],
-                          :flash_msg => flash_msg,
-                          :record    => update_ems
+      js_args = {:action    => @lastaction,
+                 :id        => update_ems.id,
+                 :display   => session[:ems_display],
+                 :flash_msg => flash_msg,
+                 :record    => update_ems}
+      javascript_redirect(javascript_process_redirect_args(js_args))
     end
 
     def update_ems_button_save

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -21,15 +21,11 @@ module Mixins
       flash_msg = _("Edit of %{model} \"%{name}\" was cancelled by the user") %
                   {:model => ui_lookup(:model => model_name),
                    :name  => update_ems.name}
-      ems_path = ems_path(update_ems, :flash_msg => flash_msg)
-      if @lastaction == "show"
-        javascript_redirect ems_path
-      else
-        javascript_redirect :action    => @lastaction,
-                            :id        => update_ems.id,
-                            :display   => session[:ems_display],
-                            :flash_msg => flash_msg
-      end
+      javascript_redirect :action    => @lastaction,
+                          :id        => update_ems.id,
+                          :display   => session[:ems_display],
+                          :flash_msg => flash_msg,
+                          :record    => update_ems
     end
 
     def update_ems_button_save

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1115,32 +1115,33 @@ module ApplicationHelper
     true
   end
 
-  def javascript_redirect(args)
+  def javascript_process_redirect_args(args)
     # there's no model for ResourceController - defaulting to traditional routing
-    model = self.class.model rescue nil
+    begin
+      model = self.class.model
+    rescue => _err
+      model = nil
+    end
     if model && args.class == Hash && args[:action] == 'show' && restful_routed?(model)
       args.delete(:action)
       polymorphic_path_redirect(model, args)
     else
-      non_polymorphic_path_redirect(args)
+      args
     end
   end
 
-  def polymorphic_path_redirect(model, args)
-    args[:record] ? record = args[:record] : record = model.find(args[:id] || params[:id])
-    args.delete(:record)
-    args.delete(:id)
-    render :update do |page|
-      page << javascript_prologue
-      page.redirect_to polymorphic_path(record, args)
-    end
-  end
-
-  def non_polymorphic_path_redirect(args)
+  def javascript_redirect(args)
     render :update do |page|
       page << javascript_prologue
       page.redirect_to args
     end
+  end
+
+  def polymorphic_path_redirect(model, args)
+    record = args[:record] ? args[:record] : model.find(args[:id] || params[:id])
+    args.delete(:record)
+    args.delete(:id)
+    polymorphic_path(record, args)
   end
 
   def javascript_flash(**args)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1125,11 +1125,12 @@ module ApplicationHelper
   end
 
   def polymorphic_path_redirect(model, args)
-    id = args[:id] || params[:id]
+    args[:record] ? record = args[:record] : record = model.find(args[:id] || params[:id])
+    args.delete(:record)
     args.delete(:id)
     render :update do |page|
       page << javascript_prologue
-      page.redirect_to polymorphic_path(model.find(id), args)
+      page.redirect_to polymorphic_path(record, args)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1116,6 +1116,24 @@ module ApplicationHelper
   end
 
   def javascript_redirect(args)
+    if args.class == Hash && args[:action] == 'show' && restful_routed?(self.class.model)
+      args.delete(:action)
+      polymorphic_path_redirect(model, args)
+    else
+      non_polymorphic_path_redirect(args)
+    end
+  end
+
+  def polymorphic_path_redirect(model, args)
+    id = args[:id] || params[:id]
+    args.delete(:id)
+    render :update do |page|
+      page << javascript_prologue
+      page.redirect_to polymorphic_path(model.find(id), args)
+    end
+  end
+
+  def non_polymorphic_path_redirect(args)
     render :update do |page|
       page << javascript_prologue
       page.redirect_to args

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1116,7 +1116,9 @@ module ApplicationHelper
   end
 
   def javascript_redirect(args)
-    if args.class == Hash && args[:action] == 'show' && restful_routed?(self.class.model)
+    # there's no model for ResourceController - defaulting to traditional routing
+    model = self.class.model rescue nil
+    if model && args.class == Hash && args[:action] == 'show' && restful_routed?(model)
       args.delete(:action)
       polymorphic_path_redirect(model, args)
     else


### PR DESCRIPTION
Ideally, methods calling `javascript_redirect` should be oblivious to the fact that a controller is RESTful or not. That way we can eliminate the conditional `if restful_routed?(model)` in multiple places every time we have to redirect to a URL. 

`javascript_redirect` now does the RESTful check for us.

Fixes https://github.com/ManageIQ/manageiq/issues/1002

(This refactor is mostly applicable for the `show` route)
