### PR TITLE
Generalize config management mixin for region and zone

### DIFF
--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -46,8 +46,7 @@ class MiqDatabase < ApplicationRecord
   def update_repo_name=(repos)
     return unless repos
     hash = {:product => {:update_repo_names => repos.split}}
-    Vmdb::Settings.save!(MiqRegion.my_region, hash)
-    Settings.reload!
+    MiqRegion.my_region.add_settings_for_resource(hash)
   end
 
   def self.seed

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -2,7 +2,6 @@ class MiqRegion < ApplicationRecord
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger
-  has_many :settings_changes, :as => :resource, :dependent => :destroy
 
   virtual_has_many :database_backups,       :class_name => "DatabaseBackup"
   virtual_has_many :ext_management_systems, :class_name => "ExtManagementSystem"
@@ -25,6 +24,7 @@ class MiqRegion < ApplicationRecord
   include UuidMixin
   include NamingSequenceMixin
   include AggregationMixin
+  include ConfigurationManagementMixin
 
   include MiqPolicyMixin
   include Metric::CiMixin
@@ -67,6 +67,10 @@ class MiqRegion < ApplicationRecord
 
   def miq_servers
     MiqServer.in_region(region_number)
+  end
+
+  def servers_for_settings_reload
+    miq_servers.where(:status => "started")
   end
 
   def active_miq_servers

--- a/app/models/mixins/configuration_management_mixin.rb
+++ b/app/models/mixins/configuration_management_mixin.rb
@@ -1,0 +1,27 @@
+module ConfigurationManagementMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :settings_changes, :as => :resource, :dependent => :destroy
+  end
+
+  def settings_for_resource
+    Vmdb::Settings.for_resource(self)
+  end
+
+  def add_settings_for_resource(settings)
+    Vmdb::Settings.save!(self, settings)
+    # Reload the settings immediately for this worker. This is typically a UI
+    # worker making the change, who will need to see the changes right away.
+    Vmdb::Settings.reload!
+
+    # Reload the settings for all workers on the servers whether local or remote.
+    reload_all_server_settings
+  end
+
+  def reload_all_server_settings
+    servers_for_settings_reload.each do |server|
+      server.enqueue_for_server("reload_settings") if server.started?
+    end
+  end
+end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -14,7 +14,6 @@ class Zone < ApplicationRecord
   has_many :storage_managers
   has_many :ldap_regions
   has_many :providers
-  has_many :settings_changes, :as => :resource, :dependent => :destroy
 
   virtual_has_many :hosts,              :uses => {:ext_management_systems => :hosts}
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
@@ -27,9 +26,14 @@ class Zone < ApplicationRecord
 
   include Metric::CiMixin
   include AggregationMixin
+  include ConfigurationManagementMixin
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)
+  end
+
+  def servers_for_settings_reload
+    miq_servers.where(:status => "started")
   end
 
   def find_master_server

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -75,7 +75,7 @@ module Vmdb
     private_class_method :configure_external_loggers
 
     def self.apply_config_value(config, logger, key, mirror_key = nil)
-      return if logger == Vmdb.null_logger
+      return if logger.kind_of?(Vmdb::Loggers::NullLogger)
       apply_config_value_logged(config, logger, :level, key)
       apply_config_value_logged(config, logger, :mirror_level, mirror_key) if mirror_key
     end

--- a/spec/controllers/ops_controller/settings/common_spec.rb
+++ b/spec/controllers/ops_controller/settings/common_spec.rb
@@ -136,7 +136,7 @@ describe OpsController do
       before do
         MiqDatabase.seed
         MiqRegion.seed
-        EvmSpecHelper.create_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server(:zone => Zone.seed)
       end
 
       it "won't render form buttons after rhn settings submission" do

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -35,4 +35,40 @@ describe MiqServer, "::ConfigurationManagement" do
       include_examples "#get_config"
     end
   end
+
+  context "ConfigurationManagementMixin" do
+    let(:miq_server) { FactoryGirl.create(:miq_server) }
+
+    describe "#settings_for_resource" do
+      it "returns the resource's settings" do
+        settings = {:some_thing => [1, 2, 3]}
+        stub_settings(settings)
+        expect(miq_server.settings_for_resource.to_hash).to eq(settings)
+      end
+    end
+
+    describe "#add_settings_for_resource" do
+      it "sets the specified settings" do
+        settings = {:some_test_setting => {:setting => 1}}
+        expect(miq_server).to receive(:reload_all_server_settings)
+
+        miq_server.add_settings_for_resource(settings)
+
+        expect(Vmdb::Settings.for_resource(miq_server).some_test_setting.setting).to eq(1)
+      end
+    end
+
+    describe "#reload_all_server_settings" do
+      it "queues #reload_settings for the started servers" do
+        FactoryGirl.create(:miq_server, :status => "started")
+
+        miq_server.reload_all_server_settings
+
+        expect(MiqQueue.count).to eq(1)
+        message = MiqQueue.first
+        expect(message.instance_id).to eq(miq_server.id)
+        expect(message.method_name).to eq("reload_settings")
+      end
+    end
+  end
 end

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -1,6 +1,6 @@
 describe MiqServer do
   before do
-    _, @server, = EvmSpecHelper.create_guid_miq_server_zone
+    @server = EvmSpecHelper.local_miq_server(:zone => Zone.seed)
   end
 
   let!(:database) do


### PR DESCRIPTION
This PR extracts the configuration handling from https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_server/configuration_management.rb and makes it usable for other resources that are currently usable as settings resources (`Zone` and `MiqRegion`).

This is a follow up to https://github.com/ManageIQ/manageiq/pull/11304 which added yum repo names as a config parameter attached to a region resource, rather than being in a database column.
Specifically, this PR is required to address the feedback [here](https://github.com/ManageIQ/manageiq/pull/11304#r79164661).

Using the `#add_settings_for_resource` method will both refresh the settings for the current worker as well as enqueue messages for all other servers that could be affected by the change.

@Fryguy please review
@miq-bot add_label core, enhancement