### PR TITLE
Refactor UI Capacity views not to use div_num when rendering flash_ms…

### DIFF
--- a/app/views/miq_capacity/_bottlenecks_report.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_report.html.haml
@@ -2,7 +2,7 @@
   - if x_node == ""
     = render :partial => 'layouts/info_msg', :locals => {:message => _("Select a node on the left to view Bottlenecks report.")}
   - else
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "2"}
+    = render :partial => "layouts/flash_msg"
     = render :partial => 'bottlenecks_options', :locals  => {:typ => "report"}
     - if @sb[:bottlenecks] && @sb[:bottlenecks][:report]
       %hr

--- a/app/views/miq_capacity/_bottlenecks_summary.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_summary.html.haml
@@ -2,6 +2,6 @@
   - if x_node == ""
     = render :partial => 'layouts/info_msg', :locals => {:message => _("Select a node on the left to view Bottlenecks timeline.")}
   - else
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+    = render :partial => "layouts/flash_msg"
     = render :partial => 'bottlenecks_options', :locals  => {:typ => "summ"}
   = render :partial => 'bottlenecks_tl_detail'

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -1,7 +1,7 @@
 - url = url_for(:action => 'planning_option_changed')
 -# Div to hold the planning options
 #planning_options_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "0"}
+  = render :partial => "layouts/flash_msg"
   %h3
     = _('Reference VM Selection')
   .form.horizontal

--- a/app/views/miq_capacity/_planning_report.html.haml
+++ b/app/views/miq_capacity/_planning_report.html.haml
@@ -1,5 +1,5 @@
 #planning_report_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "3"}
+  = render :partial => "layouts/flash_msg"
 
   - if @perf_record && @sb[:planning] && @sb[:planning][:rpt]
 

--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -1,6 +1,6 @@
 - url = url_for(:action => 'planning_option_changed')
 #planning_summary_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+  = render :partial => "layouts/flash_msg"
   - if @perf_record
     %h3= _('Display Options')
     %dl.dl-horizontal

--- a/app/views/miq_capacity/_utilization_details.html.haml
+++ b/app/views/miq_capacity/_utilization_details.html.haml
@@ -1,5 +1,5 @@
 #utilization_details_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "2"}
+  = render :partial => "layouts/flash_msg"
   - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "details"}
     = render(:partial => "layouts/perf_charts",

--- a/app/views/miq_capacity/_utilization_summary.html.haml
+++ b/app/views/miq_capacity/_utilization_summary.html.haml
@@ -1,5 +1,5 @@
 #utilization_summary_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+  = render :partial => "layouts/flash_msg"
   - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "summ"}
     = render(:partial => "layouts/perf_charts",


### PR DESCRIPTION
Delete passing along of div_num as local variable, used by old DHTMLX code base, when rendering layouts/_flash_msg partial view
flash_msg partial will now default to DOM ID of flash_msg_div

https://github.com/ManageIQ/manageiq/issues/11238