### PR TITLE
RBAC:List only those VMs that the user has access to in planning

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -165,7 +165,7 @@ class MiqCapacityController < ApplicationController
   private :planning_wizard_get_vms_records
 
   def planning_wizard_get_vms(filter_type, filter_value)
-    vms = planning_wizard_get_vms_records(filter_type, filter_value)
+    vms = Rbac.filtered(planning_wizard_get_vms_records(filter_type, filter_value))
     vms.each_with_object({}) do |v, h|
       description = v.ext_management_system ? "#{v.ext_management_system.name}:#{v.name}" : v.name
       h[v.id.to_s] = description


### PR DESCRIPTION
Optimize -> Planning -> Reference VM Selection

A user could select VM that he had no access rights to. Now the dropdown shows only VMs that a user has access rights to. 

Before:
![screen shot 2016-09-19 at 10 32 55 am](https://cloud.githubusercontent.com/assets/9210860/18626306/78ff63f0-7e54-11e6-9c6b-b42bc75ed738.png)

After:
![screen shot 2016-09-19 at 10 24 44 am](https://cloud.githubusercontent.com/assets/9210860/18626254/216b86e6-7e54-11e6-9211-3fe139bc2bea.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1375854

@miq-bot add_label ui, bug