### PR TITLE
Fixed issue in user copy method

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -34,7 +34,10 @@ module OpsController::OpsRbac
   end
 
   def rbac_user_copy
-    user = User.find(from_cid(params[:miq_grid_checks]))
+    # get users id either from gtl check or detail id
+    user_id = params[:miq_grid_checks].present? ? params[:miq_grid_checks] : params[:id]
+    user = User.find(from_cid(user_id))
+    # check if it is allowed to copy the user
     if rbac_user_copy_restriction?(user)
       rbac_restricted_user_copy_flash(user)
     end


### PR DESCRIPTION
I've found an issue in my PR #11147, causing fatal error, if I've tried to copy user from the detail page.

```log
[----] F, [2016-09-19T14:19:29.981783 #15605:2b08ae3be638] FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find User with 'id'=
/home/rblanco/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-5.0.0.1/lib/active_record/core.rb:173:in `find'
/home/rblanco/devel/manageiq/app/controllers/ops_controller/ops_rbac.rb:38:in `rbac_user_copy'
/home/rblanco/devel/manageiq/app/controllers/ops_controller.rb:99:in `x_button'
```

## Links
#11147

## Steps for Testing/QA
Go to users detail page, button `Copy this user to a new User` should now work correctly

@dclarizio 