### PR TITLE
Eliminate send call in Api::BaseController#destroy

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -25,7 +25,7 @@ module Api
         if @req.subcollection
           delete_subcollection_resource @req.subcollection.to_sym, @req.s_id
         else
-          send(target_resource_method(false, @req.collection.to_sym, :delete), @req.collection.to_sym, @req.c_id)
+          delete_resource(@req.collection.to_sym, @req.c_id)
         end
         render_normal_destroy
       end


### PR DESCRIPTION
Since the target_resource_method call ignores the type for primary
collections, we can replace the `send` by calling the method it always
returns directly, `delete_resource`.

@miq-bot add-label api, refactoring, technical debt
@miq-bot assign @abellotti 

:tophat: :sparkles: :wave:  