### PR TITLE
Implement VMware Cloud EventCatcher backend

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -100,6 +100,10 @@ class EmsEvent < EventStream
     add(ems_id, ManageIQ::Providers::Google::CloudManager::EventParser.event_to_hash(event, ems_id))
   end
 
+  def self.add_vmware_vcloud(ems_id, event)
+    add(ems_id, ManageIQ::Providers::Vmware::CloudManager::EventParser.event_to_hash(event, ems_id))
+  end
+
   def self.add(ems_id, event_hash)
     event_type = event_hash[:event_type]
     raise MiqException::Error, _("event_type must be set in event") if event_type.nil?

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :Vm
 
   include ManageIQ::Providers::Vmware::ManagerAuthMixin
-  include ManageIQ::Providers::Vmware::ManagerEventsMixin
+  include ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
   include HasNetworkManagerMixin
 
   before_validation :ensure_managers

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -2,6 +2,8 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :AvailabilityZone
   require_nested :OrchestrationStack
   require_nested :OrchestrationTemplate
+  require_nested :EventCatcher
+  require_nested :EventParser
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
@@ -9,6 +11,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   require_nested :Vm
 
   include ManageIQ::Providers::Vmware::ManagerAuthMixin
+  include ManageIQ::Providers::Vmware::ManagerEventsMixin
   include HasNetworkManagerMixin
 
   before_validation :ensure_managers
@@ -38,7 +41,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   end
 
   def supported_auth_types
-    %w(default)
+    %w(default amqp)
   end
 
   def supports_authentication?(authtype)
@@ -77,6 +80,12 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
     case err
     when Fog::Compute::VcloudDirector::Unauthorized
       MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+    when Excon::Errors::Timeout
+      MiqException::MiqUnreachableError.new "Login attempt timed out"
+    when Excon::Errors::SocketError
+      MiqException::MiqHostError.new "Socket error: #{err.message}"
+    when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError
+      err
     else
       MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
     end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher.rb
@@ -1,0 +1,11 @@
+class ManageIQ::Providers::Vmware::CloudManager::EventCatcher < ::MiqEventCatcher
+  require_nested :Runner
+
+  def self.ems_class
+    ManageIQ::Providers::Vmware::CloudManager
+  end
+
+  def self.settings_name
+    :event_catcher_vmware_cloud
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/event.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/event.rb
@@ -1,0 +1,59 @@
+# Message format description:
+# https://pubs.vmware.com/vca/index.jsp#com.vmware.vcloud.api.doc_56/GUID-7C1F16FF-C530-404E-8533-329670B20A19.html
+
+class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Event
+  attr_accessor :payload, :metadata, :delivery_info
+
+  TYPE_KEY              = 'notification.type'.freeze
+  ORGANIZATION_UUID_KEY = 'notification.orgUUID'.freeze
+  ENTITY_TYPE_KEY       = 'notification.entityType'.freeze
+  ENTITY_UUID_KEY       = 'notification.entityUUID'.freeze
+  TIMESTAMP_KEY         = 'notification.timestamp'.freeze
+
+  def required_header_keys
+    [TYPE_KEY, ORGANIZATION_UUID_KEY, ENTITY_TYPE_KEY, ENTITY_UUID_KEY, TIMESTAMP_KEY]
+  end
+
+  def initialize(payload, metadata, delivery_info)
+    raise "AMQP message missing header" unless metadata.respond_to? :headers
+    raise "AMQP message missing required headers" if required_header_keys.any? { |s| !metadata.headers.key? s }
+
+    @payload       = payload
+    @payload_hash  = payload_hash
+    @metadata      = metadata
+    @delivery_info = delivery_info
+  end
+
+  def header(key)
+    @metadata.headers[key]
+  end
+
+  def payload_hash
+    begin
+      @payload_hash ||= { :eventId => Hash.from_xml(@payload)['Notification']['eventId'] }
+    rescue
+      raise "AMQP message invalid payload"
+    end
+    @payload_hash
+  end
+
+  def type
+    t = header TYPE_KEY
+    if t.nil?
+      return ""
+    end
+    t
+  end
+
+  # Serialization.
+  def to_hash
+    {
+      :id                => payload_hash[:eventId],
+      :type              => type,
+      :organization_uuid => header(ORGANIZATION_UUID_KEY),
+      :entity_type       => header(ENTITY_TYPE_KEY),
+      :entity_uuid       => header(ENTITY_UUID_KEY),
+      :timestamp         => header(TIMESTAMP_KEY),
+    }
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/runner.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  include ManageIQ::Providers::Vmware::EventCatcherMixin
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/runner.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
-  include ManageIQ::Providers::Vmware::EventCatcherMixin
+  include ManageIQ::Providers::Vmware::CloudManager::EventCatcherMixin
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/stream.rb
@@ -1,0 +1,105 @@
+require 'bunny'
+require 'thread'
+
+# Listens to RabbitMQ events
+class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream
+  def self.test_amqp_connection(options = {})
+    connection = nil
+    begin
+      connection = connect(options)
+      connection.start
+      return true
+    rescue Bunny::AuthenticationFailureError => e
+      $log.info("#{log_prefix} Failed testing rabbit amqp connection: #{e.message}")
+      raise MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+    rescue Bunny::TCPConnectionFailedForAllHosts => e
+      raise MiqException::MiqHostError.new "Socket error: #{e.message}"
+    rescue
+      $log.info("#{log_prefix} Failed testing rabbit amqp connection for #{options[:hostname]}. ")
+      raise
+    ensure
+      connection.close if connection.respond_to? :close
+    end
+  end
+
+  def self.connect(connection_options = {})
+    Bunny.new(connection_options)
+  end
+
+  def self.log_prefix
+    "MIQ(#{self.class.name})"
+  end
+
+  def initialize(options = {})
+    @options          = options
+    @client_ip        = @options[:client_ip]
+    @collecting_events = false
+
+    # protect threaded access to the events array
+    @events_array_mutex = Mutex.new
+    @events = []
+  end
+
+  def start
+    $log.debug("#{self.class.log_prefix} Opening amqp connection to #{@options}")
+    connection.start
+    @channel = connection.create_channel
+    initialize_queues(@channel)
+  end
+
+  def stop
+    @connection.close if @connection.respond_to? :close
+    @collecting_events = false
+  end
+
+  def each_batch
+    @collecting_events = true
+    listen_queues
+    while @collecting_events
+      @events_array_mutex.synchronize do
+        yield @events
+        @events.clear
+      end
+      sleep 5
+    end
+  end
+
+  private
+
+  def connection
+    @connection ||= self.class.connect(@options)
+  end
+
+  def initialize_queues(channel)
+    @queues = {}
+    @options[:queues].each do |queue_name|
+      begin
+        @queues[queue_name] = channel.queue(queue_name, :durable => true)
+      rescue Bunny::AccessRefused => err
+        $log.warn("#{self.class.log_prefix} Could not start listening to queue '#{queue_name}' due to: #{err}")
+      end
+    end
+  end
+
+  def listen_queues
+    @queues.each do |queue_name, queue|
+      queue.subscribe do |delivery_info, metadata, payload|
+        begin
+
+          # Parse amqp message
+          event = ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Event.new(payload, metadata, delivery_info)
+
+          # Ignore message if not related to event, see link below
+          if event.type.start_with? "com/vmware/vcloud/event/"
+            @events_array_mutex.synchronize do
+              @events << event
+            end
+          end
+        rescue => e
+          $log.error("#{self.class.log_prefix} Exception receiving Rabbit (amqp)"\
+                     " event on #{queue_name} from #{@options[:hostname]}: #{e}")
+        end
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher_mixin.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::Vmware::EventCatcherMixin
+module ManageIQ::Providers::Vmware::CloudManager::EventCatcherMixin
 
   def event_monitor_handle
     unless @event_monitor_handle
@@ -45,8 +45,8 @@ module ManageIQ::Providers::Vmware::EventCatcherMixin
   def stop_event_monitor
     @event_monitor_handle.stop unless @event_monitor_handle.nil?
   rescue StandardException => err
-    _log.warn("#{log_prefix} Event Monitor Stop errored because [#{err.message}]")
-    _log.warn("#{log_prefix} Error details: [#{err.details}]")
+    _log.warn("Event Monitor Stop errored because [#{err.message}]")
+    _log.warn("Error details: [#{err.details}]")
     _log.log_backtrace(err)
   ensure
     reset_event_monitor_handle
@@ -54,9 +54,9 @@ module ManageIQ::Providers::Vmware::EventCatcherMixin
 
   def process_event(event)
     if filtered_events.include?(event.type)
-      _log.info "#{log_prefix} Skipping caught event [#{event.type}]"
+      _log.info "Skipping caught event [#{event.type}]"
     else
-      _log.info "#{log_prefix} Caught event [#{event.type}]"
+      _log.info "Caught event [#{event.type}]"
       add_to_worker_queue(event)
     end
   end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_parser.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers::Vmware::CloudManager::EventParser
+  def self.event_to_hash(event, ems_id)
+    event_hash = {
+      :event_type => event[:type].sub('com/vmware/vcloud/event/', '').gsub('/', '-'),  # normalized
+      :source     => "VMWARE-VCLOUD",
+      :message    => event.to_hash,
+      :timestamp  => event[:timestamp],
+      :vm_ems_ref => event[:instance_id],
+      :full_data  => event,
+      :ems_id     => ems_id,
+    }
+    event_hash
+  end
+end

--- a/app/models/manageiq/providers/vmware/cloud_manager/manager_events_mixin.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/manager_events_mixin.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::Vmware::ManagerEventsMixin
+module ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
   extend ActiveSupport::Concern
 
   def event_monitor_options

--- a/app/models/manageiq/providers/vmware/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/vmware/event_catcher_mixin.rb
@@ -1,0 +1,67 @@
+module ManageIQ::Providers::Vmware::EventCatcherMixin
+
+  def event_monitor_handle
+    unless @event_monitor_handle
+      options = @ems.event_monitor_options
+      options[:queues]                        = queue_names
+      options[:duration]                      = worker_settings[:duration]
+      options[:capacity]                      = worker_settings[:capacity]
+      options[:heartbeat]                     = worker_settings[:amqp_heartbeat]
+      options[:recovery_attempts]             = worker_settings[:amqp_recovery_attempts]
+      options[:client_ip]                     = server.ipaddress
+      options[:automatic_recovery]            = true
+      options[:recover_from_connection_close] = true
+      options[:ems]                           = @ems
+
+      @event_monitor_handle = ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream.new(options)
+    end
+    @event_monitor_handle
+  end
+
+  def queue_names
+    @ems.connect.organizations.all.map do |org|
+      "queue-#{org.id}"
+    end
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  # Start monitoring for events. This method blocks forever until stop_event_monitor is called.
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.each_batch do |events|
+      event_monitor_running
+      if events && !events.empty?
+        @queue.enq events
+      end
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.stop unless @event_monitor_handle.nil?
+  rescue StandardException => err
+    _log.warn("#{log_prefix} Event Monitor Stop errored because [#{err.message}]")
+    _log.warn("#{log_prefix} Error details: [#{err.details}]")
+    _log.log_backtrace(err)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def process_event(event)
+    if filtered_events.include?(event.type)
+      _log.info "#{log_prefix} Skipping caught event [#{event.type}]"
+    else
+      _log.info "#{log_prefix} Caught event [#{event.type}]"
+      add_to_worker_queue(event)
+    end
+  end
+
+  def add_to_worker_queue(event)
+    EmsEvent.add_queue('add_vmware_vcloud', @cfg[:ems_id], event.to_hash)
+  end
+end

--- a/app/models/manageiq/providers/vmware/manager_events_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_events_mixin.rb
@@ -1,0 +1,30 @@
+module ManageIQ::Providers::Vmware::ManagerEventsMixin
+  extend ActiveSupport::Concern
+
+  def event_monitor_options
+    @event_monitor_options ||= begin
+      opts = {
+        :ems          => self,
+        :virtual_host => "/",
+      }
+      amqp = connection_configuration_by_role("amqp")
+      if (endpoint = amqp.try(:endpoint))
+        opts[:hostname]          = endpoint.hostname
+        opts[:port]              = endpoint.port
+        opts[:security_protocol] = endpoint.security_protocol
+      end
+
+      if (authentication = amqp.try(:authentication))
+        opts[:username] = authentication.userid
+        opts[:password] = authentication.password
+      end
+      opts
+    end
+  end
+
+  def verify_amqp_credentials(_options = {})
+    ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream.test_amqp_connection(event_monitor_options)
+  rescue => err
+    raise translate_exception(err)
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -52,6 +52,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Openstack::InfraManager::EventCatcher
     ManageIQ::Providers::StorageManager::CinderManager::EventCatcher
     ManageIQ::Providers::Vmware::InfraManager::EventCatcher
+    ManageIQ::Providers::Vmware::CloudManager::EventCatcher
     MiqEventHandler
     MiqGenericWorker
     MiqNetappRefreshWorker
@@ -118,6 +119,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqWebServiceWorker
     MiqEmsRefreshCoreWorker
     MiqVimBrokerWorker
+    ManageIQ::Providers::Vmware::CloudManager::EventCatcher
     ManageIQ::Providers::Vmware::InfraManager::EventCatcher
     ManageIQ::Providers::Redhat::InfraManager::EventCatcher
     ManageIQ::Providers::Openstack::CloudManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1231,6 +1231,13 @@
         :flooding_monitor_enabled: true
         :poll: 1.seconds
         :ems_event_max_wait: 60
+      :event_catcher_vmware_cloud:
+        :poll: 15.seconds
+        :duration: 10.seconds
+        :capacity: 50
+        :amqp_port: 5672
+        :amqp_heartbeat: 30
+        :amqp_recovery_attempts: 4
       :event_catcher_openstack:
         :poll: 15.seconds
         :topics:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/__class__.yaml
@@ -1,0 +1,433 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description:
+    display_name: VMware
+    name: VMWARE-VCLOUD
+    type:
+    inherits:
+    visibility:
+    owner:
+  schema:
+  - field:
+      aetype: assertion
+      name: guard
+      display_name:
+      datatype:
+      priority: 1
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: attribute
+      name: logical_event
+      display_name:
+      datatype:
+      priority: 2
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: on_entry
+      display_name:
+      datatype:
+      priority: 3
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel1
+      display_name:
+      datatype:
+      priority: 4
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth1
+      display_name:
+      datatype:
+      priority: 5
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel2
+      display_name:
+      datatype:
+      priority: 6
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth2
+      display_name:
+      datatype:
+      priority: 7
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel3
+      display_name:
+      datatype:
+      priority: 8
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth3
+      display_name:
+      datatype:
+      priority: 9
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel4
+      display_name:
+      datatype:
+      priority: 10
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth4
+      display_name:
+      datatype:
+      priority: 11
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel5
+      display_name:
+      datatype:
+      priority: 12
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth5
+      display_name:
+      datatype:
+      priority: 13
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel6
+      display_name:
+      datatype:
+      priority: 14
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth6
+      display_name:
+      datatype:
+      priority: 15
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel7
+      display_name:
+      datatype:
+      priority: 16
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth7
+      display_name:
+      datatype:
+      priority: 17
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel8
+      display_name:
+      datatype:
+      priority: 18
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: meth8
+      display_name:
+      datatype:
+      priority: 19
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: relationship
+      name: rel9
+      display_name:
+      datatype:
+      priority: 20
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:
+  - field:
+      aetype: method
+      name: on_exit
+      display_name:
+      datatype:
+      priority: 21
+      owner:
+      default_value:
+      substitute: true
+      message: create
+      visibility:
+      collect:
+      scope:
+      description:
+      condition:
+      on_entry:
+      on_exit:
+      on_error:
+      max_retries:
+      max_time:

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: ".missing"
+    inherits:
+    description:
+  fields: []

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalog-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalog-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: catalog-create
+    inherits:
+    description: A catalog was created.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalog-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalog-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: catalog-delete
+    inherits:
+    description: A catalog was deleted.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalog-modify.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalog-modify.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: catalog-modify
+    inherits:
+    description: One or more properties of a catalog were modified.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalogItem-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalogItem-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: catalogItem-create
+    inherits:
+    description: An item was added to a catalog.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalogItem-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/catalogItem-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: catalogItem-delete
+    inherits:
+    description: An item was removed from a catalog.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: network-create
+    inherits:
+    description: A network was created.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: network-delete
+    inherits:
+    description: A network was deleted.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-deploy.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-deploy.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: network-deploy
+    inherits:
+    description: A network was deployed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-modify.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-modify.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: network-modify
+    inherits:
+    description: A network was modified.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-undeploy.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/network-undeploy.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: network-undeploy
+    inherits:
+    description: A network was undeployed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vapp-create
+    inherits:
+    description: A vApp was created (instantiated)
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vapp-delete
+    inherits:
+    description: A vApp was deleted.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-deploy.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-deploy.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vapp-deploy
+    inherits:
+    description: A vApp was deployed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-modify.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-modify.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vapp-modify
+    inherits:
+    description: One or more properties of a vApp were modified.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-undeploy.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vapp-undeploy.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vapp-undeploy
+    inherits:
+    description: A vApp was undeployed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vappTemplate-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vappTemplate-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vappTemplate-create
+    inherits:
+    description: A vApp template was created.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vappTemplate-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vappTemplate-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vappTemplate-delete
+    inherits:
+    description: A vApp template was deleted.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vappTemplate-modify.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vappTemplate-modify.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vappTemplate-modify
+    inherits:
+    description: One or more properties of a vApp template were modified.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vdc-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vdc-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vdc-create
+    inherits:
+    description: A VDC was created.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vdc-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vdc-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vdc-delete
+    inherits:
+    description: A VDC was deleted.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vdc-modify.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vdc-modify.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vdc-modify
+    inherits:
+    description: One or more properties of a VDC was modified.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-change_state.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-change_state.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-change_state
+    inherits:
+    description: The power state of a virtual machine has changed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-consolidate.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-consolidate.yaml
@@ -1,0 +1,13 @@
+
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-consolidate
+    inherits:
+    description: A virtual machine was consolidated.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-create.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-create.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-create
+    inherits:
+    description: A virtual machine was created by instantiating a vApp.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-delete.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-delete.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-delete
+    inherits:
+    description: A virtual machine was deleted.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-deploy.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-deploy.yaml
@@ -1,0 +1,13 @@
+
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-deploy
+    inherits:
+    description: A virtual machine was deployed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-ip_address_changed.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-ip_address_changed.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-ip_address_changed
+    inherits:
+    description: The IP address of a virtual machine has changed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-modify.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-modify.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-modify
+    inherits:
+    description: One or more properties of a virtual machine were modified.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-undeploy.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/VMWARE-VCLOUD.class/vm-undeploy.yaml
@@ -1,0 +1,13 @@
+
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name:
+    name: vm-undeploy
+    inherits:
+    description: A virtual machine was undeployed.
+  fields:
+  - rel4:
+        value: "/System/event_handlers/event_action_refresh?target=ems"


### PR DESCRIPTION
This patch implements whole EventCatcher backend that connects to RabbitMQ where VMware Cloud Director drops notifications. Any registered event (i.e. if a fixture in 'System/Event/EmsEvent/VMWARE-VCLOUD.class' exists) triggers a full refresh of the ems.

This PR is a result of discussion from [PR#10274](https://github.com/ManageIQ/manageiq/pull/10274).

## Links [Optional]

* [Message Format](https://pubs.vmware.com/vca/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_56%2FGUID-7C1F16FF-C530-404E-8533-329670B20A19.html)
* [Original PR](https://github.com/ManageIQ/manageiq/pull/10274)

## Steps for Testing/QA [Optional]

Since GUI form to input Rabbit credentials is not yet implemented, one must create ems from Rails CLI as shown in [this file](https://github.com/ManageIQ/manageiq/files/480034/create_ems.txt).

Note that vCD installation must be configured to support event capturing thru RabbitMQ as described in [this document](https://github.com/ManageIQ/manageiq/files/480039/VMware_vCloud_Director_for_ManageIQ.pdf).


