### PR TITLE
[WIP] refactor SupportsFeatureMixin to do less metaprogramming

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -102,15 +102,43 @@ module SupportsFeatureMixin
     :update_network_router      => 'Network Router Update',
   }.freeze
 
-  # Whenever this mixin is included we define all features as unsupported by default.
-  # This way we can query for every feature
   included do
     QUERYABLE_FEATURES.keys.each do |feature|
-      supports_not(feature)
+      method_name = "supports_#{feature}?"
+
+      # defines the method on the instance
+      define_method(method_name) do
+        supports?(feature)
+      end
+
+      # defines the method on the class
+      define_singleton_method(method_name) do
+        supports?(feature)
+      end
     end
   end
 
   class UnknownFeatureError < StandardError; end
+
+  class FeatureDefinition
+    def initialize(supported: false, block: nil, unsupported_reason: nil)
+      @supported = supported
+      @block = block
+      @unsupported_reason = unsupported_reason
+    end
+
+    def supported?
+      @supported
+    end
+
+    def unsupported_reason
+      SupportsFeatureMixin.reason_or_default(@unsupported_reason) unless supported?
+    end
+
+    def block
+      @block
+    end
+  end
 
   def self.guard_queryable_feature(feature)
     unless QUERYABLE_FEATURES.key?(feature.to_sym)
@@ -118,7 +146,7 @@ module SupportsFeatureMixin
     end
   end
 
-  def self.reason_or_default(reason)
+  def self.reason_or_default(reason = nil)
     reason.present? ? reason : _("Feature not available/supported")
   end
 
@@ -126,14 +154,25 @@ module SupportsFeatureMixin
   def unsupported_reason(feature)
     SupportsFeatureMixin.guard_queryable_feature(feature)
     feature = feature.to_sym
-    public_send("supports_#{feature}?") unless unsupported.key?(feature)
+    supports?(feature) unless unsupported.key?(feature)
     unsupported[feature]
   end
 
   # query the instance if the feature is supported or not
   def supports?(feature)
     SupportsFeatureMixin.guard_queryable_feature(feature)
-    public_send("supports_#{feature}?")
+
+    feature = feature.to_sym
+    feature_definition = self.class.feature_definition_for(feature)
+    if feature_definition.supported?
+      unsupported.delete(feature)
+      if feature_definition.block
+        instance_eval(&feature_definition.block)
+      end
+    else
+      unsupported_reason_add(feature, feature_definition.unsupported_reason)
+    end
+    !unsupported.key?(feature)
   end
 
   # query the instance if a feature is generally known
@@ -159,28 +198,26 @@ module SupportsFeatureMixin
     # This is the DSL used a class level to define what is supported
     def supports(feature, &block)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      define_supports_feature_methods(feature, &block)
+      supported_feature_definitions[feature.to_sym] = FeatureDefinition.new(supported: true, block: block)
     end
 
     # supports_not does not take a block, because its never supported
     # and not conditionally supported
     def supports_not(feature, reason: nil)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      define_supports_feature_methods(feature, :is_supported => false, :reason => reason)
+      supported_feature_definitions[feature.to_sym] = FeatureDefinition.new(unsupported_reason: reason)
     end
 
     # query the class if the feature is supported or not
     def supports?(feature)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      public_send("supports_#{feature}?")
+      feature_definition_for(feature).supported?
     end
 
     # query the class for the reason why something is unsupported
     def unsupported_reason(feature)
       SupportsFeatureMixin.guard_queryable_feature(feature)
-      feature = feature.to_sym
-      public_send("supports_#{feature}?") unless unsupported.key?(feature)
-      unsupported[feature]
+      feature_definition_for(feature).unsupported_reason
     end
 
     # query the class if a feature is generally known
@@ -188,43 +225,23 @@ module SupportsFeatureMixin
       SupportsFeatureMixin::QUERYABLE_FEATURES.key?(feature.to_sym)
     end
 
+    def feature_definition_for(feature)
+      feature = feature.to_sym
+      feature_definition = nil
+      ancestors.detect do |ancestor|
+        feature_definition = ancestor.try(:supported_feature_definition, feature)
+      end
+      feature_definition || FeatureDefinition.new
+    end
+
+    def supported_feature_definition(feature)
+      supported_feature_definitions[feature]
+    end
+
     private
 
-    def unsupported
-      # This is a class variable and it might be modified during runtime
-      # because we dont eager load all classes at boot time, so it needs to be thread safe
-      @unsupported ||= Concurrent::Hash.new
-    end
-
-    # use this for making a class not support a feature
-    def unsupported_reason_add(feature, reason = nil)
-      SupportsFeatureMixin.guard_queryable_feature(feature)
-      feature = feature.to_sym
-      unsupported[feature] = SupportsFeatureMixin.reason_or_default(reason)
-    end
-
-    def define_supports_feature_methods(feature, is_supported: true, reason: nil, &block)
-      method_name = "supports_#{feature}?"
-      feature = feature.to_sym
-
-      # defines the method on the instance
-      define_method(method_name) do
-        unsupported.delete(feature)
-        if block_given?
-          instance_eval(&block)
-        else
-          unsupported_reason_add(feature, reason) unless is_supported
-        end
-        !unsupported.key?(feature)
-      end
-
-      # defines the method on the class
-      define_singleton_method(method_name) do
-        unsupported.delete(feature)
-        # TODO: durandom - make reason evaluate in class context, to e.g. include the name of a subclass (.to_proc?)
-        unsupported_reason_add(feature, reason) unless is_supported
-        !unsupported.key?(feature)
-      end
+    def supported_feature_definitions
+      @supported_feature_definitions ||= Concurrent::Hash.new
     end
   end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -156,9 +156,8 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     let(:supported_api_versions) { [3, 4] }
     context "#process_api_features_support" do
       before(:each) do
-        allow(SupportsFeatureMixin).to receive(:guard_queryable_feature).and_return(true)
         allow(described_class).to receive(:api_features)
-          .and_return('3' => %w(feature1 feature3), '4' => %w(feature2 feature3))
+          .and_return('3' => %w(delete suspend), '4' => %w(create suspend))
         described_class.process_api_features_support
         allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
       end
@@ -166,36 +165,36 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       context "no versions supported" do
         let(:supported_api_versions) { [] }
         it 'supports the right features' do
-          expect(ems.supports_feature1?).to be_falsey
-          expect(ems.supports_feature2?).to be_falsey
-          expect(ems.supports_feature3?).to be_falsey
+          expect(ems.supports_delete?).to be_falsey
+          expect(ems.supports_create?).to be_falsey
+          expect(ems.supports_suspend?).to be_falsey
         end
       end
 
       context "version 3 supported" do
         let(:supported_api_versions) { [3] }
         it 'supports the right features' do
-          expect(ems.supports_feature1?).to be_truthy
-          expect(ems.supports_feature2?).to be_falsey
-          expect(ems.supports_feature3?).to be_truthy
+          expect(ems.supports_delete?).to be_truthy
+          expect(ems.supports_create?).to be_falsey
+          expect(ems.supports_suspend?).to be_truthy
         end
       end
 
       context "version 4 supported" do
         let(:supported_api_versions) { [4] }
         it 'supports the right features' do
-          expect(ems.supports_feature1?).to be_falsey
-          expect(ems.supports_feature2?).to be_truthy
-          expect(ems.supports_feature3?).to be_truthy
+          expect(ems.supports_delete?).to be_falsey
+          expect(ems.supports_create?).to be_truthy
+          expect(ems.supports_suspend?).to be_truthy
         end
       end
 
       context "all versions supported" do
         let(:supported_api_versions) { [3, 4] }
         it 'supports the right features' do
-          expect(ems.supports_feature1?).to be_truthy
-          expect(ems.supports_feature2?).to be_truthy
-          expect(ems.supports_feature3?).to be_truthy
+          expect(ems.supports_delete?).to be_truthy
+          expect(ems.supports_create?).to be_truthy
+          expect(ems.supports_suspend?).to be_truthy
         end
       end
     end


### PR DESCRIPTION
**Before** SupportsFeature should not be included in modules because methods get created on inclusion time.

``` ruby
class Vm
  include SupportsFeatureMixin
  supports :foo
end
Vm.new.supports_foo? #> true

module Operations
  extend ActiveSupport::Concern
  include SupportsFeatureMixin
end
Operations.supports_foo? #> false

class SpecialVm < Vm
  include Operations
end
# now SpecialVm.new.supports_foo? does not resolve to Vm.new.supports_foo? but Operations.supports_foo?
SpecialVm.new.supports_foo? #> false
```

> I think part of the oddity is the creation of methods being inside included which isn't "normal" mixin behavior. I wonder if it's better to just have the methods defined directly in the SupportsFeatureMixin, then mixed in naturally, instead of dynamically creating them into the includee.

I refactored the Mixin to **not** generate the `supports_feature?` methods upon calling the DSL `supports :feature` methods. The reason of doing that was to leverage rubys method lookupchain and have subclasses override default behavior of base classes.

Now I store a `FeatureDefinition` into a class or module variable `supported_feature_definitions` upon calling the DSL. When asking an object `supports?(:feature)` I traverse the `ancestors` to find the first `FeatureDefinition` and use that to determine if the feature is supported or not.

While both solutions look similar, the first one fails when `SupportsFeatureMixin` is included into a Module and the DSL methods are called on the module (like in the example above). This created methods which would hide other methods (because every feature would be unsupported by default).

I think this approach makes it easier to use, because now you _can_ use the `included` block and `ActiveSupport::Concern` to forward the DSL to the included module. But you dont have to.
