### PR TITLE
Replace send with method call in put_resource

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -30,7 +30,7 @@ module Api
       end
 
       def put_resource(type, id)
-        send(target_resource_method(false, type, "edit"), type, id, @req.json_body)
+        edit_resource(type, id, @req.json_body)
       end
 
       #


### PR DESCRIPTION
The result of `target_resource_method` in the context of `put_resource`
will always be `"edit_resource"`, so rather than sending this message we
can call it directly.

@miq-bot add-label api, refactoring, technical debt
@miq-bot assign @abellotti 