### PR TITLE
Lock hashie gem to the last working version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false
 gem "hamlit",                         "~>2.0.0",       :require => false
 gem "hamlit-rails",                   "~>0.1.0"
+gem "hashie",                         "=3.4.4",        :require => false
 gem "high_voltage",                   "~>2.4.0"
 gem "htauth",                         "2.0.0",         :require => false
 gem "inifile",                        "~>3.0",         :require => false


### PR DESCRIPTION
This can be reverted when https://github.com/intridea/hashie/pull/368 is merged and released.

@jrafanie 