### PR TITLE
Load virtual custom columns from miq expression automatically

### DIFF
--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -34,6 +34,8 @@ module CustomAttributeMixin
     end
 
     def self.add_custom_attribute(custom_attribute)
+      return if respond_to?(custom_attribute)
+
       virtual_column(custom_attribute.to_sym, :type => :string, :uses => :custom_attributes)
 
       define_method(custom_attribute.to_sym) do

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -340,6 +340,18 @@ class MiqExpression
   def initialize(exp, ctype = nil)
     @exp = exp
     @context_type = ctype
+
+    load_virtual_custom_attributes
+  end
+
+  def load_virtual_custom_attributes
+    return unless @exp
+
+    custom_attributes_group_by_model = custom_attribute_columns_and_models.compact.group_by { |x| x[:model] }
+
+    custom_attributes_group_by_model.each do |model, custom_attribute|
+      model.load_custom_attributes_for(custom_attribute.map { |x| x[:column] })
+    end
   end
 
   def self.proto?
@@ -1539,6 +1551,35 @@ class MiqExpression
     end
   end
 
+  def custom_attribute_columns_and_models(expression = nil)
+    return custom_attribute_columns_and_models(exp).uniq if expression.nil?
+
+    case expression
+    when Array
+      expression.flat_map { |x| custom_attribute_columns_and_models(x) }
+    when Hash
+      expression_values = expression.values
+      return [] unless expression.keys.first
+
+      if expression.keys.first == "field"
+        begin
+          field = Field.parse(expression_values.first)
+        rescue StandardError => err
+          _log.error("Cannot parse field #{field}" + err.message)
+          _log.log_backtrace(err)
+        end
+
+        return [] unless field
+
+        field.custom_attribute_column? ? [:model => field.model, :column => field.column] : []
+      else
+        expression.keys.first.casecmp('find').try(:zero?) ? [] : custom_attribute_columns_and_models(expression_values)
+      end
+    else
+      []
+    end
+  end
+
   def custom_attribute_columns(expression = nil)
     return custom_attribute_columns(exp).uniq if expression.nil?
 
@@ -1552,7 +1593,7 @@ class MiqExpression
         field = Field.parse(expression_values.first)
         field.custom_attribute_column? ? [field.column] : []
       else
-        expression.keys.first.casecmp('find').zero? ? [] : custom_attribute_columns(expression_values)
+        expression.keys.first.casecmp('find').try(:zero?) ? [] : custom_attribute_columns(expression_values)
       end
     else
       []

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1,4 +1,16 @@
 describe MiqExpression do
+  context "virtual custom attributes" do
+    let(:virtual_custom_attribute) { "virtual_custom_attribute_attribute" }
+    let(:klass)                    { Vm }
+    let(:vm)                       { FactoryGirl.create(:vm) }
+
+    it "automatically loads virtual custom attributes from MiqExpression on class" do
+      expect do
+        MiqExpression.new("EQUAL" => {"field" => "#{klass}-#{virtual_custom_attribute}", "value" => "foo"})
+      end.to change { vm.respond_to?(virtual_custom_attribute) }.from(false).to(true)
+    end
+  end
+
   describe "#to_sql" do
     it "generates the SQL for an EQUAL expression" do
       sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-name", "value" => "foo"}).to_sql


### PR DESCRIPTION
Load virtual custom columns  == create dynamically method which is virtual and such methods 
contain loading attributes from table CustomAttribute and we are getting ability that attributes in CustomAttribute#name have behavior as normal column.

If we have some in MiqExpression we need to load them first. This PR is moving loading when MiqExpression object is created.

* this is fixing filtering advanced search by custom attributes
* future clean up https://github.com/ManageIQ/manageiq/issues/11365

@miq-bot assign @gtanzillo 

can you please review?
 @imtayadeway @alongoldboim 


WIP: requires fix: https://github.com/ManageIQ/manageiq/pull/11380 and https://github.com/ManageIQ/manageiq/pull/11415 [unmerged]

