### PR TITLE
Refactor UI AE Class views not to use div_num when rendering flash_ms…

### DIFF
--- a/app/views/miq_ae_class/_class_add.html.haml
+++ b/app/views/miq_ae_class/_class_add.html.haml
@@ -1,5 +1,5 @@
 #add_class_props_div
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_props"}
+= render :partial => "layouts/flash_msg"
 - if @in_a_form_fields && x_node.split('-')[0] == "aec" || params[:pressed] || %w(field_select field_accept field_delete).include?(params[:action])
   #form_div
     = render :partial => "class_form"

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -1,6 +1,6 @@
 #class_instances_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"}
+    = render :partial => "layouts/flash_msg"
     %h3= _('Instances')
     - if @record.ae_instances.present?
       %table#class_instances_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
@@ -31,5 +31,5 @@
                :locals  => {:message => _("No instances found")}
   - elsif @edit[:new][:ae_inst]
     #form_div
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "instance_form", :locals => {:prefix => "cls_"}

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -1,6 +1,6 @@
 #class_methods_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_methods"}
+    = render :partial => "layouts/flash_msg"
     %h3= _('Methods')
     - if @record.ae_methods.present?
       %table#class_methods_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
@@ -31,5 +31,5 @@
                :locals  => {:message => _("No methods found")}
   - elsif @edit[:new][:fields]
     #form_div
-      = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_class_methods"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "method_form", :locals  => {:prefix => "cls_"}

--- a/app/views/miq_ae_class/_copy_objects_form.html.haml
+++ b/app/views/miq_ae_class/_copy_objects_form.html.haml
@@ -1,5 +1,5 @@
 - url = url_for(:action => 'form_copy_objects_field_changed', :id => @edit[:rec_id])
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_copy"}
+= render :partial => "layouts/flash_msg"
 #form_div
   = hidden_div_if(!@edit[:new][:namespace], :id => "ae_tree_select_div") do
     = render(:partial => 'layouts/ae_tree_select', :locals => {:entry_point => "Namespace"})

--- a/app/views/miq_ae_class/_domains_priority_form.html.haml
+++ b/app/views/miq_ae_class/_domains_priority_form.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_domains_priority"}
+= render :partial => "layouts/flash_msg"
 #domains_list
   %table#formtest.form{:width => '50%'}
     %tr

--- a/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_fields_seq"}
+= render :partial => "layouts/flash_msg"
 #column_lists
   %p
   %table#formtest.form{:width => '50%'}

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_git_refresh"}
+= render :partial => "layouts/flash_msg"
 
 %form#form_div
   = hidden_field_tag(:git_repo_id, @git_repo_id, :class => "hidden-git-repo-id")

--- a/app/views/miq_ae_class/_instance_fields.html.haml
+++ b/app/views/miq_ae_class/_instance_fields.html.haml
@@ -2,7 +2,7 @@
 %h3= _('Fields')
 #instance_fields_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_instance_fields"}
+    = render :partial => "layouts/flash_msg"
 
     %table#instance_fields_grid.table.table-striped.table-bordered
       %thead
@@ -48,5 +48,5 @@
 
   - else
     #form_div
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_instance_fields"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "instance_form", :locals => {:prefix => ""}

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -1,6 +1,6 @@
 #method_inputs_div
   - if !@in_a_form && @ae_method
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_method_inputs"}
+    = render :partial => "layouts/flash_msg"
     %h3
       = _('Main Info')
     .form-horizontal.static
@@ -73,6 +73,6 @@
               %td= record.datatype.blank? ? 'string' : record.datatype
   - else
     #method_form_div
-      = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_method_inputs"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "method_form", :locals  => {:prefix => ""}
   %br

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -3,7 +3,7 @@
     - unless @version_messages.blank?
       - @version_messages.each do |msg|
         = render :partial => 'layouts/info_msg', :locals => {:message => msg}
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
+    = render :partial => "layouts/flash_msg"
     %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.narrow
@@ -37,7 +37,7 @@
 
   - else
     - url = url_for(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
+    = render :partial => "layouts/flash_msg"
     #form_ns_div
       %h3
         = _('Info')


### PR DESCRIPTION
Delete passing along of div_num as local variable, used by old DHTMLX code base, when rendering layouts/_flash_msg partial view
flash_msg partial will now default to DOM ID of flash_msg_div

https://github.com/ManageIQ/manageiq/issues/11238