### PR TITLE
[WIP] Fix miqService.miqAjaxButton calls to not rely on automagic form_div serialization

### DIFF
--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -30,8 +30,6 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
   };
 
   var keyPairEditButtonClicked = function(buttonName, data) {
-    miqService.sparkleOn();
-
     var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
     miqService.miqAjaxButton(url, data);
   };

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -49,9 +49,7 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
     keyPairEditButtonClicked('save', $scope.keyPairModel);
   };
 
-  $scope.addClicked = function() {
-    $scope.saveClicked();
-  };
+  $scope.addClicked = $scope.saveClicked;
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -36,7 +36,6 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
 
   $scope.cancelClicked = function() {
     keyPairEditButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
@@ -48,7 +47,6 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
   $scope.saveClicked = function() {
     $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
     keyPairEditButtonClicked('save', $scope.keyPairModel);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = function() {

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -1,67 +1,67 @@
 ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope', 'keyPairFormId', 'miqService', function($http, $scope, keyPairFormId, miqService) {
-    var init = function() {
-        $scope.keyPairModel = {
-            name: '',
-            public_key: '',
-            ems_id: ''
-        };
-        $scope.formId = keyPairFormId;
-        $scope.afterGet = false;
-        $scope.modelCopy = angular.copy( $scope.keyPairModel );
-        $scope.model = 'keyPairModel';
-        $scope.ems_choices = [];
-        ManageIQ.angular.scope = $scope;
-
-        miqService.sparkleOn();
-        $http.get('/auth_key_pair_cloud/ems_form_choices').success(function(data) {
-            $scope.ems_choices = data.ems_choices;
-            if($scope.ems_choices.length > 0) {
-                $scope.keyPairModel.ems = $scope.ems_choices[0];
-            }
-            $scope.afterGet = true;
-            miqService.sparkleOff();
-        });
-
-        if (keyPairFormId == 'new') {
-            $scope.newRecord = true;
-        } else {
-            $scope.newRecord = false;
-        }
+  var init = function() {
+    $scope.keyPairModel = {
+      name: '',
+      public_key: '',
+      ems_id: ''
     };
+    $scope.formId = keyPairFormId;
+    $scope.afterGet = false;
+    $scope.modelCopy = angular.copy( $scope.keyPairModel );
+    $scope.model = 'keyPairModel';
+    $scope.ems_choices = [];
+    ManageIQ.angular.scope = $scope;
 
-    var keyPairEditButtonClicked = function(buttonName, serializeFields) {
-        miqService.sparkleOn();
+    miqService.sparkleOn();
+    $http.get('/auth_key_pair_cloud/ems_form_choices').success(function(data) {
+      $scope.ems_choices = data.ems_choices;
+      if ($scope.ems_choices.length > 0) {
+        $scope.keyPairModel.ems = $scope.ems_choices[0];
+      }
+      $scope.afterGet = true;
+      miqService.sparkleOff();
+    });
 
-        var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
-        $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
-        if (serializeFields) {
-          // FIXME serializeModel should be useless here, except for maybe angular.copy?
-          miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
-        } else {
-          miqService.miqAjaxButton(url);
-        }
-        miqService.sparkleOff();
-    };
+    if (keyPairFormId == 'new') {
+      $scope.newRecord = true;
+    } else {
+      $scope.newRecord = false;
+    }
+  };
 
-    $scope.cancelClicked = function() {
-        keyPairEditButtonClicked('cancel');
-        $scope.angularForm.$setPristine(true);
-    };
+  var keyPairEditButtonClicked = function(buttonName, serializeFields) {
+    miqService.sparkleOn();
 
-    $scope.resetClicked = function() {
-        $scope.keyPairModel = angular.copy( $scope.modelCopy );
-        $scope.angularForm.$setPristine(true);
-        miqService.miqFlash("warn", __("All changes have been reset"));
-    };
+    var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
+    $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
+    if (serializeFields) {
+      // FIXME serializeModel should be useless here, except for maybe angular.copy?
+      miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
+    } else {
+      miqService.miqAjaxButton(url);
+    }
+    miqService.sparkleOff();
+  };
 
-    $scope.saveClicked = function() {
-        keyPairEditButtonClicked('save', true);
-        $scope.angularForm.$setPristine(true);
-    };
+  $scope.cancelClicked = function() {
+    keyPairEditButtonClicked('cancel');
+    $scope.angularForm.$setPristine(true);
+  };
 
-    $scope.addClicked = function() {
-        $scope.saveClicked();
-    };
+  $scope.resetClicked = function() {
+    $scope.keyPairModel = angular.copy( $scope.modelCopy );
+    $scope.angularForm.$setPristine(true);
+    miqService.miqFlash("warn", __("All changes have been reset"));
+  };
 
-    init();
+  $scope.saveClicked = function() {
+    keyPairEditButtonClicked('save', true);
+    $scope.angularForm.$setPristine(true);
+  };
+
+  $scope.addClicked = function() {
+    $scope.saveClicked();
+  };
+
+  init();
 }]);

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -29,18 +29,11 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
     }
   };
 
-  var keyPairEditButtonClicked = function(buttonName, serializeFields) {
+  var keyPairEditButtonClicked = function(buttonName, data) {
     miqService.sparkleOn();
 
     var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
-    $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
-    if (serializeFields) {
-      // FIXME serializeModel should be useless here, except for maybe angular.copy?
-      miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
-    } else {
-      miqService.miqAjaxButton(url);
-    }
-    miqService.sparkleOff();
+    miqService.miqAjaxButton(url, data);
   };
 
   $scope.cancelClicked = function() {
@@ -55,7 +48,8 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
   };
 
   $scope.saveClicked = function() {
-    keyPairEditButtonClicked('save', true);
+    $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
+    keyPairEditButtonClicked('save', $scope.keyPairModel);
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
+++ b/app/assets/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller.js
@@ -34,16 +34,17 @@ ManageIQ.angular.app.controller('keyPairCloudFormController', ['$http', '$scope'
 
         var url = '/auth_key_pair_cloud/create/' + keyPairFormId + '?button=' + buttonName;
         $scope.keyPairModel.ems_id = $scope.keyPairModel.ems.id;
-        if(serializeFields) {
-            miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
+        if (serializeFields) {
+          // FIXME serializeModel should be useless here, except for maybe angular.copy?
+          miqService.miqAjaxButton(url, miqService.serializeModel($scope.keyPairModel));
         } else {
-            miqService.miqAjaxButton(url, false);
+          miqService.miqAjaxButton(url);
         }
         miqService.sparkleOff();
     };
 
     $scope.cancelClicked = function() {
-        keyPairEditButtonClicked('cancel', false);
+        keyPairEditButtonClicked('cancel');
         $scope.angularForm.$setPristine(true);
     };
 

--- a/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
@@ -26,13 +26,11 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
   }
 
   $scope.addClicked = function() {
-    miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
     miqService.miqAjaxButton(url, $scope.cloudSubnetModel);
   };
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     if (cloudSubnetFormId == 'new') {
       var url = '/cloud_subnet/create/new' + '?button=cancel';
     } else {
@@ -42,7 +40,6 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
   };
 
   $scope.saveClicked = function() {
-    miqService.sparkleOn();
     var url = '/cloud_subnet/update/' + cloudSubnetFormId + '?button=save';
     miqService.miqAjaxButton(url, $scope.cloudSubnetModel);
   };

--- a/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_subnet/cloud_subnet_form_controller.js
@@ -28,7 +28,7 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
   $scope.addClicked = function() {
     miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, $scope.cloudSubnetModel);
   };
 
   $scope.cancelClicked = function() {
@@ -44,7 +44,7 @@ ManageIQ.angular.app.controller('cloudSubnetFormController', ['$http', '$scope',
   $scope.saveClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_subnet/update/' + cloudSubnetFormId + '?button=save';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, $scope.cloudSubnetModel);
   };
 
   $scope.resetClicked = function() {

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -24,7 +24,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   $scope.addClicked = function() {
     miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.cancelClicked = function() {
@@ -40,19 +40,19 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   $scope.saveClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_volume/update/' + cloudVolumeFormId + '?button=save';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.attachClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_volume/attach_volume/' + cloudVolumeFormId + '?button=attach';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.detachClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_volume/detach_volume/' + cloudVolumeFormId + '?button=detach';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.cancelAttachClicked = function() {

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -22,13 +22,11 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   }
 
   $scope.addClicked = function() {
-    miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
     miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     if (cloudVolumeFormId == 'new') {
       var url = '/cloud_volume/create/new' + '?button=cancel';
     } else {
@@ -38,31 +36,26 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   };
 
   $scope.saveClicked = function() {
-    miqService.sparkleOn();
     var url = '/cloud_volume/update/' + cloudVolumeFormId + '?button=save';
     miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.attachClicked = function() {
-    miqService.sparkleOn();
     var url = '/cloud_volume/attach_volume/' + cloudVolumeFormId + '?button=attach';
     miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.detachClicked = function() {
-    miqService.sparkleOn();
     var url = '/cloud_volume/detach_volume/' + cloudVolumeFormId + '?button=detach';
     miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.cancelAttachClicked = function() {
-    miqService.sparkleOn();
     var url = '/cloud_volume/attach_volume/' + cloudVolumeFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };
 
   $scope.cancelDetachClicked = function() {
-    miqService.sparkleOn();
     var url = '/cloud_volume/detach_volume/' + cloudVolumeFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };

--- a/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
+++ b/app/assets/javascripts/controllers/cloud_volume/cloud_volume_form_controller.js
@@ -24,7 +24,7 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   $scope.addClicked = function() {
     miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.cancelClicked = function() {
@@ -40,19 +40,19 @@ ManageIQ.angular.app.controller('cloudVolumeFormController', ['$http', '$scope',
   $scope.saveClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_volume/update/' + cloudVolumeFormId + '?button=save';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.attachClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_volume/attach_volume/' + cloudVolumeFormId + '?button=attach';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.detachClicked = function() {
     miqService.sparkleOn();
     var url = '/cloud_volume/detach_volume/' + cloudVolumeFormId + '?button=detach';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.cloudVolumeModel);
   };
 
   $scope.cancelAttachClicked = function() {

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -181,7 +181,6 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
   };
 
   var timeProfileEditButtonClicked = function(buttonName, data) {
-    miqService.sparkleOn();
     var url = '/configuration/timeprofile_update/' + timeProfileFormId + '?button=' + buttonName;
 
     miqService.miqAjaxButton(url, data);

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -180,15 +180,11 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     $scope.calculateTimeProfileHourValues();
   };
 
-  var timeProfileEditButtonClicked = function(buttonName, serializeFields) {
+  var timeProfileEditButtonClicked = function(buttonName, data) {
     miqService.sparkleOn();
     var url = '/configuration/timeprofile_update/' + timeProfileFormId + '?button=' + buttonName;
-    var timeProfileModelObj = angular.copy($scope.timeProfileModel);
-    delete timeProfileModelObj.profile_tz;
-    var moreUrlParams = $.param(miqService.serializeModel(timeProfileModelObj));
-    if (moreUrlParams)
-      url += '&' + decodeURIComponent(moreUrlParams);
-    miqService.miqAjaxButton(url, true);  // FIXME - a lot!
+
+    miqService.miqAjaxButton(url, data);
   };
 
   $scope.cancelClicked = function() {
@@ -203,13 +199,14 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
   };
 
   $scope.saveClicked = function() {
-    timeProfileEditButtonClicked('save', true);
+    var timeProfileModelObj = angular.copy($scope.timeProfileModel);
+    delete timeProfileModelObj.profile_tz;
+
+    timeProfileEditButtonClicked('save', timeProfileModelObj);
     $scope.angularForm.$setPristine(true);
   };
 
-  $scope.addClicked = function() {
-    $scope.saveClicked();
-  };
+  $scope.addClicked = $scope.saveClicked;
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -186,9 +186,9 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     var timeProfileModelObj = angular.copy($scope.timeProfileModel);
     delete timeProfileModelObj.profile_tz;
     var moreUrlParams = $.param(miqService.serializeModel(timeProfileModelObj));
-    if(moreUrlParams)
+    if (moreUrlParams)
       url += '&' + decodeURIComponent(moreUrlParams);
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME - a lot!
   };
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
+++ b/app/assets/javascripts/controllers/configuration/time_profile_form_controller.js
@@ -188,7 +188,6 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
 
   $scope.cancelClicked = function() {
     timeProfileEditButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
@@ -202,7 +201,6 @@ ManageIQ.angular.app.controller('timeProfileFormController', ['$http', '$scope',
     delete timeProfileModelObj.profile_tz;
 
     timeProfileEditButtonClicked('save', timeProfileModelObj);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = $scope.saveClicked;

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -104,7 +104,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
   $scope.addClicked = function() {
     miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.cancelClicked = function() {
@@ -126,7 +126,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     } else {
       var url = $scope.updateUrl + hostFormId + '?button=save';
     }
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.resetClicked = function() {
@@ -167,18 +167,12 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
   };
 
   $scope.canValidate = function () {
-    if ($scope.isBasicInfoValid() && $scope.validateFieldsDirty())
-      return true;
-    else
-      return false;
-  }
+    return $scope.isBasicInfoValid() && $scope.validateFieldsDirty();
+  };
 
   $scope.canValidateBasicInfo = function () {
-    if ($scope.isBasicInfoValid())
-      return true;
-    else
-      return false;
-  }
+    return $scope.isBasicInfoValid();
+  };
 
   $scope.validateFieldsDirty = function () {
     if(($scope.currentTab == "default") &&
@@ -205,9 +199,10 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
       $scope.angularForm.ipmi_password.$dirty &&
       $scope.angularForm.ipmi_verify.$dirty)) {
       return true;
-    } else
+    } else {
       return false;
-  }
+    }
+  };
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -102,13 +102,11 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
   }
 
   $scope.addClicked = function() {
-    miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
     miqService.miqAjaxButton(url, $scope.hostModel);
   };
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     if (hostFormId == 'new') {
       var url = $scope.createUrl + 'new?button=cancel';
     } else if (hostFormId.split(",").length == 1) {
@@ -120,7 +118,6 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
   };
 
   $scope.saveClicked = function() {
-    miqService.sparkleOn();
     if (hostFormId.split(",").length > 1) {
       var url = $scope.updateUrl + '?button=save';
     } else {

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -104,7 +104,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
   $scope.addClicked = function() {
     miqService.sparkleOn();
     var url = 'create/new' + '?button=add';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.hostModel);
   };
 
   $scope.cancelClicked = function() {
@@ -126,7 +126,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     } else {
       var url = $scope.updateUrl + hostFormId + '?button=save';
     }
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.hostModel);
   };
 
   $scope.resetClicked = function() {

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -22,7 +22,7 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
   };
 
   $scope.backupScheduleTypeChanged = function() {
-    if($scope.diagnosticsDatabaseModel.backup_schedule_type == '') {
+    if ($scope.diagnosticsDatabaseModel.backup_schedule_type === '') {
       $scope.diagnosticsDatabaseModel.depot_name = '';
       $scope.diagnosticsDatabaseModel.uri = '';
       $scope.diagnosticsDatabaseModel.uri_prefix = '';
@@ -50,7 +50,7 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
 
       $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
 
-      if($scope.diagnosticsDatabaseModel.log_userid != '') {
+      if ($scope.diagnosticsDatabaseModel.log_userid !== '') {
         $scope.diagnosticsDatabaseModel.log_password = $scope.diagnosticsDatabaseModel.log_verify = miqService.storedPasswordPlaceholder;
       }
 
@@ -64,30 +64,28 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
 
   $scope.showSubmitButton = function() {
     return true;
-  }
+  };
 
   $scope.isBasicInfoValid = function() {
-    if($scope.angularForm.depot_name.$valid &&
+    return $scope.angularForm.depot_name.$valid &&
       $scope.angularForm.uri.$valid &&
       $scope.angularForm.log_userid.$valid &&
       $scope.angularForm.log_password.$valid &&
-      $scope.angularForm.log_verify.$valid)
-      return true;
-    else
-      return false;
+      $scope.angularForm.log_verify.$valid;
   };
 
   $scope.submitButtonClicked = function(confirm_msg) {
     if (confirm(confirm_msg)) {
       miqService.sparkleOn();
       var url = $scope.submitUrl;
+      // FIXME
       miqService.miqAjaxButton(url, true);
     }
   };
 
   $scope.canValidateBasicInfo = function () {
     return $scope.isBasicInfoValid();
-  }
+  };
 
   $scope.logProtocolChanged = function() {
     $scope.diagnosticsDatabaseModel.backup_schedule_type = '';

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -43,10 +43,11 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
       $scope.diagnosticsDatabaseModel.uri_prefix = data.uri_prefix;
       $scope.diagnosticsDatabaseModel.log_userid = data.log_userid;
 
-      if($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs')
+      if ($scope.diagnosticsDatabaseModel.uri_prefix == 'nfs') {
         $scope.diagnosticsDatabaseModel.log_protocol = 'Network File System';
-      else
+      } else {
         $scope.diagnosticsDatabaseModel.log_protocol = 'Samba';
+      }
 
       $scope.diagnosticsDatabaseModel.action_typ = 'db_backup';
 
@@ -77,9 +78,7 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
   $scope.submitButtonClicked = function(confirm_msg) {
     if (confirm(confirm_msg)) {
       miqService.sparkleOn();
-      var url = $scope.submitUrl;
-      // FIXME
-      miqService.miqAjaxButton(url, true);
+      miqService.miqAjaxButton($scope.submitUrl, $scope.diagnosticsDatabaseModel);
     }
   };
 
@@ -89,7 +88,7 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
 
   $scope.logProtocolChanged = function() {
     $scope.diagnosticsDatabaseModel.backup_schedule_type = '';
-    if($scope.logProtocolSelected()) {
+    if ($scope.logProtocolSelected()) {
       $scope.$broadcast('setNewRecord');
       $scope.$broadcast('reactiveFocus');
       miqDBBackupService.logProtocolChanged($scope.diagnosticsDatabaseModel);

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -77,7 +77,6 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
 
   $scope.submitButtonClicked = function(confirm_msg) {
     if (confirm(confirm_msg)) {
-      miqService.sparkleOn();
       miqService.miqAjaxButton($scope.submitUrl, $scope.diagnosticsDatabaseModel);
     }
   };

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -83,7 +83,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   $scope.saveClicked = function() {
     var url = $scope.saveUrl + serverId + '?button=save';
     miqService.miqAjaxButton(url, $scope.logCollectionModel);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
@@ -96,7 +95,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   $scope.cancelClicked = function() {
     var url = $scope.saveUrl + serverId + '?button=cancel';
     miqService.miqAjaxButton(url);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.canValidateBasicInfo = function () {

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -57,7 +57,7 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   $scope.logProtocolChanged = function() {
     $scope.$broadcast('setNewRecord');
 
-    if(miqDBBackupService.knownProtocolsList.indexOf($scope.logCollectionModel.log_protocol) == -1 &&
+    if (miqDBBackupService.knownProtocolsList.indexOf($scope.logCollectionModel.log_protocol) == -1 &&
        $scope.logCollectionModel.log_protocol != '') {
       var url = $scope.logProtocolChangedUrl;
       miqService.sparkleOn();
@@ -73,14 +73,11 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   };
 
   $scope.isBasicInfoValid = function() {
-    if($scope.angularForm.depot_name.$valid &&
+    return $scope.angularForm.depot_name.$valid &&
       $scope.angularForm.uri.$valid &&
       $scope.angularForm.log_userid.$valid &&
       $scope.angularForm.log_password.$valid &&
-      $scope.angularForm.log_verify.$valid)
-      return true;
-    else
-      return false;
+      $scope.angularForm.log_verify.$valid;
   };
 
   $scope.saveClicked = function() {
@@ -90,7 +87,8 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
     if (moreUrlParams) {
       url += '&' + decodeURIComponent(moreUrlParams);
     }
-    miqService.miqAjaxButton(url, false);
+    // FIXME this is even worse, we send everything in the query string
+    miqService.miqAjaxButton(url);
     $scope.angularForm.$setPristine(true);
   };
 
@@ -104,16 +102,14 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
     var url = $scope.saveUrl + serverId + '?button=cancel';
+    // FIXME true with cancel!? probably nil
     miqService.miqAjaxButton(url, true);
     $scope.angularForm.$setPristine(true);
   };
 
   $scope.canValidateBasicInfo = function () {
-    if ($scope.isBasicInfoValid())
-      return true;
-    else
-      return false;
-  }
+    return $scope.isBasicInfoValid();
+  };
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -83,12 +83,7 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   $scope.saveClicked = function() {
     miqService.sparkleOn();
     var url = $scope.saveUrl + serverId + '?button=save';
-    var moreUrlParams = $.param(miqService.serializeModel($scope.logCollectionModel));
-    if (moreUrlParams) {
-      url += '&' + decodeURIComponent(moreUrlParams);
-    }
-    // FIXME this is even worse, we send everything in the query string
-    miqService.miqAjaxButton(url);
+    miqService.miqAjaxButton(url, $scope.logCollectionModel);
     $scope.angularForm.$setPristine(true);
   };
 
@@ -102,8 +97,7 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   $scope.cancelClicked = function() {
     miqService.sparkleOn();
     var url = $scope.saveUrl + serverId + '?button=cancel';
-    // FIXME true with cancel!? probably nil
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url);
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -42,7 +42,7 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
         $scope.logCollectionModel.uri_prefix = data.uri_prefix;
         $scope.logCollectionModel.log_userid = data.log_userid;
 
-        if($scope.logCollectionModel.log_userid != '') {
+        if ($scope.logCollectionModel.log_userid != '') {
           $scope.logCollectionModel.log_password = $scope.logCollectionModel.log_verify = miqService.storedPasswordPlaceholder;
         }
 
@@ -81,7 +81,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   };
 
   $scope.saveClicked = function() {
-    miqService.sparkleOn();
     var url = $scope.saveUrl + serverId + '?button=save';
     miqService.miqAjaxButton(url, $scope.logCollectionModel);
     $scope.angularForm.$setPristine(true);
@@ -95,7 +94,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
   };
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = $scope.saveUrl + serverId + '?button=cancel';
     miqService.miqAjaxButton(url);
     $scope.angularForm.$setPristine(true);

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -51,7 +51,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       replication_type: $scope.pglogicalReplicationModel.replication_type,
       subscriptions: $scope.pglogicalReplicationModel.subscriptions,
     });
-    $scope.angularForm.$setPristine(true);
   };
 
   // check if subscription values have been changed

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -28,10 +28,10 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
     });
   };
 
-  var pglogicalManageSubscriptionsButtonClicked = function(buttonName, serializeFields) {
+  var pglogicalManageSubscriptionsButtonClicked = function(buttonName, data) {
     miqService.sparkleOn();
     var url = '/ops/pglogical_save_subscriptions/' + pglogicalReplicationFormId + '?button=' + buttonName;
-    miqService.miqAjaxButton(url, serializeFields);
+    miqService.miqAjaxButton(url, data);
   };
 
   $scope.resetClicked = function() {
@@ -49,8 +49,8 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       }
     });
     pglogicalManageSubscriptionsButtonClicked('save', {
-      'replication_type': $scope.pglogicalReplicationModel.replication_type,
-      'subscriptions' : $scope.pglogicalReplicationModel.subscriptions
+      replication_type: $scope.pglogicalReplicationModel.replication_type,
+      subscriptions: $scope.pglogicalReplicationModel.subscriptions,
     });
     $scope.angularForm.$setPristine(true);
   };
@@ -206,32 +206,29 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
 
   // method to set flag to disable certain buttons when add of subscription in progress
   $scope.addInProgress = function() {
-    if ($scope.pglogicalReplicationModel.addEnabled === true)
-      return true;
-    else
-      return false;
+    return ($scope.pglogicalReplicationModel.addEnabled === true);
   }
 
   // validate new/existing subscription
   $scope.validateSubscription = function(idx) {
     var data = {};
     if (typeof idx == 'undefined') {
-      data["dbname"] = $scope.pglogicalReplicationModel.dbname;
-      data["host"]     = $scope.pglogicalReplicationModel.host;
-      data["user"] = $scope.pglogicalReplicationModel.user;
-      data["password"] = $scope.pglogicalReplicationModel.password;
-      data["port"]     = $scope.pglogicalReplicationModel.port;
+      data.dbname = $scope.pglogicalReplicationModel.dbname;
+      data.host = $scope.pglogicalReplicationModel.host;
+      data.user = $scope.pglogicalReplicationModel.user;
+      data.password = $scope.pglogicalReplicationModel.password;
+      data.port = $scope.pglogicalReplicationModel.port;
     } else {
       var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
-      data["dbname"] = subscription.dbname;
-      data["host"]     = subscription.host;
-      data["user"] = subscription.user;
-      data["password"] = subscription.password;
-      data["port"]     = subscription.port;
-      data["id"] = subscription.id
+      data.dbname = subscription.dbname;
+      data.host = subscription.host;
+      data.user = subscription.user;
+      data.password = subscription.password;
+      data.port = subscription.port;
+      data.id = subscription.id;
     }
     miqService.sparkleOn();
-    var url = '/ops/pglogical_validate_subscription'
+    var url = '/ops/pglogical_validate_subscription';
     miqService.miqAjaxButton(url, data);
   };
 
@@ -239,16 +236,13 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
   $scope.showCancelDelete = function(idx) {
     var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
     // only show subscriptions in red if they were saved subscriptions and deleted in current edit session
-    if (subscription.remove === true)
-      return true;
-    else
-      return false;
+    return (subscription.remove === true);
   }
 
   // put back subscription that was deleted into new subscriptions array
   $scope.cancelDelete = function(idx) {
     var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
-    delete subscription["remove"];
+    delete subscription.remove;
   }
 
   $scope.showChanged = function(idx, fieldName) {
@@ -256,28 +250,23 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
     // if updating a record use form fields to compare
     if ($scope.pglogicalReplicationModel.updateEnabled) {
       var subscription = {};
-      subscription["dbname"]  = $scope.pglogicalReplicationModel.dbname;
-      subscription["host"]     = $scope.pglogicalReplicationModel.host;
-      subscription["user"]     = $scope.pglogicalReplicationModel.user;
-      subscription["password"] = $scope.pglogicalReplicationModel.password;
-      subscription["port"]     = $scope.pglogicalReplicationModel.port;
-    } else
+      subscription.dbname = $scope.pglogicalReplicationModel.dbname;
+      subscription.host = $scope.pglogicalReplicationModel.host;
+      subscription.user = $scope.pglogicalReplicationModel.user;
+      subscription.password = $scope.pglogicalReplicationModel.password;
+      subscription.port = $scope.pglogicalReplicationModel.port;
+    } else {
       var subscription = $scope.pglogicalReplicationModel.subscriptions[idx];
+    }
 
-    if (typeof original_values != 'undefined' && original_values[fieldName] != subscription[fieldName])
-      return true;
-    else
-      return false;
+    return (typeof original_values != 'undefined' && original_values[fieldName] != subscription[fieldName]);
   }
 
   $scope.subscriptionInValidMessage = function() {
-    if ($scope.pglogicalReplicationModel.replication_type == 'global' &&
+    return $scope.pglogicalReplicationModel.replication_type == 'global' &&
       ($scope.pglogicalReplicationModel.subscriptions.length === 0 ||
-      ($scope.pglogicalReplicationModel.subscriptions.length == 1 && $scope.pglogicalReplicationModel.subscriptions[0].remove === true)))
-      return true;
-    else
-      return false;
-  }
+      ($scope.pglogicalReplicationModel.subscriptions.length === 1 && $scope.pglogicalReplicationModel.subscriptions[0].remove === true));
+  };
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/pglogical_replication_form_controller.js
@@ -29,7 +29,6 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
   };
 
   var pglogicalManageSubscriptionsButtonClicked = function(buttonName, data) {
-    miqService.sparkleOn();
     var url = '/ops/pglogical_save_subscriptions/' + pglogicalReplicationFormId + '?button=' + buttonName;
     miqService.miqAjaxButton(url, data);
   };
@@ -227,7 +226,7 @@ ManageIQ.angular.app.controller('pglogicalReplicationFormController', ['$http', 
       data.port = subscription.port;
       data.id = subscription.id;
     }
-    miqService.sparkleOn();
+
     var url = '/ops/pglogical_validate_subscription';
     miqService.miqAjaxButton(url, data);
   };

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -61,9 +61,7 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       tenantEditButtonClicked('save', $scope.tenantModel);
     };
 
-    $scope.addClicked = function() {
-      $scope.saveClicked();
-    };
+    $scope.addClicked = $scope.saveClicked;
 
     $scope.toggleValueForWatch =   function(watchValue, initialValue) {
       if ($scope[watchValue] == initialValue)

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -42,7 +42,6 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
     };
 
     var tenantEditButtonClicked = function(buttonName, data) {
-      miqService.sparkleOn();
       var url = '/ops/rbac_tenant_edit/' + tenantFormId + '?button=' + buttonName;
       miqService.miqAjaxButton(url, data);
     };

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -48,7 +48,6 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
 
     $scope.cancelClicked = function() {
       tenantEditButtonClicked('cancel', { divisible: $scope.tenantModel.divisible });
-      $scope.angularForm.$setPristine(true);
     };
 
     $scope.resetClicked = function() {
@@ -60,7 +59,6 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
 
     $scope.saveClicked = function() {
       tenantEditButtonClicked('save', $scope.tenantModel);
-      $scope.angularForm.$setPristine(true);
     };
 
     $scope.addClicked = function() {

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -41,18 +41,14 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       }
     };
 
-    var tenantEditButtonClicked = function(buttonName, serializeFields) {
+    var tenantEditButtonClicked = function(buttonName, data) {
       miqService.sparkleOn();
-      var url = '/ops/rbac_tenant_edit/' + tenantFormId + '?button=' + buttonName + '&divisible=' + tenantType;
-      if (serializeFields === undefined) {
-        miqService.miqAjaxButton(url);
-      } else {
-        miqService.miqAjaxButton(url, true);  // FIXME
-      }
+      var url = '/ops/rbac_tenant_edit/' + tenantFormId + '?button=' + buttonName;
+      miqService.miqAjaxButton(url, data);
     };
 
     $scope.cancelClicked = function() {
-      tenantEditButtonClicked('cancel');
+      tenantEditButtonClicked('cancel', { divisible: $scope.tenantModel.divisible });
       $scope.angularForm.$setPristine(true);
     };
 
@@ -64,7 +60,7 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
     };
 
     $scope.saveClicked = function() {
-      tenantEditButtonClicked('save', true);
+      tenantEditButtonClicked('save', $scope.tenantModel);
       $scope.angularForm.$setPristine(true);
     };
 
@@ -73,9 +69,9 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
     };
 
     $scope.toggleValueForWatch =   function(watchValue, initialValue) {
-      if($scope[watchValue] == initialValue)
+      if ($scope[watchValue] == initialValue)
         $scope[watchValue] = "NO-OP";
-      else if($scope[watchValue] == "NO-OP")
+      else if ($scope[watchValue] == "NO-OP")
         $scope[watchValue] = initialValue;
     };
 

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -47,7 +47,7 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       if (serializeFields === undefined) {
         miqService.miqAjaxButton(url);
       } else {
-        miqService.miqAjaxButton(url, serializeFields);
+        miqService.miqAjaxButton(url, true);  // FIXME
       }
     };
 

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -27,7 +27,7 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
             quota['enforced'] = false;
 
           if (quota['format'] === "general_number_precision_0")
-            quota['valpattern'] = "^[1-9][0-9]*$";
+            quota['valpattern'] = /^[1-9][0-9]*$/;
           else
             quota['valpattern'] = /^\s*(?=.*[1-9])\d*(?:\.\d{1,6})?\s*$/;
         }
@@ -38,14 +38,10 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
     });
   };
 
-  var tenantManageQuotasButtonClicked = function(buttonName, serializeFields) {
+  var tenantManageQuotasButtonClicked = function(buttonName, data) {
     miqService.sparkleOn();
     var url = '/ops/rbac_tenant_manage_quotas/' + tenantQuotaFormId + '?button=' + buttonName + '&divisible=' + tenantType;
-    if(serializeFields === undefined) {
-      miqService.miqAjaxButton(url);
-    } else {
-      miqService.miqAjaxButton(url, serializeFields);
-    }
+    miqService.miqAjaxButton(url, data);
   };
 
   $scope.cancelClicked = function() {
@@ -76,7 +72,9 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
         }
       }
     }
-    tenantManageQuotasButtonClicked('save', { 'quotas' : data});
+    tenantManageQuotasButtonClicked('save', {
+      quotas: data,
+    });
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -45,7 +45,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
 
   $scope.cancelClicked = function() {
     tenantManageQuotasButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
@@ -74,7 +73,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
     tenantManageQuotasButtonClicked('save', {
       quotas: data,
     });
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.toggleValueForWatch =   function(watchValue, initialValue) {

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -39,7 +39,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController', ['$http', '$scope',
   };
 
   var tenantManageQuotasButtonClicked = function(buttonName, data) {
-    miqService.sparkleOn();
     var url = '/ops/rbac_tenant_manage_quotas/' + tenantQuotaFormId + '?button=' + buttonName + '&divisible=' + tenantType;
     miqService.miqAjaxButton(url, data);
   };

--- a/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
+++ b/app/assets/javascripts/controllers/orchestration_template/orchestration_template_copy_controller.js
@@ -33,12 +33,10 @@ ManageIQ.angular.app.controller('orchestrationTemplateCopyController', ['$http',
   });
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     miqService.miqAjaxButton(submitUrl + '?button=cancel&id=' + $scope.stackId);
   };
 
   $scope.addClicked = function() {
-    miqService.sparkleOn();
     miqService.miqAjaxButton(submitUrl + '?button=add', $scope.templateInfo);
   };
 }]);

--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -49,7 +49,6 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
 
   $scope.cancelClicked = function() {
     ownershipEditButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {

--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -33,18 +33,9 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
   };
 
 
-  var ownershipEditButtonClicked = function(buttonName, serializeFields) {
-    miqService.sparkleOn();
+  var ownershipEditButtonClicked = function(buttonName, data) {
     var url = 'ownership_update/' + '?button=' + buttonName;
-    if (serializeFields === undefined) {
-      miqService.miqAjaxButton(url);
-    } else {
-      miqService.miqAjaxButton(url, {
-        objectIds: $scope.objectIds,
-        user:  $scope.ownershipModel.user,
-        group: $scope.ownershipModel.group,
-      });
-    }
+    miqService.miqAjaxButton(url, data);
   };
 
   $scope.cancelClicked = function() {
@@ -58,8 +49,11 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
   };
 
   $scope.saveClicked = function() {
-    ownershipEditButtonClicked('save', true);
-    $scope.angularForm.$setPristine(true);
+    ownershipEditButtonClicked('save', {
+      objectIds: $scope.objectIds,
+      user: $scope.ownershipModel.user,
+      group: $scope.ownershipModel.group,
+    });
   };
 
   $scope.addClicked = $scope.saveClicked;

--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -62,9 +62,7 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
     $scope.angularForm.$setPristine(true);
   };
 
-  $scope.addClicked = function() {
-    $scope.saveClicked();
-  };
+  $scope.addClicked = $scope.saveClicked;
 
   init();
 }]);

--- a/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
+++ b/app/assets/javascripts/controllers/ownership/ownership_form_controller.js
@@ -42,7 +42,7 @@ ManageIQ.angular.app.controller('ownershipFormController', ['$http', '$scope', '
       miqService.miqAjaxButton(url, {
         objectIds: $scope.objectIds,
         user:  $scope.ownershipModel.user,
-        group: $scope.ownershipModel.group
+        group: $scope.ownershipModel.group,
       });
     }
   };

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -49,7 +49,7 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
 
           $scope.providerForemanModel.log_userid   = data.log_userid;
 
-          if($scope.providerForemanModel.log_userid != '') {
+          if ($scope.providerForemanModel.log_userid !== '') {
             $scope.providerForemanModel.log_password = $scope.providerForemanModel.log_verify = miqService.storedPasswordPlaceholder;
           }
 
@@ -72,15 +72,11 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
         $scope.angularForm.log_verify.$valid;
     };
 
-    var providerForemanEditButtonClicked = function(buttonName, serializeFields) {
-      miqService.sparkleOn();
+    var providerForemanEditButtonClicked = function(buttonName, data) {
       var url = '/provider_foreman/edit/' + providerForemanFormId + '?button=' + buttonName;
-      if (serializeFields === undefined) {
-        miqService.miqAjaxButton(url);
-      } else {
-        // FIXME: true => object
-        miqService.miqAjaxButton(url, true);
-      }
+
+      miqService.sparkleOn();
+      miqService.miqAjaxButton(url, data);
     };
 
     $scope.cancelClicked = function() {
@@ -96,13 +92,11 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     };
 
     $scope.saveClicked = function() {
-      providerForemanEditButtonClicked('save', true);
+      providerForemanEditButtonClicked('save', $scope.providerForemanModel);
       $scope.angularForm.$setPristine(true);
     };
 
-    $scope.addClicked = function() {
-      $scope.saveClicked();
-    };
+    $scope.addClicked = $scope.saveClicked;
 
     init();
 }]);

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -62,20 +62,14 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     };
 
     $scope.canValidateBasicInfo = function () {
-      if ($scope.isBasicInfoValid())
-        return true;
-      else
-        return false;
-    }
+      return $scope.isBasicInfoValid();
+    };
 
     $scope.isBasicInfoValid = function() {
-      if($scope.angularForm.url.$valid &&
-         $scope.angularForm.log_userid.$valid &&
-         $scope.angularForm.log_password.$valid &&
-         $scope.angularForm.log_verify.$valid)
-        return true;
-      else
-        return false;
+      return $scope.angularForm.url.$valid &&
+        $scope.angularForm.log_userid.$valid &&
+        $scope.angularForm.log_password.$valid &&
+        $scope.angularForm.log_verify.$valid;
     };
 
     var providerForemanEditButtonClicked = function(buttonName, serializeFields) {
@@ -84,7 +78,8 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
       if (serializeFields === undefined) {
         miqService.miqAjaxButton(url);
       } else {
-        miqService.miqAjaxButton(url, serializeFields);
+        // FIXME: true => object
+        miqService.miqAjaxButton(url, true);
       }
     };
 

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -74,8 +74,6 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
 
     var providerForemanEditButtonClicked = function(buttonName, data) {
       var url = '/provider_foreman/edit/' + providerForemanFormId + '?button=' + buttonName;
-
-      miqService.sparkleOn();
       miqService.miqAjaxButton(url, data);
     };
 

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -79,7 +79,6 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
 
     $scope.cancelClicked = function() {
       providerForemanEditButtonClicked('cancel');
-      $scope.angularForm.$setPristine(true);
     };
 
     $scope.resetClicked = function() {
@@ -91,7 +90,6 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
 
     $scope.saveClicked = function() {
       providerForemanEditButtonClicked('save', $scope.providerForemanModel);
-      $scope.angularForm.$setPristine(true);
     };
 
     $scope.addClicked = $scope.saveClicked;

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -236,23 +236,21 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
         $scope.cb_disks = false;
     };
 
-    var reconfigureEditButtonClicked = function(buttonName, serializeFields) {
+    var reconfigureEditButtonClicked = function(buttonName) {
       miqService.sparkleOn();
       var url = 'reconfigure_update/' + reconfigureFormId + '?button=' + buttonName;
-      if (serializeFields === undefined) {
-        miqService.miqAjaxButton(url);
-      } else {
-        miqService.miqAjaxButton(url, {objectIds:              $scope.objectIds,
-                                       cb_memory:              $scope.cb_memory,
-                                       cb_cpu:                 $scope.cb_cpu,
-                                       memory:                 $scope.reconfigureModel.memory,
-                                       memory_type:            $scope.reconfigureModel.memory_type,
-                                       socket_count:           $scope.reconfigureModel.socket_count,
-                                       cores_per_socket_count: $scope.reconfigureModel.cores_per_socket_count,
-                                       vmAddDisks:             $scope.reconfigureModel.vmAddDisks,
-                                       vmRemoveDisks:          $scope.reconfigureModel.vmRemoveDisks
-                                      });
-      }
+
+      miqService.miqAjaxButton(url, {
+        objectIds:              $scope.objectIds,
+        cb_memory:              $scope.cb_memory,
+        cb_cpu:                 $scope.cb_cpu,
+        memory:                 $scope.reconfigureModel.memory,
+        memory_type:            $scope.reconfigureModel.memory_type,
+        socket_count:           $scope.reconfigureModel.socket_count,
+        cores_per_socket_count: $scope.reconfigureModel.cores_per_socket_count,
+        vmAddDisks:             $scope.reconfigureModel.vmAddDisks,
+        vmRemoveDisks:          $scope.reconfigureModel.vmRemoveDisks,
+      });
     };
 
     $scope.cancelClicked = function() {
@@ -277,7 +275,7 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
 
     $scope.submitClicked = function() {
       // change memory value based ontype
-      reconfigureEditButtonClicked('submit', true);
+      reconfigureEditButtonClicked('submit');
       $scope.angularForm.$setPristine(true);
     };
 

--- a/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
+++ b/app/assets/javascripts/controllers/reconfigure/reconfigure_form_controller.js
@@ -237,7 +237,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     };
 
     var reconfigureEditButtonClicked = function(buttonName) {
-      miqService.sparkleOn();
       var url = 'reconfigure_update/' + reconfigureFormId + '?button=' + buttonName;
 
       miqService.miqAjaxButton(url, {
@@ -254,7 +253,6 @@ ManageIQ.angular.app.controller('reconfigureFormController', ['$http', '$scope',
     };
 
     $scope.cancelClicked = function() {
-      miqService.sparkleOn();
       miqService.miqAjaxButton('reconfigure_update?button=cancel');
     };
 

--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -25,8 +25,9 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', '$scope', 
 
   $scope.saveClicked = function() {
     miqService.sparkleOn();
-    miqService.miqAjaxButton('retire?button=save',
-                             {'retire_date': $scope.retirementInfo.retirementDate,
-                              'retire_warn': $scope.retirementInfo.retirementWarning});
+    miqService.miqAjaxButton('retire?button=save', {
+      retire_date: $scope.retirementInfo.retirementDate,
+      retire_warn: $scope.retirementInfo.retirementWarning,
+    });
   };
 }]);

--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -19,12 +19,10 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', '$scope', 
   }
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     miqService.miqAjaxButton('retire?button=cancel');
   };
 
   $scope.saveClicked = function() {
-    miqService.sparkleOn();
     miqService.miqAjaxButton('retire?button=save', {
       retire_date: $scope.retirementInfo.retirementDate,
       retire_warn: $scope.retirementInfo.retirementWarning,

--- a/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
+++ b/app/assets/javascripts/controllers/retirement/retirement_form_controller.js
@@ -2,7 +2,7 @@ ManageIQ.angular.app.controller('retirementFormController', ['$http', '$scope', 
   $scope.objectIds = objectIds;
   $scope.retirementInfo = {
     retirementDate: null,
-    retirementWarning: ''
+    retirementWarning: '',
   };
   $scope.datepickerStartDate = new Date();
   $scope.modelCopy = _.extend({}, $scope.retirementInfo);

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -129,7 +129,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
   };
 
   var scheduleEditButtonClicked = function(buttonName, data) {
-    miqService.sparkleOn();
     var url = '/ops/schedule_edit/' + scheduleFormId + '?button=' + buttonName;
     miqService.miqAjaxButton(url, data);
   };

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -128,15 +128,10 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     return testType(/^host/);
   };
 
-  var scheduleEditButtonClicked = function(buttonName, serializeFields) {
+  var scheduleEditButtonClicked = function(buttonName, data) {
     miqService.sparkleOn();
     var url = '/ops/schedule_edit/' + scheduleFormId + '?button=' + buttonName;
-    if (serializeFields === undefined) {
-      miqService.miqAjaxButton(url);
-    } else {
-      // FIXME
-      miqService.miqAjaxButton(url, true);
-    }
+    miqService.miqAjaxButton(url, data);
   };
 
   $scope.buildLegend = function() {
@@ -269,7 +264,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
   };
 
   $scope.saveClicked = function() {
-    scheduleEditButtonClicked('save', true);
+    scheduleEditButtonClicked('save', $scope.scheduleModel);
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -265,9 +265,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     scheduleEditButtonClicked('save', $scope.scheduleModel);
   };
 
-  $scope.addClicked = function() {
-    $scope.saveClicked();
-  };
+  $scope.addClicked = $scope.saveClicked;
 
   $scope.filterValueRequired = function(value) {
     return !$scope.filterValuesEmpty &&

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -234,7 +234,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
   $scope.cancelClicked = function() {
     scheduleEditButtonClicked('cancel');
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.resetClicked = function() {
@@ -264,7 +263,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
 
   $scope.saveClicked = function() {
     scheduleEditButtonClicked('save', $scope.scheduleModel);
-    $scope.angularForm.$setPristine(true);
   };
 
   $scope.addClicked = function() {

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -134,7 +134,8 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     if (serializeFields === undefined) {
       miqService.miqAjaxButton(url);
     } else {
-      miqService.miqAjaxButton(url, serializeFields);
+      // FIXME
+      miqService.miqAjaxButton(url, true);
     }
   };
 

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -1,46 +1,46 @@
 ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'serviceFormId', 'miqService', function($http, $scope, serviceFormId, miqService) {
-    var init = function() {
-      $scope.serviceModel = {
-        name: '',
-        description: ''
-      };
-      $scope.formId    = serviceFormId;
-      $scope.afterGet  = false;
-      $scope.newRecord = false;
+  var init = function() {
+    $scope.serviceModel = {
+      name: '',
+      description: '',
+    };
+    $scope.formId    = serviceFormId;
+    $scope.afterGet  = false;
+    $scope.newRecord = false;
+    $scope.modelCopy = angular.copy( $scope.serviceModel );
+    $scope.model     = "serviceModel";
+    ManageIQ.angular.scope = $scope;
+
+    miqService.sparkleOn();
+    $http.get('/service/service_form_fields/' + serviceFormId).success(function(data) {
+      $scope.serviceModel.name        = data.name;
+      $scope.serviceModel.description = data.description;
+
+      $scope.afterGet = true;
       $scope.modelCopy = angular.copy( $scope.serviceModel );
-      $scope.model     = "serviceModel";
-      ManageIQ.angular.scope = $scope;
+      miqService.sparkleOff();
+    });
+  };
 
-      miqService.sparkleOn();
-      $http.get('/service/service_form_fields/' + serviceFormId).success(function(data) {
-        $scope.serviceModel.name        = data.name;
-        $scope.serviceModel.description = data.description;
+  var serviceEditButtonClicked = function(buttonName, data) {
+    var url = '/service/service_edit/' + serviceFormId + '?button=' + buttonName;
+    miqService.miqAjaxButton(url, data);
+  };
 
-        $scope.afterGet = true;
-        $scope.modelCopy = angular.copy( $scope.serviceModel );
-        miqService.sparkleOff();
-      });
-    };
+  $scope.cancelClicked = function() {
+    serviceEditButtonClicked('cancel');
+  };
 
-    var serviceEditButtonClicked = function(buttonName, data) {
-      var url = '/service/service_edit/' + serviceFormId + '?button=' + buttonName;
-      miqService.miqAjaxButton(url, data);
-    };
+  $scope.resetClicked = function() {
+    $scope.serviceModel = angular.copy( $scope.modelCopy );
+    $scope.angularForm.$setUntouched(true);
+    $scope.angularForm.$setPristine(true);
+    miqService.miqFlash("warn", __("All changes have been reset"));
+  };
 
-    $scope.cancelClicked = function() {
-      serviceEditButtonClicked('cancel');
-    };
+  $scope.saveClicked = function() {
+    serviceEditButtonClicked('save', $scope.serviceModel);
+  };
 
-    $scope.resetClicked = function() {
-      $scope.serviceModel = angular.copy( $scope.modelCopy );
-      $scope.angularForm.$setUntouched(true);
-      $scope.angularForm.$setPristine(true);
-      miqService.miqFlash("warn", __("All changes have been reset"));
-    };
-
-    $scope.saveClicked = function() {
-      serviceEditButtonClicked('save', $scope.serviceModel);
-    };
-
-    init();
+  init();
 }]);

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -22,11 +22,11 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
       });
     };
 
-    var serviceEditButtonClicked = function(buttonName, serializeFields) {
+    var serviceEditButtonClicked = function(buttonName, data) {
       miqService.sparkleOn();
       var url = '/service/service_edit/' + serviceFormId + '?button=' + buttonName;
 
-      miqService.miqAjaxButton(url, serializeFields);
+      miqService.miqAjaxButton(url, data);
     };
 
     $scope.cancelClicked = function() {
@@ -42,6 +42,7 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
     };
 
     $scope.saveClicked = function() {
+      // FIXME data should not be true but an object
       serviceEditButtonClicked('save', true);
       $scope.angularForm.$setPristine(true);
     };

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -23,9 +23,7 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
     };
 
     var serviceEditButtonClicked = function(buttonName, data) {
-      miqService.sparkleOn();
       var url = '/service/service_edit/' + serviceFormId + '?button=' + buttonName;
-
       miqService.miqAjaxButton(url, data);
     };
 

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -29,7 +29,6 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
 
     $scope.cancelClicked = function() {
       serviceEditButtonClicked('cancel');
-      $scope.angularForm.$setPristine(true);
     };
 
     $scope.resetClicked = function() {
@@ -41,7 +40,6 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
 
     $scope.saveClicked = function() {
       serviceEditButtonClicked('save', $scope.serviceModel);
-      $scope.angularForm.$setPristine(true);
     };
 
     init();

--- a/app/assets/javascripts/controllers/service/service_form_controller.js
+++ b/app/assets/javascripts/controllers/service/service_form_controller.js
@@ -42,8 +42,7 @@ ManageIQ.angular.app.controller('serviceFormController', ['$http', '$scope', 'se
     };
 
     $scope.saveClicked = function() {
-      // FIXME data should not be true but an object
-      serviceEditButtonClicked('save', true);
+      serviceEditButtonClicked('save', $scope.serviceModel);
       $scope.angularForm.$setPristine(true);
     };
 

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
@@ -15,13 +15,11 @@ ManageIQ.angular.app.controller('vmCloudAssociateFloatingIpFormController', ['$h
   });
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };
 
   $scope.submitClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=submit';
     miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
@@ -23,6 +23,6 @@ ManageIQ.angular.app.controller('vmCloudAssociateFloatingIpFormController', ['$h
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_associate_floating_ip_form_controller.js
@@ -23,6 +23,6 @@ ManageIQ.angular.app.controller('vmCloudAssociateFloatingIpFormController', ['$h
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/associate_floating_ip_vm/' + vmCloudAssociateFloatingIpFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_attach_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_attach_form_controller.js
@@ -9,7 +9,7 @@ ManageIQ.angular.app.controller('vmCloudAttachFormController', ['$scope', 'vmClo
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/attach_volume/' + vmCloudAttachFormId + '?button=attach';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_attach_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_attach_form_controller.js
@@ -7,13 +7,11 @@ ManageIQ.angular.app.controller('vmCloudAttachFormController', ['$scope', 'vmClo
   ManageIQ.angular.scope = $scope;
 
   $scope.submitClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/attach_volume/' + vmCloudAttachFormId + '?button=attach';
     miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/attach_volume/' + vmCloudAttachFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_attach_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_attach_form_controller.js
@@ -9,7 +9,7 @@ ManageIQ.angular.app.controller('vmCloudAttachFormController', ['$scope', 'vmClo
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/attach_volume/' + vmCloudAttachFormId + '?button=attach';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_detach_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_detach_form_controller.js
@@ -7,13 +7,11 @@ ManageIQ.angular.app.controller('vmCloudDetachFormController', ['$scope', 'vmClo
   ManageIQ.angular.scope = $scope;
 
   $scope.submitClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/detach_volume/' + vmCloudDetachFormId + '?button=detach';
     miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/detach_volume/' + vmCloudDetachFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_detach_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_detach_form_controller.js
@@ -9,7 +9,7 @@ ManageIQ.angular.app.controller('vmCloudDetachFormController', ['$scope', 'vmClo
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/detach_volume/' + vmCloudDetachFormId + '?button=detach';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_detach_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_detach_form_controller.js
@@ -9,7 +9,7 @@ ManageIQ.angular.app.controller('vmCloudDetachFormController', ['$scope', 'vmClo
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/detach_volume/' + vmCloudDetachFormId + '?button=detach';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
@@ -23,6 +23,6 @@ ManageIQ.angular.app.controller('vmCloudDisassociateFloatingIpFormController', [
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
@@ -23,6 +23,6 @@ ManageIQ.angular.app.controller('vmCloudDisassociateFloatingIpFormController', [
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_disassociate_floating_ip_form_controller.js
@@ -15,13 +15,11 @@ ManageIQ.angular.app.controller('vmCloudDisassociateFloatingIpFormController', [
   });
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };
 
   $scope.submitClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/disassociate_floating_ip_vm/' + vmCloudDisassociateFloatingIpFormId + '?button=submit';
     miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
@@ -18,13 +18,11 @@ ManageIQ.angular.app.controller('vmCloudEvacuateFormController', ['$http', '$sco
   });
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };
 
   $scope.submitClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=submit';
     miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
@@ -26,6 +26,6 @@ ManageIQ.angular.app.controller('vmCloudEvacuateFormController', ['$http', '$sco
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_evacuate_form_controller.js
@@ -26,6 +26,6 @@ ManageIQ.angular.app.controller('vmCloudEvacuateFormController', ['$http', '$sco
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/evacuate_vm/' + vmCloudEvacuateFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -30,6 +30,6 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);
+    miqService.miqAjaxButton(url, true);  // FIXME
   };
 }]);

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -22,13 +22,11 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
   });
 
   $scope.cancelClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=cancel';
     miqService.miqAjaxButton(url);
   };
 
   $scope.submitClicked = function() {
-    miqService.sparkleOn();
     var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
     miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -30,6 +30,6 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
   $scope.submitClicked = function() {
     miqService.sparkleOn();
     var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
-    miqService.miqAjaxButton(url, true);  // FIXME
+    miqService.miqAjaxButton(url, $scope.vmCloudModel);
   };
 }]);

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -85,7 +85,6 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', function($t
   };
 
   this.validateWithAjax = function (url) {
-    miqSparkleOn();
     miqAjaxButton(url, true); // FIXME!
   };
 

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -86,7 +86,7 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', function($t
 
   this.validateWithAjax = function (url) {
     miqSparkleOn();
-    miqAjaxButton(url, true);
+    miqAjaxButton(url, true); // FIXME!
   };
 
   this.validateWithREST = function($event, credType, url, formSubmit) {

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -16,8 +16,12 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', function($t
     miqBuildCalendar(true);
   };
 
-  this.miqAjaxButton = function(url, serializeFields, options) {
-    miqAjaxButton(url, serializeFields, options);
+  this.miqAjaxButton = function(url, data, options) {
+    if (data === true || data === false) {
+      console.error('miqService.miqAjaxButton with bool serializeFields is deprecated!');
+    }
+
+    miqAjaxButton(url, data, options);
   };
 
   this.miqAsyncAjaxButton = function(url, serializeFields) {

--- a/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
+++ b/spec/javascripts/controllers/auth_key_pair_cloud/auth_key_pair_cloud_controller_spec.js
@@ -1,93 +1,93 @@
 describe('keyPairCloudFormController', function() {
-    var $scope, $controller, $httpBackend, miqService;
+  var $scope, $controller, $httpBackend, miqService;
 
-    beforeEach(module('ManageIQ'));
+  beforeEach(module('ManageIQ'));
 
-    beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
-        miqService = _miqService_;
-        spyOn(miqService, 'showButtons');
-        spyOn(miqService, 'hideButtons');
-        spyOn(miqService, 'buildCalendar');
-        spyOn(miqService, 'miqAjaxButton');
-        spyOn(miqService, 'sparkleOn');
-        spyOn(miqService, 'sparkleOff');
-        $scope = $rootScope.$new();
-        spyOn($scope, '$broadcast');
-        $scope.keyPairModel = { name: 'name', public_key: 'key', ems_id: 4, ems: { id: 4 } };
+  beforeEach(inject(function(_$httpBackend_, $rootScope, _$controller_, _miqService_) {
+    miqService = _miqService_;
+    spyOn(miqService, 'showButtons');
+    spyOn(miqService, 'hideButtons');
+    spyOn(miqService, 'buildCalendar');
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
+    $scope = $rootScope.$new();
+    spyOn($scope, '$broadcast');
+    $scope.keyPairModel = { name: 'name', public_key: 'key', ems_id: 4, ems: { id: 4 } };
 
-        //$scope.hostForm.$invalid = false;
-        $httpBackend = _$httpBackend_;
-        var providerResponse = {"ems_choices":
-            [{"name": "OS1", "id":5}
-        ]};
+    //$scope.hostForm.$invalid = false;
+    $httpBackend = _$httpBackend_;
+    var providerResponse = {"ems_choices":
+      [{"name": "OS1", "id":5}
+    ]};
 
-        $httpBackend.whenGET('/auth_key_pair_cloud/ems_form_choices').respond(providerResponse);
-        $controller = _$controller_('keyPairCloudFormController', {
-            $scope: $scope,
-            keyPairFormId: 'new',
-            miqService: miqService
-        });
-    }));
+    $httpBackend.whenGET('/auth_key_pair_cloud/ems_form_choices').respond(providerResponse);
+    $controller = _$controller_('keyPairCloudFormController', {
+      $scope: $scope,
+      keyPairFormId: 'new',
+      miqService: miqService
+    });
+  }));
 
-    afterEach(function() {
-        $httpBackend.verifyNoOutstandingExpectation();
-        $httpBackend.verifyNoOutstandingRequest();
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('initialization', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+      $scope.angularForm = {
+        $setPristine: function (value){}
+      };
+    });
+    describe('when the keyPairFormId is new', function() {
+      it('sets the name to blank', function () {
+        expect($scope.keyPairModel.name).toEqual('');
+      });
+      it('sets the hostname to blank', function () {
+        expect($scope.keyPairModel.public_key).toEqual('');
+      });
+    });
+  });
+
+  describe('#saveClicked', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+      $scope.angularForm = {
+        $setPristine: function (value){}
+      };
+      $scope.saveClicked();
     });
 
-    describe('initialization', function() {
-        beforeEach(function() {
-            $httpBackend.flush();
-            $scope.angularForm = {
-                $setPristine: function (value){}
-            };
-        });
-        describe('when the keyPairFormId is new', function() {
-            it('sets the name to blank', function () {
-                expect($scope.keyPairModel.name).toEqual('');
-            });
-            it('sets the hostname to blank', function () {
-                expect($scope.keyPairModel.public_key).toEqual('');
-            });
-        });
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
     });
 
-    describe('#saveClicked', function() {
-        beforeEach(function() {
-            $httpBackend.flush();
-            $scope.angularForm = {
-                $setPristine: function (value){}
-            };
-            $scope.saveClicked();
-        });
-
-        it('turns the spinner on via the miqService', function() {
-            expect(miqService.sparkleOn).toHaveBeenCalled();
-        });
-
-        it('turns the spinner on twice', function() {
-            expect(miqService.sparkleOn.calls.count()).toBe(2);
-        });
-
-        it('delegates to miqService.miqAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', miqService.serializeModel($scope.keyPairModel));
-        });
+    it('turns the spinner on twice', function() {
+      expect(miqService.sparkleOn.calls.count()).toBe(2);
     });
 
-    describe('#cancelClicked', function() {
-        beforeEach(function() {
-            $httpBackend.flush();
-            $scope.angularForm = {
-                $setPristine: function (value){}
-            };
-            $scope.cancelClicked();
-        });
-
-        it('turns the spinner on via the miqService', function() {
-            expect(miqService.sparkleOn).toHaveBeenCalled();
-        });
-
-        it('delegates to miqService.restAjaxButton', function() {
-            expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel', false);
-        });
+    it('delegates to miqService.miqAjaxButton', function() {
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=save', $scope.keyPairModel);
     });
+  });
+
+  describe('#cancelClicked', function() {
+    beforeEach(function() {
+      $httpBackend.flush();
+      $scope.angularForm = {
+        $setPristine: function (value){}
+      };
+      $scope.cancelClicked();
+    });
+
+    it('turns the spinner on via the miqService', function() {
+      expect(miqService.sparkleOn).toHaveBeenCalled();
+    });
+
+    it('delegates to miqService.restAjaxButton', function() {
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/auth_key_pair_cloud/create/new?button=cancel', undefined);
+    });
+  });
 });

--- a/spec/javascripts/controllers/host/host_form_controller_spec.js
+++ b/spec/javascripts/controllers/host/host_form_controller_spec.js
@@ -166,14 +166,14 @@ describe('hostFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/host/update/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/host/update/new?button=save', jasmine.any(Object));
     });
   });
 
   describe('#addClicked', function() {
     beforeEach(function() {
       $scope.angularForm = {
-        $setPristine: function (value){}
+        $setPristine: function (value) {}
       };
       $scope.addClicked();
     });
@@ -183,7 +183,7 @@ describe('hostFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('create/new?button=add', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('create/new?button=add', jasmine.any(Object));
     });
   });
 

--- a/spec/javascripts/controllers/ops/tenant_form_controller_spec.js
+++ b/spec/javascripts/controllers/ops/tenant_form_controller_spec.js
@@ -1,5 +1,5 @@
 describe('tenantFormController', function() {
-  var $scope, $controller, $httpBackend, tenantType, miqService;
+  var $scope, $controller, $httpBackend, miqService;
 
   beforeEach(module('ManageIQ'));
 
@@ -17,7 +17,7 @@ describe('tenantFormController', function() {
     $controller = _$controller_('tenantFormController', {
       $scope: $scope,
       tenantFormId: 'new',
-      tenantType: tenantType,
+      tenantType: null,
       miqService: miqService,
     });
   }));
@@ -37,18 +37,12 @@ describe('tenantFormController', function() {
         expect($scope.afterGet).toBe(true);
       });
     });
-
-    describe('when the tenantFormId is an id', function() {
-      var tenantFormResponse = {
-        tenant_name: 'tenantName',
-        tenant_description: 'tenantDescription'
-      };
   });
 
   describe('#cancelClicked', function() {
     beforeEach(function() {
       $scope.angularForm = {
-        $setPristine: function (value){}
+        $setPristine: function (value) {},
       };
       $scope.cancelClicked();
     });
@@ -62,7 +56,7 @@ describe('tenantFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=cancel&divisible=' + tenantType);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=cancel', { divisible: null });
     });
   });
 
@@ -86,11 +80,11 @@ describe('tenantFormController', function() {
         }
       };
       $scope.angularForm = {
-        $setPristine: function (value){},
-        $setUntouched: function (value){},
+        $setPristine: function (value) {},
+        $setUntouched: function (value) {},
         filter_value: {
-          $name:       'filter_value',
-          $setViewValue: function (value){}
+          $name: 'filter_value',
+          $setViewValue: function (value) {},
         }
       };
       $scope.resetClicked();
@@ -104,7 +98,7 @@ describe('tenantFormController', function() {
   describe('#saveClicked', function() {
     beforeEach(function() {
       $scope.angularForm = {
-        $setPristine: function (value){}
+        $setPristine: function (value) {},
       };
       $scope.saveClicked();
     });
@@ -118,14 +112,14 @@ describe('tenantFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=save&divisible=' + tenantType, true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=save', jasmine.any(Object));
     });
   });
 
   describe('#addClicked', function() {
     beforeEach(function() {
       $scope.angularForm = {
-        $setPristine: function (value){}
+        $setPristine: function (value) {},
       };
       $scope.addClicked();
     });
@@ -135,7 +129,7 @@ describe('tenantFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=save&divisible='+ tenantType, true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=save', jasmine.any(Object));
     });
   });
-});})
+});

--- a/spec/javascripts/controllers/ops/tenant_quota_form_controller_spec.js
+++ b/spec/javascripts/controllers/ops/tenant_quota_form_controller_spec.js
@@ -64,7 +64,7 @@ describe('tenantQuotaFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_manage_quotas/1000000000001?button=cancel&divisible=');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_manage_quotas/1000000000001?button=cancel&divisible=', undefined);
     });
   });
 

--- a/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
+++ b/spec/javascripts/controllers/provider_foreman/provider_foreman_form_controller_spec.js
@@ -135,7 +135,7 @@ describe('providerForemanFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save', jasmine.objectContaining({ zone: 'foo_zone' }));
     });
   });
 
@@ -152,7 +152,7 @@ describe('providerForemanFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/provider_foreman/edit/new?button=save', jasmine.objectContaining({ zone: 'foo_zone' }));
     });
   });
 

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -293,7 +293,7 @@ describe('scheduleFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=cancel');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=cancel', undefined);
     });
   });
 
@@ -317,11 +317,11 @@ describe('scheduleFormController', function() {
         }
       };
       $scope.angularForm = {
-        $setPristine: function (value){},
-        $setUntouched: function (value){},
+        $setPristine: function (value) {},
+        $setUntouched: function (value) {},
         filter_value: {
-          $name:       'filter_value',
-          $setViewValue: function (value){}
+          $name: 'filter_value',
+          $setViewValue: function (value) {}
         }
       };
       $scope.resetClicked();
@@ -335,7 +335,7 @@ describe('scheduleFormController', function() {
   describe('#saveClicked', function() {
     beforeEach(function() {
       $scope.angularForm = {
-        $setPristine: function (value){}
+        $setPristine: function (value) {}
       };
       $scope.saveClicked();
     });
@@ -349,7 +349,7 @@ describe('scheduleFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', jasmine.objectContaining({ action_typ: 'vm' }));
     });
   });
 
@@ -366,7 +366,7 @@ describe('scheduleFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=save', jasmine.objectContaining({ action_typ: 'vm' }));
     });
   });
 

--- a/spec/javascripts/controllers/service/service_form_controller_spec.js
+++ b/spec/javascripts/controllers/service/service_form_controller_spec.js
@@ -86,7 +86,10 @@ describe('serviceFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/service/service_edit/1000000000001?button=save', true);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/service/service_edit/1000000000001?button=save', {
+        name: 'serviceName',
+        description: 'serviceDescription',
+      });
     });
   });
 });


### PR DESCRIPTION
`miqService.miqAjax(url, data)` can be called with no data, a data object, or `true` which looks at `#form_div`, serializes all the form fields there via jQuery, and sends that.

That makes sense in older code, but in angular controllers, that data should already be in the model, and the form itself is **not** the canonical representation of that data.

So - changing every `miqService.miqAjax(url, true)` call to something like `miqService.miqAjax(url, {the: model})`..

TODO: add implicit miqService.sparkleOn? Looks like it's always called before miqAjaxButton..
