### PR TITLE
rubocop issues: tree_builder_compliance_history.rb

### DIFF
--- a/app/presenters/tree_builder_compliance_history.rb
+++ b/app/presenters/tree_builder_compliance_history.rb
@@ -28,7 +28,7 @@ class TreeBuilderComplianceHistory < TreeBuilder
     []
   end
 
-  def x_get_tree_roots(count_only = false, _options)
+  def x_get_tree_roots(count_only = false, _options = {})
     count_only_or_objects(count_only, @root.compliances.order("timestamp DESC").limit(10))
   end
 
@@ -50,18 +50,21 @@ class TreeBuilderComplianceHistory < TreeBuilder
     count_only_or_objects(count_only, kids)
   end
 
+  def get_policy_elm(parent, node)
+    {:id          => "#{parent.id}-p_#{node.miq_policy_id}",
+     :text        => "<b>" + _("Condition: ") + "</b>" + node.condition_desc,
+     :image       => node.condition_result ? "check" : "x",
+     :tip         => nil,
+     :cfmeNoClick => true}
+  end
+
   def x_get_compliance_detail_kids(parent, count_only, parents)
     kids = []
     model, id = TreeBuilder.extract_node_model_and_id(parents.first)
     grandpa = model.constantize.find_by(:id => from_cid(id))
     grandpa.compliance_details.order("miq_policy_desc, condition_desc").each do |node|
       next unless node.miq_policy_id == parent.miq_policy_id
-      n = {:id          => "#{parent.id}-p_#{node.miq_policy_id}",
-           :text        => "<b>" + _("Condition: ") + "</b>" + node.condition_desc,
-           :image       => node.condition_result ? "check" : "x",
-           :tip         => nil,
-           :cfmeNoClick => true}
-      kids.push(n)
+      kids.push(get_policy_elm(parent, node))
     end
     count_only_or_objects(count_only, kids)
   end


### PR DESCRIPTION
== app/presenters/tree_builder_compliance_history.rb ==
    C: 31: 24: Optional arguments should appear at the end of the argument
    list.
    R: 53:  3: Assignment Branch Condition size for
    x_get_compliance_detail_kids is too high. [21.93/20]