### PR TITLE
Toolbar button instance variable check

### DIFF
--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -53,7 +53,6 @@ class ApplicationHelper::Button::Basic < Hash
 
   def skipped?
     return true unless role_allows_feature?
-    return true if self.class.record_needed && @record.nil?
     return true unless check_instance_variables
     calculate_properties
     !visible?
@@ -70,14 +69,10 @@ class ApplicationHelper::Button::Basic < Hash
   end
 
   class << self
-    attr_reader :record_needed, :instance_variables_required
+    attr_reader :instance_variables_required
 
-    # Used to avoid rendering buttons dependent on `@record` instance variable
-    # if the variable is not set
-    def needs_record
-      @record_needed = true
-    end
-
+    # Used to avoid rendering buttons dependent on instance variable if the
+    # variable is not set
     def needs(*instance_variables)
       @instance_variables_required = instance_variables
     end

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -46,14 +46,18 @@ class ApplicationHelper::Button::Basic < Hash
     self[:enabled] = !disabled? if self[:enabled].nil?
   end
 
-  def check_instance_variables
-    self.class.instance_variables_required.to_a.all? { |variable| !instance_variable_get("#{variable}").nil? }
+  # Check if all instance variables for that button works with are set and
+  # are not `nil`
+  def all_instance_variables_set
+    self.class.instance_variables_required.to_a.all? do |instance_variable|
+      instance_variable_get("#{instance_variable}").present?
+    end
   end
-  private :check_instance_variables
+  private :all_instance_variables_set
 
   def skipped?
     return true unless role_allows_feature?
-    return true unless check_instance_variables
+    return true unless all_instance_variables_set
     calculate_properties
     !visible?
   end

--- a/app/helpers/application_helper/button/generic_feature_button.rb
+++ b/app/helpers/application_helper/button/generic_feature_button.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::GenericFeatureButton < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def initialize(view_context, view_binding, instance_data, props)
     super

--- a/app/helpers/application_helper/button/generic_feature_button_with_disable.rb
+++ b/app/helpers/application_helper/button/generic_feature_button_with_disable.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::GenericFeatureButtonWithDisable < ApplicationHelper::Button::GenericFeatureButton
-  needs_record
+  needs :@record
 
   def calculate_properties
     self[:enabled] = !(self[:title] = @error_message if disabled?)

--- a/app/helpers/application_helper/button/host_feature_button.rb
+++ b/app/helpers/application_helper/button/host_feature_button.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::HostFeatureButton < ApplicationHelper::Button::GenericFeatureButton
-  needs_record
+  needs :@record
 
   def visible?
     return false if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)

--- a/app/helpers/application_helper/button/host_feature_button_with_disable.rb
+++ b/app/helpers/application_helper/button/host_feature_button_with_disable.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::HostFeatureButtonWithDisable < ApplicationHelper::Button::GenericFeatureButtonWithDisable
-  needs_record
+  needs :@record
 
   def visible?
     return false if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)

--- a/app/helpers/application_helper/button/host_protect.rb
+++ b/app/helpers/application_helper/button/host_protect.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::HostProtect < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.smart?

--- a/app/helpers/application_helper/button/host_refresh.rb
+++ b/app/helpers/application_helper/button/host_refresh.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::HostRefresh < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.is_refreshable?

--- a/app/helpers/application_helper/button/host_scan.rb
+++ b/app/helpers/application_helper/button/host_scan.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::HostScan < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.is_scannable?

--- a/app/helpers/application_helper/button/instance_reset.rb
+++ b/app/helpers/application_helper/button/instance_reset.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::InstanceReset < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     return true if @display == "instances"

--- a/app/helpers/application_helper/button/miq_request.rb
+++ b/app/helpers/application_helper/button/miq_request.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::MiqRequest < ApplicationHelper::Button::GenericFeatureButton
-  needs_record
+  needs :@record
 
   def visible?
     return false if @record.resource_type == "AutomationRequest" &&

--- a/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
+++ b/app/helpers/application_helper/button/orchestration_template_edit_remove.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::OrchestrationTemplateEditRemove < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def disabled?
     @record.in_use?

--- a/app/helpers/application_helper/button/read_only.rb
+++ b/app/helpers/application_helper/button/read_only.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::ReadOnly < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def disabled?
     @record.read_only

--- a/app/helpers/application_helper/button/vm_instance_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_scan.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmInstanceScan < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def calculate_properties
     super

--- a/app/helpers/application_helper/button/vm_policy.rb
+++ b/app/helpers/application_helper/button/vm_policy.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmPolicy < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.host.try(:vmm_product).to_s.casecmp("workstation").nonzero?

--- a/app/helpers/application_helper/button/vm_publish.rb
+++ b/app/helpers/application_helper/button/vm_publish.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmPublish < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.is_available?(:publish) && !@is_redhat

--- a/app/helpers/application_helper/button/vm_reconfigure.rb
+++ b/app/helpers/application_helper/button/vm_reconfigure.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmReconfigure < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.reconfigurable?

--- a/app/helpers/application_helper/button/vm_refresh.rb
+++ b/app/helpers/application_helper/button/vm_refresh.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmRefresh < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.ext_management_system ||

--- a/app/helpers/application_helper/button/vm_retire.rb
+++ b/app/helpers/application_helper/button/vm_retire.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmRetire < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def visible?
     @record.supports_retire?

--- a/app/helpers/application_helper/button/vm_retire_now.rb
+++ b/app/helpers/application_helper/button/vm_retire_now.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::VmRetireNow < ApplicationHelper::Button::Basic
-  needs_record
+  needs :@record
 
   def calculate_properties
     super


### PR DESCRIPTION
# Continuation of  #10865

Removing method `needs_record` from Button Basic class because new method `needs` was introduced in #10865 as a substitution for the `needs_record` to cover buttons, depending on more instance variables.

@PanSpagetka, @martinpovolny can you review?