### PR TITLE
ArVirtual use sql attribute

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -143,6 +143,7 @@ module VirtualDelegates
       if allow_nil
         method_def = [
           "def #{method_name}(#{definition})",
+          "return self[:#{method_name}] if has_attribute?(:#{method_name})",
           "_ = #{to}",
           "if !_.nil? || nil.respond_to?(:#{method})",
           "  _.#{method}(#{definition})",
@@ -154,6 +155,7 @@ module VirtualDelegates
 
         method_def = [
           "def #{method_name}(#{definition})",
+          "return self[:#{method_name}] if has_attribute?(:#{method_name})",
           " _ = #{to}",
           "  _.#{method}(#{definition})#{default}",
           "rescue NoMethodError => e",

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -549,8 +549,8 @@ describe VirtualFields do
         it "delegates to child (sql)" do
           TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
           TestClass.create(:id => 2, :ref2 => child)
-          tcs = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:child_col1).as("x"))
-          expect(tcs.map(&:x)).to match_array([nil, 2])
+          tcs = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:child_col1).as("child_col1")).to_a
+          expect { expect(tcs.map(&:child_col1)).to match_array([nil, 2]) }.to match_query_limit_of(0)
         end
       end
     end


### PR DESCRIPTION
Overview
---------

```ruby
class VmOrTemplate < ActiveRecord::Base
  belongs_do :host
  virtual_delegate :name, :to => :host, :allow_nil => true, :prefix => true
end
```

The `virtual_delegate` defines a virtual attribute that can be used by sql:

```ruby
vm = VmOrTemplate.where(:host_name => "bighost").first
```

But once the primary record (e.g.:`vm`) is in memory, the delegation works on ruby objects. So the `host` record will need to be loaded to access `host_name`.

This works well most of the time, but for reports, this causes many records to be loaded into memory.

This PR will use a virtual_attribute if it is part of the primary record's sql attributes loaded from the primary query.

**before:**

Bring back source records. (the join id must be in the query)
Bring back target records (either via `MiqPreload`, `:include =>` or N+1)

```ruby
VmOrTemplate.select(:id, :name, :host_id, \
                    VmOrTemplate.arel_attribute(:host_name).as("host_name")) \
            .map(&:host_name)

  VmOrTemplate Load (0.5ms)
  VmOrTemplate Inst Including Associations (0.3ms - 20rows)
  Host Load (0.3ms)
  Host Inst Including Associations (0.1ms - 1rows)
  Host Load (0.3ms)
  Host Inst Including Associations (0.1ms - 1rows)
  Host Load (0.3ms)
  Host Inst Including Associations (0.1ms - 1rows)
  ... 20 times in total

# preloading alternate

VmOrTemplate.select(:id, :name, :host_id, \
                    VmOrTemplate.arel_attribute(:host_name).as("host_name"))
            .includes(:host).map(&:host_name)
  VmOrTemplate Load (0.5ms)
  VmOrTemplate Inst Including Associations (0.4ms - 20rows)
  Host Load (0.4ms)
  Host Inst Including Associations (0.2ms - 1rows)
```

**after:**

```ruby
VmOrTemplate.select(:id, :name, :host_id, \
                    VmOrTemplate.arel_attribute(:host_name).as("host_name")) \
            .map(&:host_name)
  VmOrTemplate Load (0.4ms)
  VmOrTemplate Inst Including Associations (0.4ms - 20rows)
```
