### PR TITLE
Use ::Settings instead of deprecated  VMDB::Config.new in Tenant#tenant_attribute()

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -342,7 +342,8 @@ class Tenant < ApplicationRecord
   end
 
   def get_vmdb_config
-    _log.debug("Tenant#get_vmdb_config is deprecated.  Prefer using Settings directly.")
+    Vmdb::Deprecation.deprecation_warning("Tenant#get_vmdb_config",
+                                          "Prefer using ::Settings directly.", caller)
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -327,7 +327,7 @@ class Tenant < ApplicationRecord
   # @return the attribute value
   def tenant_attribute(attr_name, setting_name)
     if use_config_for_attributes?
-      ret = get_vmdb_config.fetch_path(:server, setting_name)
+      ret = ::Settings.server[setting_name]
       block_given? ? yield(ret) : ret
     else
       self[attr_name]
@@ -342,6 +342,7 @@ class Tenant < ApplicationRecord
   end
 
   def get_vmdb_config
+    _log.debug("Tenant#get_vmdb_config is deprecated.  Prefer using Settings directly.")
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -1,6 +1,6 @@
 = render :partial => 'layouts/doctype'
 <!--[if IE 9]><html class="ie9 login-pf"><![endif]-->
-%html.login-pf{:class => get_vmdb_config[:server][:custom_login_logo] ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
+%html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
   %head
     %title
       = h(title_from_layout(@layout))
@@ -14,7 +14,7 @@
     = csrf_meta_tag
     = render :partial => 'layouts/i18n_js'
 
-  %body{:onload => "miqOnLoad();", :class => get_vmdb_config[:server][:custom_login_logo] ? 'whitelabel' : ''}
+  %body{:onload => "miqOnLoad();", :class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
     - if MiqServer.my_server(true).logon_status == :starting
       :javascript
         self.setTimeout("miqAjax('/dashboard/login_retry')",10000);

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -198,8 +198,7 @@ describe OpsController do
                                          :use_config_for_attributes => "on"
                                         )
         controller.send(:tenant_set_record_vars, @tenant)
-
-        stub_server_settings(:server, :company => "Settings Company Name")
+        stub_settings(:server => {:company => "Settings Company Name"})
         expect(@tenant.name).to eq "Settings Company Name"
       end
 

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -192,13 +192,14 @@ describe OpsController do
         allow(MiqServer).to receive(:my_server).and_return(server)
       end
 
-      it "saves name in record when use_config_attributes is false" do
+      it "saves name in record when use_config_attributes is true" do
         controller.instance_variable_set(:@_params,
                                          :divisible                 => true,
                                          :use_config_for_attributes => "on"
                                         )
         controller.send(:tenant_set_record_vars, @tenant)
-        stub_server_configuration(:server => { :company => "Settings Company Name"})
+
+        stub_server_settings(:server, :company => "Settings Company Name")
         expect(@tenant.name).to eq "Settings Company Name"
       end
 

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -162,7 +162,7 @@ describe Tenant do
 
     context "for root_tenants" do
       it "reads settings" do
-        stub_server_settings(:server, :company => "settings")
+        stub_settings(:server => {:company => "settings"})
         expect(root_tenant.name).to eq("settings")
       end
 
@@ -200,13 +200,13 @@ describe Tenant do
     end
 
     it "has no logo for root_tenant" do
-      stub_server_settings(:server, {})
+      stub_settings(:server => {})
       expect(root_tenant.logo.url).to match(/missing/)
     end
 
     context "with server configurations" do
       it "uses configurations value for root_tenant" do
-        stub_server_settings(:server, :custom_logo => true)
+        stub_settings(:server => {:custom_logo => true})
         expect(root_tenant.logo.url).to eq("/uploads/custom_logo.png")
       end
 
@@ -248,7 +248,7 @@ describe Tenant do
 
       context "#with custom_logo configuration" do
         it "knows there is a logo from configuration" do
-          stub_server_settings(:server, :custom_logo => true)
+          stub_settings(:server => {:custom_logo => true})
           expect(root_tenant).to be_logo
         end
 
@@ -312,7 +312,7 @@ describe Tenant do
 
     context "with custom login logo configuration" do
       it "has custom login logo" do
-        stub_server_settings(:server, :custom_login_logo => true)
+        stub_settings(:server => {:custom_login_logo => true})
         expect(root_tenant.login_logo.url).to match(/custom_login_logo.png/)
       end
     end
@@ -340,7 +340,7 @@ describe Tenant do
 
   context "#validate_only_one_root" do
     it "allows child tenants" do
-      stub_server_settings(:server, {})
+      stub_settings(:server => {})
       root_tenant.children.create!
     end
 
@@ -829,7 +829,7 @@ describe Tenant do
 
   describe ".tenant_and_project_names" do
     before do
-      stub_server_settings(:server, :company => "root")
+      stub_settings(:server => {:company => "root"})
     end
 
     # root

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,7 +1,6 @@
 describe Tenant do
   include_examples ".seed called multiple times"
 
-  let(:config) { {} }
   let(:tenant) { described_class.new(:domain => 'x.com', :parent => default_tenant) }
 
   let(:default_tenant) do
@@ -11,10 +10,6 @@ describe Tenant do
 
   let(:root_tenant) do
     Tenant.seed
-  end
-
-  before do
-    stub_server_configuration(config)
   end
 
   describe "#default_tenant" do
@@ -135,8 +130,6 @@ describe Tenant do
   end
 
   describe "#name" do
-    let(:config) { {:server => {:company => "settings"}} }
-
     it "has default name" do
       expect(tenant.name).to eq("My Company")
     end
@@ -169,6 +162,7 @@ describe Tenant do
 
     context "for root_tenants" do
       it "reads settings" do
+        stub_server_settings(:server, :company => "settings")
         expect(root_tenant.name).to eq("settings")
       end
 
@@ -206,13 +200,13 @@ describe Tenant do
     end
 
     it "has no logo for root_tenant" do
+      stub_server_settings(:server, {})
       expect(root_tenant.logo.url).to match(/missing/)
     end
 
     context "with server configurations" do
-      let(:config) { {:server => {:custom_logo => true}} }
-
       it "uses configurations value for root_tenant" do
+        stub_server_settings(:server, :custom_logo => true)
         expect(root_tenant.logo.url).to eq("/uploads/custom_logo.png")
       end
 
@@ -253,9 +247,8 @@ describe Tenant do
       end
 
       context "#with custom_logo configuration" do
-        let(:config) { {:server => {:custom_logo => true}} }
-
         it "knows there is a logo from configuration" do
+          stub_server_settings(:server, :custom_logo => true)
           expect(root_tenant).to be_logo
         end
 
@@ -318,9 +311,8 @@ describe Tenant do
     end
 
     context "with custom login logo configuration" do
-      let(:config) { {:server => {:custom_login_logo => true}} }
-
       it "has custom login logo" do
+        stub_server_settings(:server, :custom_login_logo => true)
         expect(root_tenant.login_logo.url).to match(/custom_login_logo.png/)
       end
     end
@@ -348,6 +340,7 @@ describe Tenant do
 
   context "#validate_only_one_root" do
     it "allows child tenants" do
+      stub_server_settings(:server, {})
       root_tenant.children.create!
     end
 
@@ -835,7 +828,9 @@ describe Tenant do
   end
 
   describe ".tenant_and_project_names" do
-    let(:config) { {:server => {:company => "root"}} }
+    before do
+      stub_server_settings(:server, :company => "root")
+    end
 
     # root
     #   ten1

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -18,6 +18,6 @@ def stub_server_configuration(config, config_name = "vmdb")
   allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
 end
 
-def stub_server_settings(top_key, hash)
-  allow(::Settings).to receive(top_key).and_return(hash)
+def stub_server_settings(top_key, value)
+  allow(::Settings).to receive(top_key).and_return(value)
 end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -17,7 +17,3 @@ def stub_server_configuration(config, config_name = "vmdb")
   configuration = double(:config => config.deep_symbolize_keys)
   allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
 end
-
-def stub_server_settings(top_key, value)
-  allow(::Settings).to receive(top_key).and_return(value)
-end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -17,3 +17,7 @@ def stub_server_configuration(config, config_name = "vmdb")
   configuration = double(:config => config.deep_symbolize_keys)
   allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
 end
+
+def stub_server_settings(top_key, hash)
+  allow(::Settings).to receive(top_key).and_return(hash)
+end


### PR DESCRIPTION
Removed deprecated calls in  Tenant#tenant_attribute()

@miq-bot add-label wip, core