### PR TITLE
Prefer except to dup/delete

### DIFF
--- a/app/controllers/api/base_controller/manager.rb
+++ b/app/controllers/api/base_controller/manager.rb
@@ -108,12 +108,7 @@ module Api
       end
 
       def json_body_resource
-        resource = @req.json_body["resource"]
-        unless resource
-          resource = @req.json_body.dup
-          resource.delete("action")
-        end
-        resource
+        @req.json_body["resource"] || @req.json_body.except("action")
       end
 
       def update_one_collection(is_subcollection, target, type, id, resource)


### PR DESCRIPTION
Using AS's `except` allows us to reduce this method to one line and
removes the need to assign a temp.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 