### PR TITLE
Replace send with method call in patch_resource

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -63,7 +63,7 @@ module Api
             patched_attrs[attr] = nil if action == "remove"
           end
         end
-        send(target_resource_method(false, type, "edit"), type, id, patched_attrs)
+        edit_resource(type, id, patched_attrs)
       end
 
       def delete_subcollection_resource(type, id = nil)


### PR DESCRIPTION
The result of target_resource_method in the context of patch_resource
will always be "edit_resource", so rather than sending this message we
can call it directly.

@miq-bot add-label api, refactoring, technical debt
@miq-bot assign @abellotti 