### PR TITLE
Enable support for vApp provisioning service

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AvailabilityZone
+  require_nested :OrchestrationServiceOptionConverter
   require_nested :OrchestrationStack
   require_nested :OrchestrationTemplate
   require_nested :RefreshParser

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter.rb
@@ -1,0 +1,11 @@
+module ManageIQ::Providers
+  class Vmware::CloudManager::OrchestrationServiceOptionConverter < ::ServiceOrchestration::OptionConverter
+    def stack_create_options
+      {
+        :deploy  => stack_parameters['deploy'] == 'yes',
+        :powerOn => stack_parameters['powerOn'] == 'yes',
+        :vdc_id  => @dialog_options['dialog_availability_zone']
+      }
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -1,4 +1,34 @@
 class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < OrchestrationTemplate
+  def parameter_groups
+    [OrchestrationTemplate::OrchestrationParameterGroup.new(
+      :label      => "vApp Parameters",
+      :parameters => vapp_parameters,
+    )]
+  end
+
+  def vapp_parameters
+    [
+      OrchestrationTemplate::OrchestrationParameter.new(
+        :name          => "deploy",
+        :label         => "Deploy vApp",
+        :data_type     => "string",
+        :default_value => "yes",
+        :constraints   => [
+          OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(no yes))
+        ]
+      ),
+      OrchestrationTemplate::OrchestrationParameter.new(
+        :name          => "powerOn",
+        :label         => "Power On vApp",
+        :data_type     => "string",
+        :default_value => "no",
+        :constraints   => [
+          OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(no yes))
+        ]
+      )
+    ]
+  end
+
   def self.eligible_manager_types
     [ManageIQ::Providers::Vmware::CloudManager]
   end

--- a/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/refresh_parser.rb
@@ -207,7 +207,7 @@ class ManageIQ::Providers::Vmware::CloudManager::RefreshParser < ManageIQ::Provi
       :ems_ref     => uid,
       :name        => vapp_template.name,
       :description => vapp_template.description,
-      :orderable   => false,
+      :orderable   => true,
       :content     => content,
       # By default #save_orchestration_templates_inventory does not set the EMS
       # ID because templates are not EMS specific. We are setting the EMS

--- a/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/refresher_spec.rb
@@ -341,7 +341,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::Refresher do
     expect(@template).not_to be_nil
     expect(@template).to have_attributes(
       :ems_ref   => "vappTemplate-a19bdc8f-88fa-4dd6-8436-486590353ed5",
-      :orderable => false,
+      :orderable => true,
     )
 
     expect(@template.ems_id).to eq(@ems.id)


### PR DESCRIPTION
This patch consists of three mandatory components needed to support
provisioning of vApps from the services dialogs:

* collected vApp templates are marked orderable meaning that they will
appear in corresponding lists
* cloud manager provides service option converter using options from the
UI for the creation of the new orchestration stack
* add vApp specific parameters (`powerOn` and `deploy`) into
corresponding parameter group

@miq-bot add_label providers/vmware/cloud, enhancement