### PR TITLE
rubocop issues: tree_builder_ops_settings.rb

### DIFF
--- a/app/presenters/tree_builder_ops_settings.rb
+++ b/app/presenters/tree_builder_ops_settings.rb
@@ -16,7 +16,7 @@ class TreeBuilderOpsSettings < TreeBuilderOps
   def root_options
     region = MiqRegion.my_region
     title =  _("ManageIQ Region: %{region_description} [%{region}]") % {:region_description => region.description,
-                                                                    :region             => region.region}
+                                                                        :region             => region.region}
     [title, title, :miq_region]
   end
 


### PR DESCRIPTION
== app/presenters/tree_builder_ops_settings.rb ==
    C: 19: 69: Align the elements of a hash literal if they span more than
    one line.
