### PR TITLE
Ensure api config references only valid miq_product_features

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1659,9 +1659,9 @@
       - :name: suspend
         :identifier: vm_suspend
       - :name: shelve
-        :identifier: vm_shelve
+        :identifier: instance_shelve
       - :name: shelve_offload
-        :identifier: vm_shelve_offload
+        :identifier: instance_shelve_offload
       - :name: pause
         :identifier: vm_pause
       - :name: request_console
@@ -1703,9 +1703,9 @@
       - :name: suspend
         :identifier: vm_suspend
       - :name: shelve
-        :identifier: vm_shelve
+        :identifier: instance_shelve
       - :name: shelve_offload
-        :identifier: vm_shelve_offload
+        :identifier: instance_shelve_offload
       - :name: pause
         :identifier: vm_pause
       - :name: request_console

--- a/config/api.yml
+++ b/config/api.yml
@@ -674,10 +674,10 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: profile_show_list
+        :identifier: policy_profile_view
       :post:
       - :name: query
-        :identifier: profile_show_list
+        :identifier: policy_profile_view
       - :name: add
         :identifier: profile_new
         :disabled: true
@@ -690,7 +690,7 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: profile_show
+        :identifier: policy_profile_view
       :post:
       - :name: edit
         :identifier: profile_edit

--- a/config/api.yml
+++ b/config/api.yml
@@ -1806,7 +1806,7 @@
         :identifier: virtual_template_show
   :arbitration_profiles:
     :description: Arbitration Profiles
-    :identifier: miq_arbitration_profile
+    :identifier: ems_cloud_admin
     :options:
     - :collection
     :verbs: *gpppd

--- a/config/api.yml
+++ b/config/api.yml
@@ -607,10 +607,10 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: policy_show_list
+        :identifier: policy_view
       :post:
       - :name: query
-        :identifier: policy_show_list
+        :identifier: policy_view
       - :name: add
         :identifier: policy_new
         :disabled: true
@@ -623,7 +623,7 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: policy_show
+        :identifier: policy_view
       :post:
       - :name: edit
         :identifier: policy_edit

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5137,6 +5137,10 @@
         :description: Suspend VM
         :feature_type: control
         :identifier: vm_suspend
+      - :name: Pause
+        :description: Pause VM
+        :feature_type: control
+        :identifier: vm_pause
       - :name: Reset
         :description: Reset VM
         :feature_type: control

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1466,6 +1466,10 @@
     :hidden: true
     :identifier: policy_profile
     :children:
+    - :name: View
+      :description: View Policy Profiles
+      :feature_type: view
+      :identifier: policy_profile_view
     - :name: Modify
       :description: Modify Policy Profiles
       :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1494,6 +1494,10 @@
     :hidden: true
     :identifier: policy
     :children:
+    - :name: View
+      :description: View Policies
+      :feature_type: view
+      :identifier: policy_view
     - :name: Modify
       :description: Modify Policies
       :feature_type: admin

--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -1,0 +1,34 @@
+describe 'API configuration (config/api.yml)' do
+  let(:api_settings) { Api::Settings }
+
+  describe 'collections' do
+    let(:collection_settings) { api_settings.collections }
+
+    describe 'identifiers' do
+      let(:miq_product_features) { MiqProductFeature.seed.values.flatten.to_set }
+      let(:api_feature_identifiers) do
+        collection_settings.each_with_object(Set.new) do |(_, cfg), set|
+          set.add(cfg[:identifier]) if cfg[:identifier]
+          subcollections = Array(cfg[:subcollections]).collect { |s| "#{s}_subcollection_actions" }
+          (subcollections + [:collection_actions, :resource_actions]).each do |action_type|
+            next unless cfg[action_type]
+            cfg[action_type].each do |_, method_cfg|
+              method_cfg.each do |action_cfg|
+                set.add(action_cfg[:identifier]) if action_cfg[:identifier]
+              end
+            end
+          end
+        end
+      end
+
+      it 'is not empty' do
+        expect(api_feature_identifiers).not_to be_empty
+      end
+
+      it 'contains only valid miq_feature identifiers' do
+        dangling = api_feature_identifiers - miq_product_features
+        expect(dangling).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1376753

## Problem
The `/api/policies` and `/api/policy_profiles` was returning Forbidden even thought the spec tests were passing. That was cause by `config/api.yml` referencing invalid `miq_product_feature`. 

## Solution
This pr introduces rspec that asserts that `config/api.yml` contains only valid `miq_product_features`. And also this pr fixes all the abuses one by one.

Since each abuse was different in its nature and applied fix differs, reviewers are advised to consult respective commit messages.

@miq-bot add_label api, bug
@miq-bot assign @abellotti