### PR TITLE
Refactor OPS views not to use div_num when rendering flash_msg partial

### DIFF
--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -5,7 +5,7 @@
   :javascript
     ManageIQ.calendar.calDateFrom = null;
     ManageIQ.calendar.calDateTo = new Date();
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "cu_repair"}
+  = render :partial => "layouts/flash_msg"
 
   %h3= _("Collection Options")
   .form-horizontal

--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -1,5 +1,4 @@
 - @angular_form = true
-- div_num ||= ""
 
 %form.form-horizontal#form_div{:name                                 => "angularForm",
                                'ng-controller'                       => "logCollectionFormController",
@@ -8,7 +7,7 @@
                                'data-save-url'                       => "/#{controller_name}/log_depot_edit/",
                                'data-log-protocol-changed-url'       => "/#{controller_name}/log_protocol_changed/",
                                :novalidate                           => 1}
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => div_num}
+  = render :partial => "layouts/flash_msg"
 
   %h3
     = _("Editing Log Depot Settings for %{class}: %{display}") % {:class   => Dictionary.gettext(@record.class.name,


### PR DESCRIPTION
Delete passing along of div_num as local variable, used by old DHTMLX code base, when rendering layouts/_flash_msg partial view
flash_msg partial will now default to DOM ID of flash_msg_div

https://github.com/ManageIQ/manageiq/issues/11238