### PR TITLE
Create set_additional_attributes callback

### DIFF
--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -2,10 +2,7 @@ module Api
   class BlueprintsController < BaseController
     include Subcollections::Tags
 
-    def show
-      @additional_attributes = %w(content)
-      super
-    end
+    before_action :set_additional_attributes, :only => [:show]
 
     def create_resource(_type, _id, data)
       attributes = data.except("bundle")
@@ -32,6 +29,10 @@ module Api
     end
 
     private
+
+    def set_additional_attributes
+      @additional_attributes = %w(content)
+    end
 
     def create_bundle(blueprint, bundle)
       blueprint.create_bundle(deserialize_bundle(bundle))

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -2,14 +2,10 @@ module Api
   class CategoriesController < BaseController
     include Subcollections::Tags
 
-    def show
-      request_additional_attributes
-      super
-    end
+    before_action :set_additional_attributes, :only => [:show, :update]
 
     def edit_resource(type, id, data = {})
       raise BaseController::Forbidden if Category.find(id).read_only?
-      request_additional_attributes
       super
     end
 
@@ -20,7 +16,7 @@ module Api
 
     private
 
-    def request_additional_attributes
+    def set_additional_attributes
       @additional_attributes = %w(name)
     end
   end

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -5,12 +5,7 @@ module Api
     include Subcollections::Results
     include Subcollections::Schedules
 
-    def show
-      if @req.subcollection == "results" && (@req.s_id || @req.expand?(:resources)) && attribute_selection == "all"
-        @additional_attributes = %w(result_set)
-      end
-      super
-    end
+    before_action :set_additional_attributes, :only => [:show]
 
     def run_resource(_type, id, _data)
       report = MiqReport.find(id)
@@ -46,6 +41,12 @@ module Api
     end
 
     private
+
+    def set_additional_attributes
+      if @req.subcollection == "results" && (@req.s_id || @req.expand?(:resources)) && attribute_selection == "all"
+        @additional_attributes = %w(result_set)
+      end
+    end
 
     def schedule_reports(report, type, id, data)
       desc = "scheduling of report #{report.id}"

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,8 +1,11 @@
 module Api
   class ResultsController < BaseController
-    def show
+    before_action :set_additional_attributes, :only => [:show]
+
+    private
+
+    def set_additional_attributes
       @additional_attributes = %w(result_set)
-      super
     end
   end
 end

--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -1,9 +1,6 @@
 module Api
   class ServiceDialogsController < BaseController
-    def show
-      @additional_attributes = %w(content) if attribute_selection == "all"
-      super
-    end
+    before_action :set_additional_attributes, :only => [:show]
 
     #
     # Virtual attribute accessors
@@ -36,6 +33,10 @@ module Api
     end
 
     private
+
+    def set_additional_attributes
+      @additional_attributes = %w(content) if attribute_selection == "all"
+    end
 
     def refresh_dialog_fields_service_dialog(service_dialog, data)
       data ||= {}


### PR DESCRIPTION
This removes the need to patch the default actions and `super` them, and
is also makes cases where several actions need to return additional
virtual attributes in the response more concise.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 