### PR TITLE
Add a new column to miq_ae_namespace table for domain

### DIFF
--- a/db/migrate/20160919145034_add_top_level_namespace_to_miq_ae_namespaces.rb
+++ b/db/migrate/20160919145034_add_top_level_namespace_to_miq_ae_namespaces.rb
@@ -1,0 +1,5 @@
+class AddTopLevelNamespaceToMiqAeNamespaces < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_ae_namespaces, :top_level_namespace, :string
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -4771,6 +4771,7 @@ miq_ae_namespaces:
 - ref_type
 - last_import_on
 - source
+- top_level_namespace
 miq_ae_values:
 - id
 - instance_id


### PR DESCRIPTION
For pluggable provider domains we need a new column that would store the name of the top_level_namespace. 

