### PR TITLE
Add tenant relationship to objects to support ownership mapping.

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -6,6 +6,7 @@ class CloudNetwork < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :orchestration_stack
 
   has_many :cloud_subnets, :dependent => :destroy

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -1,6 +1,7 @@
 class CloudObjectStoreContainer < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
   has_many   :cloud_object_store_objects
 
   acts_as_miq_taggable

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -1,6 +1,7 @@
 class CloudObjectStoreObject < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :cloud_object_store_container
 
   acts_as_miq_taggable

--- a/app/models/cloud_resource_quota.rb
+++ b/app/models/cloud_resource_quota.rb
@@ -1,6 +1,7 @@
 class CloudResourceQuota < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
 
   virtual_column :used, :type => :integer
 

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -7,6 +7,7 @@ class CloudSubnet < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_network
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :availability_zone
   belongs_to :network_group
   belongs_to :network_router

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -9,6 +9,7 @@ class CloudVolume < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :availability_zone
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :base_snapshot, :class_name => 'CloudVolumeSnapshot', :foreign_key => :cloud_volume_snapshot_id
   has_many   :cloud_volume_backups
   has_many   :cloud_volume_snapshots

--- a/app/models/cloud_volume_backup.rb
+++ b/app/models/cloud_volume_backup.rb
@@ -7,4 +7,6 @@ class CloudVolumeBackup < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :availability_zone
   belongs_to :cloud_volume
+  belongs_to :cloud_tenant
+  belongs_to :tenant
 end

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -6,6 +6,7 @@ class CloudVolumeSnapshot < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :cloud_volume
   has_many   :based_volumes, :class_name => 'CloudVolume'
 

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -8,6 +8,8 @@ class Flavor < ApplicationRecord
   has_many   :vms
   has_many   :cloud_tenant_flavors, :dependent => :destroy
   has_many   :cloud_tenants, :through => :cloud_tenant_flavors
+  has_many   :tenant_flavors, :dependent => :destroy
+  has_many   :tenants, :through => :tenant_flavors
 
   virtual_total :total_vms, :vms
 

--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -7,6 +7,7 @@ class FloatingIp < ApplicationRecord
   # any network_port used
   belongs_to :vm
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :cloud_network
   belongs_to :network_port
   belongs_to :network_router

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -4,6 +4,7 @@ class NetworkPort < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :device, :polymorphic => true
 
   has_many :network_port_security_groups

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -6,6 +6,7 @@ class NetworkRouter < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :network_group
   belongs_to :cloud_network
 

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -7,6 +7,7 @@ class SecurityGroup < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_network
   belongs_to :cloud_tenant
+  belongs_to :tenant
   belongs_to :orchestration_stack
   belongs_to :network_group
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -24,6 +24,21 @@ class Tenant < ApplicationRecord
   has_many :service_template_catalogs
   has_many :service_templates
 
+  has_many :cloud_networks
+  has_many :cloud_subnets
+  has_many :cloud_object_store_containers
+  has_many :cloud_object_store_objects
+  has_many :cloud_resource_quotas
+  has_many :cloud_volumes
+  has_many :cloud_volume_backups
+  has_many :cloud_volume_snapshots
+  has_many :floating_ips
+  has_many :network_ports
+  has_many :network_routers
+  has_many :security_groups
+  has_many :tenant_flavors, :dependent => :destroy
+  has_many :flavors, :through => :tenant_flavors
+
   has_many :tenant_quotas
   has_many :miq_groups
   has_many :users, :through => :miq_groups

--- a/app/models/tenant_flavor.rb
+++ b/app/models/tenant_flavor.rb
@@ -1,0 +1,4 @@
+class TenantFlavor < ApplicationRecord
+  belongs_to :tenant
+  belongs_to :flavor
+end

--- a/db/migrate/20160919175447_add_tenant_relationship_to_objects.rb
+++ b/db/migrate/20160919175447_add_tenant_relationship_to_objects.rb
@@ -1,0 +1,23 @@
+class AddTenantRelationshipToObjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :security_groups,               :tenant_id, :bigint
+    add_column :floating_ips,                  :tenant_id, :bigint
+    add_column :cloud_networks,                :tenant_id, :bigint
+    add_column :cloud_subnets,                 :tenant_id, :bigint
+    add_column :cloud_resource_quotas,         :tenant_id, :bigint
+    add_column :cloud_object_store_containers, :tenant_id, :bigint
+    add_column :cloud_object_store_objects,    :tenant_id, :bigint
+    add_column :network_ports,                 :tenant_id, :bigint
+    add_column :network_routers,               :tenant_id, :bigint
+    add_column :cloud_volumes,                 :tenant_id, :bigint
+    add_column :cloud_volume_snapshots,        :tenant_id, :bigint
+    add_column :cloud_volume_backups,          :tenant_id, :bigint
+    add_column :cloud_volume_backups,          :cloud_tenant_id, :bigint
+
+    create_table :tenant_flavors do |t|
+      t.column :tenant_id, :bigint
+      t.column :flavor_id, :bigint
+    end
+    add_index :tenant_flavors, [:tenant_id, :flavor_id], :unique => true
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -287,6 +287,7 @@ cloud_networks:
 - vlan_transparent
 - extra_attributes
 - type
+- tenant_id
 cloud_object_store_containers:
 - id
 - ems_ref
@@ -295,6 +296,7 @@ cloud_object_store_containers:
 - bytes
 - ems_id
 - cloud_tenant_id
+- tenant_id
 cloud_object_store_objects:
 - id
 - ems_ref
@@ -306,6 +308,7 @@ cloud_object_store_objects:
 - ems_id
 - cloud_tenant_id
 - cloud_object_store_container_id
+- tenant_id
 cloud_resource_quotas:
 - id
 - ems_ref
@@ -317,6 +320,7 @@ cloud_resource_quotas:
 - cloud_tenant_id
 - created_at
 - updated_at
+- tenant_id
 cloud_services:
 - id
 - ems_ref
@@ -353,6 +357,7 @@ cloud_subnets:
 - network_router_id
 - network_group_id
 - parent_cloud_subnet_id
+- tenant_id
 cloud_subnets_network_ports:
 - id
 - cloud_subnet_id
@@ -392,6 +397,8 @@ cloud_volume_backups:
 - has_dependent_backups
 - cloud_volume_id
 - availability_zone_id
+- tenant_id
+- cloud_tenant_id
 cloud_volume_snapshots:
 - id
 - type
@@ -404,6 +411,7 @@ cloud_volume_snapshots:
 - creation_time
 - size
 - cloud_tenant_id
+- tenant_id
 cloud_volumes:
 - id
 - type
@@ -419,6 +427,7 @@ cloud_volumes:
 - bootable
 - creation_time
 - cloud_tenant_id
+- tenant_id
 compliance_details:
 - id
 - compliance_id
@@ -1325,6 +1334,7 @@ floating_ips:
 - cloud_network_id
 - fixed_ip_address
 - status
+- tenant_id
 generic_object_definitions:
 - id
 - name
@@ -5347,6 +5357,7 @@ network_ports:
 - binding_virtual_interface_type
 - extra_attributes
 - source
+- tenant_id
 network_ports_security_groups:
 - network_port_id
 - security_group_id
@@ -5363,6 +5374,7 @@ network_routers:
 - status
 - extra_attributes
 - network_group_id
+- tenant_id
 networks:
 - id
 - hardware_id
@@ -6252,6 +6264,7 @@ security_groups:
 - cloud_tenant_id
 - orchestration_stack_id
 - network_group_id
+- tenant_id
 security_groups_vms:
 - security_group_id
 - vm_id
@@ -6501,6 +6514,10 @@ taggings:
 tags:
 - id
 - name
+tenant_flavors:
+- id
+- tenant_id
+- flavor_id
 tenant_quotas:
 - id
 - tenant_id


### PR DESCRIPTION
This adds a direct relationship to the MIQ Tenant object for objects that currently only have a relationship to CloudTenant. This is already done for VMs, this changeset brings the other models into line with that. This is necessary to support the Tenant/CloudTenant mapping work being done.

@tzumainn @lpichler