### PR TITLE
Make cols in product/view/*.yml optional

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -83,6 +83,11 @@ class MiqReport < ApplicationRecord
     q
   end
 
+  # NOTE: this can by dynamically manipulated
+  def cols
+    self[:cols] ||= (self[:col_order] || []).reject { |x| x.include?(".") }
+  end
+
   def view_filter_columns
     col_order.collect { |c| [headers[col_order.index(c)], c] }
   end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -760,4 +760,28 @@ describe MiqReport do
       expect(report.sort_col).to eq(0)
     end
   end
+
+  describe ".cols" do
+    it "loads given value" do
+      report = MiqReport.new(
+        :cols      => %w(name)
+      )
+      expect(report.cols).to eq(%w(name))
+    end
+
+    it "falls back to col_order" do
+      report = MiqReport.new(
+        :col_order => %w(miq_custom_attributes.name miq_custom_attributes.value name)
+      )
+      expect(report.cols).to eq(%w(name))
+    end
+
+    it "allows manipulation" do
+      report = MiqReport.new(
+        :col_order => %w(miq_custom_attributes.name miq_custom_attributes.value name),
+      )
+      report.cols << "name2"
+      expect(report.cols).to eq(%w(name name2))
+    end
+  end
 end


### PR DESCRIPTION
Our `report.yml` files have quite a bit of overlap with `includes`, `cols` and `col_order`.

`col_order` contains all the columns in the report, including the relations that are used to fetch the columns.

`cols` contains a subset of those: Just the columns that are in the primary table. Many times, these two lists are the same.

This PR takes the first step by making `cols` optional. It derives it from all the `col_order` values that do not have a period in them.

Tested with VMs screen (that has some includes in it)

/cc @dclarizio @Fryguy 