### PR TITLE
Refactor UI Reports views not to use div_num when rendering flash_msg…

### DIFF
--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+= render :partial => "layouts/flash_msg"
 - if @sb[:active_tab] == "report_info"
   - if @sb[:miq_report_id] && @miq_report
     .form-horizontal.static

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -3,7 +3,7 @@
     - if @in_a_form
       = render :partial => 'form'
     - elsif @report && !@report_result
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+      = render :partial => "layouts/flash_msg"
 
       - if @zgraph
         - width, height = @html ? [350, 250] : [700, 500]
@@ -25,7 +25,7 @@
       - if (nodes.length == 1 && @sb[:rpt_menu].blank?) || (nodes.length == 2 && @sb[:rpt_menu][nodes[1].to_i][1].blank?) || (nodes.length == 4 && @sb[:rpt_menu][nodes[1].to_i].present? && @sb[:rpt_menu][nodes[1].to_i][1][nodes[3].to_i][1].blank?)
         = render :partial => 'layouts/info_msg', :locals => {:message => _("No Reports available.")}
       - else
-        = render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+        = render :partial => "layouts/flash_msg"
         %table.table.table-striped.table-bordered.table-hover
           - if nodes.length == 1
             -# level1 folders list

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -1,7 +1,7 @@
 #menu_roles_div
   - if @sb[:active_accord] == :roles
     - if @menu_roles_tree
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}
+      = render :partial => "layouts/flash_msg"
       .col-sm-5
         %h3
           = _("Reports")
@@ -18,7 +18,7 @@
       = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
       = render :partial => "report/menu_form2"
     - elsif @sb[:menu]
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}
+      = render :partial => "layouts/flash_msg"
       - if @sb[:menu].empty?
         = render :partial => 'layouts/info_msg', :locals => {:message => _("No Saved Reports available.")}
       - else

--- a/app/views/report/_show_schedule.html.haml
+++ b/app/views/report/_show_schedule.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_schedule_list"}
+= render :partial => "layouts/flash_msg"
 %h3= _("Schedule Info")
 .form-horizontal.static
   .form-group


### PR DESCRIPTION
Delete passing along of div_num as local variable, used by old DHTMLX code base, when rendering layouts/_flash_msg partial view
flash_msg partial will now default to DOM ID of flash_msg_div

https://github.com/ManageIQ/manageiq/issues/11238