### PR TITLE
Corrected users restriction checking  expression

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1072,9 +1072,9 @@ class ApplicationHelper::ToolbarBuilder
     when "User"
       case id
       when "rbac_user_copy"
-        return N_("User [Administrator] can not be copied") if @record.userid == "admin"
+        return N_("User [Administrator] can not be copied") if @record.super_admin_user?
       when "rbac_user_delete"
-        return N_("User [Administrator] can not be deleted") if @record.userid == "admin"
+        return N_("User [Administrator] can not be deleted") if @record.super_admin_user?
       end
     when "UserRole"
       case id


### PR DESCRIPTION
Right now, if someone tries to copy the super admin user, he is blocked by method [`rbac_user_`*action*`_restriction?`](https://github.com/ManageIQ/manageiq/blob/76ae3d7321635b4249c795fdd92af7fc059a5be3/app/controllers/ops_controller/ops_rbac.rb#L566-L572).

But in [`build_toolbar_disable_button`](https://github.com/ManageIQ/manageiq/blob/76ae3d7321635b4249c795fdd92af7fc059a5be3/app/helpers/application_helper/toolbar_builder.rb#L1074-L1077) we are only checking, if the users `userid` is `admin`. That means the buttons are not disabled, even if we can't copy the user.

This PR should fix the issue.

Before:
![screencapture-localhost-3000-ops-explorer-1474289922526](https://cloud.githubusercontent.com/assets/1187051/18632818/a5269b9a-7e79-11e6-92bc-65fcc01c6048.png)

After:
![screencapture-localhost-3000-ops-explorer-1474289869106](https://cloud.githubusercontent.com/assets/1187051/18632816/a3a4eeac-7e79-11e6-8464-25341ee92e95.png)

## Steps for Testing/QA
- See screenshots
- *Configuration* => *Access Control* => Go to super admin users (but not the one with `userid == "admin"`  detail page

@martinpovolny