### PR TITLE
Set C3 charts as default

### DIFF
--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -6,7 +6,7 @@ class C3Charting < Charting
 
   # for Charting.detect_available_plugin
   def self.priority
-    2 # TODO: set to value > JqplotCharting.priority to take effect
+    1000 # TODO: set to value > JqplotCharting.priority to take effect
   end
 
   # backend identifier


### PR DESCRIPTION
Set C3 charts priority higher, than flash charts. This should be enough for making it default in both, upstream and downstream.

ping @martinpovolny @dclarizio 