### PR TITLE
Silence threaded `bower update` in bin/update

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -35,7 +35,7 @@ Dir.chdir APP_ROOT do
 
   # Run bower in a thread and continue to do the non-js stuff
   bower_thread = Thread.new do
-    execute "bower install --allow-root -F --config.analytics=false"
+    execute "bower install --allow-root -F --silent --config.analytics=false"
   end
 
   execute "gem install bundler --conservative"

--- a/bin/setup
+++ b/bin/setup
@@ -34,6 +34,7 @@ Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
 
   # Run bower in a thread and continue to do the non-js stuff
+  puts "Updating bower assets in parallel..."
   bower_thread = Thread.new do
     execute "bower install --allow-root -F --silent --config.analytics=false"
   end
@@ -71,4 +72,5 @@ Dir.chdir APP_ROOT do
     execute "bin/rake test:vmdb:setup"
   end
   bower_thread.join
+  puts "Done running `bower update`."
 end

--- a/bin/update
+++ b/bin/update
@@ -18,6 +18,7 @@ Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
 
   # Run bower in a thread and continue to do the non-js stuff
+  puts "Updating bower assets in parallel..."
   bower_thread = Thread.new do
     execute "bower update --allow-root -F --silent --config.analytics=false"
   end
@@ -40,6 +41,7 @@ Dir.chdir APP_ROOT do
 
   # Make sure bower is done before compiling assets
   bower_thread.join
+  puts "Done running `bower update`."
 
   if ENV['RAILS_ENV'] == 'production'
     puts "\n== Recompiling assets =="

--- a/bin/update
+++ b/bin/update
@@ -19,7 +19,7 @@ Dir.chdir APP_ROOT do
 
   # Run bower in a thread and continue to do the non-js stuff
   bower_thread = Thread.new do
-    execute "bower update --allow-root -F --config.analytics=false"
+    execute "bower update --allow-root -F --silent --config.analytics=false"
   end
 
   execute "bundle update"


### PR DESCRIPTION
Purpose
-------
Makes the output of `bin/update` cleaner by silencing the output from the now threaded `bower update`.  Failures will still be outputed to `STDOUT` if `bower update` happens unsuccessfully.


This should exit the main process after a failure as well, but not positive.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/11158


Steps for Testing/QA
--------------------
Run `bin/update` on this branch and `master` to compare.