### PR TITLE
Checkbox in Catalog item details page moved to own row

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -23,9 +23,12 @@
             = _('Name / Description')
           .col-md-8
             #{@record.name} / #{@record.description}
-            = check_box_tag("display", true, @record.display, :disabled => true)
-            &nbsp;
+        .form-group
+          %label.col-md-2.control-label
             = _('Display in Catalog')
+          .col-md-8
+            &nbsp;
+            = check_box_tag("display", true, @record.display, :disabled => true)
         - if @record.display
           .form-group
             %label.col-md-2.control-label


### PR DESCRIPTION
Before:
![screencapture-localhost-3000-catalog-explorer-1474024360829](https://cloud.githubusercontent.com/assets/1187051/18584239/ba07391e-7c0f-11e6-9d7a-b22b17cfe06f.png)

After:
![screencapture-localhost-3000-catalog-explorer-1474024404868](https://cloud.githubusercontent.com/assets/1187051/18584240/bb1ce4c0-7c0f-11e6-8414-ae2491ce59d3.png)

## Steps for Testing/QA [Optional]

_Service -> Catalogs -> Catalog items_