### PR TITLE
Prevent deleting mapped tenants from cloud provider

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -360,6 +360,7 @@ class Tenant < ApplicationRecord
 
   def ensure_can_be_destroyed
     raise _("A tenant with groups associated cannot be deleted.") if miq_groups.non_tenant_groups.exists?
+    raise _("A tenant created by tenant mapping cannot be deleted") if source
   end
 
   def validate_default_tenant

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -377,10 +377,17 @@ describe Tenant do
   end
 
   context "#ensure_can_be_destroyed" do
+    let(:tenant)       { FactoryGirl.create(:tenant) }
+    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant) }
+
     it "wouldn't delete tenant with groups associated" do
-      tenant = FactoryGirl.create(:tenant)
       FactoryGirl.create(:miq_group, :tenant => tenant)
       expect { tenant.destroy! }.to raise_error(RuntimeError, /A tenant with groups.*cannot be deleted/)
+    end
+
+    it "does not delete tenant created by tenant mapping process" do
+      tenant.source = cloud_tenant
+      expect { tenant.destroy! }.to raise_error(RuntimeError, /A tenant created by tenant mapping cannot be deleted/)
     end
   end
 


### PR DESCRIPTION
Tenant which was created by tenant mapping process stores relation to Tenant#source. When this relation exists we need to prevent deletion.
![30dodmz2nc](https://cloud.githubusercontent.com/assets/14937244/18629757/0a447130-7e68-11e6-8bb1-6b1cfdd75bbe.gif)

## Links
* https://www.pivotaltracker.com/n/projects/1608513


@miq-bot assign @gtanzillo 