### PR TITLE
Refactor UI Edit Log Depot Settings view not to use div_num when rend…

### DIFF
--- a/app/views/layouts/_edit_log_depot_settings.html.haml
+++ b/app/views/layouts/_edit_log_depot_settings.html.haml
@@ -1,10 +1,9 @@
 - action ||= "log_depot_field_changed"
-- div_num ||= ""
 - record    = @schedule || @record
 - url       = url_for(:action => action, :id => (record.try(:id) || "new"))
 
 #form_filter_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => div_num}
+  = render :partial => "layouts/flash_msg"
   - if (@sb[:active_tree] == :diagnostics_tree && @sb[:active_tab] == "diagnostics_database") || (@sb[:active_tree] == :settings_tree)
     = _("Database Backup Settings")
   - else


### PR DESCRIPTION
Delete passing along of div_num as local variable, used by old DHTMLX code base, when rendering layouts/_flash_msg partial view
flash_msg partial will now default to DOM ID of flash_msg_div

https://github.com/ManageIQ/manageiq/issues/11238