### PR TITLE
Update Blueprint API to store bundle info in ui_properties

### DIFF
--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -4,19 +4,6 @@ module Api
 
     before_action :set_additional_attributes, :only => [:show]
 
-    def create_resource(_type, _id, data)
-      raise BadRequestError, 'Failed to create Blueprint - ui_properties cannot be empty' unless data['ui_properties']
-      validate_ui_properties(data['ui_properties'])
-      Blueprint.create!(data)
-    end
-
-    def edit_resource(type, id, data)
-      validate_ui_properties(data['ui_properties']) if data['ui_properties']
-      blueprint = resource_search(id, type, Blueprint)
-      blueprint.update!(data)
-      blueprint
-    end
-
     def publish_resource(type, id, data)
       blueprint = resource_search(id, type, Blueprint)
       blueprint.publish(data['bundle_name'])
@@ -24,15 +11,6 @@ module Api
     end
 
     private
-
-    def validate_ui_properties(ui_properties)
-      unless ui_properties.key?('service_catalog') && ui_properties.key?('service_dialog') &&
-             ui_properties.key?('automate_entrypoints') && ui_properties.key?('chart_data_model')
-        raise BadRequestError,
-              'Failed to create Blueprint - ' \
-              'ui_properties must include service_catalog, service_dialog, automate_entrypoints, and chart_data_model'
-      end
-    end
 
     def set_additional_attributes
       @additional_attributes = %w(content)

--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :set_additional_attributes, :only => [:show]
 
     def create_resource(_type, _id, data)
-      raise BadRequestError unless data['ui_properties']
+      raise BadRequestError, 'Failed to create Blueprint - ui_properties cannot be empty' unless data['ui_properties']
       validate_ui_properties(data['ui_properties'])
       Blueprint.create!(data)
     end
@@ -26,14 +26,16 @@ module Api
     private
 
     def validate_ui_properties(ui_properties)
-      raise BadRequestError unless ui_properties.key?('service_catalog') &&
-                                   ui_properties.key?('service_dialog') &&
-                                   ui_properties.key?('automate_entrypoints') && ui_properties.key?('ChartDataModel')
+      unless ui_properties.key?('service_catalog') && ui_properties.key?('service_dialog') &&
+             ui_properties.key?('automate_entrypoints') && ui_properties.key?('chart_data_model')
+        raise BadRequestError,
+              'Failed to create Blueprint - ' \
+              'ui_properties must include service_catalog, service_dialog, automate_entrypoints, and chart_data_model'
+      end
     end
 
     def set_additional_attributes
       @additional_attributes = %w(content)
     end
-
   end
 end

--- a/app/controllers/api/blueprints_controller.rb
+++ b/app/controllers/api/blueprints_controller.rb
@@ -5,20 +5,15 @@ module Api
     before_action :set_additional_attributes, :only => [:show]
 
     def create_resource(_type, _id, data)
-      attributes = data.except("bundle")
-      blueprint = Blueprint.new(attributes)
-      bundle = data["bundle"]
-      create_bundle(blueprint, bundle) if bundle
-      blueprint.save!
-      blueprint
+      raise BadRequestError unless data['ui_properties']
+      validate_ui_properties(data['ui_properties'])
+      Blueprint.create!(data)
     end
 
     def edit_resource(type, id, data)
-      attributes = data.except("bundle")
+      validate_ui_properties(data['ui_properties']) if data['ui_properties']
       blueprint = resource_search(id, type, Blueprint)
-      blueprint.update!(attributes)
-      bundle = data["bundle"]
-      update_bundle(blueprint, bundle) if bundle
+      blueprint.update!(data)
       blueprint
     end
 
@@ -30,48 +25,15 @@ module Api
 
     private
 
+    def validate_ui_properties(ui_properties)
+      raise BadRequestError unless ui_properties.key?('service_catalog') &&
+                                   ui_properties.key?('service_dialog') &&
+                                   ui_properties.key?('automate_entrypoints') && ui_properties.key?('ChartDataModel')
+    end
+
     def set_additional_attributes
       @additional_attributes = %w(content)
     end
 
-    def create_bundle(blueprint, bundle)
-      blueprint.create_bundle(deserialize_bundle(bundle))
-    rescue => e
-      raise BadRequestError, "Couldn't create the bundle - #{e}"
-    end
-
-    def update_bundle(blueprint, bundle)
-      blueprint.update_bundle(deserialize_bundle(bundle))
-    rescue => e
-      raise BadRequestError, "Couldn't update the bundle - #{e}"
-    end
-
-    def deserialize_bundle(bundle)
-      options = {}
-      if bundle.key?("service_catalog")
-        options[:service_catalog] = service_catalog_options(bundle)
-      end
-      if bundle.key?("service_dialog")
-        options[:service_dialog] = service_dialog_options(bundle)
-      end
-      options[:service_templates] = bundle.fetch("service_templates", []).collect do |st|
-        resource_search(parse_id(st, :service_templates), :service_templates, ServiceTemplate)
-      end
-      options[:entry_points] = bundle["automate_entrypoints"] if bundle["automate_entrypoints"]
-      options
-    end
-
-    def service_catalog_options(bundle)
-      if bundle["service_catalog"]
-        resource_search(parse_id(bundle["service_catalog"], :service_catalogs),
-                        :service_catalogs, ServiceTemplateCatalog)
-      end
-    end
-
-    def service_dialog_options(bundle)
-      if bundle["service_dialog"]
-        resource_search(parse_id(bundle["service_dialog"], :service_dialogs), :service_dialogs, Dialog)
-      end
-    end
   end
 end

--- a/spec/factories/blueprint.rb
+++ b/spec/factories/blueprint.rb
@@ -1,5 +1,24 @@
 FactoryGirl.define do
   factory :blueprint do
     sequence(:name) { |n| "Blueprint #{n}" }
+    ui_properties do
+      {
+        "service_catalog"      => { "id" => "id"},
+        "service_dialog"       => { "id" =>"id"},
+        "automate_entrypoints" => {
+          "Reconfigure" => "x\/y/\/z",
+          "Provision"   => "a\/b\/c"
+        },
+        "ChartDataModel"       => {
+          "nodes" => [
+            {
+              "x"    => 102,
+              "y"    => 100,
+              "id"   => 10,
+              "name" => "composite_generic"
+            }
+          ]}
+      }
+    end
   end
 end

--- a/spec/factories/blueprint.rb
+++ b/spec/factories/blueprint.rb
@@ -1,24 +1,5 @@
 FactoryGirl.define do
   factory :blueprint do
     sequence(:name) { |n| "Blueprint #{n}" }
-    ui_properties do
-      {
-        "service_catalog"      => { "id" => "id"},
-        "service_dialog"       => { "id" =>"id"},
-        "automate_entrypoints" => {
-          "Reconfigure" => "x\/y/\/z",
-          "Provision"   => "a\/b\/c"
-        },
-        "ChartDataModel"       => {
-          "nodes" => [
-            {
-              "x"    => 102,
-              "y"    => 100,
-              "id"   => 10,
-              "name" => "composite_generic"
-            }
-          ]}
-      }
-    end
   end
 end

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -39,31 +39,6 @@ RSpec.describe "Blueprints API" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "will show a blueprint's bundle" do
-      blueprint = FactoryGirl.create(:blueprint, :name => "Test Blueprint")
-      service_templates = FactoryGirl.create_list(:service_template, 2)
-      service_catalog   = FactoryGirl.create(:service_template_catalog)
-      service_dialog    = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      blueprint.create_bundle(:service_templates => service_templates,
-                              :service_catalog   => service_catalog,
-                              :service_dialog    => service_dialog)
-
-      api_basic_authorize action_identifier(:blueprints, :read, :resource_actions, :get)
-
-      run_get(blueprints_url(blueprint.id))
-
-      expected = {
-        "content" => a_hash_including(
-          "id"                          => kind_of(Integer),
-          "name"                        => blueprint.name,
-          "service_type"                => "composite",
-          "service_template_catalog_id" => service_catalog.id,
-          "blueprint_id"                => blueprint.id
-        )
-      }
-      expect(response.parsed_body).to include(expected)
-    end
-
     it "forbids access to a blueprint without an appropriate role" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize
@@ -77,15 +52,26 @@ RSpec.describe "Blueprints API" do
   describe "POST /api/blueprints" do
     it "can create a blueprint" do
       api_basic_authorize collection_action_identifier(:blueprints, :create)
+      ui_properties = {
+        :service_catalog      => {},
+        :service_dialog       => {},
+        :automate_entrypoints => {},
+        :ChartDataModel       => {}
+      }
 
-      run_post(blueprints_url, :name => "foo", :description => "bar", :ui_properties => {:some => {:json => "baz"}})
+      run_post(blueprints_url, :name => "foo", :description => "bar", :ui_properties => ui_properties)
 
       expected = {
         "results" => [
           a_hash_including(
             "name"          => "foo",
             "description"   => "bar",
-            "ui_properties" => {"some" => {"json" => "baz"}}
+            "ui_properties" => {
+              "service_catalog"      => {},
+              "service_dialog"       => {},
+              "automate_entrypoints" => {},
+              "ChartDataModel"       => {}
+            }
           )
         ]
       }
@@ -123,62 +109,20 @@ RSpec.describe "Blueprints API" do
       expect(response).to have_http_status(:bad_request)
     end
 
-    it "can create a blueprint with a bundle by href with an appropriate role" do
-      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      service_template_1, service_template_2 = FactoryGirl.create_list(:service_template, 2)
-      service_catalog = FactoryGirl.create(:service_template_catalog)
-      api_basic_authorize collection_action_identifier(:blueprints, :create)
-
-      run_post(
-        blueprints_url,
-        :name        => "foo",
-        :description => "bar",
-        :bundle      => {
-          :service_catalog      => {:href => service_catalogs_url(service_catalog.id)},
-          :service_dialog       => {:href => service_dialogs_url(service_dialog.id)},
-          :automate_entrypoints => {"Provision" => "a/b/c", "Reconfigure" => "x/y/z"},
-          :service_templates    => [
-            {:href => service_templates_url(service_template_1.id)},
-            {:href => service_templates_url(service_template_2.id)}
-          ]
-        }
-      )
-
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "can create a blueprint with a bundle by id with an appropriate role" do
-      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      service_template_1, service_template_2 = FactoryGirl.create_list(:service_template, 2)
-      service_catalog = FactoryGirl.create(:service_template_catalog)
-      api_basic_authorize collection_action_identifier(:blueprints, :create)
-
-      run_post(
-        blueprints_url,
-        :name        => "foo",
-        :description => "bar",
-        :bundle      => {
-          :service_catalog      => {:id => service_catalog.id},
-          :service_dialog       => {:id => service_dialog.id},
-          :automate_entrypoints => {"Provision" => "a/b/c", "Reconfigure" => "x/y/z"},
-          :service_templates    => [
-            {:id => service_template_1.id},
-            {:id => service_template_2.id}
-          ]
-        }
-      )
-
-      expect(response).to have_http_status(:ok)
-    end
-
     it "can create blueprints in bulk" do
       api_basic_authorize collection_action_identifier(:blueprints, :create)
+      ui_properties = {
+        :service_catalog      => {},
+        :service_dialog       => {},
+        :automate_entrypoints => {},
+        :ChartDataModel       => {}
+      }
 
       run_post(
         blueprints_url,
         :resources => [
-          {:name => "foo", :description => "bar"},
-          {:name => "baz", :description => "qux"}
+          {:name => "foo", :description => "bar", :ui_properties => ui_properties},
+          {:name => "baz", :description => "qux", :ui_properties => ui_properties}
         ]
       )
 
@@ -256,16 +200,8 @@ RSpec.describe "Blueprints API" do
     end
 
     it "can publish multiple blueprints" do
+      pending("update to Blueprint#publish")
       blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
-      service_template = FactoryGirl.create(:service_template)
-      service_catalog = FactoryGirl.create(:service_template_catalog)
-      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      blueprint1.create_bundle(:service_templates => [service_template],
-                               :service_dialog    => service_dialog,
-                               :service_catalog   => service_catalog)
-      blueprint2.create_bundle(:service_templates => [service_template],
-                               :service_dialog    => service_dialog,
-                               :service_catalog   => service_catalog)
 
       api_basic_authorize collection_action_identifier(:blueprints, :publish)
 
@@ -284,37 +220,6 @@ RSpec.describe "Blueprints API" do
   end
 
   describe "POST /api/blueprints/:id" do
-    it "can update a blueprint's bundle with an appropriate role" do
-      blueprint = FactoryGirl.create(:blueprint)
-
-      original_service_template = FactoryGirl.create(:service_template)
-      original_service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      original_service_catalog = FactoryGirl.create(:service_template_catalog)
-      blueprint.create_bundle(:service_templates => [original_service_template],
-                              :service_dialog    => original_service_dialog,
-                              :service_catalog   => original_service_catalog)
-      new_service_template = FactoryGirl.create(:service_template)
-      new_service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      new_service_catalog = FactoryGirl.create(:service_template_catalog)
-
-      api_basic_authorize action_identifier(:blueprints, :edit)
-
-      run_post(
-        blueprints_url(blueprint.id),
-        :action   => "edit",
-        :resource => {
-          :bundle => {
-            :service_templates    => [{:id => new_service_template.id}],
-            :service_dialog       => {:id => new_service_dialog.id},
-            :service_catalog      => {:id => new_service_catalog.id},
-            :automate_entrypoints => {"Provision" => "a/b/c", "Reconfigure" => "x/y/z"}
-          }
-        }
-      )
-
-      expect(response).to have_http_status(:ok)
-    end
-
     it "forbids the updating of blueprints without an appropriate role" do
       blueprint = FactoryGirl.create(:blueprint, :name => "foo", :description => "bar")
       api_basic_authorize
@@ -342,65 +247,10 @@ RSpec.describe "Blueprints API" do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "updates a blueprint to remove a service catalog" do
-      blueprint = FactoryGirl.create(:blueprint)
-      original_service_template = FactoryGirl.create(:service_template)
-      original_service_catalog = FactoryGirl.create(:service_template_catalog)
-      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      blueprint.create_bundle(:service_templates => [original_service_template],
-                              :service_catalog   => original_service_catalog)
-      api_basic_authorize action_identifier(:blueprints, :edit)
-
-      run_post(
-        blueprints_url(blueprint.id),
-        :action   => "edit",
-        :resource => {
-          :bundle => {
-            :service_dialog  => {
-              :id => service_dialog.id
-            },
-            :service_catalog => nil
-          }
-        }
-      )
-
-      expect(blueprint.reload.bundle.descendants).to eq([])
-    end
-
-    it "updates a blueprint to remove a service dialog" do
-      blueprint = FactoryGirl.create(:blueprint)
-      original_service_template = FactoryGirl.create(:service_template)
-      original_service_catalog = FactoryGirl.create(:service_template_catalog)
-      original_service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      blueprint.create_bundle(:service_templates => [original_service_template],
-                              :service_dialog    => original_service_dialog,
-                              :service_catalog   => original_service_catalog)
-      api_basic_authorize action_identifier(:blueprints, :edit)
-
-      run_post(
-        blueprints_url(blueprint.id),
-        :action   => "edit",
-        :resource => {
-          :bundle => {
-            :service_catalog => {
-              :id => original_service_catalog.id
-            },
-            :service_dialog  => nil
-          }
-        }
-      )
-
-      expect(blueprint.reload.bundle.dialogs).to eq([])
-    end
-
     it "publishes a single blueprint" do
+      pending("update to Blueprint#publish")
       blueprint = FactoryGirl.create(:blueprint)
-      service_template = FactoryGirl.create(:service_template)
-      service_catalog = FactoryGirl.create(:service_template_catalog)
-      service_dialog = FactoryGirl.create(:dialog_with_tab_and_group_and_field)
-      blueprint.create_bundle(:service_templates => [service_template],
-                              :service_dialog    => service_dialog,
-                              :service_catalog   => service_catalog)
+
       api_basic_authorize action_identifier(:blueprints, :publish)
 
       run_post(blueprints_url(blueprint.id), :action => "publish")

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Blueprints API" do
         :service_catalog      => {},
         :service_dialog       => {},
         :automate_entrypoints => {},
-        :ChartDataModel       => {}
+        :chart_data_model     => {}
       }
 
       run_post(blueprints_url, :name => "foo", :description => "bar", :ui_properties => ui_properties)
@@ -70,7 +70,7 @@ RSpec.describe "Blueprints API" do
               "service_catalog"      => {},
               "service_dialog"       => {},
               "automate_entrypoints" => {},
-              "ChartDataModel"       => {}
+              "chart_data_model"     => {}
             }
           )
         ]
@@ -115,7 +115,7 @@ RSpec.describe "Blueprints API" do
         :service_catalog      => {},
         :service_dialog       => {},
         :automate_entrypoints => {},
-        :ChartDataModel       => {}
+        :chart_data_model     => {}
       }
 
       run_post(
@@ -250,7 +250,6 @@ RSpec.describe "Blueprints API" do
     it "publishes a single blueprint" do
       pending("update to Blueprint#publish")
       blueprint = FactoryGirl.create(:blueprint)
-
       api_basic_authorize action_identifier(:blueprints, :publish)
 
       run_post(blueprints_url(blueprint.id), :action => "publish")


### PR DESCRIPTION
This is an update to the API to account for the Blueprint updates which will store the bundle information in `ui_properties` as follows: 

```
{
  "ui_properties": {
    "service_catalog": {"id": 1},
    "service_dialog": {"id": 1},
    "automate_entrypoints": {
      "Reconfigure": "x\/y\/z",
      "Provision": "a\/b\/c"
    },
    "chart_data_model": {
      "nodes": [
        {  // Existing Service_Template
          "id": 10,
          "name": "composite_generic",
          "tags": [{"id": 15}, {"id": 45}],
          ...additional chart data....
        },
        {  // New Generic Service_Template
          "id": null,
          "name": "my new generic vm",
          "generic_subtype": ‘vm',
          "tags": [{"id": 2}, {"id": 65}],
          "service_type": 'atomic'
          "prov_type": 'generic',
          ...additional chart data....
        },
        ...
        ...
      ]
    }
```
This PR validates the structure of the ui_properties based off of this structure. 
**Note**: Sets two specs to `pending` as they are affected by this change. Need to revisit these after @bzwei's updates to `Blueprint#publish`

@miq-bot add_label enhancement, api, service broker, darga/no