### PR TITLE
Fix odd rendering of some "single" quadicons

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -608,9 +608,8 @@ module QuadiconHelper
     size = options[:size]
     output = []
 
-    width = size == 150 ? 54 : 35
-    output << flobj_img_simple(width, "#{size}/base-single.png")
-    output << flobj_img_simple(width * 1.8, "100/#{@listicon}.png", "e#{size}")
+    output << flobj_img_simple(size, "#{size}/base-single.png")
+    output << flobj_img_simple(size * 1.8, "100/#{@listicon}.png", "e#{size}")
 
     unless options[:typ] == :listnav
       title = case @listicon

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -898,7 +898,7 @@ describe QuadiconHelper do
     end
 
     let(:item) { FactoryGirl.create(:configuration_manager_foreman) }
-    subject(:single_quad) { helper.render_single_quad_quadicon(item, :mode => :icon) }
+    subject(:single_quad) { helper.render_single_quad_quadicon(item, :mode => :icon, :size => 72) }
 
     context "when @listicon is nil" do
       include_examples :has_base_single


### PR DESCRIPTION
This change fixes the broken rendering of certain quadicons.

**Before**
![screen shot 2016-09-15 at 3 17 09 pm](https://cloud.githubusercontent.com/assets/39493/18569526/f7c2f26a-7b57-11e6-9868-666a081a4a81.png)

**After**
![screen shot 2016-09-15 at 3 16 32 pm](https://cloud.githubusercontent.com/assets/39493/18569531/ff758c98-7b57-11e6-9b3f-c6d992666b87.png)


## Links

* Fixes #10665

## Testing/QA

@epwinchell @h-kataria @dclarizio The old code seems to handle situations where the icon needed be shrunk very small (35px). This doesn't seem to be a thing any more, but I don't know for sure.