### PR TITLE
Split request and workflow logic for create and update

### DIFF
--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -241,7 +241,7 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
     values[:ws_ems_custom_attributes] = p.ws_values(options.ems_custom_attributes, :parse_ws_string, :modify_key_name => false)
     values[:ws_miq_custom_attributes] = p.ws_values(options.miq_custom_attributes, :parse_ws_string, :modify_key_name => false)
 
-    p.create_request(values, nil, values[:auto_approve]).tap do |request|
+    p.make_request(nil, values, nil, values[:auto_approve]).tap do |request|
       p.raise_validate_errors if request == false
     end
   rescue => err

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -19,12 +19,7 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
     false
   end
 
-  def create_request(values, requester, auto_approve = false)
-    update_selected_storage_names(values)
-    super
-  end
-
-  def update_request(request, values, requester)
+  def make_request(request, values, requester = nil, auto_approve = false)
     update_selected_storage_names(values)
     super
   end

--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -20,11 +20,13 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   end
 
   def create_request(values, requester, auto_approve = false)
-    super(values, requester, auto_approve) { update_selected_storage_names(values) }
+    update_selected_storage_names(values)
+    super
   end
 
   def update_request(request, values, requester)
-    super(request, values, requester) { update_selected_storage_names(values) }
+    update_selected_storage_names(values)
+    super
   end
 
   def get_source_and_targets(_refresh = false)

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -49,17 +49,13 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     super(message, [:request_type, :source_type, :target_type], extra_attrs)
   end
 
-  def create_request(values, _requester = nil, auto_approve = false)
+  def make_request(request, values, requester = nil, auto_approve = false)
     if @running_pre_dialog == true
       continue_request(values)
       password_helper(values, true)
       return nil
-    else
-      super
     end
-  end
 
-  def make_request(request, values, requester = nil, auto_approve = false)
     if request
       request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
       request.src_vm_id = get_value(values[:src_vm_id])

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -733,7 +733,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
     end
 
-    p.create_request(values, nil, auto_approve)
+    p.make_request(nil, values, nil, auto_approve)
   end
 
   def ws_template_fields(values, fields, ws_values)
@@ -935,7 +935,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     values[:ws_ems_custom_attributes] = p.ws_values(options.ems_custom_attributes, :parse_ws_string, :modify_key_name => false)
     values[:ws_miq_custom_attributes] = p.ws_values(options.miq_custom_attributes, :parse_ws_string, :modify_key_name => false)
 
-    p.create_request(values, nil, values[:auto_approve]).tap do |request|
+    p.make_request(nil, values, nil, values[:auto_approve]).tap do |request|
       p.raise_validate_errors if request == false
     end
   rescue => err

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -59,9 +59,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
   end
 
-  def update_request(request, values, _requester = nil)
-    request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
-    request.src_vm_id = get_value(values[:src_vm_id])
+  def make_request(request, values, requester = nil, auto_approve = false)
+    if request
+      request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
+      request.src_vm_id = get_value(values[:src_vm_id])
+    end
+
     super
   end
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -454,9 +454,12 @@ class MiqRequest < ApplicationRecord
 
     log_request_success(requester, :created)
 
-    call_automate_event_queue("request_created")
-    approve(requester, "Auto-Approved") if auto_approve
-    reload if auto_approve
+    if process_on_create?
+      call_automate_event_queue("request_created")
+      approve(requester, "Auto-Approved") if auto_approve
+      reload if auto_approve
+    end
+
     self
   end
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -441,9 +441,10 @@ class MiqRequest < ApplicationRecord
 
   def self.create_request(values, requester, auto_approve = false)
     values[:src_ids] = values[:src_ids].to_miq_a unless values[:src_ids].nil?
+    request_type = values.delete(:__request_type__) || request_types.first
     request = new(:options      => values,
                   :requester    => requester,
-                  :request_type => request_types.first)
+                  :request_type => request_type)
     request.save!
 
     request.post_create(auto_approve)

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -446,14 +446,18 @@ class MiqRequest < ApplicationRecord
                   :request_type => request_types.first)
     request.save!
 
-    request.set_description
+    request.post_create(auto_approve)
+  end
 
-    request.log_request_success(requester, :created)
+  def post_create(auto_approve)
+    set_description
 
-    request.call_automate_event_queue("request_created")
-    request.approve(requester, "Auto-Approved") if auto_approve
-    request.reload if auto_approve
-    request
+    log_request_success(requester, :created)
+
+    call_automate_event_queue("request_created")
+    approve(requester, "Auto-Approved") if auto_approve
+    reload if auto_approve
+    self
   end
 
   # Helper method when not using workflow

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -442,10 +442,7 @@ class MiqRequest < ApplicationRecord
   def self.create_request(values, requester, auto_approve = false)
     values[:src_ids] = values[:src_ids].to_miq_a unless values[:src_ids].nil?
     request_type = values.delete(:__request_type__) || request_types.first
-    request = new(:options      => values,
-                  :requester    => requester,
-                  :request_type => request_type)
-    request.save!
+    request = create!(:options => values, :requester => requester, :request_type => request_type)
 
     request.post_create(auto_approve)
   end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -104,18 +104,7 @@ class MiqRequestWorkflow
       return request
     end
 
-    request.set_description
-
-    request.log_request_success(@requester, :created)
-
-    if request.process_on_create?
-      # TODO: address auto-approve potential issue
-      request.call_automate_event_queue("request_created")
-      request.approve(@requester, "Auto-Approved") if auto_approve == true
-      request.reload if auto_approve
-    end
-
-    request
+    request.post_create(auto_approve)
   end
 
   def init_from_dialog(init_values)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -81,6 +81,9 @@ class MiqRequestWorkflow
 
   # Helper method when not using workflow
   def make_request(request, values, requester = nil, auto_approve = false)
+    return false unless validate(values)
+    password_helper(values, true)
+
     if request
       update_request(request, values, requester)
     else
@@ -89,10 +92,7 @@ class MiqRequestWorkflow
   end
 
   def create_request(values, _requester = nil, auto_approve = false)
-    return false unless validate(values)
-
     set_request_values(values)
-    password_helper(values, true)
 
     request = request_class.create(:options => values, :requester => @requester, :request_type => request_type.to_s)
     begin
@@ -120,12 +120,8 @@ class MiqRequestWorkflow
   def update_request(request, values, _requester = nil)
     request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
 
-    return false unless validate(values)
-
     # Ensure that tags selected in the pre-dialog get applied to the request
     values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).uniq  unless @values[:pre_dialog_vm_tags].blank?
-
-    password_helper(values, true)
 
     request.update_attribute(:options, request.options.merge(values))
     request.set_description(true)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -89,13 +89,12 @@ class MiqRequestWorkflow
     if request
       update_request(request, values, requester)
     else
+      set_request_values(values)
       create_request(values, requester, auto_approve)
     end
   end
 
   def create_request(values, _requester = nil, auto_approve = false)
-    set_request_values(values)
-
     request = request_class.create(:options => values, :requester => @requester, :request_type => request_type.to_s)
     begin
       request.save!  # Force validation errors to raise now

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -92,7 +92,8 @@ class MiqRequestWorkflow
       set_request_values(values)
       req = request_class.new(:options => values, :requester => @requester, :request_type => request_type.to_s)
       return req unless req.valid? # TODO: CatalogController#atomic_req_submit is the only one that enumerates over the errors
-      request_class.create_request(values, @requester, request_type.to_s)
+      values[:__request_type__] = request_type.to_s.presence # Pass this along to MiqRequest#create_request
+      request_class.create_request(values, @requester, auto_approve)
     end
   end
 

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -94,8 +94,6 @@ class MiqRequestWorkflow
     set_request_values(values)
     password_helper(values, true)
 
-    yield if block_given?
-
     request = request_class.create(:options => values, :requester => @requester, :request_type => request_type.to_s)
     begin
       request.save!  # Force validation errors to raise now
@@ -128,8 +126,6 @@ class MiqRequestWorkflow
     values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).uniq  unless @values[:pre_dialog_vm_tags].blank?
 
     password_helper(values, true)
-
-    yield if block_given?
 
     request.update_attribute(:options, request.options.merge(values))
     request.set_description(true)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -90,21 +90,10 @@ class MiqRequestWorkflow
       MiqRequest.update_request(request, values, @requester)
     else
       set_request_values(values)
-      create_request(values, requester, auto_approve)
+      req = request_class.new(:options => values, :requester => @requester, :request_type => request_type.to_s)
+      return req unless req.valid? # TODO: CatalogController#atomic_req_submit is the only one that enumerates over the errors
+      request_class.create_request(values, @requester, request_type.to_s)
     end
-  end
-
-  def create_request(values, _requester = nil, auto_approve = false)
-    request = request_class.create(:options => values, :requester => @requester, :request_type => request_type.to_s)
-    begin
-      request.save!  # Force validation errors to raise now
-    rescue => err
-      _log.error "[#{err}]"
-      $log.error err.backtrace.join("\n")
-      return request
-    end
-
-    request.post_create(auto_approve)
   end
 
   def init_from_dialog(init_values)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -87,7 +87,7 @@ class MiqRequestWorkflow
     values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).uniq if @values.try(:[], :pre_dialog_vm_tags).present?
 
     if request
-      update_request(request, values, requester)
+      MiqRequest.update_request(request, values, @requester)
     else
       set_request_values(values)
       create_request(values, requester, auto_approve)
@@ -115,18 +115,6 @@ class MiqRequestWorkflow
       request.reload if auto_approve
     end
 
-    request
-  end
-
-  def update_request(request, values, _requester = nil)
-    request = request.kind_of?(MiqRequest) ? request : MiqRequest.find(request)
-
-    request.update_attribute(:options, request.options.merge(values))
-    request.set_description(true)
-
-    request.log_request_success(@requester, :updated)
-
-    request.call_automate_event_queue("request_updated")
     request
   end
 

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -46,7 +46,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   def generate_request(state, values)
-    create_request(values).tap do |request|
+    make_request(nil, values).tap do |request|
       process_service_order(request, state) if request
     end
   end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -301,7 +301,7 @@ describe MiqProvisionVirtWorkflow do
     end
   end
 
-  context '#update_request' do
+  context '#make_request (update)' do
     let(:template) do
       FactoryGirl.create(
         :template_vmware,
@@ -309,8 +309,8 @@ describe MiqProvisionVirtWorkflow do
       )
     end
     let(:values)  { {:src_vm_id => [template.id, template.name]} }
-    let(:request) { workflow.create_request(:src_vm_id => [999, 'old_template']) }
-    before { workflow.update_request(request, values) }
+    let(:request) { workflow.make_request(nil, :src_vm_id => [999, 'old_template']) }
+    before { workflow.make_request(request, values) }
 
     it 'updates options' do
       expect(request.options).to include(values)

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -390,29 +390,29 @@ describe MiqRequestWorkflow do
     end
   end
 
-  context "#create_request" do
+  context "#make_request (create)" do
     it "sets requester_group" do
       values = {}
-      request = workflow.create_request(values)
+      request = workflow.make_request(nil, values)
       expect(request.options[:requester_group]).to eq(workflow.requester.miq_group_description)
     end
 
     it "doesnt set owner_group" do
       values = {}
-      request = workflow.create_request(values)
+      request = workflow.make_request(nil, values)
       expect(request.options[:owner_group]).not_to be
     end
 
     it "handles bad owner email" do
       values = {:owner_email => "bogus"}
-      request = workflow.create_request(values)
+      request = workflow.make_request(nil, values)
       expect(request.options[:owner_group]).not_to be
     end
 
     it "sets owner group" do
       owner = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
       values = {:owner_email => owner.email}
-      request = workflow.create_request(values)
+      request = workflow.make_request(nil, values)
       expect(request.options[:owner_email]).to eq(owner.email)
       expect(request.options[:owner_group]).to eq(owner.current_group.description)
     end

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -70,7 +70,7 @@ describe ResourceActionWorkflow do
 
         it "creates requests" do
           EvmSpecHelper.local_miq_server
-          expect(subject).to receive(:create_request).and_call_original
+          expect(subject).to receive(:make_request).and_call_original
           expect(AuditEvent).to receive(:success).with(
             :event        => "service_reconfigure_request_created",
             :target_class => "Service",
@@ -90,7 +90,7 @@ describe ResourceActionWorkflow do
 
         it "calls automate" do
           EvmSpecHelper.local_miq_server
-          expect(subject).not_to receive(:create_request)
+          expect(subject).not_to receive(:make_request)
           expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog).and_call_original
           expect(MiqAeEngine).to receive(:deliver_queue) # calls into automate
           expect(AuditEvent).not_to receive(:success)
@@ -108,7 +108,7 @@ describe ResourceActionWorkflow do
         end
 
         it "calls automate" do
-          expect(subject).not_to receive(:create_request)
+          expect(subject).not_to receive(:make_request)
           expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog)
 
           subject.submit_request


### PR DESCRIPTION
There was a lot of mixed logic (workflow and request) in Workflow `#create_request` and `#update_request`.  This is an effort to split them so that only the workflow logic lives in the workflow classes (via `#make_request`) and the request logic can move to the request models, which for now I'm leaving in `#create_request` and `#update_request` and plan to address in a followup PR.