### PR TITLE
Prefer find_by to send("find_by_#{foo}")

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -111,7 +111,7 @@ module Api
 
       def parse_by_attr(resource, type, attr_list)
         klass = collection_class(type)
-        objs = attr_list.map { |attr| klass.send("find_by_#{attr}", resource[attr]) if resource[attr] }.compact
+        objs = attr_list.map { |attr| klass.find_by(attr => resource[attr]) if resource[attr] }.compact
         objs.collect(&:id).first
       end
 

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -42,7 +42,8 @@ module Api
     private
 
     def fetch_category(data)
-      category_id = parse_id(data, :categories) || parse_by_attr(data, :categories, %w(name))
+      category_id = parse_id(data, :categories)
+      category_id ||= collection_class(:categories).find_by_name(data["name"]).try(:id) if data["name"]
       unless category_id
         raise BadRequestError, "Category id, href or name needs to be specified for creating a new tag resource"
       end


### PR DESCRIPTION
There was just one gotcha here - the tags controller was leveraging this
method to find categories by name, which just so happened to implement
the `.find_by_name` method. Since it's preferable to use `find_by` for
real columns, the tags controller can be updated to call what it
needs directly instead - `Category.find_by_name`.

Thanks @gtanzillo for helping me debug this.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 