### PR TITLE
fix ar_virtual delegate error

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -150,7 +150,7 @@ module VirtualDelegates
           "end"
         ].join ';'
       else
-        exception = %(raise DelegationError, "#{self}##{method_name} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
+        exception = %(raise Module::DelegationError, "#{self}##{method_name} delegated to #{to}.#{method}, but #{to} is nil: \#{self.inspect}")
 
         method_def = [
           "def #{method_name}(#{definition})",


### PR DESCRIPTION
**before:**

raised a class not defined error when delegating to a `nil`
and `:allow_nil => true` is not passed in.
(we don't do this, but best to fix just in case)

**after:**

raise a delegation error that we are attempting to delegate to a nil object.