### PR TITLE
Collect VMware VDCs as availability zones

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudManager
+  require_nested :AvailabilityZone
   require_nested :OrchestrationStack
   require_nested :OrchestrationTemplate
   require_nested :RefreshParser

--- a/app/models/manageiq/providers/vmware/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/availability_zone.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone < ::AvailabilityZone
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -47,6 +47,8 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
     @inv[:orgs].each do |org|
       @inv[:vdcs] += org.vdcs.all
     end
+
+    process_collection(@inv[:vdcs], :availability_zones) { |vdc| parse_vdc(vdc) }
   end
 
   def get_vapps
@@ -91,6 +93,18 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
     end
 
     process_collection(@inv[:images], :vms) { |image_obj| parse_image(image_obj[:image], image_obj[:is_published]) }
+  end
+
+  def parse_vdc(vdc)
+    id = vdc.id
+
+    new_result = {
+      :type    => "ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone",
+      :ems_ref => id,
+      :name    => vdc.name
+    }
+
+    return id, new_result
   end
 
   def parse_vm(vm)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager-availability_zone.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-cloud_manager-availability_zone.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Vmware_CloudManager_AvailabilityZone < MiqAeServiceAvailabilityZone
+  end
+end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -50,6 +50,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       assert_specific_orchestration_stack
       assert_table_counts
       assert_ems
+      assert_specific_vdc
       assert_specific_template
       assert_specific_vm_powered_on
       assert_specific_vm_powered_off
@@ -60,32 +61,32 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   def assert_table_counts
     expect(ExtManagementSystem.count).to eq(2) # cloud_manager + network_manager
     expect(Flavor.count).to eq(0)
-    expect(AvailabilityZone.count).to eq(0)
+    expect(AvailabilityZone.count).to eq(1)
     expect(FloatingIp.count).to eq(0)
     expect(AuthPrivateKey.count).to eq(0)
     expect(CloudNetwork.count).to eq(0)
     expect(CloudSubnet.count).to eq(0)
-    expect(OrchestrationTemplate.count).to eq(3)
-    expect(OrchestrationStack.count).to eq(4)
+    expect(OrchestrationTemplate.count).to eq(4)
+    expect(OrchestrationStack.count).to eq(3)
     expect(OrchestrationStackParameter.count).to eq(0)
     expect(OrchestrationStackOutput.count).to eq(0)
     expect(OrchestrationStackResource.count).to eq(0)
     expect(SecurityGroup.count).to eq(0)
     expect(FirewallRule.count).to eq(0)
-    expect(VmOrTemplate.count).to eq(9)
-    expect(Vm.count).to eq(6)
-    expect(MiqTemplate.count).to eq(3)
+    expect(VmOrTemplate.count).to eq(8)
+    expect(Vm.count).to eq(3)
+    expect(MiqTemplate.count).to eq(5)
 
     expect(CustomAttribute.count).to eq(0)
-    expect(Disk.count).to eq(6)
+    expect(Disk.count).to eq(3)
     expect(GuestDevice.count).to eq(0)
-    expect(Hardware.count).to eq(6)
-    expect(OperatingSystem.count).to eq(6)
+    expect(Hardware.count).to eq(3)
+    expect(OperatingSystem.count).to eq(3)
     expect(Snapshot.count).to eq(0)
     expect(SystemService.count).to eq(0)
 
     expect(Relationship.count).to eq(0)
-    expect(MiqQueue.count).to eq(10) # 8 + cloud_refresh + network_refresh
+    expect(MiqQueue.count).to eq(9)
   end
 
   def assert_ems
@@ -95,28 +96,38 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     )
 
     expect(@ems.flavors.size).to eq(0)
-    expect(@ems.availability_zones.size).to eq(0)
+    expect(@ems.availability_zones.size).to eq(1)
     expect(@ems.floating_ips.count).to eq(0)
     expect(@ems.key_pairs.size).to eq(0)
     expect(@ems.cloud_networks.count).to eq(0)
     expect(@ems.security_groups.count).to eq(0)
-    expect(@ems.vms_and_templates.size).to eq(9)
-    expect(@ems.vms.size).to eq(6)
-    expect(@ems.miq_templates.size).to eq(3)
-    expect(@ems.orchestration_stacks.size).to eq(4)
-    expect(@ems.orchestration_templates.size).to eq(3)
+    expect(@ems.vms_and_templates.size).to eq(8)
+    expect(@ems.vms.size).to eq(3)
+    expect(@ems.miq_templates.size).to eq(5)
+    expect(@ems.orchestration_stacks.size).to eq(3)
+    expect(@ems.orchestration_templates.size).to eq(4)
 
-    expect(@ems.direct_orchestration_stacks.size).to eq(4)
+    expect(@ems.direct_orchestration_stacks.size).to eq(3)
+  end
+
+  def assert_specific_vdc
+    @vdc = ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone.where(:name => "MIQDev-Default-vCD-DualSiteStorage-PAYG").first
+    expect(@vdc).to have_attributes(
+      :ems_id  => @ems.id,
+      :name    => "MIQDev-Default-vCD-DualSiteStorage-PAYG",
+      :ems_ref => "89ade969-1dc4-4156-abad-e29f79511676",
+      :type    => "ManageIQ::Providers::Vmware::CloudManager::AvailabilityZone"
+    )
   end
 
   def assert_specific_template
-    @template = ManageIQ::Providers::Vmware::CloudManager::Template.where(:name => "Small VM").first
+    @template = ManageIQ::Providers::Vmware::CloudManager::Template.where(:name => "CentOS7").first
     expect(@template).not_to be_nil
     expect(@template).to have_attributes(
       :template              => true,
-      :ems_ref               => "vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92",
+      :ems_ref               => "vm-857551b6-380c-44d0-ab34-9d144866f0b4",
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92",
+      :uid_ems               => "vm-857551b6-380c-44d0-ab34-9d144866f0b4",
       :vendor                => "vmware",
       :power_state           => "never",
       :publicly_available    => false,
@@ -145,12 +156,12 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
   end
 
   def assert_specific_vm_powered_on
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "DSL-rspec")
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1")
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "vm-224dbb24-9639-4d97-8d36-801e7ccce7e9",
+      :ems_ref               => "vm-f9ceb77c-b9d9-400c-8c06-72c785e884af",
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-224dbb24-9639-4d97-8d36-801e7ccce7e9",
+      :uid_ems               => "vm-f9ceb77c-b9d9-400c-8c06-72c785e884af",
       :vendor                => "vmware",
       :power_state           => "on",
       :location              => "unknown",
@@ -181,7 +192,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.security_groups.size).to eq(0)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "Debian GNU/Linux 4 (32-bit)",
+      :product_name => "CentOS 4/5/6/7 (64-bit)",
     )
     expect(v.custom_attributes.size).to eq(0)
     expect(v.snapshots.size).to eq(0)
@@ -189,14 +200,14 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware).to have_attributes(
       :config_version       => nil,
       :virtual_hw_version   => nil,
-      :guest_os             => "Debian GNU/Linux 4 (32-bit)",
-      :guest_os_full_name   => "Debian GNU/Linux 4 (32-bit)",
-      :cpu_sockets          => 1,
+      :guest_os             => "CentOS 4/5/6/7 (64-bit)",
+      :guest_os_full_name   => "CentOS 4/5/6/7 (64-bit)",
+      :cpu_sockets          => 2,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
       :annotation           => nil,
-      :memory_mb            => 256,
+      :memory_mb            => 2048,
       :host_id              => nil,
       :cpu_speed            => nil,
       :cpu_type             => nil,
@@ -207,12 +218,12 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :cpu_usage            => nil,
       :memory_usage         => nil,
       :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 1,
+      :cpu_total_cores      => 2,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
-      :disk_capacity        => 268_435_456,
+      :disk_capacity        => 17_179_869_184,
       :memory_console       => nil,
-      :bitness              => 32,
+      :bitness              => 64,
       :virtualization_type  => nil,
       :root_device_type     => nil,
     )
@@ -221,20 +232,20 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware.disks.first).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
-      :controller_type => "IDE Controller",
-      :size            => 268_435_456,
+      :controller_type => "SCSI Controller",
+      :size            => 17_179_869_184,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
   end
 
   def assert_specific_vm_powered_off
-    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "TTYL-rspec")
+    v = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
     expect(v).to have_attributes(
       :template              => false,
-      :ems_ref               => "vm-6844a379-61be-4652-817a-f14bb5f09512",
+      :ems_ref               => "vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6",
       :ems_ref_obj           => nil,
-      :uid_ems               => "vm-6844a379-61be-4652-817a-f14bb5f09512",
+      :uid_ems               => "vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6",
       :vendor                => "vmware",
       :power_state           => "off",
       :location              => "unknown",
@@ -265,7 +276,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.security_groups.size).to eq(0)
 
     expect(v.operating_system).to have_attributes(
-      :product_name => "Other Linux (32-bit)",
+      :product_name => "CentOS 4/5/6/7 (64-bit)",
     )
 
     expect(v.custom_attributes.size).to eq(0)
@@ -274,14 +285,14 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware).to have_attributes(
       :config_version       => nil,
       :virtual_hw_version   => nil,
-      :guest_os             => "Other Linux (32-bit)",
-      :guest_os_full_name   => "Other Linux (32-bit)",
-      :cpu_sockets          => 1,
+      :guest_os             => "CentOS 4/5/6/7 (64-bit)",
+      :guest_os_full_name   => "CentOS 4/5/6/7 (64-bit)",
+      :cpu_sockets          => 2,
       :bios                 => nil,
       :bios_location        => nil,
       :time_sync            => nil,
       :annotation           => nil,
-      :memory_mb            => 32,
+      :memory_mb            => 2048,
       :host_id              => nil,
       :cpu_speed            => nil,
       :cpu_type             => nil,
@@ -292,12 +303,12 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
       :cpu_usage            => nil,
       :memory_usage         => nil,
       :cpu_cores_per_socket => 1,
-      :cpu_total_cores      => 1,
+      :cpu_total_cores      => 2,
       :vmotion_enabled      => nil,
       :disk_free_space      => nil,
-      :disk_capacity        => 33_554_432,
+      :disk_capacity        => 17_179_869_184,
       :memory_console       => nil,
-      :bitness              => 32,
+      :bitness              => 64,
       :virtualization_type  => nil,
       :root_device_type     => nil,
     )
@@ -306,8 +317,8 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(v.hardware.disks.first).to have_attributes(
       :device_name     => "Hard disk 1",
       :device_type     => "disk",
-      :controller_type => "IDE Controller",
-      :size            => 33_554_432,
+      :controller_type => "SCSI Controller",
+      :size            => 17_179_869_184,
     )
     expect(v.hardware.guest_devices.size).to eq(0)
     expect(v.hardware.nics.size).to eq(0)
@@ -315,26 +326,26 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
 
   def assert_specific_orchestration_stack
     @orchestration_stack1 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
-                            .find_by(:name => "DSL-rspec")
+                            .find_by(:name => "spec-1")
     @orchestration_stack2 = ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack
-                            .find_by(:name => "TTYL-rspec")
-    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "DSL-rspec")
-    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "TTYL-rspec")
+                            .find_by(:name => "spec2")
+    vm1 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec1-vm1")
+    vm2 = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by(:name => "spec2-vm1")
 
     expect(vm1.orchestration_stack).to eq(@orchestration_stack1)
     expect(vm2.orchestration_stack).to eq(@orchestration_stack2)
   end
 
   def assert_specific_orchestration_template
-    @template = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.where(:name => "DSL-Linux-template").first
+    @template = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.where(:name => "vApp_CentOS_and_msWin").first
     expect(@template).not_to be_nil
     expect(@template).to have_attributes(
-      :ems_ref   => "vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868",
+      :ems_ref   => "vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5",
       :orderable => false,
     )
 
     expect(@template.ems_id).to eq(@ems.id)
     expect(@template.content.include?('ovf:Envelope')).to be_truthy
-    expect(@template.md5).to eq('48650e81c6433bd2a788766b382aaa5a')
+    expect(@template.md5).to eq('729bfcafe52065bdee376931efe104d9')
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/cloud_manager/refresher.yml
@@ -19,34 +19,34 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:51:55 GMT
+      - Fri, 16 Sep 2016 08:51:45 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 042aee1b-cae3-405e-86cc-0c27139b03fa
+      - f2446fad-ab18-4c10-87e4-52cb884be531
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '80'
+      - '78'
       Content-Type:
       - application/vnd.vmware.vcloud.session+xml;version=5.1
       Content-Length:
-      - '1160'
+      - '1300'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <Session xmlns="http://www.vmware.com/vcloud/v1.5" org="test" user="admin" href="https://10.30.2.2/api/session" type="application/vnd.vmware.vcloud.session+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="down" href="https://10.30.2.2/api/org/" type="application/vnd.vmware.vcloud.orgList+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/session"/>
-            <Link rel="down" href="https://10.30.2.2/api/admin/" type="application/vnd.vmware.admin.vcloud+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/query" type="application/vnd.vmware.vcloud.query.queryList+xml"/>
-            <Link rel="entityResolver" href="https://10.30.2.2/api/entity/" type="application/vnd.vmware.vcloud.entity+xml"/>
-            <Link rel="down:extensibility" href="https://10.30.2.2/api/extensibility" type="application/vnd.vmware.vcloud.apiextensibility+xml"/>
+        <Session xmlns="http://www.vmware.com/vcloud/v1.5" org="MIQDev" user="bergigre_remote" href="https://VMWARE_CLOUD_HOST/api/session" type="application/vnd.vmware.vcloud.session+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/session"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/admin/" type="application/vnd.vmware.admin.vcloud+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" name="MIQDev" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/query" type="application/vnd.vmware.vcloud.query.queryList+xml"/>
+            <Link rel="entityResolver" href="https://VMWARE_CLOUD_HOST/api/entity/" type="application/vnd.vmware.vcloud.entity+xml"/>
+            <Link rel="down:extensibility" href="https://VMWARE_CLOUD_HOST/api/extensibility" type="application/vnd.vmware.vcloud.apiextensibility+xml"/>
         </Session>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:51:58 GMT
+  recorded_at: Fri, 16 Sep 2016 08:51:46 GMT
 - request:
     method: get
     uri: https://VMWARE_CLOUD_HOST/api/org
@@ -59,40 +59,40 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:51:56 GMT
+      - Fri, 16 Sep 2016 08:51:51 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 5169cbfb-4dc3-41d0-8bc5-bea93e45f07c
+      - 2402f385-6a7a-4418-acfa-c516eb59d40b
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '8'
+      - '80'
       Content-Type:
       - application/vnd.vmware.vcloud.orglist+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '476'
+      - '520'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <OrgList xmlns="http://www.vmware.com/vcloud/v1.5" href="https://10.30.2.2/api/org/" type="application/vnd.vmware.vcloud.orgList+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Org href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" name="test" type="application/vnd.vmware.vcloud.org+xml"/>
+        <OrgList xmlns="http://www.vmware.com/vcloud/v1.5" href="https://VMWARE_CLOUD_HOST/api/org/" type="application/vnd.vmware.vcloud.orgList+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Org href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" name="MIQDev" type="application/vnd.vmware.vcloud.org+xml"/>
         </OrgList>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:51:58 GMT
+  recorded_at: Fri, 16 Sep 2016 08:51:51 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3
+    uri: https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f
     body:
       encoding: US-ASCII
       string: ''
@@ -102,52 +102,92 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:51:56 GMT
+      - Fri, 16 Sep 2016 08:51:56 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 085c41cf-8450-462e-adcc-c565f50995f6
+      - 3522e3c9-1d5e-4728-9348-0fc2622e3c1b
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '90'
+      - '87'
       Content-Type:
       - application/vnd.vmware.vcloud.org+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2255'
+      - '2589'
     body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Org xmlns="http://www.vmware.com/vcloud/v1.5" name="test" id="urn:vcloud:org:43b4c159-f280-4f79-a6c6-3b2f27e150c3" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="down" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" name="test-vdc" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79" name="vdc-m_in_m" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/tasksList/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.tasksList+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" name="firstcatalog" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/admin/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3/catalogs" type="application/vnd.vmware.admin.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/5b5c6310-2628-454a-be6d-95946e6941af" name="vdc-net-miha" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/supportedSystemsInfo/" type="application/vnd.vmware.vcloud.supportedSystemsInfo+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <FullName>Testers we ARE</FullName>
-        </Org>
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPE9yZyB4
+        bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBuYW1l
+        PSJNSVFEZXYiIGlkPSJ1cm46dmNsb3VkOm9yZzplMzM4YTRhYy01NTFiLTRi
+        NmMtYjVjMC1hZmYzMWI3MTQxN2YiIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NM
+        T1VEX0hPU1QvYXBpL29yZy9lMzM4YTRhYy01NTFiLTRiNmMtYjVjMC1hZmYz
+        MWI3MTQxN2YiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
+        Lm9yZyt4bWwiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9Y
+        TUxTY2hlbWEtaW5zdGFuY2UiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDov
+        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0dHA6Ly9WTVdBUkVfQ0xP
+        VURfSE9TVC9hcGkvdjEuNS9zY2hlbWEvbWFzdGVyLnhzZCI+CiAgICA8TGlu
+        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1Qv
+        YXBpL3ZkYy84OWFkZTk2OS0xZGM0LTQxNTYtYWJhZC1lMjlmNzk1MTE2NzYi
+        IG5hbWU9Ik1JUURldi1EZWZhdWx0LXZDRC1EdWFsU2l0ZVN0b3JhZ2UtUEFZ
+        RyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjK3ht
+        bCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovL1ZNV0FS
+        RV9DTE9VRF9IT1NUL2FwaS90YXNrc0xpc3QvZTMzOGE0YWMtNTUxYi00YjZj
+        LWI1YzAtYWZmMzFiNzE0MTdmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
+        YXJlLnZjbG91ZC50YXNrc0xpc3QreG1sIi8+CiAgICA8TGluayByZWw9ImRv
+        d24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFs
+        b2cvMDQ5MGFkM2ItZjM0My00YjgwLThkNWItZWNiMDM5N2ZkNDEyIiBuYW1l
+        PSJTaGFyZWQgVGlldG8gQ2F0YWxvZyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
+        LnZtd2FyZS52Y2xvdWQuY2F0YWxvZyt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
+        ZG93biIgaHJlZj0iaHR0cHM6Ly9WTVdBUkVfQ0xPVURfSE9TVC9hcGkvY2F0
+        YWxvZy8wNDkwYWQzYi1mMzQzLTRiODAtOGQ1Yi1lY2IwMzk3ZmQ0MTIvY29u
+        dHJvbEFjY2Vzcy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmNvbnRyb2xBY2Nlc3MreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24i
+        IGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cv
+        MjYxMDM3YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkIiBuYW1lPSJY
+        VGVzdENhdGFsb2ciIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmNhdGFsb2creG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
+        Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cvMjYxMDM3
+        YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkL2NvbnRyb2xBY2Nlc3Mv
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jb250cm9s
+        QWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVsPSJjb250cm9sQWNjZXNzIiBo
+        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9jYXRhbG9nLzI2
+        MTAzN2JjLTgyOTktNDJjMS05YWMxLWI4YzRjOTY0ZDk5ZC9hY3Rpb24vY29u
+        dHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
+        dWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxMaW5rIHJlbD0iYWRkIiBo
+        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9hZG1pbi9vcmcv
+        ZTMzOGE0YWMtNTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL2NhdGFsb2dz
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLmFkbWluLmNhdGFsb2cr
+        eG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1X
+        QVJFX0NMT1VEX0hPU1QvYXBpL25ldHdvcmsvNWFlODQwZGUtMTk4ZS00YTM0
+        LWEzMGEtNmMzNjM3NzQ2MGM2IiBuYW1lPSJJTlRfMTkyLjE2OC4xMC4wbTI0
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5vcmdOZXR3
+        b3JrK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczov
+        L1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9zdXBwb3J0ZWRTeXN0ZW1zSW5mby8i
+        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnN1cHBvcnRl
+        ZFN5c3RlbXNJbmZvK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVm
+        PSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9vcmcvZTMzOGE0YWMt
+        NTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL21ldGFkYXRhIiB0eXBlPSJh
+        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
+        ICAgIDxEZXNjcmlwdGlvbj5Pcmdhbml6YXRpb24gZm9yIFJlZEhhdCBkZXZl
+        bG9wbWVudCBvZiBNYW5hZ2VJUSB2Q2xvdWQgY29ubmVjdG9yDUNvbnRhY3Qg
+        RGF2aWQgQmFydG/FoTwvRGVzY3JpcHRpb24+CiAgICA8RnVsbE5hbWU+TWFu
+        YWdlSVEgRGV2ZWxvcG1lbnQ8L0Z1bGxOYW1lPgo8L09yZz4K
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:51:59 GMT
+  recorded_at: Fri, 16 Sep 2016 08:51:57 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865
+    uri: https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676
     body:
       encoding: US-ASCII
       string: ''
@@ -157,80 +197,79 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:51:57 GMT
+      - Fri, 16 Sep 2016 08:52:01 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 1bb9252f-f3aa-456a-be2e-407939cca890
+      - 8ccc9468-db65-4bc5-b4ba-18ee713a0a47
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '407'
+      - '54'
       Content-Type:
       - application/vnd.vmware.vcloud.vdc+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '6128'
+      - '6272'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <Vdc xmlns="http://www.vmware.com/vcloud/v1.5" status="1" name="test-vdc" id="urn:vcloud:vdc:0ede26a2-58c8-4494-821a-a216b149b865" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/uploadVAppTemplate" type="application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/media" type="application/vnd.vmware.vcloud.media+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/instantiateOvf" type="application/vnd.vmware.vcloud.instantiateOvfParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/instantiateVAppTemplate" type="application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/cloneVApp" type="application/vnd.vmware.vcloud.cloneVAppParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/cloneVAppTemplate" type="application/vnd.vmware.vcloud.cloneVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/cloneMedia" type="application/vnd.vmware.vcloud.cloneMediaParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/captureVApp" type="application/vnd.vmware.vcloud.captureVAppParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/action/composeVApp" type="application/vnd.vmware.vcloud.composeVAppParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865/disk" type="application/vnd.vmware.vcloud.diskCreateParams+xml"/>
-            <Link rel="edgeGateways" href="https://10.30.2.2/api/admin/vdc/0ede26a2-58c8-4494-821a-a216b149b865/edgeGateways" type="application/vnd.vmware.vcloud.query.records+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/admin/vdc/0ede26a2-58c8-4494-821a-a216b149b865/networks" type="application/vnd.vmware.vcloud.orgVdcNetwork+xml"/>
-            <Link rel="orgVdcNetworks" href="https://10.30.2.2/api/admin/vdc/0ede26a2-58c8-4494-821a-a216b149b865/networks" type="application/vnd.vmware.vcloud.query.records+xml"/>
+        <Vdc xmlns="http://www.vmware.com/vcloud/v1.5" status="1" name="MIQDev-Default-vCD-DualSiteStorage-PAYG" id="urn:vcloud:vdc:89ade969-1dc4-4156-abad-e29f79511676" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/uploadVAppTemplate" type="application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/media" type="application/vnd.vmware.vcloud.media+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/instantiateOvf" type="application/vnd.vmware.vcloud.instantiateOvfParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/instantiateVAppTemplate" type="application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/cloneVApp" type="application/vnd.vmware.vcloud.cloneVAppParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/cloneVAppTemplate" type="application/vnd.vmware.vcloud.cloneVAppTemplateParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/cloneMedia" type="application/vnd.vmware.vcloud.cloneMediaParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/captureVApp" type="application/vnd.vmware.vcloud.captureVAppParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/action/composeVApp" type="application/vnd.vmware.vcloud.composeVAppParams+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676/disk" type="application/vnd.vmware.vcloud.diskCreateParams+xml"/>
+            <Link rel="edgeGateways" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/89ade969-1dc4-4156-abad-e29f79511676/edgeGateways" type="application/vnd.vmware.vcloud.query.records+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/89ade969-1dc4-4156-abad-e29f79511676/networks" type="application/vnd.vmware.vcloud.orgVdcNetwork+xml"/>
+            <Link rel="orgVdcNetworks" href="https://VMWARE_CLOUD_HOST/api/admin/vdc/89ade969-1dc4-4156-abad-e29f79511676/networks" type="application/vnd.vmware.vcloud.query.records+xml"/>
             <Description/>
             <AllocationModel>AllocationVApp</AllocationModel>
             <ComputeCapacity>
                 <Cpu>
                     <Units>MHz</Units>
                     <Allocated>0</Allocated>
-                    <Limit>5000</Limit>
+                    <Limit>0</Limit>
                     <Reserved>0</Reserved>
-                    <Used>300</Used>
+                    <Used>2000</Used>
                     <Overhead>0</Overhead>
                 </Cpu>
                 <Memory>
                     <Units>MB</Units>
                     <Allocated>0</Allocated>
-                    <Limit>4096</Limit>
+                    <Limit>0</Limit>
                     <Reserved>0</Reserved>
-                    <Used>256</Used>
-                    <Overhead>31</Overhead>
+                    <Used>2048</Used>
+                    <Overhead>48</Overhead>
                 </Memory>
             </ComputeCapacity>
             <ResourceEntities>
-                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" name="vApp_system_5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-8e2253a9-5ce5-4e42-a3d2-701b6be2dcbb" name="DSL-rspec" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" name="TTY-Linux-vApp" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" name="TTYL-rspec" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                <ResourceEntity href="https://10.30.2.2/api/disk/e455d16d-f65e-49c3-8114-5811ac570465" name="D-linux" type="application/vnd.vmware.vcloud.disk+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4" name="spec-1" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" name="vApp_system_4" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" name="spec2" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                <ResourceEntity href="https://VMWARE_CLOUD_HOST/api/media/48ce1b6a-2c31-485d-a6ce-8f914c044459" name="CentOS 7" type="application/vnd.vmware.vcloud.media+xml"/>
             </ResourceEntities>
             <AvailableNetworks>
-                <Network href="https://10.30.2.2/api/network/44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected" type="application/vnd.vmware.vcloud.network+xml"/>
+                <Network href="https://VMWARE_CLOUD_HOST/api/network/5ae840de-198e-4a34-a30a-6c36377460c6" name="INT_192.168.10.0m24" type="application/vnd.vmware.vcloud.network+xml"/>
             </AvailableNetworks>
             <Capabilities>
                 <SupportedHardwareVersions>
@@ -239,125 +278,22 @@ http_interactions:
                     <SupportedHardwareVersion>vmx-08</SupportedHardwareVersion>
                     <SupportedHardwareVersion>vmx-09</SupportedHardwareVersion>
                     <SupportedHardwareVersion>vmx-10</SupportedHardwareVersion>
-                    <SupportedHardwareVersion>vmx-11</SupportedHardwareVersion>
                 </SupportedHardwareVersions>
             </Capabilities>
             <NicQuota>0</NicQuota>
-            <NetworkQuota>2</NetworkQuota>
-            <UsedNetworkCount>0</UsedNetworkCount>
-            <VmQuota>15</VmQuota>
-            <IsEnabled>true</IsEnabled>
-            <VdcStorageProfiles>
-                <VdcStorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            </VdcStorageProfiles>
-        </Vdc>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:00 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:51:57 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 22844f7d-46f9-4d03-afda-c1b7fbc6c72e
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '48'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vdc+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '5056'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Vdc xmlns="http://www.vmware.com/vcloud/v1.5" status="1" name="vdc-m_in_m" id="urn:vcloud:vdc:55b4531e-1b72-4a66-bc75-2e42d3b7cb79" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79" type="application/vnd.vmware.vcloud.vdc+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/uploadVAppTemplate" type="application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/media" type="application/vnd.vmware.vcloud.media+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/instantiateOvf" type="application/vnd.vmware.vcloud.instantiateOvfParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/instantiateVAppTemplate" type="application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/cloneVApp" type="application/vnd.vmware.vcloud.cloneVAppParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/cloneVAppTemplate" type="application/vnd.vmware.vcloud.cloneVAppTemplateParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/cloneMedia" type="application/vnd.vmware.vcloud.cloneMediaParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/captureVApp" type="application/vnd.vmware.vcloud.captureVAppParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/action/composeVApp" type="application/vnd.vmware.vcloud.composeVAppParams+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/disk" type="application/vnd.vmware.vcloud.diskCreateParams+xml"/>
-            <Link rel="edgeGateways" href="https://10.30.2.2/api/admin/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/edgeGateways" type="application/vnd.vmware.vcloud.query.records+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/admin/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/networks" type="application/vnd.vmware.vcloud.orgVdcNetwork+xml"/>
-            <Link rel="orgVdcNetworks" href="https://10.30.2.2/api/admin/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79/networks" type="application/vnd.vmware.vcloud.query.records+xml"/>
-            <Description/>
-            <AllocationModel>AllocationPool</AllocationModel>
-            <ComputeCapacity>
-                <Cpu>
-                    <Units>MHz</Units>
-                    <Allocated>500</Allocated>
-                    <Limit>500</Limit>
-                    <Reserved>400</Reserved>
-                    <Used>0</Used>
-                    <Overhead>0</Overhead>
-                </Cpu>
-                <Memory>
-                    <Units>MB</Units>
-                    <Allocated>1024</Allocated>
-                    <Limit>1024</Limit>
-                    <Reserved>522</Reserved>
-                    <Used>320</Used>
-                    <Overhead>92</Overhead>
-                </Memory>
-            </ComputeCapacity>
-            <ResourceEntities>
-                <ResourceEntity href="https://10.30.2.2/api/vApp/vapp-6d677e2e-fcce-4838-9ba8-0cb23fd183e5" name="mihap_vApp_networking" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            </ResourceEntities>
-            <AvailableNetworks>
-                <Network href="https://10.30.2.2/api/network/5b5c6310-2628-454a-be6d-95946e6941af" name="vdc-net-miha" type="application/vnd.vmware.vcloud.network+xml"/>
-            </AvailableNetworks>
-            <Capabilities>
-                <SupportedHardwareVersions>
-                    <SupportedHardwareVersion>vmx-04</SupportedHardwareVersion>
-                    <SupportedHardwareVersion>vmx-07</SupportedHardwareVersion>
-                    <SupportedHardwareVersion>vmx-08</SupportedHardwareVersion>
-                    <SupportedHardwareVersion>vmx-09</SupportedHardwareVersion>
-                    <SupportedHardwareVersion>vmx-10</SupportedHardwareVersion>
-                    <SupportedHardwareVersion>vmx-11</SupportedHardwareVersion>
-                </SupportedHardwareVersions>
-            </Capabilities>
-            <NicQuota>0</NicQuota>
-            <NetworkQuota>10</NetworkQuota>
+            <NetworkQuota>1000</NetworkQuota>
             <UsedNetworkCount>0</UsedNetworkCount>
             <VmQuota>100</VmQuota>
             <IsEnabled>true</IsEnabled>
             <VdcStorageProfiles>
-                <VdcStorageProfile href="https://10.30.2.2/api/vdcStorageProfile/4294f767-d9eb-4728-b7dd-81a2d76830bf" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                <VdcStorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
             </VdcStorageProfiles>
         </Vdc>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:00 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:02 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-8e2253a9-5ce5-4e42-a3d2-701b6be2dcbb
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4
     body:
       encoding: US-ASCII
       string: ''
@@ -367,598 +303,289 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:51:58 GMT
+      - Fri, 16 Sep 2016 08:52:07 GMT
       X-Vmware-Vcloud-Request-Id:
-      - ec8560d9-25a2-4ae2-bc32-515794395163
+      - 85fecf9b-221a-4dd4-86ec-01908a6cc97c
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '111'
+      - '231'
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHAg
-        eG1sbnM9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgeG1s
-        bnM6b3ZmPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUv
-        MSIgeG1sbnM6cmFzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93
-        c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0
-        dGluZ0RhdGEiIHhtbG5zOnZzc2Q9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L3diZW0vd3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lNX1ZpcnR1YWxTeXN0ZW1T
-        ZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8vd3d3LnZtd2FyZS5jb20v
-        c2NoZW1hL292ZiIgeG1sbnM6b3ZmZW52PSJodHRwOi8vc2NoZW1hcy5kbXRm
-        Lm9yZy9vdmYvZW52aXJvbm1lbnQvMSIgeG1sbnM6eHNpPSJodHRwOi8vd3d3
-        LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgb3ZmRGVzY3JpcHRv
-        clVwbG9hZGVkPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBu
-        YW1lPSJEU0wtcnNwZWMiIGlkPSJ1cm46dmNsb3VkOnZhcHA6OGUyMjUzYTkt
-        NWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2Qy
-        LTcwMWI2YmUyZGNiYiIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudkFwcCt4bWwiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDovL3Nj
-        aGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEgaHR0cDovL3NjaGVtYXMu
-        ZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvZHNwODAyM18xLjEuMC54c2QgaHR0
-        cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0dHA6Ly8xMC4zMC4y
-        LjIvYXBpL3YxLjUvc2NoZW1hL21hc3Rlci54c2QgaHR0cDovL3d3dy52bXdh
-        cmUuY29tL3NjaGVtYS9vdmYgaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVt
-        YS9vdmYgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2NpbS8xL2Np
-        bS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0dGluZ0RhdGEg
-        aHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2NpbS8xL2NpbS1zY2hl
-        bWEvMi4yMi4wL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25TZXR0aW5nRGF0YS54
-        c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmlyb25tZW50LzEg
-        aHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvZHNwODAy
-        N18xLjEuMC54c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2Np
-        bS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdEYXRh
-        IGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0vMS9jaW0tc2No
-        ZW1hLzIuMjIuMC9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdEYXRhLnhzZCI+
-        CiAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1h
-        M2QyLTcwMWI2YmUyZGNiYi9wb3dlci9hY3Rpb24vcG93ZXJPZmYiLz4KICAg
-        IDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcw
-        MWI2YmUyZGNiYi9wb3dlci9hY3Rpb24vcmVib290Ii8+CiAgICA8TGluayBy
-        ZWw9InBvd2VyOnJlc2V0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNi
-        Yi9wb3dlci9hY3Rpb24vcmVzZXQiLz4KICAgIDxMaW5rIHJlbD0icG93ZXI6
-        c2h1dGRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zh
-        cHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL3Bvd2Vy
-        L2FjdGlvbi9zaHV0ZG93biIvPgogICAgPExpbmsgcmVsPSJwb3dlcjpzdXNw
-        ZW5kIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThl
-        MjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNiYi9wb3dlci9hY3Rp
-        b24vc3VzcGVuZCIvPgogICAgPExpbmsgcmVsPSJkZXBsb3kiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00
-        ZTQyLWEzZDItNzAxYjZiZTJkY2JiL2FjdGlvbi9kZXBsb3kiIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRlcGxveVZBcHBQYXJhbXMr
-        eG1sIi8+CiAgICA8TGluayByZWw9InVuZGVwbG95IiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1h
-        M2QyLTcwMWI2YmUyZGNiYi9hY3Rpb24vdW5kZXBsb3kiIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95VkFwcFBhcmFtcyt4
-        bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL25ldHdvcmsvYjAwODUxMGEtN2Q1Yi00OGVjLWEzMjMtOGE3
-        Y2ViYTBhY2QwIiBuYW1lPSJWTSBOZXR3b3JrIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52QXBwTmV0d29yayt4bWwiLz4KICAgIDxM
-        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIv
-        Y29udHJvbEFjY2Vzcy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLmNvbnRyb2xBY2Nlc3MreG1sIi8+CiAgICA8TGluayByZWw9ImNv
-        bnRyb2xBY2Nlc3MiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL2Fj
-        dGlvbi9jb250cm9sQWNjZXNzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5jb250cm9sQWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVs
-        PSJ1cCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZkYy8wZWRlMjZh
-        Mi01OGM4LTQ0OTQtODIxYS1hMjE2YjE0OWI4NjUiIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZkYyt4bWwiLz4KICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
-        cC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZBcHAreG1sIi8+CiAg
-        ICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJk
-        Y2JiL293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRl
-        NDItYTNkMi03MDFiNmJlMmRjYmIvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgPExp
-        bmsgcmVsPSJvdmYiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL292
-        ZiIgdHlwZT0idGV4dC94bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC04ZTIyNTNhOS01
-        Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIvcHJvZHVjdFNlY3Rpb25zLyIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucHJvZHVjdFNl
-        Y3Rpb25zK3htbCIvPgogICAgPExpbmsgcmVsPSJzbmFwc2hvdDpjcmVhdGUi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUz
-        YTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL2FjdGlvbi9jcmVhdGVT
-        bmFwc2hvdCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        Y3JlYXRlU25hcHNob3RQYXJhbXMreG1sIi8+CiAgICA8RGVzY3JpcHRpb24v
-        PgogICAgPExlYXNlU2V0dGluZ3NTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDIt
-        NzAxYjZiZTJkY2JiL2xlYXNlU2V0dGluZ3NTZWN0aW9uLyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubGVhc2VTZXR0aW5nc1NlY3Rp
-        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
-        Zm8+TGVhc2Ugc2V0dGluZ3Mgc2VjdGlvbjwvb3ZmOkluZm8+CiAgICAgICAg
-        PExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNi
-        Yi9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NTZWN0aW9uK3htbCIvPgog
-        ICAgICAgIDxEZXBsb3ltZW50TGVhc2VJblNlY29uZHM+MDwvRGVwbG95bWVu
-        dExlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29u
-        ZHM+MDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgPC9MZWFzZVNldHRp
-        bmdzU2VjdGlvbj4KICAgIDxvdmY6U3RhcnR1cFNlY3Rpb24geG1sbnM6dmNs
-        b3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91
-        ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zdGFydHVw
-        U2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUy
-        ZGNiYi9zdGFydHVwU2VjdGlvbi8iPgogICAgICAgIDxvdmY6SW5mbz5WQXBw
-        IHN0YXJ0dXAgc2VjdGlvbjwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpJdGVt
-        IG92ZjppZD0iRFNMLXJzcGVjIiBvdmY6b3JkZXI9IjAiIG92ZjpzdGFydEFj
-        dGlvbj0icG93ZXJPbiIgb3ZmOnN0YXJ0RGVsYXk9IjAiIG92ZjpzdG9wQWN0
-        aW9uPSJwb3dlck9mZiIgb3ZmOnN0b3BEZWxheT0iMCIvPgogICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIv
-        c3RhcnR1cFNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC5zdGFydHVwU2VjdGlvbit4bWwiLz4KICAgIDwvb3ZmOlN0YXJ0
-        dXBTZWN0aW9uPgogICAgPG92ZjpOZXR3b3JrU2VjdGlvbiB4bWxuczp2Y2xv
-        dWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgdmNsb3Vk
-        OnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtT
-        ZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJk
-        Y2JiL25ldHdvcmtTZWN0aW9uLyI+CiAgICAgICAgPG92ZjpJbmZvPlRoZSBs
-        aXN0IG9mIGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxv
-        dmY6TmV0d29yayBvdmY6bmFtZT0iVk0gTmV0d29yayI+CiAgICAgICAgICAg
-        IDxvdmY6RGVzY3JpcHRpb24+VGhlIFZNIE5ldHdvcmsgbmV0d29yazwvb3Zm
-        OkRlc2NyaXB0aW9uPgogICAgICAgIDwvb3ZmOk5ldHdvcms+CiAgICA8L292
-        ZjpOZXR3b3JrU2VjdGlvbj4KICAgIDxOZXR3b3JrQ29uZmlnU2VjdGlvbiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5
-        LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNiYi9uZXR3b3JrQ29uZmlnU2Vj
-        dGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5l
-        dHdvcmtDb25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+
-        CiAgICAgICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRl
-        cnMgZm9yIGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIv
-        bmV0d29ya0NvbmZpZ1NlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5uZXR3b3JrQ29uZmlnU2VjdGlvbit4bWwiLz4KICAg
-        ICAgICA8TmV0d29ya0NvbmZpZyBuZXR3b3JrTmFtZT0iVk0gTmV0d29yayI+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icmVwYWlyIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvYWRtaW4vbmV0d29yay9iMDA4NTEwYS03ZDViLTQ4
-        ZWMtYTMyMy04YTdjZWJhMGFjZDAvYWN0aW9uL3Jlc2V0Ii8+CiAgICAgICAg
-        ICAgIDxEZXNjcmlwdGlvbj5UaGUgVk0gTmV0d29yayBuZXR3b3JrPC9EZXNj
-        cmlwdGlvbj4KICAgICAgICAgICAgPENvbmZpZ3VyYXRpb24+CiAgICAgICAg
-        ICAgICAgICA8SXBTY29wZXM+CiAgICAgICAgICAgICAgICAgICAgPElwU2Nv
-        cGU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJc0luaGVyaXRlZD5mYWxz
-        ZTwvSXNJbmhlcml0ZWQ+CiAgICAgICAgICAgICAgICAgICAgICAgIDxHYXRl
-        d2F5PjE5Mi4xNjguMjU0LjE8L0dhdGV3YXk+CiAgICAgICAgICAgICAgICAg
-        ICAgICAgIDxOZXRtYXNrPjI1NS4yNTUuMjU1LjA8L05ldG1hc2s+CiAgICAg
-        ICAgICAgICAgICAgICAgICAgIDxJc0VuYWJsZWQ+dHJ1ZTwvSXNFbmFibGVk
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZXM+CiAgICAgICAg
-        ICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZT4KICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgICA8U3RhcnRBZGRyZXNzPjE5Mi4xNjguMjU0LjEw
-        MDwvU3RhcnRBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAg
-        ICAgIDxFbmRBZGRyZXNzPjE5Mi4xNjguMjU0LjE5OTwvRW5kQWRkcmVzcz4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvSXBSYW5nZT4KICAgICAg
-        ICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlcz4KICAgICAgICAgICAgICAg
-        ICAgICA8L0lwU2NvcGU+CiAgICAgICAgICAgICAgICA8L0lwU2NvcGVzPgog
-        ICAgICAgICAgICAgICAgPEZlbmNlTW9kZT5pc29sYXRlZDwvRmVuY2VNb2Rl
-        PgogICAgICAgICAgICAgICAgPFJldGFpbk5ldEluZm9BY3Jvc3NEZXBsb3lt
-        ZW50cz5mYWxzZTwvUmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRzPgog
-        ICAgICAgICAgICAgICAgPEZlYXR1cmVzPgogICAgICAgICAgICAgICAgICAg
-        IDxEaGNwU2VydmljZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElzRW5h
-        YmxlZD5mYWxzZTwvSXNFbmFibGVkPgogICAgICAgICAgICAgICAgICAgICAg
-        ICA8RGVmYXVsdExlYXNlVGltZT4zNjAwPC9EZWZhdWx0TGVhc2VUaW1lPgog
-        ICAgICAgICAgICAgICAgICAgICAgICA8TWF4TGVhc2VUaW1lPjcyMDA8L01h
-        eExlYXNlVGltZT4KICAgICAgICAgICAgICAgICAgICA8L0RoY3BTZXJ2aWNl
-        PgogICAgICAgICAgICAgICAgPC9GZWF0dXJlcz4KICAgICAgICAgICAgPC9D
-        b25maWd1cmF0aW9uPgogICAgICAgICAgICA8SXNEZXBsb3llZD50cnVlPC9J
-        c0RlcGxveWVkPgogICAgICAgIDwvTmV0d29ya0NvbmZpZz4KICAgIDwvTmV0
-        d29ya0NvbmZpZ1NlY3Rpb24+CiAgICA8U25hcHNob3RTZWN0aW9uIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUzYTktNWNl
-        NS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL3NuYXBzaG90U2VjdGlvbiIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuc25hcHNob3RTZWN0
-        aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAgPG92ZjpJ
-        bmZvPlNuYXBzaG90IGluZm9ybWF0aW9uIHNlY3Rpb248L292ZjpJbmZvPgog
-        ICAgPC9TbmFwc2hvdFNlY3Rpb24+CiAgICA8RGF0ZUNyZWF0ZWQ+MjAxNi0w
-        OC0wNlQxNjo0MzoyMC4yMzArMDI6MDA8L0RhdGVDcmVhdGVkPgogICAgPE93
-        bmVyIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm93bmVy
-        K3htbCI+CiAgICAgICAgPFVzZXIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL2FkbWluL3VzZXIvODAzM2ZjMzUtYjI2Ny00NjRmLTlhNTctYTFlMmE1
-        ZjkxOWFjIiBuYW1lPSJncmVnb3JiIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPElu
-        TWFpbnRlbmFuY2VNb2RlPmZhbHNlPC9Jbk1haW50ZW5hbmNlTW9kZT4KICAg
-        IDxDaGlsZHJlbj4KICAgICAgICA8Vm0gbmVlZHNDdXN0b21pemF0aW9uPSJ0
-        cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBuYW1lPSJEU0wtcnNw
-        ZWMiIGlkPSJ1cm46dmNsb3VkOnZtOjIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2
-        LTgwMWU3Y2NjZTdlOSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5IiB0
-        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgog
-        ICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRk
-        OTctOGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3Bvd2VyT2ZmIi8+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRk
-        OTctOGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3JlYm9vdCIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJlc2V0IiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTct
-        OGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3Jlc2V0Ii8+CiAgICAg
-        ICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c2h1dGRvd24iIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04
-        ZDM2LTgwMWU3Y2NjZTdlOS9wb3dlci9hY3Rpb24vc2h1dGRvd24iLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzdXNwZW5kIiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTct
-        OGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3N1c3BlbmQiLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJ1bmRlcGxveSIgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYt
-        ODAxZTdjY2NlN2U5L2FjdGlvbi91bmRlcGxveSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQudW5kZXBsb3lWQXBwUGFyYW1zK3htbCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2
-        LTgwMWU3Y2NjZTdlOSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQt
-        OTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L21ldGFkYXRhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04
-        MDFlN2NjY2U3ZTkvcHJvZHVjdFNlY3Rpb25zLyIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQucHJvZHVjdFNlY3Rpb25zK3htbCIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9InNjcmVlbjp0aHVtYm5haWwiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2Mzkt
-        NGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS9zY3JlZW4iLz4KICAgICAgICAgICAg
-        PExpbmsgcmVsPSJzY3JlZW46YWNxdWlyZVRpY2tldCIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThk
-        MzYtODAxZTdjY2NlN2U5L3NjcmVlbi9hY3Rpb24vYWNxdWlyZVRpY2tldCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9Im1lZGlhOmluc2VydE1lZGlhIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05
-        NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvbWVkaWEvYWN0aW9uL2luc2Vy
-        dE1lZGlhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5t
-        ZWRpYUluc2VydE9yRWplY3RQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxM
-        aW5rIHJlbD0ibWVkaWE6ZWplY3RNZWRpYSIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAx
-        ZTdjY2NlN2U5L21lZGlhL2FjdGlvbi9lamVjdE1lZGlhIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZWRpYUluc2VydE9yRWplY3RQ
-        YXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZGlzazphdHRh
-        Y2giIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRi
-        YjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS9kaXNrL2FjdGlvbi9h
-        dHRhY2giIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRp
-        c2tBdHRhY2hPckRldGFjaFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExp
-        bmsgcmVsPSJkaXNrOmRldGFjaCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2Nl
-        N2U5L2Rpc2svYWN0aW9uL2RldGFjaCIgdHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQuZGlza0F0dGFjaE9yRGV0YWNoUGFyYW1zK3htbCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9Imluc3RhbGxWbXdhcmVUb29scyIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQt
-        OTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L2FjdGlvbi9pbnN0YWxsVk13
-        YXJlVG9vbHMiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJzbmFwc2hvdDpj
-        cmVhdGUiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIy
-        NGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS9hY3Rpb24vY3Jl
-        YXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgICAgICAgICA8
-        TGluayByZWw9InJlY29uZmlndXJlVm0iIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3
-        Y2NjZTdlOS9hY3Rpb24vcmVjb25maWd1cmVWbSIgbmFtZT0iRFNMLXJzcGVj
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwi
-        Lz4KICAgICAgICAgICAgPExpbmsgcmVsPSJ1cCIgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNk
-        Mi03MDFiNmJlMmRjYmIiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZBcHAreG1sIi8+CiAgICAgICAgICAgIDxEZXNjcmlwdGlvbj5J
-        4oCZdmUgY3JlYXRlZCBhbiBPVkYgdmVyc2lvbiBvZiB0aGUgaGlnaGx5IHBv
-        cHVsYXIgRGFtbiBTbWFsbCBMaW51eCBkaXN0cmlidXRpb24uIE5vcm1hbGx5
-        IHlvdSBydW4gdGhpcyBPUyB3aGljaCBpcyBvbmx5IDUwTUJzIGluIGRpc2sg
-        c2l6ZSBmcm9tIGFuIElTTyBvciBwZW4gZHJpdmUgYnV0IEnigJl2ZSBzZWVu
-        IG1vcmUgYW5kIG1vcmUgcGVvcGxlIGV4cGVyaW1lbnRpbmcgd2l0aCB0aGUg
-        dkNsb3VkIERpcmVjdG9yIGFuZCByZWFsbHkgbmVlZCBzbzwvRGVzY3JpcHRp
-        b24+CiAgICAgICAgICAgIDxvdmY6VmlydHVhbEhhcmR3YXJlU2VjdGlvbiB4
-        bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEu
-        NSIgb3ZmOnRyYW5zcG9ydD0iIiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQudmlydHVhbEhhcmR3YXJlU2VjdGlvbit4bWwi
-        IHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0y
-        MjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdmlydHVhbEhh
-        cmR3YXJlU2VjdGlvbi8iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlZp
-        cnR1YWwgaGFyZHdhcmUgcmVxdWlyZW1lbnRzPC9vdmY6SW5mbz4KICAgICAg
-        ICAgICAgICAgIDxvdmY6U3lzdGVtPgogICAgICAgICAgICAgICAgICAgIDx2
-        c3NkOkVsZW1lbnROYW1lPlZpcnR1YWwgSGFyZHdhcmUgRmFtaWx5PC92c3Nk
-        OkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDx2c3NkOkluc3Rh
-        bmNlSUQ+MDwvdnNzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAg
-        IDx2c3NkOlZpcnR1YWxTeXN0ZW1JZGVudGlmaWVyPkRTTC1yc3BlYzwvdnNz
-        ZDpWaXJ0dWFsU3lzdGVtSWRlbnRpZmllcj4KICAgICAgICAgICAgICAgICAg
-        ICA8dnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT52bXgtMDc8L3Zzc2Q6VmlydHVh
-        bFN5c3RlbVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAg
-        ICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6QWRkcmVzcz4wMDo1MDo1NjowMTowMDoyNDwvcmFzZDpBZGRyZXNz
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4w
-        PC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGlj
-        QWxsb2NhdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0
-        aW9uIHZjbG91ZDppcEFkZHJlc3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJp
-        bWFyeU5ldHdvcmtDb25uZWN0aW9uPSJ0cnVlIj5WTSBOZXR3b3JrPC9yYXNk
-        OkNvbm5lY3Rpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3Jp
-        cHRpb24+UENOZXQzMiBldGhlcm5ldCBhZGFwdGVyIG9uICJWTSBOZXR3b3Jr
-        IjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT5OZXR3b3JrIGFkYXB0ZXIgMDwvcmFzZDpFbGVtZW50
-        TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjE8
-        L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpS
-        ZXNvdXJjZVN1YlR5cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9y
-        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+
-        CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6QWRkcmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jh
-        c2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxl
-        bWVudE5hbWU+SURFIENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6
-        SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJj
-        ZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8
-        L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFk
-        ZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNj
-        cmlwdGlvbj5IYXJkIGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jh
-        c2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9z
-        dFJlc291cmNlIHZjbG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlw
-        ZT0iIiB2Y2xvdWQ6Y2FwYWNpdHk9IjI1NiIvPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkluc3RhbmNlSUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVu
-        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8
-        L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OlZpcnR1YWxRdWFudGl0eT4yNjg0MzU0NTY8L3Jhc2Q6VmlydHVhbFF1YW50
-        aXR5PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0
-        eVVuaXRzPmJ5dGU8L3Jhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        dGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3M+MTwvcmFz
-        ZDpBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0
-        aW9uPklERSBDb250cm9sbGVyPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPklERSBDb250cm9sbGVy
-        IDE8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6SW5zdGFuY2VJRD4zPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjU8L3Jhc2Q6UmVzb3VyY2VU
-        eXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAg
-        ICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRy
-        ZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxzZTwv
-        cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkRlc2NyaXB0aW9uPkNEL0RWRCBEcml2ZTwvcmFzZDpEZXNjcmlw
-        dGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5D
-        RC9EVkQgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkluc3RhbmNlSUQ+MzAwMjwvcmFzZDpJbnN0YW5jZUlEPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlBhcmVudD4zPC9yYXNkOlBhcmVu
-        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTU8
-        L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRl
-        bT4KICAgICAgICAgICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpBZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25Q
-        YXJlbnQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxs
-        b2NhdGlvbj5mYWxzZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPkZsb3BweSBEcml2
-        ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT5GbG9wcHkgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFt
-        ZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+ODAwMDwvcmFz
-        ZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291
-        cmNlVHlwZT4xNDwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAg
-        ICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtIHZjbG91
-        ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
-        bSt4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdmly
-        dHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUiPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkFsbG9jYXRpb25Vbml0cz5oZXJ0eiAqIDEwXjY8L3Jhc2Q6QWxs
-        b2NhdGlvblVuaXRzPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2Ny
-        aXB0aW9uPk51bWJlciBvZiBWaXJ0dWFsIENQVXM8L3Jhc2Q6RGVzY3JpcHRp
-        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+MSB2
-        aXJ0dWFsIENQVShzKTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjQ8L3Jhc2Q6SW5zdGFuY2VJRD4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNk
-        OlJlc2VydmF0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291
-        cmNlVHlwZT4zPC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVh
-        bnRpdHk+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6V2VpZ2h0PjA8L3Jh
-        c2Q6V2VpZ2h0PgogICAgICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJi
-        MjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJkd2Fy
-        ZVNlY3Rpb24vY3B1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5yYXNkSXRlbSt4bWwiLz4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0
-        ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNs
-        b3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRi
-        YjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uL21lbW9yeSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        QWxsb2NhdGlvblVuaXRzPmJ5dGUgKiAyXjIwPC9yYXNkOkFsbG9jYXRpb25V
-        bml0cz4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5N
-        ZW1vcnkgU2l6ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpFbGVtZW50TmFtZT4yNTYgTUIgb2YgbWVtb3J5PC9yYXNk
-        OkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3Rh
-        bmNlSUQ+NTwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOlJlc2VydmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjQ8L3Jhc2Q6UmVz
-        b3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxR
-        dWFudGl0eT4yNTY8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAg
-        ICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2
-        LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAg
-        ICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2Nj
-        Y2U3ZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2Mzkt
-        NGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L2NwdSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFz
-        ZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0
-        LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uL2NwdSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIy
-        NGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFy
-        ZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAg
-        ICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3
-        Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3ht
-        bCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRk
-        OTctOGQzNi04MDFlN2NjY2U3ZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9k
-        aXNrcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFz
-        ZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0
-        ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJk
-        d2FyZVNlY3Rpb24vbWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAg
-        ICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdl
-        OS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4
-        bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00
-        ZDk3LThkMzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
-        bmV0d29ya0NhcmRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExp
-        bmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdmly
-        dHVhbEhhcmR3YXJlU2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4K
-        ICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThk
-        MzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFs
-        UG9ydHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
-        c2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxI
-        YXJkd2FyZVNlY3Rpb24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lz
-        dGVtU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNv
-        bS92Y2xvdWQvdjEuNSIgb3ZmOmlkPSI5NSIgdmNsb3VkOnR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rp
-        b24reG1sIiB2bXc6b3NUeXBlPSJkZWJpYW40R3Vlc3QiIHZjbG91ZDpocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5
-        LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvb3BlcmF0aW5nU3lzdGVtU2VjdGlv
-        bi8iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUg
-        b3BlcmF0aW5nIHN5c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAg
-        ICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5EZWJpYW4gR05VL0xpbnV4IDQg
-        KDMyLWJpdCk8L292ZjpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L29w
-        ZXJhdGluZ1N5c3RlbVNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uK3htbCIvPgog
-        ICAgICAgICAgICA8L292ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uPgogICAg
-        ICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04
-        ZDM2LTgwMWU3Y2NjZTdlOS9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0
-        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29u
-        bmVjdGlvblNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAg
-        ICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJs
-        ZSBWTSBuZXR3b3JrIGNvbm5lY3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAg
-        ICAgICAgIDxQcmltYXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9Qcmlt
-        YXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgIDxO
-        ZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5l
-        dHdvcms9IlZNIE5ldHdvcmsiPgogICAgICAgICAgICAgICAgICAgIDxOZXR3
-        b3JrQ29ubmVjdGlvbkluZGV4PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+
-        CiAgICAgICAgICAgICAgICAgICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29u
-        bmVjdGVkPgogICAgICAgICAgICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUw
-        OjU2OjAxOjAwOjI0PC9NQUNBZGRyZXNzPgogICAgICAgICAgICAgICAgICAg
-        IDxJcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxv
-        Y2F0aW9uTW9kZT4KICAgICAgICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rp
-        b24+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5
-        Ny04ZDM2LTgwMWU3Y2NjZTdlOS9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24v
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3Jr
-        Q29ubmVjdGlvblNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvTmV0d29y
-        a0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RDdXN0b21p
-        emF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvZ3Vl
-        c3RDdXN0b21pemF0aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLmd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24reG1s
-        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
-        SW5mbz5TcGVjaWZpZXMgR3Vlc3QgT1MgQ3VzdG9taXphdGlvbiBTZXR0aW5n
-        czwvb3ZmOkluZm8+CiAgICAgICAgICAgICAgICA8RW5hYmxlZD5mYWxzZTwv
-        RW5hYmxlZD4KICAgICAgICAgICAgICAgIDxDaGFuZ2VTaWQ+ZmFsc2U8L0No
-        YW5nZVNpZD4KICAgICAgICAgICAgICAgIDxWaXJ0dWFsTWFjaGluZUlkPjIy
-        NGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOTwvVmlydHVhbE1h
-        Y2hpbmVJZD4KICAgICAgICAgICAgICAgIDxKb2luRG9tYWluRW5hYmxlZD5m
-        YWxzZTwvSm9pbkRvbWFpbkVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8VXNl
-        T3JnU2V0dGluZ3M+ZmFsc2U8L1VzZU9yZ1NldHRpbmdzPgogICAgICAgICAg
-        ICAgICAgPEFkbWluUGFzc3dvcmRFbmFibGVkPnRydWU8L0FkbWluUGFzc3dv
-        cmRFbmFibGVkPgogICAgICAgICAgICAgICAgPEFkbWluUGFzc3dvcmRBdXRv
-        PnRydWU8L0FkbWluUGFzc3dvcmRBdXRvPgogICAgICAgICAgICAgICAgPFJl
-        c2V0UGFzc3dvcmRSZXF1aXJlZD5mYWxzZTwvUmVzZXRQYXNzd29yZFJlcXVp
-        cmVkPgogICAgICAgICAgICAgICAgPENvbXB1dGVyTmFtZT5EYW1uU21hbGxM
-        aS0wMDE8L0NvbXB1dGVyTmFtZT4KICAgICAgICAgICAgICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        MjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L2d1ZXN0Q3Vz
-        dG9taXphdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIvPgog
-        ICAgICAgICAgICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAg
-        ICAgICAgIDxSdW50aW1lSW5mb1NlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRw
-        Oi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91ZDp0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdl
-        OS9ydW50aW1lSW5mb1NlY3Rpb24iPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        bmZvPlNwZWNpZmllcyBSdW50aW1lIGluZm88L292ZjpJbmZvPgogICAgICAg
-        ICAgICA8L1J1bnRpbWVJbmZvU2VjdGlvbj4KICAgICAgICAgICAgPFNuYXBz
-        aG90U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
-        bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvc25hcHNo
-        b3RTZWN0aW9uIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5zbmFwc2hvdFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4K
-        ICAgICAgICAgICAgICAgIDxvdmY6SW5mbz5TbmFwc2hvdCBpbmZvcm1hdGlv
-        biBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICAgICAgPC9TbmFwc2hvdFNl
-        Y3Rpb24+CiAgICAgICAgICAgIDxEYXRlQ3JlYXRlZD4yMDE2LTA4LTA2VDE2
-        OjQzOjI4LjUzMCswMjowMDwvRGF0ZUNyZWF0ZWQ+CiAgICAgICAgICAgIDxW
-        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
-        TG9jYWxJZD4KICAgICAgICAgICAgPG92ZmVudjpFbnZpcm9ubWVudCB4bWxu
-        czpuczExPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIg
-        b3ZmZW52OmlkPSIiIG5zMTE6dkNlbnRlcklkPSJ2bS0xMTciPgogICAgICAg
-        ICAgICAgICAgPG92ZmVudjpQbGF0Zm9ybVNlY3Rpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPG92ZmVudjpLaW5kPlZNd2FyZSBFU1hpPC9vdmZlbnY6S2lu
-        ZD4KICAgICAgICAgICAgICAgICAgICA8b3ZmZW52OlZlcnNpb24+Ni4wLjA8
-        L292ZmVudjpWZXJzaW9uPgogICAgICAgICAgICAgICAgICAgIDxvdmZlbnY6
-        VmVuZG9yPlZNd2FyZSwgSW5jLjwvb3ZmZW52OlZlbmRvcj4KICAgICAgICAg
-        ICAgICAgICAgICA8b3ZmZW52OkxvY2FsZT5lbjwvb3ZmZW52OkxvY2FsZT4K
-        ICAgICAgICAgICAgICAgIDwvb3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4KICAg
-        ICAgICAgICAgICAgIDx2ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uIHhtbG5z
-        OnZlPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgeG1s
-        bnM9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVudC8x
-        IiB4bWxuczpvZT0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmly
-        b25tZW50LzEiPgogICAgICAgICAgICAgICAgICAgIDx2ZTpBZGFwdGVyIHZl
-        Om1hYz0iMDA6NTA6NTY6MDE6MDA6MjQiIHZlOm5ldHdvcms9ImR2cy5WQ0RW
-        U1ZNIE5ldHdvcmstZTkxZDZlZjItZGY2My00MWI2LTgwYmUtZjczZjFhZGQw
-        Y2VlIiB2ZTp1bml0TnVtYmVyPSI3Ii8+CiAgIAogICAgICAgICAgICAgICAg
-        PC92ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uPgogICAgICAgICAgICA8L292
-        ZmVudjpFbnZpcm9ubWVudD4KICAgICAgICAgICAgPFZtQ2FwYWJpbGl0aWVz
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0
-        LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92bUNhcGFiaWxpdGllcy8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2FwYWJp
-        bGl0aWVzU2VjdGlvbit4bWwiPgogICAgICAgICAgICAgICAgPExpbmsgcmVs
-        PSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0y
-        MjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdm1DYXBhYmls
-        aXRpZXMvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
-        bUNhcGFiaWxpdGllc1NlY3Rpb24reG1sIi8+CiAgICAgICAgICAgICAgICA8
-        TWVtb3J5SG90QWRkRW5hYmxlZD5mYWxzZTwvTWVtb3J5SG90QWRkRW5hYmxl
-        ZD4KICAgICAgICAgICAgICAgIDxDcHVIb3RBZGRFbmFibGVkPmZhbHNlPC9D
-        cHVIb3RBZGRFbmFibGVkPgogICAgICAgICAgICA8L1ZtQ2FwYWJpbGl0aWVz
-        PgogICAgICAgICAgICA8U3RvcmFnZVByb2ZpbGUgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMt
-        NGNhYS1iNmQ4LWNkMjU4MjUxZWE4ZCIgbmFtZT0iKiIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1s
-        Ii8+CiAgICAgICAgPC9WbT4KICAgIDwvQ2hpbGRyZW4+CjwvVkFwcD4K
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VApp xmlns=\"http://www.vmware.com/vcloud/v1.5\"
+        xmlns:ovf=\"http://schemas.dmtf.org/ovf/envelope/1\" xmlns:vssd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData\"
+        xmlns:rasd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData\"
+        xmlns:vmw=\"http://www.vmware.com/schema/ovf\" xmlns:ovfenv=\"http://schemas.dmtf.org/ovf/environment/1\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ovfDescriptorUploaded=\"true\"
+        deployed=\"true\" status=\"4\" name=\"spec-1\" id=\"urn:vcloud:vapp:0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        type=\"application/vnd.vmware.vcloud.vApp+xml\" xsi:schemaLocation=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData
+        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd
+        http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1
+        http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://schemas.dmtf.org/ovf/environment/1
+        http://schemas.dmtf.org/ovf/envelope/1/dsp8027_1.1.0.xsd http://www.vmware.com/vcloud/v1.5
+        http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData
+        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd\">\n
+        \   <Link rel=\"power:powerOff\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/powerOff\"/>\n
+        \   <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reboot\"/>\n
+        \   <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reset\"/>\n
+        \   <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/shutdown\"/>\n
+        \   <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/suspend\"/>\n
+        \   <Link rel=\"deploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/deploy\"
+        type=\"application/vnd.vmware.vcloud.deployVAppParams+xml\"/>\n    <Link rel=\"undeploy\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/undeploy\"
+        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n    <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/network/a0912234-e83d-4162-aef1-b48556cef93f\"
+        name=\"INT_192.168.10.0m24\" type=\"application/vnd.vmware.vcloud.vAppNetwork+xml\"/>\n
+        \   <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/controlAccess/\"
+        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"controlAccess\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/controlAccess\"
+        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"up\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676\"
+        type=\"application/vnd.vmware.vcloud.vdc+xml\"/>\n    <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n    <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/owner\"
+        type=\"application/vnd.vmware.vcloud.owner+xml\"/>\n    <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/metadata\"
+        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n    <Link rel=\"ovf\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/ovf\"
+        type=\"text/xml\"/>\n    <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/productSections/\"
+        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n    <Link rel=\"snapshot:create\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/createSnapshot\"
+        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n    <Description/>\n
+        \   <LeaseSettingsSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
+        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\" ovf:required=\"false\">\n
+        \       <ovf:Info>Lease settings section</ovf:Info>\n        <Link rel=\"edit\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
+        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\"/>\n        <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>\n
+        \       <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>\n        <DeploymentLeaseExpiration>2016-09-23T11:46:52.987+03:00</DeploymentLeaseExpiration>\n
+        \   </LeaseSettingsSection>\n    <ovf:StartupSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.startupSection+xml\">\n        <ovf:Info>VApp
+        startup section</ovf:Info>\n        <ovf:Item ovf:id=\"spec1-vm1\" ovf:order=\"0\"
+        ovf:startAction=\"powerOn\" ovf:startDelay=\"0\" ovf:stopAction=\"powerOff\"
+        ovf:stopDelay=\"0\"/>\n        <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
+        type=\"application/vnd.vmware.vcloud.startupSection+xml\"/>\n    </ovf:StartupSection>\n
+        \   <ovf:NetworkSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.networkSection+xml\">\n        <ovf:Info>The
+        list of logical networks</ovf:Info>\n        <ovf:Network ovf:name=\"INT_192.168.10.0m24\">\n
+        \           <ovf:Description/>\n        </ovf:Network>\n    </ovf:NetworkSection>\n
+        \   <NetworkConfigSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\" ovf:required=\"false\">\n
+        \       <ovf:Info>The configuration parameters for logical networks</ovf:Info>\n
+        \       <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\"/>\n        <NetworkConfig
+        networkName=\"INT_192.168.10.0m24\">\n            <Link rel=\"repair\" href=\"https://VMWARE_CLOUD_HOST/api/admin/network/a0912234-e83d-4162-aef1-b48556cef93f/action/reset\"/>\n
+        \           <Description/>\n            <Configuration>\n                <IpScopes>\n
+        \                   <IpScope>\n                        <IsInherited>true</IsInherited>\n
+        \                       <Gateway>192.168.10.1</Gateway>\n                        <Netmask>255.255.255.0</Netmask>\n
+        \                       <Dns1>192.168.10.1</Dns1>\n                        <DnsSuffix>test.local</DnsSuffix>\n
+        \                       <IsEnabled>true</IsEnabled>\n                        <IpRanges>\n
+        \                           <IpRange>\n                                <StartAddress>192.168.10.100</StartAddress>\n
+        \                               <EndAddress>192.168.10.199</EndAddress>\n
+        \                           </IpRange>\n                        </IpRanges>\n
+        \                   </IpScope>\n                </IpScopes>\n                <ParentNetwork
+        href=\"https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6\"
+        id=\"5ae840de-198e-4a34-a30a-6c36377460c6\" name=\"INT_192.168.10.0m24\"/>\n
+        \               <FenceMode>bridged</FenceMode>\n                <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>\n
+        \           </Configuration>\n            <IsDeployed>true</IsDeployed>\n
+        \       </NetworkConfig>\n    </NetworkConfigSection>\n    <SnapshotSection
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/snapshotSection\"
+        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
+        \       <ovf:Info>Snapshot information section</ovf:Info>\n    </SnapshotSection>\n
+        \   <DateCreated>2016-09-16T11:45:24.897+03:00</DateCreated>\n    <Owner type=\"application/vnd.vmware.vcloud.owner+xml\">\n
+        \       <User href=\"https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6\"
+        name=\"bergigre_remote\" type=\"application/vnd.vmware.admin.user+xml\"/>\n
+        \   </Owner>\n    <InMaintenanceMode>false</InMaintenanceMode>\n    <Children>\n
+        \       <Vm needsCustomization=\"false\" nestedHypervisorEnabled=\"false\"
+        deployed=\"true\" status=\"4\" name=\"spec1-vm1\" id=\"urn:vcloud:vm:f9ceb77c-b9d9-400c-8c06-72c785e884af\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
+        type=\"application/vnd.vmware.vcloud.vm+xml\">\n            <Link rel=\"power:powerOff\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/powerOff\"/>\n
+        \           <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reboot\"/>\n
+        \           <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reset\"/>\n
+        \           <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/shutdown\"/>\n
+        \           <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/suspend\"/>\n
+        \           <Link rel=\"undeploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/undeploy\"
+        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n            <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
+        type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/metadata\"
+        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n            <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/productSections/\"
+        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n            <Link
+        rel=\"screen:thumbnail\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen\"/>\n
+        \           <Link rel=\"screen:acquireTicket\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen/action/acquireTicket\"/>\n
+        \           <Link rel=\"media:insertMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/insertMedia\"
+        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
+        rel=\"media:ejectMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/ejectMedia\"
+        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
+        rel=\"disk:attach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/attach\"
+        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
+        rel=\"disk:detach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/detach\"
+        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
+        rel=\"installVmwareTools\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/installVMwareTools\"/>\n
+        \           <Link rel=\"snapshot:create\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/createSnapshot\"
+        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n            <Link
+        rel=\"reconfigureVm\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/reconfigureVm\"
+        name=\"spec1-vm1\" type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link
+        rel=\"up\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n            <Description/>\n
+        \           <ovf:VirtualHardwareSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        ovf:transport=\"\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
+        \               <ovf:Info>Virtual hardware requirements</ovf:Info>\n                <ovf:System>\n
+        \                   <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>\n
+        \                   <vssd:InstanceID>0</vssd:InstanceID>\n                    <vssd:VirtualSystemIdentifier>spec1-vm1</vssd:VirtualSystemIdentifier>\n
+        \                   <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>\n
+        \               </ovf:System>\n                <ovf:Item>\n                    <rasd:Address>00:50:56:01:00:64</rasd:Address>\n
+        \                   <rasd:AddressOnParent>0</rasd:AddressOnParent>\n                    <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>\n
+        \                   <rasd:Connection vcloud:ipAddress=\"192.168.10.100\" vcloud:primaryNetworkConnection=\"true\"
+        vcloud:ipAddressingMode=\"POOL\">INT_192.168.10.0m24</rasd:Connection>\n                    <rasd:Description>Vmxnet3
+        ethernet adapter on \"INT_192.168.10.0m24\"</rasd:Description>\n                    <rasd:ElementName>Network
+        adapter 0</rasd:ElementName>\n                    <rasd:InstanceID>1</rasd:InstanceID>\n
+        \                   <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>\n
+        \                   <rasd:ResourceType>10</rasd:ResourceType>\n                </ovf:Item>\n
+        \               <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
+        \                   <rasd:Description>SCSI Controller</rasd:Description>\n
+        \                   <rasd:ElementName>SCSI Controller 0</rasd:ElementName>\n
+        \                   <rasd:InstanceID>2</rasd:InstanceID>\n                    <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>\n
+        \                   <rasd:ResourceType>6</rasd:ResourceType>\n                </ovf:Item>\n
+        \               <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
+        \                   <rasd:Description>Hard disk</rasd:Description>\n                    <rasd:ElementName>Hard
+        disk 1</rasd:ElementName>\n                    <rasd:HostResource vcloud:capacity=\"16384\"
+        vcloud:busSubType=\"lsilogic\" vcloud:busType=\"6\"/>\n                    <rasd:InstanceID>2000</rasd:InstanceID>\n
+        \                   <rasd:Parent>2</rasd:Parent>\n                    <rasd:ResourceType>17</rasd:ResourceType>\n
+        \                   <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>\n
+        \                   <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>\n
+        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
+        \                   <rasd:Description>IDE Controller</rasd:Description>\n
+        \                   <rasd:ElementName>IDE Controller 0</rasd:ElementName>\n
+        \                   <rasd:InstanceID>3</rasd:InstanceID>\n                    <rasd:ResourceType>5</rasd:ResourceType>\n
+        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
+        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
+        \                   <rasd:Description>CD/DVD Drive</rasd:Description>\n                    <rasd:ElementName>CD/DVD
+        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>3000</rasd:InstanceID>\n
+        \                   <rasd:Parent>3</rasd:Parent>\n                    <rasd:ResourceType>15</rasd:ResourceType>\n
+        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
+        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
+        \                   <rasd:Description>Floppy Drive</rasd:Description>\n                    <rasd:ElementName>Floppy
+        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>8000</rasd:InstanceID>\n
+        \                   <rasd:ResourceType>14</rasd:ResourceType>\n                </ovf:Item>\n
+        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>hertz
+        * 10^6</rasd:AllocationUnits>\n                    <rasd:Description>Number
+        of Virtual CPUs</rasd:Description>\n                    <rasd:ElementName>2
+        virtual CPU(s)</rasd:ElementName>\n                    <rasd:InstanceID>4</rasd:InstanceID>\n
+        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>3</rasd:ResourceType>\n
+        \                   <rasd:VirtualQuantity>2</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
+        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
+        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>byte
+        * 2^20</rasd:AllocationUnits>\n                    <rasd:Description>Memory
+        Size</rasd:Description>\n                    <rasd:ElementName>2048 MB of
+        memory</rasd:ElementName>\n                    <rasd:InstanceID>5</rasd:InstanceID>\n
+        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>4</rasd:ResourceType>\n
+        \                   <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
+        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
+        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
+        type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/media\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n            </ovf:VirtualHardwareSection>\n
+        \           <ovf:OperatingSystemSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        ovf:id=\"101\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\" vmw:osType=\"centos64Guest\">\n
+        \               <ovf:Info>Specifies the operating system installed</ovf:Info>\n
+        \               <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>\n
+        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
+        type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\"/>\n            </ovf:OperatingSystemSection>\n
+        \           <NetworkConnectionSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\" ovf:required=\"false\">\n
+        \               <ovf:Info>Specifies the available VM network connections</ovf:Info>\n
+        \               <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>\n
+        \               <NetworkConnection needsCustomization=\"true\" network=\"INT_192.168.10.0m24\">\n
+        \                   <NetworkConnectionIndex>0</NetworkConnectionIndex>\n                    <IpAddress>192.168.10.100</IpAddress>\n
+        \                   <IsConnected>true</IsConnected>\n                    <MACAddress>00:50:56:01:00:64</MACAddress>\n
+        \                   <IpAddressAllocationMode>POOL</IpAddressAllocationMode>\n
+        \               </NetworkConnection>\n                <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\"/>\n            </NetworkConnectionSection>\n
+        \           <GuestCustomizationSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
+        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\" ovf:required=\"false\">\n
+        \               <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>\n
+        \               <Enabled>false</Enabled>\n                <ChangeSid>false</ChangeSid>\n
+        \               <VirtualMachineId>f9ceb77c-b9d9-400c-8c06-72c785e884af</VirtualMachineId>\n
+        \               <JoinDomainEnabled>false</JoinDomainEnabled>\n                <UseOrgSettings>false</UseOrgSettings>\n
+        \               <AdminPasswordEnabled>true</AdminPasswordEnabled>\n                <AdminPasswordAuto>true</AdminPasswordAuto>\n
+        \               <ResetPasswordRequired>false</ResetPasswordRequired>\n                <ComputerName>CentOS7-0</ComputerName>\n
+        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
+        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\"/>\n            </GuestCustomizationSection>\n
+        \           <RuntimeInfoSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/runtimeInfoSection\"
+        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
+        \               <ovf:Info>Specifies Runtime info</ovf:Info>\n                <VMWareTools
+        version=\"10240\"/>\n            </RuntimeInfoSection>\n            <SnapshotSection
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/snapshotSection\"
+        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
+        \               <ovf:Info>Snapshot information section</ovf:Info>\n            </SnapshotSection>\n
+        \           <DateCreated>2016-09-16T11:45:30.557+03:00</DateCreated>\n            <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>\n
+        \           <ovfenv:Environment xmlns:ns11=\"http://www.vmware.com/schema/ovfenv\"
+        ovfenv:id=\"\" ns11:vCenterId=\"vm-589\">\n                <ovfenv:PlatformSection>\n
+        \                   <ovfenv:Kind>VMware ESXi</ovfenv:Kind>\n                    <ovfenv:Version>6.0.0</ovfenv:Version>\n
+        \                   <ovfenv:Vendor>VMware, Inc.</ovfenv:Vendor>\n                    <ovfenv:Locale>en</ovfenv:Locale>\n
+        \               </ovfenv:PlatformSection>\n                <ve:EthernetAdapterSection
+        xmlns:ve=\"http://www.vmware.com/schema/ovfenv\" xmlns=\"http://schemas.dmtf.org/ovf/environment/1\"
+        xmlns:oe=\"http://schemas.dmtf.org/ovf/environment/1\">\n                    <ve:Adapter
+        ve:mac=\"00:50:56:01:00:64\" ve:network=\"vxw-dvs-128-virtualwire-18-sid-5004-dvs.VCDVSINT_192.168.10.0m24-55dcece1-954f-4\"
+        ve:unitNumber=\"7\"/>\n   \n                </ve:EthernetAdapterSection>\n
+        \           </ovfenv:Environment>\n            <VmCapabilities href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
+        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\">\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
+        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\"/>\n                <MemoryHotAddEnabled>false</MemoryHotAddEnabled>\n
+        \               <CpuHotAddEnabled>false</CpuHotAddEnabled>\n            </VmCapabilities>\n
+        \           <StorageProfile href=\"https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8\"
+        name=\"Dual site - Tier 1\" type=\"application/vnd.vmware.vcloud.vdcStorageProfile+xml\"/>\n
+        \       </Vm>\n    </Children>\n</VApp>\n"
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:00 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:08 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d
     body:
       encoding: US-ASCII
       string: ''
@@ -968,442 +595,157 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:51:58 GMT
+      - Fri, 16 Sep 2016 08:52:13 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 39ebadcb-ba26-41c4-9ce2-138ea376a72e
+      - 61b8690b-d111-4af9-9e4f-f82ae31f670a
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '109'
+      - '145'
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="true" status="8" name="TTY-Linux-vApp" id="urn:vcloud:vapp:b74cbaa5-0680-4a9b-a623-1335cb62fff0" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/power/action/powerOn"/>
-            <Link rel="power:powerOff" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/power/action/powerOff"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="undeploy" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="3" name="vApp_system_4" id="urn:vcloud:vapp:6aa2d7ae-5245-45a0-82e8-4984e759ba5d" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/power/action/powerOn"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/discardSuspendedState"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/82759035-35af-4b27-a273-65e3dcaefb73" name="testnet" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
             <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-15T16:56:20.453+03:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/">
+            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="TTYLinux" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
+                <ovf:Network ovf:name="testnet">
+                    <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="VM Network">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c/action/reset"/>
-                    <Description>The VM Network network</Description>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="testnet">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/82759035-35af-4b27-a273-65e3dcaefb73/action/reset"/>
+                    <Description/>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
                                 <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
+                                <Gateway>192.168.2.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
+                                        <StartAddress>192.168.2.100</StartAddress>
+                                        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
                         <FenceMode>isolated</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <DhcpService>
-                                <IsEnabled>false</IsEnabled>
-                                <DefaultLeaseTime>3600</DefaultLeaseTime>
-                                <MaxLeaseTime>7200</MaxLeaseTime>
-                            </DhcpService>
-                        </Features>
-                    </Configuration>
-                    <IsDeployed>true</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                <ovf:Info>Snapshot information section</ovf:Info>
-            </SnapshotSection>
-            <DateCreated>2016-08-01T14:50:04.300+02:00</DateCreated>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/17d06c5f-f2fe-4767-8006-ebfa36b12c44" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <InMaintenanceMode>false</InMaintenanceMode>
-            <Children>
-                <Vm needsCustomization="true" deployed="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/screen"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="upgrade" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/upgradeHardwareVersion"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/reconfigureVm" name="TTYLinux" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>TTYLinux</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:13</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
-                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>1</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
-                            <rasd:HostResource/>
-                            <rasd:InstanceID>3002</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="36" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="otherLinuxGuest" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:13</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
-                        </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f4625547-9bba-4ec9-bcd8-7cb3c5ca0290</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-                    </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-08-01T14:50:13.840+02:00</DateCreated>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                </Vm>
-            </Children>
-        </VApp>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:01 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:51:59 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 7c976c97-9231-4a22-98e2-35cf6913c0a3
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '103'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="TTYL-rspec" id="urn:vcloud:vapp:f86685ad-320c-4c8e-9148-1783f9999628" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/power/action/powerOn"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/2f35f44d-17e4-4564-8ee6-f927e23d7e94" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/disableDownload"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
-            </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/startupSection/">
-                <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="TTYL-rspec" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
-            </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/networkSection/">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="VM Network">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/2f35f44d-17e4-4564-8ee6-f927e23d7e94/action/reset"/>
-                    <Description>The VM Network network</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <DhcpService>
-                                <IsEnabled>false</IsEnabled>
-                                <DefaultLeaseTime>3600</DefaultLeaseTime>
-                                <MaxLeaseTime>7200</MaxLeaseTime>
-                            </DhcpService>
-                        </Features>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                 <ovf:Info>Snapshot information section</ovf:Info>
             </SnapshotSection>
-            <DateCreated>2016-08-06T16:44:37.970+02:00</DateCreated>
+            <DateCreated>2016-09-08T16:48:46.357+03:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/8033fc35-b267-464f-9a57-a1e2a5f919ac" name="gregorb" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/3fde93ae-0521-4a75-8dec-cb4bcb7dcbb0" name="system" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="true" deployed="false" status="8" name="TTYL-rspec" id="urn:vcloud:vm:6844a379-61be-4652-817a-f14bb5f09512" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/screen"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="upgrade" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/upgradeHardwareVersion"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/reconfigureVm" name="TTYL-rspec" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/">
+                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="3" name="CentOS7" id="urn:vcloud:vm:8df2faf3-fd33-40de-9b26-da34c146f55d" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/discardSuspendedState"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/screen"/>
+                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/enableNestedHypervisor"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/reconfigureVm" name="CentOS7" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description/>
+                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>TTYL-rspec</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
+                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:25</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:4a</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
-                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
+                            <rasd:Connection vcloud:ipAddress="192.168.2.100" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">testnet</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "testnet"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                             <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
                             <rasd:Parent>2</rasd:Parent>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
                         </ovf:Item>
                         <ovf:Item>
-                            <rasd:Address>1</rasd:Address>
+                            <rasd:Address>0</rasd:Address>
                             <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
                             <rasd:InstanceID>3</rasd:InstanceID>
                             <rasd:ResourceType>5</rasd:ResourceType>
                         </ovf:Item>
@@ -1413,2434 +755,108 @@ http_interactions:
                             <rasd:Description>CD/DVD Drive</rasd:Description>
                             <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
                             <rasd:HostResource/>
-                            <rasd:InstanceID>3002</rasd:InstanceID>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
                             <rasd:Parent>3</rasd:Parent>
                             <rasd:ResourceType>15</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu">
-                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
-                            <rasd:InstanceID>4</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory">
-                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-                            <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
-                            <rasd:InstanceID>5</rasd:InstanceID>
-                            <rasd:Reservation>0</rasd:Reservation>
-                            <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
-                            <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                    </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="36" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="otherLinuxGuest" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/operatingSystemSection/">
-                        <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
-                    </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:25</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
-                        </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>6844a379-61be-4652-817a-f14bb5f09512</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
-                    </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/runtimeInfoSection">
-                        <ovf:Info>Specifies Runtime info</ovf:Info>
-                    </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                        <ovf:Info>Snapshot information section</ovf:Info>
-                    </SnapshotSection>
-                    <DateCreated>2016-08-06T16:44:47.657+02:00</DateCreated>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
-                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
-                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
-                    </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                </Vm>
-            </Children>
-        </VApp>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:02 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-6d677e2e-fcce-4838-9ba8-0cb23fd183e5
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:00 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 5a8a42f6-ff26-4407-b9a2-2d943ed8feb3
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '274'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHAg
-        eG1sbnM9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgeG1s
-        bnM6b3ZmPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUv
-        MSIgeG1sbnM6cmFzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93
-        c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0
-        dGluZ0RhdGEiIHhtbG5zOnZzc2Q9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L3diZW0vd3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lNX1ZpcnR1YWxTeXN0ZW1T
-        ZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8vd3d3LnZtd2FyZS5jb20v
-        c2NoZW1hL292ZiIgeG1sbnM6b3ZmZW52PSJodHRwOi8vc2NoZW1hcy5kbXRm
-        Lm9yZy9vdmYvZW52aXJvbm1lbnQvMSIgeG1sbnM6eHNpPSJodHRwOi8vd3d3
-        LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgb3ZmRGVzY3JpcHRv
-        clVwbG9hZGVkPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBu
-        YW1lPSJtaWhhcF92QXBwX25ldHdvcmtpbmciIGlkPSJ1cm46dmNsb3VkOnZh
-        cHA6NmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZj
-        Y2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNSIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQudkFwcCt4bWwiIHhzaTpzY2hlbWFMb2NhdGlv
-        bj0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEgaHR0
-        cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvZHNwODAyM18x
-        LjEuMC54c2QgaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0
-        dHA6Ly8xMC4zMC4yLjIvYXBpL3YxLjUvc2NoZW1hL21hc3Rlci54c2QgaHR0
-        cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9vdmYgaHR0cDovL3d3dy52bXdh
-        cmUuY29tL3NjaGVtYS9vdmYgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2Jl
-        bS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9u
-        U2V0dGluZ0RhdGEgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2Np
-        bS8xL2NpbS1zY2hlbWEvMi4yMi4wL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25T
-        ZXR0aW5nRGF0YS54c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vu
-        dmlyb25tZW50LzEgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVs
-        b3BlLzEvZHNwODAyN18xLjEuMC54c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5v
-        cmcvd2JlbS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3Rl
-        bVNldHRpbmdEYXRhIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3Nj
-        aW0vMS9jaW0tc2NoZW1hLzIuMjIuMC9DSU1fVmlydHVhbFN5c3RlbVNldHRp
-        bmdEYXRhLnhzZCI+CiAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJl
-        LWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9wb3dlci9hY3Rpb24vcG93
-        ZXJPZmYiLz4KICAgIDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2Ut
-        NDgzOC05YmE4LTBjYjIzZmQxODNlNS9wb3dlci9hY3Rpb24vcmVib290Ii8+
-        CiAgICA8TGluayByZWw9InBvd2VyOnJlc2V0IiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4
-        LTBjYjIzZmQxODNlNS9wb3dlci9hY3Rpb24vcmVzZXQiLz4KICAgIDxMaW5r
-        IHJlbD0icG93ZXI6c2h1dGRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNm
-        ZDE4M2U1L3Bvd2VyL2FjdGlvbi9zaHV0ZG93biIvPgogICAgPExpbmsgcmVs
-        PSJwb3dlcjpzdXNwZW5kIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNl
-        NS9wb3dlci9hY3Rpb24vc3VzcGVuZCIvPgogICAgPExpbmsgcmVsPSJkZXBs
-        b3kiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2
-        NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L2FjdGlvbi9kZXBs
-        b3kiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRlcGxv
-        eVZBcHBQYXJhbXMreG1sIi8+CiAgICA8TGluayByZWw9InVuZGVwbG95IiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJl
-        LWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9hY3Rpb24vdW5kZXBsb3ki
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95
-        VkFwcFBhcmFtcyt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL25ldHdvcmsvNDQzNGUzZDYtZmVjYy00
-        Y2I5LWEwMTQtMTE3MDZmNTAwMTllIiBuYW1lPSJ2ZGMtbmV0LW1paGEiIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZBcHBOZXR3b3Jr
-        K3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvbmV0d29yay8zNTUwYTVjOC05ZGU4LTQ0NDctYjI4MS02
-        ZWVjMGEwMjQ0ZjIiIG5hbWU9InRhZHJ1Z2ktdmFwcC1uZXR3b3JrIiB0eXBl
-        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwTmV0d29yayt4
-        bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL25ldHdvcmsvZjQ0MjAxOGUtMWE3NC00YTI1LTlmYjQtNzUw
-        YzA0NTY1MzE1IiBuYW1lPSJ2YXBwLW5ldHdvcmstbWloYSIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcE5ldHdvcmsreG1sIi8+
-        CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNm
-        ZDE4M2U1L2NvbnRyb2xBY2Nlc3MvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5jb250cm9sQWNjZXNzK3htbCIvPgogICAgPExpbmsg
-        cmVsPSJjb250cm9sQWNjZXNzIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQx
-        ODNlNS9hY3Rpb24vY29udHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxM
-        aW5rIHJlbD0idXAiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMv
-        NTViNDUzMWUtMWI3Mi00YTY2LWJjNzUtMmU0MmQzYjdjYjc5IiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52ZGMreG1sIi8+CiAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwK3ht
-        bCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBj
-        YjIzZmQxODNlNS9vd25lciIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQub3duZXIreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUt
-        ZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L21ldGFkYXRhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
-        ICAgIDxMaW5rIHJlbD0ib3ZmIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQx
-        ODNlNS9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9ImRv
-        d24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2
-        NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L3Byb2R1Y3RTZWN0
-        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
-        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxMaW5rIHJlbD0ic25hcHNob3Q6
-        Y3JlYXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBw
-        LTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9hY3Rpb24v
-        Y3JlYXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgPERlc2Ny
-        aXB0aW9uLz4KICAgIDxMZWFzZVNldHRpbmdzU2VjdGlvbiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgz
-        OC05YmE4LTBjYjIzZmQxODNlNS9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGlu
-        Z3NTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAg
-        PG92ZjpJbmZvPkxlYXNlIHNldHRpbmdzIHNlY3Rpb248L292ZjpJbmZvPgog
-        ICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL3ZBcHAvdmFwcC02ZDY3N2UyZS1mY2NlLTQ4MzgtOWJhOC0wY2Iy
-        M2ZkMTgzZTUvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlvbit4
-        bWwiLz4KICAgICAgICA8RGVwbG95bWVudExlYXNlSW5TZWNvbmRzPjA8L0Rl
-        cGxveW1lbnRMZWFzZUluU2Vjb25kcz4KICAgICAgICA8U3RvcmFnZUxlYXNl
-        SW5TZWNvbmRzPjA8L1N0b3JhZ2VMZWFzZUluU2Vjb25kcz4KICAgIDwvTGVh
-        c2VTZXR0aW5nc1NlY3Rpb24+CiAgICA8b3ZmOlN0YXJ0dXBTZWN0aW9uIHht
-        bG5zOnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41
-        IiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        c3RhcnR1cFNlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdmFwcC02ZDY3N2UyZS1mY2NlLTQ4MzgtOWJhOC0w
-        Y2IyM2ZkMTgzZTUvc3RhcnR1cFNlY3Rpb24vIj4KICAgICAgICA8b3ZmOklu
-        Zm8+VkFwcCBzdGFydHVwIHNlY3Rpb248L292ZjpJbmZvPgogICAgICAgIDxv
-        dmY6SXRlbSBvdmY6aWQ9IkRhbW4gU21hbGwgTGludXgtbW0iIG92ZjpvcmRl
-        cj0iMCIgb3ZmOnN0YXJ0QWN0aW9uPSJwb3dlck9uIiBvdmY6c3RhcnREZWxh
-        eT0iMCIgb3ZmOnN0b3BBY3Rpb249InBvd2VyT2ZmIiBvdmY6c3RvcERlbGF5
-        PSIwIi8+CiAgICAgICAgPG92ZjpJdGVtIG92ZjppZD0iVFRZTGludXgtMS1t
-        bSIgb3ZmOm9yZGVyPSIwIiBvdmY6c3RhcnRBY3Rpb249InBvd2VyT24iIG92
-        ZjpzdGFydERlbGF5PSIwIiBvdmY6c3RvcEFjdGlvbj0icG93ZXJPZmYiIG92
-        ZjpzdG9wRGVsYXk9IjAiLz4KICAgICAgICA8b3ZmOkl0ZW0gb3ZmOmlkPSJU
-        VFlMaW51eC0yLW1tIiBvdmY6b3JkZXI9IjAiIG92ZjpzdGFydEFjdGlvbj0i
-        cG93ZXJPbiIgb3ZmOnN0YXJ0RGVsYXk9IjAiIG92ZjpzdG9wQWN0aW9uPSJw
-        b3dlck9mZiIgb3ZmOnN0b3BEZWxheT0iMCIvPgogICAgICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
-        cC02ZDY3N2UyZS1mY2NlLTQ4MzgtOWJhOC0wY2IyM2ZkMTgzZTUvc3RhcnR1
-        cFNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5zdGFydHVwU2VjdGlvbit4bWwiLz4KICAgIDwvb3ZmOlN0YXJ0dXBTZWN0
-        aW9uPgogICAgPG92ZjpOZXR3b3JrU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0
-        dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgdmNsb3VkOnR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtTZWN0aW9u
-        K3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L25l
-        dHdvcmtTZWN0aW9uLyI+CiAgICAgICAgPG92ZjpJbmZvPlRoZSBsaXN0IG9m
-        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxvdmY6TmV0
-        d29yayBvdmY6bmFtZT0idmRjLW5ldC1taWhhIj4KICAgICAgICAgICAgPG92
-        ZjpEZXNjcmlwdGlvbi8+CiAgICAgICAgPC9vdmY6TmV0d29yaz4KICAgICAg
-        ICA8b3ZmOk5ldHdvcmsgb3ZmOm5hbWU9InRhZHJ1Z2ktdmFwcC1uZXR3b3Jr
-        Ij4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbi8+CiAgICAgICAgPC9v
-        dmY6TmV0d29yaz4KICAgICAgICA8b3ZmOk5ldHdvcmsgb3ZmOm5hbWU9InZh
-        cHAtbmV0d29yay1taWhhIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlv
-        bi8+CiAgICAgICAgPC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtT
-        ZWN0aW9uPgogICAgPE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4
-        LTliYTgtMGNiMjNmZDE4M2U1L25ldHdvcmtDb25maWdTZWN0aW9uLyIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubmV0d29ya0NvbmZp
-        Z1NlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8
-        b3ZmOkluZm8+VGhlIGNvbmZpZ3VyYXRpb24gcGFyYW1ldGVycyBmb3IgbG9n
-        aWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+CiAgICAgICAgPExpbmsgcmVsPSJl
-        ZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZk
-        Njc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9uZXR3b3JrQ29u
-        ZmlnU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLm5ldHdvcmtDb25maWdTZWN0aW9uK3htbCIvPgogICAgICAgIDxOZXR3
-        b3JrQ29uZmlnIG5ldHdvcmtOYW1lPSJ2ZGMtbmV0LW1paGEiPgogICAgICAg
-        ICAgICA8TGluayByZWw9InJlcGFpciIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL2FkbWluL25ldHdvcmsvNDQzNGUzZDYtZmVjYy00Y2I5LWEwMTQt
-        MTE3MDZmNTAwMTllL2FjdGlvbi9yZXNldCIvPgogICAgICAgICAgICA8RGVz
-        Y3JpcHRpb24vPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAg
-        ICAgICAgICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBT
-        Y29wZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPnRy
-        dWU8L0lzSW5oZXJpdGVkPgogICAgICAgICAgICAgICAgICAgICAgICA8R2F0
-        ZXdheT4xMC4zMC4yLjE8L0dhdGV3YXk+CiAgICAgICAgICAgICAgICAgICAg
-        ICAgIDxOZXRtYXNrPjI1NS4yNTUuMjU1LjA8L05ldG1hc2s+CiAgICAgICAg
-        ICAgICAgICAgICAgICAgIDxEbnMxPjguOC44Ljg8L0RuczE+CiAgICAgICAg
-        ICAgICAgICAgICAgICAgIDxEbnMyPjguOC40LjQ8L0RuczI+CiAgICAgICAg
-        ICAgICAgICAgICAgICAgIDxJc0VuYWJsZWQ+dHJ1ZTwvSXNFbmFibGVkPgog
-        ICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZXM+CiAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgICA8SXBSYW5nZT4KICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgICA8U3RhcnRBZGRyZXNzPjEwLjMwLjIuNTE8L1N0YXJ0
-        QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8RW5k
-        QWRkcmVzcz4xMC4zMC4yLjYwPC9FbmRBZGRyZXNzPgogICAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
-        ICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAgIDwvSXBTY29w
-        ZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAgICAgICAgICAg
-        ICA8UGFyZW50TmV0d29yayBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        YWRtaW4vbmV0d29yay81YjVjNjMxMC0yNjI4LTQ1NGEtYmU2ZC05NTk0NmU2
-        OTQxYWYiIGlkPSI1YjVjNjMxMC0yNjI4LTQ1NGEtYmU2ZC05NTk0NmU2OTQx
-        YWYiIG5hbWU9InZkYy1uZXQtbWloYSIvPgogICAgICAgICAgICAgICAgPEZl
-        bmNlTW9kZT5icmlkZ2VkPC9GZW5jZU1vZGU+CiAgICAgICAgICAgICAgICA8
-        UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRzPmZhbHNlPC9SZXRhaW5O
-        ZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAgICAgICAgIDwvQ29uZmln
-        dXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95ZWQ+dHJ1ZTwvSXNEZXBs
-        b3llZD4KICAgICAgICA8L05ldHdvcmtDb25maWc+CiAgICAgICAgPE5ldHdv
-        cmtDb25maWcgbmV0d29ya05hbWU9InRhZHJ1Z2ktdmFwcC1uZXR3b3JrIj4K
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJyZXBhaXIiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS9hZG1pbi9uZXR3b3JrLzM1NTBhNWM4LTlkZTgtNDQ0
-        Ny1iMjgxLTZlZWMwYTAyNDRmMi9hY3Rpb24vcmVzZXQiLz4KICAgICAgICAg
-        ICAgPERlc2NyaXB0aW9uLz4KICAgICAgICAgICAgPENvbmZpZ3VyYXRpb24+
-        CiAgICAgICAgICAgICAgICA8SXBTY29wZXM+CiAgICAgICAgICAgICAgICAg
-        ICAgPElwU2NvcGU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJc0luaGVy
-        aXRlZD5mYWxzZTwvSXNJbmhlcml0ZWQ+CiAgICAgICAgICAgICAgICAgICAg
-        ICAgIDxHYXRld2F5PjE5Mi4xNjguMi4xPC9HYXRld2F5PgogICAgICAgICAg
-        ICAgICAgICAgICAgICA8TmV0bWFzaz4yNTUuMjU1LjI1NS4wPC9OZXRtYXNr
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8SXNFbmFibGVkPnRydWU8L0lz
-        RW5hYmxlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPElwUmFuZ2VzPgog
-        ICAgICAgICAgICAgICAgICAgICAgICAgICAgPElwUmFuZ2U+CiAgICAgICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgPFN0YXJ0QWRkcmVzcz4xOTIuMTY4
-        LjIuMTAwPC9TdGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgPEVuZEFkZHJlc3M+MTkyLjE2OC4yLjE5OTwvRW5kQWRkcmVz
-        cz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvSXBSYW5nZT4KICAg
-        ICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlcz4KICAgICAgICAgICAg
-        ICAgICAgICA8L0lwU2NvcGU+CiAgICAgICAgICAgICAgICA8L0lwU2NvcGVz
-        PgogICAgICAgICAgICAgICAgPEZlbmNlTW9kZT5pc29sYXRlZDwvRmVuY2VN
-        b2RlPgogICAgICAgICAgICAgICAgPFJldGFpbk5ldEluZm9BY3Jvc3NEZXBs
-        b3ltZW50cz5mYWxzZTwvUmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
-        PgogICAgICAgICAgICAgICAgPEZlYXR1cmVzPgogICAgICAgICAgICAgICAg
-        ICAgIDxEaGNwU2VydmljZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElz
-        RW5hYmxlZD5mYWxzZTwvSXNFbmFibGVkPgogICAgICAgICAgICAgICAgICAg
-        ICAgICA8RGVmYXVsdExlYXNlVGltZT4zNjAwPC9EZWZhdWx0TGVhc2VUaW1l
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8TWF4TGVhc2VUaW1lPjcyMDA8
-        L01heExlYXNlVGltZT4KICAgICAgICAgICAgICAgICAgICA8L0RoY3BTZXJ2
-        aWNlPgogICAgICAgICAgICAgICAgPC9GZWF0dXJlcz4KICAgICAgICAgICAg
-        PC9Db25maWd1cmF0aW9uPgogICAgICAgICAgICA8SXNEZXBsb3llZD50cnVl
-        PC9Jc0RlcGxveWVkPgogICAgICAgIDwvTmV0d29ya0NvbmZpZz4KICAgICAg
-        ICA8TmV0d29ya0NvbmZpZyBuZXR3b3JrTmFtZT0idmFwcC1uZXR3b3JrLW1p
-        aGEiPgogICAgICAgICAgICA8TGluayByZWw9InJlcGFpciIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL2FkbWluL25ldHdvcmsvZjQ0MjAxOGUtMWE3
-        NC00YTI1LTlmYjQtNzUwYzA0NTY1MzE1L2FjdGlvbi9yZXNldCIvPgogICAg
-        ICAgICAgICA8RGVzY3JpcHRpb24vPgogICAgICAgICAgICA8Q29uZmlndXJh
-        dGlvbj4KICAgICAgICAgICAgICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAg
-        ICAgICAgICA8SXBTY29wZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElz
-        SW5oZXJpdGVkPmZhbHNlPC9Jc0luaGVyaXRlZD4KICAgICAgICAgICAgICAg
-        ICAgICAgICAgPEdhdGV3YXk+MTkyLjE2OC4yLjE8L0dhdGV3YXk+CiAgICAg
-        ICAgICAgICAgICAgICAgICAgIDxOZXRtYXNrPjI1NS4yNTUuMjU1LjA8L05l
-        dG1hc2s+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJc0VuYWJsZWQ+dHJ1
-        ZTwvSXNFbmFibGVkPgogICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5n
-        ZXM+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZT4KICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8U3RhcnRBZGRyZXNzPjE5
-        Mi4xNjguMi4xMDA8L1N0YXJ0QWRkcmVzcz4KICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgICA8RW5kQWRkcmVzcz4xOTIuMTY4LjIuMTk5PC9FbmRB
-        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdl
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAg
-        ICAgICAgICAgICAgIDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBT
-        Y29wZXM+CiAgICAgICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9G
-        ZW5jZU1vZGU+CiAgICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9z
-        c0RlcGxveW1lbnRzPmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95
-        bWVudHM+CiAgICAgICAgICAgICAgICA8RmVhdHVyZXM+CiAgICAgICAgICAg
-        ICAgICAgICAgPERoY3BTZXJ2aWNlPgogICAgICAgICAgICAgICAgICAgICAg
-        ICA8SXNFbmFibGVkPmZhbHNlPC9Jc0VuYWJsZWQ+CiAgICAgICAgICAgICAg
-        ICAgICAgICAgIDxEZWZhdWx0TGVhc2VUaW1lPjM2MDA8L0RlZmF1bHRMZWFz
-        ZVRpbWU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxNYXhMZWFzZVRpbWU+
-        NzIwMDwvTWF4TGVhc2VUaW1lPgogICAgICAgICAgICAgICAgICAgIDwvRGhj
-        cFNlcnZpY2U+CiAgICAgICAgICAgICAgICA8L0ZlYXR1cmVzPgogICAgICAg
-        ICAgICA8L0NvbmZpZ3VyYXRpb24+CiAgICAgICAgICAgIDxJc0RlcGxveWVk
-        PnRydWU8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmlnPgog
-        ICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxTbmFwc2hvdFNlY3Rp
-        b24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC02ZDY3
-        N2UyZS1mY2NlLTQ4MzgtOWJhOC0wY2IyM2ZkMTgzZTUvc25hcHNob3RTZWN0
-        aW9uIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zbmFw
-        c2hvdFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAg
-        ICA8b3ZmOkluZm8+U25hcHNob3QgaW5mb3JtYXRpb24gc2VjdGlvbjwvb3Zm
-        OkluZm8+CiAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgIDxEYXRlQ3JlYXRl
-        ZD4yMDE2LTA4LTAzVDEzOjQxOjIwLjE4NyswMjowMDwvRGF0ZUNyZWF0ZWQ+
-        CiAgICA8T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQub3duZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvYWRtaW4vdXNlci9mN2ZmMmJkMS1kZTFkLTQ4NzItOWIz
-        ZC1mMmQxM2JmZWI1OGIiIG5hbWU9Im1paGFwIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgog
-        ICAgPEluTWFpbnRlbmFuY2VNb2RlPmZhbHNlPC9Jbk1haW50ZW5hbmNlTW9k
-        ZT4KICAgIDxDaGlsZHJlbj4KICAgICAgICA8Vm0gbmVlZHNDdXN0b21pemF0
-        aW9uPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBuYW1lPSJU
-        VFlMaW51eC0yLW1tIiBpZD0idXJuOnZjbG91ZDp2bTozMjgzNDRlNC0yMmZj
-        LTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkiIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZl
-        NjQwMzJlOSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        dm0reG1sIj4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpwb3dlck9m
-        ZiIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0
-        ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3Bvd2VyL2FjdGlvbi9w
-        b3dlck9mZiIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJlYm9v
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0
-        ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3Bvd2VyL2FjdGlvbi9y
-        ZWJvb3QiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpyZXNldCIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQt
-        MjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3Bvd2VyL2FjdGlvbi9yZXNl
-        dCIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnNodXRkb3duIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0y
-        MmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvcG93ZXIvYWN0aW9uL3NodXRk
-        b3duIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c3VzcGVuZCIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQt
-        MjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3Bvd2VyL2FjdGlvbi9zdXNw
-        ZW5kIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0idW5kZXBsb3kiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMt
-        NDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9hY3Rpb24vdW5kZXBsb3kiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95VkFwcFBh
-        cmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZj
-        LTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkiIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLnZtK3htbCIvPgogICAgICAgICAgICA8TGluayBy
-        ZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9tZXRhZGF0
-        YSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubWV0YWRh
-        dGEreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00
-        M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3Byb2R1Y3RTZWN0aW9ucy8iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnByb2R1Y3RTZWN0aW9u
-        cyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJzY3JlZW46dGh1bWJu
-        YWlsIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgz
-        NDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvc2NyZWVuIi8+CiAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0ic2NyZWVuOmFjcXVpcmVUaWNrZXQiIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIy
-        ZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9zY3JlZW4vYWN0aW9uL2FjcXVp
-        cmVUaWNrZXQiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJtZWRpYTppbnNl
-        cnRNZWRpYSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        MzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L21lZGlhL2Fj
-        dGlvbi9pbnNlcnRNZWRpYSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQubWVkaWFJbnNlcnRPckVqZWN0UGFyYW1zK3htbCIvPgogICAg
-        ICAgICAgICA8TGluayByZWw9Im1lZGlhOmVqZWN0TWVkaWEiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNh
-        MS1hNTFkLWIwOTZlNjQwMzJlOS9tZWRpYS9hY3Rpb24vZWplY3RNZWRpYSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubWVkaWFJbnNl
-        cnRPckVqZWN0UGFyYW1zK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
-        ImRpc2s6YXR0YWNoIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvZGlz
-        ay9hY3Rpb24vYXR0YWNoIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC5kaXNrQXR0YWNoT3JEZXRhY2hQYXJhbXMreG1sIi8+CiAgICAg
-        ICAgICAgIDxMaW5rIHJlbD0iZGlzazpkZXRhY2giIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFk
-        LWIwOTZlNjQwMzJlOS9kaXNrL2FjdGlvbi9kZXRhY2giIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRpc2tBdHRhY2hPckRldGFjaFBh
-        cmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJpbnN0YWxsVm13
-        YXJlVG9vbHMiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9hY3Rpb24v
-        aW5zdGFsbFZNd2FyZVRvb2xzIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        c25hcHNob3Q6Y3JlYXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkv
-        YWN0aW9uL2NyZWF0ZVNuYXBzaG90IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5jcmVhdGVTbmFwc2hvdFBhcmFtcyt4bWwiLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJyZWNvbmZpZ3VyZVZtIiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEt
-        YTUxZC1iMDk2ZTY0MDMyZTkvYWN0aW9uL3JlY29uZmlndXJlVm0iIG5hbWU9
-        IlRUWUxpbnV4LTItbW0iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZtK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9InVwIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJl
-        LWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcCt4bWwiLz4KICAgICAgICAgICAg
-        PERlc2NyaXB0aW9uPkNyZWF0ZWQgYnk6IE1pa2UgTGF2ZXJpY2sNQmxvZzog
-        d3d3Lm1pa2VsYXZlcmljay5jb20NVHdpdHRlcjogQG1pa2VfbGF2ZXJpY2sN
-        DVNlcnZpY2VzIEVuYWJsZWQ6IFNTSCwgRlRQLCBIVFRQDVJPT1QgUGFzc3dv
-        cmQ6IHBhc3N3b3JkPC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPG92ZjpW
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uIHhtbG5zOnZjbG91ZD0iaHR0cDovL3d3
-        dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBvdmY6dHJhbnNwb3J0PSIiIHZj
-        bG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52aXJ0
-        dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFk
-        LWIwOTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uLyI+CiAgICAg
-        ICAgICAgICAgICA8b3ZmOkluZm8+VmlydHVhbCBoYXJkd2FyZSByZXF1aXJl
-        bWVudHM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpTeXN0ZW0+
-        CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6RWxlbWVudE5hbWU+VmlydHVh
-        bCBIYXJkd2FyZSBGYW1pbHk8L3Zzc2Q6RWxlbWVudE5hbWU+CiAgICAgICAg
-        ICAgICAgICAgICAgPHZzc2Q6SW5zdGFuY2VJRD4wPC92c3NkOkluc3RhbmNl
-        SUQ+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3RlbUlk
-        ZW50aWZpZXI+VFRZTGludXgtMi1tbTwvdnNzZDpWaXJ0dWFsU3lzdGVtSWRl
-        bnRpZmllcj4KICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0dWFsU3lz
-        dGVtVHlwZT52bXgtMDg8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAgICAgICAgICAgICAgICA8b3Zm
-        Okl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4wMDo1
-        MDo1NjowMTowMDoxODwvcmFzZDpBZGRyZXNzPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBh
-        cmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBdXRvbWF0aWNBbGxv
-        Y2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91ZDppcEFkZHJl
-        c3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtDb25uZWN0
-        aW9uPSJ0cnVlIj52YXBwLW5ldHdvcmstbWloYTwvcmFzZDpDb25uZWN0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPkUxMDAw
-        IGV0aGVybmV0IGFkYXB0ZXIgb24gInZhcHAtbmV0d29yay1taWhhIjwvcmFz
-        ZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVt
-        ZW50TmFtZT5OZXR3b3JrIGFkYXB0ZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjE8L3Jhc2Q6
-        SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJj
-        ZVN1YlR5cGU+RTEwMDA8L3Jhc2Q6UmVzb3VyY2VTdWJUeXBlPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xMDwvcmFzZDpSZXNv
-        dXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OkFkZHJlc3M+MDwvcmFzZDpBZGRyZXNzPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkRlc2NyaXB0aW9uPklERSBDb250cm9sbGVyPC9yYXNkOkRlc2Ny
-        aXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1l
-        PklERSBDb250cm9sbGVyIDA8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJRD4yPC9yYXNkOkluc3RhbmNl
-        SUQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjU8
-        L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRl
-        bT4KICAgICAgICAgICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpBZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25Q
-        YXJlbnQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+
-        SGFyZCBkaXNrPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkVsZW1lbnROYW1lPkhhcmQgZGlzayAxPC9yYXNkOkVsZW1l
-        bnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkhvc3RSZXNvdXJj
-        ZSB2Y2xvdWQ6YnVzVHlwZT0iNSIgdmNsb3VkOmJ1c1N1YlR5cGU9IiIgdmNs
-        b3VkOmNhcGFjaXR5PSIzMiIvPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        Okluc3RhbmNlSUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVudD4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8L3Jhc2Q6UmVz
-        b3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxR
-        dWFudGl0eT4zMzU1NDQzMjwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+Ynl0
-        ZTwvcmFzZDpWaXJ0dWFsUXVhbnRpdHlVbml0cz4KICAgICAgICAgICAgICAg
-        IDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4xPC9yYXNkOkFkZHJlc3M+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+SURFIENv
-        bnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6RWxlbWVudE5hbWU+SURFIENvbnRyb2xsZXIgMTwvcmFzZDpF
-        bGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5j
-        ZUlEPjM8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        dGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVu
-        dD4wPC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPmZhbHNlPC9yYXNkOkF1dG9t
-        YXRpY0FsbG9jYXRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVz
-        Y3JpcHRpb24+Q0QvRFZEIERyaXZlPC9yYXNkOkRlc2NyaXB0aW9uPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPkNEL0RWRCBEcml2
-        ZSAxPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOkhvc3RSZXNvdXJjZS8+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        SW5zdGFuY2VJRD4zMDAyPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6UGFyZW50PjM8L3Jhc2Q6UGFyZW50PgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNTwvcmFzZDpSZXNv
-        dXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJdGVtIHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiIHZjbG91ZDpocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQz
-        YTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9j
-        cHUiPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFsbG9jYXRpb25Vbml0
-        cz5oZXJ0eiAqIDEwXjY8L3Jhc2Q6QWxsb2NhdGlvblVuaXRzPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk51bWJlciBvZiBWaXJ0
-        dWFsIENQVXM8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6RWxlbWVudE5hbWU+MSB2aXJ0dWFsIENQVShzKTwvcmFzZDpF
-        bGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5j
-        ZUlEPjQ8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNkOlJlc2VydmF0aW9uPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4zPC9yYXNkOlJlc291
-        cmNlVHlwZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpWaXJ0dWFsUXVh
-        bnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6V2VpZ2h0PjA8L3Jhc2Q6V2VpZ2h0PgogICAgICAgICAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5
-        NmU2NDAzMmU5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vY3B1IiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiLz4K
-        ICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICA8
-        b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIw
-        OTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSI+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2NhdGlvblVuaXRzPmJ5dGUg
-        KiAyXjIwPC9yYXNkOkFsbG9jYXRpb25Vbml0cz4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpEZXNjcmlwdGlvbj5NZW1vcnkgU2l6ZTwvcmFzZDpEZXNj
-        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
-        ZT4zMiBNQiBvZiBtZW1vcnk8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJRD41PC9yYXNkOkluc3RhbmNl
-        SUQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzZXJ2YXRpb24+MDwv
-        cmFzZDpSZXNlcnZhdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpS
-        ZXNvdXJjZVR5cGU+NDwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6VmlydHVhbFF1YW50aXR5PjMyPC9yYXNkOlZpcnR1
-        YWxRdWFudGl0eT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpXZWlnaHQ+
-        MDwvcmFzZDpXZWlnaHQ+CiAgICAgICAgICAgICAgICAgICAgPExpbmsgcmVs
-        PSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0z
-        MjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhh
-        cmR3YXJlU2VjdGlvbi9tZW1vcnkiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIvPgogICAgICAgICAgICAgICAg
-        PC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQt
-        MjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3ZpcnR1YWxIYXJkd2FyZVNl
-        Y3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIvPgogICAgICAgICAgICAgICAg
-        PExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkv
-        dmlydHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUiIHR5cGU9ImFwcGxpY2F0aW9u
-        L3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIvPgogICAgICAgICAg
-        ICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0
-        MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUiIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIvPgogICAg
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1i
-        MDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9tZW1vcnkiIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3ht
-        bCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQz
-        YTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9t
-        ZW1vcnkiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
-        c2RJdGVtK3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3du
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRl
-        NC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJl
-        U2VjdGlvbi9kaXNrcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3Zp
-        cnR1YWxIYXJkd2FyZVNlY3Rpb24vZGlza3MiIHR5cGU9ImFwcGxpY2F0aW9u
-        L3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAg
-        ICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIw
-        OTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lZGlhIiB0eXBl
-        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0
-        K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZj
-        LTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlv
-        bi9uZXR3b3JrQ2FyZHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwi
-        Lz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2Ex
-        LWE1MWQtYjA5NmU2NDAzMmU5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2Vy
-        aWFsUG9ydHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
-        LnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayBy
-        ZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92aXJ0dWFs
-        SGFyZHdhcmVTZWN0aW9uL3NlcmlhbFBvcnRzIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAg
-        ICAgICAgICA8L292ZjpWaXJ0dWFsSGFyZHdhcmVTZWN0aW9uPgogICAgICAg
-        ICAgICA8b3ZmOk9wZXJhdGluZ1N5c3RlbVNlY3Rpb24geG1sbnM6dmNsb3Vk
-        PSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUiIG92ZjppZD0i
-        MzYiIHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uK3htbCIgdm13Om9zVHlwZT0ib3Ro
-        ZXJMaW51eEd1ZXN0IiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAz
-        MmU5L29wZXJhdGluZ1N5c3RlbVNlY3Rpb24vIj4KICAgICAgICAgICAgICAg
-        IDxvdmY6SW5mbz5TcGVjaWZpZXMgdGhlIG9wZXJhdGluZyBzeXN0ZW0gaW5z
-        dGFsbGVkPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxvdmY6RGVzY3Jp
-        cHRpb24+T3RoZXIgTGludXggKDMyLWJpdCk8L292ZjpEZXNjcmlwdGlvbj4K
-        ICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1
-        MWQtYjA5NmU2NDAzMmU5L29wZXJhdGluZ1N5c3RlbVNlY3Rpb24vIiB0eXBl
-        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5vcGVyYXRpbmdTeXN0
-        ZW1TZWN0aW9uK3htbCIvPgogICAgICAgICAgICA8L292ZjpPcGVyYXRpbmdT
-        eXN0ZW1TZWN0aW9uPgogICAgICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25T
-        ZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMy
-        ODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9uZXR3b3JrQ29u
-        bmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1sIiBvdmY6cmVx
-        dWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVj
-        aWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5lY3Rpb25zPC9v
-        dmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0d29ya0Nvbm5l
-        Y3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4K
-        ICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3Rv
-        bWl6YXRpb249InRydWUiIG5ldHdvcms9InZhcHAtbmV0d29yay1taWhhIj4K
-        ICAgICAgICAgICAgICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4w
-        PC9OZXR3b3JrQ29ubmVjdGlvbkluZGV4PgogICAgICAgICAgICAgICAgICAg
-        IDxJc0Nvbm5lY3RlZD50cnVlPC9Jc0Nvbm5lY3RlZD4KICAgICAgICAgICAg
-        ICAgICAgICA8TUFDQWRkcmVzcz4wMDo1MDo1NjowMTowMDoxODwvTUFDQWRk
-        cmVzcz4KICAgICAgICAgICAgICAgICAgICA8SXBBZGRyZXNzQWxsb2NhdGlv
-        bk1vZGU+REhDUDwvSXBBZGRyZXNzQWxsb2NhdGlvbk1vZGU+CiAgICAgICAg
-        ICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uPgogICAgICAgICAgICAgICAg
-        PExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkv
-        bmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQubmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uK3ht
-        bCIvPgogICAgICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uU2VjdGlvbj4K
-        ICAgICAgICAgICAgPEd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24gaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00
-        M2ExLWE1MWQtYjA5NmU2NDAzMmU5L2d1ZXN0Q3VzdG9taXphdGlvblNlY3Rp
-        b24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5ndWVz
-        dEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxz
-        ZSI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIEd1ZXN0
-        IE9TIEN1c3RvbWl6YXRpb24gU2V0dGluZ3M8L292ZjpJbmZvPgogICAgICAg
-        ICAgICAgICAgPEVuYWJsZWQ+ZmFsc2U8L0VuYWJsZWQ+CiAgICAgICAgICAg
-        ICAgICA8Q2hhbmdlU2lkPmZhbHNlPC9DaGFuZ2VTaWQ+CiAgICAgICAgICAg
-        ICAgICA8VmlydHVhbE1hY2hpbmVJZD4zMjgzNDRlNC0yMmZjLTQzYTEtYTUx
-        ZC1iMDk2ZTY0MDMyZTk8L1ZpcnR1YWxNYWNoaW5lSWQ+CiAgICAgICAgICAg
-        ICAgICA8Sm9pbkRvbWFpbkVuYWJsZWQ+ZmFsc2U8L0pvaW5Eb21haW5FbmFi
-        bGVkPgogICAgICAgICAgICAgICAgPFVzZU9yZ1NldHRpbmdzPmZhbHNlPC9V
-        c2VPcmdTZXR0aW5ncz4KICAgICAgICAgICAgICAgIDxBZG1pblBhc3N3b3Jk
-        RW5hYmxlZD50cnVlPC9BZG1pblBhc3N3b3JkRW5hYmxlZD4KICAgICAgICAg
-        ICAgICAgIDxBZG1pblBhc3N3b3JkQXV0bz50cnVlPC9BZG1pblBhc3N3b3Jk
-        QXV0bz4KICAgICAgICAgICAgICAgIDxSZXNldFBhc3N3b3JkUmVxdWlyZWQ+
-        ZmFsc2U8L1Jlc2V0UGFzc3dvcmRSZXF1aXJlZD4KICAgICAgICAgICAgICAg
-        IDxDb21wdXRlck5hbWU+VFRZTGludXgtMDAtMS1tbTwvQ29tcHV0ZXJOYW1l
-        PgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEt
-        YTUxZC1iMDk2ZTY0MDMyZTkvZ3Vlc3RDdXN0b21pemF0aW9uU2VjdGlvbi8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmd1ZXN0Q3Vz
-        dG9taXphdGlvblNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvR3Vlc3RD
-        dXN0b21pemF0aW9uU2VjdGlvbj4KICAgICAgICAgICAgPFJ1bnRpbWVJbmZv
-        U2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92
-        Y2xvdWQvdjEuNSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIiB2Y2xvdWQ6
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQt
-        MjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3J1bnRpbWVJbmZvU2VjdGlv
-        biI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIFJ1bnRp
-        bWUgaW5mbzwvb3ZmOkluZm8+CiAgICAgICAgICAgIDwvUnVudGltZUluZm9T
-        ZWN0aW9uPgogICAgICAgICAgICA8U25hcHNob3RTZWN0aW9uIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNh
-        MS1hNTFkLWIwOTZlNjQwMzJlOS9zbmFwc2hvdFNlY3Rpb24iIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnNuYXBzaG90U2VjdGlvbit4
-        bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAgPG92
-        ZjpJbmZvPlNuYXBzaG90IGluZm9ybWF0aW9uIHNlY3Rpb248L292ZjpJbmZv
-        PgogICAgICAgICAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgICAgICAgICAg
-        PERhdGVDcmVhdGVkPjIwMTYtMDgtMDNUMTM6NDE6MjQuNjY3KzAyOjAwPC9E
-        YXRlQ3JlYXRlZD4KICAgICAgICAgICAgPFZBcHBTY29wZWRMb2NhbElkPjkw
-        NWIxMDRlLTViZjAtNDY5Mi04MTUwLTYzYjIzMjcxODhhYjwvVkFwcFNjb3Bl
-        ZExvY2FsSWQ+CiAgICAgICAgICAgIDxvdmZlbnY6RW52aXJvbm1lbnQgeG1s
-        bnM6bnMxMT0iaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9vdmZlbnYi
-        IG92ZmVudjppZD0iIiBuczExOnZDZW50ZXJJZD0idm0tOTQiPgogICAgICAg
-        ICAgICAgICAgPG92ZmVudjpQbGF0Zm9ybVNlY3Rpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPG92ZmVudjpLaW5kPlZNd2FyZSBFU1hpPC9vdmZlbnY6S2lu
-        ZD4KICAgICAgICAgICAgICAgICAgICA8b3ZmZW52OlZlcnNpb24+Ni4wLjA8
-        L292ZmVudjpWZXJzaW9uPgogICAgICAgICAgICAgICAgICAgIDxvdmZlbnY6
-        VmVuZG9yPlZNd2FyZSwgSW5jLjwvb3ZmZW52OlZlbmRvcj4KICAgICAgICAg
-        ICAgICAgICAgICA8b3ZmZW52OkxvY2FsZT5lbjwvb3ZmZW52OkxvY2FsZT4K
-        ICAgICAgICAgICAgICAgIDwvb3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4KICAg
-        ICAgICAgICAgICAgIDx2ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uIHhtbG5z
-        OnZlPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgeG1s
-        bnM9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVudC8x
-        IiB4bWxuczpvZT0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmly
-        b25tZW50LzEiPgogICAgICAgICAgICAgICAgICAgIDx2ZTpBZGFwdGVyIHZl
-        Om1hYz0iMDA6NTA6NTY6MDE6MDA6MTgiIHZlOm5ldHdvcms9Im5vbmUiIHZl
-        OnVuaXROdW1iZXI9IjciLz4KICAgCiAgICAgICAgICAgICAgICA8L3ZlOkV0
-        aGVybmV0QWRhcHRlclNlY3Rpb24+CiAgICAgICAgICAgIDwvb3ZmZW52OkVu
-        dmlyb25tZW50PgogICAgICAgICAgICA8Vm1DYXBhYmlsaXRpZXMgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00
-        M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3ZtQ2FwYWJpbGl0aWVzLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRpZXNT
-        ZWN0aW9uK3htbCI+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0
-        LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92bUNhcGFiaWxpdGllcy8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2FwYWJp
-        bGl0aWVzU2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgICAgIDxNZW1vcnlI
-        b3RBZGRFbmFibGVkPmZhbHNlPC9NZW1vcnlIb3RBZGRFbmFibGVkPgogICAg
-        ICAgICAgICAgICAgPENwdUhvdEFkZEVuYWJsZWQ+ZmFsc2U8L0NwdUhvdEFk
-        ZEVuYWJsZWQ+CiAgICAgICAgICAgIDwvVm1DYXBhYmlsaXRpZXM+CiAgICAg
-        ICAgICAgIDxTdG9yYWdlUHJvZmlsZSBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdmRjU3RvcmFnZVByb2ZpbGUvNDI5NGY3NjctZDllYi00NzI4LWI3
-        ZGQtODFhMmQ3NjgzMGJmIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAg
-        ICAgICA8L1ZtPgogICAgICAgIDxWbSBuZWVkc0N1c3RvbWl6YXRpb249InRy
-        dWUiIGRlcGxveWVkPSJ0cnVlIiBzdGF0dXM9IjQiIG5hbWU9IkRhbW4gU21h
-        bGwgTGludXgtbW0iIGlkPSJ1cm46dmNsb3VkOnZtOmFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNk
-        NjViNDU1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
-        bSt4bWwiPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2Zm
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvcG93ZXIvYWN0aW9uL3Bv
-        d2VyT2ZmIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6cmVib290
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvcG93ZXIvYWN0aW9uL3Jl
-        Ym9vdCIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJlc2V0IiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1k
-        MGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvcG93ZXIvYWN0aW9uL3Jlc2V0
-        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c2h1dGRvd24iIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQw
-        YTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9wb3dlci9hY3Rpb24vc2h1dGRv
-        d24iLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzdXNwZW5kIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1k
-        MGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvcG93ZXIvYWN0aW9uL3N1c3Bl
-        bmQiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJ1bmRlcGxveSIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00
-        YjdmLWFlNmQtNjFhMjNkNjViNDU1L2FjdGlvbi91bmRlcGxveSIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudW5kZXBsb3lWQXBwUGFy
-        YW1zK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NSIgdHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJl
-        bD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        YWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L21ldGFkYXRh
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0
-        YSt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRi
-        N2YtYWU2ZC02MWEyM2Q2NWI0NTUvcHJvZHVjdFNlY3Rpb25zLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucHJvZHVjdFNlY3Rpb25z
-        K3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9InNjcmVlbjp0aHVtYm5h
-        aWwiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFh
-        MjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9zY3JlZW4iLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJzY3JlZW46YWNxdWlyZVRpY2tldCIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBh
-        My00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3NjcmVlbi9hY3Rpb24vYWNxdWly
-        ZVRpY2tldCIvPgogICAgICAgICAgICA8TGluayByZWw9Im1lZGlhOmluc2Vy
-        dE1lZGlhIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1h
-        ZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvbWVkaWEvYWN0
-        aW9uL2luc2VydE1lZGlhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC5tZWRpYUluc2VydE9yRWplY3RQYXJhbXMreG1sIi8+CiAgICAg
-        ICAgICAgIDxMaW5rIHJlbD0ibWVkaWE6ZWplY3RNZWRpYSIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00Yjdm
-        LWFlNmQtNjFhMjNkNjViNDU1L21lZGlhL2FjdGlvbi9lamVjdE1lZGlhIiB0
-        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZWRpYUluc2Vy
-        dE9yRWplY3RQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        ZGlzazphdHRhY2giIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9kaXNr
-        L2FjdGlvbi9hdHRhY2giIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLmRpc2tBdHRhY2hPckRldGFjaFBhcmFtcyt4bWwiLz4KICAgICAg
-        ICAgICAgPExpbmsgcmVsPSJkaXNrOmRldGFjaCIgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQt
-        NjFhMjNkNjViNDU1L2Rpc2svYWN0aW9uL2RldGFjaCIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZGlza0F0dGFjaE9yRGV0YWNoUGFy
-        YW1zK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9Imluc3RhbGxWbXdh
-        cmVUb29scyIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        YWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L2FjdGlvbi9p
-        bnN0YWxsVk13YXJlVG9vbHMiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJz
-        bmFwc2hvdDpjcmVhdGUiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9h
-        Y3Rpb24vY3JlYXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAg
-        ICAgICAgICA8TGluayByZWw9InJlY29uZmlndXJlVm0iIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1h
-        ZTZkLTYxYTIzZDY1YjQ1NS9hY3Rpb24vcmVjb25maWd1cmVWbSIgbmFtZT0i
-        RGFtbiBTbWFsbCBMaW51eC1tbSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        dXAiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2
-        NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1IiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwK3htbCIvPgogICAgICAg
-        ICAgICA8RGVzY3JpcHRpb24+SeKAmXZlIGNyZWF0ZWQgYW4gT1ZGIHZlcnNp
-        b24gb2YgdGhlIGhpZ2hseSBwb3B1bGFyIERhbW4gU21hbGwgTGludXggZGlz
-        dHJpYnV0aW9uLiBOb3JtYWxseSB5b3UgcnVuIHRoaXMgT1Mgd2hpY2ggaXMg
-        b25seSA1ME1CcyBpbiBkaXNrIHNpemUgZnJvbSBhbiBJU08gb3IgcGVuIGRy
-        aXZlIGJ1dCBJ4oCZdmUgc2VlbiBtb3JlIGFuZCBtb3JlIHBlb3BsZSBleHBl
-        cmltZW50aW5nIHdpdGggdGhlIHZDbG91ZCBEaXJlY3RvciBhbmQgcmVhbGx5
-        IG5lZWQgc288L0Rlc2NyaXB0aW9uPgogICAgICAgICAgICA8b3ZmOlZpcnR1
-        YWxIYXJkd2FyZVNlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRwOi8vd3d3LnZt
-        d2FyZS5jb20vdmNsb3VkL3YxLjUiIG92Zjp0cmFuc3BvcnQ9IiIgdmNsb3Vk
-        OnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZpcnR1YWxI
-        YXJkd2FyZVNlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFh
-        MjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vIj4KICAgICAgICAg
-        ICAgICAgIDxvdmY6SW5mbz5WaXJ0dWFsIGhhcmR3YXJlIHJlcXVpcmVtZW50
-        czwvb3ZmOkluZm8+CiAgICAgICAgICAgICAgICA8b3ZmOlN5c3RlbT4KICAg
-        ICAgICAgICAgICAgICAgICA8dnNzZDpFbGVtZW50TmFtZT5WaXJ0dWFsIEhh
-        cmR3YXJlIEZhbWlseTwvdnNzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
-        ICAgICAgICA8dnNzZDpJbnN0YW5jZUlEPjA8L3Zzc2Q6SW5zdGFuY2VJRD4K
-        ICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0dWFsU3lzdGVtSWRlbnRp
-        Zmllcj5EYW1uIFNtYWxsIExpbnV4LW1tPC92c3NkOlZpcnR1YWxTeXN0ZW1J
-        ZGVudGlmaWVyPgogICAgICAgICAgICAgICAgICAgIDx2c3NkOlZpcnR1YWxT
-        eXN0ZW1UeXBlPnZteC0wNzwvdnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT4KICAg
-        ICAgICAgICAgICAgIDwvb3ZmOlN5c3RlbT4KICAgICAgICAgICAgICAgIDxv
-        dmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzPjAw
-        OjUwOjU2OjAxOjAwOjE3PC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6QWRkcmVzc09uUGFyZW50PjA8L3Jhc2Q6QWRkcmVzc09u
-        UGFyZW50PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkF1dG9tYXRpY0Fs
-        bG9jYXRpb24+dHJ1ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkNvbm5lY3Rpb24gdmNsb3VkOmlwQWRk
-        cmVzc2luZ01vZGU9IkRIQ1AiIHZjbG91ZDpwcmltYXJ5TmV0d29ya0Nvbm5l
-        Y3Rpb249InRydWUiPnZkYy1uZXQtbWloYTwvcmFzZDpDb25uZWN0aW9uPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPlBDTmV0MzIg
-        ZXRoZXJuZXQgYWRhcHRlciBvbiAidmRjLW5ldC1taWhhIjwvcmFzZDpEZXNj
-        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
-        ZT5OZXR3b3JrIGFkYXB0ZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjE8L3Jhc2Q6SW5zdGFu
-        Y2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVN1YlR5
-        cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291cmNl
-        VHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAg
-        ICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRk
-        cmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRp
-        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SURF
-        IENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6SW5zdGFuY2VJRD4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFz
-        ZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgog
-        ICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVu
-        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5IYXJk
-        IGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jhc2Q6RWxlbWVudE5h
-        bWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9zdFJlc291cmNlIHZj
-        bG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlwZT0iIiB2Y2xvdWQ6
-        Y2FwYWNpdHk9IjI1NiIvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOklu
-        c3RhbmNlSUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVudD4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8L3Jhc2Q6UmVzb3Vy
-        Y2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFu
-        dGl0eT4yNjg0MzU0NTY8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eVVuaXRzPmJ5dGU8
-        L3Jhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+CiAgICAgICAgICAgICAgICA8
-        L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3M+MTwvcmFzZDpBZGRyZXNzPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPklERSBDb250
-        cm9sbGVyPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkVsZW1lbnROYW1lPklERSBDb250cm9sbGVyIDE8L3Jhc2Q6RWxl
-        bWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJ
-        RD4zPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6UmVzb3VyY2VUeXBlPjU8L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAg
-        ICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRl
-        bT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzT25QYXJlbnQ+
-        MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxzZTwvcmFzZDpBdXRvbWF0
-        aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2Ny
-        aXB0aW9uPkNEL0RWRCBEcml2ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5DRC9EVkQgRHJpdmUg
-        MTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOklu
-        c3RhbmNlSUQ+MzAwMjwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOlBhcmVudD4zPC9yYXNkOlBhcmVudD4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTU8L3Jhc2Q6UmVzb3Vy
-        Y2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAg
-        ICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpB
-        ZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxz
-        ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkRlc2NyaXB0aW9uPkZsb3BweSBEcml2ZTwvcmFzZDpEZXNj
-        cmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFt
-        ZT5GbG9wcHkgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+ODAwMDwvcmFzZDpJbnN0YW5jZUlE
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNDwv
-        cmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVt
-        PgogICAgICAgICAgICAgICAgPG92ZjpJdGVtIHZjbG91ZDp0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiIHZjbG91
-        ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvdmlydHVhbEhhcmR3YXJl
-        U2VjdGlvbi9jcHUiPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFsbG9j
-        YXRpb25Vbml0cz5oZXJ0eiAqIDEwXjY8L3Jhc2Q6QWxsb2NhdGlvblVuaXRz
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk51bWJl
-        ciBvZiBWaXJ0dWFsIENQVXM8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+MSB2aXJ0dWFsIENQVShz
-        KTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpJbnN0YW5jZUlEPjQ8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNkOlJlc2VydmF0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4zPC9y
-        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpW
-        aXJ0dWFsUXVhbnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6V2VpZ2h0PjA8L3Jhc2Q6V2VpZ2h0Pgog
-        ICAgICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00Yjdm
-        LWFlNmQtNjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vY3B1
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
-        bSt4bWwiLz4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAg
-        ICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3VkOmhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3
-        Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21l
-        bW9yeSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2NhdGlvblVu
-        aXRzPmJ5dGUgKiAyXjIwPC9yYXNkOkFsbG9jYXRpb25Vbml0cz4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5NZW1vcnkgU2l6ZTwv
-        cmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpF
-        bGVtZW50TmFtZT4yNTYgTUIgb2YgbWVtb3J5PC9yYXNkOkVsZW1lbnROYW1l
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+NTwvcmFz
-        ZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc2Vy
-        dmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjQ8L3Jhc2Q6UmVzb3VyY2VUeXBlPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eT4yNTY8
-        L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAgICAgICAgICAgICAg
-        ICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1
-        NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPExpbmsg
-        cmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
-        bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvdmlydHVh
-        bEhhcmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIi8+CiAgICAg
-        ICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYx
-        YTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+
-        CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1h
-        ZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        cmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
-        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFh
-        MjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGlu
-        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0
-        dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEy
-        M2Q2NWI0NTUvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9kaXNrcyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4
-        bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00
-        YjdmLWFlNmQtNjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
-        bWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
-        c2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFl
-        MDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFy
-        ZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFh
-        MjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbmV0d29ya0NhcmRz
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
-        bXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3du
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvdmlydHVhbEhhcmR3YXJl
-        U2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAg
-        ICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjVi
-        NDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFsUG9ydHMiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3Qr
-        eG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rp
-        b24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbiB4
-        bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEu
-        NSIgb3ZmOmlkPSI5NSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rpb24reG1sIiB2bXc6
-        b3NUeXBlPSJkZWJpYW40R3Vlc3QiIHZjbG91ZDpocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02
-        MWEyM2Q2NWI0NTUvb3BlcmF0aW5nU3lzdGVtU2VjdGlvbi8iPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5nIHN5
-        c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92
-        ZjpEZXNjcmlwdGlvbj5EZWJpYW4gR05VL0xpbnV4IDQgKDMyLWJpdCk8L292
-        ZjpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEy
-        MmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L29wZXJhdGluZ1N5c3Rl
-        bVNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uK3htbCIvPgogICAgICAgICAgICA8
-        L292ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uPgogICAgICAgICAgICA8TmV0
-        d29ya0Nvbm5lY3Rpb25TZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1
-        YjQ1NS9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rp
-        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAg
-        IDxvdmY6SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3Jr
-        IGNvbm5lY3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmlt
-        YXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nv
-        bm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVj
-        dGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9InZkYy1u
-        ZXQtbWloYSI+CiAgICAgICAgICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0
-        aW9uSW5kZXg+MDwvTmV0d29ya0Nvbm5lY3Rpb25JbmRleD4KICAgICAgICAg
-        ICAgICAgICAgICA8SXNDb25uZWN0ZWQ+dHJ1ZTwvSXNDb25uZWN0ZWQ+CiAg
-        ICAgICAgICAgICAgICAgICAgPE1BQ0FkZHJlc3M+MDA6NTA6NTY6MDE6MDA6
-        MTc8L01BQ0FkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPElwQWRkcmVz
-        c0FsbG9jYXRpb25Nb2RlPkRIQ1A8L0lwQWRkcmVzc0FsbG9jYXRpb25Nb2Rl
-        PgogICAgICAgICAgICAgICAgPC9OZXR3b3JrQ29ubmVjdGlvbj4KICAgICAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFh
-        MjNkNjViNDU1L25ldHdvcmtDb25uZWN0aW9uU2VjdGlvbi8iIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtDb25uZWN0aW9u
-        U2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgPC9OZXR3b3JrQ29ubmVjdGlv
-        blNlY3Rpb24+CiAgICAgICAgICAgIDxHdWVzdEN1c3RvbWl6YXRpb25TZWN0
-        aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFh
-        MjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9ndWVzdEN1c3RvbWl6
-        YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQuZ3Vlc3RDdXN0b21pemF0aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1
-        aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNp
-        ZmllcyBHdWVzdCBPUyBDdXN0b21pemF0aW9uIFNldHRpbmdzPC9vdmY6SW5m
-        bz4KICAgICAgICAgICAgICAgIDxFbmFibGVkPmZhbHNlPC9FbmFibGVkPgog
-        ICAgICAgICAgICAgICAgPENoYW5nZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgog
-        ICAgICAgICAgICAgICAgPFZpcnR1YWxNYWNoaW5lSWQ+YWUwMWEyMmUtZDBh
-        My00YjdmLWFlNmQtNjFhMjNkNjViNDU1PC9WaXJ0dWFsTWFjaGluZUlkPgog
-        ICAgICAgICAgICAgICAgPEpvaW5Eb21haW5FbmFibGVkPmZhbHNlPC9Kb2lu
-        RG9tYWluRW5hYmxlZD4KICAgICAgICAgICAgICAgIDxVc2VPcmdTZXR0aW5n
-        cz5mYWxzZTwvVXNlT3JnU2V0dGluZ3M+CiAgICAgICAgICAgICAgICA8QWRt
-        aW5QYXNzd29yZEVuYWJsZWQ+dHJ1ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+
-        CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRt
-        aW5QYXNzd29yZEF1dG8+CiAgICAgICAgICAgICAgICA8UmVzZXRQYXNzd29y
-        ZFJlcXVpcmVkPmZhbHNlPC9SZXNldFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAg
-        ICAgICAgICAgICA8Q29tcHV0ZXJOYW1lPkRhbW5TbWFsbExpLTAtbW08L0Nv
-        bXB1dGVyTmFtZT4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUt
-        ZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L2d1ZXN0Q3VzdG9taXphdGlv
-        blNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIvPgogICAgICAgICAg
-        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxS
-        dW50aW1lSW5mb1NlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRwOi8vd3d3LnZt
-        d2FyZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3ht
-        bCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9ydW50aW1l
-        SW5mb1NlY3Rpb24iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNp
-        ZmllcyBSdW50aW1lIGluZm88L292ZjpJbmZvPgogICAgICAgICAgICA8L1J1
-        bnRpbWVJbmZvU2VjdGlvbj4KICAgICAgICAgICAgPFNuYXBzaG90U2VjdGlv
-        biBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvc25hcHNob3RTZWN0aW9u
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zbmFwc2hv
-        dFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAg
-        ICAgICAgIDxvdmY6SW5mbz5TbmFwc2hvdCBpbmZvcm1hdGlvbiBzZWN0aW9u
-        PC9vdmY6SW5mbz4KICAgICAgICAgICAgPC9TbmFwc2hvdFNlY3Rpb24+CiAg
-        ICAgICAgICAgIDxEYXRlQ3JlYXRlZD4yMDE2LTA4LTAzVDEzOjQxOjI0LjUz
-        MCswMjowMDwvRGF0ZUNyZWF0ZWQ+CiAgICAgICAgICAgIDxWQXBwU2NvcGVk
-        TG9jYWxJZD45Zjc1NmQ3My03YjE5LTRiMWUtODA0Zi1mN2EwNDFhYmMxMTQ8
-        L1ZBcHBTY29wZWRMb2NhbElkPgogICAgICAgICAgICA8b3ZmZW52OkVudmly
-        b25tZW50IHhtbG5zOm5zMTE9Imh0dHA6Ly93d3cudm13YXJlLmNvbS9zY2hl
-        bWEvb3ZmZW52IiBvdmZlbnY6aWQ9IiIgbnMxMTp2Q2VudGVySWQ9InZtLTkz
-        Ij4KICAgICAgICAgICAgICAgIDxvdmZlbnY6UGxhdGZvcm1TZWN0aW9uPgog
-        ICAgICAgICAgICAgICAgICAgIDxvdmZlbnY6S2luZD5WTXdhcmUgRVNYaTwv
-        b3ZmZW52OktpbmQ+CiAgICAgICAgICAgICAgICAgICAgPG92ZmVudjpWZXJz
-        aW9uPjYuMC4wPC9vdmZlbnY6VmVyc2lvbj4KICAgICAgICAgICAgICAgICAg
-        ICA8b3ZmZW52OlZlbmRvcj5WTXdhcmUsIEluYy48L292ZmVudjpWZW5kb3I+
-        CiAgICAgICAgICAgICAgICAgICAgPG92ZmVudjpMb2NhbGU+ZW48L292ZmVu
-        djpMb2NhbGU+CiAgICAgICAgICAgICAgICA8L292ZmVudjpQbGF0Zm9ybVNl
-        Y3Rpb24+CiAgICAgICAgICAgICAgICA8dmU6RXRoZXJuZXRBZGFwdGVyU2Vj
-        dGlvbiB4bWxuczp2ZT0iaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9v
-        dmZlbnYiIHhtbG5zPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52
-        aXJvbm1lbnQvMSIgeG1sbnM6b2U9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L292Zi9lbnZpcm9ubWVudC8xIj4KICAgICAgICAgICAgICAgICAgICA8dmU6
-        QWRhcHRlciB2ZTptYWM9IjAwOjUwOjU2OjAxOjAwOjE3IiB2ZTpuZXR3b3Jr
-        PSJub25lIiB2ZTp1bml0TnVtYmVyPSI3Ii8+CiAgIAogICAgICAgICAgICAg
-        ICAgPC92ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uPgogICAgICAgICAgICA8
-        L292ZmVudjpFbnZpcm9ubWVudD4KICAgICAgICAgICAgPFZtQ2FwYWJpbGl0
-        aWVzIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFh
-        MjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92bUNhcGFiaWxpdGll
-        cy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2Fw
-        YWJpbGl0aWVzU2VjdGlvbit4bWwiPgogICAgICAgICAgICAgICAgPExpbmsg
-        cmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
-        bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvdm1DYXBh
-        YmlsaXRpZXMvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC52bUNhcGFiaWxpdGllc1NlY3Rpb24reG1sIi8+CiAgICAgICAgICAgICAg
-        ICA8TWVtb3J5SG90QWRkRW5hYmxlZD5mYWxzZTwvTWVtb3J5SG90QWRkRW5h
-        YmxlZD4KICAgICAgICAgICAgICAgIDxDcHVIb3RBZGRFbmFibGVkPmZhbHNl
-        PC9DcHVIb3RBZGRFbmFibGVkPgogICAgICAgICAgICA8L1ZtQ2FwYWJpbGl0
-        aWVzPgogICAgICAgICAgICA8U3RvcmFnZVByb2ZpbGUgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzQyOTRmNzY3LWQ5
-        ZWItNDcyOC1iN2RkLTgxYTJkNzY4MzBiZiIgbmFtZT0iKiIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUr
-        eG1sIi8+CiAgICAgICAgPC9WbT4KICAgICAgICA8Vm0gbmVlZHNDdXN0b21p
-        emF0aW9uPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBuYW1l
-        PSJUVFlMaW51eC0xLW1tIiBpZD0idXJuOnZjbG91ZDp2bTozZjE1ZGYxNC00
-        NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEiIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBk
-        ZGY3YjE0NDQyYSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQudm0reG1sIj4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpwb3dl
-        ck9mZiIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2Yx
-        NWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlv
-        bi9wb3dlck9mZiIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJl
-        Ym9vdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2Yx
-        NWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlv
-        bi9yZWJvb3QiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpyZXNl
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRm
-        MTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlvbi9y
-        ZXNldCIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnNodXRkb3du
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYx
-        NC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvcG93ZXIvYWN0aW9uL3No
-        dXRkb3duIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c3VzcGVu
-        ZCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRm
-        MTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlvbi9z
-        dXNwZW5kIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0idW5kZXBsb3kiIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2
-        NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9hY3Rpb24vdW5kZXBsb3kiIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95VkFw
-        cFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00
-        NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEiIHR5cGU9ImFwcGxpY2F0aW9u
-        L3ZuZC52bXdhcmUudmNsb3VkLnZtK3htbCIvPgogICAgICAgICAgICA8TGlu
-        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9tZXRh
-        ZGF0YSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubWV0
-        YWRhdGEreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3
-        Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Byb2R1Y3RTZWN0aW9ucy8iIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnByb2R1Y3RTZWN0
-        aW9ucyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJzY3JlZW46dGh1
-        bWJuYWlsIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0z
-        ZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvc2NyZWVuIi8+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0ic2NyZWVuOmFjcXVpcmVUaWNrZXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0
-        LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9zY3JlZW4vYWN0aW9uL2Fj
-        cXVpcmVUaWNrZXQiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJtZWRpYTpp
-        bnNlcnRNZWRpYSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAv
-        dm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL21lZGlh
-        L2FjdGlvbi9pbnNlcnRNZWRpYSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQubWVkaWFJbnNlcnRPckVqZWN0UGFyYW1zK3htbCIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9Im1lZGlhOmVqZWN0TWVkaWEiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzIt
-        NGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9tZWRpYS9hY3Rpb24vZWplY3RNZWRp
-        YSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubWVkaWFJ
-        bnNlcnRPckVqZWN0UGFyYW1zK3htbCIvPgogICAgICAgICAgICA8TGluayBy
-        ZWw9ImRpc2s6YXR0YWNoIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEv
-        ZGlzay9hY3Rpb24vYXR0YWNoIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5kaXNrQXR0YWNoT3JEZXRhY2hQYXJhbXMreG1sIi8+CiAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0iZGlzazpkZXRhY2giIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1h
-        Mzk2LTBkZGY3YjE0NDQyYS9kaXNrL2FjdGlvbi9kZXRhY2giIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRpc2tBdHRhY2hPckRldGFj
-        aFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJpbnN0YWxs
-        Vm13YXJlVG9vbHMiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9hY3Rp
-        b24vaW5zdGFsbFZNd2FyZVRvb2xzIi8+CiAgICAgICAgICAgIDxMaW5rIHJl
-        bD0ic25hcHNob3Q6Y3JlYXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0
-        MmEvYWN0aW9uL2NyZWF0ZVNuYXBzaG90IiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5jcmVhdGVTbmFwc2hvdFBhcmFtcyt4bWwiLz4K
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJyZWNvbmZpZ3VyZVZtIiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRk
-        MTQtYTM5Ni0wZGRmN2IxNDQ0MmEvYWN0aW9uL3JlY29uZmlndXJlVm0iIG5h
-        bWU9IlRUWUxpbnV4LTEtbW0iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnZtK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9InVw
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3
-        ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNSIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcCt4bWwiLz4KICAgICAgICAg
-        ICAgPERlc2NyaXB0aW9uPkNyZWF0ZWQgYnk6IE1pa2UgTGF2ZXJpY2sNQmxv
-        Zzogd3d3Lm1pa2VsYXZlcmljay5jb20NVHdpdHRlcjogQG1pa2VfbGF2ZXJp
-        Y2sNDVNlcnZpY2VzIEVuYWJsZWQ6IFNTSCwgRlRQLCBIVFRQDVJPT1QgUGFz
-        c3dvcmQ6IHBhc3N3b3JkPC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPG92
-        ZjpWaXJ0dWFsSGFyZHdhcmVTZWN0aW9uIHhtbG5zOnZjbG91ZD0iaHR0cDov
-        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBvdmY6dHJhbnNwb3J0PSIi
-        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1h
-        Mzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uLyI+CiAg
-        ICAgICAgICAgICAgICA8b3ZmOkluZm8+VmlydHVhbCBoYXJkd2FyZSByZXF1
-        aXJlbWVudHM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpTeXN0
-        ZW0+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6RWxlbWVudE5hbWU+Vmly
-        dHVhbCBIYXJkd2FyZSBGYW1pbHk8L3Zzc2Q6RWxlbWVudE5hbWU+CiAgICAg
-        ICAgICAgICAgICAgICAgPHZzc2Q6SW5zdGFuY2VJRD4wPC92c3NkOkluc3Rh
-        bmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3Rl
-        bUlkZW50aWZpZXI+VFRZTGludXgtMS1tbTwvdnNzZDpWaXJ0dWFsU3lzdGVt
-        SWRlbnRpZmllcj4KICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0dWFs
-        U3lzdGVtVHlwZT52bXgtMDg8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+CiAg
-        ICAgICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAgICAgICAgICAgICAgICA8
-        b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4w
-        MDo1MDo1NjowMTowMDoxYjwvcmFzZDpBZGRyZXNzPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4xPC9yYXNkOkFkZHJlc3NP
-        blBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBdXRvbWF0aWNB
-        bGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91ZDppcEFk
-        ZHJlc3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtDb25u
-        ZWN0aW9uPSJmYWxzZSI+dmRjLW5ldC1taWhhPC9yYXNkOkNvbm5lY3Rpb24+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+UENOZXQz
-        MiBldGhlcm5ldCBhZGFwdGVyIG9uICJ2ZGMtbmV0LW1paGEiPC9yYXNkOkRl
-        c2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnRO
-        YW1lPk5ldHdvcmsgYWRhcHRlciAxPC9yYXNkOkVsZW1lbnROYW1lPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+MTwvcmFzZDpJbnN0
-        YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlU3Vi
-        VHlwZT5QQ05ldDMyPC9yYXNkOlJlc291cmNlU3ViVHlwZT4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTA8L3Jhc2Q6UmVzb3Vy
-        Y2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAg
-        ICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpB
-        ZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjE2PC9yYXNkOkFkZHJlc3M+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzc09uUGFyZW50PjA8L3Jhc2Q6
-        QWRkcmVzc09uUGFyZW50PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkF1
-        dG9tYXRpY0FsbG9jYXRpb24+dHJ1ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0
-        aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkNvbm5lY3Rpb24gdmNs
-        b3VkOmlwQWRkcmVzc2luZ01vZGU9IlBPT0wiIHZjbG91ZDppcEFkZHJlc3M9
-        IjE5Mi4xNjguMi4xMDAiIHZjbG91ZDpwcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
-        b249InRydWUiPnZhcHAtbmV0d29yay1taWhhPC9yYXNkOkNvbm5lY3Rpb24+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+RTEwMDAg
-        ZXRoZXJuZXQgYWRhcHRlciBvbiAidmFwcC1uZXR3b3JrLW1paGEiPC9yYXNk
-        OkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1l
-        bnROYW1lPk5ldHdvcmsgYWRhcHRlciAwPC9yYXNkOkVsZW1lbnROYW1lPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+MjwvcmFzZDpJ
-        bnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNl
-        U3ViVHlwZT5FMTAwMDwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291
-        cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAg
-        ICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        QWRkcmVzcz4wMDo1MDo1NjowMTowMDoyMDwvcmFzZDpBZGRyZXNzPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4yPC9yYXNk
-        OkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpB
-        dXRvbWF0aWNBbGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2Nh
-        dGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZj
-        bG91ZDppcEFkZHJlc3NpbmdNb2RlPSJQT09MIiB2Y2xvdWQ6aXBBZGRyZXNz
-        PSIxOTIuMTY4LjIuMTAwIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtDb25uZWN0
-        aW9uPSJmYWxzZSI+dGFkcnVnaS12YXBwLW5ldHdvcms8L3Jhc2Q6Q29ubmVj
-        dGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5Q
-        Q05ldDMyIGV0aGVybmV0IGFkYXB0ZXIgb24gInRhZHJ1Z2ktdmFwcC1uZXR3
-        b3JrIjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpFbGVtZW50TmFtZT5OZXR3b3JrIGFkYXB0ZXIgMjwvcmFzZDpFbGVt
-        ZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlE
-        PjM8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpSZXNvdXJjZVN1YlR5cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5
-        cGU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEw
-        PC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0
-        ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6QWRkcmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8
-        L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        RWxlbWVudE5hbWU+SURFIENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFt
-        ZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjQ8L3Jh
-        c2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNv
-        dXJjZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAg
-        ICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNk
-        OkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpE
-        ZXNjcmlwdGlvbj5IYXJkIGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8
-        L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        SG9zdFJlc291cmNlIHZjbG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3Vi
-        VHlwZT0iIiB2Y2xvdWQ6Y2FwYWNpdHk9IjMyIi8+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6SW5zdGFuY2VJRD4zMDAwPC9yYXNkOkluc3RhbmNlSUQ+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UGFyZW50PjQ8L3Jhc2Q6UGFy
-        ZW50PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4x
-        NzwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6VmlydHVhbFF1YW50aXR5PjMzNTU0NDMyPC9yYXNkOlZpcnR1YWxRdWFu
-        dGl0eT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRp
-        dHlVbml0cz5ieXRlPC9yYXNkOlZpcnR1YWxRdWFudGl0eVVuaXRzPgogICAg
-        ICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6
-        SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzPjE8L3Jh
-        c2Q6QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlw
-        dGlvbj5JREUgQ29udHJvbGxlcjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5JREUgQ29udHJvbGxl
-        ciAxPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOkluc3RhbmNlSUQ+NTwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT41PC9yYXNkOlJlc291cmNl
-        VHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAg
-        ICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRk
-        cmVzc09uUGFyZW50PjA8L3Jhc2Q6QWRkcmVzc09uUGFyZW50PgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkF1dG9tYXRpY0FsbG9jYXRpb24+ZmFsc2U8
-        L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpEZXNjcmlwdGlvbj5DRC9EVkQgRHJpdmU8L3Jhc2Q6RGVzY3Jp
-        cHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+
-        Q0QvRFZEIERyaXZlIDE8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6SG9zdFJlc291cmNlLz4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpJbnN0YW5jZUlEPjMwMDI8L3Jhc2Q6SW5zdGFuY2VJRD4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpQYXJlbnQ+NTwvcmFzZDpQYXJl
-        bnQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjE1
-        PC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0
-        ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNs
-        b3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVk
-        ZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uL2NwdSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxs
-        b2NhdGlvblVuaXRzPmhlcnR6ICogMTBeNjwvcmFzZDpBbGxvY2F0aW9uVW5p
-        dHM+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+TnVt
-        YmVyIG9mIFZpcnR1YWwgQ1BVczwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT4xIHZpcnR1YWwgQ1BV
-        KHMpPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOkluc3RhbmNlSUQ+NjwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOlJlc2VydmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRp
-        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjM8
-        L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OlZpcnR1YWxRdWFudGl0eT4xPC9yYXNkOlZpcnR1YWxRdWFudGl0eT4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpXZWlnaHQ+MDwvcmFzZDpXZWlnaHQ+
-        CiAgICAgICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRk
-        MTQtYTM5Ni0wZGRmN2IxNDQ0MmEvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9j
-        cHUiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJ
-        dGVtK3htbCIvPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAg
-        ICAgICAgICAgIDxvdmY6SXRlbSB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIiB2Y2xvdWQ6aHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00
-        ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
-        bWVtb3J5Ij4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBbGxvY2F0aW9u
-        VW5pdHM+Ynl0ZSAqIDJeMjA8L3Jhc2Q6QWxsb2NhdGlvblVuaXRzPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk1lbW9yeSBTaXpl
-        PC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OkVsZW1lbnROYW1lPjMyIE1CIG9mIG1lbW9yeTwvcmFzZDpFbGVtZW50TmFt
-        ZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjc8L3Jh
-        c2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNl
-        cnZhdGlvbj4wPC9yYXNkOlJlc2VydmF0aW9uPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOlJlc291cmNlVHlwZT40PC9yYXNkOlJlc291cmNlVHlwZT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MzI8
-        L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAgICAgICAgICAgICAg
-        ICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQy
-        YS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPExpbmsg
-        cmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
-        bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvdmlydHVh
-        bEhhcmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIi8+CiAgICAg
-        ICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBk
-        ZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+
-        CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1h
-        Mzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzIt
-        NGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        cmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
-        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVk
-        ZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGlu
-        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0
-        dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRm
-        N2IxNDQ0MmEvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9kaXNrcyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4
-        bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00
-        ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
-        bWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
-        c2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNm
-        MTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFy
-        ZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRk
-        ZjdiMTQ0NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbmV0d29ya0NhcmRz
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
-        bXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3du
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYx
-        NC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvdmlydHVhbEhhcmR3YXJl
-        U2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAg
-        ICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0
-        NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFsUG9ydHMiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3Qr
-        eG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rp
-        b24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbiB4
-        bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEu
-        NSIgb3ZmOmlkPSIzNiIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rpb24reG1sIiB2bXc6
-        b3NUeXBlPSJvdGhlckxpbnV4R3Vlc3QiIHZjbG91ZDpocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5
-        Ni0wZGRmN2IxNDQ0MmEvb3BlcmF0aW5nU3lzdGVtU2VjdGlvbi8iPgogICAg
-        ICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5n
-        IHN5c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAgICAgICAgICAg
-        PG92ZjpEZXNjcmlwdGlvbj5PdGhlciBMaW51eCAoMzItYml0KTwvb3ZmOkRl
-        c2NyaXB0aW9uPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00
-        NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvb3BlcmF0aW5nU3lzdGVtU2Vj
-        dGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9w
-        ZXJhdGluZ1N5c3RlbVNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvb3Zm
-        Ok9wZXJhdGluZ1N5c3RlbVNlY3Rpb24+CiAgICAgICAgICAgIDxOZXR3b3Jr
-        Q29ubmVjdGlvblNlY3Rpb24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBp
-        L3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJh
-        L25ldHdvcmtDb25uZWN0aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9u
-        L3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtDb25uZWN0aW9uU2VjdGlvbit4
-        bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAgPG92
-        ZjpJbmZvPlNwZWNpZmllcyB0aGUgYXZhaWxhYmxlIFZNIG5ldHdvcmsgY29u
-        bmVjdGlvbnM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPFByaW1hcnlO
-        ZXR3b3JrQ29ubmVjdGlvbkluZGV4PjA8L1ByaW1hcnlOZXR3b3JrQ29ubmVj
-        dGlvbkluZGV4PgogICAgICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
-        IG5lZWRzQ3VzdG9taXphdGlvbj0iZmFsc2UiIG5ldHdvcms9InZkYy1uZXQt
-        bWloYSI+CiAgICAgICAgICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
-        SW5kZXg+MTwvTmV0d29ya0Nvbm5lY3Rpb25JbmRleD4KICAgICAgICAgICAg
-        ICAgICAgICA8SXNDb25uZWN0ZWQ+dHJ1ZTwvSXNDb25uZWN0ZWQ+CiAgICAg
-        ICAgICAgICAgICAgICAgPE1BQ0FkZHJlc3M+MDA6NTA6NTY6MDE6MDA6MWI8
-        L01BQ0FkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPElwQWRkcmVzc0Fs
-        bG9jYXRpb25Nb2RlPkRIQ1A8L0lwQWRkcmVzc0FsbG9jYXRpb25Nb2RlPgog
-        ICAgICAgICAgICAgICAgPC9OZXR3b3JrQ29ubmVjdGlvbj4KICAgICAgICAg
-        ICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3RvbWl6YXRpb249
-        ImZhbHNlIiBuZXR3b3JrPSJ2YXBwLW5ldHdvcmstbWloYSI+CiAgICAgICAg
-        ICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9uSW5kZXg+MDwvTmV0d29y
-        a0Nvbm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgICAgICA8SXBBZGRy
-        ZXNzPjE5Mi4xNjguMi4xMDA8L0lwQWRkcmVzcz4KICAgICAgICAgICAgICAg
-        ICAgICA8SXNDb25uZWN0ZWQ+dHJ1ZTwvSXNDb25uZWN0ZWQ+CiAgICAgICAg
-        ICAgICAgICAgICAgPE1BQ0FkZHJlc3M+MDA6NTA6NTY6MDE6MDA6MTY8L01B
-        Q0FkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPElwQWRkcmVzc0FsbG9j
-        YXRpb25Nb2RlPlBPT0w8L0lwQWRkcmVzc0FsbG9jYXRpb25Nb2RlPgogICAg
-        ICAgICAgICAgICAgPC9OZXR3b3JrQ29ubmVjdGlvbj4KICAgICAgICAgICAg
-        ICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRy
-        dWUiIG5ldHdvcms9InRhZHJ1Z2ktdmFwcC1uZXR3b3JrIj4KICAgICAgICAg
-        ICAgICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4yPC9OZXR3b3Jr
-        Q29ubmVjdGlvbkluZGV4PgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJl
-        c3M+MTkyLjE2OC4yLjEwMDwvSXBBZGRyZXNzPgogICAgICAgICAgICAgICAg
-        ICAgIDxJc0Nvbm5lY3RlZD50cnVlPC9Jc0Nvbm5lY3RlZD4KICAgICAgICAg
-        ICAgICAgICAgICA8TUFDQWRkcmVzcz4wMDo1MDo1NjowMTowMDoyMDwvTUFD
-        QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICA8SXBBZGRyZXNzQWxsb2Nh
-        dGlvbk1vZGU+UE9PTDwvSXBBZGRyZXNzQWxsb2NhdGlvbk1vZGU+CiAgICAg
-        ICAgICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uPgogICAgICAgICAgICAg
-        ICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0
-        MmEvbmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQubmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9u
-        K3htbCIvPgogICAgICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uU2VjdGlv
-        bj4KICAgICAgICAgICAgPEd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24gaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3
-        Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL2d1ZXN0Q3VzdG9taXphdGlvblNl
-        Y3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5n
-        dWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJm
-        YWxzZSI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIEd1
-        ZXN0IE9TIEN1c3RvbWl6YXRpb24gU2V0dGluZ3M8L292ZjpJbmZvPgogICAg
-        ICAgICAgICAgICAgPEVuYWJsZWQ+ZmFsc2U8L0VuYWJsZWQ+CiAgICAgICAg
-        ICAgICAgICA8Q2hhbmdlU2lkPmZhbHNlPC9DaGFuZ2VTaWQ+CiAgICAgICAg
-        ICAgICAgICA8VmlydHVhbE1hY2hpbmVJZD4zZjE1ZGYxNC00NjcyLTRkMTQt
-        YTM5Ni0wZGRmN2IxNDQ0MmE8L1ZpcnR1YWxNYWNoaW5lSWQ+CiAgICAgICAg
-        ICAgICAgICA8Sm9pbkRvbWFpbkVuYWJsZWQ+ZmFsc2U8L0pvaW5Eb21haW5F
-        bmFibGVkPgogICAgICAgICAgICAgICAgPFVzZU9yZ1NldHRpbmdzPmZhbHNl
-        PC9Vc2VPcmdTZXR0aW5ncz4KICAgICAgICAgICAgICAgIDxBZG1pblBhc3N3
-        b3JkRW5hYmxlZD50cnVlPC9BZG1pblBhc3N3b3JkRW5hYmxlZD4KICAgICAg
-        ICAgICAgICAgIDxBZG1pblBhc3N3b3JkQXV0bz50cnVlPC9BZG1pblBhc3N3
-        b3JkQXV0bz4KICAgICAgICAgICAgICAgIDxSZXNldFBhc3N3b3JkUmVxdWly
-        ZWQ+ZmFsc2U8L1Jlc2V0UGFzc3dvcmRSZXF1aXJlZD4KICAgICAgICAgICAg
-        ICAgIDxDb21wdXRlck5hbWU+VFRZTGludXgtMDAtMC1tbTwvQ29tcHV0ZXJO
-        YW1lPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRk
-        MTQtYTM5Ni0wZGRmN2IxNDQ0MmEvZ3Vlc3RDdXN0b21pemF0aW9uU2VjdGlv
-        bi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmd1ZXN0
-        Q3VzdG9taXphdGlvblNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvR3Vl
-        c3RDdXN0b21pemF0aW9uU2VjdGlvbj4KICAgICAgICAgICAgPFJ1bnRpbWVJ
-        bmZvU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNv
-        bS92Y2xvdWQvdjEuNSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIiB2Y2xv
-        dWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRm
-        MTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3J1bnRpbWVJbmZvU2Vj
-        dGlvbiI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIFJ1
-        bnRpbWUgaW5mbzwvb3ZmOkluZm8+CiAgICAgICAgICAgIDwvUnVudGltZUlu
-        Zm9TZWN0aW9uPgogICAgICAgICAgICA8U25hcHNob3RTZWN0aW9uIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzIt
-        NGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9zbmFwc2hvdFNlY3Rpb24iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnNuYXBzaG90U2VjdGlv
-        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAg
-        PG92ZjpJbmZvPlNuYXBzaG90IGluZm9ybWF0aW9uIHNlY3Rpb248L292ZjpJ
-        bmZvPgogICAgICAgICAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgICAgICAg
-        ICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDNUMTM6NDE6MjQuNDIzKzAyOjAw
-        PC9EYXRlQ3JlYXRlZD4KICAgICAgICAgICAgPFZBcHBTY29wZWRMb2NhbElk
-        PmMyYzViZDIyLTBiNzctNDE4Ny1hM2YzLWNjYjY4YjBlYjYyZjwvVkFwcFNj
-        b3BlZExvY2FsSWQ+CiAgICAgICAgICAgIDxvdmZlbnY6RW52aXJvbm1lbnQg
-        eG1sbnM6bnMxMT0iaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9vdmZl
-        bnYiIG92ZmVudjppZD0iIiBuczExOnZDZW50ZXJJZD0idm0tOTIiPgogICAg
-        ICAgICAgICAgICAgPG92ZmVudjpQbGF0Zm9ybVNlY3Rpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPG92ZmVudjpLaW5kPlZNd2FyZSBFU1hpPC9vdmZlbnY6
-        S2luZD4KICAgICAgICAgICAgICAgICAgICA8b3ZmZW52OlZlcnNpb24+Ni4w
-        LjA8L292ZmVudjpWZXJzaW9uPgogICAgICAgICAgICAgICAgICAgIDxvdmZl
-        bnY6VmVuZG9yPlZNd2FyZSwgSW5jLjwvb3ZmZW52OlZlbmRvcj4KICAgICAg
-        ICAgICAgICAgICAgICA8b3ZmZW52OkxvY2FsZT5lbjwvb3ZmZW52OkxvY2Fs
-        ZT4KICAgICAgICAgICAgICAgIDwvb3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4K
-        ICAgICAgICAgICAgICAgIDx2ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uIHht
-        bG5zOnZlPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIg
-        eG1sbnM9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVu
-        dC8xIiB4bWxuczpvZT0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vu
-        dmlyb25tZW50LzEiPgogICAgICAgICAgICAgICAgICAgIDx2ZTpBZGFwdGVy
-        IHZlOm1hYz0iMDA6NTA6NTY6MDE6MDA6MTYiIHZlOm5ldHdvcms9Im5vbmUi
-        IHZlOnVuaXROdW1iZXI9IjciLz4KICAgCiAgICAgICAgICAgICAgICA8L3Zl
-        OkV0aGVybmV0QWRhcHRlclNlY3Rpb24+CiAgICAgICAgICAgIDwvb3ZmZW52
-        OkVudmlyb25tZW50PgogICAgICAgICAgICA8Vm1DYXBhYmlsaXRpZXMgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3
-        Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3ZtQ2FwYWJpbGl0aWVzLyIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRp
-        ZXNTZWN0aW9uK3htbCI+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
-        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVk
-        ZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92bUNhcGFiaWxpdGll
-        cy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2Fw
-        YWJpbGl0aWVzU2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgICAgIDxNZW1v
-        cnlIb3RBZGRFbmFibGVkPmZhbHNlPC9NZW1vcnlIb3RBZGRFbmFibGVkPgog
-        ICAgICAgICAgICAgICAgPENwdUhvdEFkZEVuYWJsZWQ+ZmFsc2U8L0NwdUhv
-        dEFkZEVuYWJsZWQ+CiAgICAgICAgICAgIDwvVm1DYXBhYmlsaXRpZXM+CiAg
-        ICAgICAgICAgIDxTdG9yYWdlUHJvZmlsZSBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdmRjU3RvcmFnZVByb2ZpbGUvNDI5NGY3NjctZDllYi00NzI4
-        LWI3ZGQtODFhMmQ3NjgzMGJmIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4K
-        ICAgICAgICA8L1ZtPgogICAgPC9DaGlsZHJlbj4KPC9WQXBwPgo=
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:03 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-8e2253a9-5ce5-4e42-a3d2-701b6be2dcbb
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:01 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 1b007062-4559-41ea-983d-ffb2a285c245
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '110'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHAg
-        eG1sbnM9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgeG1s
-        bnM6b3ZmPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUv
-        MSIgeG1sbnM6cmFzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93
-        c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0
-        dGluZ0RhdGEiIHhtbG5zOnZzc2Q9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L3diZW0vd3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lNX1ZpcnR1YWxTeXN0ZW1T
-        ZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8vd3d3LnZtd2FyZS5jb20v
-        c2NoZW1hL292ZiIgeG1sbnM6b3ZmZW52PSJodHRwOi8vc2NoZW1hcy5kbXRm
-        Lm9yZy9vdmYvZW52aXJvbm1lbnQvMSIgeG1sbnM6eHNpPSJodHRwOi8vd3d3
-        LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgb3ZmRGVzY3JpcHRv
-        clVwbG9hZGVkPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBu
-        YW1lPSJEU0wtcnNwZWMiIGlkPSJ1cm46dmNsb3VkOnZhcHA6OGUyMjUzYTkt
-        NWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2Qy
-        LTcwMWI2YmUyZGNiYiIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudkFwcCt4bWwiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDovL3Nj
-        aGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEgaHR0cDovL3NjaGVtYXMu
-        ZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvZHNwODAyM18xLjEuMC54c2QgaHR0
-        cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0dHA6Ly8xMC4zMC4y
-        LjIvYXBpL3YxLjUvc2NoZW1hL21hc3Rlci54c2QgaHR0cDovL3d3dy52bXdh
-        cmUuY29tL3NjaGVtYS9vdmYgaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVt
-        YS9vdmYgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2NpbS8xL2Np
-        bS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0dGluZ0RhdGEg
-        aHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2NpbS8xL2NpbS1zY2hl
-        bWEvMi4yMi4wL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25TZXR0aW5nRGF0YS54
-        c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmlyb25tZW50LzEg
-        aHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvZHNwODAy
-        N18xLjEuMC54c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2Np
-        bS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdEYXRh
-        IGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0vMS9jaW0tc2No
-        ZW1hLzIuMjIuMC9DSU1fVmlydHVhbFN5c3RlbVNldHRpbmdEYXRhLnhzZCI+
-        CiAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1h
-        M2QyLTcwMWI2YmUyZGNiYi9wb3dlci9hY3Rpb24vcG93ZXJPZmYiLz4KICAg
-        IDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcw
-        MWI2YmUyZGNiYi9wb3dlci9hY3Rpb24vcmVib290Ii8+CiAgICA8TGluayBy
-        ZWw9InBvd2VyOnJlc2V0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNi
-        Yi9wb3dlci9hY3Rpb24vcmVzZXQiLz4KICAgIDxMaW5rIHJlbD0icG93ZXI6
-        c2h1dGRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zh
-        cHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL3Bvd2Vy
-        L2FjdGlvbi9zaHV0ZG93biIvPgogICAgPExpbmsgcmVsPSJwb3dlcjpzdXNw
-        ZW5kIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThl
-        MjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNiYi9wb3dlci9hY3Rp
-        b24vc3VzcGVuZCIvPgogICAgPExpbmsgcmVsPSJkZXBsb3kiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00
-        ZTQyLWEzZDItNzAxYjZiZTJkY2JiL2FjdGlvbi9kZXBsb3kiIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRlcGxveVZBcHBQYXJhbXMr
-        eG1sIi8+CiAgICA8TGluayByZWw9InVuZGVwbG95IiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1h
-        M2QyLTcwMWI2YmUyZGNiYi9hY3Rpb24vdW5kZXBsb3kiIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95VkFwcFBhcmFtcyt4
-        bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL25ldHdvcmsvYjAwODUxMGEtN2Q1Yi00OGVjLWEzMjMtOGE3
-        Y2ViYTBhY2QwIiBuYW1lPSJWTSBOZXR3b3JrIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52QXBwTmV0d29yayt4bWwiLz4KICAgIDxM
-        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIv
-        Y29udHJvbEFjY2Vzcy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLmNvbnRyb2xBY2Nlc3MreG1sIi8+CiAgICA8TGluayByZWw9ImNv
-        bnRyb2xBY2Nlc3MiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL2Fj
-        dGlvbi9jb250cm9sQWNjZXNzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5jb250cm9sQWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVs
-        PSJ1cCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZkYy8wZWRlMjZh
-        Mi01OGM4LTQ0OTQtODIxYS1hMjE2YjE0OWI4NjUiIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZkYyt4bWwiLz4KICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
-        cC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZBcHAreG1sIi8+CiAg
-        ICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJk
-        Y2JiL293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRl
-        NDItYTNkMi03MDFiNmJlMmRjYmIvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgPExp
-        bmsgcmVsPSJvdmYiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL292
-        ZiIgdHlwZT0idGV4dC94bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC04ZTIyNTNhOS01
-        Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIvcHJvZHVjdFNlY3Rpb25zLyIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucHJvZHVjdFNl
-        Y3Rpb25zK3htbCIvPgogICAgPExpbmsgcmVsPSJzbmFwc2hvdDpjcmVhdGUi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUz
-        YTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL2FjdGlvbi9jcmVhdGVT
-        bmFwc2hvdCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        Y3JlYXRlU25hcHNob3RQYXJhbXMreG1sIi8+CiAgICA8RGVzY3JpcHRpb24v
-        PgogICAgPExlYXNlU2V0dGluZ3NTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDIt
-        NzAxYjZiZTJkY2JiL2xlYXNlU2V0dGluZ3NTZWN0aW9uLyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubGVhc2VTZXR0aW5nc1NlY3Rp
-        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
-        Zm8+TGVhc2Ugc2V0dGluZ3Mgc2VjdGlvbjwvb3ZmOkluZm8+CiAgICAgICAg
-        PExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNi
-        Yi9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NTZWN0aW9uK3htbCIvPgog
-        ICAgICAgIDxEZXBsb3ltZW50TGVhc2VJblNlY29uZHM+MDwvRGVwbG95bWVu
-        dExlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29u
-        ZHM+MDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgPC9MZWFzZVNldHRp
-        bmdzU2VjdGlvbj4KICAgIDxvdmY6U3RhcnR1cFNlY3Rpb24geG1sbnM6dmNs
-        b3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91
-        ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zdGFydHVw
-        U2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92YXBwLThlMjI1M2E5LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUy
-        ZGNiYi9zdGFydHVwU2VjdGlvbi8iPgogICAgICAgIDxvdmY6SW5mbz5WQXBw
-        IHN0YXJ0dXAgc2VjdGlvbjwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpJdGVt
-        IG92ZjppZD0iRFNMLXJzcGVjIiBvdmY6b3JkZXI9IjAiIG92ZjpzdGFydEFj
-        dGlvbj0icG93ZXJPbiIgb3ZmOnN0YXJ0RGVsYXk9IjAiIG92ZjpzdG9wQWN0
-        aW9uPSJwb3dlck9mZiIgb3ZmOnN0b3BEZWxheT0iMCIvPgogICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIv
-        c3RhcnR1cFNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC5zdGFydHVwU2VjdGlvbit4bWwiLz4KICAgIDwvb3ZmOlN0YXJ0
-        dXBTZWN0aW9uPgogICAgPG92ZjpOZXR3b3JrU2VjdGlvbiB4bWxuczp2Y2xv
-        dWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgdmNsb3Vk
-        OnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtT
-        ZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZhcHAtOGUyMjUzYTktNWNlNS00ZTQyLWEzZDItNzAxYjZiZTJk
-        Y2JiL25ldHdvcmtTZWN0aW9uLyI+CiAgICAgICAgPG92ZjpJbmZvPlRoZSBs
-        aXN0IG9mIGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxv
-        dmY6TmV0d29yayBvdmY6bmFtZT0iVk0gTmV0d29yayI+CiAgICAgICAgICAg
-        IDxvdmY6RGVzY3JpcHRpb24+VGhlIFZNIE5ldHdvcmsgbmV0d29yazwvb3Zm
-        OkRlc2NyaXB0aW9uPgogICAgICAgIDwvb3ZmOk5ldHdvcms+CiAgICA8L292
-        ZjpOZXR3b3JrU2VjdGlvbj4KICAgIDxOZXR3b3JrQ29uZmlnU2VjdGlvbiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLThlMjI1M2E5
-        LTVjZTUtNGU0Mi1hM2QyLTcwMWI2YmUyZGNiYi9uZXR3b3JrQ29uZmlnU2Vj
-        dGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5l
-        dHdvcmtDb25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+
-        CiAgICAgICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRl
-        cnMgZm9yIGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNkMi03MDFiNmJlMmRjYmIv
-        bmV0d29ya0NvbmZpZ1NlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5uZXR3b3JrQ29uZmlnU2VjdGlvbit4bWwiLz4KICAg
-        ICAgICA8TmV0d29ya0NvbmZpZyBuZXR3b3JrTmFtZT0iVk0gTmV0d29yayI+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icmVwYWlyIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvYWRtaW4vbmV0d29yay9iMDA4NTEwYS03ZDViLTQ4
-        ZWMtYTMyMy04YTdjZWJhMGFjZDAvYWN0aW9uL3Jlc2V0Ii8+CiAgICAgICAg
-        ICAgIDxEZXNjcmlwdGlvbj5UaGUgVk0gTmV0d29yayBuZXR3b3JrPC9EZXNj
-        cmlwdGlvbj4KICAgICAgICAgICAgPENvbmZpZ3VyYXRpb24+CiAgICAgICAg
-        ICAgICAgICA8SXBTY29wZXM+CiAgICAgICAgICAgICAgICAgICAgPElwU2Nv
-        cGU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJc0luaGVyaXRlZD5mYWxz
-        ZTwvSXNJbmhlcml0ZWQ+CiAgICAgICAgICAgICAgICAgICAgICAgIDxHYXRl
-        d2F5PjE5Mi4xNjguMjU0LjE8L0dhdGV3YXk+CiAgICAgICAgICAgICAgICAg
-        ICAgICAgIDxOZXRtYXNrPjI1NS4yNTUuMjU1LjA8L05ldG1hc2s+CiAgICAg
-        ICAgICAgICAgICAgICAgICAgIDxJc0VuYWJsZWQ+dHJ1ZTwvSXNFbmFibGVk
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZXM+CiAgICAgICAg
-        ICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZT4KICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgICA8U3RhcnRBZGRyZXNzPjE5Mi4xNjguMjU0LjEw
-        MDwvU3RhcnRBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAg
-        ICAgIDxFbmRBZGRyZXNzPjE5Mi4xNjguMjU0LjE5OTwvRW5kQWRkcmVzcz4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvSXBSYW5nZT4KICAgICAg
-        ICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlcz4KICAgICAgICAgICAgICAg
-        ICAgICA8L0lwU2NvcGU+CiAgICAgICAgICAgICAgICA8L0lwU2NvcGVzPgog
-        ICAgICAgICAgICAgICAgPEZlbmNlTW9kZT5pc29sYXRlZDwvRmVuY2VNb2Rl
-        PgogICAgICAgICAgICAgICAgPFJldGFpbk5ldEluZm9BY3Jvc3NEZXBsb3lt
-        ZW50cz5mYWxzZTwvUmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRzPgog
-        ICAgICAgICAgICAgICAgPEZlYXR1cmVzPgogICAgICAgICAgICAgICAgICAg
-        IDxEaGNwU2VydmljZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElzRW5h
-        YmxlZD5mYWxzZTwvSXNFbmFibGVkPgogICAgICAgICAgICAgICAgICAgICAg
-        ICA8RGVmYXVsdExlYXNlVGltZT4zNjAwPC9EZWZhdWx0TGVhc2VUaW1lPgog
-        ICAgICAgICAgICAgICAgICAgICAgICA8TWF4TGVhc2VUaW1lPjcyMDA8L01h
-        eExlYXNlVGltZT4KICAgICAgICAgICAgICAgICAgICA8L0RoY3BTZXJ2aWNl
-        PgogICAgICAgICAgICAgICAgPC9GZWF0dXJlcz4KICAgICAgICAgICAgPC9D
-        b25maWd1cmF0aW9uPgogICAgICAgICAgICA8SXNEZXBsb3llZD50cnVlPC9J
-        c0RlcGxveWVkPgogICAgICAgIDwvTmV0d29ya0NvbmZpZz4KICAgIDwvTmV0
-        d29ya0NvbmZpZ1NlY3Rpb24+CiAgICA8U25hcHNob3RTZWN0aW9uIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtOGUyMjUzYTktNWNl
-        NS00ZTQyLWEzZDItNzAxYjZiZTJkY2JiL3NuYXBzaG90U2VjdGlvbiIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuc25hcHNob3RTZWN0
-        aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAgPG92ZjpJ
-        bmZvPlNuYXBzaG90IGluZm9ybWF0aW9uIHNlY3Rpb248L292ZjpJbmZvPgog
-        ICAgPC9TbmFwc2hvdFNlY3Rpb24+CiAgICA8RGF0ZUNyZWF0ZWQ+MjAxNi0w
-        OC0wNlQxNjo0MzoyMC4yMzArMDI6MDA8L0RhdGVDcmVhdGVkPgogICAgPE93
-        bmVyIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm93bmVy
-        K3htbCI+CiAgICAgICAgPFVzZXIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL2FkbWluL3VzZXIvODAzM2ZjMzUtYjI2Ny00NjRmLTlhNTctYTFlMmE1
-        ZjkxOWFjIiBuYW1lPSJncmVnb3JiIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPElu
-        TWFpbnRlbmFuY2VNb2RlPmZhbHNlPC9Jbk1haW50ZW5hbmNlTW9kZT4KICAg
-        IDxDaGlsZHJlbj4KICAgICAgICA8Vm0gbmVlZHNDdXN0b21pemF0aW9uPSJ0
-        cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBuYW1lPSJEU0wtcnNw
-        ZWMiIGlkPSJ1cm46dmNsb3VkOnZtOjIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2
-        LTgwMWU3Y2NjZTdlOSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5IiB0
-        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgog
-        ICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRk
-        OTctOGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3Bvd2VyT2ZmIi8+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRk
-        OTctOGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3JlYm9vdCIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJlc2V0IiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTct
-        OGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3Jlc2V0Ii8+CiAgICAg
-        ICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c2h1dGRvd24iIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04
-        ZDM2LTgwMWU3Y2NjZTdlOS9wb3dlci9hY3Rpb24vc2h1dGRvd24iLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzdXNwZW5kIiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTct
-        OGQzNi04MDFlN2NjY2U3ZTkvcG93ZXIvYWN0aW9uL3N1c3BlbmQiLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJ1bmRlcGxveSIgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYt
-        ODAxZTdjY2NlN2U5L2FjdGlvbi91bmRlcGxveSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQudW5kZXBsb3lWQXBwUGFyYW1zK3htbCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2
-        LTgwMWU3Y2NjZTdlOSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQt
-        OTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L21ldGFkYXRhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04
-        MDFlN2NjY2U3ZTkvcHJvZHVjdFNlY3Rpb25zLyIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQucHJvZHVjdFNlY3Rpb25zK3htbCIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9InNjcmVlbjp0aHVtYm5haWwiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2Mzkt
-        NGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS9zY3JlZW4iLz4KICAgICAgICAgICAg
-        PExpbmsgcmVsPSJzY3JlZW46YWNxdWlyZVRpY2tldCIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThk
-        MzYtODAxZTdjY2NlN2U5L3NjcmVlbi9hY3Rpb24vYWNxdWlyZVRpY2tldCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9Im1lZGlhOmluc2VydE1lZGlhIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05
-        NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvbWVkaWEvYWN0aW9uL2luc2Vy
-        dE1lZGlhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5t
-        ZWRpYUluc2VydE9yRWplY3RQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxM
-        aW5rIHJlbD0ibWVkaWE6ZWplY3RNZWRpYSIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAx
-        ZTdjY2NlN2U5L21lZGlhL2FjdGlvbi9lamVjdE1lZGlhIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZWRpYUluc2VydE9yRWplY3RQ
-        YXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZGlzazphdHRh
-        Y2giIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRi
-        YjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS9kaXNrL2FjdGlvbi9h
-        dHRhY2giIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRp
-        c2tBdHRhY2hPckRldGFjaFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExp
-        bmsgcmVsPSJkaXNrOmRldGFjaCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2Nl
-        N2U5L2Rpc2svYWN0aW9uL2RldGFjaCIgdHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQuZGlza0F0dGFjaE9yRGV0YWNoUGFyYW1zK3htbCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9Imluc3RhbGxWbXdhcmVUb29scyIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQt
-        OTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L2FjdGlvbi9pbnN0YWxsVk13
-        YXJlVG9vbHMiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJzbmFwc2hvdDpj
-        cmVhdGUiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIy
-        NGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS9hY3Rpb24vY3Jl
-        YXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgICAgICAgICA8
-        TGluayByZWw9InJlY29uZmlndXJlVm0iIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3
-        Y2NjZTdlOS9hY3Rpb24vcmVjb25maWd1cmVWbSIgbmFtZT0iRFNMLXJzcGVj
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwi
-        Lz4KICAgICAgICAgICAgPExpbmsgcmVsPSJ1cCIgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC04ZTIyNTNhOS01Y2U1LTRlNDItYTNk
-        Mi03MDFiNmJlMmRjYmIiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZBcHAreG1sIi8+CiAgICAgICAgICAgIDxEZXNjcmlwdGlvbj5J
-        4oCZdmUgY3JlYXRlZCBhbiBPVkYgdmVyc2lvbiBvZiB0aGUgaGlnaGx5IHBv
-        cHVsYXIgRGFtbiBTbWFsbCBMaW51eCBkaXN0cmlidXRpb24uIE5vcm1hbGx5
-        IHlvdSBydW4gdGhpcyBPUyB3aGljaCBpcyBvbmx5IDUwTUJzIGluIGRpc2sg
-        c2l6ZSBmcm9tIGFuIElTTyBvciBwZW4gZHJpdmUgYnV0IEnigJl2ZSBzZWVu
-        IG1vcmUgYW5kIG1vcmUgcGVvcGxlIGV4cGVyaW1lbnRpbmcgd2l0aCB0aGUg
-        dkNsb3VkIERpcmVjdG9yIGFuZCByZWFsbHkgbmVlZCBzbzwvRGVzY3JpcHRp
-        b24+CiAgICAgICAgICAgIDxvdmY6VmlydHVhbEhhcmR3YXJlU2VjdGlvbiB4
-        bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEu
-        NSIgb3ZmOnRyYW5zcG9ydD0iIiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQudmlydHVhbEhhcmR3YXJlU2VjdGlvbit4bWwi
-        IHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0y
-        MjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdmlydHVhbEhh
-        cmR3YXJlU2VjdGlvbi8iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlZp
-        cnR1YWwgaGFyZHdhcmUgcmVxdWlyZW1lbnRzPC9vdmY6SW5mbz4KICAgICAg
-        ICAgICAgICAgIDxvdmY6U3lzdGVtPgogICAgICAgICAgICAgICAgICAgIDx2
-        c3NkOkVsZW1lbnROYW1lPlZpcnR1YWwgSGFyZHdhcmUgRmFtaWx5PC92c3Nk
-        OkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDx2c3NkOkluc3Rh
-        bmNlSUQ+MDwvdnNzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAg
-        IDx2c3NkOlZpcnR1YWxTeXN0ZW1JZGVudGlmaWVyPkRTTC1yc3BlYzwvdnNz
-        ZDpWaXJ0dWFsU3lzdGVtSWRlbnRpZmllcj4KICAgICAgICAgICAgICAgICAg
-        ICA8dnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT52bXgtMDc8L3Zzc2Q6VmlydHVh
-        bFN5c3RlbVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAg
-        ICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6QWRkcmVzcz4wMDo1MDo1NjowMTowMDoyNDwvcmFzZDpBZGRyZXNz
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4w
-        PC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGlj
-        QWxsb2NhdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0
-        aW9uIHZjbG91ZDppcEFkZHJlc3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJp
-        bWFyeU5ldHdvcmtDb25uZWN0aW9uPSJ0cnVlIj5WTSBOZXR3b3JrPC9yYXNk
-        OkNvbm5lY3Rpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3Jp
-        cHRpb24+UENOZXQzMiBldGhlcm5ldCBhZGFwdGVyIG9uICJWTSBOZXR3b3Jr
-        IjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT5OZXR3b3JrIGFkYXB0ZXIgMDwvcmFzZDpFbGVtZW50
-        TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjE8
-        L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpS
-        ZXNvdXJjZVN1YlR5cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9y
-        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+
-        CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6QWRkcmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jh
-        c2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxl
-        bWVudE5hbWU+SURFIENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6
-        SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJj
-        ZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8
-        L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFk
-        ZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNj
-        cmlwdGlvbj5IYXJkIGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jh
-        c2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9z
-        dFJlc291cmNlIHZjbG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlw
-        ZT0iIiB2Y2xvdWQ6Y2FwYWNpdHk9IjI1NiIvPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkluc3RhbmNlSUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVu
-        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8
-        L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OlZpcnR1YWxRdWFudGl0eT4yNjg0MzU0NTY8L3Jhc2Q6VmlydHVhbFF1YW50
-        aXR5PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0
-        eVVuaXRzPmJ5dGU8L3Jhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        dGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3M+MTwvcmFz
-        ZDpBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0
-        aW9uPklERSBDb250cm9sbGVyPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPklERSBDb250cm9sbGVy
-        IDE8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6SW5zdGFuY2VJRD4zPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjU8L3Jhc2Q6UmVzb3VyY2VU
-        eXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAg
-        ICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRy
-        ZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj5mYWxzZTwv
-        cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkRlc2NyaXB0aW9uPkNEL0RWRCBEcml2ZTwvcmFzZDpEZXNjcmlw
-        dGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5D
-        RC9EVkQgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkluc3RhbmNlSUQ+MzAwMjwvcmFzZDpJbnN0YW5jZUlEPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlBhcmVudD4zPC9yYXNkOlBhcmVu
-        dD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTU8
-        L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRl
-        bT4KICAgICAgICAgICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpBZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25Q
-        YXJlbnQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxs
-        b2NhdGlvbj5mYWxzZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPkZsb3BweSBEcml2
-        ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT5GbG9wcHkgRHJpdmUgMTwvcmFzZDpFbGVtZW50TmFt
-        ZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UvPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+ODAwMDwvcmFz
-        ZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291
-        cmNlVHlwZT4xNDwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAg
-        ICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtIHZjbG91
-        ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
-        bSt4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdmly
-        dHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUiPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkFsbG9jYXRpb25Vbml0cz5oZXJ0eiAqIDEwXjY8L3Jhc2Q6QWxs
-        b2NhdGlvblVuaXRzPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkRlc2Ny
-        aXB0aW9uPk51bWJlciBvZiBWaXJ0dWFsIENQVXM8L3Jhc2Q6RGVzY3JpcHRp
-        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+MSB2
-        aXJ0dWFsIENQVShzKTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjQ8L3Jhc2Q6SW5zdGFuY2VJRD4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNk
-        OlJlc2VydmF0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291
-        cmNlVHlwZT4zPC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MTwvcmFzZDpWaXJ0dWFsUXVh
-        bnRpdHk+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6V2VpZ2h0PjA8L3Jh
-        c2Q6V2VpZ2h0PgogICAgICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJi
-        MjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJkd2Fy
-        ZVNlY3Rpb24vY3B1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5yYXNkSXRlbSt4bWwiLz4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0
-        ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNs
-        b3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRi
-        YjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uL21lbW9yeSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        QWxsb2NhdGlvblVuaXRzPmJ5dGUgKiAyXjIwPC9yYXNkOkFsbG9jYXRpb25V
-        bml0cz4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5N
-        ZW1vcnkgU2l6ZTwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpFbGVtZW50TmFtZT4yNTYgTUIgb2YgbWVtb3J5PC9yYXNk
-        OkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3Rh
-        bmNlSUQ+NTwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOlJlc2VydmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjQ8L3Jhc2Q6UmVz
-        b3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxR
-        dWFudGl0eT4yNTY8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAg
-        ICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2
-        LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAg
-        ICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2Nj
-        Y2U3ZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2Mzkt
-        NGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L2NwdSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFz
-        ZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0
-        LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uL2NwdSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIy
-        NGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92aXJ0dWFsSGFy
-        ZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAg
-        ICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3
-        Y2NjZTdlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3ht
-        bCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5LTRk
-        OTctOGQzNi04MDFlN2NjY2U3ZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9k
-        aXNrcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFz
-        ZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0
-        ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJk
-        d2FyZVNlY3Rpb24vbWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAg
-        ICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdl
-        OS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4
-        bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00
-        ZDk3LThkMzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24v
-        bmV0d29ya0NhcmRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExp
-        bmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdmly
-        dHVhbEhhcmR3YXJlU2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4K
-        ICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThk
-        MzYtODAxZTdjY2NlN2U5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFs
-        UG9ydHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJh
-        c2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxI
-        YXJkd2FyZVNlY3Rpb24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lz
-        dGVtU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNv
-        bS92Y2xvdWQvdjEuNSIgb3ZmOmlkPSI5NSIgdmNsb3VkOnR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rp
-        b24reG1sIiB2bXc6b3NUeXBlPSJkZWJpYW40R3Vlc3QiIHZjbG91ZDpocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0yMjRkYmIyNC05NjM5
-        LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvb3BlcmF0aW5nU3lzdGVtU2VjdGlv
-        bi8iPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUg
-        b3BlcmF0aW5nIHN5c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAg
-        ICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5EZWJpYW4gR05VL0xpbnV4IDQg
-        KDMyLWJpdCk8L292ZjpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgIDxM
-        aW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tMjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L29w
-        ZXJhdGluZ1N5c3RlbVNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uK3htbCIvPgog
-        ICAgICAgICAgICA8L292ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uPgogICAg
-        ICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04
-        ZDM2LTgwMWU3Y2NjZTdlOS9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0
-        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29u
-        bmVjdGlvblNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAg
-        ICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJs
-        ZSBWTSBuZXR3b3JrIGNvbm5lY3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAg
-        ICAgICAgIDxQcmltYXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9Qcmlt
-        YXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgIDxO
-        ZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5l
-        dHdvcms9IlZNIE5ldHdvcmsiPgogICAgICAgICAgICAgICAgICAgIDxOZXR3
-        b3JrQ29ubmVjdGlvbkluZGV4PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+
-        CiAgICAgICAgICAgICAgICAgICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29u
-        bmVjdGVkPgogICAgICAgICAgICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUw
-        OjU2OjAxOjAwOjI0PC9NQUNBZGRyZXNzPgogICAgICAgICAgICAgICAgICAg
-        IDxJcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxv
-        Y2F0aW9uTW9kZT4KICAgICAgICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rp
-        b24+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5
-        Ny04ZDM2LTgwMWU3Y2NjZTdlOS9uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24v
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5uZXR3b3Jr
-        Q29ubmVjdGlvblNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvTmV0d29y
-        a0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RDdXN0b21p
-        emF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvZ3Vl
-        c3RDdXN0b21pemF0aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLmd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24reG1s
-        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
-        SW5mbz5TcGVjaWZpZXMgR3Vlc3QgT1MgQ3VzdG9taXphdGlvbiBTZXR0aW5n
-        czwvb3ZmOkluZm8+CiAgICAgICAgICAgICAgICA8RW5hYmxlZD5mYWxzZTwv
-        RW5hYmxlZD4KICAgICAgICAgICAgICAgIDxDaGFuZ2VTaWQ+ZmFsc2U8L0No
-        YW5nZVNpZD4KICAgICAgICAgICAgICAgIDxWaXJ0dWFsTWFjaGluZUlkPjIy
-        NGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOTwvVmlydHVhbE1h
-        Y2hpbmVJZD4KICAgICAgICAgICAgICAgIDxKb2luRG9tYWluRW5hYmxlZD5m
-        YWxzZTwvSm9pbkRvbWFpbkVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8VXNl
-        T3JnU2V0dGluZ3M+ZmFsc2U8L1VzZU9yZ1NldHRpbmdzPgogICAgICAgICAg
-        ICAgICAgPEFkbWluUGFzc3dvcmRFbmFibGVkPnRydWU8L0FkbWluUGFzc3dv
-        cmRFbmFibGVkPgogICAgICAgICAgICAgICAgPEFkbWluUGFzc3dvcmRBdXRv
-        PnRydWU8L0FkbWluUGFzc3dvcmRBdXRvPgogICAgICAgICAgICAgICAgPFJl
-        c2V0UGFzc3dvcmRSZXF1aXJlZD5mYWxzZTwvUmVzZXRQYXNzd29yZFJlcXVp
-        cmVkPgogICAgICAgICAgICAgICAgPENvbXB1dGVyTmFtZT5EYW1uU21hbGxM
-        aS0wMDE8L0NvbXB1dGVyTmFtZT4KICAgICAgICAgICAgICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        MjI0ZGJiMjQtOTYzOS00ZDk3LThkMzYtODAxZTdjY2NlN2U5L2d1ZXN0Q3Vz
-        dG9taXphdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIvPgog
-        ICAgICAgICAgICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAg
-        ICAgICAgIDxSdW50aW1lSW5mb1NlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRw
-        Oi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUiIHZjbG91ZDp0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLTIyNGRiYjI0LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdl
-        OS9ydW50aW1lSW5mb1NlY3Rpb24iPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        bmZvPlNwZWNpZmllcyBSdW50aW1lIGluZm88L292ZjpJbmZvPgogICAgICAg
-        ICAgICA8L1J1bnRpbWVJbmZvU2VjdGlvbj4KICAgICAgICAgICAgPFNuYXBz
-        aG90U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92
-        bS0yMjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvc25hcHNo
-        b3RTZWN0aW9uIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5zbmFwc2hvdFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4K
-        ICAgICAgICAgICAgICAgIDxvdmY6SW5mbz5TbmFwc2hvdCBpbmZvcm1hdGlv
-        biBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICAgICAgPC9TbmFwc2hvdFNl
-        Y3Rpb24+CiAgICAgICAgICAgIDxEYXRlQ3JlYXRlZD4yMDE2LTA4LTA2VDE2
-        OjQzOjI4LjUzMCswMjowMDwvRGF0ZUNyZWF0ZWQ+CiAgICAgICAgICAgIDxW
-        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
-        TG9jYWxJZD4KICAgICAgICAgICAgPG92ZmVudjpFbnZpcm9ubWVudCB4bWxu
-        czpuczExPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIg
-        b3ZmZW52OmlkPSIiIG5zMTE6dkNlbnRlcklkPSJ2bS0xMTciPgogICAgICAg
-        ICAgICAgICAgPG92ZmVudjpQbGF0Zm9ybVNlY3Rpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPG92ZmVudjpLaW5kPlZNd2FyZSBFU1hpPC9vdmZlbnY6S2lu
-        ZD4KICAgICAgICAgICAgICAgICAgICA8b3ZmZW52OlZlcnNpb24+Ni4wLjA8
-        L292ZmVudjpWZXJzaW9uPgogICAgICAgICAgICAgICAgICAgIDxvdmZlbnY6
-        VmVuZG9yPlZNd2FyZSwgSW5jLjwvb3ZmZW52OlZlbmRvcj4KICAgICAgICAg
-        ICAgICAgICAgICA8b3ZmZW52OkxvY2FsZT5lbjwvb3ZmZW52OkxvY2FsZT4K
-        ICAgICAgICAgICAgICAgIDwvb3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4KICAg
-        ICAgICAgICAgICAgIDx2ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uIHhtbG5z
-        OnZlPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgeG1s
-        bnM9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVudC8x
-        IiB4bWxuczpvZT0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmly
-        b25tZW50LzEiPgogICAgICAgICAgICAgICAgICAgIDx2ZTpBZGFwdGVyIHZl
-        Om1hYz0iMDA6NTA6NTY6MDE6MDA6MjQiIHZlOm5ldHdvcms9ImR2cy5WQ0RW
-        U1ZNIE5ldHdvcmstZTkxZDZlZjItZGY2My00MWI2LTgwYmUtZjczZjFhZGQw
-        Y2VlIiB2ZTp1bml0TnVtYmVyPSI3Ii8+CiAgIAogICAgICAgICAgICAgICAg
-        PC92ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uPgogICAgICAgICAgICA8L292
-        ZmVudjpFbnZpcm9ubWVudD4KICAgICAgICAgICAgPFZtQ2FwYWJpbGl0aWVz
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTIyNGRiYjI0
-        LTk2MzktNGQ5Ny04ZDM2LTgwMWU3Y2NjZTdlOS92bUNhcGFiaWxpdGllcy8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2FwYWJp
-        bGl0aWVzU2VjdGlvbit4bWwiPgogICAgICAgICAgICAgICAgPExpbmsgcmVs
-        PSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0y
-        MjRkYmIyNC05NjM5LTRkOTctOGQzNi04MDFlN2NjY2U3ZTkvdm1DYXBhYmls
-        aXRpZXMvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52
-        bUNhcGFiaWxpdGllc1NlY3Rpb24reG1sIi8+CiAgICAgICAgICAgICAgICA8
-        TWVtb3J5SG90QWRkRW5hYmxlZD5mYWxzZTwvTWVtb3J5SG90QWRkRW5hYmxl
-        ZD4KICAgICAgICAgICAgICAgIDxDcHVIb3RBZGRFbmFibGVkPmZhbHNlPC9D
-        cHVIb3RBZGRFbmFibGVkPgogICAgICAgICAgICA8L1ZtQ2FwYWJpbGl0aWVz
-        PgogICAgICAgICAgICA8U3RvcmFnZVByb2ZpbGUgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMt
-        NGNhYS1iNmQ4LWNkMjU4MjUxZWE4ZCIgbmFtZT0iKiIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1s
-        Ii8+CiAgICAgICAgPC9WbT4KICAgIDwvQ2hpbGRyZW4+CjwvVkFwcD4K
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:03 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:01 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - febf5ea2-7383-43c9-acb7-ebcf9303427c
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '99'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="true" status="8" name="TTY-Linux-vApp" id="urn:vcloud:vapp:b74cbaa5-0680-4a9b-a623-1335cb62fff0" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/power/action/powerOn"/>
-            <Link rel="power:powerOff" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/power/action/powerOff"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="undeploy" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/undeploy" type="application/vnd.vmware.vcloud.undeployVAppParams+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-            <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
-            </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/">
-                <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="TTYLinux" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
-            </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkSection/">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="VM Network">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/1fab59c1-209c-4c4f-8f1e-6123cd85cd9c/action/reset"/>
-                    <Description>The VM Network network</Description>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <FenceMode>isolated</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <DhcpService>
-                                <IsEnabled>false</IsEnabled>
-                                <DefaultLeaseTime>3600</DefaultLeaseTime>
-                                <MaxLeaseTime>7200</MaxLeaseTime>
-                            </DhcpService>
-                        </Features>
-                    </Configuration>
-                    <IsDeployed>true</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
-                <ovf:Info>Snapshot information section</ovf:Info>
-            </SnapshotSection>
-            <DateCreated>2016-08-01T14:50:04.300+02:00</DateCreated>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/17d06c5f-f2fe-4767-8006-ebfa36b12c44" name="system" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <InMaintenanceMode>false</InMaintenanceMode>
-            <Children>
-                <Vm needsCustomization="true" deployed="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/screen"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="upgrade" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/upgradeHardwareVersion"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/action/reconfigureVm" name="TTYLinux" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-b74cbaa5-0680-4a9b-a623-1335cb62fff0" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/">
-                        <ovf:Info>Virtual hardware requirements</ovf:Info>
-                        <ovf:System>
-                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
-                            <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>TTYLinux</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
-                        </ovf:System>
-                        <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:13</rasd:Address>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
-                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
-                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
-                            <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
-                            <rasd:ResourceType>10</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                            <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                            <rasd:Description>Hard disk</rasd:Description>
-                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
-                            <rasd:Parent>2</rasd:Parent>
-                            <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
-                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-                        </ovf:Item>
-                        <ovf:Item>
-                            <rasd:Address>1</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
-                            <rasd:InstanceID>3</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
-                            <rasd:Description>CD/DVD Drive</rasd:Description>
-                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
                             <rasd:HostResource/>
-                            <rasd:InstanceID>3002</rasd:InstanceID>
-                            <rasd:Parent>3</rasd:Parent>
-                            <rasd:ResourceType>15</rasd:ResourceType>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
                         </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu">
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory">
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
                             <rasd:InstanceID>5</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
                     </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="36" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="otherLinuxGuest" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/">
+                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
                     </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
+                        <NetworkConnection needsCustomization="false" network="testnet">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.2.100</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:13</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:4a</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
+                        <Enabled>true</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f4625547-9bba-4ec9-bcd8-7cb3c5ca0290</VirtualMachineId>
+                        <VirtualMachineId>8df2faf3-fd33-40de-9b26-da34c146f55d</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <AdminPassword>nN%9oQTG</AdminPassword>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>CentOS7-0</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/runtimeInfoSection">
+                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
                         <ovf:Info>Specifies Runtime info</ovf:Info>
+                        <VMWareTools version="10240"/>
                     </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                         <ovf:Info>Snapshot information section</ovf:Info>
                     </SnapshotSection>
-                    <DateCreated>2016-08-01T14:50:13.840+02:00</DateCreated>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                    <DateCreated>2016-09-08T16:48:57.753+03:00</DateCreated>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
                         <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
                         <CpuHotAddEnabled>false</CpuHotAddEnabled>
                     </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
             </Children>
         </VApp>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:04 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:14 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd
     body:
       encoding: US-ASCII
       string: ''
@@ -3850,171 +866,164 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:01 GMT
+      - Fri, 16 Sep 2016 08:52:19 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 438d0db9-112b-4d07-90f5-d4d87453bf1b
+      - de2c3411-6ab5-4911-b92c-173f829ae43d
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '148'
+      - '166'
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="TTYL-rspec" id="urn:vcloud:vapp:f86685ad-320c-4c8e-9148-1783f9999628" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
-            <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/power/action/powerOn"/>
-            <Link rel="deploy" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/2f35f44d-17e4-4564-8ee6-f927e23d7e94" name="VM Network" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="recompose" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" type="application/vnd.vmware.vcloud.vApp+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/disableDownload"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/ovf" type="text/xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="spec2" id="urn:vcloud:vapp:f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/power/action/powerOn"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/d91117a6-33d6-4a51-96e3-8d761b145726" name="INT_192.168.10.0m24" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/disableDownload"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
             <Description/>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <DeploymentLeaseInSeconds>0</DeploymentLeaseInSeconds>
-                <StorageLeaseInSeconds>0</StorageLeaseInSeconds>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-16T11:46:10.463+03:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/startupSection/">
+            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
                 <ovf:Info>VApp startup section</ovf:Info>
-                <ovf:Item ovf:id="TTYL-rspec" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+                <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
             </ovf:StartupSection>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
+                <ovf:Network ovf:name="INT_192.168.10.0m24">
+                    <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
-                <NetworkConfig networkName="VM Network">
-                    <Link rel="repair" href="https://10.30.2.2/api/admin/network/2f35f44d-17e4-4564-8ee6-f927e23d7e94/action/reset"/>
-                    <Description>The VM Network network</Description>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="INT_192.168.10.0m24">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/d91117a6-33d6-4a51-96e3-8d761b145726/action/reset"/>
+                    <Description/>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
+                                <IsInherited>true</IsInherited>
+                                <Gateway>192.168.10.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
+                                <Dns1>192.168.10.1</Dns1>
+                                <DnsSuffix>test.local</DnsSuffix>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
+                                        <StartAddress>192.168.10.100</StartAddress>
+                                        <EndAddress>192.168.10.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <FenceMode>isolated</FenceMode>
+                        <ParentNetwork href="https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6" id="5ae840de-198e-4a34-a30a-6c36377460c6" name="INT_192.168.10.0m24"/>
+                        <FenceMode>bridged</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <DhcpService>
-                                <IsEnabled>false</IsEnabled>
-                                <DefaultLeaseTime>3600</DefaultLeaseTime>
-                                <MaxLeaseTime>7200</MaxLeaseTime>
-                            </DhcpService>
-                        </Features>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <SnapshotSection href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                 <ovf:Info>Snapshot information section</ovf:Info>
             </SnapshotSection>
-            <DateCreated>2016-08-06T16:44:37.970+02:00</DateCreated>
+            <DateCreated>2016-09-16T11:46:10.347+03:00</DateCreated>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/8033fc35-b267-464f-9a57-a1e2a5f919ac" name="gregorb" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6" name="bergigre_remote" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <InMaintenanceMode>false</InMaintenanceMode>
             <Children>
-                <Vm needsCustomization="true" deployed="false" status="8" name="TTYL-rspec" id="urn:vcloud:vm:6844a379-61be-4652-817a-f14bb5f09512" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="power:powerOn" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/power/action/powerOn"/>
-                    <Link rel="deploy" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
-                    <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="remove" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Link rel="screen:thumbnail" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/screen"/>
-                    <Link rel="media:insertMedia" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="media:ejectMedia" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
-                    <Link rel="disk:attach" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="disk:detach" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
-                    <Link rel="upgrade" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/upgradeHardwareVersion"/>
-                    <Link rel="snapshot:create" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
-                    <Link rel="reconfigureVm" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/action/reconfigureVm" name="TTYL-rspec" type="application/vnd.vmware.vcloud.vm+xml"/>
-                    <Link rel="up" href="https://10.30.2.2/api/vApp/vapp-f86685ad-320c-4c8e-9148-1783f9999628" type="application/vnd.vmware.vcloud.vApp+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/">
+                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:a28be0c0-d70d-4047-92f8-fc217bbaa7f6" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/screen"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/enableNestedHypervisor"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/reconfigureVm" name="spec2-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description/>
+                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>TTYL-rspec</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
+                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:25</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:65</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
-                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
+                            <rasd:Connection vcloud:ipAddress="192.168.10.101" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">INT_192.168.10.0m24</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "INT_192.168.10.0m24"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                             <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
                             <rasd:Parent>2</rasd:Parent>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
                         </ovf:Item>
                         <ovf:Item>
-                            <rasd:Address>1</rasd:Address>
+                            <rasd:Address>0</rasd:Address>
                             <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
                             <rasd:InstanceID>3</rasd:InstanceID>
                             <rasd:ResourceType>5</rasd:ResourceType>
                         </ovf:Item>
@@ -4024,96 +1033,107 @@ http_interactions:
                             <rasd:Description>CD/DVD Drive</rasd:Description>
                             <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
                             <rasd:HostResource/>
-                            <rasd:InstanceID>3002</rasd:InstanceID>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
                             <rasd:Parent>3</rasd:Parent>
                             <rasd:ResourceType>15</rasd:ResourceType>
                         </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu">
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <ovf:Item vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory">
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
                             <rasd:InstanceID>5</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
-                            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
                         </ovf:Item>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="down" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
                     </ovf:VirtualHardwareSection>
-                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="36" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="otherLinuxGuest" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/operatingSystemSection/">
+                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
                     </ovf:OperatingSystemSection>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
+                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.10.101</IpAddress>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:25</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:65</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>6844a379-61be-4652-817a-f14bb5f09512</VirtualMachineId>
+                        <VirtualMachineId>a28be0c0-d70d-4047-92f8-fc217bbaa7f6</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                        <ComputerName>CentOS7-0</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
                     </GuestCustomizationSection>
-                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml" vcloud:href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/runtimeInfoSection">
+                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
                         <ovf:Info>Specifies Runtime info</ovf:Info>
+                        <VMWareTools version="10240"/>
                     </RuntimeInfoSection>
-                    <SnapshotSection href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
                         <ovf:Info>Snapshot information section</ovf:Info>
                     </SnapshotSection>
-                    <DateCreated>2016-08-06T16:44:47.657+02:00</DateCreated>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <VmCapabilities href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
-                        <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                    <DateCreated>2016-09-16T11:46:14.080+03:00</DateCreated>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
                         <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
                         <CpuHotAddEnabled>false</CpuHotAddEnabled>
                     </VmCapabilities>
-                    <StorageProfile href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
                 </Vm>
             </Children>
         </VApp>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:04 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:19 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-6d677e2e-fcce-4838-9ba8-0cb23fd183e5
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4
     body:
       encoding: US-ASCII
       string: ''
@@ -4123,1463 +1143,289 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:02 GMT
+      - Fri, 16 Sep 2016 08:52:24 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 2ecfc173-6312-40e1-a37d-58e189f154ca
+      - 49618612-4f80-4e01-bd82-b1c762a59b52
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '289'
+      - '202'
       Content-Type:
       - application/vnd.vmware.vcloud.vapp+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHAg
-        eG1sbnM9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgeG1s
-        bnM6b3ZmPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUv
-        MSIgeG1sbnM6cmFzZD0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93
-        c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9uU2V0
-        dGluZ0RhdGEiIHhtbG5zOnZzc2Q9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L3diZW0vd3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lNX1ZpcnR1YWxTeXN0ZW1T
-        ZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8vd3d3LnZtd2FyZS5jb20v
-        c2NoZW1hL292ZiIgeG1sbnM6b3ZmZW52PSJodHRwOi8vc2NoZW1hcy5kbXRm
-        Lm9yZy9vdmYvZW52aXJvbm1lbnQvMSIgeG1sbnM6eHNpPSJodHRwOi8vd3d3
-        LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgb3ZmRGVzY3JpcHRv
-        clVwbG9hZGVkPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBu
-        YW1lPSJtaWhhcF92QXBwX25ldHdvcmtpbmciIGlkPSJ1cm46dmNsb3VkOnZh
-        cHA6NmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZj
-        Y2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNSIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQudkFwcCt4bWwiIHhzaTpzY2hlbWFMb2NhdGlv
-        bj0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEgaHR0
-        cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVsb3BlLzEvZHNwODAyM18x
-        LjEuMC54c2QgaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0
-        dHA6Ly8xMC4zMC4yLjIvYXBpL3YxLjUvc2NoZW1hL21hc3Rlci54c2QgaHR0
-        cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9vdmYgaHR0cDovL3d3dy52bXdh
-        cmUuY29tL3NjaGVtYS9vdmYgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2Jl
-        bS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3VyY2VBbGxvY2F0aW9u
-        U2V0dGluZ0RhdGEgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2Np
-        bS8xL2NpbS1zY2hlbWEvMi4yMi4wL0NJTV9SZXNvdXJjZUFsbG9jYXRpb25T
-        ZXR0aW5nRGF0YS54c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vu
-        dmlyb25tZW50LzEgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2VudmVs
-        b3BlLzEvZHNwODAyN18xLjEuMC54c2QgaHR0cDovL3NjaGVtYXMuZG10Zi5v
-        cmcvd2JlbS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fVmlydHVhbFN5c3Rl
-        bVNldHRpbmdEYXRhIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL3diZW0vd3Nj
-        aW0vMS9jaW0tc2NoZW1hLzIuMjIuMC9DSU1fVmlydHVhbFN5c3RlbVNldHRp
-        bmdEYXRhLnhzZCI+CiAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJl
-        LWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9wb3dlci9hY3Rpb24vcG93
-        ZXJPZmYiLz4KICAgIDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2Ut
-        NDgzOC05YmE4LTBjYjIzZmQxODNlNS9wb3dlci9hY3Rpb24vcmVib290Ii8+
-        CiAgICA8TGluayByZWw9InBvd2VyOnJlc2V0IiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4
-        LTBjYjIzZmQxODNlNS9wb3dlci9hY3Rpb24vcmVzZXQiLz4KICAgIDxMaW5r
-        IHJlbD0icG93ZXI6c2h1dGRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNm
-        ZDE4M2U1L3Bvd2VyL2FjdGlvbi9zaHV0ZG93biIvPgogICAgPExpbmsgcmVs
-        PSJwb3dlcjpzdXNwZW5kIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNl
-        NS9wb3dlci9hY3Rpb24vc3VzcGVuZCIvPgogICAgPExpbmsgcmVsPSJkZXBs
-        b3kiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2
-        NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L2FjdGlvbi9kZXBs
-        b3kiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRlcGxv
-        eVZBcHBQYXJhbXMreG1sIi8+CiAgICA8TGluayByZWw9InVuZGVwbG95IiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJl
-        LWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9hY3Rpb24vdW5kZXBsb3ki
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95
-        VkFwcFBhcmFtcyt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL25ldHdvcmsvMzU1MGE1YzgtOWRlOC00
-        NDQ3LWIyODEtNmVlYzBhMDI0NGYyIiBuYW1lPSJ0YWRydWdpLXZhcHAtbmV0
-        d29yayIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudkFw
-        cE5ldHdvcmsreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS9uZXR3b3JrLzQ0MzRlM2Q2LWZlY2MtNGNi
-        OS1hMDE0LTExNzA2ZjUwMDE5ZSIgbmFtZT0idmRjLW5ldC1taWhhIiB0eXBl
-        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwTmV0d29yayt4
-        bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL25ldHdvcmsvZjQ0MjAxOGUtMWE3NC00YTI1LTlmYjQtNzUw
-        YzA0NTY1MzE1IiBuYW1lPSJ2YXBwLW5ldHdvcmstbWloYSIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcE5ldHdvcmsreG1sIi8+
-        CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNm
-        ZDE4M2U1L2NvbnRyb2xBY2Nlc3MvIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5jb250cm9sQWNjZXNzK3htbCIvPgogICAgPExpbmsg
-        cmVsPSJjb250cm9sQWNjZXNzIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQx
-        ODNlNS9hY3Rpb24vY29udHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxM
-        aW5rIHJlbD0idXAiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMv
-        NTViNDUzMWUtMWI3Mi00YTY2LWJjNzUtMmU0MmQzYjdjYjc5IiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52ZGMreG1sIi8+CiAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBwK3ht
-        bCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBj
-        YjIzZmQxODNlNS9vd25lciIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQub3duZXIreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUt
-        ZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L21ldGFkYXRhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
-        ICAgIDxMaW5rIHJlbD0ib3ZmIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQx
-        ODNlNS9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9ImRv
-        d24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2
-        NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L3Byb2R1Y3RTZWN0
-        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
-        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxMaW5rIHJlbD0ic25hcHNob3Q6
-        Y3JlYXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBw
-        LTZkNjc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9hY3Rpb24v
-        Y3JlYXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgPERlc2Ny
-        aXB0aW9uLz4KICAgIDxMZWFzZVNldHRpbmdzU2VjdGlvbiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJlLWZjY2UtNDgz
-        OC05YmE4LTBjYjIzZmQxODNlNS9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGlu
-        Z3NTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAg
-        PG92ZjpJbmZvPkxlYXNlIHNldHRpbmdzIHNlY3Rpb248L292ZjpJbmZvPgog
-        ICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL3ZBcHAvdmFwcC02ZDY3N2UyZS1mY2NlLTQ4MzgtOWJhOC0wY2Iy
-        M2ZkMTgzZTUvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlvbit4
-        bWwiLz4KICAgICAgICA8RGVwbG95bWVudExlYXNlSW5TZWNvbmRzPjA8L0Rl
-        cGxveW1lbnRMZWFzZUluU2Vjb25kcz4KICAgICAgICA8U3RvcmFnZUxlYXNl
-        SW5TZWNvbmRzPjA8L1N0b3JhZ2VMZWFzZUluU2Vjb25kcz4KICAgIDwvTGVh
-        c2VTZXR0aW5nc1NlY3Rpb24+CiAgICA8b3ZmOlN0YXJ0dXBTZWN0aW9uIHht
-        bG5zOnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41
-        IiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        c3RhcnR1cFNlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdmFwcC02ZDY3N2UyZS1mY2NlLTQ4MzgtOWJhOC0w
-        Y2IyM2ZkMTgzZTUvc3RhcnR1cFNlY3Rpb24vIj4KICAgICAgICA8b3ZmOklu
-        Zm8+VkFwcCBzdGFydHVwIHNlY3Rpb248L292ZjpJbmZvPgogICAgICAgIDxv
-        dmY6SXRlbSBvdmY6aWQ9IlRUWUxpbnV4LTEtbW0iIG92ZjpvcmRlcj0iMCIg
-        b3ZmOnN0YXJ0QWN0aW9uPSJwb3dlck9uIiBvdmY6c3RhcnREZWxheT0iMCIg
-        b3ZmOnN0b3BBY3Rpb249InBvd2VyT2ZmIiBvdmY6c3RvcERlbGF5PSIwIi8+
-        CiAgICAgICAgPG92ZjpJdGVtIG92ZjppZD0iVFRZTGludXgtMi1tbSIgb3Zm
-        Om9yZGVyPSIwIiBvdmY6c3RhcnRBY3Rpb249InBvd2VyT24iIG92ZjpzdGFy
-        dERlbGF5PSIwIiBvdmY6c3RvcEFjdGlvbj0icG93ZXJPZmYiIG92ZjpzdG9w
-        RGVsYXk9IjAiLz4KICAgICAgICA8b3ZmOkl0ZW0gb3ZmOmlkPSJEYW1uIFNt
-        YWxsIExpbnV4LW1tIiBvdmY6b3JkZXI9IjAiIG92ZjpzdGFydEFjdGlvbj0i
-        cG93ZXJPbiIgb3ZmOnN0YXJ0RGVsYXk9IjAiIG92ZjpzdG9wQWN0aW9uPSJw
-        b3dlck9mZiIgb3ZmOnN0b3BEZWxheT0iMCIvPgogICAgICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFw
-        cC02ZDY3N2UyZS1mY2NlLTQ4MzgtOWJhOC0wY2IyM2ZkMTgzZTUvc3RhcnR1
-        cFNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5zdGFydHVwU2VjdGlvbit4bWwiLz4KICAgIDwvb3ZmOlN0YXJ0dXBTZWN0
-        aW9uPgogICAgPG92ZjpOZXR3b3JrU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0
-        dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgdmNsb3VkOnR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtTZWN0aW9u
-        K3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBw
-        L3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4LTliYTgtMGNiMjNmZDE4M2U1L25l
-        dHdvcmtTZWN0aW9uLyI+CiAgICAgICAgPG92ZjpJbmZvPlRoZSBsaXN0IG9m
-        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxvdmY6TmV0
-        d29yayBvdmY6bmFtZT0idGFkcnVnaS12YXBwLW5ldHdvcmsiPgogICAgICAg
-        ICAgICA8b3ZmOkRlc2NyaXB0aW9uLz4KICAgICAgICA8L292ZjpOZXR3b3Jr
-        PgogICAgICAgIDxvdmY6TmV0d29yayBvdmY6bmFtZT0idmRjLW5ldC1taWhh
-        Ij4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbi8+CiAgICAgICAgPC9v
-        dmY6TmV0d29yaz4KICAgICAgICA8b3ZmOk5ldHdvcmsgb3ZmOm5hbWU9InZh
-        cHAtbmV0d29yay1taWhhIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlv
-        bi8+CiAgICAgICAgPC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtT
-        ZWN0aW9uPgogICAgPE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00ODM4
-        LTliYTgtMGNiMjNmZDE4M2U1L25ldHdvcmtDb25maWdTZWN0aW9uLyIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubmV0d29ya0NvbmZp
-        Z1NlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8
-        b3ZmOkluZm8+VGhlIGNvbmZpZ3VyYXRpb24gcGFyYW1ldGVycyBmb3IgbG9n
-        aWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+CiAgICAgICAgPExpbmsgcmVsPSJl
-        ZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZk
-        Njc3ZTJlLWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNS9uZXR3b3JrQ29u
-        ZmlnU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
-        b3VkLm5ldHdvcmtDb25maWdTZWN0aW9uK3htbCIvPgogICAgICAgIDxOZXR3
-        b3JrQ29uZmlnIG5ldHdvcmtOYW1lPSJ0YWRydWdpLXZhcHAtbmV0d29yayI+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icmVwYWlyIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvYWRtaW4vbmV0d29yay8zNTUwYTVjOC05ZGU4LTQ0
-        NDctYjI4MS02ZWVjMGEwMjQ0ZjIvYWN0aW9uL3Jlc2V0Ii8+CiAgICAgICAg
-        ICAgIDxEZXNjcmlwdGlvbi8+CiAgICAgICAgICAgIDxDb25maWd1cmF0aW9u
-        PgogICAgICAgICAgICAgICAgPElwU2NvcGVzPgogICAgICAgICAgICAgICAg
-        ICAgIDxJcFNjb3BlPgogICAgICAgICAgICAgICAgICAgICAgICA8SXNJbmhl
-        cml0ZWQ+ZmFsc2U8L0lzSW5oZXJpdGVkPgogICAgICAgICAgICAgICAgICAg
-        ICAgICA8R2F0ZXdheT4xOTIuMTY4LjIuMTwvR2F0ZXdheT4KICAgICAgICAg
-        ICAgICAgICAgICAgICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFz
-        az4KICAgICAgICAgICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9J
-        c0VuYWJsZWQ+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2
-        OC4yLjEwMDwvU3RhcnRBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgIDxFbmRBZGRyZXNzPjE5Mi4xNjguMi4xOTk8L0VuZEFkZHJl
-        c3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8L0lwUmFuZ2U+CiAg
-        ICAgICAgICAgICAgICAgICAgICAgIDwvSXBSYW5nZXM+CiAgICAgICAgICAg
-        ICAgICAgICAgPC9JcFNjb3BlPgogICAgICAgICAgICAgICAgPC9JcFNjb3Bl
-        cz4KICAgICAgICAgICAgICAgIDxGZW5jZU1vZGU+aXNvbGF0ZWQ8L0ZlbmNl
-        TW9kZT4KICAgICAgICAgICAgICAgIDxSZXRhaW5OZXRJbmZvQWNyb3NzRGVw
-        bG95bWVudHM+ZmFsc2U8L1JldGFpbk5ldEluZm9BY3Jvc3NEZXBsb3ltZW50
-        cz4KICAgICAgICAgICAgICAgIDxGZWF0dXJlcz4KICAgICAgICAgICAgICAg
-        ICAgICA8RGhjcFNlcnZpY2U+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJ
-        c0VuYWJsZWQ+ZmFsc2U8L0lzRW5hYmxlZD4KICAgICAgICAgICAgICAgICAg
-        ICAgICAgPERlZmF1bHRMZWFzZVRpbWU+MzYwMDwvRGVmYXVsdExlYXNlVGlt
-        ZT4KICAgICAgICAgICAgICAgICAgICAgICAgPE1heExlYXNlVGltZT43MjAw
-        PC9NYXhMZWFzZVRpbWU+CiAgICAgICAgICAgICAgICAgICAgPC9EaGNwU2Vy
-        dmljZT4KICAgICAgICAgICAgICAgIDwvRmVhdHVyZXM+CiAgICAgICAgICAg
-        IDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95ZWQ+dHJ1
-        ZTwvSXNEZXBsb3llZD4KICAgICAgICA8L05ldHdvcmtDb25maWc+CiAgICAg
-        ICAgPE5ldHdvcmtDb25maWcgbmV0d29ya05hbWU9InZkYy1uZXQtbWloYSI+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icmVwYWlyIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvYWRtaW4vbmV0d29yay80NDM0ZTNkNi1mZWNjLTRj
-        YjktYTAxNC0xMTcwNmY1MDAxOWUvYWN0aW9uL3Jlc2V0Ii8+CiAgICAgICAg
-        ICAgIDxEZXNjcmlwdGlvbi8+CiAgICAgICAgICAgIDxDb25maWd1cmF0aW9u
-        PgogICAgICAgICAgICAgICAgPElwU2NvcGVzPgogICAgICAgICAgICAgICAg
-        ICAgIDxJcFNjb3BlPgogICAgICAgICAgICAgICAgICAgICAgICA8SXNJbmhl
-        cml0ZWQ+dHJ1ZTwvSXNJbmhlcml0ZWQ+CiAgICAgICAgICAgICAgICAgICAg
-        ICAgIDxHYXRld2F5PjEwLjMwLjIuMTwvR2F0ZXdheT4KICAgICAgICAgICAg
-        ICAgICAgICAgICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgPERuczE+OC44LjguODwvRG5zMT4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgPERuczI+OC44LjQuNDwvRG5zMj4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0Vu
-        YWJsZWQ+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAg
-        ICAgICAgICAgICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTAuMzAuMi41
-        MTwvU3RhcnRBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAg
-        ICAgIDxFbmRBZGRyZXNzPjEwLjMwLjIuNjA8L0VuZEFkZHJlc3M+CiAgICAg
-        ICAgICAgICAgICAgICAgICAgICAgICA8L0lwUmFuZ2U+CiAgICAgICAgICAg
-        ICAgICAgICAgICAgIDwvSXBSYW5nZXM+CiAgICAgICAgICAgICAgICAgICAg
-        PC9JcFNjb3BlPgogICAgICAgICAgICAgICAgPC9JcFNjb3Blcz4KICAgICAg
-        ICAgICAgICAgIDxQYXJlbnROZXR3b3JrIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS9hZG1pbi9uZXR3b3JrLzViNWM2MzEwLTI2MjgtNDU0YS1iZTZk
-        LTk1OTQ2ZTY5NDFhZiIgaWQ9IjViNWM2MzEwLTI2MjgtNDU0YS1iZTZkLTk1
-        OTQ2ZTY5NDFhZiIgbmFtZT0idmRjLW5ldC1taWhhIi8+CiAgICAgICAgICAg
-        ICAgICA8RmVuY2VNb2RlPmJyaWRnZWQ8L0ZlbmNlTW9kZT4KICAgICAgICAg
-        ICAgICAgIDxSZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+ZmFsc2U8
-        L1JldGFpbk5ldEluZm9BY3Jvc3NEZXBsb3ltZW50cz4KICAgICAgICAgICAg
-        PC9Db25maWd1cmF0aW9uPgogICAgICAgICAgICA8SXNEZXBsb3llZD50cnVl
-        PC9Jc0RlcGxveWVkPgogICAgICAgIDwvTmV0d29ya0NvbmZpZz4KICAgICAg
-        ICA8TmV0d29ya0NvbmZpZyBuZXR3b3JrTmFtZT0idmFwcC1uZXR3b3JrLW1p
-        aGEiPgogICAgICAgICAgICA8TGluayByZWw9InJlcGFpciIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL2FkbWluL25ldHdvcmsvZjQ0MjAxOGUtMWE3
-        NC00YTI1LTlmYjQtNzUwYzA0NTY1MzE1L2FjdGlvbi9yZXNldCIvPgogICAg
-        ICAgICAgICA8RGVzY3JpcHRpb24vPgogICAgICAgICAgICA8Q29uZmlndXJh
-        dGlvbj4KICAgICAgICAgICAgICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAg
-        ICAgICAgICA8SXBTY29wZT4KICAgICAgICAgICAgICAgICAgICAgICAgPElz
-        SW5oZXJpdGVkPmZhbHNlPC9Jc0luaGVyaXRlZD4KICAgICAgICAgICAgICAg
-        ICAgICAgICAgPEdhdGV3YXk+MTkyLjE2OC4yLjE8L0dhdGV3YXk+CiAgICAg
-        ICAgICAgICAgICAgICAgICAgIDxOZXRtYXNrPjI1NS4yNTUuMjU1LjA8L05l
-        dG1hc2s+CiAgICAgICAgICAgICAgICAgICAgICAgIDxJc0VuYWJsZWQ+dHJ1
-        ZTwvSXNFbmFibGVkPgogICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5n
-        ZXM+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8SXBSYW5nZT4KICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8U3RhcnRBZGRyZXNzPjE5
-        Mi4xNjguMi4xMDA8L1N0YXJ0QWRkcmVzcz4KICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgICA8RW5kQWRkcmVzcz4xOTIuMTY4LjIuMTk5PC9FbmRB
-        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdl
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAg
-        ICAgICAgICAgICAgIDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBT
-        Y29wZXM+CiAgICAgICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9G
-        ZW5jZU1vZGU+CiAgICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9z
-        c0RlcGxveW1lbnRzPmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95
-        bWVudHM+CiAgICAgICAgICAgICAgICA8RmVhdHVyZXM+CiAgICAgICAgICAg
-        ICAgICAgICAgPERoY3BTZXJ2aWNlPgogICAgICAgICAgICAgICAgICAgICAg
-        ICA8SXNFbmFibGVkPmZhbHNlPC9Jc0VuYWJsZWQ+CiAgICAgICAgICAgICAg
-        ICAgICAgICAgIDxEZWZhdWx0TGVhc2VUaW1lPjM2MDA8L0RlZmF1bHRMZWFz
-        ZVRpbWU+CiAgICAgICAgICAgICAgICAgICAgICAgIDxNYXhMZWFzZVRpbWU+
-        NzIwMDwvTWF4TGVhc2VUaW1lPgogICAgICAgICAgICAgICAgICAgIDwvRGhj
-        cFNlcnZpY2U+CiAgICAgICAgICAgICAgICA8L0ZlYXR1cmVzPgogICAgICAg
-        ICAgICA8L0NvbmZpZ3VyYXRpb24+CiAgICAgICAgICAgIDxJc0RlcGxveWVk
-        PnRydWU8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmlnPgog
-        ICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxTbmFwc2hvdFNlY3Rp
-        b24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC02ZDY3
-        N2UyZS1mY2NlLTQ4MzgtOWJhOC0wY2IyM2ZkMTgzZTUvc25hcHNob3RTZWN0
-        aW9uIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5zbmFw
-        c2hvdFNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAg
-        ICA8b3ZmOkluZm8+U25hcHNob3QgaW5mb3JtYXRpb24gc2VjdGlvbjwvb3Zm
-        OkluZm8+CiAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgIDxEYXRlQ3JlYXRl
-        ZD4yMDE2LTA4LTAzVDEzOjQxOjIwLjE4NyswMjowMDwvRGF0ZUNyZWF0ZWQ+
-        CiAgICA8T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQub3duZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvYWRtaW4vdXNlci9mN2ZmMmJkMS1kZTFkLTQ4NzItOWIz
-        ZC1mMmQxM2JmZWI1OGIiIG5hbWU9Im1paGFwIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgog
-        ICAgPEluTWFpbnRlbmFuY2VNb2RlPmZhbHNlPC9Jbk1haW50ZW5hbmNlTW9k
-        ZT4KICAgIDxDaGlsZHJlbj4KICAgICAgICA8Vm0gbmVlZHNDdXN0b21pemF0
-        aW9uPSJ0cnVlIiBkZXBsb3llZD0idHJ1ZSIgc3RhdHVzPSI0IiBuYW1lPSJU
-        VFlMaW51eC0xLW1tIiBpZD0idXJuOnZjbG91ZDp2bTozZjE1ZGYxNC00Njcy
-        LTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEiIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3
-        YjE0NDQyYSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        dm0reG1sIj4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpwb3dlck9m
-        ZiIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRm
-        MTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlvbi9w
-        b3dlck9mZiIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJlYm9v
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRm
-        MTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlvbi9y
-        ZWJvb3QiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpyZXNldCIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQt
-        NDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlvbi9yZXNl
-        dCIvPgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnNodXRkb3duIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00
-        NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvcG93ZXIvYWN0aW9uL3NodXRk
-        b3duIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c3VzcGVuZCIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQt
-        NDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Bvd2VyL2FjdGlvbi9zdXNw
-        ZW5kIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0idW5kZXBsb3kiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzIt
-        NGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9hY3Rpb24vdW5kZXBsb3kiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnVuZGVwbG95VkFwcFBh
-        cmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00Njcy
-        LTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEiIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLnZtK3htbCIvPgogICAgICAgICAgICA8TGluayBy
-        ZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9tZXRhZGF0
-        YSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubWV0YWRh
-        dGEreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00
-        ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3Byb2R1Y3RTZWN0aW9ucy8iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnByb2R1Y3RTZWN0aW9u
-        cyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJzY3JlZW46dGh1bWJu
-        YWlsIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1
-        ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvc2NyZWVuIi8+CiAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0ic2NyZWVuOmFjcXVpcmVUaWNrZXQiIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2
-        NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9zY3JlZW4vYWN0aW9uL2FjcXVp
-        cmVUaWNrZXQiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJtZWRpYTppbnNl
-        cnRNZWRpYSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        M2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL21lZGlhL2Fj
-        dGlvbi9pbnNlcnRNZWRpYSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQubWVkaWFJbnNlcnRPckVqZWN0UGFyYW1zK3htbCIvPgogICAg
-        ICAgICAgICA8TGluayByZWw9Im1lZGlhOmVqZWN0TWVkaWEiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQx
-        NC1hMzk2LTBkZGY3YjE0NDQyYS9tZWRpYS9hY3Rpb24vZWplY3RNZWRpYSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQubWVkaWFJbnNl
-        cnRPckVqZWN0UGFyYW1zK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
-        ImRpc2s6YXR0YWNoIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvZGlz
-        ay9hY3Rpb24vYXR0YWNoIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC5kaXNrQXR0YWNoT3JEZXRhY2hQYXJhbXMreG1sIi8+CiAgICAg
-        ICAgICAgIDxMaW5rIHJlbD0iZGlzazpkZXRhY2giIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2
-        LTBkZGY3YjE0NDQyYS9kaXNrL2FjdGlvbi9kZXRhY2giIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmRpc2tBdHRhY2hPckRldGFjaFBh
-        cmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJpbnN0YWxsVm13
-        YXJlVG9vbHMiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS9hY3Rpb24v
-        aW5zdGFsbFZNd2FyZVRvb2xzIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        c25hcHNob3Q6Y3JlYXRlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEv
-        YWN0aW9uL2NyZWF0ZVNuYXBzaG90IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5jcmVhdGVTbmFwc2hvdFBhcmFtcyt4bWwiLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJyZWNvbmZpZ3VyZVZtIiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQt
-        YTM5Ni0wZGRmN2IxNDQ0MmEvYWN0aW9uL3JlY29uZmlndXJlVm0iIG5hbWU9
-        IlRUWUxpbnV4LTEtbW0iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZtK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9InVwIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92YXBwLTZkNjc3ZTJl
-        LWZjY2UtNDgzOC05YmE4LTBjYjIzZmQxODNlNSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQudkFwcCt4bWwiLz4KICAgICAgICAgICAg
-        PERlc2NyaXB0aW9uPkNyZWF0ZWQgYnk6IE1pa2UgTGF2ZXJpY2sNQmxvZzog
-        d3d3Lm1pa2VsYXZlcmljay5jb20NVHdpdHRlcjogQG1pa2VfbGF2ZXJpY2sN
-        DVNlcnZpY2VzIEVuYWJsZWQ6IFNTSCwgRlRQLCBIVFRQDVJPT1QgUGFzc3dv
-        cmQ6IHBhc3N3b3JkPC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPG92ZjpW
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uIHhtbG5zOnZjbG91ZD0iaHR0cDovL3d3
-        dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBvdmY6dHJhbnNwb3J0PSIiIHZj
-        bG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52aXJ0
-        dWFsSGFyZHdhcmVTZWN0aW9uK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2
-        LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uLyI+CiAgICAg
-        ICAgICAgICAgICA8b3ZmOkluZm8+VmlydHVhbCBoYXJkd2FyZSByZXF1aXJl
-        bWVudHM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpTeXN0ZW0+
-        CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6RWxlbWVudE5hbWU+VmlydHVh
-        bCBIYXJkd2FyZSBGYW1pbHk8L3Zzc2Q6RWxlbWVudE5hbWU+CiAgICAgICAg
-        ICAgICAgICAgICAgPHZzc2Q6SW5zdGFuY2VJRD4wPC92c3NkOkluc3RhbmNl
-        SUQ+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3RlbUlk
-        ZW50aWZpZXI+VFRZTGludXgtMS1tbTwvdnNzZDpWaXJ0dWFsU3lzdGVtSWRl
-        bnRpZmllcj4KICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0dWFsU3lz
-        dGVtVHlwZT52bXgtMDg8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+CiAgICAg
-        ICAgICAgICAgICA8L292ZjpTeXN0ZW0+CiAgICAgICAgICAgICAgICA8b3Zm
-        Okl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4wMDo1
-        MDo1NjowMTowMDoxYjwvcmFzZDpBZGRyZXNzPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4xPC9yYXNkOkFkZHJlc3NPblBh
-        cmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBdXRvbWF0aWNBbGxv
-        Y2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91ZDppcEFkZHJl
-        c3NpbmdNb2RlPSJESENQIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtDb25uZWN0
-        aW9uPSJmYWxzZSI+dmRjLW5ldC1taWhhPC9yYXNkOkNvbm5lY3Rpb24+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+UENOZXQzMiBl
-        dGhlcm5ldCBhZGFwdGVyIG9uICJ2ZGMtbmV0LW1paGEiPC9yYXNkOkRlc2Ny
-        aXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1l
-        Pk5ldHdvcmsgYWRhcHRlciAxPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+MTwvcmFzZDpJbnN0YW5j
-        ZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlU3ViVHlw
-        ZT5QQ05ldDMyPC9yYXNkOlJlc291cmNlU3ViVHlwZT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTA8L3Jhc2Q6UmVzb3VyY2VU
-        eXBlPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAg
-        ICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRy
-        ZXNzPjAwOjUwOjU2OjAxOjAwOjE2PC9yYXNkOkFkZHJlc3M+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6QWRkcmVzc09uUGFyZW50PjA8L3Jhc2Q6QWRk
-        cmVzc09uUGFyZW50PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkF1dG9t
-        YXRpY0FsbG9jYXRpb24+dHJ1ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkNvbm5lY3Rpb24gdmNsb3Vk
-        OmlwQWRkcmVzc2luZ01vZGU9IlBPT0wiIHZjbG91ZDppcEFkZHJlc3M9IjE5
-        Mi4xNjguMi4xMDAiIHZjbG91ZDpwcmltYXJ5TmV0d29ya0Nvbm5lY3Rpb249
-        InRydWUiPnZhcHAtbmV0d29yay1taWhhPC9yYXNkOkNvbm5lY3Rpb24+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+RTEwMDAgZXRo
-        ZXJuZXQgYWRhcHRlciBvbiAidmFwcC1uZXR3b3JrLW1paGEiPC9yYXNkOkRl
-        c2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnRO
-        YW1lPk5ldHdvcmsgYWRhcHRlciAwPC9yYXNkOkVsZW1lbnROYW1lPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+MjwvcmFzZDpJbnN0
-        YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlU3Vi
-        VHlwZT5FMTAwMDwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291cmNl
-        VHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAg
-        ICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRk
-        cmVzcz4wMDo1MDo1NjowMTowMDoyMDwvcmFzZDpBZGRyZXNzPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4yPC9yYXNkOkFk
-        ZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBdXRv
-        bWF0aWNBbGxvY2F0aW9uPnRydWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlv
-        bj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91
-        ZDppcEFkZHJlc3NpbmdNb2RlPSJQT09MIiB2Y2xvdWQ6aXBBZGRyZXNzPSIx
-        OTIuMTY4LjIuMTAwIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtDb25uZWN0aW9u
-        PSJmYWxzZSI+dGFkcnVnaS12YXBwLW5ldHdvcms8L3Jhc2Q6Q29ubmVjdGlv
-        bj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5QQ05l
-        dDMyIGV0aGVybmV0IGFkYXB0ZXIgb24gInRhZHJ1Z2ktdmFwcC1uZXR3b3Jr
-        IjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT5OZXR3b3JrIGFkYXB0ZXIgMjwvcmFzZDpFbGVtZW50
-        TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjM8
-        L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpS
-        ZXNvdXJjZVN1YlR5cGU+UENOZXQzMjwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9y
-        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+
-        CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6QWRkcmVzcz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jh
-        c2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxl
-        bWVudE5hbWU+SURFIENvbnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjQ8L3Jhc2Q6
-        SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJj
-        ZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8
-        L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFk
-        ZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNj
-        cmlwdGlvbj5IYXJkIGRpc2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jh
-        c2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9z
-        dFJlc291cmNlIHZjbG91ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlw
-        ZT0iIiB2Y2xvdWQ6Y2FwYWNpdHk9IjMyIi8+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6SW5zdGFuY2VJRD4zMDAwPC9yYXNkOkluc3RhbmNlSUQ+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6UGFyZW50PjQ8L3Jhc2Q6UGFyZW50
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNzwv
-        cmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        VmlydHVhbFF1YW50aXR5PjMzNTU0NDMyPC9yYXNkOlZpcnR1YWxRdWFudGl0
-        eT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHlV
-        bml0cz5ieXRlPC9yYXNkOlZpcnR1YWxRdWFudGl0eVVuaXRzPgogICAgICAg
-        ICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRl
-        bT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzPjE8L3Jhc2Q6
-        QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlv
-        bj5JREUgQ29udHJvbGxlcjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5JREUgQ29udHJvbGxlciAx
-        PC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        Okluc3RhbmNlSUQ+NTwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT41PC9yYXNkOlJlc291cmNlVHlw
-        ZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAg
-        ICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVz
-        c09uUGFyZW50PjA8L3Jhc2Q6QWRkcmVzc09uUGFyZW50PgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOkF1dG9tYXRpY0FsbG9jYXRpb24+ZmFsc2U8L3Jh
-        c2Q6QXV0b21hdGljQWxsb2NhdGlvbj4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpEZXNjcmlwdGlvbj5DRC9EVkQgRHJpdmU8L3Jhc2Q6RGVzY3JpcHRp
-        b24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+Q0Qv
-        RFZEIERyaXZlIDE8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6SG9zdFJlc291cmNlLz4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpJbnN0YW5jZUlEPjMwMDI8L3Jhc2Q6SW5zdGFuY2VJRD4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpQYXJlbnQ+NTwvcmFzZDpQYXJlbnQ+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjE1PC9y
-        YXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+
-        CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3Vk
-        OmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0
-        LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uL2NwdSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2Nh
-        dGlvblVuaXRzPmhlcnR6ICogMTBeNjwvcmFzZDpBbGxvY2F0aW9uVW5pdHM+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+TnVtYmVy
-        IG9mIFZpcnR1YWwgQ1BVczwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT4xIHZpcnR1YWwgQ1BVKHMp
-        PC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        Okluc3RhbmNlSUQ+NjwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOlJlc2VydmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjM8L3Jh
-        c2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZp
-        cnR1YWxRdWFudGl0eT4xPC9yYXNkOlZpcnR1YWxRdWFudGl0eT4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpXZWlnaHQ+MDwvcmFzZDpXZWlnaHQ+CiAg
-        ICAgICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQt
-        YTM5Ni0wZGRmN2IxNDQ0MmEvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUi
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVt
-        K3htbCIvPgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAg
-        ICAgICAgIDxvdmY6SXRlbSB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0
-        LWEzOTYtMGRkZjdiMTQ0NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbWVt
-        b3J5Ij4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBbGxvY2F0aW9uVW5p
-        dHM+Ynl0ZSAqIDJeMjA8L3Jhc2Q6QWxsb2NhdGlvblVuaXRzPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk1lbW9yeSBTaXplPC9y
-        YXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVs
-        ZW1lbnROYW1lPjMyIE1CIG9mIG1lbW9yeTwvcmFzZDpFbGVtZW50TmFtZT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjc8L3Jhc2Q6
-        SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNlcnZh
-        dGlvbj4wPC9yYXNkOlJlc2VydmF0aW9uPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOlJlc291cmNlVHlwZT40PC9yYXNkOlJlc291cmNlVHlwZT4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MzI8L3Jh
-        c2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OldlaWdodD4wPC9yYXNkOldlaWdodD4KICAgICAgICAgICAgICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAg
-        ICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPExpbmsgcmVs
-        PSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0z
-        ZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvdmlydHVhbEhh
-        cmR3YXJlU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIi8+CiAgICAgICAg
-        ICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAu
-        Mi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3
-        YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAg
-        ICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2
-        LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1s
-        Ii8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQx
-        NC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21l
-        bW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFz
-        ZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0
-        LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayBy
-        ZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTNmMTVkZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFs
-        SGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAgICAg
-        ICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2Ix
-        NDQ0MmEvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9kaXNrcyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwi
-        Lz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0
-        LWEzOTYtMGRkZjdiMTQ0NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbWVk
-        aWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJ
-        dGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRv
-        d24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVk
-        ZjE0LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uL25ldHdvcmtDYXJkcyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
-        LnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAg
-        ICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdi
-        MTQ0NDJhL3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbmV0d29ya0NhcmRzIiB0
-        eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNM
-        aXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00
-        NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvdmlydHVhbEhhcmR3YXJlU2Vj
-        dGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAgICAg
-        IDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBp
-        L3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJh
-        L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vc2VyaWFsUG9ydHMiIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1s
-        Ii8+CiAgICAgICAgICAgIDwvb3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rpb24+
-        CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbiB4bWxu
-        czp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIg
-        b3ZmOmlkPSIzNiIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rpb24reG1sIiB2bXc6b3NU
-        eXBlPSJvdGhlckxpbnV4R3Vlc3QiIHZjbG91ZDpocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0w
-        ZGRmN2IxNDQ0MmEvb3BlcmF0aW5nU3lzdGVtU2VjdGlvbi8iPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5nIHN5
-        c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92
-        ZjpEZXNjcmlwdGlvbj5PdGhlciBMaW51eCAoMzItYml0KTwvb3ZmOkRlc2Ny
-        aXB0aW9uPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00Njcy
-        LTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEvb3BlcmF0aW5nU3lzdGVtU2VjdGlv
-        bi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9wZXJh
-        dGluZ1N5c3RlbVNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOk9w
-        ZXJhdGluZ1N5c3RlbVNlY3Rpb24+CiAgICAgICAgICAgIDxOZXR3b3JrQ29u
-        bmVjdGlvblNlY3Rpb24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tM2YxNWRmMTQtNDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL25l
-        dHdvcmtDb25uZWN0aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLm5ldHdvcmtDb25uZWN0aW9uU2VjdGlvbit4bWwi
-        IG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        bmZvPlNwZWNpZmllcyB0aGUgYXZhaWxhYmxlIFZNIG5ldHdvcmsgY29ubmVj
-        dGlvbnM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPFByaW1hcnlOZXR3
-        b3JrQ29ubmVjdGlvbkluZGV4PjA8L1ByaW1hcnlOZXR3b3JrQ29ubmVjdGlv
-        bkluZGV4PgogICAgICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9uIG5l
-        ZWRzQ3VzdG9taXphdGlvbj0iZmFsc2UiIG5ldHdvcms9InZkYy1uZXQtbWlo
-        YSI+CiAgICAgICAgICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9uSW5k
-        ZXg+MTwvTmV0d29ya0Nvbm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAg
-        ICAgICA8SXNDb25uZWN0ZWQ+dHJ1ZTwvSXNDb25uZWN0ZWQ+CiAgICAgICAg
-        ICAgICAgICAgICAgPE1BQ0FkZHJlc3M+MDA6NTA6NTY6MDE6MDA6MWI8L01B
-        Q0FkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPElwQWRkcmVzc0FsbG9j
-        YXRpb25Nb2RlPkRIQ1A8L0lwQWRkcmVzc0FsbG9jYXRpb25Nb2RlPgogICAg
-        ICAgICAgICAgICAgPC9OZXR3b3JrQ29ubmVjdGlvbj4KICAgICAgICAgICAg
-        ICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3RvbWl6YXRpb249ImZh
-        bHNlIiBuZXR3b3JrPSJ2YXBwLW5ldHdvcmstbWloYSI+CiAgICAgICAgICAg
-        ICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9uSW5kZXg+MDwvTmV0d29ya0Nv
-        bm5lY3Rpb25JbmRleD4KICAgICAgICAgICAgICAgICAgICA8SXBBZGRyZXNz
-        PjE5Mi4xNjguMi4xMDA8L0lwQWRkcmVzcz4KICAgICAgICAgICAgICAgICAg
-        ICA8SXNDb25uZWN0ZWQ+dHJ1ZTwvSXNDb25uZWN0ZWQ+CiAgICAgICAgICAg
-        ICAgICAgICAgPE1BQ0FkZHJlc3M+MDA6NTA6NTY6MDE6MDA6MTY8L01BQ0Fk
-        ZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPElwQWRkcmVzc0FsbG9jYXRp
-        b25Nb2RlPlBPT0w8L0lwQWRkcmVzc0FsbG9jYXRpb25Nb2RlPgogICAgICAg
-        ICAgICAgICAgPC9OZXR3b3JrQ29ubmVjdGlvbj4KICAgICAgICAgICAgICAg
-        IDxOZXR3b3JrQ29ubmVjdGlvbiBuZWVkc0N1c3RvbWl6YXRpb249InRydWUi
-        IG5ldHdvcms9InRhZHJ1Z2ktdmFwcC1uZXR3b3JrIj4KICAgICAgICAgICAg
-        ICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4yPC9OZXR3b3JrQ29u
-        bmVjdGlvbkluZGV4PgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3M+
-        MTkyLjE2OC4yLjEwMDwvSXBBZGRyZXNzPgogICAgICAgICAgICAgICAgICAg
-        IDxJc0Nvbm5lY3RlZD50cnVlPC9Jc0Nvbm5lY3RlZD4KICAgICAgICAgICAg
-        ICAgICAgICA8TUFDQWRkcmVzcz4wMDo1MDo1NjowMTowMDoyMDwvTUFDQWRk
-        cmVzcz4KICAgICAgICAgICAgICAgICAgICA8SXBBZGRyZXNzQWxsb2NhdGlv
-        bk1vZGU+UE9PTDwvSXBBZGRyZXNzQWxsb2NhdGlvbk1vZGU+CiAgICAgICAg
-        ICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uPgogICAgICAgICAgICAgICAg
-        PExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQtYTM5Ni0wZGRmN2IxNDQ0MmEv
-        bmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQubmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uK3ht
-        bCIvPgogICAgICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uU2VjdGlvbj4K
-        ICAgICAgICAgICAgPEd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24gaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00
-        ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL2d1ZXN0Q3VzdG9taXphdGlvblNlY3Rp
-        b24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5ndWVz
-        dEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxz
-        ZSI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIEd1ZXN0
-        IE9TIEN1c3RvbWl6YXRpb24gU2V0dGluZ3M8L292ZjpJbmZvPgogICAgICAg
-        ICAgICAgICAgPEVuYWJsZWQ+ZmFsc2U8L0VuYWJsZWQ+CiAgICAgICAgICAg
-        ICAgICA8Q2hhbmdlU2lkPmZhbHNlPC9DaGFuZ2VTaWQ+CiAgICAgICAgICAg
-        ICAgICA8VmlydHVhbE1hY2hpbmVJZD4zZjE1ZGYxNC00NjcyLTRkMTQtYTM5
-        Ni0wZGRmN2IxNDQ0MmE8L1ZpcnR1YWxNYWNoaW5lSWQ+CiAgICAgICAgICAg
-        ICAgICA8Sm9pbkRvbWFpbkVuYWJsZWQ+ZmFsc2U8L0pvaW5Eb21haW5FbmFi
-        bGVkPgogICAgICAgICAgICAgICAgPFVzZU9yZ1NldHRpbmdzPmZhbHNlPC9V
-        c2VPcmdTZXR0aW5ncz4KICAgICAgICAgICAgICAgIDxBZG1pblBhc3N3b3Jk
-        RW5hYmxlZD50cnVlPC9BZG1pblBhc3N3b3JkRW5hYmxlZD4KICAgICAgICAg
-        ICAgICAgIDxBZG1pblBhc3N3b3JkQXV0bz50cnVlPC9BZG1pblBhc3N3b3Jk
-        QXV0bz4KICAgICAgICAgICAgICAgIDxSZXNldFBhc3N3b3JkUmVxdWlyZWQ+
-        ZmFsc2U8L1Jlc2V0UGFzc3dvcmRSZXF1aXJlZD4KICAgICAgICAgICAgICAg
-        IDxDb21wdXRlck5hbWU+VFRZTGludXgtMDAtMC1tbTwvQ29tcHV0ZXJOYW1l
-        PgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zZjE1ZGYxNC00NjcyLTRkMTQt
-        YTM5Ni0wZGRmN2IxNDQ0MmEvZ3Vlc3RDdXN0b21pemF0aW9uU2VjdGlvbi8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmd1ZXN0Q3Vz
-        dG9taXphdGlvblNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvR3Vlc3RD
-        dXN0b21pemF0aW9uU2VjdGlvbj4KICAgICAgICAgICAgPFJ1bnRpbWVJbmZv
-        U2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNvbS92
-        Y2xvdWQvdjEuNSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIiB2Y2xvdWQ6
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQt
-        NDY3Mi00ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3J1bnRpbWVJbmZvU2VjdGlv
-        biI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIFJ1bnRp
-        bWUgaW5mbzwvb3ZmOkluZm8+CiAgICAgICAgICAgIDwvUnVudGltZUluZm9T
-        ZWN0aW9uPgogICAgICAgICAgICA8U25hcHNob3RTZWN0aW9uIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0LTQ2NzItNGQx
-        NC1hMzk2LTBkZGY3YjE0NDQyYS9zbmFwc2hvdFNlY3Rpb24iIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnNuYXBzaG90U2VjdGlvbit4
-        bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAgPG92
-        ZjpJbmZvPlNuYXBzaG90IGluZm9ybWF0aW9uIHNlY3Rpb248L292ZjpJbmZv
-        PgogICAgICAgICAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgICAgICAgICAg
-        PERhdGVDcmVhdGVkPjIwMTYtMDgtMDNUMTM6NDE6MjQuNDIzKzAyOjAwPC9E
-        YXRlQ3JlYXRlZD4KICAgICAgICAgICAgPFZBcHBTY29wZWRMb2NhbElkPmMy
-        YzViZDIyLTBiNzctNDE4Ny1hM2YzLWNjYjY4YjBlYjYyZjwvVkFwcFNjb3Bl
-        ZExvY2FsSWQ+CiAgICAgICAgICAgIDxvdmZlbnY6RW52aXJvbm1lbnQgeG1s
-        bnM6bnMxMT0iaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9vdmZlbnYi
-        IG92ZmVudjppZD0iIiBuczExOnZDZW50ZXJJZD0idm0tOTIiPgogICAgICAg
-        ICAgICAgICAgPG92ZmVudjpQbGF0Zm9ybVNlY3Rpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPG92ZmVudjpLaW5kPlZNd2FyZSBFU1hpPC9vdmZlbnY6S2lu
-        ZD4KICAgICAgICAgICAgICAgICAgICA8b3ZmZW52OlZlcnNpb24+Ni4wLjA8
-        L292ZmVudjpWZXJzaW9uPgogICAgICAgICAgICAgICAgICAgIDxvdmZlbnY6
-        VmVuZG9yPlZNd2FyZSwgSW5jLjwvb3ZmZW52OlZlbmRvcj4KICAgICAgICAg
-        ICAgICAgICAgICA8b3ZmZW52OkxvY2FsZT5lbjwvb3ZmZW52OkxvY2FsZT4K
-        ICAgICAgICAgICAgICAgIDwvb3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4KICAg
-        ICAgICAgICAgICAgIDx2ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uIHhtbG5z
-        OnZlPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgeG1s
-        bnM9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVudC8x
-        IiB4bWxuczpvZT0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmly
-        b25tZW50LzEiPgogICAgICAgICAgICAgICAgICAgIDx2ZTpBZGFwdGVyIHZl
-        Om1hYz0iMDA6NTA6NTY6MDE6MDA6MTYiIHZlOm5ldHdvcms9Im5vbmUiIHZl
-        OnVuaXROdW1iZXI9IjciLz4KICAgCiAgICAgICAgICAgICAgICA8L3ZlOkV0
-        aGVybmV0QWRhcHRlclNlY3Rpb24+CiAgICAgICAgICAgIDwvb3ZmZW52OkVu
-        dmlyb25tZW50PgogICAgICAgICAgICA8Vm1DYXBhYmlsaXRpZXMgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tM2YxNWRmMTQtNDY3Mi00
-        ZDE0LWEzOTYtMGRkZjdiMTQ0NDJhL3ZtQ2FwYWJpbGl0aWVzLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRpZXNT
-        ZWN0aW9uK3htbCI+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTNmMTVkZjE0
-        LTQ2NzItNGQxNC1hMzk2LTBkZGY3YjE0NDQyYS92bUNhcGFiaWxpdGllcy8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2FwYWJp
-        bGl0aWVzU2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgICAgIDxNZW1vcnlI
-        b3RBZGRFbmFibGVkPmZhbHNlPC9NZW1vcnlIb3RBZGRFbmFibGVkPgogICAg
-        ICAgICAgICAgICAgPENwdUhvdEFkZEVuYWJsZWQ+ZmFsc2U8L0NwdUhvdEFk
-        ZEVuYWJsZWQ+CiAgICAgICAgICAgIDwvVm1DYXBhYmlsaXRpZXM+CiAgICAg
-        ICAgICAgIDxTdG9yYWdlUHJvZmlsZSBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdmRjU3RvcmFnZVByb2ZpbGUvNDI5NGY3NjctZDllYi00NzI4LWI3
-        ZGQtODFhMmQ3NjgzMGJmIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAg
-        ICAgICA8L1ZtPgogICAgICAgIDxWbSBuZWVkc0N1c3RvbWl6YXRpb249InRy
-        dWUiIGRlcGxveWVkPSJ0cnVlIiBzdGF0dXM9IjQiIG5hbWU9IlRUWUxpbnV4
-        LTItbW0iIGlkPSJ1cm46dmNsb3VkOnZtOjMyODM0NGU0LTIyZmMtNDNhMS1h
-        NTFkLWIwOTZlNjQwMzJlOSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBp
-        L3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwi
-        PgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnBvd2VyT2ZmIiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZj
-        LTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvcG93ZXIvYWN0aW9uL3Bvd2VyT2Zm
-        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6cmVib290IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZj
-        LTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvcG93ZXIvYWN0aW9uL3JlYm9vdCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnJlc2V0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQz
-        YTEtYTUxZC1iMDk2ZTY0MDMyZTkvcG93ZXIvYWN0aW9uL3Jlc2V0Ii8+CiAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6c2h1dGRvd24iIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNh
-        MS1hNTFkLWIwOTZlNjQwMzJlOS9wb3dlci9hY3Rpb24vc2h1dGRvd24iLz4K
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzdXNwZW5kIiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQz
-        YTEtYTUxZC1iMDk2ZTY0MDMyZTkvcG93ZXIvYWN0aW9uL3N1c3BlbmQiLz4K
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJ1bmRlcGxveSIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1
-        MWQtYjA5NmU2NDAzMmU5L2FjdGlvbi91bmRlcGxveSIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudW5kZXBsb3lWQXBwUGFyYW1zK3ht
-        bCIvPgogICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1h
-        NTFkLWIwOTZlNjQwMzJlOSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQudm0reG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93
-        biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0
-        ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L21ldGFkYXRhIiB0eXBl
-        PSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwi
-        Lz4KICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUx
-        ZC1iMDk2ZTY0MDMyZTkvcHJvZHVjdFNlY3Rpb25zLyIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucHJvZHVjdFNlY3Rpb25zK3htbCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9InNjcmVlbjp0aHVtYm5haWwiIGhy
-        ZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIy
-        ZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9zY3JlZW4iLz4KICAgICAgICAg
-        ICAgPExpbmsgcmVsPSJzY3JlZW46YWNxdWlyZVRpY2tldCIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2Ex
-        LWE1MWQtYjA5NmU2NDAzMmU5L3NjcmVlbi9hY3Rpb24vYWNxdWlyZVRpY2tl
-        dCIvPgogICAgICAgICAgICA8TGluayByZWw9Im1lZGlhOmluc2VydE1lZGlh
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRl
-        NC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvbWVkaWEvYWN0aW9uL2lu
-        c2VydE1lZGlhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5tZWRpYUluc2VydE9yRWplY3RQYXJhbXMreG1sIi8+CiAgICAgICAgICAg
-        IDxMaW5rIHJlbD0ibWVkaWE6ZWplY3RNZWRpYSIgaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQt
-        YjA5NmU2NDAzMmU5L21lZGlhL2FjdGlvbi9lamVjdE1lZGlhIiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZWRpYUluc2VydE9yRWpl
-        Y3RQYXJhbXMreG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZGlzazph
-        dHRhY2giIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMy
-        ODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9kaXNrL2FjdGlv
-        bi9hdHRhY2giIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
-        LmRpc2tBdHRhY2hPckRldGFjaFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAg
-        PExpbmsgcmVsPSJkaXNrOmRldGFjaCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2
-        NDAzMmU5L2Rpc2svYWN0aW9uL2RldGFjaCIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQuZGlza0F0dGFjaE9yRGV0YWNoUGFyYW1zK3ht
-        bCIvPgogICAgICAgICAgICA8TGluayByZWw9Imluc3RhbGxWbXdhcmVUb29s
-        cyIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0
-        ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L2FjdGlvbi9pbnN0YWxs
-        Vk13YXJlVG9vbHMiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJzbmFwc2hv
-        dDpjcmVhdGUiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9hY3Rpb24v
-        Y3JlYXRlU25hcHNob3QiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLmNyZWF0ZVNuYXBzaG90UGFyYW1zK3htbCIvPgogICAgICAgICAg
-        ICA8TGluayByZWw9InJlY29uZmlndXJlVm0iIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIw
-        OTZlNjQwMzJlOS9hY3Rpb24vcmVjb25maWd1cmVWbSIgbmFtZT0iVFRZTGlu
-        dXgtMi1tbSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        dm0reG1sIi8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZhcHAtNmQ2NzdlMmUtZmNjZS00
-        ODM4LTliYTgtMGNiMjNmZDE4M2U1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLnZjbG91ZC52QXBwK3htbCIvPgogICAgICAgICAgICA8RGVzY3Jp
-        cHRpb24+Q3JlYXRlZCBieTogTWlrZSBMYXZlcmljaw1CbG9nOiB3d3cubWlr
-        ZWxhdmVyaWNrLmNvbQ1Ud2l0dGVyOiBAbWlrZV9sYXZlcmljaw0NU2Vydmlj
-        ZXMgRW5hYmxlZDogU1NILCBGVFAsIEhUVFANUk9PVCBQYXNzd29yZDogcGFz
-        c3dvcmQ8L0Rlc2NyaXB0aW9uPgogICAgICAgICAgICA8b3ZmOlZpcnR1YWxI
-        YXJkd2FyZVNlY3Rpb24geG1sbnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2Fy
-        ZS5jb20vdmNsb3VkL3YxLjUiIG92Zjp0cmFuc3BvcnQ9IiIgdmNsb3VkOnR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZpcnR1YWxIYXJk
-        d2FyZVNlY3Rpb24reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4y
-        LjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2
-        NDAzMmU5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vIj4KICAgICAgICAgICAg
-        ICAgIDxvdmY6SW5mbz5WaXJ0dWFsIGhhcmR3YXJlIHJlcXVpcmVtZW50czwv
-        b3ZmOkluZm8+CiAgICAgICAgICAgICAgICA8b3ZmOlN5c3RlbT4KICAgICAg
-        ICAgICAgICAgICAgICA8dnNzZDpFbGVtZW50TmFtZT5WaXJ0dWFsIEhhcmR3
-        YXJlIEZhbWlseTwvdnNzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAg
-        ICAgICA8dnNzZDpJbnN0YW5jZUlEPjA8L3Zzc2Q6SW5zdGFuY2VJRD4KICAg
-        ICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0dWFsU3lzdGVtSWRlbnRpZmll
-        cj5UVFlMaW51eC0yLW1tPC92c3NkOlZpcnR1YWxTeXN0ZW1JZGVudGlmaWVy
-        PgogICAgICAgICAgICAgICAgICAgIDx2c3NkOlZpcnR1YWxTeXN0ZW1UeXBl
-        PnZteC0wODwvdnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT4KICAgICAgICAgICAg
-        ICAgIDwvb3ZmOlN5c3RlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRlbT4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzPjAwOjUwOjU2OjAx
-        OjAwOjE4PC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6QWRkcmVzc09uUGFyZW50PjA8L3Jhc2Q6QWRkcmVzc09uUGFyZW50Pgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOkF1dG9tYXRpY0FsbG9jYXRpb24+
-        dHJ1ZTwvcmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOkNvbm5lY3Rpb24gdmNsb3VkOmlwQWRkcmVzc2luZ01v
-        ZGU9IkRIQ1AiIHZjbG91ZDpwcmltYXJ5TmV0d29ya0Nvbm5lY3Rpb249InRy
-        dWUiPnZhcHAtbmV0d29yay1taWhhPC9yYXNkOkNvbm5lY3Rpb24+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+RTEwMDAgZXRoZXJu
-        ZXQgYWRhcHRlciBvbiAidmFwcC1uZXR3b3JrLW1paGEiPC9yYXNkOkRlc2Ny
-        aXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1l
-        Pk5ldHdvcmsgYWRhcHRlciAwPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+MTwvcmFzZDpJbnN0YW5j
-        ZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlU3ViVHlw
-        ZT5FMTAwMDwvcmFzZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291cmNlVHlw
-        ZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAg
-        ICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVz
-        cz4wPC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRpb24+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SURFIENv
-        bnRyb2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6SW5zdGFuY2VJRD4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFzZDpS
-        ZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAg
-        ICAgICAgICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVudD4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5IYXJkIGRp
-        c2s8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jhc2Q6RWxlbWVudE5hbWU+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9zdFJlc291cmNlIHZjbG91
-        ZDpidXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlwZT0iIiB2Y2xvdWQ6Y2Fw
-        YWNpdHk9IjMyIi8+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFu
-        Y2VJRD4zMDAwPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6UGFyZW50PjI8L3Jhc2Q6UGFyZW50PgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNzwvcmFzZDpSZXNvdXJjZVR5
-        cGU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6VmlydHVhbFF1YW50aXR5
-        PjMzNTU0NDMyPC9yYXNkOlZpcnR1YWxRdWFudGl0eT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHlVbml0cz5ieXRlPC9yYXNk
-        OlZpcnR1YWxRdWFudGl0eVVuaXRzPgogICAgICAgICAgICAgICAgPC9vdmY6
-        SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRlbT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpBZGRyZXNzPjE8L3Jhc2Q6QWRkcmVzcz4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5JREUgQ29udHJvbGxl
-        cjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT5JREUgQ29udHJvbGxlciAxPC9yYXNkOkVsZW1lbnRO
-        YW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+Mzwv
-        cmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJl
-        c291cmNlVHlwZT41PC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAg
-        ICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzc09uUGFyZW50PjA8L3Jh
-        c2Q6QWRkcmVzc09uUGFyZW50PgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OkF1dG9tYXRpY0FsbG9jYXRpb24+ZmFsc2U8L3Jhc2Q6QXV0b21hdGljQWxs
-        b2NhdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlv
-        bj5DRC9EVkQgRHJpdmU8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+Q0QvRFZEIERyaXZlIDE8L3Jh
-        c2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9z
-        dFJlc291cmNlLz4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5j
-        ZUlEPjMwMDI8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpQYXJlbnQ+MzwvcmFzZDpQYXJlbnQ+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjE1PC9yYXNkOlJlc291cmNlVHlw
-        ZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAg
-        ICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFk
-        LWIwOTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSI+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2NhdGlvblVuaXRzPmhlcnR6
-        ICogMTBeNjwvcmFzZDpBbGxvY2F0aW9uVW5pdHM+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+TnVtYmVyIG9mIFZpcnR1YWwgQ1BV
-        czwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpFbGVtZW50TmFtZT4xIHZpcnR1YWwgQ1BVKHMpPC9yYXNkOkVsZW1lbnRO
-        YW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+NDwv
-        cmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJl
-        c2VydmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjM8L3Jhc2Q6UmVzb3VyY2VUeXBl
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eT4x
-        PC9yYXNkOlZpcnR1YWxRdWFudGl0eT4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpXZWlnaHQ+MDwvcmFzZDpXZWlnaHQ+CiAgICAgICAgICAgICAgICAg
-        ICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMy
-        ZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUiIHR5cGU9ImFwcGxpY2F0
-        aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIvPgogICAgICAg
-        ICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxvdmY6SXRl
-        bSB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        cmFzZEl0ZW0reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAz
-        MmU5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbWVtb3J5Ij4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpBbGxvY2F0aW9uVW5pdHM+Ynl0ZSAqIDJeMjA8
-        L3Jhc2Q6QWxsb2NhdGlvblVuaXRzPgogICAgICAgICAgICAgICAgICAgIDxy
-        YXNkOkRlc2NyaXB0aW9uPk1lbW9yeSBTaXplPC9yYXNkOkRlc2NyaXB0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPjMyIE1C
-        IG9mIG1lbW9yeTwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpJbnN0YW5jZUlEPjU8L3Jhc2Q6SW5zdGFuY2VJRD4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNkOlJl
-        c2VydmF0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNl
-        VHlwZT40PC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpWaXJ0dWFsUXVhbnRpdHk+MzI8L3Jhc2Q6VmlydHVhbFF1YW50
-        aXR5PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOldlaWdodD4wPC9yYXNk
-        OldlaWdodD4KICAgICAgICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0
-        LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVT
-        ZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8L292ZjpJ
-        dGVtPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQz
-        YTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZpcnR1YWxI
-        YXJkd2FyZVNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayBy
-        ZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92aXJ0dWFs
-        SGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92
-        aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2NwdSIgdHlwZT0iYXBwbGljYXRpb24v
-        dm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAgICAgICAgICAg
-        ICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQw
-        MzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0reG1sIi8+CiAg
-        ICAgICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFk
-        LWIwOTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL21lbW9yeSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW0r
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMt
-        NDNhMS1hNTFkLWIwOTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L2Rpc2tzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5y
-        YXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExpbmsgcmVs
-        PSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0z
-        MjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvdmlydHVhbEhh
-        cmR3YXJlU2VjdGlvbi9kaXNrcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZt
-        d2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAg
-        ICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAz
-        MmU5L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbWVkaWEiIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+
-        CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBz
-        Oi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1h
-        NTFkLWIwOTZlNjQwMzJlOS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL25ldHdv
-        cmtDYXJkcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        cmFzZEl0ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJl
-        bD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        MzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3ZpcnR1YWxI
-        YXJkd2FyZVNlY3Rpb24vbmV0d29ya0NhcmRzIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAg
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1i
-        MDk2ZTY0MDMyZTkvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9zZXJpYWxQb3J0
-        cyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0
-        ZW1zTGlzdCt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0
-        ZTQtMjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3ZpcnR1YWxIYXJkd2Fy
-        ZVNlY3Rpb24vc2VyaWFsUG9ydHMiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAg
-        IDwvb3ZmOlZpcnR1YWxIYXJkd2FyZVNlY3Rpb24+CiAgICAgICAgICAgIDxv
-        dmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6
-        Ly93d3cudm13YXJlLmNvbS92Y2xvdWQvdjEuNSIgb3ZmOmlkPSIzNiIgdmNs
-        b3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9wZXJh
-        dGluZ1N5c3RlbVNlY3Rpb24reG1sIiB2bXc6b3NUeXBlPSJvdGhlckxpbnV4
-        R3Vlc3QiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2ZTY0MDMyZTkvb3Bl
-        cmF0aW5nU3lzdGVtU2VjdGlvbi8iPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        bmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5nIHN5c3RlbSBpbnN0YWxsZWQ8
-        L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5P
-        dGhlciBMaW51eCAoMzItYml0KTwvb3ZmOkRlc2NyaXB0aW9uPgogICAgICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUxZC1iMDk2
-        ZTY0MDMyZTkvb3BlcmF0aW5nU3lzdGVtU2VjdGlvbi8iIHR5cGU9ImFwcGxp
-        Y2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9wZXJhdGluZ1N5c3RlbVNlY3Rp
-        b24reG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOk9wZXJhdGluZ1N5c3RlbVNl
-        Y3Rpb24+CiAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24g
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQt
-        MjJmYy00M2ExLWE1MWQtYjA5NmU2NDAzMmU5L25ldHdvcmtDb25uZWN0aW9u
-        U2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
-        Lm5ldHdvcmtDb25uZWN0aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0i
-        ZmFsc2UiPgogICAgICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0
-        aGUgYXZhaWxhYmxlIFZNIG5ldHdvcmsgY29ubmVjdGlvbnM8L292ZjpJbmZv
-        PgogICAgICAgICAgICAgICAgPFByaW1hcnlOZXR3b3JrQ29ubmVjdGlvbklu
-        ZGV4PjA8L1ByaW1hcnlOZXR3b3JrQ29ubmVjdGlvbkluZGV4PgogICAgICAg
-        ICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9uIG5lZWRzQ3VzdG9taXphdGlv
-        bj0idHJ1ZSIgbmV0d29yaz0idmFwcC1uZXR3b3JrLW1paGEiPgogICAgICAg
-        ICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4PjA8L05ldHdv
-        cmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAgICAgPElzQ29u
-        bmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAgICAgICAgICAg
-        IDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjE4PC9NQUNBZGRyZXNzPgog
-        ICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT5E
-        SENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAgICAgICAgICAg
-        IDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgICAgICA8TGluayBy
-        ZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3Zt
-        LTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZlNjQwMzJlOS9uZXR3b3Jr
-        Q29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1sIi8+CiAg
-        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAg
-        ICAgICA8R3Vlc3RDdXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUx
-        ZC1iMDk2ZTY0MDMyZTkvZ3Vlc3RDdXN0b21pemF0aW9uU2VjdGlvbi8iIHR5
-        cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmd1ZXN0Q3VzdG9t
-        aXphdGlvblNlY3Rpb24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAg
-        ICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVjaWZpZXMgR3Vlc3QgT1MgQ3Vz
-        dG9taXphdGlvbiBTZXR0aW5nczwvb3ZmOkluZm8+CiAgICAgICAgICAgICAg
-        ICA8RW5hYmxlZD5mYWxzZTwvRW5hYmxlZD4KICAgICAgICAgICAgICAgIDxD
-        aGFuZ2VTaWQ+ZmFsc2U8L0NoYW5nZVNpZD4KICAgICAgICAgICAgICAgIDxW
-        aXJ0dWFsTWFjaGluZUlkPjMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIwOTZl
-        NjQwMzJlOTwvVmlydHVhbE1hY2hpbmVJZD4KICAgICAgICAgICAgICAgIDxK
-        b2luRG9tYWluRW5hYmxlZD5mYWxzZTwvSm9pbkRvbWFpbkVuYWJsZWQ+CiAg
-        ICAgICAgICAgICAgICA8VXNlT3JnU2V0dGluZ3M+ZmFsc2U8L1VzZU9yZ1Nl
-        dHRpbmdzPgogICAgICAgICAgICAgICAgPEFkbWluUGFzc3dvcmRFbmFibGVk
-        PnRydWU8L0FkbWluUGFzc3dvcmRFbmFibGVkPgogICAgICAgICAgICAgICAg
-        PEFkbWluUGFzc3dvcmRBdXRvPnRydWU8L0FkbWluUGFzc3dvcmRBdXRvPgog
-        ICAgICAgICAgICAgICAgPFJlc2V0UGFzc3dvcmRSZXF1aXJlZD5mYWxzZTwv
-        UmVzZXRQYXNzd29yZFJlcXVpcmVkPgogICAgICAgICAgICAgICAgPENvbXB1
-        dGVyTmFtZT5UVFlMaW51eC0wMC0xLW1tPC9Db21wdXRlck5hbWU+CiAgICAg
-        ICAgICAgICAgICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAu
-        MzAuMi4yL2FwaS92QXBwL3ZtLTMyODM0NGU0LTIyZmMtNDNhMS1hNTFkLWIw
-        OTZlNjQwMzJlOS9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
-        aW9uU2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgPC9HdWVzdEN1c3RvbWl6
-        YXRpb25TZWN0aW9uPgogICAgICAgICAgICA8UnVudGltZUluZm9TZWN0aW9u
-        IHhtbG5zOnZjbG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
-        MS41IiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQudmlydHVhbEhhcmR3YXJlU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQz
-        YTEtYTUxZC1iMDk2ZTY0MDMyZTkvcnVudGltZUluZm9TZWN0aW9uIj4KICAg
-        ICAgICAgICAgICAgIDxvdmY6SW5mbz5TcGVjaWZpZXMgUnVudGltZSBpbmZv
-        PC9vdmY6SW5mbz4KICAgICAgICAgICAgPC9SdW50aW1lSW5mb1NlY3Rpb24+
-        CiAgICAgICAgICAgIDxTbmFwc2hvdFNlY3Rpb24gaHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00M2ExLWE1MWQt
-        YjA5NmU2NDAzMmU5L3NuYXBzaG90U2VjdGlvbiIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQuc25hcHNob3RTZWN0aW9uK3htbCIgb3Zm
-        OnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+
-        U25hcHNob3QgaW5mb3JtYXRpb24gc2VjdGlvbjwvb3ZmOkluZm8+CiAgICAg
-        ICAgICAgIDwvU25hcHNob3RTZWN0aW9uPgogICAgICAgICAgICA8RGF0ZUNy
-        ZWF0ZWQ+MjAxNi0wOC0wM1QxMzo0MToyNC42NjcrMDI6MDA8L0RhdGVDcmVh
-        dGVkPgogICAgICAgICAgICA8VkFwcFNjb3BlZExvY2FsSWQ+OTA1YjEwNGUt
-        NWJmMC00NjkyLTgxNTAtNjNiMjMyNzE4OGFiPC9WQXBwU2NvcGVkTG9jYWxJ
-        ZD4KICAgICAgICAgICAgPG92ZmVudjpFbnZpcm9ubWVudCB4bWxuczpuczEx
-        PSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIgb3ZmZW52
-        OmlkPSIiIG5zMTE6dkNlbnRlcklkPSJ2bS05NCI+CiAgICAgICAgICAgICAg
-        ICA8b3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4KICAgICAgICAgICAgICAgICAg
-        ICA8b3ZmZW52OktpbmQ+Vk13YXJlIEVTWGk8L292ZmVudjpLaW5kPgogICAg
-        ICAgICAgICAgICAgICAgIDxvdmZlbnY6VmVyc2lvbj42LjAuMDwvb3ZmZW52
-        OlZlcnNpb24+CiAgICAgICAgICAgICAgICAgICAgPG92ZmVudjpWZW5kb3I+
-        Vk13YXJlLCBJbmMuPC9vdmZlbnY6VmVuZG9yPgogICAgICAgICAgICAgICAg
-        ICAgIDxvdmZlbnY6TG9jYWxlPmVuPC9vdmZlbnY6TG9jYWxlPgogICAgICAg
-        ICAgICAgICAgPC9vdmZlbnY6UGxhdGZvcm1TZWN0aW9uPgogICAgICAgICAg
-        ICAgICAgPHZlOkV0aGVybmV0QWRhcHRlclNlY3Rpb24geG1sbnM6dmU9Imh0
-        dHA6Ly93d3cudm13YXJlLmNvbS9zY2hlbWEvb3ZmZW52IiB4bWxucz0iaHR0
-        cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vudmlyb25tZW50LzEiIHhtbG5z
-        Om9lPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52aXJvbm1lbnQv
-        MSI+CiAgICAgICAgICAgICAgICAgICAgPHZlOkFkYXB0ZXIgdmU6bWFjPSIw
-        MDo1MDo1NjowMTowMDoxOCIgdmU6bmV0d29yaz0ibm9uZSIgdmU6dW5pdE51
-        bWJlcj0iNyIvPgogICAKICAgICAgICAgICAgICAgIDwvdmU6RXRoZXJuZXRB
-        ZGFwdGVyU2VjdGlvbj4KICAgICAgICAgICAgPC9vdmZlbnY6RW52aXJvbm1l
-        bnQ+CiAgICAgICAgICAgIDxWbUNhcGFiaWxpdGllcyBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS0zMjgzNDRlNC0yMmZjLTQzYTEtYTUx
-        ZC1iMDk2ZTY0MDMyZTkvdm1DYXBhYmlsaXRpZXMvIiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bUNhcGFiaWxpdGllc1NlY3Rpb24r
-        eG1sIj4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tMzI4MzQ0ZTQtMjJmYy00
-        M2ExLWE1MWQtYjA5NmU2NDAzMmU5L3ZtQ2FwYWJpbGl0aWVzLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRpZXNT
-        ZWN0aW9uK3htbCIvPgogICAgICAgICAgICAgICAgPE1lbW9yeUhvdEFkZEVu
-        YWJsZWQ+ZmFsc2U8L01lbW9yeUhvdEFkZEVuYWJsZWQ+CiAgICAgICAgICAg
-        ICAgICA8Q3B1SG90QWRkRW5hYmxlZD5mYWxzZTwvQ3B1SG90QWRkRW5hYmxl
-        ZD4KICAgICAgICAgICAgPC9WbUNhcGFiaWxpdGllcz4KICAgICAgICAgICAg
-        PFN0b3JhZ2VQcm9maWxlIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        ZGNTdG9yYWdlUHJvZmlsZS80Mjk0Zjc2Ny1kOWViLTQ3MjgtYjdkZC04MWEy
-        ZDc2ODMwYmYiIG5hbWU9IioiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnZkY1N0b3JhZ2VQcm9maWxlK3htbCIvPgogICAgICAgIDwv
-        Vm0+CiAgICAgICAgPFZtIG5lZWRzQ3VzdG9taXphdGlvbj0idHJ1ZSIgZGVw
-        bG95ZWQ9InRydWUiIHN0YXR1cz0iNCIgbmFtZT0iRGFtbiBTbWFsbCBMaW51
-        eC1tbSIgaWQ9InVybjp2Y2xvdWQ6dm06YWUwMWEyMmUtZDBhMy00YjdmLWFl
-        NmQtNjFhMjNkNjViNDU1IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkv
-        dkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUi
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtK3htbCI+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6cG93ZXJPZmYiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9wb3dlci9hY3Rpb24vcG93ZXJPZmYi
-        Lz4KICAgICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpyZWJvb3QiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9wb3dlci9hY3Rpb24vcmVib290Ii8+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0icG93ZXI6cmVzZXQiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3
-        Zi1hZTZkLTYxYTIzZDY1YjQ1NS9wb3dlci9hY3Rpb24vcmVzZXQiLz4KICAg
-        ICAgICAgICAgPExpbmsgcmVsPSJwb3dlcjpzaHV0ZG93biIgaHJlZj0iaHR0
-        cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00Yjdm
-        LWFlNmQtNjFhMjNkNjViNDU1L3Bvd2VyL2FjdGlvbi9zaHV0ZG93biIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9InBvd2VyOnN1c3BlbmQiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3
-        Zi1hZTZkLTYxYTIzZDY1YjQ1NS9wb3dlci9hY3Rpb24vc3VzcGVuZCIvPgog
-        ICAgICAgICAgICA8TGluayByZWw9InVuZGVwbG95IiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2
-        ZC02MWEyM2Q2NWI0NTUvYWN0aW9uL3VuZGVwbG95IiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC51bmRlcGxveVZBcHBQYXJhbXMreG1s
-        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFl
-        NmQtNjFhMjNkNjViNDU1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC52bSt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJkb3du
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvbWV0YWRhdGEiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm1ldGFkYXRhK3htbCIv
-        PgogICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8v
-        MTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZk
-        LTYxYTIzZDY1YjQ1NS9wcm9kdWN0U2VjdGlvbnMvIiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC5wcm9kdWN0U2VjdGlvbnMreG1sIi8+
-        CiAgICAgICAgICAgIDxMaW5rIHJlbD0ic2NyZWVuOnRodW1ibmFpbCIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBh
-        My00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3NjcmVlbiIvPgogICAgICAgICAg
-        ICA8TGluayByZWw9InNjcmVlbjphY3F1aXJlVGlja2V0IiBocmVmPSJodHRw
-        czovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2Yt
-        YWU2ZC02MWEyM2Q2NWI0NTUvc2NyZWVuL2FjdGlvbi9hY3F1aXJlVGlja2V0
-        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0ibWVkaWE6aW5zZXJ0TWVkaWEi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJl
-        LWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9tZWRpYS9hY3Rpb24vaW5z
-        ZXJ0TWVkaWEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
-        Lm1lZGlhSW5zZXJ0T3JFamVjdFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAg
-        PExpbmsgcmVsPSJtZWRpYTplamVjdE1lZGlhIiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02
-        MWEyM2Q2NWI0NTUvbWVkaWEvYWN0aW9uL2VqZWN0TWVkaWEiIHR5cGU9ImFw
-        cGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm1lZGlhSW5zZXJ0T3JFamVj
-        dFBhcmFtcyt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJkaXNrOmF0
-        dGFjaCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUw
-        MWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L2Rpc2svYWN0aW9u
-        L2F0dGFjaCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQu
-        ZGlza0F0dGFjaE9yRGV0YWNoUGFyYW1zK3htbCIvPgogICAgICAgICAgICA8
-        TGluayByZWw9ImRpc2s6ZGV0YWNoIiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2
-        NWI0NTUvZGlzay9hY3Rpb24vZGV0YWNoIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5kaXNrQXR0YWNoT3JEZXRhY2hQYXJhbXMreG1s
-        Ii8+CiAgICAgICAgICAgIDxMaW5rIHJlbD0iaW5zdGFsbFZtd2FyZVRvb2xz
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIy
-        ZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvYWN0aW9uL2luc3RhbGxW
-        TXdhcmVUb29scyIvPgogICAgICAgICAgICA8TGluayByZWw9InNuYXBzaG90
-        OmNyZWF0ZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0t
-        YWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L2FjdGlvbi9j
-        cmVhdGVTbmFwc2hvdCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQuY3JlYXRlU25hcHNob3RQYXJhbXMreG1sIi8+CiAgICAgICAgICAg
-        IDxMaW5rIHJlbD0icmVjb25maWd1cmVWbSIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFh
-        MjNkNjViNDU1L2FjdGlvbi9yZWNvbmZpZ3VyZVZtIiBuYW1lPSJEYW1uIFNt
-        YWxsIExpbnV4LW1tIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC52bSt4bWwiLz4KICAgICAgICAgICAgPExpbmsgcmVsPSJ1cCIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdmFwcC02ZDY3N2UyZS1m
-        Y2NlLTQ4MzgtOWJhOC0wY2IyM2ZkMTgzZTUiIHR5cGU9ImFwcGxpY2F0aW9u
-        L3ZuZC52bXdhcmUudmNsb3VkLnZBcHAreG1sIi8+CiAgICAgICAgICAgIDxE
-        ZXNjcmlwdGlvbj5J4oCZdmUgY3JlYXRlZCBhbiBPVkYgdmVyc2lvbiBvZiB0
-        aGUgaGlnaGx5IHBvcHVsYXIgRGFtbiBTbWFsbCBMaW51eCBkaXN0cmlidXRp
-        b24uIE5vcm1hbGx5IHlvdSBydW4gdGhpcyBPUyB3aGljaCBpcyBvbmx5IDUw
-        TUJzIGluIGRpc2sgc2l6ZSBmcm9tIGFuIElTTyBvciBwZW4gZHJpdmUgYnV0
-        IEnigJl2ZSBzZWVuIG1vcmUgYW5kIG1vcmUgcGVvcGxlIGV4cGVyaW1lbnRp
-        bmcgd2l0aCB0aGUgdkNsb3VkIERpcmVjdG9yIGFuZCByZWFsbHkgbmVlZCBz
-        bzwvRGVzY3JpcHRpb24+CiAgICAgICAgICAgIDxvdmY6VmlydHVhbEhhcmR3
-        YXJlU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNv
-        bS92Y2xvdWQvdjEuNSIgb3ZmOnRyYW5zcG9ydD0iIiB2Y2xvdWQ6dHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmlydHVhbEhhcmR3YXJl
-        U2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0
-        NTUvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi8iPgogICAgICAgICAgICAgICAg
-        PG92ZjpJbmZvPlZpcnR1YWwgaGFyZHdhcmUgcmVxdWlyZW1lbnRzPC9vdmY6
-        SW5mbz4KICAgICAgICAgICAgICAgIDxvdmY6U3lzdGVtPgogICAgICAgICAg
-        ICAgICAgICAgIDx2c3NkOkVsZW1lbnROYW1lPlZpcnR1YWwgSGFyZHdhcmUg
-        RmFtaWx5PC92c3NkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAg
-        IDx2c3NkOkluc3RhbmNlSUQ+MDwvdnNzZDpJbnN0YW5jZUlEPgogICAgICAg
-        ICAgICAgICAgICAgIDx2c3NkOlZpcnR1YWxTeXN0ZW1JZGVudGlmaWVyPkRh
-        bW4gU21hbGwgTGludXgtbW08L3Zzc2Q6VmlydHVhbFN5c3RlbUlkZW50aWZp
-        ZXI+CiAgICAgICAgICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3RlbVR5
-        cGU+dm14LTA3PC92c3NkOlZpcnR1YWxTeXN0ZW1UeXBlPgogICAgICAgICAg
-        ICAgICAgPC9vdmY6U3lzdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVt
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3M+MDA6NTA6NTY6
-        MDE6MDA6MTc8L3Jhc2Q6QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpBZGRyZXNzT25QYXJlbnQ+MDwvcmFzZDpBZGRyZXNzT25QYXJlbnQ+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QXV0b21hdGljQWxsb2NhdGlv
-        bj50cnVlPC9yYXNkOkF1dG9tYXRpY0FsbG9jYXRpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6Q29ubmVjdGlvbiB2Y2xvdWQ6aXBBZGRyZXNzaW5n
-        TW9kZT0iREhDUCIgdmNsb3VkOnByaW1hcnlOZXR3b3JrQ29ubmVjdGlvbj0i
-        dHJ1ZSI+dmRjLW5ldC1taWhhPC9yYXNkOkNvbm5lY3Rpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+UENOZXQzMiBldGhlcm5l
-        dCBhZGFwdGVyIG9uICJ2ZGMtbmV0LW1paGEiPC9yYXNkOkRlc2NyaXB0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPk5ldHdv
-        cmsgYWRhcHRlciAwPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOkluc3RhbmNlSUQ+MTwvcmFzZDpJbnN0YW5jZUlEPgog
-        ICAgICAgICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlU3ViVHlwZT5QQ05l
-        dDMyPC9yYXNkOlJlc291cmNlU3ViVHlwZT4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpSZXNvdXJjZVR5cGU+MTA8L3Jhc2Q6UmVzb3VyY2VUeXBlPgog
-        ICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAgIDxv
-        dmY6SXRlbT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpBZGRyZXNzPjA8
-        L3Jhc2Q6QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpEZXNj
-        cmlwdGlvbj5JREUgQ29udHJvbGxlcjwvcmFzZDpEZXNjcmlwdGlvbj4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5JREUgQ29udHJv
-        bGxlciAwPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOkluc3RhbmNlSUQ+MjwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT41PC9yYXNkOlJlc291
-        cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAg
-        ICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        QWRkcmVzc09uUGFyZW50PjA8L3Jhc2Q6QWRkcmVzc09uUGFyZW50PgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPkhhcmQgZGlzazwv
-        cmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpF
-        bGVtZW50TmFtZT5IYXJkIGRpc2sgMTwvcmFzZDpFbGVtZW50TmFtZT4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpIb3N0UmVzb3VyY2UgdmNsb3VkOmJ1
-        c1R5cGU9IjUiIHZjbG91ZDpidXNTdWJUeXBlPSIiIHZjbG91ZDpjYXBhY2l0
-        eT0iMjU2Ii8+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJ
-        RD4zMDAwPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6UGFyZW50PjI8L3Jhc2Q6UGFyZW50PgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNzwvcmFzZDpSZXNvdXJjZVR5cGU+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6VmlydHVhbFF1YW50aXR5PjI2
-        ODQzNTQ1NjwvcmFzZDpWaXJ0dWFsUXVhbnRpdHk+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6VmlydHVhbFF1YW50aXR5VW5pdHM+Ynl0ZTwvcmFzZDpW
-        aXJ0dWFsUXVhbnRpdHlVbml0cz4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0
-        ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6QWRkcmVzcz4xPC9yYXNkOkFkZHJlc3M+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+SURFIENvbnRyb2xsZXI8
-        L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        RWxlbWVudE5hbWU+SURFIENvbnRyb2xsZXIgMTwvcmFzZDpFbGVtZW50TmFt
-        ZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5jZUlEPjM8L3Jh
-        c2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpSZXNv
-        dXJjZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAgICAgICAg
-        ICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVtPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4wPC9yYXNk
-        OkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpB
-        dXRvbWF0aWNBbGxvY2F0aW9uPmZhbHNlPC9yYXNkOkF1dG9tYXRpY0FsbG9j
-        YXRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+
-        Q0QvRFZEIERyaXZlPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPkNEL0RWRCBEcml2ZSAxPC9yYXNk
-        OkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkhvc3RS
-        ZXNvdXJjZS8+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJ
-        RD4zMDAyPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6UGFyZW50PjM8L3Jhc2Q6UGFyZW50PgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNTwvcmFzZDpSZXNvdXJjZVR5cGU+
-        CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAg
-        PG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NP
-        blBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPmZhbHNlPC9yYXNk
-        OkF1dG9tYXRpY0FsbG9jYXRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6RGVzY3JpcHRpb24+RmxvcHB5IERyaXZlPC9yYXNkOkRlc2NyaXB0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPkZsb3Bw
-        eSBEcml2ZSAxPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkhvc3RSZXNvdXJjZS8+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6SW5zdGFuY2VJRD44MDAwPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjE0PC9yYXNkOlJl
-        c291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAg
-        ICAgICAgICAgICA8b3ZmOkl0ZW0gdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9u
-        L3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIgdmNsb3VkOmhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L2NwdSI+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWxsb2NhdGlvblVu
-        aXRzPmhlcnR6ICogMTBeNjwvcmFzZDpBbGxvY2F0aW9uVW5pdHM+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+TnVtYmVyIG9mIFZp
-        cnR1YWwgQ1BVczwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpFbGVtZW50TmFtZT4xIHZpcnR1YWwgQ1BVKHMpPC9yYXNk
-        OkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3Rh
-        bmNlSUQ+NDwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOlJlc2VydmF0aW9uPjA8L3Jhc2Q6UmVzZXJ2YXRpb24+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjM8L3Jhc2Q6UmVz
-        b3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxR
-        dWFudGl0eT4xPC9yYXNkOlZpcnR1YWxRdWFudGl0eT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpXZWlnaHQ+MDwvcmFzZDpXZWlnaHQ+CiAgICAgICAg
-        ICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEw
-        LjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02
-        MWEyM2Q2NWI0NTUvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9jcHUiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtK3htbCIv
-        PgogICAgICAgICAgICAgICAgPC9vdmY6SXRlbT4KICAgICAgICAgICAgICAg
-        IDxvdmY6SXRlbSB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2Fy
-        ZS52Y2xvdWQucmFzZEl0ZW0reG1sIiB2Y2xvdWQ6aHJlZj0iaHR0cHM6Ly8x
-        MC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQt
-        NjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbWVtb3J5Ij4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpBbGxvY2F0aW9uVW5pdHM+Ynl0
-        ZSAqIDJeMjA8L3Jhc2Q6QWxsb2NhdGlvblVuaXRzPgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOkRlc2NyaXB0aW9uPk1lbW9yeSBTaXplPC9yYXNkOkRl
-        c2NyaXB0aW9uPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnRO
-        YW1lPjI1NiBNQiBvZiBtZW1vcnk8L3Jhc2Q6RWxlbWVudE5hbWU+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6SW5zdGFuY2VJRD41PC9yYXNkOkluc3Rh
-        bmNlSUQ+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzZXJ2YXRpb24+
-        MDwvcmFzZDpSZXNlcnZhdGlvbj4KICAgICAgICAgICAgICAgICAgICA8cmFz
-        ZDpSZXNvdXJjZVR5cGU+NDwvcmFzZDpSZXNvdXJjZVR5cGU+CiAgICAgICAg
-        ICAgICAgICAgICAgPHJhc2Q6VmlydHVhbFF1YW50aXR5PjI1NjwvcmFzZDpW
-        aXJ0dWFsUXVhbnRpdHk+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6V2Vp
-        Z2h0PjA8L3Jhc2Q6V2VpZ2h0PgogICAgICAgICAgICAgICAgICAgIDxMaW5r
-        IHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAv
-        dm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3ZpcnR1
-        YWxIYXJkd2FyZVNlY3Rpb24vbWVtb3J5IiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiLz4KICAgICAgICAgICAg
-        ICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
-        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFh
-        MjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
-        dWQudmlydHVhbEhhcmR3YXJlU2VjdGlvbit4bWwiLz4KICAgICAgICAgICAg
-        ICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjVi
-        NDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vY3B1IiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiLz4KICAgICAg
-        ICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFh
-        MjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vY3B1IiB0eXBlPSJh
-        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbSt4bWwiLz4K
-        ICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFl
-        NmQtNjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rpb24vbWVtb3J5
-        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRl
-        bSt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZWRpdCIgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBh
-        My00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNlY3Rp
-        b24vbWVtb3J5IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91
-        ZC5yYXNkSXRlbSt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUw
-        MWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJk
-        d2FyZVNlY3Rpb24vZGlza3MiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdh
-        cmUudmNsb3VkLnJhc2RJdGVtc0xpc3QreG1sIi8+CiAgICAgICAgICAgICAg
-        ICA8TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2Fw
-        aS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1
-        NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9uL2Rpc2tzIiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgog
-        ICAgICAgICAgICAgICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczov
-        LzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2
-        ZC02MWEyM2Q2NWI0NTUvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9tZWRpYSIg
-        dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1z
-        TGlzdCt4bWwiLz4KICAgICAgICAgICAgICAgIDxMaW5rIHJlbD0iZG93biIg
-        aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUt
-        ZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3ZpcnR1YWxIYXJkd2FyZVNl
-        Y3Rpb24vbmV0d29ya0NhcmRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
-        YXJlLnZjbG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAgICAgICAg
-        ICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0
-        NTUvdmlydHVhbEhhcmR3YXJlU2VjdGlvbi9uZXR3b3JrQ2FyZHMiIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnJhc2RJdGVtc0xpc3Qr
-        eG1sIi8+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92aXJ0dWFsSGFyZHdhcmVTZWN0aW9u
-        L3NlcmlhbFBvcnRzIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5yYXNkSXRlbXNMaXN0K3htbCIvPgogICAgICAgICAgICAgICAgPExp
-        bmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvdmly
-        dHVhbEhhcmR3YXJlU2VjdGlvbi9zZXJpYWxQb3J0cyIgdHlwZT0iYXBwbGlj
-        YXRpb24vdm5kLnZtd2FyZS52Y2xvdWQucmFzZEl0ZW1zTGlzdCt4bWwiLz4K
-        ICAgICAgICAgICAgPC9vdmY6VmlydHVhbEhhcmR3YXJlU2VjdGlvbj4KICAg
-        ICAgICAgICAgPG92ZjpPcGVyYXRpbmdTeXN0ZW1TZWN0aW9uIHhtbG5zOnZj
-        bG91ZD0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBvdmY6
-        aWQ9Ijk1IiB2Y2xvdWQ6dHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQub3BlcmF0aW5nU3lzdGVtU2VjdGlvbit4bWwiIHZtdzpvc1R5cGU9
-        ImRlYmlhbjRHdWVzdCIgdmNsb3VkOmhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1
-        YjQ1NS9vcGVyYXRpbmdTeXN0ZW1TZWN0aW9uLyI+CiAgICAgICAgICAgICAg
-        ICA8b3ZmOkluZm8+U3BlY2lmaWVzIHRoZSBvcGVyYXRpbmcgc3lzdGVtIGlu
-        c3RhbGxlZDwvb3ZmOkluZm8+CiAgICAgICAgICAgICAgICA8b3ZmOkRlc2Ny
-        aXB0aW9uPkRlYmlhbiBHTlUvTGludXggNCAoMzItYml0KTwvb3ZmOkRlc2Ny
-        aXB0aW9uPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVm
-        PSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEz
-        LTRiN2YtYWU2ZC02MWEyM2Q2NWI0NTUvb3BlcmF0aW5nU3lzdGVtU2VjdGlv
-        bi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm9wZXJh
-        dGluZ1N5c3RlbVNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvb3ZmOk9w
-        ZXJhdGluZ1N5c3RlbVNlY3Rpb24+CiAgICAgICAgICAgIDxOZXR3b3JrQ29u
-        bmVjdGlvblNlY3Rpb24gaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHAvdm0tYWUwMWEyMmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L25l
-        dHdvcmtDb25uZWN0aW9uU2VjdGlvbi8iIHR5cGU9ImFwcGxpY2F0aW9uL3Zu
-        ZC52bXdhcmUudmNsb3VkLm5ldHdvcmtDb25uZWN0aW9uU2VjdGlvbit4bWwi
-        IG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAgPG92ZjpJ
-        bmZvPlNwZWNpZmllcyB0aGUgYXZhaWxhYmxlIFZNIG5ldHdvcmsgY29ubmVj
-        dGlvbnM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPFByaW1hcnlOZXR3
-        b3JrQ29ubmVjdGlvbkluZGV4PjA8L1ByaW1hcnlOZXR3b3JrQ29ubmVjdGlv
-        bkluZGV4PgogICAgICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9uIG5l
-        ZWRzQ3VzdG9taXphdGlvbj0idHJ1ZSIgbmV0d29yaz0idmRjLW5ldC1taWhh
-        Ij4KICAgICAgICAgICAgICAgICAgICA8TmV0d29ya0Nvbm5lY3Rpb25JbmRl
-        eD4wPC9OZXR3b3JrQ29ubmVjdGlvbkluZGV4PgogICAgICAgICAgICAgICAg
-        ICAgIDxJc0Nvbm5lY3RlZD50cnVlPC9Jc0Nvbm5lY3RlZD4KICAgICAgICAg
-        ICAgICAgICAgICA8TUFDQWRkcmVzcz4wMDo1MDo1NjowMTowMDoxNzwvTUFD
-        QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICA8SXBBZGRyZXNzQWxsb2Nh
-        dGlvbk1vZGU+REhDUDwvSXBBZGRyZXNzQWxsb2NhdGlvbk1vZGU+CiAgICAg
-        ICAgICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uPgogICAgICAgICAgICAg
-        ICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRiN2YtYWU2ZC02MWEyM2Q2NWI0
-        NTUvbmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uLyIgdHlwZT0iYXBwbGljYXRp
-        b24vdm5kLnZtd2FyZS52Y2xvdWQubmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9u
-        K3htbCIvPgogICAgICAgICAgICA8L05ldHdvcmtDb25uZWN0aW9uU2VjdGlv
-        bj4KICAgICAgICAgICAgPEd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24gaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBh
-        My00YjdmLWFlNmQtNjFhMjNkNjViNDU1L2d1ZXN0Q3VzdG9taXphdGlvblNl
-        Y3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5n
-        dWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJm
-        YWxzZSI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIEd1
-        ZXN0IE9TIEN1c3RvbWl6YXRpb24gU2V0dGluZ3M8L292ZjpJbmZvPgogICAg
-        ICAgICAgICAgICAgPEVuYWJsZWQ+ZmFsc2U8L0VuYWJsZWQ+CiAgICAgICAg
-        ICAgICAgICA8Q2hhbmdlU2lkPmZhbHNlPC9DaGFuZ2VTaWQ+CiAgICAgICAg
-        ICAgICAgICA8VmlydHVhbE1hY2hpbmVJZD5hZTAxYTIyZS1kMGEzLTRiN2Yt
-        YWU2ZC02MWEyM2Q2NWI0NTU8L1ZpcnR1YWxNYWNoaW5lSWQ+CiAgICAgICAg
-        ICAgICAgICA8Sm9pbkRvbWFpbkVuYWJsZWQ+ZmFsc2U8L0pvaW5Eb21haW5F
-        bmFibGVkPgogICAgICAgICAgICAgICAgPFVzZU9yZ1NldHRpbmdzPmZhbHNl
-        PC9Vc2VPcmdTZXR0aW5ncz4KICAgICAgICAgICAgICAgIDxBZG1pblBhc3N3
-        b3JkRW5hYmxlZD50cnVlPC9BZG1pblBhc3N3b3JkRW5hYmxlZD4KICAgICAg
-        ICAgICAgICAgIDxBZG1pblBhc3N3b3JkQXV0bz50cnVlPC9BZG1pblBhc3N3
-        b3JkQXV0bz4KICAgICAgICAgICAgICAgIDxSZXNldFBhc3N3b3JkUmVxdWly
-        ZWQ+ZmFsc2U8L1Jlc2V0UGFzc3dvcmRSZXF1aXJlZD4KICAgICAgICAgICAg
-        ICAgIDxDb21wdXRlck5hbWU+RGFtblNtYWxsTGktMC1tbTwvQ29tcHV0ZXJO
-        YW1lPgogICAgICAgICAgICAgICAgPExpbmsgcmVsPSJlZGl0IiBocmVmPSJo
-        dHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcC92bS1hZTAxYTIyZS1kMGEzLTRi
-        N2YtYWU2ZC02MWEyM2Q2NWI0NTUvZ3Vlc3RDdXN0b21pemF0aW9uU2VjdGlv
-        bi8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmd1ZXN0
-        Q3VzdG9taXphdGlvblNlY3Rpb24reG1sIi8+CiAgICAgICAgICAgIDwvR3Vl
-        c3RDdXN0b21pemF0aW9uU2VjdGlvbj4KICAgICAgICAgICAgPFJ1bnRpbWVJ
-        bmZvU2VjdGlvbiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJlLmNv
-        bS92Y2xvdWQvdjEuNSIgdmNsb3VkOnR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52
-        bXdhcmUudmNsb3VkLnZpcnR1YWxIYXJkd2FyZVNlY3Rpb24reG1sIiB2Y2xv
-        dWQ6aHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEy
-        MmUtZDBhMy00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3J1bnRpbWVJbmZvU2Vj
-        dGlvbiI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+U3BlY2lmaWVzIFJ1
-        bnRpbWUgaW5mbzwvb3ZmOkluZm8+CiAgICAgICAgICAgIDwvUnVudGltZUlu
-        Zm9TZWN0aW9uPgogICAgICAgICAgICA8U25hcHNob3RTZWN0aW9uIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFhMjJlLWQwYTMt
-        NGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS9zbmFwc2hvdFNlY3Rpb24iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnNuYXBzaG90U2VjdGlv
-        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAgICAg
-        PG92ZjpJbmZvPlNuYXBzaG90IGluZm9ybWF0aW9uIHNlY3Rpb248L292ZjpJ
-        bmZvPgogICAgICAgICAgICA8L1NuYXBzaG90U2VjdGlvbj4KICAgICAgICAg
-        ICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDNUMTM6NDE6MjQuNTMwKzAyOjAw
-        PC9EYXRlQ3JlYXRlZD4KICAgICAgICAgICAgPFZBcHBTY29wZWRMb2NhbElk
-        PjlmNzU2ZDczLTdiMTktNGIxZS04MDRmLWY3YTA0MWFiYzExNDwvVkFwcFNj
-        b3BlZExvY2FsSWQ+CiAgICAgICAgICAgIDxvdmZlbnY6RW52aXJvbm1lbnQg
-        eG1sbnM6bnMxMT0iaHR0cDovL3d3dy52bXdhcmUuY29tL3NjaGVtYS9vdmZl
-        bnYiIG92ZmVudjppZD0iIiBuczExOnZDZW50ZXJJZD0idm0tOTMiPgogICAg
-        ICAgICAgICAgICAgPG92ZmVudjpQbGF0Zm9ybVNlY3Rpb24+CiAgICAgICAg
-        ICAgICAgICAgICAgPG92ZmVudjpLaW5kPlZNd2FyZSBFU1hpPC9vdmZlbnY6
-        S2luZD4KICAgICAgICAgICAgICAgICAgICA8b3ZmZW52OlZlcnNpb24+Ni4w
-        LjA8L292ZmVudjpWZXJzaW9uPgogICAgICAgICAgICAgICAgICAgIDxvdmZl
-        bnY6VmVuZG9yPlZNd2FyZSwgSW5jLjwvb3ZmZW52OlZlbmRvcj4KICAgICAg
-        ICAgICAgICAgICAgICA8b3ZmZW52OkxvY2FsZT5lbjwvb3ZmZW52OkxvY2Fs
-        ZT4KICAgICAgICAgICAgICAgIDwvb3ZmZW52OlBsYXRmb3JtU2VjdGlvbj4K
-        ICAgICAgICAgICAgICAgIDx2ZTpFdGhlcm5ldEFkYXB0ZXJTZWN0aW9uIHht
-        bG5zOnZlPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZmVudiIg
-        eG1sbnM9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9lbnZpcm9ubWVu
-        dC8xIiB4bWxuczpvZT0iaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvb3ZmL2Vu
-        dmlyb25tZW50LzEiPgogICAgICAgICAgICAgICAgICAgIDx2ZTpBZGFwdGVy
-        IHZlOm1hYz0iMDA6NTA6NTY6MDE6MDA6MTciIHZlOm5ldHdvcms9Im5vbmUi
-        IHZlOnVuaXROdW1iZXI9IjciLz4KICAgCiAgICAgICAgICAgICAgICA8L3Zl
-        OkV0aGVybmV0QWRhcHRlclNlY3Rpb24+CiAgICAgICAgICAgIDwvb3ZmZW52
-        OkVudmlyb25tZW50PgogICAgICAgICAgICA8Vm1DYXBhYmlsaXRpZXMgaHJl
-        Zj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHAvdm0tYWUwMWEyMmUtZDBh
-        My00YjdmLWFlNmQtNjFhMjNkNjViNDU1L3ZtQ2FwYWJpbGl0aWVzLyIgdHlw
-        ZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudm1DYXBhYmlsaXRp
-        ZXNTZWN0aW9uK3htbCI+CiAgICAgICAgICAgICAgICA8TGluayByZWw9ImVk
-        aXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwL3ZtLWFlMDFh
-        MjJlLWQwYTMtNGI3Zi1hZTZkLTYxYTIzZDY1YjQ1NS92bUNhcGFiaWxpdGll
-        cy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnZtQ2Fw
-        YWJpbGl0aWVzU2VjdGlvbit4bWwiLz4KICAgICAgICAgICAgICAgIDxNZW1v
-        cnlIb3RBZGRFbmFibGVkPmZhbHNlPC9NZW1vcnlIb3RBZGRFbmFibGVkPgog
-        ICAgICAgICAgICAgICAgPENwdUhvdEFkZEVuYWJsZWQ+ZmFsc2U8L0NwdUhv
-        dEFkZEVuYWJsZWQ+CiAgICAgICAgICAgIDwvVm1DYXBhYmlsaXRpZXM+CiAg
-        ICAgICAgICAgIDxTdG9yYWdlUHJvZmlsZSBocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdmRjU3RvcmFnZVByb2ZpbGUvNDI5NGY3NjctZDllYi00NzI4
-        LWI3ZGQtODFhMmQ3NjgzMGJmIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4K
-        ICAgICAgICA8L1ZtPgogICAgPC9DaGlsZHJlbj4KPC9WQXBwPgo=
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VApp xmlns=\"http://www.vmware.com/vcloud/v1.5\"
+        xmlns:ovf=\"http://schemas.dmtf.org/ovf/envelope/1\" xmlns:vssd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData\"
+        xmlns:rasd=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData\"
+        xmlns:vmw=\"http://www.vmware.com/schema/ovf\" xmlns:ovfenv=\"http://schemas.dmtf.org/ovf/environment/1\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ovfDescriptorUploaded=\"true\"
+        deployed=\"true\" status=\"4\" name=\"spec-1\" id=\"urn:vcloud:vapp:0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        type=\"application/vnd.vmware.vcloud.vApp+xml\" xsi:schemaLocation=\"http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData
+        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd
+        http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1
+        http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://schemas.dmtf.org/ovf/environment/1
+        http://schemas.dmtf.org/ovf/envelope/1/dsp8027_1.1.0.xsd http://www.vmware.com/vcloud/v1.5
+        http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData
+        http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd\">\n
+        \   <Link rel=\"power:powerOff\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/powerOff\"/>\n
+        \   <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reboot\"/>\n
+        \   <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/reset\"/>\n
+        \   <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/shutdown\"/>\n
+        \   <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/power/action/suspend\"/>\n
+        \   <Link rel=\"deploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/deploy\"
+        type=\"application/vnd.vmware.vcloud.deployVAppParams+xml\"/>\n    <Link rel=\"undeploy\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/undeploy\"
+        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n    <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/network/a0912234-e83d-4162-aef1-b48556cef93f\"
+        name=\"INT_192.168.10.0m24\" type=\"application/vnd.vmware.vcloud.vAppNetwork+xml\"/>\n
+        \   <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/controlAccess/\"
+        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"controlAccess\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/controlAccess\"
+        type=\"application/vnd.vmware.vcloud.controlAccess+xml\"/>\n    <Link rel=\"up\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676\"
+        type=\"application/vnd.vmware.vcloud.vdc+xml\"/>\n    <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n    <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/owner\"
+        type=\"application/vnd.vmware.vcloud.owner+xml\"/>\n    <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/metadata\"
+        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n    <Link rel=\"ovf\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/ovf\"
+        type=\"text/xml\"/>\n    <Link rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/productSections/\"
+        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n    <Link rel=\"snapshot:create\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/action/createSnapshot\"
+        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n    <Description/>\n
+        \   <LeaseSettingsSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
+        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\" ovf:required=\"false\">\n
+        \       <ovf:Info>Lease settings section</ovf:Info>\n        <Link rel=\"edit\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/leaseSettingsSection/\"
+        type=\"application/vnd.vmware.vcloud.leaseSettingsSection+xml\"/>\n        <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>\n
+        \       <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>\n        <DeploymentLeaseExpiration>2016-09-23T11:46:52.987+03:00</DeploymentLeaseExpiration>\n
+        \   </LeaseSettingsSection>\n    <ovf:StartupSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.startupSection+xml\">\n        <ovf:Info>VApp
+        startup section</ovf:Info>\n        <ovf:Item ovf:id=\"spec1-vm1\" ovf:order=\"0\"
+        ovf:startAction=\"powerOn\" ovf:startDelay=\"0\" ovf:stopAction=\"powerOff\"
+        ovf:stopDelay=\"0\"/>\n        <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/startupSection/\"
+        type=\"application/vnd.vmware.vcloud.startupSection+xml\"/>\n    </ovf:StartupSection>\n
+        \   <ovf:NetworkSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.networkSection+xml\">\n        <ovf:Info>The
+        list of logical networks</ovf:Info>\n        <ovf:Network ovf:name=\"INT_192.168.10.0m24\">\n
+        \           <ovf:Description/>\n        </ovf:Network>\n    </ovf:NetworkSection>\n
+        \   <NetworkConfigSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\" ovf:required=\"false\">\n
+        \       <ovf:Info>The configuration parameters for logical networks</ovf:Info>\n
+        \       <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/networkConfigSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConfigSection+xml\"/>\n        <NetworkConfig
+        networkName=\"INT_192.168.10.0m24\">\n            <Link rel=\"repair\" href=\"https://VMWARE_CLOUD_HOST/api/admin/network/a0912234-e83d-4162-aef1-b48556cef93f/action/reset\"/>\n
+        \           <Description/>\n            <Configuration>\n                <IpScopes>\n
+        \                   <IpScope>\n                        <IsInherited>true</IsInherited>\n
+        \                       <Gateway>192.168.10.1</Gateway>\n                        <Netmask>255.255.255.0</Netmask>\n
+        \                       <Dns1>192.168.10.1</Dns1>\n                        <DnsSuffix>test.local</DnsSuffix>\n
+        \                       <IsEnabled>true</IsEnabled>\n                        <IpRanges>\n
+        \                           <IpRange>\n                                <StartAddress>192.168.10.100</StartAddress>\n
+        \                               <EndAddress>192.168.10.199</EndAddress>\n
+        \                           </IpRange>\n                        </IpRanges>\n
+        \                   </IpScope>\n                </IpScopes>\n                <ParentNetwork
+        href=\"https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6\"
+        id=\"5ae840de-198e-4a34-a30a-6c36377460c6\" name=\"INT_192.168.10.0m24\"/>\n
+        \               <FenceMode>bridged</FenceMode>\n                <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>\n
+        \           </Configuration>\n            <IsDeployed>true</IsDeployed>\n
+        \       </NetworkConfig>\n    </NetworkConfigSection>\n    <SnapshotSection
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4/snapshotSection\"
+        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
+        \       <ovf:Info>Snapshot information section</ovf:Info>\n    </SnapshotSection>\n
+        \   <DateCreated>2016-09-16T11:45:24.897+03:00</DateCreated>\n    <Owner type=\"application/vnd.vmware.vcloud.owner+xml\">\n
+        \       <User href=\"https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6\"
+        name=\"bergigre_remote\" type=\"application/vnd.vmware.admin.user+xml\"/>\n
+        \   </Owner>\n    <InMaintenanceMode>false</InMaintenanceMode>\n    <Children>\n
+        \       <Vm needsCustomization=\"false\" nestedHypervisorEnabled=\"false\"
+        deployed=\"true\" status=\"4\" name=\"spec1-vm1\" id=\"urn:vcloud:vm:f9ceb77c-b9d9-400c-8c06-72c785e884af\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
+        type=\"application/vnd.vmware.vcloud.vm+xml\">\n            <Link rel=\"power:powerOff\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/powerOff\"/>\n
+        \           <Link rel=\"power:reboot\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reboot\"/>\n
+        \           <Link rel=\"power:reset\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/reset\"/>\n
+        \           <Link rel=\"power:shutdown\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/shutdown\"/>\n
+        \           <Link rel=\"power:suspend\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/power/action/suspend\"/>\n
+        \           <Link rel=\"undeploy\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/undeploy\"
+        type=\"application/vnd.vmware.vcloud.undeployVAppParams+xml\"/>\n            <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af\"
+        type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/metadata\"
+        type=\"application/vnd.vmware.vcloud.metadata+xml\"/>\n            <Link rel=\"down\"
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/productSections/\"
+        type=\"application/vnd.vmware.vcloud.productSections+xml\"/>\n            <Link
+        rel=\"screen:thumbnail\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen\"/>\n
+        \           <Link rel=\"screen:acquireTicket\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/screen/action/acquireTicket\"/>\n
+        \           <Link rel=\"media:insertMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/insertMedia\"
+        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
+        rel=\"media:ejectMedia\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/media/action/ejectMedia\"
+        type=\"application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml\"/>\n            <Link
+        rel=\"disk:attach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/attach\"
+        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
+        rel=\"disk:detach\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/disk/action/detach\"
+        type=\"application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml\"/>\n            <Link
+        rel=\"installVmwareTools\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/installVMwareTools\"/>\n
+        \           <Link rel=\"snapshot:create\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/createSnapshot\"
+        type=\"application/vnd.vmware.vcloud.createSnapshotParams+xml\"/>\n            <Link
+        rel=\"reconfigureVm\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/action/reconfigureVm\"
+        name=\"spec1-vm1\" type=\"application/vnd.vmware.vcloud.vm+xml\"/>\n            <Link
+        rel=\"up\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vapp-0d7614c3-a61d-4d11-a733-aa2a8f6038b4\"
+        type=\"application/vnd.vmware.vcloud.vApp+xml\"/>\n            <Description/>\n
+        \           <ovf:VirtualHardwareSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        ovf:transport=\"\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
+        \               <ovf:Info>Virtual hardware requirements</ovf:Info>\n                <ovf:System>\n
+        \                   <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>\n
+        \                   <vssd:InstanceID>0</vssd:InstanceID>\n                    <vssd:VirtualSystemIdentifier>spec1-vm1</vssd:VirtualSystemIdentifier>\n
+        \                   <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>\n
+        \               </ovf:System>\n                <ovf:Item>\n                    <rasd:Address>00:50:56:01:00:64</rasd:Address>\n
+        \                   <rasd:AddressOnParent>0</rasd:AddressOnParent>\n                    <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>\n
+        \                   <rasd:Connection vcloud:ipAddress=\"192.168.10.100\" vcloud:primaryNetworkConnection=\"true\"
+        vcloud:ipAddressingMode=\"POOL\">INT_192.168.10.0m24</rasd:Connection>\n                    <rasd:Description>Vmxnet3
+        ethernet adapter on \"INT_192.168.10.0m24\"</rasd:Description>\n                    <rasd:ElementName>Network
+        adapter 0</rasd:ElementName>\n                    <rasd:InstanceID>1</rasd:InstanceID>\n
+        \                   <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>\n
+        \                   <rasd:ResourceType>10</rasd:ResourceType>\n                </ovf:Item>\n
+        \               <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
+        \                   <rasd:Description>SCSI Controller</rasd:Description>\n
+        \                   <rasd:ElementName>SCSI Controller 0</rasd:ElementName>\n
+        \                   <rasd:InstanceID>2</rasd:InstanceID>\n                    <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>\n
+        \                   <rasd:ResourceType>6</rasd:ResourceType>\n                </ovf:Item>\n
+        \               <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
+        \                   <rasd:Description>Hard disk</rasd:Description>\n                    <rasd:ElementName>Hard
+        disk 1</rasd:ElementName>\n                    <rasd:HostResource vcloud:capacity=\"16384\"
+        vcloud:busSubType=\"lsilogic\" vcloud:busType=\"6\"/>\n                    <rasd:InstanceID>2000</rasd:InstanceID>\n
+        \                   <rasd:Parent>2</rasd:Parent>\n                    <rasd:ResourceType>17</rasd:ResourceType>\n
+        \                   <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>\n
+        \                   <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>\n
+        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:Address>0</rasd:Address>\n
+        \                   <rasd:Description>IDE Controller</rasd:Description>\n
+        \                   <rasd:ElementName>IDE Controller 0</rasd:ElementName>\n
+        \                   <rasd:InstanceID>3</rasd:InstanceID>\n                    <rasd:ResourceType>5</rasd:ResourceType>\n
+        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
+        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
+        \                   <rasd:Description>CD/DVD Drive</rasd:Description>\n                    <rasd:ElementName>CD/DVD
+        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>3000</rasd:InstanceID>\n
+        \                   <rasd:Parent>3</rasd:Parent>\n                    <rasd:ResourceType>15</rasd:ResourceType>\n
+        \               </ovf:Item>\n                <ovf:Item>\n                    <rasd:AddressOnParent>0</rasd:AddressOnParent>\n
+        \                   <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>\n
+        \                   <rasd:Description>Floppy Drive</rasd:Description>\n                    <rasd:ElementName>Floppy
+        Drive 1</rasd:ElementName>\n                    <rasd:HostResource/>\n                    <rasd:InstanceID>8000</rasd:InstanceID>\n
+        \                   <rasd:ResourceType>14</rasd:ResourceType>\n                </ovf:Item>\n
+        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>hertz
+        * 10^6</rasd:AllocationUnits>\n                    <rasd:Description>Number
+        of Virtual CPUs</rasd:Description>\n                    <rasd:ElementName>2
+        virtual CPU(s)</rasd:ElementName>\n                    <rasd:InstanceID>4</rasd:InstanceID>\n
+        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>3</rasd:ResourceType>\n
+        \                   <rasd:VirtualQuantity>2</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
+        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
+        \               <ovf:Item vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        vcloud:type=\"application/vnd.vmware.vcloud.rasdItem+xml\">\n                    <rasd:AllocationUnits>byte
+        * 2^20</rasd:AllocationUnits>\n                    <rasd:Description>Memory
+        Size</rasd:Description>\n                    <rasd:ElementName>2048 MB of
+        memory</rasd:ElementName>\n                    <rasd:InstanceID>5</rasd:InstanceID>\n
+        \                   <rasd:Reservation>0</rasd:Reservation>\n                    <rasd:ResourceType>4</rasd:ResourceType>\n
+        \                   <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>\n                    <rasd:Weight>0</rasd:Weight>\n
+        \                   <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                </ovf:Item>\n
+        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/\"
+        type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/cpu\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/memory\"
+        type=\"application/vnd.vmware.vcloud.rasdItem+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/media\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/networkCards\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"down\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/serialPorts\"
+        type=\"application/vnd.vmware.vcloud.rasdItemsList+xml\"/>\n            </ovf:VirtualHardwareSection>\n
+        \           <ovf:OperatingSystemSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        ovf:id=\"101\" vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
+        vcloud:type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\" vmw:osType=\"centos64Guest\">\n
+        \               <ovf:Info>Specifies the operating system installed</ovf:Info>\n
+        \               <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>\n
+        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/operatingSystemSection/\"
+        type=\"application/vnd.vmware.vcloud.operatingSystemSection+xml\"/>\n            </ovf:OperatingSystemSection>\n
+        \           <NetworkConnectionSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\" ovf:required=\"false\">\n
+        \               <ovf:Info>Specifies the available VM network connections</ovf:Info>\n
+        \               <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>\n
+        \               <NetworkConnection needsCustomization=\"true\" network=\"INT_192.168.10.0m24\">\n
+        \                   <NetworkConnectionIndex>0</NetworkConnectionIndex>\n                    <IpAddress>192.168.10.100</IpAddress>\n
+        \                   <IsConnected>true</IsConnected>\n                    <MACAddress>00:50:56:01:00:64</MACAddress>\n
+        \                   <IpAddressAllocationMode>POOL</IpAddressAllocationMode>\n
+        \               </NetworkConnection>\n                <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/networkConnectionSection/\"
+        type=\"application/vnd.vmware.vcloud.networkConnectionSection+xml\"/>\n            </NetworkConnectionSection>\n
+        \           <GuestCustomizationSection href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
+        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\" ovf:required=\"false\">\n
+        \               <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>\n
+        \               <Enabled>false</Enabled>\n                <ChangeSid>false</ChangeSid>\n
+        \               <VirtualMachineId>f9ceb77c-b9d9-400c-8c06-72c785e884af</VirtualMachineId>\n
+        \               <JoinDomainEnabled>false</JoinDomainEnabled>\n                <UseOrgSettings>false</UseOrgSettings>\n
+        \               <AdminPasswordEnabled>true</AdminPasswordEnabled>\n                <AdminPasswordAuto>true</AdminPasswordAuto>\n
+        \               <ResetPasswordRequired>false</ResetPasswordRequired>\n                <ComputerName>CentOS7-0</ComputerName>\n
+        \               <Link rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/guestCustomizationSection/\"
+        type=\"application/vnd.vmware.vcloud.guestCustomizationSection+xml\"/>\n            </GuestCustomizationSection>\n
+        \           <RuntimeInfoSection xmlns:vcloud=\"http://www.vmware.com/vcloud/v1.5\"
+        vcloud:href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/runtimeInfoSection\"
+        vcloud:type=\"application/vnd.vmware.vcloud.virtualHardwareSection+xml\">\n
+        \               <ovf:Info>Specifies Runtime info</ovf:Info>\n                <VMWareTools
+        version=\"10240\"/>\n            </RuntimeInfoSection>\n            <SnapshotSection
+        href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/snapshotSection\"
+        type=\"application/vnd.vmware.vcloud.snapshotSection+xml\" ovf:required=\"false\">\n
+        \               <ovf:Info>Snapshot information section</ovf:Info>\n            </SnapshotSection>\n
+        \           <DateCreated>2016-09-16T11:45:30.557+03:00</DateCreated>\n            <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>\n
+        \           <ovfenv:Environment xmlns:ns11=\"http://www.vmware.com/schema/ovfenv\"
+        ovfenv:id=\"\" ns11:vCenterId=\"vm-589\">\n                <ovfenv:PlatformSection>\n
+        \                   <ovfenv:Kind>VMware ESXi</ovfenv:Kind>\n                    <ovfenv:Version>6.0.0</ovfenv:Version>\n
+        \                   <ovfenv:Vendor>VMware, Inc.</ovfenv:Vendor>\n                    <ovfenv:Locale>en</ovfenv:Locale>\n
+        \               </ovfenv:PlatformSection>\n                <ve:EthernetAdapterSection
+        xmlns:ve=\"http://www.vmware.com/schema/ovfenv\" xmlns=\"http://schemas.dmtf.org/ovf/environment/1\"
+        xmlns:oe=\"http://schemas.dmtf.org/ovf/environment/1\">\n                    <ve:Adapter
+        ve:mac=\"00:50:56:01:00:64\" ve:network=\"vxw-dvs-128-virtualwire-18-sid-5004-dvs.VCDVSINT_192.168.10.0m24-55dcece1-954f-4\"
+        ve:unitNumber=\"7\"/>\n   \n                </ve:EthernetAdapterSection>\n
+        \           </ovfenv:Environment>\n            <VmCapabilities href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
+        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\">\n                <Link
+        rel=\"edit\" href=\"https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/vmCapabilities/\"
+        type=\"application/vnd.vmware.vcloud.vmCapabilitiesSection+xml\"/>\n                <MemoryHotAddEnabled>false</MemoryHotAddEnabled>\n
+        \               <CpuHotAddEnabled>false</CpuHotAddEnabled>\n            </VmCapabilities>\n
+        \           <StorageProfile href=\"https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8\"
+        name=\"Dual site - Tier 1\" type=\"application/vnd.vmware.vcloud.vdcStorageProfile+xml\"/>\n
+        \       </Vm>\n    </Children>\n</VApp>\n"
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:05 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:25 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-224dbb24-9639-4d97-8d36-801e7ccce7e9/virtualHardwareSection/disks
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d
     body:
       encoding: US-ASCII
       string: ''
@@ -5589,65 +1435,614 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:03 GMT
+      - Fri, 16 Sep 2016 08:52:30 GMT
       X-Vmware-Vcloud-Request-Id:
-      - cacd8e2d-f40e-40a7-b5ed-ea1c8675f154
+      - b8589d88-f899-4e82-a6df-6886e1e71a6b
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '44'
+      - '275'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="3" name="vApp_system_4" id="urn:vcloud:vapp:6aa2d7ae-5245-45a0-82e8-4984e759ba5d" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/power/action/powerOn"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/discardSuspendedState"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/82759035-35af-4b27-a273-65e3dcaefb73" name="testnet" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Description/>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-15T16:56:20.453+03:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
+                <ovf:Info>VApp startup section</ovf:Info>
+                <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+            </ovf:StartupSection>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="testnet">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="testnet">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/82759035-35af-4b27-a273-65e3dcaefb73/action/reset"/>
+                    <Description/>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.2.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.2.100</StartAddress>
+                                        <EndAddress>192.168.2.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                <ovf:Info>Snapshot information section</ovf:Info>
+            </SnapshotSection>
+            <DateCreated>2016-09-08T16:48:46.357+03:00</DateCreated>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/3fde93ae-0521-4a75-8dec-cb4bcb7dcbb0" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <InMaintenanceMode>false</InMaintenanceMode>
+            <Children>
+                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="3" name="CentOS7" id="urn:vcloud:vm:8df2faf3-fd33-40de-9b26-da34c146f55d" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="discardState" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/discardSuspendedState"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/screen"/>
+                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/enableNestedHypervisor"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/action/reconfigureVm" name="CentOS7" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-6aa2d7ae-5245-45a0-82e8-4984e759ba5d" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description/>
+                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:4a</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+                            <rasd:Connection vcloud:ipAddress="192.168.2.100" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">testnet</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "testnet"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                    </ovf:VirtualHardwareSection>
+                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                    </ovf:OperatingSystemSection>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="false" network="testnet">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.2.100</IpAddress>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:4a</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>8df2faf3-fd33-40de-9b26-da34c146f55d</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <AdminPassword>nN%9oQTG</AdminPassword>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7-0</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                    </GuestCustomizationSection>
+                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                        <ovf:Info>Specifies Runtime info</ovf:Info>
+                        <VMWareTools version="10240"/>
+                    </RuntimeInfoSection>
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                        <ovf:Info>Snapshot information section</ovf:Info>
+                    </SnapshotSection>
+                    <DateCreated>2016-09-08T16:48:57.753+03:00</DateCreated>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                    </VmCapabilities>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                </Vm>
+            </Children>
+        </VApp>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:52:31 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:52:36 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 077b9e5c-02b4-4a62-9d36-9f1e134fdcd8
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '138'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapp+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VApp xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ovfDescriptorUploaded="true" deployed="false" status="8" name="spec2" id="urn:vcloud:vapp:f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/power/action/powerOn"/>
+            <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/network/d91117a6-33d6-4a51-96e3-8d761b145726" name="INT_192.168.10.0m24" type="application/vnd.vmware.vcloud.vAppNetwork+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="recompose" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/recomposeVApp" type="application/vnd.vmware.vcloud.recomposeVAppParams+xml"/>
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/disableDownload"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/ovf" type="text/xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+            <Description/>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <DeploymentLeaseInSeconds>604800</DeploymentLeaseInSeconds>
+                <StorageLeaseInSeconds>2592000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-10-16T11:46:10.463+03:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <ovf:StartupSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" vcloud:type="application/vnd.vmware.vcloud.startupSection+xml">
+                <ovf:Info>VApp startup section</ovf:Info>
+                <ovf:Item ovf:id="spec2-vm1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/startupSection/" type="application/vnd.vmware.vcloud.startupSection+xml"/>
+            </ovf:StartupSection>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="INT_192.168.10.0m24">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml"/>
+                <NetworkConfig networkName="INT_192.168.10.0m24">
+                    <Link rel="repair" href="https://VMWARE_CLOUD_HOST/api/admin/network/d91117a6-33d6-4a51-96e3-8d761b145726/action/reset"/>
+                    <Description/>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>true</IsInherited>
+                                <Gateway>192.168.10.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <Dns1>192.168.10.1</Dns1>
+                                <DnsSuffix>test.local</DnsSuffix>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.10.100</StartAddress>
+                                        <EndAddress>192.168.10.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <ParentNetwork href="https://VMWARE_CLOUD_HOST/api/admin/network/5ae840de-198e-4a34-a30a-6c36377460c6" id="5ae840de-198e-4a34-a30a-6c36377460c6" name="INT_192.168.10.0m24"/>
+                        <FenceMode>bridged</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                <ovf:Info>Snapshot information section</ovf:Info>
+            </SnapshotSection>
+            <DateCreated>2016-09-16T11:46:10.347+03:00</DateCreated>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/81585659-9eaa-46e7-8100-3b0ea0aa4fd6" name="bergigre_remote" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <InMaintenanceMode>false</InMaintenanceMode>
+            <Children>
+                <Vm needsCustomization="false" nestedHypervisorEnabled="false" deployed="false" status="8" name="spec2-vm1" id="urn:vcloud:vm:a28be0c0-d70d-4047-92f8-fc217bbaa7f6" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="power:powerOn" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/power/action/powerOn"/>
+                    <Link rel="deploy" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+                    <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Link rel="screen:thumbnail" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/screen"/>
+                    <Link rel="media:insertMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="media:ejectMedia" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+                    <Link rel="disk:attach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="disk:detach" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+                    <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/enableNestedHypervisor"/>
+                    <Link rel="snapshot:create" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+                    <Link rel="reconfigureVm" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/action/reconfigureVm" name="spec2-vm1" type="application/vnd.vmware.vcloud.vm+xml"/>
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vApp/vapp-f1cc4bb2-b1be-4c11-b5d5-0587c482a7cd" type="application/vnd.vmware.vcloud.vApp+xml"/>
+                    <Description/>
+                    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:VirtualSystemIdentifier>spec2-vm1</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:65</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+                            <rasd:Connection vcloud:ipAddress="192.168.10.101" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">INT_192.168.10.0m24</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "INT_192.168.10.0m24"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <ovf:Item vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        </ovf:Item>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+                    </ovf:VirtualHardwareSection>
+                    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+                    </ovf:OperatingSystemSection>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IpAddress>192.168.10.101</IpAddress>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:65</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>a28be0c0-d70d-4047-92f8-fc217bbaa7f6</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7-0</ComputerName>
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+                    </GuestCustomizationSection>
+                    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+                        <ovf:Info>Specifies Runtime info</ovf:Info>
+                        <VMWareTools version="10240"/>
+                    </RuntimeInfoSection>
+                    <SnapshotSection href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+                        <ovf:Info>Snapshot information section</ovf:Info>
+                    </SnapshotSection>
+                    <DateCreated>2016-09-16T11:46:14.080+03:00</DateCreated>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <VmCapabilities href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+                        <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+                        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+                        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+                    </VmCapabilities>
+                    <StorageProfile href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                </Vm>
+            </Children>
+        </VApp>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:52:37 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:52:42 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - a7d426e0-3df1-4e09-b6eb-5936ee702e36
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '132'
       Content-Type:
       - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2051'
+      - '2169'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-224dbb24-9639-4d97-8d36-801e7ccce7e9/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-224dbb24-9639-4d97-8d36-801e7ccce7e9/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-f9ceb77c-b9d9-400c-8c06-72c785e884af/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
             <Item>
                 <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:Description>SCSI Controller</rasd:Description>
+                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                 <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
+                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                <rasd:ResourceType>6</rasd:ResourceType>
             </Item>
             <Item>
                 <rasd:AddressOnParent>0</rasd:AddressOnParent>
                 <rasd:Description>Hard disk</rasd:Description>
                 <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="256"></rasd:HostResource>
-                <rasd:InstanceID>3000</rasd:InstanceID>
+                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"></rasd:HostResource>
+                <rasd:InstanceID>2000</rasd:InstanceID>
                 <rasd:Parent>2</rasd:Parent>
                 <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>268435456</rasd:VirtualQuantity>
+                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                 <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
             </Item>
             <Item>
-                <rasd:Address>1</rasd:Address>
+                <rasd:Address>0</rasd:Address>
                 <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
                 <rasd:InstanceID>3</rasd:InstanceID>
                 <rasd:ResourceType>5</rasd:ResourceType>
             </Item>
         </RasdItemsList>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:05 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:42 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5657,156 +2052,20 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:03 GMT
+      - Fri, 16 Sep 2016 08:52:47 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 1134f062-a70d-4b8b-97a6-b5811b067cc7
+      - 578a96d1-4580-4cba-9bf9-b7056c040f13
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '36'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2049'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-f4625547-9bba-4ec9-bcd8-7cb3c5ca0290/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"></rasd:HostResource>
-                <rasd:InstanceID>3000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>1</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:05 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:03 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 76816cca-97f1-4058-bb09-bca6de8f7630
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '41'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2049'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-6844a379-61be-4652-817a-f14bb5f09512/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"></rasd:HostResource>
-                <rasd:InstanceID>3000</rasd:InstanceID>
-                <rasd:Parent>2</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>1</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
-                <rasd:InstanceID>3</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:06 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-3f15df14-4672-4d14-a396-0ddf7b14442a/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:04 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - c2022d86-d330-4ff3-a5ee-7e9e36b91fa8
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
       - '45'
       Content-Type:
@@ -5814,112 +2073,45 @@ http_interactions:
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2049'
+      - '2169'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-3f15df14-4672-4d14-a396-0ddf7b14442a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-3f15df14-4672-4d14-a396-0ddf7b14442a/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-8df2faf3-fd33-40de-9b26-da34c146f55d/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
             <Item>
                 <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
-                <rasd:InstanceID>4</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-            <Item>
-                <rasd:AddressOnParent>0</rasd:AddressOnParent>
-                <rasd:Description>Hard disk</rasd:Description>
-                <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"></rasd:HostResource>
-                <rasd:InstanceID>3000</rasd:InstanceID>
-                <rasd:Parent>4</rasd:Parent>
-                <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
-                <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
-            </Item>
-            <Item>
-                <rasd:Address>1</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
-                <rasd:InstanceID>5</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
-            </Item>
-        </RasdItemsList>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:06 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-328344e4-22fc-43a1-a51d-b096e64032e9/virtualHardwareSection/disks
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:04 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - b3a8dfc9-2a1d-4ad1-a7d9-bbfc59223f2a
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '39'
-      Content-Type:
-      - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '2049'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-328344e4-22fc-43a1-a51d-b096e64032e9/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-328344e4-22fc-43a1-a51d-b096e64032e9/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
-            <Item>
-                <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:Description>SCSI Controller</rasd:Description>
+                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                 <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
+                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                <rasd:ResourceType>6</rasd:ResourceType>
             </Item>
             <Item>
                 <rasd:AddressOnParent>0</rasd:AddressOnParent>
                 <rasd:Description>Hard disk</rasd:Description>
                 <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"></rasd:HostResource>
-                <rasd:InstanceID>3000</rasd:InstanceID>
+                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"></rasd:HostResource>
+                <rasd:InstanceID>2000</rasd:InstanceID>
                 <rasd:Parent>2</rasd:Parent>
                 <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                 <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
             </Item>
             <Item>
-                <rasd:Address>1</rasd:Address>
+                <rasd:Address>0</rasd:Address>
                 <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
                 <rasd:InstanceID>3</rasd:InstanceID>
                 <rasd:ResourceType>5</rasd:ResourceType>
             </Item>
         </RasdItemsList>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:06 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:48 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-ae01a22e-d0a3-4b7f-ae6d-61a23d65b455/virtualHardwareSection/disks
+    uri: https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks
     body:
       encoding: US-ASCII
       string: ''
@@ -5929,65 +2121,66 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:04 GMT
+      - Fri, 16 Sep 2016 08:52:52 GMT
       X-Vmware-Vcloud-Request-Id:
-      - d45efbbd-3b14-49c6-9cc7-639ced883c88
+      - 53ee9bf5-f808-49d8-afbe-a7a5f7d2485f
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '37'
+      - '42'
       Content-Type:
       - application/vnd.vmware.vcloud.rasditemslist+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2051'
+      - '2169'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://10.30.2.2/api/vApp/vm-ae01a22e-d0a3-4b7f-ae6d-61a23d65b455/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <Link rel="edit" href="https://10.30.2.2/api/vApp/vm-ae01a22e-d0a3-4b7f-ae6d-61a23d65b455/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <RasdItemsList xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vApp/vm-a28be0c0-d70d-4047-92f8-fc217bbaa7f6/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
             <Item>
                 <rasd:Address>0</rasd:Address>
-                <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                <rasd:Description>SCSI Controller</rasd:Description>
+                <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                 <rasd:InstanceID>2</rasd:InstanceID>
-                <rasd:ResourceType>5</rasd:ResourceType>
+                <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                <rasd:ResourceType>6</rasd:ResourceType>
             </Item>
             <Item>
                 <rasd:AddressOnParent>0</rasd:AddressOnParent>
                 <rasd:Description>Hard disk</rasd:Description>
                 <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="256"></rasd:HostResource>
-                <rasd:InstanceID>3000</rasd:InstanceID>
+                <rasd:HostResource xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"></rasd:HostResource>
+                <rasd:InstanceID>2000</rasd:InstanceID>
                 <rasd:Parent>2</rasd:Parent>
                 <rasd:ResourceType>17</rasd:ResourceType>
-                <rasd:VirtualQuantity>268435456</rasd:VirtualQuantity>
+                <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                 <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
             </Item>
             <Item>
-                <rasd:Address>1</rasd:Address>
+                <rasd:Address>0</rasd:Address>
                 <rasd:Description>IDE Controller</rasd:Description>
-                <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                <rasd:ElementName>IDE Controller 0</rasd:ElementName>
                 <rasd:InstanceID>3</rasd:InstanceID>
                 <rasd:ResourceType>5</rasd:ResourceType>
             </Item>
         </RasdItemsList>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:07 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:53 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3
+    uri: https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f
     body:
       encoding: US-ASCII
       string: ''
@@ -5997,52 +2190,92 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:04 GMT
+      - Fri, 16 Sep 2016 08:52:58 GMT
       X-Vmware-Vcloud-Request-Id:
-      - c8c5be92-07d3-4303-9677-09a05a168030
+      - 1f376632-d0db-4d65-b5b1-308fff5bba56
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '83'
+      - '140'
       Content-Type:
       - application/vnd.vmware.vcloud.org+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2255'
+      - '2589'
     body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Org xmlns="http://www.vmware.com/vcloud/v1.5" name="test" id="urn:vcloud:org:43b4c159-f280-4f79-a6c6-3b2f27e150c3" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="down" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" name="test-vdc" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vdc/55b4531e-1b72-4a66-bc75-2e42d3b7cb79" name="vdc-m_in_m" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/tasksList/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.tasksList+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" name="firstcatalog" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/admin/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3/catalogs" type="application/vnd.vmware.admin.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/44e44269-2fd3-4764-a071-cd8fe752b88b" name="test-direct-connected" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/network/5b5c6310-2628-454a-be6d-95946e6941af" name="vdc-net-miha" type="application/vnd.vmware.vcloud.orgNetwork+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/supportedSystemsInfo/" type="application/vnd.vmware.vcloud.supportedSystemsInfo+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Description/>
-            <FullName>Testers we ARE</FullName>
-        </Org>
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPE9yZyB4
+        bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IiBuYW1l
+        PSJNSVFEZXYiIGlkPSJ1cm46dmNsb3VkOm9yZzplMzM4YTRhYy01NTFiLTRi
+        NmMtYjVjMC1hZmYzMWI3MTQxN2YiIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NM
+        T1VEX0hPU1QvYXBpL29yZy9lMzM4YTRhYy01NTFiLTRiNmMtYjVjMC1hZmYz
+        MWI3MTQxN2YiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3Vk
+        Lm9yZyt4bWwiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9Y
+        TUxTY2hlbWEtaW5zdGFuY2UiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDov
+        L3d3dy52bXdhcmUuY29tL3ZjbG91ZC92MS41IGh0dHA6Ly9WTVdBUkVfQ0xP
+        VURfSE9TVC9hcGkvdjEuNS9zY2hlbWEvbWFzdGVyLnhzZCI+CiAgICA8TGlu
+        ayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1Qv
+        YXBpL3ZkYy84OWFkZTk2OS0xZGM0LTQxNTYtYWJhZC1lMjlmNzk1MTE2NzYi
+        IG5hbWU9Ik1JUURldi1EZWZhdWx0LXZDRC1EdWFsU2l0ZVN0b3JhZ2UtUEFZ
+        RyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQudmRjK3ht
+        bCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczovL1ZNV0FS
+        RV9DTE9VRF9IT1NUL2FwaS90YXNrc0xpc3QvZTMzOGE0YWMtNTUxYi00YjZj
+        LWI1YzAtYWZmMzFiNzE0MTdmIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13
+        YXJlLnZjbG91ZC50YXNrc0xpc3QreG1sIi8+CiAgICA8TGluayByZWw9ImRv
+        d24iIGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFs
+        b2cvMDQ5MGFkM2ItZjM0My00YjgwLThkNWItZWNiMDM5N2ZkNDEyIiBuYW1l
+        PSJTaGFyZWQgVGlldG8gQ2F0YWxvZyIgdHlwZT0iYXBwbGljYXRpb24vdm5k
+        LnZtd2FyZS52Y2xvdWQuY2F0YWxvZyt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
+        ZG93biIgaHJlZj0iaHR0cHM6Ly9WTVdBUkVfQ0xPVURfSE9TVC9hcGkvY2F0
+        YWxvZy8wNDkwYWQzYi1mMzQzLTRiODAtOGQ1Yi1lY2IwMzk3ZmQ0MTIvY29u
+        dHJvbEFjY2Vzcy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmNvbnRyb2xBY2Nlc3MreG1sIi8+CiAgICA8TGluayByZWw9ImRvd24i
+        IGhyZWY9Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cv
+        MjYxMDM3YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkIiBuYW1lPSJY
+        VGVzdENhdGFsb2ciIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNs
+        b3VkLmNhdGFsb2creG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9
+        Imh0dHBzOi8vVk1XQVJFX0NMT1VEX0hPU1QvYXBpL2NhdGFsb2cvMjYxMDM3
+        YmMtODI5OS00MmMxLTlhYzEtYjhjNGM5NjRkOTlkL2NvbnRyb2xBY2Nlc3Mv
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jb250cm9s
+        QWNjZXNzK3htbCIvPgogICAgPExpbmsgcmVsPSJjb250cm9sQWNjZXNzIiBo
+        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9jYXRhbG9nLzI2
+        MTAzN2JjLTgyOTktNDJjMS05YWMxLWI4YzRjOTY0ZDk5ZC9hY3Rpb24vY29u
+        dHJvbEFjY2VzcyIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xv
+        dWQuY29udHJvbEFjY2Vzcyt4bWwiLz4KICAgIDxMaW5rIHJlbD0iYWRkIiBo
+        cmVmPSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9hZG1pbi9vcmcv
+        ZTMzOGE0YWMtNTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL2NhdGFsb2dz
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLmFkbWluLmNhdGFsb2cr
+        eG1sIi8+CiAgICA8TGluayByZWw9ImRvd24iIGhyZWY9Imh0dHBzOi8vVk1X
+        QVJFX0NMT1VEX0hPU1QvYXBpL25ldHdvcmsvNWFlODQwZGUtMTk4ZS00YTM0
+        LWEzMGEtNmMzNjM3NzQ2MGM2IiBuYW1lPSJJTlRfMTkyLjE2OC4xMC4wbTI0
+        IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5vcmdOZXR3
+        b3JrK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVmPSJodHRwczov
+        L1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9zdXBwb3J0ZWRTeXN0ZW1zSW5mby8i
+        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnN1cHBvcnRl
+        ZFN5c3RlbXNJbmZvK3htbCIvPgogICAgPExpbmsgcmVsPSJkb3duIiBocmVm
+        PSJodHRwczovL1ZNV0FSRV9DTE9VRF9IT1NUL2FwaS9vcmcvZTMzOGE0YWMt
+        NTUxYi00YjZjLWI1YzAtYWZmMzFiNzE0MTdmL21ldGFkYXRhIiB0eXBlPSJh
+        cHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRhZGF0YSt4bWwiLz4K
+        ICAgIDxEZXNjcmlwdGlvbj5Pcmdhbml6YXRpb24gZm9yIFJlZEhhdCBkZXZl
+        bG9wbWVudCBvZiBNYW5hZ2VJUSB2Q2xvdWQgY29ubmVjdG9yDUNvbnRhY3Qg
+        RGF2aWQgQmFydG/FoTwvRGVzY3JpcHRpb24+CiAgICA8RnVsbE5hbWU+TWFu
+        YWdlSVEgRGV2ZWxvcG1lbnQ8L0Z1bGxOYW1lPgo8L09yZz4K
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:07 GMT
+  recorded_at: Fri, 16 Sep 2016 08:52:59 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412
     body:
       encoding: US-ASCII
       string: ''
@@ -6052,52 +2285,51 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:05 GMT
+      - Fri, 16 Sep 2016 08:53:03 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 585f76d0-c337-46f7-b0f7-732e615e43e6
+      - fd94a0ab-4175-49ae-9961-ba67eb000e13
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '25'
+      - '91'
       Content-Type:
       - application/vnd.vmware.vcloud.catalog+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2081'
+      - '2211'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="firstcatalog" id="urn:vcloud:catalog:b7705e3a-14ec-43a1-bf8c-6b5df417d849" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Description/>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="Shared Tieto Catalog" id="urn:vcloud:catalog:0490ad3b-f343-4b80-8d5b-ecb0397fd412" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description>Tieto Shared Catalog</Description>
             <CatalogItems>
-                <CatalogItem href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" id="322441c4-d47c-4346-9188-b6044fdca875" name="vApp_system_5" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" id="90edc242-bf2a-4ee3-892f-0a3f87e6e680" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" id="e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" id="23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" name="Tieto Linux CentOS 7.0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a" id="42800327-57ed-433e-8ca4-17a33843cc0a" name="CentOS 7 Everything" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936" id="59d0aebb-aad0-4f01-9fd6-082fca414936" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12" id="6d250e6a-0cfe-4749-af3d-700fe490cb12" name="Win2012R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" id="e8734bdb-af24-443e-9496-10f367424316" name="Tieto Windows Server 2012 R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
             </CatalogItems>
             <IsPublished>false</IsPublished>
-            <DateCreated>2016-07-14T14:54:21.233+02:00</DateCreated>
+            <DateCreated>2016-08-02T11:09:57.957+03:00</DateCreated>
         </Catalog>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:07 GMT
+  recorded_at: Fri, 16 Sep 2016 08:53:04 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412
     body:
       encoding: US-ASCII
       string: ''
@@ -6107,52 +2339,51 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:05 GMT
+      - Fri, 16 Sep 2016 08:53:09 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 2ea0f619-3f59-45ee-978a-cc35951665ef
+      - 6b25fe17-0b30-4402-82ec-c3182765f3cc
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '17'
+      - '63'
       Content-Type:
       - application/vnd.vmware.vcloud.catalog+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '2081'
+      - '2211'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="firstcatalog" id="urn:vcloud:catalog:b7705e3a-14ec-43a1-bf8c-6b5df417d849" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/org/43b4c159-f280-4f79-a6c6-3b2f27e150c3" type="application/vnd.vmware.vcloud.org+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="add" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Link rel="controlAccess" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
-            <Description/>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="Shared Tieto Catalog" id="urn:vcloud:catalog:0490ad3b-f343-4b80-8d5b-ecb0397fd412" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description>Tieto Shared Catalog</Description>
             <CatalogItems>
-                <CatalogItem href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" id="322441c4-d47c-4346-9188-b6044fdca875" name="vApp_system_5" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" id="90edc242-bf2a-4ee3-892f-0a3f87e6e680" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-                <CatalogItem href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" id="e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" id="23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" name="Tieto Linux CentOS 7.0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a" id="42800327-57ed-433e-8ca4-17a33843cc0a" name="CentOS 7 Everything" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936" id="59d0aebb-aad0-4f01-9fd6-082fca414936" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12" id="6d250e6a-0cfe-4749-af3d-700fe490cb12" name="Win2012R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" id="e8734bdb-af24-443e-9496-10f367424316" name="Tieto Windows Server 2012 R2" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
             </CatalogItems>
             <IsPublished>false</IsPublished>
-            <DateCreated>2016-07-14T14:54:21.233+02:00</DateCreated>
+            <DateCreated>2016-08-02T11:09:57.957+03:00</DateCreated>
         </Catalog>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:08 GMT
+  recorded_at: Fri, 16 Sep 2016 08:53:09 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0
     body:
       encoding: US-ASCII
       string: ''
@@ -6162,46 +2393,44 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:06 GMT
+      - Fri, 16 Sep 2016 08:53:14 GMT
       X-Vmware-Vcloud-Request-Id:
-      - cfe7f9b6-2e8b-4798-bc25-7649a4e45d22
+      - b92fb332-f42a-4548-a6f9-8d33543c5138
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '195'
+      - '172'
       Content-Type:
       - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '1311'
+      - '1142'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="vApp_system_5" id="urn:vcloud:catalogitem:322441c4-d47c-4346-9188-b6044fdca875" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875"/>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="Tieto Linux CentOS 7.0" id="urn:vcloud:catalogitem:23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
             <Description/>
-            <Entity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" name="vApp_system_5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-07-29T09:48:01.087+02:00</DateCreated>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" name="Tieto Linux CentOS 7.0" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-08-02T16:34:24.980+03:00</DateCreated>
         </CatalogItem>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:08 GMT
+  recorded_at: Fri, 16 Sep 2016 08:53:15 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57
     body:
       encoding: US-ASCII
       string: ''
@@ -6211,592 +2440,124 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:06 GMT
+      - Fri, 16 Sep 2016 08:53:20 GMT
       X-Vmware-Vcloud-Request-Id:
-      - a260a394-f585-4b23-8f7c-ca7c7147c2a0
+      - 52fbe006-bb92-439f-98c7-89b7f4ae90c3
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '320'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_system_5" id="urn:vcloud:vapptemplate:674bc33b-c6be-4c70-9813-c9bda69839ee" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/disableDownload"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="Small VM" id="urn:vcloud:vm:2ef97da4-7b83-4d92-9cbc-a3df64eeca92" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="test-direct-connected">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:08</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>SmallVM</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>0e6c69f9-eea7-4d99-bda3-13687febaca5</VAppScopedLocalId>
-                    <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkSection/">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="test-direct-connected">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="test-direct-connected">
-                    <Description/>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>10.30.2.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>8.8.8.8</Dns1>
-                                <Dns2>8.8.4.4</Dns2>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>10.30.2.51</StartAddress>
-                                        <EndAddress>10.30.2.60</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <ParentNetwork href="" name="test-direct-connected"/>
-                        <FenceMode>natRouted</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <FirewallService>
-                                <IsEnabled>true</IsEnabled>
-                                <DefaultAction>drop</DefaultAction>
-                                <LogDefaultAction>false</LogDefaultAction>
-                                <FirewallRule>
-                                    <IsEnabled>true</IsEnabled>
-                                    <MatchOnTranslate>false</MatchOnTranslate>
-                                    <Description>Allow all outgoing traffic</Description>
-                                    <Policy>allow</Policy>
-                                    <Protocols>
-                                        <Any>true</Any>
-                                    </Protocols>
-                                    <Port>-1</Port>
-                                    <DestinationPortRange>Any</DestinationPortRange>
-                                    <DestinationIp>external</DestinationIp>
-                                    <SourcePort>-1</SourcePort>
-                                    <SourcePortRange>Any</SourcePortRange>
-                                    <SourceIp>internal</SourceIp>
-                                    <EnableLogging>false</EnableLogging>
-                                </FirewallRule>
-                            </FirewallService>
-                        </Features>
-                        <SyslogServerSettings/>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:09 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:07 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 68a7aaf8-2120-49a3-8c76-51b45ba1aeaa
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '314'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_system_5" id="urn:vcloud:vapptemplate:674bc33b-c6be-4c70-9813-c9bda69839ee" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/disableDownload"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="Small VM" id="urn:vcloud:vm:2ef97da4-7b83-4d92-9cbc-a3df64eeca92" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="test-direct-connected">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:08</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>SmallVM</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>0e6c69f9-eea7-4d99-bda3-13687febaca5</VAppScopedLocalId>
-                    <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkSection/">
-                <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="test-direct-connected">
-                    <ovf:Description/>
-                </ovf:Network>
-            </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="test-direct-connected">
-                    <Description/>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>10.30.2.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>8.8.8.8</Dns1>
-                                <Dns2>8.8.4.4</Dns2>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>10.30.2.51</StartAddress>
-                                        <EndAddress>10.30.2.60</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <ParentNetwork href="" name="test-direct-connected"/>
-                        <FenceMode>natRouted</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <FirewallService>
-                                <IsEnabled>true</IsEnabled>
-                                <DefaultAction>drop</DefaultAction>
-                                <LogDefaultAction>false</LogDefaultAction>
-                                <FirewallRule>
-                                    <IsEnabled>true</IsEnabled>
-                                    <MatchOnTranslate>false</MatchOnTranslate>
-                                    <Description>Allow all outgoing traffic</Description>
-                                    <Policy>allow</Policy>
-                                    <Protocols>
-                                        <Any>true</Any>
-                                    </Protocols>
-                                    <Port>-1</Port>
-                                    <DestinationPortRange>Any</DestinationPortRange>
-                                    <DestinationIp>external</DestinationIp>
-                                    <SourcePort>-1</SourcePort>
-                                    <SourcePortRange>Any</SourcePortRange>
-                                    <SourceIp>internal</SourceIp>
-                                    <EnableLogging>false</EnableLogging>
-                                </FirewallRule>
-                            </FirewallService>
-                        </Features>
-                        <SyslogServerSettings/>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
-                <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
-        </VAppTemplate>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:10 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:08 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 1d909ba9-c569-42b5-becc-bdbea2c373d9
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '147'
-      Content-Type:
-      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-      Content-Length:
-      - '1321'
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="DSL-Linux-template" id="urn:vcloud:catalogitem:90edc242-bf2a-4ee3-892f-0a3f87e6e680" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/catalogItem/90edc242-bf2a-4ee3-892f-0a3f87e6e680"/>
-            <Description/>
-            <Entity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868" name="DSL-Linux-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-08-01T14:04:44.247+02:00</DateCreated>
-        </CatalogItem>
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:10 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:08 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 4cca3559-728c-4092-8b31-2576149f8aa1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '226'
+      - '855'
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHBU
-        ZW1wbGF0ZSB4bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
-        MS41IiB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
-        bnZlbG9wZS8xIiBnb2xkTWFzdGVyPSJmYWxzZSIgb3ZmRGVzY3JpcHRvclVw
-        bG9hZGVkPSJ0cnVlIiBzdGF0dXM9IjgiIG5hbWU9IkRTTC1MaW51eC10ZW1w
-        bGF0ZSIgaWQ9InVybjp2Y2xvdWQ6dmFwcHRlbXBsYXRlOjQ0YjY4NmZiLWQ0
-        YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2OCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmIt
-        ZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4IiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52QXBwVGVtcGxhdGUreG1sIiB4bWxuczp4
-        c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNl
-        IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
-        bnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNkIGh0dHA6Ly93d3cudm13YXJl
-        LmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAuMzAuMi4yL2FwaS92MS41L3Nj
-        aGVtYS9tYXN0ZXIueHNkIj4KICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVkZTI2YTItNThjOC00NDk0LTgy
-        MWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGluayByZWw9ImNhdGFsb2dJdGVt
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvY2F0YWxvZ0l0ZW0vOTBl
-        ZGMyNDItYmYyYS00ZWUzLTg5MmYtMGEzZjg3ZTZlNjgwIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jYXRhbG9nSXRlbSt4bWwiLz4K
-        ICAgIDxMaW5rIHJlbD0icmVtb3ZlIiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJm
-        LTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgiLz4KICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92
-        YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYx
-        ODY4IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBw
-        VGVtcGxhdGUreG1sIi8+CiAgICA8TGluayByZWw9ImVuYWJsZSIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
-        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L2FjdGlv
-        bi9lbmFibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJkaXNhYmxlIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBU
-        ZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4Njgv
-        YWN0aW9uL2Rpc2FibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJvdmYi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdmFw
-        cFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2
-        OC9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9InN0b3Jh
-        Z2VQcm9maWxlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdmRjU3Rv
-        cmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2QyNTgyNTFl
-        YThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0
-        ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAw
-        OGYxODY4L293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
-        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L21ldGFk
-        YXRhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRh
-        ZGF0YSt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRi
-        Njg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L3Byb2R1Y3RTZWN0
-        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
-        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxEZXNjcmlwdGlvbi8+CiAgICA8
-        T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQub3du
-        ZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvYWRtaW4vdXNlci9kNjVmNzRiZS0yMzlmLTQ5YjctODdmZi0zOWUz
-        MTU0MTMzNTEiIG5hbWU9ImFkbWluIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPENo
-        aWxkcmVuPgogICAgICAgIDxWbSBnb2xkTWFzdGVyPSJmYWxzZSIgc3RhdHVz
-        PSI4IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiBpZD0idXJuOnZjbG91ZDp2
-        bTowZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0MzY1OTYiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdm0tMGViMjBm
-        OTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2IiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgogICAgICAgICAgICA8
-        TGluayByZWw9InVwIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNm
-        Yi02NTU0MDA4ZjE4NjgiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZBcHBUZW1wbGF0ZSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
-        cmVsPSJzdG9yYWdlUHJvZmlsZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMtNGNhYS1iNmQ4
-        LWNkMjU4MjUxZWE4ZCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1sIi8+CiAgICAgICAgICAgIDxM
-        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHBUZW1wbGF0ZS92bS0wZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0
-        MzY1OTYvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxh
-        dGUvdm0tMGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2L3By
-        b2R1Y3RTZWN0aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnByb2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgICAgICAgICAgPERl
-        c2NyaXB0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRo
-        ZSBoaWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlv
-        bi4gTm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBN
-        QnMgaW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQg
-        SeKAmXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGlu
-        ZyB3aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNv
-        PC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
-        U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBs
-        YXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1NGYwNjQzNjU5Ni9u
-        ZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1s
-        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
-        SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5l
-        Y3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0
-        d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
-        b25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBu
-        ZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5ldHdvcmsi
-        PgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4
-        PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAg
-        ICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAg
-        ICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjBmPC9NQUNB
-        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0
-        aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAg
-        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgIDwv
-        TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RD
-        dXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcFRlbXBsYXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1
-        NGYwNjQzNjU5Ni9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
-        aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyBHdWVzdCBPUyBDdXN0b21p
-        emF0aW9uIFNldHRpbmdzPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxF
-        bmFibGVkPmZhbHNlPC9FbmFibGVkPgogICAgICAgICAgICAgICAgPENoYW5n
-        ZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgogICAgICAgICAgICAgICAgPFZpcnR1
-        YWxNYWNoaW5lSWQ+MGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2
-        NTk2PC9WaXJ0dWFsTWFjaGluZUlkPgogICAgICAgICAgICAgICAgPEpvaW5E
-        b21haW5FbmFibGVkPmZhbHNlPC9Kb2luRG9tYWluRW5hYmxlZD4KICAgICAg
-        ICAgICAgICAgIDxVc2VPcmdTZXR0aW5ncz5mYWxzZTwvVXNlT3JnU2V0dGlu
-        Z3M+CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEVuYWJsZWQ+dHJ1
-        ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8QWRt
-        aW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRtaW5QYXNzd29yZEF1dG8+CiAgICAg
-        ICAgICAgICAgICA8UmVzZXRQYXNzd29yZFJlcXVpcmVkPmZhbHNlPC9SZXNl
-        dFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8Q29tcHV0ZXJO
-        YW1lPkRhbW5TbWFsbExpLTAwMTwvQ29tcHV0ZXJOYW1lPgogICAgICAgICAg
-        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxW
-        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
-        TG9jYWxJZD4KICAgICAgICAgICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFU
-        MTQ6MDQ6NDQuMTYwKzAyOjAwPC9EYXRlQ3JlYXRlZD4KICAgICAgICA8L1Zt
-        PgogICAgPC9DaGlsZHJlbj4KICAgIDxvdmY6TmV0d29ya1NlY3Rpb24geG1s
-        bnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUi
-        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5u
-        ZXR3b3JrU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1k
-        NGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgvbmV0d29ya1NlY3Rpb24vIj4K
-        ICAgICAgICA8b3ZmOkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jr
-        czwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJW
-        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUg
-        Vk0gTmV0d29yayBuZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAg
-        PC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAg
-        PE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYt
-        NGVjNC1iM2ZiLTY1NTQwMDhmMTg2OC9uZXR3b3JrQ29uZmlnU2VjdGlvbi8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtD
-        b25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAg
-        ICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRlcnMgZm9y
-        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxOZXR3b3Jr
-        Q29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4KICAgICAgICAgICAg
-        PERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L0Rlc2NyaXB0
-        aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAg
-        ICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBTY29wZT4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPmZhbHNlPC9J
-        c0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPEdhdGV3YXk+
-        MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAg
-        ICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4KICAgICAgICAg
-        ICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0VuYWJsZWQ+CiAg
-        ICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2OC4yNTQuMTAwPC9T
-        dGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
-        PEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9FbmRBZGRyZXNzPgogICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAg
-        ICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAg
-        IDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAg
-        ICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9GZW5jZU1vZGU+CiAg
-        ICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
-        PmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAg
-        ICAgICAgIDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95
-        ZWQ+ZmFsc2U8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
-        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxMZWFzZVNldHRp
-        bmdzU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRl
-        bXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02
-        NTU0MDA4ZjE4NjgvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlv
-        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgIDxvdmY6SW5m
-        bz5MZWFzZSBzZXR0aW5ncyBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1i
-        M2ZiLTY1NTQwMDhmMTg2OC9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
-        ZWN0aW9uK3htbCIvPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29uZHM+
-        Nzc3NjAwMDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9y
-        YWdlTGVhc2VFeHBpcmF0aW9uPjIwMTYtMTEtMDRUMTU6NDM6NDYuNjczKzAx
-        OjAwPC9TdG9yYWdlTGVhc2VFeHBpcmF0aW9uPgogICAgPC9MZWFzZVNldHRp
-        bmdzU2VjdGlvbj4KICAgIDxDdXN0b21pemF0aW9uU2VjdGlvbiBnb2xkTWFz
-        dGVyPSJmYWxzZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBU
-        ZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmIt
-        NjU1NDAwOGYxODY4L2N1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuY3VzdG9taXphdGlvblNlY3Rp
-        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
-        Zm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rpb248L292ZjpJ
-        bmZvPgogICAgICAgIDxDdXN0b21pemVPbkluc3RhbnRpYXRlPnRydWU8L0N1
-        c3RvbWl6ZU9uSW5zdGFudGlhdGU+CiAgICA8L0N1c3RvbWl6YXRpb25TZWN0
-        aW9uPgogICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFUMTQ6MDQ6NDQuMTYw
-        KzAyOjAwPC9EYXRlQ3JlYXRlZD4KPC9WQXBwVGVtcGxhdGU+Cg==
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Linux CentOS 7.0" id="urn:vcloud:vapptemplate:ab27a332-2cc3-4ce8-a50f-138036cf7f57" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="true" status="8" name="CentOS7" id="urn:vcloud:vm:857551b6-380c-44d0-ab34-9d144866f0b4" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="internal">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:2b</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>d0733827-5a41-4816-b4a9-3cb8deb98583</VAppScopedLocalId>
+                    <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="internal">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="internal">
+                    <Description/>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.2.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.2.100</StartAddress>
+                                        <EndAddress>192.168.2.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+        </VAppTemplate>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:11 GMT
+  recorded_at: Fri, 16 Sep 2016 08:53:21 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57
     body:
       encoding: US-ASCII
       string: ''
@@ -6806,229 +2567,124 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:09 GMT
+      - Fri, 16 Sep 2016 08:53:26 GMT
       X-Vmware-Vcloud-Request-Id:
-      - b8a5b827-6591-4852-827d-072d2fb052f9
+      - 6e55e332-622e-4b78-baeb-5538532232fb
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '271'
+      - '244'
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHBU
-        ZW1wbGF0ZSB4bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
-        MS41IiB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
-        bnZlbG9wZS8xIiBnb2xkTWFzdGVyPSJmYWxzZSIgb3ZmRGVzY3JpcHRvclVw
-        bG9hZGVkPSJ0cnVlIiBzdGF0dXM9IjgiIG5hbWU9IkRTTC1MaW51eC10ZW1w
-        bGF0ZSIgaWQ9InVybjp2Y2xvdWQ6dmFwcHRlbXBsYXRlOjQ0YjY4NmZiLWQ0
-        YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2OCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmIt
-        ZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4IiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52QXBwVGVtcGxhdGUreG1sIiB4bWxuczp4
-        c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNl
-        IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
-        bnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNkIGh0dHA6Ly93d3cudm13YXJl
-        LmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAuMzAuMi4yL2FwaS92MS41L3Nj
-        aGVtYS9tYXN0ZXIueHNkIj4KICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVkZTI2YTItNThjOC00NDk0LTgy
-        MWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGluayByZWw9ImNhdGFsb2dJdGVt
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvY2F0YWxvZ0l0ZW0vOTBl
-        ZGMyNDItYmYyYS00ZWUzLTg5MmYtMGEzZjg3ZTZlNjgwIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jYXRhbG9nSXRlbSt4bWwiLz4K
-        ICAgIDxMaW5rIHJlbD0icmVtb3ZlIiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJm
-        LTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgiLz4KICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92
-        YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYx
-        ODY4IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBw
-        VGVtcGxhdGUreG1sIi8+CiAgICA8TGluayByZWw9ImVuYWJsZSIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
-        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L2FjdGlv
-        bi9lbmFibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJkaXNhYmxlIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBU
-        ZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4Njgv
-        YWN0aW9uL2Rpc2FibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJvdmYi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdmFw
-        cFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2
-        OC9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9InN0b3Jh
-        Z2VQcm9maWxlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdmRjU3Rv
-        cmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2QyNTgyNTFl
-        YThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0
-        ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAw
-        OGYxODY4L293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
-        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L21ldGFk
-        YXRhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRh
-        ZGF0YSt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRi
-        Njg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L3Byb2R1Y3RTZWN0
-        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
-        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxEZXNjcmlwdGlvbi8+CiAgICA8
-        T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQub3du
-        ZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvYWRtaW4vdXNlci9kNjVmNzRiZS0yMzlmLTQ5YjctODdmZi0zOWUz
-        MTU0MTMzNTEiIG5hbWU9ImFkbWluIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPENo
-        aWxkcmVuPgogICAgICAgIDxWbSBnb2xkTWFzdGVyPSJmYWxzZSIgc3RhdHVz
-        PSI4IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiBpZD0idXJuOnZjbG91ZDp2
-        bTowZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0MzY1OTYiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdm0tMGViMjBm
-        OTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2IiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgogICAgICAgICAgICA8
-        TGluayByZWw9InVwIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNm
-        Yi02NTU0MDA4ZjE4NjgiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZBcHBUZW1wbGF0ZSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
-        cmVsPSJzdG9yYWdlUHJvZmlsZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMtNGNhYS1iNmQ4
-        LWNkMjU4MjUxZWE4ZCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1sIi8+CiAgICAgICAgICAgIDxM
-        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHBUZW1wbGF0ZS92bS0wZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0
-        MzY1OTYvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxh
-        dGUvdm0tMGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2L3By
-        b2R1Y3RTZWN0aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnByb2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgICAgICAgICAgPERl
-        c2NyaXB0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRo
-        ZSBoaWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlv
-        bi4gTm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBN
-        QnMgaW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQg
-        SeKAmXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGlu
-        ZyB3aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNv
-        PC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
-        U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBs
-        YXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1NGYwNjQzNjU5Ni9u
-        ZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1s
-        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
-        SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5l
-        Y3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0
-        d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
-        b25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBu
-        ZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5ldHdvcmsi
-        PgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4
-        PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAg
-        ICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAg
-        ICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjBmPC9NQUNB
-        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0
-        aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAg
-        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgIDwv
-        TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RD
-        dXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcFRlbXBsYXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1
-        NGYwNjQzNjU5Ni9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
-        aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyBHdWVzdCBPUyBDdXN0b21p
-        emF0aW9uIFNldHRpbmdzPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxF
-        bmFibGVkPmZhbHNlPC9FbmFibGVkPgogICAgICAgICAgICAgICAgPENoYW5n
-        ZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgogICAgICAgICAgICAgICAgPFZpcnR1
-        YWxNYWNoaW5lSWQ+MGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2
-        NTk2PC9WaXJ0dWFsTWFjaGluZUlkPgogICAgICAgICAgICAgICAgPEpvaW5E
-        b21haW5FbmFibGVkPmZhbHNlPC9Kb2luRG9tYWluRW5hYmxlZD4KICAgICAg
-        ICAgICAgICAgIDxVc2VPcmdTZXR0aW5ncz5mYWxzZTwvVXNlT3JnU2V0dGlu
-        Z3M+CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEVuYWJsZWQ+dHJ1
-        ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8QWRt
-        aW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRtaW5QYXNzd29yZEF1dG8+CiAgICAg
-        ICAgICAgICAgICA8UmVzZXRQYXNzd29yZFJlcXVpcmVkPmZhbHNlPC9SZXNl
-        dFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8Q29tcHV0ZXJO
-        YW1lPkRhbW5TbWFsbExpLTAwMTwvQ29tcHV0ZXJOYW1lPgogICAgICAgICAg
-        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxW
-        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
-        TG9jYWxJZD4KICAgICAgICAgICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFU
-        MTQ6MDQ6NDQuMTYwKzAyOjAwPC9EYXRlQ3JlYXRlZD4KICAgICAgICA8L1Zt
-        PgogICAgPC9DaGlsZHJlbj4KICAgIDxvdmY6TmV0d29ya1NlY3Rpb24geG1s
-        bnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUi
-        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5u
-        ZXR3b3JrU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1k
-        NGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgvbmV0d29ya1NlY3Rpb24vIj4K
-        ICAgICAgICA8b3ZmOkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jr
-        czwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJW
-        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUg
-        Vk0gTmV0d29yayBuZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAg
-        PC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAg
-        PE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYt
-        NGVjNC1iM2ZiLTY1NTQwMDhmMTg2OC9uZXR3b3JrQ29uZmlnU2VjdGlvbi8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtD
-        b25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAg
-        ICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRlcnMgZm9y
-        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxOZXR3b3Jr
-        Q29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4KICAgICAgICAgICAg
-        PERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L0Rlc2NyaXB0
-        aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAg
-        ICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBTY29wZT4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPmZhbHNlPC9J
-        c0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPEdhdGV3YXk+
-        MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAg
-        ICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4KICAgICAgICAg
-        ICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0VuYWJsZWQ+CiAg
-        ICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2OC4yNTQuMTAwPC9T
-        dGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
-        PEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9FbmRBZGRyZXNzPgogICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAg
-        ICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAg
-        IDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAg
-        ICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9GZW5jZU1vZGU+CiAg
-        ICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
-        PmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAg
-        ICAgICAgIDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95
-        ZWQ+ZmFsc2U8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
-        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxMZWFzZVNldHRp
-        bmdzU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRl
-        bXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02
-        NTU0MDA4ZjE4NjgvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlv
-        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgIDxvdmY6SW5m
-        bz5MZWFzZSBzZXR0aW5ncyBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1i
-        M2ZiLTY1NTQwMDhmMTg2OC9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
-        ZWN0aW9uK3htbCIvPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29uZHM+
-        Nzc3NjAwMDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9y
-        YWdlTGVhc2VFeHBpcmF0aW9uPjIwMTYtMTEtMDRUMTU6NDM6NDYuNjczKzAx
-        OjAwPC9TdG9yYWdlTGVhc2VFeHBpcmF0aW9uPgogICAgPC9MZWFzZVNldHRp
-        bmdzU2VjdGlvbj4KICAgIDxDdXN0b21pemF0aW9uU2VjdGlvbiBnb2xkTWFz
-        dGVyPSJmYWxzZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBU
-        ZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmIt
-        NjU1NDAwOGYxODY4L2N1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuY3VzdG9taXphdGlvblNlY3Rp
-        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
-        Zm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rpb248L292ZjpJ
-        bmZvPgogICAgICAgIDxDdXN0b21pemVPbkluc3RhbnRpYXRlPnRydWU8L0N1
-        c3RvbWl6ZU9uSW5zdGFudGlhdGU+CiAgICA8L0N1c3RvbWl6YXRpb25TZWN0
-        aW9uPgogICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFUMTQ6MDQ6NDQuMTYw
-        KzAyOjAwPC9EYXRlQ3JlYXRlZD4KPC9WQXBwVGVtcGxhdGU+Cg==
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Linux CentOS 7.0" id="urn:vcloud:vapptemplate:ab27a332-2cc3-4ce8-a50f-138036cf7f57" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="true" status="8" name="CentOS7" id="urn:vcloud:vm:857551b6-380c-44d0-ab34-9d144866f0b4" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="internal">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:2b</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>d0733827-5a41-4816-b4a9-3cb8deb98583</VAppScopedLocalId>
+                    <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="internal">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="internal">
+                    <Description/>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>192.168.2.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.2.100</StartAddress>
+                                        <EndAddress>192.168.2.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
+        </VAppTemplate>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:12 GMT
+  recorded_at: Fri, 16 Sep 2016 08:53:27 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a
     body:
       encoding: US-ASCII
       string: ''
@@ -7038,45 +2694,44 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:10 GMT
+      - Fri, 16 Sep 2016 08:53:31 GMT
       X-Vmware-Vcloud-Request-Id:
-      - abafe800-09a0-4eb5-941b-75c6134859b6
+      - 3010f569-fc58-4be7-ba22-bd5ba252a35c
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '163'
+      - '66'
       Content-Type:
       - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
       Content-Length:
-      - '1306'
+      - '1118'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="TinyLinuxVM-template" id="urn:vcloud:catalogitem:e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/catalog/b7705e3a-14ec-43a1-bf8c-6b5df417d849" type="application/vnd.vmware.vcloud.catalog+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="edit" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0"/>
-            <Entity href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" name="TinyLinuxVM-template" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <DateCreated>2016-08-01T14:37:56.943+02:00</DateCreated>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="7782531072" name="CentOS 7 Everything" id="urn:vcloud:catalogitem:42800327-57ed-433e-8ca4-17a33843cc0a" href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/42800327-57ed-433e-8ca4-17a33843cc0a/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/media/485da411-6e5b-4c32-ae34-dd82c2b78f4d" name="CentOS 7 Everything" type="application/vnd.vmware.vcloud.media+xml"/>
+            <DateCreated>2016-08-02T16:01:46.560+03:00</DateCreated>
         </CatalogItem>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:12 GMT
+  recorded_at: Fri, 16 Sep 2016 08:53:32 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936
     body:
       encoding: US-ASCII
       string: ''
@@ -7086,20 +2741,697 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:10 GMT
+      - Fri, 16 Sep 2016 08:53:37 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 53e008b5-e65f-4b30-9d68-9ce5079dba14
+      - 20ac7621-c6d1-41b7-ae7b-14b8b2e45686
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '124'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1095'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="634388480" name="CentOS 7" id="urn:vcloud:catalogitem:59d0aebb-aad0-4f01-9fd6-082fca414936" href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/59d0aebb-aad0-4f01-9fd6-082fca414936/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/media/ff3852a3-bd3d-43b4-95c5-ec00d84b356d" name="CentOS 7" type="application/vnd.vmware.vcloud.media+xml"/>
+            <DateCreated>2016-08-02T14:44:53.647+03:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:53:37 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:53:42 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 65712a29-9eea-4a3d-bd3b-899daa64dc47
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '63'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1098'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="5397889024" name="Win2012R2" id="urn:vcloud:catalogitem:6d250e6a-0cfe-4749-af3d-700fe490cb12" href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/6d250e6a-0cfe-4749-af3d-700fe490cb12/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/media/871ab1ed-816b-4708-b998-5e05dbc28bf1" name="Win2012R2" type="application/vnd.vmware.vcloud.media+xml"/>
+            <DateCreated>2016-08-02T14:44:23.147+03:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:53:43 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:53:47 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 0902cfbc-8f47-4395-9fa0-5e1e5fb04bdb
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '93'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1154'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="Tieto Windows Server 2012 R2" id="urn:vcloud:catalogitem:e8734bdb-af24-443e-9496-10f367424316" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/0490ad3b-f343-4b80-8d5b-ecb0397fd412" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" name="Tieto Windows Server 2012 R2" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-08-02T11:11:00.127+03:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:53:48 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:53:53 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 040fdfdd-3a20-4b13-b54b-98e3b68e94a7
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '138'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '8142'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vapptemplate:cfff2e62-3746-4007-bcfe-a054fb30c510" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:84:02:de</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TietoWindow-001</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>Tieto Windows Server 2012 R2</VAppScopedLocalId>
+                    <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:53:54 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:53:58 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 287fca52-7906-467c-a42c-b2470fb95330
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '132'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '8142'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vapptemplate:cfff2e62-3746-4007-bcfe-a054fb30c510" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:84:02:de</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TietoWindow-001</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>Tieto Windows Server 2012 R2</VAppScopedLocalId>
+                    <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:53:59 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:04 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - c39d975b-632a-420b-86e8-38274ffee112
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '36'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2221'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="XTestCatalog" id="urn:vcloud:catalog:261037bc-8299-42c1-9ac1-b8c4c964d99d" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description/>
+            <CatalogItems>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" id="77519250-ce5a-45d5-939d-fbe79704e18d" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" id="8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" id="fd9c3a97-14bd-499b-bd52-054a1602ae89" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            </CatalogItems>
+            <IsPublished>false</IsPublished>
+            <DateCreated>2016-08-11T15:14:05.377+03:00</DateCreated>
+        </Catalog>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:04 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:09 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 6876d973-576a-4674-9c52-1548d26ff07c
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '30'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalog+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '2221'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Catalog xmlns="http://www.vmware.com/vcloud/v1.5" name="XTestCatalog" id="urn:vcloud:catalog:261037bc-8299-42c1-9ac1-b8c4c964d99d" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/org/e338a4ac-551b-4b6c-b5c0-aff31b71417f" type="application/vnd.vmware.vcloud.org+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="add" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/catalogItems" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/controlAccess/" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Link rel="controlAccess" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d/action/controlAccess" type="application/vnd.vmware.vcloud.controlAccess+xml"/>
+            <Description/>
+            <CatalogItems>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" id="77519250-ce5a-45d5-939d-fbe79704e18d" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" id="8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+                <CatalogItem href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" id="fd9c3a97-14bd-499b-bd52-054a1602ae89" name="CentOS 7" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            </CatalogItems>
+            <IsPublished>false</IsPublished>
+            <DateCreated>2016-08-11T15:14:05.377+03:00</DateCreated>
+        </Catalog>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:10 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:14 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 89494e8c-3023-41b7-831b-61f42610094e
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '132'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1427'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="vApp_cankamat_remote_1" id="urn:vcloud:catalogitem:77519250-ce5a-45d5-939d-fbe79704e18d" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" name="vApp_cankamat_remote_1" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-08-11T15:15:51.703+03:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:15 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:21 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 0634bbd5-2b90-4dd5-ac1d-18e4833a9ea9
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '1516'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_cankamat_remote_1" id="urn:vcloud:vapptemplate:5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:3c6fd87c-d8f1-4add-827f-c35982f3e5b1" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:2d</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="INT_192.168.10.0m24">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="INT_192.168.10.0m24">
+                    <Description/>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>true</IsInherited>
+                                <Gateway>192.168.10.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <Dns1>192.168.10.1</Dns1>
+                                <DnsSuffix>test.local</DnsSuffix>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.10.100</StartAddress>
+                                        <EndAddress>192.168.10.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <ParentNetwork href="" name="INT_192.168.10.0m24"/>
+                        <FenceMode>bridged</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:22 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:27 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 7d2aaaf8-2ad6-4ed7-845c-4035d1b191bf
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
       - '215'
       Content-Type:
@@ -7107,110 +3439,109 @@ http_interactions:
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="TinyLinuxVM-template" id="urn:vcloud:vapptemplate:7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/disableDownload"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_cankamat_remote_1" id="urn:vcloud:vapptemplate:5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <Children>
-                <Vm goldMaster="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f289215f-5a4b-4106-b14d-8376447068e8" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:3c6fd87c-d8f1-4add-827f-c35982f3e5b1" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
+                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:12</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:2d</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</VirtualMachineId>
+                        <VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
+                        <ComputerName>CentOS7-0</ComputerName>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
+                <ovf:Network ovf:name="INT_192.168.10.0m24">
+                    <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="VM Network">
-                    <Description>The VM Network network</Description>
+                <NetworkConfig networkName="INT_192.168.10.0m24">
+                    <Description/>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
-                                <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
+                                <IsInherited>true</IsInherited>
+                                <Gateway>192.168.10.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
+                                <Dns1>192.168.10.1</Dns1>
+                                <DnsSuffix>test.local</DnsSuffix>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
+                                        <StartAddress>192.168.10.100</StartAddress>
+                                        <EndAddress>192.168.10.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
                         </IpScopes>
-                        <FenceMode>isolated</FenceMode>
+                        <ParentNetwork href="" name="INT_192.168.10.0m24"/>
+                        <FenceMode>bridged</FenceMode>
                         <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-11-04T15:45:03.693+01:00</StorageLeaseExpiration>
+                <StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
             </CustomizationSection>
-            <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+            <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
         </VAppTemplate>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:13 GMT
+  recorded_at: Fri, 16 Sep 2016 08:54:28 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d
     body:
       encoding: US-ASCII
       string: ''
@@ -7220,131 +3551,200 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:11 GMT
+      - Fri, 16 Sep 2016 08:54:32 GMT
       X-Vmware-Vcloud-Request-Id:
-      - f398afbb-4b62-4cd2-a78c-60b1d6133303
+      - a9977575-f0a7-4f85-8259-339636807f73
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '205'
+      - '228'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1425'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="0" name="vApp_CentOS_and_msWin" id="urn:vcloud:catalogitem:8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" name="vApp_CentOS_and_msWin" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <DateCreated>2016-09-09T10:08:37.550+03:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:33 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:38 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 49c3fdb5-0920-4ad3-9896-2c87fb8167e4
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '317'
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="TinyLinuxVM-template" id="urn:vcloud:vapptemplate:7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/disableDownload"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_CentOS_and_msWin" id="urn:vcloud:vapptemplate:a19bdc8f-88fa-4dd6-8436-486590353ed5" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <Children>
-                <Vm goldMaster="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f289215f-5a4b-4106-b14d-8376447068e8" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:e9b55b85-640b-462c-9e7a-d18c47a7a5f3" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
+                        <NetworkConnection needsCustomization="true" network="none">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:12</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:01:00:4d</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
                         </NetworkConnection>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</VirtualMachineId>
+                        <VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
+                        <ComputerName>CentOS7-0-0</ComputerName>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+                    <VAppScopedLocalId>926f501b-c7ea-4b9d-a155-6695c3345150</VAppScopedLocalId>
+                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+                </Vm>
+                <Vm goldMaster="false" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:04f85cca-3f8d-43b4-8473-7aa099f95c1b" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:01:00:4c</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TietoWindow-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>2e9ee64a-2368-40fc-94ee-0473373f0f4c</VAppScopedLocalId>
+                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="VM Network">
-                    <Description>The VM Network network</Description>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
                                 <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
                             </IpScope>
                         </IpScopes>
                         <FenceMode>isolated</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
                     </Configuration>
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-11-04T15:45:03.693+01:00</StorageLeaseExpiration>
+                <StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
             </CustomizationSection>
-            <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+            <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
         </VAppTemplate>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:13 GMT
+  recorded_at: Fri, 16 Sep 2016 08:54:39 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5
     body:
       encoding: US-ASCII
       string: ''
@@ -7354,90 +3754,266 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:11 GMT
+      - Fri, 16 Sep 2016 08:54:44 GMT
       X-Vmware-Vcloud-Request-Id:
-      - dee69f6b-4979-4595-9f10-6092b5ad1142
+      - 7abe8560-d20c-46e0-818d-dd8fba08989b
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '255'
+      - '308'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_CentOS_and_msWin" id="urn:vcloud:vapptemplate:a19bdc8f-88fa-4dd6-8436-486590353ed5" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:e9b55b85-640b-462c-9e7a-d18c47a7a5f3" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:01:00:4d</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7-0-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>926f501b-c7ea-4b9d-a155-6695c3345150</VAppScopedLocalId>
+                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+                </Vm>
+                <Vm goldMaster="false" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:04f85cca-3f8d-43b4-8473-7aa099f95c1b" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:01:00:4c</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TietoWindow-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>2e9ee64a-2368-40fc-94ee-0473373f0f4c</VAppScopedLocalId>
+                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:45 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:49 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 53e3db9b-cbd0-4660-a5b6-cbb11125e2b8
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '55'
+      Content-Type:
+      - application/vnd.vmware.vcloud.catalogitem+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1380'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CatalogItem xmlns="http://www.vmware.com/vcloud/v1.5" size="634388480" name="CentOS 7" id="urn:vcloud:catalogitem:fd9c3a97-14bd-499b-bd52-054a1602ae89" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" type="application/vnd.vmware.vcloud.catalogItem+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/catalog/261037bc-8299-42c1-9ac1-b8c4c964d99d" type="application/vnd.vmware.vcloud.catalog+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/catalogItem/fd9c3a97-14bd-499b-bd52-054a1602ae89"/>
+            <Description/>
+            <Entity href="https://VMWARE_CLOUD_HOST/api/media/48ce1b6a-2c31-485d-a6ce-8f914c044459" name="CentOS 7" type="application/vnd.vmware.vcloud.media+xml"/>
+            <DateCreated>2016-08-11T15:56:57.053+03:00</DateCreated>
+        </CatalogItem>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:54:50 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:54:55 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - e11ebd6b-8b8e-48b4-b9aa-4985519e11f1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '519'
       Content-Type:
       - application/*+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
+        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
             <ovf:References/>
             <ovf:NetworkSection>
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="test-direct-connected">
+                <ovf:Network ovf:name="internal">
                     <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
+            <vcloud:CustomizationSection goldMaster="true" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
             </vcloud:CustomizationSection>
             <vcloud:NetworkConfigSection ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <vcloud:NetworkConfig networkName="test-direct-connected">
+                <vcloud:NetworkConfig networkName="internal">
                     <vcloud:Description/>
                     <vcloud:Configuration>
                         <vcloud:IpScopes>
                             <vcloud:IpScope>
-                                <vcloud:IsInherited>true</vcloud:IsInherited>
-                                <vcloud:Gateway>10.30.2.1</vcloud:Gateway>
+                                <vcloud:IsInherited>false</vcloud:IsInherited>
+                                <vcloud:Gateway>192.168.2.1</vcloud:Gateway>
                                 <vcloud:Netmask>255.255.255.0</vcloud:Netmask>
-                                <vcloud:Dns1>8.8.8.8</vcloud:Dns1>
-                                <vcloud:Dns2>8.8.4.4</vcloud:Dns2>
                                 <vcloud:IsEnabled>true</vcloud:IsEnabled>
                                 <vcloud:IpRanges>
                                     <vcloud:IpRange>
-                                        <vcloud:StartAddress>10.30.2.51</vcloud:StartAddress>
-                                        <vcloud:EndAddress>10.30.2.60</vcloud:EndAddress>
+                                        <vcloud:StartAddress>192.168.2.100</vcloud:StartAddress>
+                                        <vcloud:EndAddress>192.168.2.199</vcloud:EndAddress>
                                     </vcloud:IpRange>
                                 </vcloud:IpRanges>
                             </vcloud:IpScope>
                         </vcloud:IpScopes>
-                        <vcloud:ParentNetwork href="" name="test-direct-connected"/>
-                        <vcloud:FenceMode>natRouted</vcloud:FenceMode>
+                        <vcloud:FenceMode>isolated</vcloud:FenceMode>
                         <vcloud:RetainNetInfoAcrossDeployments>false</vcloud:RetainNetInfoAcrossDeployments>
-                        <vcloud:Features>
-                            <vcloud:FirewallService>
-                                <vcloud:IsEnabled>true</vcloud:IsEnabled>
-                                <vcloud:DefaultAction>drop</vcloud:DefaultAction>
-                                <vcloud:LogDefaultAction>false</vcloud:LogDefaultAction>
-                                <vcloud:FirewallRule>
-                                    <vcloud:IsEnabled>true</vcloud:IsEnabled>
-                                    <vcloud:MatchOnTranslate>false</vcloud:MatchOnTranslate>
-                                    <vcloud:Description>Allow all outgoing traffic</vcloud:Description>
-                                    <vcloud:Policy>allow</vcloud:Policy>
-                                    <vcloud:Protocols>
-                                        <vcloud:Any>true</vcloud:Any>
-                                    </vcloud:Protocols>
-                                    <vcloud:Port>-1</vcloud:Port>
-                                    <vcloud:DestinationPortRange>Any</vcloud:DestinationPortRange>
-                                    <vcloud:DestinationIp>external</vcloud:DestinationIp>
-                                    <vcloud:SourcePort>-1</vcloud:SourcePort>
-                                    <vcloud:SourcePortRange>Any</vcloud:SourcePortRange>
-                                    <vcloud:SourceIp>internal</vcloud:SourceIp>
-                                    <vcloud:EnableLogging>false</vcloud:EnableLogging>
-                                </vcloud:FirewallRule>
-                            </vcloud:FirewallService>
-                        </vcloud:Features>
-                        <vcloud:SyslogServerSettings/>
                     </vcloud:Configuration>
                     <vcloud:IsDeployed>false</vcloud:IsDeployed>
                 </vcloud:NetworkConfig>
@@ -7445,39 +4021,39 @@ http_interactions:
             <vcloud:LeaseSettingsSection ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
                 <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
-                <vcloud:StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</vcloud:StorageLeaseExpiration>
+                <vcloud:StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</vcloud:StorageLeaseExpiration>
             </vcloud:LeaseSettingsSection>
-            <ovf:VirtualSystemCollection ovf:id="vApp_system_5">
+            <ovf:VirtualSystemCollection ovf:id="Tieto Linux CentOS 7.0">
                 <ovf:Info>A collection of virtual machines</ovf:Info>
-                <ovf:Name>vApp_system_5</ovf:Name>
+                <ovf:Name>Tieto Linux CentOS 7.0</ovf:Name>
                 <ovf:StartupSection>
                     <ovf:Info>VApp startup section</ovf:Info>
-                    <ovf:Item ovf:id="Small VM" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                    <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
                 </ovf:StartupSection>
-                <ovf:VirtualSystem ovf:id="Small VM">
+                <ovf:VirtualSystem ovf:id="CentOS7">
                     <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>Small VM</ovf:Name>
-                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="otherLinux64Guest">
+                    <ovf:Name>CentOS7</ovf:Name>
+                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Other Linux (64-bit)</ovf:Description>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
                     </ovf:OperatingSystemSection>
                     <ovf:VirtualHardwareSection ovf:transport="">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>Small VM</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
+                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:08</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:2b</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="POOL" vcloud:primaryNetworkConnection="true">test-direct-connected</rasd:Connection>
-                            <rasd:Description>E1000 ethernet adapter on "test-direct-connected"</rasd:Description>
+                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">internal</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "internal"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
                             <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
                         </ovf:Item>
@@ -7493,11 +4069,11 @@ http_interactions:
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="6" vcloud:busSubType="lsilogic" vcloud:capacity="1024"/>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
                             <rasd:InstanceID>2000</rasd:InstanceID>
                             <rasd:Parent>2</rasd:Parent>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1073741824</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
                             <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
                         </ovf:Item>
@@ -7520,21 +4096,21 @@ http_interactions:
                         <ovf:Item>
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>384 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
                             <rasd:InstanceID>5</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>384</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
                         </ovf:Item>
                         <ovf:Item>
@@ -7546,7 +4122,6 @@ http_interactions:
                             <rasd:InstanceID>3000</rasd:InstanceID>
                             <rasd:Parent>3</rasd:Parent>
                             <rasd:ResourceType>15</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="backing.exclusive" vmw:value="false"/>
                         </ovf:Item>
                         <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
                         <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
@@ -7565,27 +4140,27 @@ http_interactions:
                         <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
                         <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
                         <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="423eedbf-6e9b-ff16-9898-5edf0eb4d364"/>
+                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
                     </ovf:VirtualHardwareSection>
                     <vcloud:GuestCustomizationSection ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <vcloud:Enabled>false</vcloud:Enabled>
                         <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</vcloud:VirtualMachineId>
+                        <vcloud:VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</vcloud:VirtualMachineId>
                         <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
                         <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
                         <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
                         <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
                         <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>SmallVM</vcloud:ComputerName>
+                        <vcloud:ComputerName>CentOS7</vcloud:ComputerName>
                     </vcloud:GuestCustomizationSection>
                     <vcloud:NetworkConnectionSection ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="test-direct-connected">
+                        <vcloud:NetworkConnection needsCustomization="true" network="internal">
                             <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
                             <vcloud:IsConnected>true</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:01:00:08</vcloud:MACAddress>
+                            <vcloud:MACAddress>00:50:56:01:00:2b</vcloud:MACAddress>
                             <vcloud:IpAddressAllocationMode>POOL</vcloud:IpAddressAllocationMode>
                         </vcloud:NetworkConnection>
                     </vcloud:NetworkConnectionSection>
@@ -7593,10 +4168,10 @@ http_interactions:
             </ovf:VirtualSystemCollection>
         </ovf:Envelope>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:14 GMT
+  recorded_at: Fri, 16 Sep 2016 08:54:56 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868/ovf
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf
     body:
       encoding: US-ASCII
       string: ''
@@ -7606,329 +4181,215 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:12 GMT
+      - Fri, 16 Sep 2016 08:55:01 GMT
       X-Vmware-Vcloud-Request-Id:
-      - f8444a98-2082-4d9b-a868-50a1a651da80
+      - 42f16231-6625-4ec3-963b-a3858b88d570
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '169'
+      - '385'
       Content-Type:
       - application/*+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG92ZjpF
-        bnZlbG9wZSB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292
-        Zi9lbnZlbG9wZS8xIiB4bWxuczp2Y2xvdWQ9Imh0dHA6Ly93d3cudm13YXJl
-        LmNvbS92Y2xvdWQvdjEuNSIgeG1sbnM6cmFzZD0iaHR0cDovL3NjaGVtYXMu
-        ZG10Zi5vcmcvd2JlbS93c2NpbS8xL2NpbS1zY2hlbWEvMi9DSU1fUmVzb3Vy
-        Y2VBbGxvY2F0aW9uU2V0dGluZ0RhdGEiIHhtbG5zOnZzc2Q9Imh0dHA6Ly9z
-        Y2hlbWFzLmRtdGYub3JnL3diZW0vd3NjaW0vMS9jaW0tc2NoZW1hLzIvQ0lN
-        X1ZpcnR1YWxTeXN0ZW1TZXR0aW5nRGF0YSIgeG1sbnM6dm13PSJodHRwOi8v
-        d3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZiIgeG1sbnM6eHNpPSJodHRwOi8v
-        d3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeHNpOnNjaGVt
-        YUxvY2F0aW9uPSJodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxv
-        cGUvMSBodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy9vdmYvZW52ZWxvcGUvMS9k
-        c3A4MDIzXzEuMS4wLnhzZCBodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3Vk
-        L3YxLjUgaHR0cDovLzEwLjMwLjIuMi9hcGkvdjEuNS9zY2hlbWEvbWFzdGVy
-        LnhzZCBodHRwOi8vd3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZiBodHRwOi8v
-        d3d3LnZtd2FyZS5jb20vc2NoZW1hL292ZiBodHRwOi8vc2NoZW1hcy5kbXRm
-        Lm9yZy93YmVtL3dzY2ltLzEvY2ltLXNjaGVtYS8yL0NJTV9SZXNvdXJjZUFs
-        bG9jYXRpb25TZXR0aW5nRGF0YSBodHRwOi8vc2NoZW1hcy5kbXRmLm9yZy93
-        YmVtL3dzY2ltLzEvY2ltLXNjaGVtYS8yLjIyLjAvQ0lNX1Jlc291cmNlQWxs
-        b2NhdGlvblNldHRpbmdEYXRhLnhzZCBodHRwOi8vc2NoZW1hcy5kbXRmLm9y
-        Zy93YmVtL3dzY2ltLzEvY2ltLXNjaGVtYS8yL0NJTV9WaXJ0dWFsU3lzdGVt
-        U2V0dGluZ0RhdGEgaHR0cDovL3NjaGVtYXMuZG10Zi5vcmcvd2JlbS93c2Np
-        bS8xL2NpbS1zY2hlbWEvMi4yMi4wL0NJTV9WaXJ0dWFsU3lzdGVtU2V0dGlu
-        Z0RhdGEueHNkIj4KICAgIDxvdmY6UmVmZXJlbmNlcy8+CiAgICA8b3ZmOk5l
-        dHdvcmtTZWN0aW9uPgogICAgICAgIDxvdmY6SW5mbz5UaGUgbGlzdCBvZiBs
-        b2dpY2FsIG5ldHdvcmtzPC9vdmY6SW5mbz4KICAgICAgICA8b3ZmOk5ldHdv
-        cmsgb3ZmOm5hbWU9IlZNIE5ldHdvcmsiPgogICAgICAgICAgICA8b3ZmOkRl
-        c2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L292ZjpEZXNjcmlw
-        dGlvbj4KICAgICAgICA8L292ZjpOZXR3b3JrPgogICAgPC9vdmY6TmV0d29y
-        a1NlY3Rpb24+CiAgICA8dmNsb3VkOkN1c3RvbWl6YXRpb25TZWN0aW9uIGdv
-        bGRNYXN0ZXI9ImZhbHNlIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAg
-        ICA8b3ZmOkluZm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rp
-        b248L292ZjpJbmZvPgogICAgICAgIDx2Y2xvdWQ6Q3VzdG9taXplT25JbnN0
-        YW50aWF0ZT50cnVlPC92Y2xvdWQ6Q3VzdG9taXplT25JbnN0YW50aWF0ZT4K
-        ICAgIDwvdmNsb3VkOkN1c3RvbWl6YXRpb25TZWN0aW9uPgogICAgPHZjbG91
-        ZDpOZXR3b3JrQ29uZmlnU2VjdGlvbiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4K
-        ICAgICAgICA8b3ZmOkluZm8+VGhlIGNvbmZpZ3VyYXRpb24gcGFyYW1ldGVy
-        cyBmb3IgbG9naWNhbCBuZXR3b3Jrczwvb3ZmOkluZm8+CiAgICAgICAgPHZj
-        bG91ZDpOZXR3b3JrQ29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4K
-        ICAgICAgICAgICAgPHZjbG91ZDpEZXNjcmlwdGlvbj5UaGUgVk0gTmV0d29y
-        ayBuZXR3b3JrPC92Y2xvdWQ6RGVzY3JpcHRpb24+CiAgICAgICAgICAgIDx2
-        Y2xvdWQ6Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAgICAgIDx2Y2xvdWQ6
-        SXBTY29wZXM+CiAgICAgICAgICAgICAgICAgICAgPHZjbG91ZDpJcFNjb3Bl
-        PgogICAgICAgICAgICAgICAgICAgICAgICA8dmNsb3VkOklzSW5oZXJpdGVk
-        PmZhbHNlPC92Y2xvdWQ6SXNJbmhlcml0ZWQ+CiAgICAgICAgICAgICAgICAg
-        ICAgICAgIDx2Y2xvdWQ6R2F0ZXdheT4xOTIuMTY4LjI1NC4xPC92Y2xvdWQ6
-        R2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAgICAgPHZjbG91ZDpOZXRt
-        YXNrPjI1NS4yNTUuMjU1LjA8L3ZjbG91ZDpOZXRtYXNrPgogICAgICAgICAg
-        ICAgICAgICAgICAgICA8dmNsb3VkOklzRW5hYmxlZD50cnVlPC92Y2xvdWQ6
-        SXNFbmFibGVkPgogICAgICAgICAgICAgICAgICAgICAgICA8dmNsb3VkOklw
-        UmFuZ2VzPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPHZjbG91ZDpJ
-        cFJhbmdlPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDx2Y2xv
-        dWQ6U3RhcnRBZGRyZXNzPjE5Mi4xNjguMjU0LjEwMDwvdmNsb3VkOlN0YXJ0
-        QWRkcmVzcz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8dmNs
-        b3VkOkVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC92Y2xvdWQ6RW5kQWRk
-        cmVzcz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvdmNsb3VkOklw
-        UmFuZ2U+CiAgICAgICAgICAgICAgICAgICAgICAgIDwvdmNsb3VkOklwUmFu
-        Z2VzPgogICAgICAgICAgICAgICAgICAgIDwvdmNsb3VkOklwU2NvcGU+CiAg
-        ICAgICAgICAgICAgICA8L3ZjbG91ZDpJcFNjb3Blcz4KICAgICAgICAgICAg
-        ICAgIDx2Y2xvdWQ6RmVuY2VNb2RlPmlzb2xhdGVkPC92Y2xvdWQ6RmVuY2VN
-        b2RlPgogICAgICAgICAgICAgICAgPHZjbG91ZDpSZXRhaW5OZXRJbmZvQWNy
-        b3NzRGVwbG95bWVudHM+ZmFsc2U8L3ZjbG91ZDpSZXRhaW5OZXRJbmZvQWNy
-        b3NzRGVwbG95bWVudHM+CiAgICAgICAgICAgIDwvdmNsb3VkOkNvbmZpZ3Vy
-        YXRpb24+CiAgICAgICAgICAgIDx2Y2xvdWQ6SXNEZXBsb3llZD5mYWxzZTwv
-        dmNsb3VkOklzRGVwbG95ZWQ+CiAgICAgICAgPC92Y2xvdWQ6TmV0d29ya0Nv
-        bmZpZz4KICAgIDwvdmNsb3VkOk5ldHdvcmtDb25maWdTZWN0aW9uPgogICAg
-        PHZjbG91ZDpMZWFzZVNldHRpbmdzU2VjdGlvbiBvdmY6cmVxdWlyZWQ9ImZh
-        bHNlIj4KICAgICAgICA8b3ZmOkluZm8+TGVhc2Ugc2V0dGluZ3Mgc2VjdGlv
-        bjwvb3ZmOkluZm8+CiAgICAgICAgPHZjbG91ZDpTdG9yYWdlTGVhc2VJblNl
-        Y29uZHM+Nzc3NjAwMDwvdmNsb3VkOlN0b3JhZ2VMZWFzZUluU2Vjb25kcz4K
-        ICAgICAgICA8dmNsb3VkOlN0b3JhZ2VMZWFzZUV4cGlyYXRpb24+MjAxNi0x
-        MS0wNFQxNTo0Mzo0Ni42NzMrMDE6MDA8L3ZjbG91ZDpTdG9yYWdlTGVhc2VF
-        eHBpcmF0aW9uPgogICAgPC92Y2xvdWQ6TGVhc2VTZXR0aW5nc1NlY3Rpb24+
-        CiAgICA8b3ZmOlZpcnR1YWxTeXN0ZW1Db2xsZWN0aW9uIG92ZjppZD0iRFNM
-        LUxpbnV4LXRlbXBsYXRlIj4KICAgICAgICA8b3ZmOkluZm8+QSBjb2xsZWN0
-        aW9uIG9mIHZpcnR1YWwgbWFjaGluZXM8L292ZjpJbmZvPgogICAgICAgIDxv
-        dmY6TmFtZT5EU0wtTGludXgtdGVtcGxhdGU8L292ZjpOYW1lPgogICAgICAg
-        IDxvdmY6U3RhcnR1cFNlY3Rpb24+CiAgICAgICAgICAgIDxvdmY6SW5mbz5W
-        QXBwIHN0YXJ0dXAgc2VjdGlvbjwvb3ZmOkluZm8+CiAgICAgICAgICAgIDxv
-        dmY6SXRlbSBvdmY6aWQ9IkRhbW4gU21hbGwgTGludXgiIG92ZjpvcmRlcj0i
-        MCIgb3ZmOnN0YXJ0QWN0aW9uPSJwb3dlck9uIiBvdmY6c3RhcnREZWxheT0i
-        MCIgb3ZmOnN0b3BBY3Rpb249InBvd2VyT2ZmIiBvdmY6c3RvcERlbGF5PSIw
-        Ii8+CiAgICAgICAgPC9vdmY6U3RhcnR1cFNlY3Rpb24+CiAgICAgICAgPG92
-        ZjpWaXJ0dWFsU3lzdGVtIG92ZjppZD0iRGFtbiBTbWFsbCBMaW51eCI+CiAg
-        ICAgICAgICAgIDxvdmY6SW5mbz5BIHZpcnR1YWwgbWFjaGluZTwvb3ZmOklu
-        Zm8+CiAgICAgICAgICAgIDxvdmY6TmFtZT5EYW1uIFNtYWxsIExpbnV4PC9v
-        dmY6TmFtZT4KICAgICAgICAgICAgPG92ZjpBbm5vdGF0aW9uU2VjdGlvbj4K
-        ICAgICAgICAgICAgICAgIDxvdmY6SW5mbz5BIGh1bWFuLXJlYWRhYmxlIGFu
-        bm90YXRpb248L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPG92ZjpBbm5v
-        dGF0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRoZSBo
-        aWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlvbi4g
-        Tm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBNQnMg
-        aW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQgSeKA
-        mXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGluZyB3
-        aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNvPC9v
-        dmY6QW5ub3RhdGlvbj4KICAgICAgICAgICAgPC9vdmY6QW5ub3RhdGlvblNl
-        Y3Rpb24+CiAgICAgICAgICAgIDxvdmY6T3BlcmF0aW5nU3lzdGVtU2VjdGlv
-        biBvdmY6aWQ9Ijk1IiB2bXc6b3NUeXBlPSJkZWJpYW40R3Vlc3QiPgogICAg
-        ICAgICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgb3BlcmF0aW5n
-        IHN5c3RlbSBpbnN0YWxsZWQ8L292ZjpJbmZvPgogICAgICAgICAgICAgICAg
-        PG92ZjpEZXNjcmlwdGlvbj5EZWJpYW4gR05VL0xpbnV4IDQgKDMyLWJpdCk8
-        L292ZjpEZXNjcmlwdGlvbj4KICAgICAgICAgICAgPC9vdmY6T3BlcmF0aW5n
-        U3lzdGVtU2VjdGlvbj4KICAgICAgICAgICAgPG92ZjpWaXJ0dWFsSGFyZHdh
-        cmVTZWN0aW9uIG92Zjp0cmFuc3BvcnQ9IiI+CiAgICAgICAgICAgICAgICA8
-        b3ZmOkluZm8+VmlydHVhbCBoYXJkd2FyZSByZXF1aXJlbWVudHM8L292ZjpJ
-        bmZvPgogICAgICAgICAgICAgICAgPG92ZjpTeXN0ZW0+CiAgICAgICAgICAg
-        ICAgICAgICAgPHZzc2Q6RWxlbWVudE5hbWU+VmlydHVhbCBIYXJkd2FyZSBG
-        YW1pbHk8L3Zzc2Q6RWxlbWVudE5hbWU+CiAgICAgICAgICAgICAgICAgICAg
-        PHZzc2Q6SW5zdGFuY2VJRD4wPC92c3NkOkluc3RhbmNlSUQ+CiAgICAgICAg
-        ICAgICAgICAgICAgPHZzc2Q6VmlydHVhbFN5c3RlbUlkZW50aWZpZXI+RGFt
-        biBTbWFsbCBMaW51eDwvdnNzZDpWaXJ0dWFsU3lzdGVtSWRlbnRpZmllcj4K
-        ICAgICAgICAgICAgICAgICAgICA8dnNzZDpWaXJ0dWFsU3lzdGVtVHlwZT52
-        bXgtMDc8L3Zzc2Q6VmlydHVhbFN5c3RlbVR5cGU+CiAgICAgICAgICAgICAg
-        ICA8L292ZjpTeXN0ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4wMDo1MDo1NjowMTow
-        MDowZjwvcmFzZDpBZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPnRy
-        dWU8L3Jhc2Q6QXV0b21hdGljQWxsb2NhdGlvbj4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpDb25uZWN0aW9uIHZjbG91ZDppcEFkZHJlc3NpbmdNb2Rl
-        PSJESENQIiB2Y2xvdWQ6cHJpbWFyeU5ldHdvcmtDb25uZWN0aW9uPSJ0cnVl
-        Ij5WTSBOZXR3b3JrPC9yYXNkOkNvbm5lY3Rpb24+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+UENOZXQzMiBldGhlcm5ldCBhZGFw
-        dGVyIG9uICJWTSBOZXR3b3JrIjwvcmFzZDpEZXNjcmlwdGlvbj4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT5OZXR3b3JrIGFkYXB0
-        ZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpJbnN0YW5jZUlEPjE8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAg
-        ICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVN1YlR5cGU+UENOZXQzMjwvcmFz
-        ZDpSZXNvdXJjZVN1YlR5cGU+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        UmVzb3VyY2VUeXBlPjEwPC9yYXNkOlJlc291cmNlVHlwZT4KICAgICAgICAg
-        ICAgICAgICAgICA8dm13OkNvbmZpZyBvdmY6cmVxdWlyZWQ9ImZhbHNlIiB2
-        bXc6a2V5PSJ3YWtlT25MYW5FbmFibGVkIiB2bXc6dmFsdWU9InRydWUiLz4K
-        ICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICA8
-        b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4w
-        PC9yYXNkOkFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVz
-        Y3JpcHRpb24+SURFIENvbnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRpb24+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SURFIENvbnRy
-        b2xsZXIgMDwvcmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAg
-        ICA8cmFzZDpJbnN0YW5jZUlEPjI8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAg
-        ICAgICAgICAgICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFzZDpSZXNv
-        dXJjZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        OkFkZHJlc3NPblBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAg
-        ICAgICAgICAgICAgICAgICA8cmFzZDpEZXNjcmlwdGlvbj5IYXJkIGRpc2s8
-        L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6
-        RWxlbWVudE5hbWU+SGFyZCBkaXNrIDE8L3Jhc2Q6RWxlbWVudE5hbWU+CiAg
-        ICAgICAgICAgICAgICAgICAgPHJhc2Q6SG9zdFJlc291cmNlIHZjbG91ZDpi
-        dXNUeXBlPSI1IiB2Y2xvdWQ6YnVzU3ViVHlwZT0iIiB2Y2xvdWQ6Y2FwYWNp
-        dHk9IjI1NiIvPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkluc3RhbmNl
-        SUQ+MzAwMDwvcmFzZDpJbnN0YW5jZUlEPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOlBhcmVudD4yPC9yYXNkOlBhcmVudD4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+MTc8L3Jhc2Q6UmVzb3VyY2VUeXBl
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eT4y
-        Njg0MzU0NTY8L3Jhc2Q6VmlydHVhbFF1YW50aXR5PgogICAgICAgICAgICAg
-        ICAgICAgIDxyYXNkOlZpcnR1YWxRdWFudGl0eVVuaXRzPmJ5dGU8L3Jhc2Q6
-        VmlydHVhbFF1YW50aXR5VW5pdHM+CiAgICAgICAgICAgICAgICAgICAgPHZt
-        dzpDb25maWcgb3ZmOnJlcXVpcmVkPSJmYWxzZSIgdm13OmtleT0iYmFja2lu
-        Zy53cml0ZVRocm91Z2giIHZtdzp2YWx1ZT0iZmFsc2UiLz4KICAgICAgICAg
-        ICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICA8b3ZmOkl0ZW0+
-        CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6QWRkcmVzcz4xPC9yYXNkOkFk
-        ZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+
-        SURFIENvbnRyb2xsZXI8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAg
-        ICAgICAgICAgPHJhc2Q6RWxlbWVudE5hbWU+SURFIENvbnRyb2xsZXIgMTwv
-        cmFzZDpFbGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJ
-        bnN0YW5jZUlEPjM8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAg
-        ICAgICA8cmFzZDpSZXNvdXJjZVR5cGU+NTwvcmFzZDpSZXNvdXJjZVR5cGU+
-        CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAg
-        PG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NP
-        blBhcmVudD4wPC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPmZhbHNlPC9yYXNk
-        OkF1dG9tYXRpY0FsbG9jYXRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6RGVzY3JpcHRpb24+RmxvcHB5IERyaXZlPC9yYXNkOkRlc2NyaXB0aW9u
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPkZsb3Bw
-        eSBEcml2ZSAxPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkhvc3RSZXNvdXJjZS8+CiAgICAgICAgICAgICAgICAgICAg
-        PHJhc2Q6SW5zdGFuY2VJRD44MDAwPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAg
-        ICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VUeXBlPjE0PC9yYXNkOlJl
-        c291cmNlVHlwZT4KICAgICAgICAgICAgICAgIDwvb3ZmOkl0ZW0+CiAgICAg
-        ICAgICAgICAgICA8b3ZmOkl0ZW0+CiAgICAgICAgICAgICAgICAgICAgPHJh
-        c2Q6QWxsb2NhdGlvblVuaXRzPmhlcnR6ICogMTBeNjwvcmFzZDpBbGxvY2F0
-        aW9uVW5pdHM+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRp
-        b24+TnVtYmVyIG9mIFZpcnR1YWwgQ1BVczwvcmFzZDpEZXNjcmlwdGlvbj4K
-        ICAgICAgICAgICAgICAgICAgICA8cmFzZDpFbGVtZW50TmFtZT4xIHZpcnR1
-        YWwgQ1BVKHMpPC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAg
-        ICAgIDxyYXNkOkluc3RhbmNlSUQ+NDwvcmFzZDpJbnN0YW5jZUlEPgogICAg
-        ICAgICAgICAgICAgICAgIDxyYXNkOlJlc2VydmF0aW9uPjA8L3Jhc2Q6UmVz
-        ZXJ2YXRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6UmVzb3VyY2VU
-        eXBlPjM8L3Jhc2Q6UmVzb3VyY2VUeXBlPgogICAgICAgICAgICAgICAgICAg
-        IDxyYXNkOlZpcnR1YWxRdWFudGl0eT4xPC9yYXNkOlZpcnR1YWxRdWFudGl0
-        eT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpXZWlnaHQ+MDwvcmFzZDpX
-        ZWlnaHQ+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAg
-        ICAgICAgPG92ZjpJdGVtPgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFs
-        bG9jYXRpb25Vbml0cz5ieXRlICogMl4yMDwvcmFzZDpBbGxvY2F0aW9uVW5p
-        dHM+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3JpcHRpb24+TWVt
-        b3J5IFNpemU8L3Jhc2Q6RGVzY3JpcHRpb24+CiAgICAgICAgICAgICAgICAg
-        ICAgPHJhc2Q6RWxlbWVudE5hbWU+MjU2IE1CIG9mIG1lbW9yeTwvcmFzZDpF
-        bGVtZW50TmFtZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpJbnN0YW5j
-        ZUlEPjU8L3Jhc2Q6SW5zdGFuY2VJRD4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpSZXNlcnZhdGlvbj4wPC9yYXNkOlJlc2VydmF0aW9uPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT40PC9yYXNkOlJlc291
-        cmNlVHlwZT4KICAgICAgICAgICAgICAgICAgICA8cmFzZDpWaXJ0dWFsUXVh
-        bnRpdHk+MjU2PC9yYXNkOlZpcnR1YWxRdWFudGl0eT4KICAgICAgICAgICAg
-        ICAgICAgICA8cmFzZDpXZWlnaHQ+MDwvcmFzZDpXZWlnaHQ+CiAgICAgICAg
-        ICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAgICAgICAgPG92ZjpJdGVt
-        PgogICAgICAgICAgICAgICAgICAgIDxyYXNkOkFkZHJlc3NPblBhcmVudD4w
-        PC9yYXNkOkFkZHJlc3NPblBhcmVudD4KICAgICAgICAgICAgICAgICAgICA8
-        cmFzZDpBdXRvbWF0aWNBbGxvY2F0aW9uPmZhbHNlPC9yYXNkOkF1dG9tYXRp
-        Y0FsbG9jYXRpb24+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6RGVzY3Jp
-        cHRpb24+Q0QvRFZEIERyaXZlPC9yYXNkOkRlc2NyaXB0aW9uPgogICAgICAg
-        ICAgICAgICAgICAgIDxyYXNkOkVsZW1lbnROYW1lPkNEL0RWRCBEcml2ZSAx
-        PC9yYXNkOkVsZW1lbnROYW1lPgogICAgICAgICAgICAgICAgICAgIDxyYXNk
-        Okhvc3RSZXNvdXJjZS8+CiAgICAgICAgICAgICAgICAgICAgPHJhc2Q6SW5z
-        dGFuY2VJRD4zMDAyPC9yYXNkOkluc3RhbmNlSUQ+CiAgICAgICAgICAgICAg
-        ICAgICAgPHJhc2Q6UGFyZW50PjM8L3Jhc2Q6UGFyZW50PgogICAgICAgICAg
-        ICAgICAgICAgIDxyYXNkOlJlc291cmNlVHlwZT4xNTwvcmFzZDpSZXNvdXJj
-        ZVR5cGU+CiAgICAgICAgICAgICAgICA8L292ZjpJdGVtPgogICAgICAgICAg
-        ICAgICAgPHZtdzpDb25maWcgb3ZmOnJlcXVpcmVkPSJmYWxzZSIgdm13Omtl
-        eT0iY3B1SG90QWRkRW5hYmxlZCIgdm13OnZhbHVlPSJmYWxzZSIvPgogICAg
-        ICAgICAgICAgICAgPHZtdzpDb25maWcgb3ZmOnJlcXVpcmVkPSJmYWxzZSIg
-        dm13OmtleT0iY3B1SG90UmVtb3ZlRW5hYmxlZCIgdm13OnZhbHVlPSJmYWxz
-        ZSIvPgogICAgICAgICAgICAgICAgPHZtdzpDb25maWcgb3ZmOnJlcXVpcmVk
-        PSJmYWxzZSIgdm13OmtleT0iZmlybXdhcmUiIHZtdzp2YWx1ZT0iYmlvcyIv
-        PgogICAgICAgICAgICAgICAgPHZtdzpDb25maWcgb3ZmOnJlcXVpcmVkPSJm
-        YWxzZSIgdm13OmtleT0idmlydHVhbElDSDdNUHJlc2VudCIgdm13OnZhbHVl
-        PSJmYWxzZSIvPgogICAgICAgICAgICAgICAgPHZtdzpDb25maWcgb3ZmOnJl
-        cXVpcmVkPSJmYWxzZSIgdm13OmtleT0idmlydHVhbFNNQ1ByZXNlbnQiIHZt
-        dzp2YWx1ZT0iZmFsc2UiLz4KICAgICAgICAgICAgICAgIDx2bXc6Q29uZmln
-        IG92ZjpyZXF1aXJlZD0iZmFsc2UiIHZtdzprZXk9Im1lbW9yeUhvdEFkZEVu
-        YWJsZWQiIHZtdzp2YWx1ZT0iZmFsc2UiLz4KICAgICAgICAgICAgICAgIDx2
-        bXc6Q29uZmlnIG92ZjpyZXF1aXJlZD0iZmFsc2UiIHZtdzprZXk9Im5lc3Rl
-        ZEhWRW5hYmxlZCIgdm13OnZhbHVlPSJmYWxzZSIvPgogICAgICAgICAgICAg
-        ICAgPHZtdzpDb25maWcgb3ZmOnJlcXVpcmVkPSJmYWxzZSIgdm13OmtleT0i
-        cG93ZXJPcEluZm8ucG93ZXJPZmZUeXBlIiB2bXc6dmFsdWU9InNvZnQiLz4K
-        ICAgICAgICAgICAgICAgIDx2bXc6Q29uZmlnIG92ZjpyZXF1aXJlZD0iZmFs
-        c2UiIHZtdzprZXk9InBvd2VyT3BJbmZvLnJlc2V0VHlwZSIgdm13OnZhbHVl
-        PSJzb2Z0Ii8+CiAgICAgICAgICAgICAgICA8dm13OkNvbmZpZyBvdmY6cmVx
-        dWlyZWQ9ImZhbHNlIiB2bXc6a2V5PSJwb3dlck9wSW5mby5zdGFuZGJ5QWN0
-        aW9uIiB2bXc6dmFsdWU9ImNoZWNrcG9pbnQiLz4KICAgICAgICAgICAgICAg
-        IDx2bXc6Q29uZmlnIG92ZjpyZXF1aXJlZD0iZmFsc2UiIHZtdzprZXk9InBv
-        d2VyT3BJbmZvLnN1c3BlbmRUeXBlIiB2bXc6dmFsdWU9ImhhcmQiLz4KICAg
-        ICAgICAgICAgICAgIDx2bXc6Q29uZmlnIG92ZjpyZXF1aXJlZD0iZmFsc2Ui
-        IHZtdzprZXk9InRvb2xzLmFmdGVyUG93ZXJPbiIgdm13OnZhbHVlPSJ0cnVl
-        Ii8+CiAgICAgICAgICAgICAgICA8dm13OkNvbmZpZyBvdmY6cmVxdWlyZWQ9
-        ImZhbHNlIiB2bXc6a2V5PSJ0b29scy5hZnRlclJlc3VtZSIgdm13OnZhbHVl
-        PSJ0cnVlIi8+CiAgICAgICAgICAgICAgICA8dm13OkNvbmZpZyBvdmY6cmVx
-        dWlyZWQ9ImZhbHNlIiB2bXc6a2V5PSJ0b29scy5iZWZvcmVHdWVzdFNodXRk
-        b3duIiB2bXc6dmFsdWU9InRydWUiLz4KICAgICAgICAgICAgICAgIDx2bXc6
-        Q29uZmlnIG92ZjpyZXF1aXJlZD0iZmFsc2UiIHZtdzprZXk9InRvb2xzLmJl
-        Zm9yZUd1ZXN0U3RhbmRieSIgdm13OnZhbHVlPSJ0cnVlIi8+CiAgICAgICAg
-        ICAgICAgICA8dm13OkNvbmZpZyBvdmY6cmVxdWlyZWQ9ImZhbHNlIiB2bXc6
-        a2V5PSJ0b29scy5zeW5jVGltZVdpdGhIb3N0IiB2bXc6dmFsdWU9ImZhbHNl
-        Ii8+CiAgICAgICAgICAgICAgICA8dm13OkNvbmZpZyBvdmY6cmVxdWlyZWQ9
-        ImZhbHNlIiB2bXc6a2V5PSJ0b29scy50b29sc1VwZ3JhZGVQb2xpY3kiIHZt
-        dzp2YWx1ZT0ibWFudWFsIi8+CiAgICAgICAgICAgICAgICA8dm13OkNvbmZp
-        ZyBvdmY6cmVxdWlyZWQ9ImZhbHNlIiB2bXc6a2V5PSJ1dWlkIiB2bXc6dmFs
-        dWU9IjQyM2U1YzUyLTQ2M2ItYzA2Zi00OWY2LTkyN2QzY2VmZDg5NCIvPgog
-        ICAgICAgICAgICA8L292ZjpWaXJ0dWFsSGFyZHdhcmVTZWN0aW9uPgogICAg
-        ICAgICAgICA8dmNsb3VkOkd1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24gb3Zm
-        OnJlcXVpcmVkPSJmYWxzZSI+CiAgICAgICAgICAgICAgICA8b3ZmOkluZm8+
-        U3BlY2lmaWVzIEd1ZXN0IE9TIEN1c3RvbWl6YXRpb24gU2V0dGluZ3M8L292
-        ZjpJbmZvPgogICAgICAgICAgICAgICAgPHZjbG91ZDpFbmFibGVkPmZhbHNl
-        PC92Y2xvdWQ6RW5hYmxlZD4KICAgICAgICAgICAgICAgIDx2Y2xvdWQ6Q2hh
-        bmdlU2lkPmZhbHNlPC92Y2xvdWQ6Q2hhbmdlU2lkPgogICAgICAgICAgICAg
-        ICAgPHZjbG91ZDpWaXJ0dWFsTWFjaGluZUlkPjBlYjIwZjk0LTljM2MtNDQw
-        Ny1iNDIwLWE1NGYwNjQzNjU5NjwvdmNsb3VkOlZpcnR1YWxNYWNoaW5lSWQ+
-        CiAgICAgICAgICAgICAgICA8dmNsb3VkOkpvaW5Eb21haW5FbmFibGVkPmZh
-        bHNlPC92Y2xvdWQ6Sm9pbkRvbWFpbkVuYWJsZWQ+CiAgICAgICAgICAgICAg
-        ICA8dmNsb3VkOlVzZU9yZ1NldHRpbmdzPmZhbHNlPC92Y2xvdWQ6VXNlT3Jn
-        U2V0dGluZ3M+CiAgICAgICAgICAgICAgICA8dmNsb3VkOkFkbWluUGFzc3dv
-        cmRFbmFibGVkPnRydWU8L3ZjbG91ZDpBZG1pblBhc3N3b3JkRW5hYmxlZD4K
-        ICAgICAgICAgICAgICAgIDx2Y2xvdWQ6QWRtaW5QYXNzd29yZEF1dG8+dHJ1
-        ZTwvdmNsb3VkOkFkbWluUGFzc3dvcmRBdXRvPgogICAgICAgICAgICAgICAg
-        PHZjbG91ZDpSZXNldFBhc3N3b3JkUmVxdWlyZWQ+ZmFsc2U8L3ZjbG91ZDpS
-        ZXNldFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8dmNsb3Vk
-        OkNvbXB1dGVyTmFtZT5EYW1uU21hbGxMaS0wMDE8L3ZjbG91ZDpDb21wdXRl
-        ck5hbWU+CiAgICAgICAgICAgIDwvdmNsb3VkOkd1ZXN0Q3VzdG9taXphdGlv
-        blNlY3Rpb24+CiAgICAgICAgICAgIDx2Y2xvdWQ6TmV0d29ya0Nvbm5lY3Rp
-        b25TZWN0aW9uIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgICAgICAg
-        ICAgPG92ZjpJbmZvPlNwZWNpZmllcyB0aGUgYXZhaWxhYmxlIFZNIG5ldHdv
-        cmsgY29ubmVjdGlvbnM8L292ZjpJbmZvPgogICAgICAgICAgICAgICAgPHZj
-        bG91ZDpQcmltYXJ5TmV0d29ya0Nvbm5lY3Rpb25JbmRleD4wPC92Y2xvdWQ6
-        UHJpbWFyeU5ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAg
-        ICA8dmNsb3VkOk5ldHdvcmtDb25uZWN0aW9uIG5lZWRzQ3VzdG9taXphdGlv
-        bj0idHJ1ZSIgbmV0d29yaz0iVk0gTmV0d29yayI+CiAgICAgICAgICAgICAg
-        ICAgICAgPHZjbG91ZDpOZXR3b3JrQ29ubmVjdGlvbkluZGV4PjA8L3ZjbG91
-        ZDpOZXR3b3JrQ29ubmVjdGlvbkluZGV4PgogICAgICAgICAgICAgICAgICAg
-        IDx2Y2xvdWQ6SXNDb25uZWN0ZWQ+dHJ1ZTwvdmNsb3VkOklzQ29ubmVjdGVk
-        PgogICAgICAgICAgICAgICAgICAgIDx2Y2xvdWQ6TUFDQWRkcmVzcz4wMDo1
-        MDo1NjowMTowMDowZjwvdmNsb3VkOk1BQ0FkZHJlc3M+CiAgICAgICAgICAg
-        ICAgICAgICAgPHZjbG91ZDpJcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT5ESENQ
-        PC92Y2xvdWQ6SXBBZGRyZXNzQWxsb2NhdGlvbk1vZGU+CiAgICAgICAgICAg
-        ICAgICA8L3ZjbG91ZDpOZXR3b3JrQ29ubmVjdGlvbj4KICAgICAgICAgICAg
-        PC92Y2xvdWQ6TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgIDwv
-        b3ZmOlZpcnR1YWxTeXN0ZW0+CiAgICA8L292ZjpWaXJ0dWFsU3lzdGVtQ29s
-        bGVjdGlvbj4KPC9vdmY6RW52ZWxvcGU+Cg==
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <ovf:References/>
+            <ovf:NetworkSection>
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <vcloud:CustomizationSection goldMaster="true" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
+            </vcloud:CustomizationSection>
+            <vcloud:NetworkConfigSection ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <vcloud:NetworkConfig networkName="none">
+                    <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
+                    <vcloud:Configuration>
+                        <vcloud:IpScopes>
+                            <vcloud:IpScope>
+                                <vcloud:IsInherited>false</vcloud:IsInherited>
+                                <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
+                                <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
+                                <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
+                            </vcloud:IpScope>
+                        </vcloud:IpScopes>
+                        <vcloud:FenceMode>isolated</vcloud:FenceMode>
+                    </vcloud:Configuration>
+                    <vcloud:IsDeployed>false</vcloud:IsDeployed>
+                </vcloud:NetworkConfig>
+            </vcloud:NetworkConfigSection>
+            <vcloud:LeaseSettingsSection ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
+                <vcloud:StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</vcloud:StorageLeaseExpiration>
+            </vcloud:LeaseSettingsSection>
+            <ovf:VirtualSystemCollection ovf:id="Tieto Windows Server 2012 R2">
+                <ovf:Info>A collection of virtual machines</ovf:Info>
+                <ovf:Name>Tieto Windows Server 2012 R2</ovf:Name>
+                <ovf:StartupSection>
+                    <ovf:Info>VApp startup section</ovf:Info>
+                    <ovf:Item ovf:id="Tieto Windows Server 2012 R2" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                </ovf:StartupSection>
+                <ovf:VirtualSystem ovf:id="Tieto Windows Server 2012 R2">
+                    <ovf:Info>A virtual machine</ovf:Info>
+                    <ovf:Name>Tieto Windows Server 2012 R2</ovf:Name>
+                    <ovf:OperatingSystemSection ovf:id="112" vmw:osType="windows8Server64Guest">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>Microsoft Windows Server 2012 (64-bit)</ovf:Description>
+                    </ovf:OperatingSystemSection>
+                    <ovf:VirtualHardwareSection ovf:transport="">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:VirtualSystemIdentifier>Tieto Windows Server 2012 R2</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:84:02:de</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:capacity="40960" vcloud:busSubType="lsilogicsas" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>42949672960</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SATA Controller</rasd:Description>
+                            <rasd:ElementName>SATA Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
+                            <rasd:ResourceType>20</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>16000</rasd:InstanceID>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>4096 MB of memory</rasd:ElementName>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                        </ovf:Item>
+                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204a04c-cb69-b862-2a14-5d573643bf78"/>
+                    </ovf:VirtualHardwareSection>
+                    <vcloud:GuestCustomizationSection ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <vcloud:Enabled>true</vcloud:Enabled>
+                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                        <vcloud:VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</vcloud:VirtualMachineId>
+                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                        <vcloud:AdminPasswordEnabled>false</vcloud:AdminPasswordEnabled>
+                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                        <vcloud:ComputerName>TietoWindow-001</vcloud:ComputerName>
+                    </vcloud:GuestCustomizationSection>
+                    <vcloud:NetworkConnectionSection ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                        <vcloud:NetworkConnection needsCustomization="true" network="none">
+                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                            <vcloud:IsConnected>false</vcloud:IsConnected>
+                            <vcloud:MACAddress>00:50:56:84:02:de</vcloud:MACAddress>
+                            <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                        </vcloud:NetworkConnection>
+                    </vcloud:NetworkConnectionSection>
+                </ovf:VirtualSystem>
+            </ovf:VirtualSystemCollection>
+        </ovf:Envelope>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:15 GMT
+  recorded_at: Fri, 16 Sep 2016 08:55:02 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf
     body:
       encoding: US-ASCII
       string: ''
@@ -7938,36 +4399,36 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:13 GMT
+      - Fri, 16 Sep 2016 08:55:07 GMT
       X-Vmware-Vcloud-Request-Id:
-      - a33bd1f1-ac23-47e2-9657-f3ed450dfe67
+      - 408b91ef-c857-43dd-9dce-2dd720c26725
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '166'
+      - '437'
       Content-Type:
       - application/*+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd">
+        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
             <ovf:References/>
             <ovf:NetworkSection>
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
+                <ovf:Network ovf:name="INT_192.168.10.0m24">
+                    <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
             <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
@@ -7976,24 +4437,27 @@ http_interactions:
             </vcloud:CustomizationSection>
             <vcloud:NetworkConfigSection ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <vcloud:NetworkConfig networkName="VM Network">
-                    <vcloud:Description>The VM Network network</vcloud:Description>
+                <vcloud:NetworkConfig networkName="INT_192.168.10.0m24">
+                    <vcloud:Description/>
                     <vcloud:Configuration>
                         <vcloud:IpScopes>
                             <vcloud:IpScope>
-                                <vcloud:IsInherited>false</vcloud:IsInherited>
-                                <vcloud:Gateway>192.168.254.1</vcloud:Gateway>
+                                <vcloud:IsInherited>true</vcloud:IsInherited>
+                                <vcloud:Gateway>192.168.10.1</vcloud:Gateway>
                                 <vcloud:Netmask>255.255.255.0</vcloud:Netmask>
+                                <vcloud:Dns1>192.168.10.1</vcloud:Dns1>
+                                <vcloud:DnsSuffix>test.local</vcloud:DnsSuffix>
                                 <vcloud:IsEnabled>true</vcloud:IsEnabled>
                                 <vcloud:IpRanges>
                                     <vcloud:IpRange>
-                                        <vcloud:StartAddress>192.168.254.100</vcloud:StartAddress>
-                                        <vcloud:EndAddress>192.168.254.199</vcloud:EndAddress>
+                                        <vcloud:StartAddress>192.168.10.100</vcloud:StartAddress>
+                                        <vcloud:EndAddress>192.168.10.199</vcloud:EndAddress>
                                     </vcloud:IpRange>
                                 </vcloud:IpRanges>
                             </vcloud:IpScope>
                         </vcloud:IpScopes>
-                        <vcloud:FenceMode>isolated</vcloud:FenceMode>
+                        <vcloud:ParentNetwork href="" name="INT_192.168.10.0m24"/>
+                        <vcloud:FenceMode>bridged</vcloud:FenceMode>
                         <vcloud:RetainNetInfoAcrossDeployments>false</vcloud:RetainNetInfoAcrossDeployments>
                     </vcloud:Configuration>
                     <vcloud:IsDeployed>false</vcloud:IsDeployed>
@@ -8002,96 +4466,96 @@ http_interactions:
             <vcloud:LeaseSettingsSection ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
                 <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
-                <vcloud:StorageLeaseExpiration>2016-11-04T15:45:03.693+01:00</vcloud:StorageLeaseExpiration>
+                <vcloud:StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</vcloud:StorageLeaseExpiration>
             </vcloud:LeaseSettingsSection>
-            <ovf:VirtualSystemCollection ovf:id="TinyLinuxVM-template">
+            <ovf:VirtualSystemCollection ovf:id="vApp_cankamat_remote_1">
                 <ovf:Info>A collection of virtual machines</ovf:Info>
-                <ovf:Name>TinyLinuxVM-template</ovf:Name>
+                <ovf:Name>vApp_cankamat_remote_1</ovf:Name>
                 <ovf:StartupSection>
                     <ovf:Info>VApp startup section</ovf:Info>
-                    <ovf:Item ovf:id="TTYLinux" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                    <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
                 </ovf:StartupSection>
-                <ovf:VirtualSystem ovf:id="TTYLinux">
+                <ovf:VirtualSystem ovf:id="CentOS7">
                     <ovf:Info>A virtual machine</ovf:Info>
-                    <ovf:Name>TTYLinux</ovf:Name>
-                    <ovf:AnnotationSection>
-                        <ovf:Info>A human-readable annotation</ovf:Info>
-                        <ovf:Annotation>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</ovf:Annotation>
-                    </ovf:AnnotationSection>
-                    <ovf:OperatingSystemSection ovf:id="36" vmw:osType="otherLinuxGuest">
+                    <ovf:Name>CentOS7</ovf:Name>
+                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
                         <ovf:Info>Specifies the operating system installed</ovf:Info>
-                        <ovf:Description>Other Linux (32-bit)</ovf:Description>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
                     </ovf:OperatingSystemSection>
                     <ovf:VirtualHardwareSection ovf:transport="">
                         <ovf:Info>Virtual hardware requirements</ovf:Info>
                         <ovf:System>
                             <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
                             <vssd:InstanceID>0</vssd:InstanceID>
-                            <vssd:VirtualSystemIdentifier>TTYLinux</vssd:VirtualSystemIdentifier>
-                            <vssd:VirtualSystemType>vmx-08</vssd:VirtualSystemType>
+                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
                         </ovf:System>
                         <ovf:Item>
-                            <rasd:Address>00:50:56:01:00:12</rasd:Address>
+                            <rasd:Address>00:50:56:01:00:2d</rasd:Address>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
-                            <rasd:Connection vcloud:ipAddressingMode="DHCP" vcloud:primaryNetworkConnection="true">VM Network</rasd:Connection>
-                            <rasd:Description>E1000 ethernet adapter on "VM Network"</rasd:Description>
+                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">INT_192.168.10.0m24</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "INT_192.168.10.0m24"</rasd:Description>
                             <rasd:ElementName>Network adapter 0</rasd:ElementName>
                             <rasd:InstanceID>1</rasd:InstanceID>
-                            <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
                             <rasd:ResourceType>10</rasd:ResourceType>
-                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="32"/>
                             <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:Address>0</rasd:Address>
-                            <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
                             <rasd:InstanceID>2</rasd:InstanceID>
-                            <rasd:ResourceType>5</rasd:ResourceType>
+                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AddressOnParent>0</rasd:AddressOnParent>
                             <rasd:Description>Hard disk</rasd:Description>
                             <rasd:ElementName>Hard disk 1</rasd:ElementName>
-                            <rasd:HostResource vcloud:busType="5" vcloud:busSubType="" vcloud:capacity="32"/>
-                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
                             <rasd:Parent>2</rasd:Parent>
                             <rasd:ResourceType>17</rasd:ResourceType>
-                            <rasd:VirtualQuantity>33554432</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
                             <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
                             <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
                         </ovf:Item>
                         <ovf:Item>
-                            <rasd:Address>1</rasd:Address>
+                            <rasd:Address>0</rasd:Address>
                             <rasd:Description>IDE Controller</rasd:Description>
-                            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
                             <rasd:InstanceID>3</rasd:InstanceID>
                             <rasd:ResourceType>5</rasd:ResourceType>
                         </ovf:Item>
                         <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
                             <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
                             <rasd:Description>Number of Virtual CPUs</rasd:Description>
-                            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
                             <rasd:InstanceID>4</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>3</rasd:ResourceType>
-                            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
                         </ovf:Item>
                         <ovf:Item>
                             <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
                             <rasd:Description>Memory Size</rasd:Description>
-                            <rasd:ElementName>32 MB of memory</rasd:ElementName>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
                             <rasd:InstanceID>5</rasd:InstanceID>
                             <rasd:Reservation>0</rasd:Reservation>
                             <rasd:ResourceType>4</rasd:ResourceType>
-                            <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
                             <rasd:Weight>0</rasd:Weight>
                         </ovf:Item>
                         <ovf:Item>
@@ -8100,7 +4564,7 @@ http_interactions:
                             <rasd:Description>CD/DVD Drive</rasd:Description>
                             <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
                             <rasd:HostResource/>
-                            <rasd:InstanceID>3002</rasd:InstanceID>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
                             <rasd:Parent>3</rasd:Parent>
                             <rasd:ResourceType>15</rasd:ResourceType>
                         </ovf:Item>
@@ -8121,38 +4585,38 @@ http_interactions:
                         <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
                         <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
                         <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
-                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="423e203b-367d-3156-8c95-d21a32b517bf"/>
+                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
                     </ovf:VirtualHardwareSection>
                     <vcloud:GuestCustomizationSection ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <vcloud:Enabled>false</vcloud:Enabled>
                         <vcloud:ChangeSid>false</vcloud:ChangeSid>
-                        <vcloud:VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</vcloud:VirtualMachineId>
+                        <vcloud:VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</vcloud:VirtualMachineId>
                         <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
                         <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
                         <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
                         <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
                         <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
-                        <vcloud:ComputerName>TTYLinux-001</vcloud:ComputerName>
+                        <vcloud:ComputerName>CentOS7-0</vcloud:ComputerName>
                     </vcloud:GuestCustomizationSection>
                     <vcloud:NetworkConnectionSection ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
-                        <vcloud:NetworkConnection needsCustomization="true" network="VM Network">
+                        <vcloud:NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
                             <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
                             <vcloud:IsConnected>true</vcloud:IsConnected>
-                            <vcloud:MACAddress>00:50:56:01:00:12</vcloud:MACAddress>
-                            <vcloud:IpAddressAllocationMode>DHCP</vcloud:IpAddressAllocationMode>
+                            <vcloud:MACAddress>00:50:56:01:00:2d</vcloud:MACAddress>
+                            <vcloud:IpAddressAllocationMode>POOL</vcloud:IpAddressAllocationMode>
                         </vcloud:NetworkConnection>
                     </vcloud:NetworkConnectionSection>
                 </ovf:VirtualSystem>
             </ovf:VirtualSystemCollection>
         </ovf:Envelope>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:15 GMT
+  recorded_at: Fri, 16 Sep 2016 08:55:08 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf
     body:
       encoding: US-ASCII
       string: ''
@@ -8162,154 +4626,356 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:13 GMT
+      - Fri, 16 Sep 2016 08:55:13 GMT
       X-Vmware-Vcloud-Request-Id:
-      - e4f37186-18dd-4f7b-adca-d692ce85f46d
+      - 2b6e6fcf-e19e-4851-be1d-382e39b8472b
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '318'
+      - '799'
       Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      - application/*+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_system_5" id="urn:vcloud:vapptemplate:674bc33b-c6be-4c70-9813-c9bda69839ee" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/322441c4-d47c-4346-9188-b6044fdca875" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/action/disableDownload"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-            <Description/>
-            <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
-            </Owner>
-            <Children>
-                <Vm goldMaster="false" status="8" name="Small VM" id="urn:vcloud:vm:2ef97da4-7b83-4d92-9cbc-a3df64eeca92" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description/>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
-                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="test-direct-connected">
-                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
-                            <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:08</MACAddress>
-                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
-                        </NetworkConnection>
-                    </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-2ef97da4-7b83-4d92-9cbc-a3df64eeca92/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
-                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
-                        <Enabled>false</Enabled>
-                        <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>2ef97da4-7b83-4d92-9cbc-a3df64eeca92</VirtualMachineId>
-                        <JoinDomainEnabled>false</JoinDomainEnabled>
-                        <UseOrgSettings>false</UseOrgSettings>
-                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
-                        <AdminPasswordAuto>true</AdminPasswordAuto>
-                        <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>SmallVM</ComputerName>
-                    </GuestCustomizationSection>
-                    <VAppScopedLocalId>0e6c69f9-eea7-4d99-bda3-13687febaca5</VAppScopedLocalId>
-                    <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
-                </Vm>
-            </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkSection/">
+        <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+            <ovf:References/>
+            <ovf:NetworkSection>
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="test-direct-connected">
-                    <ovf:Description/>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
-                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="test-direct-connected">
-                    <Description/>
-                    <Configuration>
-                        <IpScopes>
-                            <IpScope>
-                                <IsInherited>true</IsInherited>
-                                <Gateway>10.30.2.1</Gateway>
-                                <Netmask>255.255.255.0</Netmask>
-                                <Dns1>8.8.8.8</Dns1>
-                                <Dns2>8.8.4.4</Dns2>
-                                <IsEnabled>true</IsEnabled>
-                                <IpRanges>
-                                    <IpRange>
-                                        <StartAddress>10.30.2.51</StartAddress>
-                                        <EndAddress>10.30.2.60</EndAddress>
-                                    </IpRange>
-                                </IpRanges>
-                            </IpScope>
-                        </IpScopes>
-                        <ParentNetwork href="" name="test-direct-connected"/>
-                        <FenceMode>natRouted</FenceMode>
-                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-                        <Features>
-                            <FirewallService>
-                                <IsEnabled>true</IsEnabled>
-                                <DefaultAction>drop</DefaultAction>
-                                <LogDefaultAction>false</LogDefaultAction>
-                                <FirewallRule>
-                                    <IsEnabled>true</IsEnabled>
-                                    <MatchOnTranslate>false</MatchOnTranslate>
-                                    <Description>Allow all outgoing traffic</Description>
-                                    <Policy>allow</Policy>
-                                    <Protocols>
-                                        <Any>true</Any>
-                                    </Protocols>
-                                    <Port>-1</Port>
-                                    <DestinationPortRange>Any</DestinationPortRange>
-                                    <DestinationIp>external</DestinationIp>
-                                    <SourcePort>-1</SourcePort>
-                                    <SourcePortRange>Any</SourcePortRange>
-                                    <SourceIp>internal</SourceIp>
-                                    <EnableLogging>false</EnableLogging>
-                                </FirewallRule>
-                            </FirewallService>
-                        </Features>
-                        <SyslogServerSettings/>
-                    </Configuration>
-                    <IsDeployed>false</IsDeployed>
-                </NetworkConfig>
-            </NetworkConfigSection>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
-                <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
-                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-10-30T12:38:19.000+01:00</StorageLeaseExpiration>
-            </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-674bc33b-c6be-4c70-9813-c9bda69839ee/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
-                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
-            </CustomizationSection>
-            <DateCreated>2016-07-29T09:48:01.393+02:00</DateCreated>
-        </VAppTemplate>
+                <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
+            </vcloud:CustomizationSection>
+            <vcloud:NetworkConfigSection ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <vcloud:NetworkConfig networkName="none">
+                    <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
+                    <vcloud:Configuration>
+                        <vcloud:IpScopes>
+                            <vcloud:IpScope>
+                                <vcloud:IsInherited>false</vcloud:IsInherited>
+                                <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
+                                <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
+                                <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
+                            </vcloud:IpScope>
+                        </vcloud:IpScopes>
+                        <vcloud:FenceMode>isolated</vcloud:FenceMode>
+                    </vcloud:Configuration>
+                    <vcloud:IsDeployed>false</vcloud:IsDeployed>
+                </vcloud:NetworkConfig>
+            </vcloud:NetworkConfigSection>
+            <vcloud:LeaseSettingsSection ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
+                <vcloud:StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</vcloud:StorageLeaseExpiration>
+            </vcloud:LeaseSettingsSection>
+            <ovf:VirtualSystemCollection ovf:id="vApp_CentOS_and_msWin">
+                <ovf:Info>A collection of virtual machines</ovf:Info>
+                <ovf:Name>vApp_CentOS_and_msWin</ovf:Name>
+                <ovf:StartupSection>
+                    <ovf:Info>VApp startup section</ovf:Info>
+                    <ovf:Item ovf:id="CentOS7" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                    <ovf:Item ovf:id="Tieto Windows Server 2012 R2" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+                </ovf:StartupSection>
+                <ovf:VirtualSystem ovf:id="Tieto Windows Server 2012 R2">
+                    <ovf:Info>A virtual machine</ovf:Info>
+                    <ovf:Name>Tieto Windows Server 2012 R2</ovf:Name>
+                    <ovf:OperatingSystemSection ovf:id="112" vmw:osType="windows8Server64Guest">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>Microsoft Windows Server 2012 (64-bit)</ovf:Description>
+                    </ovf:OperatingSystemSection>
+                    <ovf:VirtualHardwareSection ovf:transport="">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:VirtualSystemIdentifier>Tieto Windows Server 2012 R2</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:4c</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="192"/>
+                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:capacity="40960" vcloud:busSubType="lsilogicsas" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>42949672960</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SATA Controller</rasd:Description>
+                            <rasd:ElementName>SATA Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
+                            <rasd:ResourceType>20</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="33"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>16000</rasd:InstanceID>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>4096 MB of memory</rasd:ElementName>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                        </ovf:Item>
+                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204a04c-cb69-b862-2a14-5d573643bf78"/>
+                    </ovf:VirtualHardwareSection>
+                    <vcloud:GuestCustomizationSection ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <vcloud:Enabled>true</vcloud:Enabled>
+                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                        <vcloud:VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</vcloud:VirtualMachineId>
+                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                        <vcloud:AdminPasswordEnabled>false</vcloud:AdminPasswordEnabled>
+                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                        <vcloud:ComputerName>TietoWindow-0</vcloud:ComputerName>
+                    </vcloud:GuestCustomizationSection>
+                    <vcloud:NetworkConnectionSection ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                        <vcloud:NetworkConnection needsCustomization="true" network="none">
+                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                            <vcloud:IsConnected>false</vcloud:IsConnected>
+                            <vcloud:MACAddress>00:50:56:01:00:4c</vcloud:MACAddress>
+                            <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                        </vcloud:NetworkConnection>
+                    </vcloud:NetworkConnectionSection>
+                </ovf:VirtualSystem>
+                <ovf:VirtualSystem ovf:id="CentOS7">
+                    <ovf:Info>A virtual machine</ovf:Info>
+                    <ovf:Name>CentOS7</ovf:Name>
+                    <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
+                        <ovf:Info>Specifies the operating system installed</ovf:Info>
+                        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+                    </ovf:OperatingSystemSection>
+                    <ovf:VirtualHardwareSection ovf:transport="">
+                        <ovf:Info>Virtual hardware requirements</ovf:Info>
+                        <ovf:System>
+                            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                            <vssd:InstanceID>0</vssd:InstanceID>
+                            <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                            <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                        </ovf:System>
+                        <ovf:Item>
+                            <rasd:Address>00:50:56:01:00:4d</rasd:Address>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                            <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                            <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                            <rasd:InstanceID>1</rasd:InstanceID>
+                            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                            <rasd:ResourceType>10</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+                            <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>SCSI Controller</rasd:Description>
+                            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>2</rasd:InstanceID>
+                            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                            <rasd:ResourceType>6</rasd:ResourceType>
+                            <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="16"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:Description>Hard disk</rasd:Description>
+                            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                            <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                            <rasd:InstanceID>2000</rasd:InstanceID>
+                            <rasd:Parent>2</rasd:Parent>
+                            <rasd:ResourceType>17</rasd:ResourceType>
+                            <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                            <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                            <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:Address>0</rasd:Address>
+                            <rasd:Description>IDE Controller</rasd:Description>
+                            <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                            <rasd:InstanceID>3</rasd:InstanceID>
+                            <rasd:ResourceType>5</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>Floppy Drive</rasd:Description>
+                            <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>8000</rasd:InstanceID>
+                            <rasd:ResourceType>14</rasd:ResourceType>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                            <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                            <rasd:InstanceID>4</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>3</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                            <rasd:Description>Memory Size</rasd:Description>
+                            <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                            <rasd:InstanceID>5</rasd:InstanceID>
+                            <rasd:Reservation>0</rasd:Reservation>
+                            <rasd:ResourceType>4</rasd:ResourceType>
+                            <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                            <rasd:Weight>0</rasd:Weight>
+                        </ovf:Item>
+                        <ovf:Item>
+                            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                            <rasd:Description>CD/DVD Drive</rasd:Description>
+                            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                            <rasd:HostResource/>
+                            <rasd:InstanceID>3000</rasd:InstanceID>
+                            <rasd:Parent>3</rasd:Parent>
+                            <rasd:ResourceType>15</rasd:ResourceType>
+                        </ovf:Item>
+                        <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                        <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                        <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                        <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                        <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
+                    </ovf:VirtualHardwareSection>
+                    <vcloud:GuestCustomizationSection ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <vcloud:Enabled>false</vcloud:Enabled>
+                        <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                        <vcloud:VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</vcloud:VirtualMachineId>
+                        <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                        <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                        <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
+                        <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                        <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                        <vcloud:ComputerName>CentOS7-0-0</vcloud:ComputerName>
+                    </vcloud:GuestCustomizationSection>
+                    <vcloud:NetworkConnectionSection ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                        <vcloud:NetworkConnection needsCustomization="true" network="none">
+                            <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                            <vcloud:IsConnected>false</vcloud:IsConnected>
+                            <vcloud:MACAddress>00:50:56:01:00:4d</vcloud:MACAddress>
+                            <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                        </vcloud:NetworkConnection>
+                    </vcloud:NetworkConnectionSection>
+                </ovf:VirtualSystem>
+            </ovf:VirtualSystemCollection>
+        </ovf:Envelope>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:16 GMT
+  recorded_at: Fri, 16 Sep 2016 08:55:14 GMT
 - request:
     method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-44b686fb-d4bf-4ec4-b3fb-6554008f1868
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57
     body:
       encoding: US-ASCII
       string: ''
@@ -8319,336 +4985,97 @@ http_interactions:
       Accept:
       - application/*+xml;version=5.1
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Sat, 06 Aug 2016 14:52:14 GMT
+      - Fri, 16 Sep 2016 08:55:19 GMT
       X-Vmware-Vcloud-Request-Id:
-      - 850c79db-09eb-411f-9008-674392495b25
+      - 491d6303-09cb-418a-9ad0-68882938436c
       X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
+      - 5654e38c198f4265bc768fea28d3b1bf
       Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
       X-Vmware-Vcloud-Request-Execution-Time:
-      - '214'
+      - '258'
       Content-Type:
       - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
       Vary:
       - Accept-Encoding, User-Agent
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZBcHBU
-        ZW1wbGF0ZSB4bWxucz0iaHR0cDovL3d3dy52bXdhcmUuY29tL3ZjbG91ZC92
-        MS41IiB4bWxuczpvdmY9Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
-        bnZlbG9wZS8xIiBnb2xkTWFzdGVyPSJmYWxzZSIgb3ZmRGVzY3JpcHRvclVw
-        bG9hZGVkPSJ0cnVlIiBzdGF0dXM9IjgiIG5hbWU9IkRTTC1MaW51eC10ZW1w
-        bGF0ZSIgaWQ9InVybjp2Y2xvdWQ6dmFwcHRlbXBsYXRlOjQ0YjY4NmZiLWQ0
-        YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2OCIgaHJlZj0iaHR0cHM6Ly8xMC4z
-        MC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmIt
-        ZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4IiB0eXBlPSJhcHBsaWNhdGlv
-        bi92bmQudm13YXJlLnZjbG91ZC52QXBwVGVtcGxhdGUreG1sIiB4bWxuczp4
-        c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNl
-        IiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9zY2hlbWFzLmRtdGYub3Jn
-        L292Zi9lbnZlbG9wZS8xIGh0dHA6Ly9zY2hlbWFzLmRtdGYub3JnL292Zi9l
-        bnZlbG9wZS8xL2RzcDgwMjNfMS4xLjAueHNkIGh0dHA6Ly93d3cudm13YXJl
-        LmNvbS92Y2xvdWQvdjEuNSBodHRwOi8vMTAuMzAuMi4yL2FwaS92MS41L3Nj
-        aGVtYS9tYXN0ZXIueHNkIj4KICAgIDxMaW5rIHJlbD0idXAiIGhyZWY9Imh0
-        dHBzOi8vMTAuMzAuMi4yL2FwaS92ZGMvMGVkZTI2YTItNThjOC00NDk0LTgy
-        MWEtYTIxNmIxNDliODY1IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJl
-        LnZjbG91ZC52ZGMreG1sIi8+CiAgICA8TGluayByZWw9ImNhdGFsb2dJdGVt
-        IiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvY2F0YWxvZ0l0ZW0vOTBl
-        ZGMyNDItYmYyYS00ZWUzLTg5MmYtMGEzZjg3ZTZlNjgwIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5jYXRhbG9nSXRlbSt4bWwiLz4K
-        ICAgIDxMaW5rIHJlbD0icmVtb3ZlIiBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJm
-        LTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgiLz4KICAgIDxMaW5rIHJlbD0iZWRp
-        dCIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92
-        YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYx
-        ODY4IiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC52QXBw
-        VGVtcGxhdGUreG1sIi8+CiAgICA8TGluayByZWw9ImVuYWJsZSIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
-        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L2FjdGlv
-        bi9lbmFibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJkaXNhYmxlIiBo
-        cmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBU
-        ZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4Njgv
-        YWN0aW9uL2Rpc2FibGVEb3dubG9hZCIvPgogICAgPExpbmsgcmVsPSJvdmYi
-        IGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdmFw
-        cFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1iM2ZiLTY1NTQwMDhmMTg2
-        OC9vdmYiIHR5cGU9InRleHQveG1sIi8+CiAgICA8TGluayByZWw9InN0b3Jh
-        Z2VQcm9maWxlIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdmRjU3Rv
-        cmFnZVByb2ZpbGUvNjk5ZTE5NDktMDY4My00Y2FhLWI2ZDgtY2QyNTgyNTFl
-        YThkIiBuYW1lPSIqIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC52ZGNTdG9yYWdlUHJvZmlsZSt4bWwiLz4KICAgIDxMaW5rIHJlbD0i
-        ZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0
-        ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAw
-        OGYxODY4L293bmVyIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZj
-        bG91ZC5vd25lcit4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0i
-        aHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxh
-        dGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L21ldGFk
-        YXRhIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5tZXRh
-        ZGF0YSt4bWwiLz4KICAgIDxMaW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6
-        Ly8xMC4zMC4yLjIvYXBpL3ZBcHBUZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRi
-        Njg2ZmItZDRiZi00ZWM0LWIzZmItNjU1NDAwOGYxODY4L3Byb2R1Y3RTZWN0
-        aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLnBy
-        b2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgIDxEZXNjcmlwdGlvbi8+CiAgICA8
-        T3duZXIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQub3du
-        ZXIreG1sIj4KICAgICAgICA8VXNlciBocmVmPSJodHRwczovLzEwLjMwLjIu
-        Mi9hcGkvYWRtaW4vdXNlci9kNjVmNzRiZS0yMzlmLTQ5YjctODdmZi0zOWUz
-        MTU0MTMzNTEiIG5hbWU9ImFkbWluIiB0eXBlPSJhcHBsaWNhdGlvbi92bmQu
-        dm13YXJlLmFkbWluLnVzZXIreG1sIi8+CiAgICA8L093bmVyPgogICAgPENo
-        aWxkcmVuPgogICAgICAgIDxWbSBnb2xkTWFzdGVyPSJmYWxzZSIgc3RhdHVz
-        PSI4IiBuYW1lPSJEYW1uIFNtYWxsIExpbnV4IiBpZD0idXJuOnZjbG91ZDp2
-        bTowZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0MzY1OTYiIGhyZWY9
-        Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxhdGUvdm0tMGViMjBm
-        OTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2IiB0eXBlPSJhcHBsaWNh
-        dGlvbi92bmQudm13YXJlLnZjbG91ZC52bSt4bWwiPgogICAgICAgICAgICA8
-        TGluayByZWw9InVwIiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFw
-        cFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNm
-        Yi02NTU0MDA4ZjE4NjgiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnZBcHBUZW1wbGF0ZSt4bWwiLz4KICAgICAgICAgICAgPExpbmsg
-        cmVsPSJzdG9yYWdlUHJvZmlsZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIv
-        YXBpL3ZkY1N0b3JhZ2VQcm9maWxlLzY5OWUxOTQ5LTA2ODMtNGNhYS1iNmQ4
-        LWNkMjU4MjUxZWE4ZCIgdHlwZT0iYXBwbGljYXRpb24vdm5kLnZtd2FyZS52
-        Y2xvdWQudmRjU3RvcmFnZVByb2ZpbGUreG1sIi8+CiAgICAgICAgICAgIDxM
-        aW5rIHJlbD0iZG93biIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZB
-        cHBUZW1wbGF0ZS92bS0wZWIyMGY5NC05YzNjLTQ0MDctYjQyMC1hNTRmMDY0
-        MzY1OTYvbWV0YWRhdGEiIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLm1ldGFkYXRhK3htbCIvPgogICAgICAgICAgICA8TGluayByZWw9
-        ImRvd24iIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92QXBwVGVtcGxh
-        dGUvdm0tMGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2NTk2L3By
-        b2R1Y3RTZWN0aW9ucy8iIHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUu
-        dmNsb3VkLnByb2R1Y3RTZWN0aW9ucyt4bWwiLz4KICAgICAgICAgICAgPERl
-        c2NyaXB0aW9uPknigJl2ZSBjcmVhdGVkIGFuIE9WRiB2ZXJzaW9uIG9mIHRo
-        ZSBoaWdobHkgcG9wdWxhciBEYW1uIFNtYWxsIExpbnV4IGRpc3RyaWJ1dGlv
-        bi4gTm9ybWFsbHkgeW91IHJ1biB0aGlzIE9TIHdoaWNoIGlzIG9ubHkgNTBN
-        QnMgaW4gZGlzayBzaXplIGZyb20gYW4gSVNPIG9yIHBlbiBkcml2ZSBidXQg
-        SeKAmXZlIHNlZW4gbW9yZSBhbmQgbW9yZSBwZW9wbGUgZXhwZXJpbWVudGlu
-        ZyB3aXRoIHRoZSB2Q2xvdWQgRGlyZWN0b3IgYW5kIHJlYWxseSBuZWVkIHNv
-        PC9EZXNjcmlwdGlvbj4KICAgICAgICAgICAgPE5ldHdvcmtDb25uZWN0aW9u
-        U2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRlbXBs
-        YXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1NGYwNjQzNjU5Ni9u
-        ZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24vIiB0eXBlPSJhcHBsaWNhdGlvbi92
-        bmQudm13YXJlLnZjbG91ZC5uZXR3b3JrQ29ubmVjdGlvblNlY3Rpb24reG1s
-        IiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICAgICAgICAgIDxvdmY6
-        SW5mbz5TcGVjaWZpZXMgdGhlIGF2YWlsYWJsZSBWTSBuZXR3b3JrIGNvbm5l
-        Y3Rpb25zPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxQcmltYXJ5TmV0
-        d29ya0Nvbm5lY3Rpb25JbmRleD4wPC9QcmltYXJ5TmV0d29ya0Nvbm5lY3Rp
-        b25JbmRleD4KICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbiBu
-        ZWVkc0N1c3RvbWl6YXRpb249InRydWUiIG5ldHdvcms9IlZNIE5ldHdvcmsi
-        PgogICAgICAgICAgICAgICAgICAgIDxOZXR3b3JrQ29ubmVjdGlvbkluZGV4
-        PjA8L05ldHdvcmtDb25uZWN0aW9uSW5kZXg+CiAgICAgICAgICAgICAgICAg
-        ICAgPElzQ29ubmVjdGVkPnRydWU8L0lzQ29ubmVjdGVkPgogICAgICAgICAg
-        ICAgICAgICAgIDxNQUNBZGRyZXNzPjAwOjUwOjU2OjAxOjAwOjBmPC9NQUNB
-        ZGRyZXNzPgogICAgICAgICAgICAgICAgICAgIDxJcEFkZHJlc3NBbGxvY2F0
-        aW9uTW9kZT5ESENQPC9JcEFkZHJlc3NBbGxvY2F0aW9uTW9kZT4KICAgICAg
-        ICAgICAgICAgIDwvTmV0d29ya0Nvbm5lY3Rpb24+CiAgICAgICAgICAgIDwv
-        TmV0d29ya0Nvbm5lY3Rpb25TZWN0aW9uPgogICAgICAgICAgICA8R3Vlc3RD
-        dXN0b21pemF0aW9uU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9h
-        cGkvdkFwcFRlbXBsYXRlL3ZtLTBlYjIwZjk0LTljM2MtNDQwNy1iNDIwLWE1
-        NGYwNjQzNjU5Ni9ndWVzdEN1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0i
-        YXBwbGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuZ3Vlc3RDdXN0b21pemF0
-        aW9uU2VjdGlvbit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAg
-        ICAgICAgICAgPG92ZjpJbmZvPlNwZWNpZmllcyBHdWVzdCBPUyBDdXN0b21p
-        emF0aW9uIFNldHRpbmdzPC9vdmY6SW5mbz4KICAgICAgICAgICAgICAgIDxF
-        bmFibGVkPmZhbHNlPC9FbmFibGVkPgogICAgICAgICAgICAgICAgPENoYW5n
-        ZVNpZD5mYWxzZTwvQ2hhbmdlU2lkPgogICAgICAgICAgICAgICAgPFZpcnR1
-        YWxNYWNoaW5lSWQ+MGViMjBmOTQtOWMzYy00NDA3LWI0MjAtYTU0ZjA2NDM2
-        NTk2PC9WaXJ0dWFsTWFjaGluZUlkPgogICAgICAgICAgICAgICAgPEpvaW5E
-        b21haW5FbmFibGVkPmZhbHNlPC9Kb2luRG9tYWluRW5hYmxlZD4KICAgICAg
-        ICAgICAgICAgIDxVc2VPcmdTZXR0aW5ncz5mYWxzZTwvVXNlT3JnU2V0dGlu
-        Z3M+CiAgICAgICAgICAgICAgICA8QWRtaW5QYXNzd29yZEVuYWJsZWQ+dHJ1
-        ZTwvQWRtaW5QYXNzd29yZEVuYWJsZWQ+CiAgICAgICAgICAgICAgICA8QWRt
-        aW5QYXNzd29yZEF1dG8+dHJ1ZTwvQWRtaW5QYXNzd29yZEF1dG8+CiAgICAg
-        ICAgICAgICAgICA8UmVzZXRQYXNzd29yZFJlcXVpcmVkPmZhbHNlPC9SZXNl
-        dFBhc3N3b3JkUmVxdWlyZWQ+CiAgICAgICAgICAgICAgICA8Q29tcHV0ZXJO
-        YW1lPkRhbW5TbWFsbExpLTAwMTwvQ29tcHV0ZXJOYW1lPgogICAgICAgICAg
-        ICA8L0d1ZXN0Q3VzdG9taXphdGlvblNlY3Rpb24+CiAgICAgICAgICAgIDxW
-        QXBwU2NvcGVkTG9jYWxJZD5EYW1uIFNtYWxsIExpbnV4PC9WQXBwU2NvcGVk
-        TG9jYWxJZD4KICAgICAgICAgICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFU
-        MTQ6MDQ6NDQuMTYwKzAyOjAwPC9EYXRlQ3JlYXRlZD4KICAgICAgICA8L1Zt
-        PgogICAgPC9DaGlsZHJlbj4KICAgIDxvdmY6TmV0d29ya1NlY3Rpb24geG1s
-        bnM6dmNsb3VkPSJodHRwOi8vd3d3LnZtd2FyZS5jb20vdmNsb3VkL3YxLjUi
-        IHZjbG91ZDp0eXBlPSJhcHBsaWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5u
-        ZXR3b3JrU2VjdGlvbit4bWwiIHZjbG91ZDpocmVmPSJodHRwczovLzEwLjMw
-        LjIuMi9hcGkvdkFwcFRlbXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1k
-        NGJmLTRlYzQtYjNmYi02NTU0MDA4ZjE4NjgvbmV0d29ya1NlY3Rpb24vIj4K
-        ICAgICAgICA8b3ZmOkluZm8+VGhlIGxpc3Qgb2YgbG9naWNhbCBuZXR3b3Jr
-        czwvb3ZmOkluZm8+CiAgICAgICAgPG92ZjpOZXR3b3JrIG92ZjpuYW1lPSJW
-        TSBOZXR3b3JrIj4KICAgICAgICAgICAgPG92ZjpEZXNjcmlwdGlvbj5UaGUg
-        Vk0gTmV0d29yayBuZXR3b3JrPC9vdmY6RGVzY3JpcHRpb24+CiAgICAgICAg
-        PC9vdmY6TmV0d29yaz4KICAgIDwvb3ZmOk5ldHdvcmtTZWN0aW9uPgogICAg
-        PE5ldHdvcmtDb25maWdTZWN0aW9uIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4y
-        L2FwaS92QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYt
-        NGVjNC1iM2ZiLTY1NTQwMDhmMTg2OC9uZXR3b3JrQ29uZmlnU2VjdGlvbi8i
-        IHR5cGU9ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLm5ldHdvcmtD
-        b25maWdTZWN0aW9uK3htbCIgb3ZmOnJlcXVpcmVkPSJmYWxzZSI+CiAgICAg
-        ICAgPG92ZjpJbmZvPlRoZSBjb25maWd1cmF0aW9uIHBhcmFtZXRlcnMgZm9y
-        IGxvZ2ljYWwgbmV0d29ya3M8L292ZjpJbmZvPgogICAgICAgIDxOZXR3b3Jr
-        Q29uZmlnIG5ldHdvcmtOYW1lPSJWTSBOZXR3b3JrIj4KICAgICAgICAgICAg
-        PERlc2NyaXB0aW9uPlRoZSBWTSBOZXR3b3JrIG5ldHdvcms8L0Rlc2NyaXB0
-        aW9uPgogICAgICAgICAgICA8Q29uZmlndXJhdGlvbj4KICAgICAgICAgICAg
-        ICAgIDxJcFNjb3Blcz4KICAgICAgICAgICAgICAgICAgICA8SXBTY29wZT4K
-        ICAgICAgICAgICAgICAgICAgICAgICAgPElzSW5oZXJpdGVkPmZhbHNlPC9J
-        c0luaGVyaXRlZD4KICAgICAgICAgICAgICAgICAgICAgICAgPEdhdGV3YXk+
-        MTkyLjE2OC4yNTQuMTwvR2F0ZXdheT4KICAgICAgICAgICAgICAgICAgICAg
-        ICAgPE5ldG1hc2s+MjU1LjI1NS4yNTUuMDwvTmV0bWFzaz4KICAgICAgICAg
-        ICAgICAgICAgICAgICAgPElzRW5hYmxlZD50cnVlPC9Jc0VuYWJsZWQ+CiAg
-        ICAgICAgICAgICAgICAgICAgICAgIDxJcFJhbmdlcz4KICAgICAgICAgICAg
-        ICAgICAgICAgICAgICAgIDxJcFJhbmdlPgogICAgICAgICAgICAgICAgICAg
-        ICAgICAgICAgICAgIDxTdGFydEFkZHJlc3M+MTkyLjE2OC4yNTQuMTAwPC9T
-        dGFydEFkZHJlc3M+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
-        PEVuZEFkZHJlc3M+MTkyLjE2OC4yNTQuMTk5PC9FbmRBZGRyZXNzPgogICAg
-        ICAgICAgICAgICAgICAgICAgICAgICAgPC9JcFJhbmdlPgogICAgICAgICAg
-        ICAgICAgICAgICAgICA8L0lwUmFuZ2VzPgogICAgICAgICAgICAgICAgICAg
-        IDwvSXBTY29wZT4KICAgICAgICAgICAgICAgIDwvSXBTY29wZXM+CiAgICAg
-        ICAgICAgICAgICA8RmVuY2VNb2RlPmlzb2xhdGVkPC9GZW5jZU1vZGU+CiAg
-        ICAgICAgICAgICAgICA8UmV0YWluTmV0SW5mb0Fjcm9zc0RlcGxveW1lbnRz
-        PmZhbHNlPC9SZXRhaW5OZXRJbmZvQWNyb3NzRGVwbG95bWVudHM+CiAgICAg
-        ICAgICAgIDwvQ29uZmlndXJhdGlvbj4KICAgICAgICAgICAgPElzRGVwbG95
-        ZWQ+ZmFsc2U8L0lzRGVwbG95ZWQ+CiAgICAgICAgPC9OZXR3b3JrQ29uZmln
-        PgogICAgPC9OZXR3b3JrQ29uZmlnU2VjdGlvbj4KICAgIDxMZWFzZVNldHRp
-        bmdzU2VjdGlvbiBocmVmPSJodHRwczovLzEwLjMwLjIuMi9hcGkvdkFwcFRl
-        bXBsYXRlL3ZhcHBUZW1wbGF0ZS00NGI2ODZmYi1kNGJmLTRlYzQtYjNmYi02
-        NTU0MDA4ZjE4NjgvbGVhc2VTZXR0aW5nc1NlY3Rpb24vIiB0eXBlPSJhcHBs
-        aWNhdGlvbi92bmQudm13YXJlLnZjbG91ZC5sZWFzZVNldHRpbmdzU2VjdGlv
-        bit4bWwiIG92ZjpyZXF1aXJlZD0iZmFsc2UiPgogICAgICAgIDxvdmY6SW5m
-        bz5MZWFzZSBzZXR0aW5ncyBzZWN0aW9uPC9vdmY6SW5mbz4KICAgICAgICA8
-        TGluayByZWw9ImVkaXQiIGhyZWY9Imh0dHBzOi8vMTAuMzAuMi4yL2FwaS92
-        QXBwVGVtcGxhdGUvdmFwcFRlbXBsYXRlLTQ0YjY4NmZiLWQ0YmYtNGVjNC1i
-        M2ZiLTY1NTQwMDhmMTg2OC9sZWFzZVNldHRpbmdzU2VjdGlvbi8iIHR5cGU9
-        ImFwcGxpY2F0aW9uL3ZuZC52bXdhcmUudmNsb3VkLmxlYXNlU2V0dGluZ3NT
-        ZWN0aW9uK3htbCIvPgogICAgICAgIDxTdG9yYWdlTGVhc2VJblNlY29uZHM+
-        Nzc3NjAwMDwvU3RvcmFnZUxlYXNlSW5TZWNvbmRzPgogICAgICAgIDxTdG9y
-        YWdlTGVhc2VFeHBpcmF0aW9uPjIwMTYtMTEtMDRUMTU6NDM6NDYuNjczKzAx
-        OjAwPC9TdG9yYWdlTGVhc2VFeHBpcmF0aW9uPgogICAgPC9MZWFzZVNldHRp
-        bmdzU2VjdGlvbj4KICAgIDxDdXN0b21pemF0aW9uU2VjdGlvbiBnb2xkTWFz
-        dGVyPSJmYWxzZSIgaHJlZj0iaHR0cHM6Ly8xMC4zMC4yLjIvYXBpL3ZBcHBU
-        ZW1wbGF0ZS92YXBwVGVtcGxhdGUtNDRiNjg2ZmItZDRiZi00ZWM0LWIzZmIt
-        NjU1NDAwOGYxODY4L2N1c3RvbWl6YXRpb25TZWN0aW9uLyIgdHlwZT0iYXBw
-        bGljYXRpb24vdm5kLnZtd2FyZS52Y2xvdWQuY3VzdG9taXphdGlvblNlY3Rp
-        b24reG1sIiBvdmY6cmVxdWlyZWQ9ImZhbHNlIj4KICAgICAgICA8b3ZmOklu
-        Zm8+VkFwcCB0ZW1wbGF0ZSBjdXN0b21pemF0aW9uIHNlY3Rpb248L292ZjpJ
-        bmZvPgogICAgICAgIDxDdXN0b21pemVPbkluc3RhbnRpYXRlPnRydWU8L0N1
-        c3RvbWl6ZU9uSW5zdGFudGlhdGU+CiAgICA8L0N1c3RvbWl6YXRpb25TZWN0
-        aW9uPgogICAgPERhdGVDcmVhdGVkPjIwMTYtMDgtMDFUMTQ6MDQ6NDQuMTYw
-        KzAyOjAwPC9EYXRlQ3JlYXRlZD4KPC9WQXBwVGVtcGxhdGU+Cg==
-    http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:17 GMT
-- request:
-    method: get
-    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.42.0
-      Accept:
-      - application/*+xml;version=5.1
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Sat, 06 Aug 2016 14:52:15 GMT
-      X-Vmware-Vcloud-Request-Id:
-      - 6106bd53-cdf6-413b-9919-1e41ebb840e6
-      X-Vcloud-Authorization:
-      - 493d9fde52514d36874255acabce5b5a
-      Set-Cookie:
-      - vcloud-token=493d9fde52514d36874255acabce5b5a; Secure; Path=/
-      X-Vmware-Vcloud-Request-Execution-Time:
-      - '213'
-      Content-Type:
-      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
-      Vary:
-      - Accept-Encoding, User-Agent
-    body:
-      encoding: UTF-8
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
-        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="TinyLinuxVM-template" id="urn:vcloud:vapptemplate:7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.30.2.2/api/v1.5/schema/master.xsd">
-            <Link rel="up" href="https://10.30.2.2/api/vdc/0ede26a2-58c8-4494-821a-a216b149b865" type="application/vnd.vmware.vcloud.vdc+xml"/>
-            <Link rel="catalogItem" href="https://10.30.2.2/api/catalogItem/e8091cfc-a193-46a1-bc6c-80cfe9e7acd0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
-            <Link rel="remove" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6"/>
-            <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-            <Link rel="enable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/enableDownload"/>
-            <Link rel="disable" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/action/disableDownload"/>
-            <Link rel="ovf" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/ovf" type="text/xml"/>
-            <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" name="*" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-            <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Linux CentOS 7.0" id="urn:vcloud:vapptemplate:ab27a332-2cc3-4ce8-a50f-138036cf7f57" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/23a9d1e6-a80a-4fc8-ad25-664f282d9ac0" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
             <Owner type="application/vnd.vmware.vcloud.owner+xml">
-                <User href="https://10.30.2.2/api/admin/user/d65f74be-239f-49b7-87ff-39e315413351" name="admin" type="application/vnd.vmware.admin.user+xml"/>
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
             </Owner>
             <Children>
-                <Vm goldMaster="false" status="8" name="TTYLinux" id="urn:vcloud:vm:f289215f-5a4b-4106-b14d-8376447068e8" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8" type="application/vnd.vmware.vcloud.vm+xml">
-                    <Link rel="up" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
-                    <Link rel="storageProfile" href="https://10.30.2.2/api/vdcStorageProfile/699e1949-0683-4caa-b6d8-cd258251ea8d" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
-                    <Link rel="down" href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
-                    <Description>Created by: Mike Laverick
-        Blog: www.mikelaverick.com
-        Twitter: @mike_laverick
-
-        Services Enabled: SSH, FTP, HTTP
-        ROOT Password: password</Description>
-                    <NetworkConnectionSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                <Vm goldMaster="true" status="8" name="CentOS7" id="urn:vcloud:vm:857551b6-380c-44d0-ab34-9d144866f0b4" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
                         <ovf:Info>Specifies the available VM network connections</ovf:Info>
                         <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
-                        <NetworkConnection needsCustomization="true" network="VM Network">
+                        <NetworkConnection needsCustomization="true" network="internal">
                             <NetworkConnectionIndex>0</NetworkConnectionIndex>
                             <IsConnected>true</IsConnected>
-                            <MACAddress>00:50:56:01:00:12</MACAddress>
-                            <IpAddressAllocationMode>DHCP</IpAddressAllocationMode>
+                            <MACAddress>00:50:56:01:00:2b</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
                         </NetworkConnection>
                     </NetworkConnectionSection>
-                    <GuestCustomizationSection href="https://10.30.2.2/api/vAppTemplate/vm-f289215f-5a4b-4106-b14d-8376447068e8/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-857551b6-380c-44d0-ab34-9d144866f0b4/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
                         <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
                         <Enabled>false</Enabled>
                         <ChangeSid>false</ChangeSid>
-                        <VirtualMachineId>f289215f-5a4b-4106-b14d-8376447068e8</VirtualMachineId>
+                        <VirtualMachineId>857551b6-380c-44d0-ab34-9d144866f0b4</VirtualMachineId>
                         <JoinDomainEnabled>false</JoinDomainEnabled>
                         <UseOrgSettings>false</UseOrgSettings>
                         <AdminPasswordEnabled>true</AdminPasswordEnabled>
                         <AdminPasswordAuto>true</AdminPasswordAuto>
                         <ResetPasswordRequired>false</ResetPasswordRequired>
-                        <ComputerName>TTYLinux-001</ComputerName>
+                        <ComputerName>CentOS7</ComputerName>
                     </GuestCustomizationSection>
-                    <VAppScopedLocalId>TTYLinux</VAppScopedLocalId>
-                    <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+                    <VAppScopedLocalId>d0733827-5a41-4816-b4a9-3cb8deb98583</VAppScopedLocalId>
+                    <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
                 </Vm>
             </Children>
-            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml" vcloud:href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkSection/">
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
                 <ovf:Info>The list of logical networks</ovf:Info>
-                <ovf:Network ovf:name="VM Network">
-                    <ovf:Description>The VM Network network</ovf:Description>
+                <ovf:Network ovf:name="internal">
+                    <ovf:Description/>
                 </ovf:Network>
             </ovf:NetworkSection>
-            <NetworkConfigSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
                 <ovf:Info>The configuration parameters for logical networks</ovf:Info>
-                <NetworkConfig networkName="VM Network">
-                    <Description>The VM Network network</Description>
+                <NetworkConfig networkName="internal">
+                    <Description/>
                     <Configuration>
                         <IpScopes>
                             <IpScope>
                                 <IsInherited>false</IsInherited>
-                                <Gateway>192.168.254.1</Gateway>
+                                <Gateway>192.168.2.1</Gateway>
                                 <Netmask>255.255.255.0</Netmask>
                                 <IsEnabled>true</IsEnabled>
                                 <IpRanges>
                                     <IpRange>
-                                        <StartAddress>192.168.254.100</StartAddress>
-                                        <EndAddress>192.168.254.199</EndAddress>
+                                        <StartAddress>192.168.2.100</StartAddress>
+                                        <EndAddress>192.168.2.199</EndAddress>
                                     </IpRange>
                                 </IpRanges>
                             </IpScope>
@@ -8659,18 +5086,427 @@ http_interactions:
                     <IsDeployed>false</IsDeployed>
                 </NetworkConfig>
             </NetworkConfigSection>
-            <LeaseSettingsSection href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
                 <ovf:Info>Lease settings section</ovf:Info>
-                <Link rel="edit" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
                 <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
-                <StorageLeaseExpiration>2016-11-04T15:45:03.693+01:00</StorageLeaseExpiration>
+                <StorageLeaseExpiration>2016-12-11T10:12:59.137+02:00</StorageLeaseExpiration>
             </LeaseSettingsSection>
-            <CustomizationSection goldMaster="false" href="https://10.30.2.2/api/vAppTemplate/vappTemplate-7b5ba1a0-b35d-4471-ae64-f3f9ffe9d2e6/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-ab27a332-2cc3-4ce8-a50f-138036cf7f57/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
                 <ovf:Info>VApp template customization section</ovf:Info>
                 <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
             </CustomizationSection>
-            <DateCreated>2016-08-01T14:37:56.693+02:00</DateCreated>
+            <DateCreated>2016-08-02T16:34:25.103+03:00</DateCreated>
         </VAppTemplate>
     http_version: 
-  recorded_at: Sat, 06 Aug 2016 14:52:17 GMT
+  recorded_at: Fri, 16 Sep 2016 08:55:19 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:55:24 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - d0bf0543-3426-4eff-807c-a8ba3399165a
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '130'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '8142'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="true" ovfDescriptorUploaded="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vapptemplate:cfff2e62-3746-4007-bcfe-a054fb30c510" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/e8734bdb-af24-443e-9496-10f367424316" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/2f90cae3-8ddf-48ce-b55e-45adde7a8bf6" name="system" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="true" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8767eafe-b288-450f-b0de-eacf30f95589" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:84:02:de</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-ac5fcf96-2b9d-4e90-9a2f-7792160da1ae/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>ac5fcf96-2b9d-4e90-9a2f-7792160da1ae</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TietoWindow-001</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>Tieto Windows Server 2012 R2</VAppScopedLocalId>
+                    <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-08T09:07:24.827+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="true" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-cfff2e62-3746-4007-bcfe-a054fb30c510/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-02T11:11:07.407+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:55:25 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:55:30 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 2a6150f9-4a9d-4853-bbee-6bdddd4cb018
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '202'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_cankamat_remote_1" id="urn:vcloud:vapptemplate:5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/77519250-ce5a-45d5-939d-fbe79704e18d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:3c6fd87c-d8f1-4add-827f-c35982f3e5b1" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="INT_192.168.10.0m24">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>true</IsConnected>
+                            <MACAddress>00:50:56:01:00:2d</MACAddress>
+                            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-3c6fd87c-d8f1-4add-827f-c35982f3e5b1/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>3c6fd87c-d8f1-4add-827f-c35982f3e5b1</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>7ff5cc28-e2e0-4466-bf78-e39a3522d539</VAppScopedLocalId>
+                    <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="INT_192.168.10.0m24">
+                    <ovf:Description/>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="INT_192.168.10.0m24">
+                    <Description/>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>true</IsInherited>
+                                <Gateway>192.168.10.1</Gateway>
+                                <Netmask>255.255.255.0</Netmask>
+                                <Dns1>192.168.10.1</Dns1>
+                                <DnsSuffix>test.local</DnsSuffix>
+                                <IsEnabled>true</IsEnabled>
+                                <IpRanges>
+                                    <IpRange>
+                                        <StartAddress>192.168.10.100</StartAddress>
+                                        <EndAddress>192.168.10.199</EndAddress>
+                                    </IpRange>
+                                </IpRanges>
+                            </IpScope>
+                        </IpScopes>
+                        <ParentNetwork href="" name="INT_192.168.10.0m24"/>
+                        <FenceMode>bridged</FenceMode>
+                        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-15T10:46:33.057+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-5c0dfa2f-35e3-4fa3-8bd7-863e8c5f4c31/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-08-11T15:15:51.933+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:55:30 GMT
+- request:
+    method: get
+    uri: https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.42.0
+      Accept:
+      - application/*+xml;version=5.1
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 16 Sep 2016 08:55:35 GMT
+      X-Vmware-Vcloud-Request-Id:
+      - 79aa1829-0574-4a9c-b806-4afe0b1a521e
+      X-Vcloud-Authorization:
+      - 5654e38c198f4265bc768fea28d3b1bf
+      Set-Cookie:
+      - vcloud-token=5654e38c198f4265bc768fea28d3b1bf; Secure; Path=/
+      X-Vmware-Vcloud-Request-Execution-Time:
+      - '326'
+      Content-Type:
+      - application/vnd.vmware.vcloud.vapptemplate+xml;version=5.1
+      Vary:
+      - Accept-Encoding, User-Agent
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <VAppTemplate xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" goldMaster="false" ovfDescriptorUploaded="true" status="8" name="vApp_CentOS_and_msWin" id="urn:vcloud:vapptemplate:a19bdc8f-88fa-4dd6-8436-486590353ed5" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://VMWARE_CLOUD_HOST/api/v1.5/schema/master.xsd">
+            <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vdc/89ade969-1dc4-4156-abad-e29f79511676" type="application/vnd.vmware.vcloud.vdc+xml"/>
+            <Link rel="catalogItem" href="https://VMWARE_CLOUD_HOST/api/catalogItem/8b6cbea1-9608-4fc4-a9ee-e67a0849ef6d" type="application/vnd.vmware.vcloud.catalogItem+xml"/>
+            <Link rel="remove" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5"/>
+            <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+            <Link rel="enable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/enableDownload"/>
+            <Link rel="disable" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/action/disableDownload"/>
+            <Link rel="ovf" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/ovf" type="text/xml"/>
+            <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" name="Dual site - Tier 1" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/owner" type="application/vnd.vmware.vcloud.owner+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+            <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+            <Description/>
+            <Owner type="application/vnd.vmware.vcloud.owner+xml">
+                <User href="https://VMWARE_CLOUD_HOST/api/admin/user/ab07ee17-4acb-4d7c-b15f-ccdc4aefd77d" name="cankamat_remote" type="application/vnd.vmware.admin.user+xml"/>
+            </Owner>
+            <Children>
+                <Vm goldMaster="false" status="8" name="Tieto Windows Server 2012 R2" id="urn:vcloud:vm:04f85cca-3f8d-43b4-8473-7aa099f95c1b" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:01:00:4c</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-04f85cca-3f8d-43b4-8473-7aa099f95c1b/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>true</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>false</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>TietoWindow-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>2e9ee64a-2368-40fc-94ee-0473373f0f4c</VAppScopedLocalId>
+                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+                </Vm>
+                <Vm goldMaster="false" status="8" name="CentOS7" id="urn:vcloud:vm:e9b55b85-640b-462c-9e7a-d18c47a7a5f3" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3" type="application/vnd.vmware.vcloud.vm+xml">
+                    <Link rel="up" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5" type="application/vnd.vmware.vcloud.vAppTemplate+xml"/>
+                    <Link rel="storageProfile" href="https://VMWARE_CLOUD_HOST/api/vdcStorageProfile/8a0436ee-f67a-49c9-bdf4-7dbaa21f7ff8" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+                    <Link rel="down" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+                    <Description/>
+                    <NetworkConnectionSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                        <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+                        <NetworkConnection needsCustomization="true" network="none">
+                            <NetworkConnectionIndex>0</NetworkConnectionIndex>
+                            <IsConnected>false</IsConnected>
+                            <MACAddress>00:50:56:01:00:4d</MACAddress>
+                            <IpAddressAllocationMode>NONE</IpAddressAllocationMode>
+                        </NetworkConnection>
+                    </NetworkConnectionSection>
+                    <GuestCustomizationSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vm-e9b55b85-640b-462c-9e7a-d18c47a7a5f3/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+                        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                        <Enabled>false</Enabled>
+                        <ChangeSid>false</ChangeSid>
+                        <VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</VirtualMachineId>
+                        <JoinDomainEnabled>false</JoinDomainEnabled>
+                        <UseOrgSettings>false</UseOrgSettings>
+                        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+                        <AdminPasswordAuto>true</AdminPasswordAuto>
+                        <ResetPasswordRequired>false</ResetPasswordRequired>
+                        <ComputerName>CentOS7-0-0</ComputerName>
+                    </GuestCustomizationSection>
+                    <VAppScopedLocalId>926f501b-c7ea-4b9d-a155-6695c3345150</VAppScopedLocalId>
+                    <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+                </Vm>
+            </Children>
+            <ovf:NetworkSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkSection/" vcloud:type="application/vnd.vmware.vcloud.networkSection+xml">
+                <ovf:Info>The list of logical networks</ovf:Info>
+                <ovf:Network ovf:name="none">
+                    <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+                </ovf:Network>
+            </ovf:NetworkSection>
+            <NetworkConfigSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/networkConfigSection/" type="application/vnd.vmware.vcloud.networkConfigSection+xml" ovf:required="false">
+                <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+                <NetworkConfig networkName="none">
+                    <Description>This is a special place-holder used for disconnected network interfaces.</Description>
+                    <Configuration>
+                        <IpScopes>
+                            <IpScope>
+                                <IsInherited>false</IsInherited>
+                                <Gateway>196.254.254.254</Gateway>
+                                <Netmask>255.255.0.0</Netmask>
+                                <Dns1>196.254.254.254</Dns1>
+                            </IpScope>
+                        </IpScopes>
+                        <FenceMode>isolated</FenceMode>
+                    </Configuration>
+                    <IsDeployed>false</IsDeployed>
+                </NetworkConfig>
+            </NetworkConfigSection>
+            <LeaseSettingsSection href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml" ovf:required="false">
+                <ovf:Info>Lease settings section</ovf:Info>
+                <Link rel="edit" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/leaseSettingsSection/" type="application/vnd.vmware.vcloud.leaseSettingsSection+xml"/>
+                <StorageLeaseInSeconds>7776000</StorageLeaseInSeconds>
+                <StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</StorageLeaseExpiration>
+            </LeaseSettingsSection>
+            <CustomizationSection goldMaster="false" href="https://VMWARE_CLOUD_HOST/api/vAppTemplate/vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5/customizationSection/" type="application/vnd.vmware.vcloud.customizationSection+xml" ovf:required="false">
+                <ovf:Info>VApp template customization section</ovf:Info>
+                <CustomizeOnInstantiate>true</CustomizeOnInstantiate>
+            </CustomizationSection>
+            <DateCreated>2016-09-09T10:08:38.767+03:00</DateCreated>
+        </VAppTemplate>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 08:55:36 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This patch extends the VMware's cloud manager to collect organisation
Virtual Data Centers (VDCs) as and stores them as availability zones.
Availability zones are required for the provisioning of the
orchestration stacks (vApps) from existing vApp templates.

@miq-bot add_label providers/vmware/cloud, enhancement