### PR TITLE
Add operation for listing availability zones

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.rb
@@ -1,0 +1,25 @@
+#
+# Description: provide the dynamic list content from available resource groups
+#
+az_list = {nil => "<select>"}
+service = $evm.root.attributes["service_template"] || $evm.root.attributes["service"]
+if service.respond_to?(:orchestration_manager) && service.orchestration_manager
+  service.orchestration_manager.availability_zones.each { |t| az_list[t.ems_ref] = t.name }
+end
+
+dialog_field = $evm.object
+
+# sort_by: value / description / none
+dialog_field["sort_by"] = "description"
+
+# sort_order: ascending / descending
+dialog_field["sort_order"] = "ascending"
+
+# data_type: string / integer
+dialog_field["data_type"] = "string"
+
+# required: true / false
+dialog_field["required"] = "true"
+
+dialog_field["values"] = az_list
+dialog_field["default_value"] = nil

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.rb
@@ -1,10 +1,20 @@
 #
 # Description: provide the dynamic list content from available resource groups
 #
-az_list = {nil => "<select>"}
+az_list = {}
 service = $evm.root.attributes["service_template"] || $evm.root.attributes["service"]
 if service.respond_to?(:orchestration_manager) && service.orchestration_manager
   service.orchestration_manager.availability_zones.each { |t| az_list[t.ems_ref] = t.name }
+end
+
+default_value = nil
+case az_list.length
+when 0
+  az_list = {nil => "<none>"}
+when 1
+  default_value = az_list.keys.first
+else
+  az_list[nil] = "<select>"
 end
 
 dialog_field = $evm.object
@@ -22,4 +32,4 @@ dialog_field["data_type"] = "string"
 dialog_field["required"] = "true"
 
 dialog_field["values"] = az_list
-dialog_field["default_value"] = nil
+dialog_field["default_value"] = default_value

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/__methods__/available_availability_zones.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: Available_Availability_Zones
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_availability_zones.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/Methods.class/available_availability_zones.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: Available_Availability_Zones
+    name: Available_Availability_Zones
+    inherits: 
+    description: 
+  fields:
+  - execute:
+      value: Available_Availability_Zones

--- a/spec/automation/unit/method_validation/available_availability_zones_spec.rb
+++ b/spec/automation/unit/method_validation/available_availability_zones_spec.rb
@@ -1,6 +1,7 @@
 describe "Available_Availability_Zones Method Validation" do
   let(:user) { FactoryGirl.create(:user_with_group) }
-  let(:default_desc) { "<select>" }
+  let(:default_desc_none) { "<none>" }
+  let(:default_desc_multiple) { "<select>" }
   before do
     @ins = "/Cloud/Orchestration/Operations/Methods/Available_Availability_Zones"
   end
@@ -8,7 +9,8 @@ describe "Available_Availability_Zones Method Validation" do
   context "workspace has no service template" do
     it "provides only the no availability zones info" do
       ws = MiqAeEngine.instantiate(@ins.to_s, user)
-      expect(ws.root["values"]).to eq(nil => default_desc)
+      expect(ws.root["values"]).to eq(nil => default_desc_none)
+      expect(ws.root["default_value"]).to eq(nil)
     end
   end
 
@@ -17,17 +19,27 @@ describe "Available_Availability_Zones Method Validation" do
 
     it "provides only the no availability zones info" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
-      expect(ws.root["values"]).to eq(nil => default_desc)
+      expect(ws.root["values"]).to eq(nil => default_desc_none)
+      expect(ws.root["default_value"]).to eq(nil)
     end
   end
 
-  let(:ems) do
+  let(:ems_with_single_az) do
     @az1 = FactoryGirl.create(:availability_zone, :ems_ref => "ref1")
-    @az2 = FactoryGirl.create(:availability_zone, :ems_ref => "ref2")
-    FactoryGirl.create(:ems_vmware_cloud, :availability_zones => [@az1, @az2])
+    FactoryGirl.create(:ems_vmware_cloud, :availability_zones => [@az1])
+  end
+
+  let(:ems) do
+    @az2 = FactoryGirl.create(:availability_zone, :ems_ref => "ref1")
+    @az3 = FactoryGirl.create(:availability_zone, :ems_ref => "ref2")
+    FactoryGirl.create(:ems_vmware_cloud, :availability_zones => [@az2, @az3])
   end
 
   context "workspace has orchestration service template" do
+    let(:service_template_single_az) do
+      FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems_with_single_az)
+    end
+
     let(:service_template) do
       FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
     end
@@ -36,22 +48,36 @@ describe "Available_Availability_Zones Method Validation" do
       FactoryGirl.create(:service_template_orchestration)
     end
 
+    it "finds a single availabilty zone and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_single_az.id}", user)
+      expect(ws.root["values"]).to include(
+        @az1.ems_ref => @az1.name,
+      )
+      expect(ws.root["default_value"]).to eq(@az1.ems_ref)
+    end
+
     it "finds all the availability zones and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
       expect(ws.root["values"]).to include(
-        nil          => default_desc,
-        @az1.ems_ref => @az1.name,
-        @az2.ems_ref => @az2.name
+        nil          => default_desc_multiple,
+        @az2.ems_ref => @az2.name,
+        @az3.ems_ref => @az3.name
       )
+      expect(ws.root["default_value"]).to eq(nil)
     end
 
     it "provides only default value to the availability zones list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
-      expect(ws.root["values"]).to eq(nil => default_desc)
+      expect(ws.root["values"]).to eq(nil => default_desc_none)
+      expect(ws.root["default_value"]).to eq(nil)
     end
   end
 
   context "workspace has orchestration service" do
+    let(:service_single_az) do
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems_with_single_az)
+    end
+
     let(:service) do
       FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
     end
@@ -60,18 +86,28 @@ describe "Available_Availability_Zones Method Validation" do
       FactoryGirl.create(:service_orchestration)
     end
 
+    it "finds a single availabilty zone and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_single_az.id}", user)
+      expect(ws.root["values"]).to include(
+        @az1.ems_ref => @az1.name,
+      )
+      expect(ws.root["default_value"]).to eq(@az1.ems_ref)
+    end
+
     it "finds all the availability zones and populates the list" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
       expect(ws.root["values"]).to include(
-        nil          => default_desc,
-        @az1.ems_ref => @az1.name,
-        @az2.ems_ref => @az2.name
+        nil          => default_desc_multiple,
+        @az2.ems_ref => @az2.name,
+        @az3.ems_ref => @az3.name
       )
+      expect(ws.root["default_value"]).to eq(nil)
     end
 
     it "provides only default value to the availability zones list if orchestration manager does not exist" do
       ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
-      expect(ws.root["values"]).to eq(nil => default_desc)
+      expect(ws.root["values"]).to eq(nil => default_desc_none)
+      expect(ws.root["default_value"]).to eq(nil)
     end
   end
 end

--- a/spec/automation/unit/method_validation/available_availability_zones_spec.rb
+++ b/spec/automation/unit/method_validation/available_availability_zones_spec.rb
@@ -1,0 +1,77 @@
+describe "Available_Availability_Zones Method Validation" do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:default_desc) { "<select>" }
+  before do
+    @ins = "/Cloud/Orchestration/Operations/Methods/Available_Availability_Zones"
+  end
+
+  context "workspace has no service template" do
+    it "provides only the no availability zones info" do
+      ws = MiqAeEngine.instantiate(@ins.to_s, user)
+      expect(ws.root["values"]).to eq(nil => default_desc)
+    end
+  end
+
+  context "workspace has service template other than orchestration" do
+    let(:service_template) { FactoryGirl.create(:service_template) }
+
+    it "provides only the no availability zones info" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+      expect(ws.root["values"]).to eq(nil => default_desc)
+    end
+  end
+
+  let(:ems) do
+    @az1 = FactoryGirl.create(:availability_zone, :ems_ref => "ref1")
+    @az2 = FactoryGirl.create(:availability_zone, :ems_ref => "ref2")
+    FactoryGirl.create(:ems_vmware_cloud, :availability_zones => [@az1, @az2])
+  end
+
+  context "workspace has orchestration service template" do
+    let(:service_template) do
+      FactoryGirl.create(:service_template_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_template_no_ems) do
+      FactoryGirl.create(:service_template_orchestration)
+    end
+
+    it "finds all the availability zones and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template.id}", user)
+      expect(ws.root["values"]).to include(
+        nil          => default_desc,
+        @az1.ems_ref => @az1.name,
+        @az2.ems_ref => @az2.name
+      )
+    end
+
+    it "provides only default value to the availability zones list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?ServiceTemplate::service_template=#{service_template_no_ems.id}", user)
+      expect(ws.root["values"]).to eq(nil => default_desc)
+    end
+  end
+
+  context "workspace has orchestration service" do
+    let(:service) do
+      FactoryGirl.create(:service_orchestration, :orchestration_manager => ems)
+    end
+
+    let(:service_no_ems) do
+      FactoryGirl.create(:service_orchestration)
+    end
+
+    it "finds all the availability zones and populates the list" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service.id}", user)
+      expect(ws.root["values"]).to include(
+        nil          => default_desc,
+        @az1.ems_ref => @az1.name,
+        @az2.ems_ref => @az2.name
+      )
+    end
+
+    it "provides only default value to the availability zones list if orchestration manager does not exist" do
+      ws = MiqAeEngine.instantiate("#{@ins}?Service::service=#{service_no_ems.id}", user)
+      expect(ws.root["values"]).to eq(nil => default_desc)
+    end
+  end
+end


### PR DESCRIPTION
Similar to listing available tenants, this patch adds support for
listing available availability zones. For the VMware cloud provider it
is mandatory to allow listing availability zones in order to enable
support for provisioning of orchestration stacks onto availability zone
(in VMware vCloud, availability zone is VDC -- Virtual Data Center).