### PR TITLE
Fix wrong format of column in specs of MiqExpression

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2183,9 +2183,9 @@ describe MiqExpression do
     end
 
     it "supports sql for model.association-virtualfield (with arel)" do
-      field = "Host.vms.archived"
+      field = "Host.vms-archived"
       expression = {"=" => {"field" => field, "value" => "true"}}
-      expect(described_class.new(expression).sql_supports_atom?(expression)).to eq(false)
+      expect(described_class.new(expression).sql_supports_atom?(expression)).to eq(true)
     end
 
     it "does not supports sql for model.association-virtualfield (no arel)" do


### PR DESCRIPTION
before column is always "-"

cc @imtayadeway 

@miq-bot assign @gtanzillo 
