### PR TITLE
Use ::Settings instead of deprecated VMDB::Config.new in MiqServer

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -59,7 +59,7 @@ class MiqServer < ApplicationRecord
       ::Settings.save!(MiqServer.my_server, :server => {:role => roles})
       ::Settings.reload!
     end
-    
+
     # Roles Changed!
     if roles != starting_roles
       # tell the server to pick up the role change

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -597,7 +597,7 @@ class MiqServer < ApplicationRecord
   end
 
   def server_timezone
-    ::Settings.server['timezone'] || "UTC"
+    ::Settings.server.timezone || "UTC"
   end
 
   def tenant_identity

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -56,11 +56,11 @@ class MiqServer < ApplicationRecord
     # Change the database role to database_operations
     roles = starting_roles.dup
     if roles.gsub!(/\bdatabase\b/, 'database_operations')
-      ::Settings.save!(MiqServer.my_server, :server => {:role => roles})
-      ::Settings.reload!
+      MiqServer.my_server.set_config(:server => {:role => roles})
     end
 
     # Roles Changed!
+    roles = ::Settings.server.role
     if roles != starting_roles
       # tell the server to pick up the role change
       server = MiqServer.my_server

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -76,7 +76,7 @@ module MiqServer::EnvironmentManagement
       return unless ::Settings.server.session_store.to_s == 'cache'
       return unless MiqEnvironment::Command.supports_memcached?
       require "#{Rails.root}/lib/miq_memcached" unless Object.const_defined?(:MiqMemcached)
-      svr, port = ::Settings.session.memcache_server.to_s.split(":")
+      _svr, port = ::Settings.session.memcache_server.to_s.split(":")
       opts = ::Settings.session.memcache_server_opts.to_s
       MiqMemcached::Control.restart!(:port => port, :options => opts)
       _log.info("Status: #{MiqMemcached::Control.status[1]}")

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -71,13 +71,13 @@ module MiqServer::EnvironmentManagement
       _log.info "Database Adapter: [#{ActiveRecord::Base.connection.adapter_name}], detailed version: [#{ActiveRecord::Base.connection.detailed_database_version}]" if ActiveRecord::Base.connection.respond_to?(:detailed_database_version)
     end
 
-    def start_memcached(cfg = VMDB::Config.new('vmdb'))
+    def start_memcached
       # TODO: Need to periodically check the memcached instance to see if it's up, and bounce it and notify the UiWorkers to re-connect
-      return unless cfg.config.fetch_path(:server, :session_store).to_s == 'cache'
+      return unless ::Settings.server.session_store.to_s == 'cache'
       return unless MiqEnvironment::Command.supports_memcached?
       require "#{Rails.root}/lib/miq_memcached" unless Object.const_defined?(:MiqMemcached)
-      svr, port = cfg.config.fetch_path(:session, :memcache_server).to_s.split(":")
-      opts = cfg.config.fetch_path(:session, :memcache_server_opts).to_s
+      svr, port = ::Settings.session.memcache_server.to_s.split(":")
+      opts = ::Settings.session.memcache_server_opts.to_s
       MiqMemcached::Control.restart!(:port => port, :options => opts)
       _log.info("Status: #{MiqMemcached::Control.status[1]}")
     end

--- a/spec/controllers/application_controller/timezone_spec.rb
+++ b/spec/controllers/application_controller/timezone_spec.rb
@@ -6,7 +6,7 @@ describe ApplicationController, "#Timezone" do
   context "#get_timezone_offset" do
     context "for a server" do
       it "with a system default" do
-        stub_server_settings(:server, 'timezone' => "Eastern Time (US & Canada)")
+        stub_settings(:server => {:timezone => "Eastern Time (US & Canada)"})
 
         Timecop.freeze(Time.utc(2013, 1, 1)) do
           expect(subject.get_timezone_offset).to eq(-5.hours)
@@ -14,7 +14,7 @@ describe ApplicationController, "#Timezone" do
       end
 
       it "without a system default" do
-        stub_server_settings(:server, {})
+        stub_settings(:server => {})
         expect(subject.get_timezone_offset).to eq(0.hours)
       end
     end
@@ -50,7 +50,7 @@ describe ApplicationController, "#Timezone" do
 
         it "without a system default" do
           user = FactoryGirl.create(:user)
-          stub_server_settings(:server, {})
+          stub_settings(:server => {})
 
           expect(subject.get_timezone_offset(user)).to eq(0.hours)
         end

--- a/spec/controllers/application_controller/timezone_spec.rb
+++ b/spec/controllers/application_controller/timezone_spec.rb
@@ -6,7 +6,7 @@ describe ApplicationController, "#Timezone" do
   context "#get_timezone_offset" do
     context "for a server" do
       it "with a system default" do
-        stub_settings(:server => {:timezone => "Eastern Time (US & Canada)"})
+        stub_server_settings(:server, 'timezone' => "Eastern Time (US & Canada)")
 
         Timecop.freeze(Time.utc(2013, 1, 1)) do
           expect(subject.get_timezone_offset).to eq(-5.hours)
@@ -14,7 +14,7 @@ describe ApplicationController, "#Timezone" do
       end
 
       it "without a system default" do
-        stub_settings({})
+        stub_server_settings(:server, {})
         expect(subject.get_timezone_offset).to eq(0.hours)
       end
     end
@@ -50,7 +50,7 @@ describe ApplicationController, "#Timezone" do
 
         it "without a system default" do
           user = FactoryGirl.create(:user)
-          stub_settings({})
+          stub_server_settings(:server, {})
 
           expect(subject.get_timezone_offset(user)).to eq(0.hours)
         end

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -407,16 +407,17 @@ describe MiqWidget do
     end
 
     it "with report_sync" do
-      stub_settings(:product => {:report_sync => true})
+      stub_server_configuration(:product => {:report_sync => true})
 
       user_est =  FactoryGirl.create(:user, :userid => 'user_est', :miq_groups => [@group2], :settings => {:display => {:timezone => "Eastern Time (US & Canada)"}})
       expect(user_est.get_timezone).to eq("Eastern Time (US & Canada)")
       ws = FactoryGirl.create(:miq_widget_set, :name => "default", :userid => "user_est", :group_id => @group2.id)
       ws.add_member(@widget)
 
-      expect_any_instance_of(MiqWidget).to receive(:generate_content).with("MiqGroup", @group2.name, nil, ["Eastern Time (US & Canada)", "UTC"])
+      expect_any_instance_of(MiqWidget).to receive(:generate_content).with("MiqGroup", @group2.name, nil,
+                                                                           ["Eastern Time (US & Canada)"])
 
-      stub_server_settings(:server, :timezone => "Eastern Time (US & Canada)")
+      stub_settings(:server => {:timezone => "Eastern Time (US & Canada)"})
 
       @widget.queue_generate_content
       expect(MiqQueue.where(@q_options).count).to eq(0)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -415,6 +415,9 @@ describe MiqWidget do
       ws.add_member(@widget)
 
       expect_any_instance_of(MiqWidget).to receive(:generate_content).with("MiqGroup", @group2.name, nil, ["Eastern Time (US & Canada)", "UTC"])
+
+      stub_server_settings(:server, :timezone => "Eastern Time (US & Canada)")
+
       @widget.queue_generate_content
       expect(MiqQueue.where(@q_options).count).to eq(0)
     end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -18,6 +18,6 @@ def stub_server_configuration(config, config_name = "vmdb")
   allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
 end
 
-def stub_server_settings(top_key, hash)
-  allow(::Settings).to receive(top_key).and_return(hash)
+def stub_server_settings(top_key, value)
+  allow(::Settings).to receive(top_key).and_return(value)
 end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -17,7 +17,3 @@ def stub_server_configuration(config, config_name = "vmdb")
   configuration = double(:config => config.deep_symbolize_keys)
   allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
 end
-
-def stub_server_settings(top_key, value)
-  allow(::Settings).to receive(top_key).and_return(value)
-end

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -17,3 +17,7 @@ def stub_server_configuration(config, config_name = "vmdb")
   configuration = double(:config => config.deep_symbolize_keys)
   allow(VMDB::Config).to receive(:new).with(config_name) { configuration }
 end
+
+def stub_server_settings(top_key, hash)
+  allow(::Settings).to receive(top_key).and_return(hash)
+end


### PR DESCRIPTION
Removed deprecated calls to VMDB::Config.new in MiqServer.

@miq-bot add-label wip, core
