### PR TITLE
Use correct adjustment in chargeback reports

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -42,15 +42,16 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def hourly(rate)
-    case per_time
-    when "hourly"  then rate
-    when "daily"   then rate / 24
-    when "weekly"  then rate / 24 / 7
-    when "monthly" then rate / 24 / 30
-    when "yearly"  then rate / 24 / 365
-    else raise "rate time unit of '#{per_time}' not supported"
-    end
+    hourly_rate = case per_time
+                  when "hourly"  then rate
+                  when "daily"   then rate / 24
+                  when "weekly"  then rate / 24 / 7
+                  when "monthly" then rate / 24 / 30
+                  when "yearly"  then rate / 24 / 365
+                  else raise "rate time unit of '#{per_time}' not supported"
+                  end
 
+    rate_adjustment(hourly_rate)
   end
 
   # Scale the rate in the unit difine by user to the default unit of the metric

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -367,10 +367,8 @@ describe ChargebackVm do
       expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes *
-                                                   @count_hourly_rate *
-                                                   @metric_size)
-      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage * @count_hourly_rate * @metric_size)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
   end
@@ -604,10 +602,8 @@ describe ChargebackVm do
       expect(subject.storage_used_metric).to eq(@vm_used_disk_storage.gigabytes * @metric_size)
       expect(subject.storage_metric).to eq(subject.storage_allocated_metric + subject.storage_used_metric)
 
-      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage.gigabytes *
-                                                   @count_hourly_rate *
-                                                   @metric_size)
-      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage.gigabytes * @count_hourly_rate * @metric_size)
+      expect(subject.storage_allocated_cost).to eq(@vm_allocated_disk_storage * @count_hourly_rate * @metric_size)
+      expect(subject.storage_used_cost).to eq(@vm_used_disk_storage * @count_hourly_rate * @metric_size)
       expect(subject.storage_cost).to eq(subject.storage_allocated_cost + subject.storage_used_cost)
     end
 


### PR DESCRIPTION
Costs of [Storage|Memory] [used|allocated] were wrong.

Caused by https://github.com/ManageIQ/manageiq/pull/5828
that in https://github.com/miq-consumption/manageiq/blob/5a0c474a5be974d11e4404631f5c31749fdcad37/app/models/chargeback_rate_detail.rb 
method `hourly_rate` has been replaced by `hourly`  but without adjusting according to per_unit  `rate_adjustment(hr)`

before
![screen shot 2016-09-20 at 15 06 12](https://cloud.githubusercontent.com/assets/14937244/18671406/3c2677a2-7f44-11e6-8901-822bcab6630f.png)

after
![screen shot 2016-09-20 at 15 02 43](https://cloud.githubusercontent.com/assets/14937244/18671333/1179d774-7f44-11e6-979f-d67777672d6c.png)




Fix is about using correct adjustment for storage and memory metrics
We was using bad unit for calculating cost of
derived_vm_allocated_disk_storage
derived_vm_used_disk_storage
derived_memory_used
derived_memory_available
fyi @zeari 

@miq-bot assign @gtanzillo 
