### PR TITLE
Add Api::BaseController#index action

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -6,8 +6,8 @@ module Api
       #
 
       def index
-        klass = collection_class(@req.subject.to_sym)
-        res = collection_search(@req.subcollection?, @req.subject.to_sym, klass)
+        klass = collection_class(@req.subject)
+        res = collection_search(@req.subcollection?, @req.subject, klass)
         opts = {
           :name             => @req.subject,
           :is_subcollection => @req.subcollection?,
@@ -17,13 +17,13 @@ module Api
           :subcount         => res.length
         }
 
-        render_collection(@req.subject.to_sym, res, opts)
+        render_collection(@req.subject, res, opts)
       end
 
       def show
-        klass = collection_class(@req.subject.to_sym)
+        klass = collection_class(@req.subject)
         opts  = {:name => @req.subject, :is_subcollection => @req.subcollection?, :expand_actions => true}
-        render_resource(@req.subject.to_sym, resource_search(@req.subject_id, @req.subject.to_sym, klass), opts)
+        render_resource(@req.subject, resource_search(@req.subject_id, @req.subject, klass), opts)
       end
 
       def update

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -6,11 +6,24 @@ module Api
       #
 
       def index
-        render_collection_type @req.subject.to_sym, @req.subject_id
+        klass = collection_class(@req.subject.to_sym)
+        res = collection_search(@req.subcollection?, @req.subject.to_sym, klass)
+        opts = {
+          :name             => @req.subject,
+          :is_subcollection => @req.subcollection?,
+          :expand_actions   => true,
+          :count            => klass.count,
+          :expand_resources => @req.expand?(:resources),
+          :subcount         => res.length
+        }
+
+        render_collection(@req.subject.to_sym, res, opts)
       end
 
       def show
-        render_collection_type @req.subject.to_sym, @req.subject_id
+        klass = collection_class(@req.subject.to_sym)
+        opts  = {:name => @req.subject, :is_subcollection => @req.subcollection?, :expand_actions => true}
+        render_resource(@req.subject.to_sym, resource_search(@req.subject_id, @req.subject.to_sym, klass), opts)
       end
 
       def update

--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -5,6 +5,10 @@ module Api
       # Primary Methods
       #
 
+      def index
+        render_collection_type @req.subject.to_sym, @req.subject_id
+      end
+
       def show
         render_collection_type @req.subject.to_sym, @req.subject_id
       end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -2,26 +2,6 @@ module Api
   class BaseController
     module Renderer
       #
-      # Helper proc for rendering a collection of type specified.
-      #
-      def render_collection_type(type, id)
-        klass = collection_class(type)
-        opts  = {:name => type.to_s, :is_subcollection => @req.subcollection?, :expand_actions => true}
-        if id
-          render_resource type, resource_search(id, type, klass), opts
-        else
-          opts[:count]            = klass.count
-          opts[:expand_resources] = @req.expand?(:resources)
-
-          res = collection_search(@req.subcollection?, type, klass)
-
-          opts[:subcount] = res.length
-
-          render_collection type, res, opts
-        end
-      end
-
-      #
       # Helper proc to render a collection
       #
       def render_collection(type, resources, opts = {})

--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -2,7 +2,7 @@ module Api
   class BlueprintsController < BaseController
     include Subcollections::Tags
 
-    before_action :set_additional_attributes, :only => [:show]
+    before_action :set_additional_attributes, :only => [:index, :show]
 
     def publish_resource(type, id, data)
       blueprint = resource_search(id, type, Blueprint)

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -2,7 +2,7 @@ module Api
   class CategoriesController < BaseController
     include Subcollections::Tags
 
-    before_action :set_additional_attributes, :only => [:show, :update]
+    before_action :set_additional_attributes, :only => [:index, :show, :update]
 
     def edit_resource(type, id, data = {})
       raise ForbiddenError if Category.find(id).read_only?

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -5,7 +5,7 @@ module Api
     include Subcollections::Results
     include Subcollections::Schedules
 
-    before_action :set_additional_attributes, :only => [:show]
+    before_action :set_additional_attributes, :only => [:index, :show]
 
     def run_resource(_type, id, _data)
       report = MiqReport.find(id)

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ResultsController < BaseController
-    before_action :set_additional_attributes, :only => [:show]
+    before_action :set_additional_attributes, :only => [:index, :show]
 
     private
 

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ServiceDialogsController < BaseController
-    before_action :set_additional_attributes, :only => [:show]
+    before_action :set_additional_attributes, :only => [:index, :show]
 
     def refresh_dialog_fields_resource(type, id = nil, data = nil)
       raise BadRequestError, "Must specify an id for Reconfiguring a #{type} resource" unless id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,13 +37,25 @@ Vmdb::Application.routes.draw do
           if collection.options.include?(:arbitrary_resource_path)
             match "(/*c_suffix)", :action => API_ACTIONS[verb], :via => verb
           else
-            match "(/:c_id)", :action => API_ACTIONS[verb], :via => verb
+            case verb
+            when :get
+              root :action => :index
+              get "/:c_id", :action => :show
+            else
+              match "(/:c_id)", :action => API_ACTIONS[verb], :via => verb
+            end
           end
         end
 
         Array(collection.subcollections).each do |subcollection_name|
           Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
-            match("/:c_id/#{subcollection_name}(/:s_id)", :action => API_ACTIONS[verb], :via => verb)
+            case verb
+            when :get
+              get "/:c_id/#{subcollection_name}", :action => :index
+              get "/:c_id/#{subcollection_name}/:s_id", :action => :show
+            else
+              match("/:c_id/#{subcollection_name}(/:s_id)", :action => API_ACTIONS[verb], :via => verb)
+            end
           end
         end
       end


### PR DESCRIPTION
This revision adds an #index action to all API controllers in order to distinguish collection/member GET requests at the routing-level. Some pros:
- Adds more certainty to the routes by removing dynamic segments from GETs
- Moves us more in the direction of Rails' resourceful routes
- Removes some branching in the controller where it would previously ask a `#show`, do I have an id?

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 
