### PR TITLE
rubocop issues: tree_builder_snapshots.rb

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -255,7 +255,7 @@ module VmCommon
     elsif @display == "snapshot_info"
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
-      @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, @record)
+      @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
       @button_group = "snapshot"
     elsif @display == "devices"
       drop_breadcrumb(:name => @record.name + _(" (Devices)"),
@@ -432,7 +432,12 @@ module VmCommon
       @display = "snapshot_info"
       add_flash(_("Last selected Snapshot no longer exists"), :error)
     end
-    @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, @record, session[:snap_selected])
+    @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree,
+                                              :snapshot,
+                                              @sb,
+                                              true,
+                                              :root          => @record,
+                                              :selected_node => session[:snap_selected])
     @active = @snap_selected.current.to_i == 1 if @snap_selected
     @button_group = "snapshot"
     @explorer = true

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -3,9 +3,9 @@ class TreeBuilderSnapshots < TreeBuilder
 
   attr_reader :selected_node
 
-  def initialize(name, type, sandbox, build = true, root = nil, selected_node = nil)
-    @record = root
-    @selected_node = selected_node.present? ? id(selected_node) : nil
+  def initialize(name, type, sandbox, build = true, **params)
+    @record = params[:root]
+    @selected_node = params.key?(:selected_node) ? id(params[:selected_node]) : nil
     super(name, type, sandbox, build)
   end
 
@@ -24,7 +24,7 @@ class TreeBuilderSnapshots < TreeBuilder
     [@record.name, @record.name, 'vm', {:cfmeNoClick => true}]
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only = false, _options = {})
     root_kid = @record.snapshots.present? ? [@record.snapshots.find { |x| x.parent_id.nil? }] : []
     open_node("sn-#{to_cid(root_kid.first.id)}") if root_kid.present?
     count_only_or_objects(count_only, root_kid)

--- a/spec/presenters/tree_builder_snapshots_spec.rb
+++ b/spec/presenters/tree_builder_snapshots_spec.rb
@@ -13,7 +13,7 @@ describe TreeBuilderSnapshots do
                                     :children    => [snapshot_kid])
       snapshot_kid.parent_id = snapshot.id
       @record = FactoryGirl.create(:vm_infra, :snapshots => [snapshot])
-      @s_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, {}, true, @record)
+      @s_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, {}, true, :root => @record)
     end
     it 'sets root correctly' do
       root = @s_tree.send(:root_options)


### PR DESCRIPTION
== app/presenters/tree_builder_snapshots.rb ==
    R:  6: 17: Avoid parameter lists longer than 5 parameters.
    C: 31: 24: Optional arguments should appear at the end of the argument
    list.
