### PR TITLE
Remove div_num from flash_msg_div.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -361,17 +361,14 @@ class ApplicationController < ActionController::Base
       if @sb[:active_tab] == "diagnostics_database"
         # coming from diagnostics/database tab
         pfx = "dbbackup"
-        flash_div_num = "database"
       end
     else
       if session[:edit] && session[:edit].key?(:pxe_id)
         # add/edit pxe server
         pfx = "pxe"
-        flash_div_num = ""
       else
         # add/edit dbbackup schedule
         pfx = "schedule"
-        flash_div_num = ""
       end
     end
 
@@ -403,7 +400,7 @@ class ApplicationController < ActionController::Base
     @changed = (@edit[:new] != @edit[:current]) if pfx == "pxe"
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_div#{flash_div_num}", :partial => "layouts/flash_msg", :locals => {:div_num => flash_div_num})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
     end
   end
 

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -11,7 +11,6 @@ module ApplicationController::Filter
   # Handle buttons pressed in the expression editor
   def exp_button
     @edit = session[:edit]
-    div_num = @edit[:flash_div_num] ? @edit[:flash_div_num] : ""
     case params[:pressed]
     when "undo", "redo"
       @edit[@expkey][:expression] = exp_array(params[:pressed].to_sym)
@@ -54,7 +53,7 @@ module ApplicationController::Filter
     if flash_errors?
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div#{div_num}", :partial => "layouts/flash_msg", :locals => {:div_num => div_num})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     else
       if ["commit", "not", "remove"].include?(params[:pressed])
@@ -70,7 +69,7 @@ module ApplicationController::Filter
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div#{div_num}", :partial => "layouts/flash_msg", :locals => {:div_num => div_num})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         #       page.replace("form_expression_div", :partial=>"form_expression")
         if !@edit[:adv_search_open].nil?
           page.replace("adv_search_body", :partial => "layouts/adv_search_body")
@@ -95,13 +94,12 @@ module ApplicationController::Filter
   # A token was pressed on the exp editor
   def exp_token_pressed
     @edit = session[:edit]
-    div_num = @edit[:flash_div_num] ? @edit[:flash_div_num] : ""
     token = params[:token].to_i
     if token == @edit[@expkey][:exp_token] || # User selected same token as already selected
        (@edit[@expkey][:exp_token] && @edit[:edit_exp].key?("???")) # or new token in process
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div#{div_num}", :partial => "layouts/flash_msg", :locals => {:div_num => div_num})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     else
       exp = exp_find_by_token(@edit[@expkey][:expression], token)
@@ -116,7 +114,7 @@ module ApplicationController::Filter
       @edit[@expkey][:exp_token] = token
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div#{div_num}", :partial => "layouts/flash_msg", :locals => {:div_num => div_num})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace("exp_editor_div", :partial => "layouts/exp_editor")
         page << "$('#exp_#{token}').css({'background-color': 'yellow'})"
         page << javascript_hide("exp_buttons_off")
@@ -148,7 +146,6 @@ module ApplicationController::Filter
   # Handle items changed in the expression editor
   def exp_changed
     @edit = session[:edit]
-    div_num = @edit[:flash_div_num] ? @edit[:flash_div_num] : ""
     if params[:chosen_typ] && params[:chosen_typ] != @edit[@expkey][:exp_typ] # Did the type field change?
       @edit[@expkey][:exp_typ] = params[:chosen_typ]
 
@@ -429,10 +426,10 @@ module ApplicationController::Filter
         page << javascript_prologue
         if !@refresh_partial.nil?
           if @refresh_div == "flash_msg_div"
-            page.replace(@refresh_div + div_num, :partial => @refresh_partial, :locals => {:div_num => div_num})
+            page.replace('flash_msg_div', :partial => @refresh_partial)
           end
         else
-          page.replace("flash_msg_div" + div_num, :partial => "layouts/flash_msg", :locals => {:div_num => div_num})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
           page.replace("exp_atom_editor_div", :partial => "layouts/exp_atom/editor")
 
           page << ENABLE_CALENDAR if calendar_needed?
@@ -1513,7 +1510,6 @@ module ApplicationController::Filter
       exp_array(:init, @edit[@expkey][:expression])                     # Initialize the exp array
       @edit[:adv_search_open] = false
       @edit[@expkey][:exp_model] = model.to_s
-      @edit[:flash_div_num] = "2"
     end
     @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Build the table to display the exp
     @edit[:in_explorer] = @explorer # Remember if we're in an explorer

--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -64,12 +64,7 @@ module ApplicationController::ReportDownloads
       add_flash(_("Report generation returned: Status [%{status}] Message [%{message}]") % {:status => miq_task.status, :message => miq_task.message}, :error)
       render :update do |page|
         page << javascript_prologue
-        page << "if (miqDomElementExists('flash_msg_div_report_list')){"
-        page.replace("flash_msg_div_report_list", :partial => "layouts/flash_msg",
-                                                  :locals  => {:div_num => "_report_list"})
-        page << "} else {"
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
-        page << "}"
         page << "miqSparkle(false);"
       end
     else

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -21,19 +21,9 @@ class MiqAeClassController < ApplicationController
     @record = @ae_class = MiqAeClass.find_by_id(from_cid(x_node.split('-').last))
     @sb[:active_tab] = params[:tab_id]
     c_tb = build_toolbar(center_toolbar_filename)
-    case params[:tab_id]
-    when "instances"
-      div_suffix = "_class_instances"
-    when "methods"
-      div_suffix = "_class_methods"
-    when "props"
-      div_suffix = "_class_props"
-    when "schema"
-      div_suffix = "_class_fields"
-    end
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_div#{div_suffix}", :partial => "layouts/flash_msg", :locals => {:div_num => div_suffix})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << javascript_pf_toolbar_reload('center_tb', c_tb)
       page << "miqSparkle(false);"
     end
@@ -300,21 +290,21 @@ class MiqAeClassController < ApplicationController
 
     if @sb[:action] == "miq_ae_field_seq"
       if @flash_array
-        replace_partial_div = :flash_msg_div_fields_seq
+        replace_partial_div = :flash_msg_div
         replace_partial_div_num = "_fields_seq"
       end
       update_partial_div = :class_fields_div
       update_partial = "fields_seq_form"
     elsif @sb[:action] == "miq_ae_domain_priority_edit"
       if @flash_array
-        replace_partial_div = :flash_msg_div_domains_priority
+        replace_partial_div = :flash_msg_div
         replace_partial_div_num = "_domains_priority"
       end
       update_partial_div = :ns_list_div
       update_partial = "domains_priority_form"
     elsif MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       if @flash_array
-        replace_partial_div = :flash_msg_div_copy
+        replace_partial_div = :flash_msg_div
         replace_partial_div_num = "_copy"
       end
       update_partial_div = :main_div
@@ -328,10 +318,7 @@ class MiqAeClassController < ApplicationController
       update_partial_div = :main_div
       update_partial = "all_tabs"
     end
-    presenter.replace(replace_partial_div, r[
-        :partial => "layouts/flash_msg",
-        :locals  => {:div_num => replace_partial_div_num}
-    ]) if replace_partial_div
+    presenter.replace(replace_partial_div, r[:partial => "layouts/flash_msg"]) if replace_partial_div
     presenter.update(update_partial_div, r[:partial => update_partial]) if update_partial
     if @in_a_form
       action_url =  create_action_url(nodes.first)
@@ -599,11 +586,7 @@ class MiqAeClassController < ApplicationController
       if @flash_array
         render :update do |page|
           page << javascript_prologue
-          if @sb[:row_selected]
-            page.replace("flash_msg_div_class_instances", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"})
-          else
-            page.replace("flash_msg_div_instance_fields", :partial => "layouts/flash_msg", :locals => {:div_num => "_instance_fields"})
-          end
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
         return
       end
@@ -621,11 +604,7 @@ class MiqAeClassController < ApplicationController
         @in_a_form = true
         render :update do |page|
           page << javascript_prologue
-          if @sb[:row_selected]
-            page.replace("flash_msg_div_class_instances", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"})
-          else
-            page.replace("flash_msg_div_instance_fields", :partial => "layouts/flash_msg", :locals => {:div_num => "_instance_fields"})
-          end
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         AuditEvent.success(build_saved_audit(@ae_class, @edit))
@@ -661,7 +640,7 @@ class MiqAeClassController < ApplicationController
       if @flash_array
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_class_instances", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
         return
       end
@@ -679,7 +658,7 @@ class MiqAeClassController < ApplicationController
         @in_a_form = true
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_class_instances", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         AuditEvent.success(build_created_audit(add_aeinst, @edit))
@@ -824,12 +803,11 @@ class MiqAeClassController < ApplicationController
     render :update do |page|
       page << javascript_prologue
       page << "if (miqDomElementExists('cls_method_data')){"
-      page.replace("flash_msg_div_class_methods", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_methods"})
       page << "var ta = document.getElementById('cls_method_data');"
       page << "} else {"
-      page.replace("flash_msg_div_method_inputs", :partial => "layouts/flash_msg", :locals => {:div_num => "_method_inputs"})
       page << "var ta = document.getElementById('method_data');"
       page << "}"
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "var lineHeight = ta.clientHeight / ta.rows;"
       page << "ta.scrollTop = (#{line.to_i}-1) * lineHeight;"
       if line > 0
@@ -1028,7 +1006,7 @@ class MiqAeClassController < ApplicationController
         @changed = true
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_class_props", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_props"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqAeClass"), :name => ae_class.fqname})
@@ -1074,9 +1052,7 @@ class MiqAeClassController < ApplicationController
         session[:changed] = @changed = true
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_class_fields",
-                       :partial => "layouts/flash_msg",
-                       :locals  => {:div_num => "_class_fields"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         add_flash(_("Schema for %{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqAeClass"), :name => ae_class.name})
@@ -1121,9 +1097,7 @@ class MiqAeClassController < ApplicationController
         @changed = true
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_ns_list",
-                       :partial => "layouts/flash_msg",
-                       :locals  => {:div_num => "_ns_list"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => @edit[:typ]), :name  => ae_ns.name})
@@ -1172,11 +1146,7 @@ class MiqAeClassController < ApplicationController
         @changed = true
         render :update do |page|
           page << javascript_prologue
-          if @sb[:row_selected]
-            page.replace("flash_msg_div_class_methods", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_methods"})
-          else
-            page.replace("flash_msg_div_method_inputs", :partial => "layouts/flash_msg", :locals => {:div_num => "_method_inputs"})
-          end
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqAeMethod"), :name => ae_method.name})
@@ -1246,7 +1216,7 @@ class MiqAeClassController < ApplicationController
         @in_a_form = true
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_class_props", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_props"})
+          page.replace("flash_msg", :partial => "layouts/flash_msg")
         end
       else
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqAeClass"), :name => add_aeclass.fqname})
@@ -1284,7 +1254,7 @@ class MiqAeClassController < ApplicationController
         @in_a_form = true
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_class_methods", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_methods"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqAeMethod"), :name => add_aemethod.name})
@@ -1325,9 +1295,7 @@ class MiqAeClassController < ApplicationController
         end
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_ns_list",
-                       :partial => "layouts/flash_msg",
-                       :locals  => {:div_num => "_ns_list"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       end
     else
@@ -1470,9 +1438,7 @@ class MiqAeClassController < ApplicationController
     @changed = (@edit[:new] != @edit[:current])
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_div_fields_seq",
-                   :partial => "layouts/flash_msg",
-                   :locals  => {:div_num => "_fields_seq"}) unless @refresh_div && @refresh_div != "column_lists"
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg") unless @refresh_div && @refresh_div != "column_lists"
       page.replace(@refresh_div, :partial => @refresh_partial) if @refresh_div
       if @changed
         page << javascript_for_miq_button_visibility(@changed)
@@ -1531,9 +1497,7 @@ class MiqAeClassController < ApplicationController
     render :update do |page|
       page << javascript_prologue
       changed = (@edit[:new] != @edit[:current])
-      page.replace("flash_msg_div_domains_priority",
-                   :partial => "layouts/flash_msg",
-                   :locals  => {:div_num => "_domains_priority"}) if @flash_array
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg") if @flash_array
       page.replace(@refresh_div,
                    :partial => @refresh_partial,
                    :locals  => {:action => "domains_priority_edit"}) if @refresh_div
@@ -1618,7 +1582,7 @@ class MiqAeClassController < ApplicationController
     @changed = @edit[:new][:override_source] if @edit[:new][:namespace].nil?
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_div_copy", :partial => "layouts/flash_msg", :locals  => {:div_num => "_copy"})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page.replace("form_div", :partial => "copy_objects_form") if params[:domain] || params[:override_source]
       page << javascript_for_miq_button_visibility(@changed)
     end
@@ -1738,7 +1702,7 @@ class MiqAeClassController < ApplicationController
         {:record => ui_lookup(:model => @edit[:typ].to_s), :error_message => bang.message}, :error)
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div_copy", :partial => "layouts/flash_msg", :locals  => {:div_num => "_copy"})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     else
       model = @edit[:selected_items].count > 1 ? :models : :model

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -291,21 +291,18 @@ class MiqAeClassController < ApplicationController
     if @sb[:action] == "miq_ae_field_seq"
       if @flash_array
         replace_partial_div = :flash_msg_div
-        replace_partial_div_num = "_fields_seq"
       end
       update_partial_div = :class_fields_div
       update_partial = "fields_seq_form"
     elsif @sb[:action] == "miq_ae_domain_priority_edit"
       if @flash_array
         replace_partial_div = :flash_msg_div
-        replace_partial_div_num = "_domains_priority"
       end
       update_partial_div = :ns_list_div
       update_partial = "domains_priority_form"
     elsif MIQ_AE_COPY_ACTIONS.include?(@sb[:action])
       if @flash_array
         replace_partial_div = :flash_msg_div
-        replace_partial_div_num = "_copy"
       end
       update_partial_div = :main_div
       update_partial = "copy_objects_form"

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -232,7 +232,7 @@ module OpsController::Diagnostics
     cu_repair_get_form_vars
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_divcu_repair", :partial => "layouts/flash_msg", :locals => {:div_num => "cu_repair"})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page.replace_html("diagnostics_cu_repair", :partial => "diagnostics_cu_repair_tab")
       page << "ManageIQ.calendar.calDateFrom = null;"
       page << "ManageIQ.calendar.calDateTo = new Date();"
@@ -268,7 +268,7 @@ module OpsController::Diagnostics
 
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_divcu_repair", :partial => "layouts/flash_msg", :locals => {:div_num => "cu_repair"})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page.replace_html("diagnostics_cu_repair", :partial => "diagnostics_cu_repair_tab")
       page << "ManageIQ.calendar.calDateFrom = null;"
       page << "ManageIQ.calendar.calDateTo = new Date();"
@@ -328,7 +328,7 @@ module OpsController::Diagnostics
     if @flash_array
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_divvalidate", :partial => "layouts/flash_msg", :locals => {:div_num => "validate"})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page << "miqSparkle(false);"
       end
       return
@@ -342,7 +342,7 @@ module OpsController::Diagnostics
       diagnostics_set_form_vars
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_divdatabase", :partial => "layouts/flash_msg", :locals => {:div_num => "database"})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace_html("diagnostics_database", :partial => "diagnostics_database_tab")
         page << "miqSparkle(false);"
       end
@@ -352,7 +352,7 @@ module OpsController::Diagnostics
       end
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_divdatabase", :partial => "layouts/flash_msg", :locals => {:div_num => "database"})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page << "miqSparkle(false);"
       end
     end
@@ -417,7 +417,7 @@ module OpsController::Diagnostics
     end
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_divdatabase", :partial => "layouts/flash_msg", :locals => {:div_num => "database"})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/ops_controller/settings/ldap.rb
+++ b/app/controllers/ops_controller/settings/ldap.rb
@@ -149,7 +149,7 @@ module OpsController::Settings::Ldap
       end
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div_entries", :partial => "layouts/flash_msg", :locals => {:div_num => "entries"})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     elsif params[:button] == "cancel"
       @ldap_domain = session[:edit][:ldap_domain] if session[:edit] && session[:edit][:ldap_domain]
@@ -209,7 +209,7 @@ module OpsController::Settings::Ldap
           add_flash(_("Hostname is required"), :error)
           render :update do |page|
             page << javascript_prologue
-            page.replace("flash_msg_div_entries", :partial => "layouts/flash_msg", :locals => {:div_num => "entries"})
+            page.replace("flash_msg_div", :partial => "layouts/flash_msg")
           end
           return
         else

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -762,7 +762,7 @@ class ReportController < ApplicationController
         end
         presenter.update(:main_div, r[:partial => partial])
         presenter[:element_updates][:menu1_legend] = {:legend => fieldset_title}
-        presenter.show(:menu_div1).hide(:menu_div2, :flash_msg_div_menu_list)
+        presenter.show(:menu_div1).hide(:menu_div2, :flash_msg_div)
         presenter[:element_updates][:menu_roles_treebox] = {:class => 'disabled', :add => true}
         presenter[:element_updates][:folder_top]      = {:title => img_title_top}
         presenter[:element_updates][:folder_up]       = {:title => img_title_up}
@@ -791,15 +791,15 @@ class ReportController < ApplicationController
       # set changed to true if menu has been set to default
       session[:changed] = @sb[:menu_default] ? true : (@edit[:new] != @edit[:current])
     elsif nodetype == "menu_edit_reports"
-      presenter.replace(:flash_msg_div_menu_list, r[:partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}]) if @flash_array
+      presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
       presenter.show(:menu_div1)
       presenter[:element_updates][:menu_roles_treebox] = {:class => 'disabled', :add => true}
       presenter.replace(:menu_div2, r[:partial => "menu_form2"])
       presenter.hide(:menu_div1, :menu_div3).show(:menu_div2)
     elsif nodetype == "menu_commit_reports"
-      presenter.replace(:flash_msg_div_menu_list, r[:partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}]) if @flash_array
+      presenter.replace(:flash_msg_div, r[:partial => "layouts/flash_msg"]) if @flash_array
       if @refresh_div
-        presenter.hide(:flash_msg_div_menu_list)
+        presenter.hide(:flash_msg_div)
         presenter.replace(@refresh_div.to_s, r[:partial => @refresh_partial, :locals => {:action_url => "menu_update"}])
         presenter.hide(:menu_div1)
         if params[:pressed] == "commit"
@@ -810,7 +810,7 @@ class ReportController < ApplicationController
       elsif !@flash_array
         presenter.replace(:menu_roles_div, r[:partial => "role_list"])
         if params[:pressed] == "commit"
-          presenter.hide(:flash_msg_div_menu_list).show(:menu_div3).hide(:menu_div1, :menu_div2)
+          presenter.hide(:flash_msg_div).show(:menu_div3).hide(:menu_div1, :menu_div2)
         else
           presenter.hide(:menu_div1, :menu_div3).show(:menu_div2)
         end
@@ -819,10 +819,9 @@ class ReportController < ApplicationController
     elsif nodetype == 'menu_commit_folders'
       # Hide flash_msg if it's being shown from New folder add event
       if flash_errors?
-        presenter.replace(:flash_msg_div_menu_list, r[:partial => 'layouts/flash_msg',
-                                                                   :locals  => {:div_num => '_menu_list'}])
+        presenter.replace(:flash_msg_div, r[:partial => 'layouts/flash_msg'])
       else
-        presenter.hide(:flash_msg_div_menu_list)
+        presenter.hide(:flash_msg_div)
       end
 
       if @sb[:tree_err]
@@ -834,7 +833,7 @@ class ReportController < ApplicationController
       end
       @sb[:tree_err] = false
     elsif nodetype == 'menu_discard_folders' || nodetype == 'menu_discard_reports'
-      presenter.replace(:flash_msg_div_menu_list, r[:partial => 'layouts/flash_msg', :locals => {:div_num => '_menu_list'}])
+      presenter.replace(:flash_msg_div, r[:partial => 'layouts/flash_msg'])
       presenter.replace(:menu_div1,               r[:partial => 'menu_form1', :locals => {:folders => @grid_folders}])
       presenter.hide(:menu_div1, :menu_div2).show(:menu_div3)
       presenter[:element_updates][:menu_roles_treebox] = {:class => 'disabled', :remove => true}

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -50,7 +50,7 @@ module ReportController::Menus
       add_flash(_("Double Click on 'New Folder' to edit"), :warning)
     render :update do |page|
       page << javascript_prologue
-      page.replace("flash_msg_div_menu_list", :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"})
+      page.replace("flash_msg_div", :partial => "layouts/flash_msg")
     end
   end
 

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -87,7 +87,7 @@ module ReportController::Reports
       add_flash(_("Report cannot be deleted if it's being used by one or more Widgets"), :error)
       render :update do |page|
         page << javascript_prologue
-        page.replace("flash_msg_div_report_list", :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"})
+        page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     else
       begin
@@ -100,7 +100,7 @@ module ReportController::Reports
                     {:model => ui_lookup(:model => "MiqReport"), :name => rpt_name, :message =>  bang.message}, :error)
         render :update do |page|
           page << javascript_prologue
-          page.replace("flash_msg_div_report_list", :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"})
+          page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
         return
       else

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -8,8 +8,7 @@
       = " (#{h(@edit[@expkey][:selected][:description])})"
     - elsif @edit && @edit[:adv_search_report]
       = " (from report #{h(@edit[:adv_search_report])})"
-    = render(:partial => 'layouts/flash_msg',
-             :locals  => {:div_num => "2"})
+    = render :partial => 'layouts/flash_msg'
     %br
     - if @edit && @edit[@expkey][:expression]
       = render(:partial => 'layouts/exp_editor')
@@ -51,8 +50,7 @@
                 = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
   - elsif mode == "save"
     .modal-body
-      = render(:partial => "layouts/flash_msg",
-               :locals  => {:div_num => "2"})
+      = render :partial => "layouts/flash_msg"
       .form-horizontal.static
         .form-group
           %label.control-label.col-md-5

--- a/app/views/layouts/_edit_log_depot_settings.html.haml
+++ b/app/views/layouts/_edit_log_depot_settings.html.haml
@@ -4,7 +4,7 @@
 - url       = url_for(:action => action, :id => (record.try(:id) || "new"))
 
 #form_filter_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => div_num}
+  = render :partial => "layouts/flash_msg"
   - if (@sb[:active_tree] == :diagnostics_tree && @sb[:active_tab] == "diagnostics_database") || (@sb[:active_tree] == :settings_tree)
     = _("Database Backup Settings")
   - else

--- a/app/views/layouts/_edit_log_depot_settings.html.haml
+++ b/app/views/layouts/_edit_log_depot_settings.html.haml
@@ -1,5 +1,4 @@
 - action ||= "log_depot_field_changed"
-- div_num ||= ""
 - record    = @schedule || @record
 - url       = url_for(:action => action, :id => (record.try(:id) || "new"))
 

--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -1,13 +1,12 @@
 - click_remove = true if click_remove.nil?
-- div_num ||= ""
 - top_pad ||= false
 - bottom_pad ||= false
 
-%div{:id => "flash_msg_div#{div_num}", :style => ("display: none" unless @flash_array)}
+%div{:id => "flash_msg_div", :style => ("display: none" unless @flash_array)}
   - if top_pad
     %div{:style => "padding-top: #{top_pad}px;"}
   - if @flash_array
-    %div{:id      => "flash_text_div#{div_num}"}
+    %div{:id      => "flash_text_div"}
       - @flash_array.each do |fl|
         - case fl[:level]
         - when :error

--- a/app/views/miq_ae_class/_class_add.html.haml
+++ b/app/views/miq_ae_class/_class_add.html.haml
@@ -1,5 +1,5 @@
 #add_class_props_div
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_props"}
+= render :partial => "layouts/flash_msg"
 - if @in_a_form_fields && x_node.split('-')[0] == "aec" || params[:pressed] || %w(field_select field_accept field_delete).include?(params[:action])
   #form_div
     = render :partial => "class_form"

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -2,7 +2,7 @@
   - if x_node.split('-')[0] == "aec" || params[:pressed] || %w(field_select field_accept field_delete).include?(params[:action])
     - if !@in_a_form_fields
       / Show Schema
-      = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_class_fields"}
+      = render :partial => "layouts/flash_msg"
       %h3= _('Schema')
       - if @ae_class.ae_fields.present?
         %table.table.table-striped.table-bordered
@@ -47,7 +47,7 @@
       - obs = {:interval => '.5', :url => url}.to_json
       / Edit Schema
       #form_div
-        = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_class_fields"}
+        = render :partial => "layouts/flash_msg"
         %h3= _('Schema')
         %table.table.table-striped.table-bordered
           %thead

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -1,6 +1,6 @@
 #class_instances_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"}
+    = render :partial => "layouts/flash_msg"
     %h3= _('Instances')
     - if @record.ae_instances.present?
       %table#class_instances_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
@@ -31,5 +31,5 @@
                :locals  => {:message => _("No instances found")}
   - elsif @edit[:new][:ae_inst]
     #form_div
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_instances"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "instance_form", :locals => {:prefix => "cls_"}

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -1,6 +1,6 @@
 #class_methods_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_class_methods"}
+    = render :partial => "layouts/flash_msg"
     %h3= _('Methods')
     - if @record.ae_methods.present?
       %table#class_methods_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
@@ -31,5 +31,5 @@
                :locals  => {:message => _("No methods found")}
   - elsif @edit[:new][:fields]
     #form_div
-      = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_class_methods"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "method_form", :locals  => {:prefix => "cls_"}

--- a/app/views/miq_ae_class/_class_props.html.haml
+++ b/app/views/miq_ae_class/_class_props.html.haml
@@ -1,7 +1,7 @@
 #class_props_div
   - if x_node.split('-')[0] == "aec" || params[:pressed] || ["field_select","field_accept","field_delete"].include?(params[:action]) || (x_node.split('-')[0] == "aen" && params[:button] == "reset")
     - if !@in_a_form_props
-      = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_class_props"}
+      = render :partial => "layouts/flash_msg"
       %h3= _('Properties')
       %table.table.table-striped.table-bordered
         %tbody
@@ -34,5 +34,5 @@
     - else
       #form_div
         %div{:style => "padding-top: 10px;"}
-        = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_class_props"}
+        = render :partial => "layouts/flash_msg"
         = render :partial => "class_form"

--- a/app/views/miq_ae_class/_copy_objects_form.html.haml
+++ b/app/views/miq_ae_class/_copy_objects_form.html.haml
@@ -1,5 +1,5 @@
 - url = url_for(:action => 'form_copy_objects_field_changed', :id => @edit[:rec_id])
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_copy"}
+= render :partial => "layouts/flash_msg"
 #form_div
   = hidden_div_if(!@edit[:new][:namespace], :id => "ae_tree_select_div") do
     = render(:partial => 'layouts/ae_tree_select', :locals => {:entry_point => "Namespace"})

--- a/app/views/miq_ae_class/_domains_priority_form.html.haml
+++ b/app/views/miq_ae_class/_domains_priority_form.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_domains_priority"}
+= render :partial => "layouts/flash_msg"
 #domains_list
   %table#formtest.form{:width => '50%'}
     %tr

--- a/app/views/miq_ae_class/_fields_seq_form.html.haml
+++ b/app/views/miq_ae_class/_fields_seq_form.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_fields_seq"}
+= render :partial => "layouts/flash_msg"
 #column_lists
   %p
   %table#formtest.form{:width => '50%'}

--- a/app/views/miq_ae_class/_git_domain_refresh.html.haml
+++ b/app/views/miq_ae_class/_git_domain_refresh.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_git_refresh"}
+= render :partial => "layouts/flash_msg"
 
 %form#form_div
   = hidden_field_tag(:git_repo_id, @git_repo_id, :class => "hidden-git-repo-id")

--- a/app/views/miq_ae_class/_instance_fields.html.haml
+++ b/app/views/miq_ae_class/_instance_fields.html.haml
@@ -2,7 +2,7 @@
 %h3= _('Fields')
 #instance_fields_div
   - if !@in_a_form
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_instance_fields"}
+    = render :partial => "layouts/flash_msg"
 
     %table#instance_fields_grid.table.table-striped.table-bordered
       %thead
@@ -48,5 +48,5 @@
 
   - else
     #form_div
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_instance_fields"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "instance_form", :locals => {:prefix => ""}

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -1,6 +1,6 @@
 #method_inputs_div
   - if !@in_a_form && @ae_method
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_method_inputs"}
+    = render :partial => "layouts/flash_msg"
     %h3
       = _('Main Info')
     .form-horizontal.static
@@ -73,6 +73,6 @@
               %td= record.datatype.blank? ? 'string' : record.datatype
   - else
     #method_form_div
-      = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_method_inputs"}
+      = render :partial => "layouts/flash_msg"
       = render :partial => "method_form", :locals  => {:prefix => ""}
   %br

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -1,7 +1,7 @@
 #ns_details_div
   - unless @in_a_form
     = render :partial => 'layouts/info_msg', :locals => {:message => @version_message} if @version_message
-    = render :partial => "layouts/flash_msg", :locals  => {:div_num => "_ns_details"}
+    = render :partial => "layouts/flash_msg"
     %table#ns_details_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.narrow

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -3,7 +3,7 @@
     - unless @version_messages.blank?
       - @version_messages.each do |msg|
         = render :partial => 'layouts/info_msg', :locals => {:message => msg}
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
+    = render :partial => "layouts/flash_msg"
     %table#ns_list_grid.table.table-striped.table-bordered.table-hover.table-clickable.table-checkable
       %thead
         %th.narrow
@@ -41,7 +41,7 @@
 
   - else
     - url = url_for(:action => 'form_ns_field_changed', :id => "#{@ae_ns.id || 'new'}")
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "_ns_list"}
+    = render :partial => "layouts/flash_msg"
     #form_ns_div
       %h3
         = _('Info')

--- a/app/views/miq_capacity/_bottlenecks_report.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_report.html.haml
@@ -2,7 +2,7 @@
   - if x_node == ""
     = render :partial => 'layouts/info_msg', :locals => {:message => _("Select a node on the left to view Bottlenecks report.")}
   - else
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "2"}
+    = render :partial => "layouts/flash_msg"
     = render :partial => 'bottlenecks_options', :locals  => {:typ => "report"}
     - if @sb[:bottlenecks] && @sb[:bottlenecks][:report]
       %hr

--- a/app/views/miq_capacity/_bottlenecks_summary.html.haml
+++ b/app/views/miq_capacity/_bottlenecks_summary.html.haml
@@ -2,6 +2,6 @@
   - if x_node == ""
     = render :partial => 'layouts/info_msg', :locals => {:message => _("Select a node on the left to view Bottlenecks timeline.")}
   - else
-    = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+    = render :partial => "layouts/flash_msg"
     = render :partial => 'bottlenecks_options', :locals  => {:typ => "summ"}
   = render :partial => 'bottlenecks_tl_detail'

--- a/app/views/miq_capacity/_planning_options.html.haml
+++ b/app/views/miq_capacity/_planning_options.html.haml
@@ -1,7 +1,7 @@
 - url = url_for(:action => 'planning_option_changed')
 -# Div to hold the planning options
 #planning_options_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "0"}
+  = render :partial => "layouts/flash_msg"
   %h3
     = _('Reference VM Selection')
   .form.horizontal

--- a/app/views/miq_capacity/_planning_report.html.haml
+++ b/app/views/miq_capacity/_planning_report.html.haml
@@ -1,5 +1,5 @@
 #planning_report_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "3"}
+  = render :partial => "layouts/flash_msg"
 
   - if @perf_record && @sb[:planning] && @sb[:planning][:rpt]
 

--- a/app/views/miq_capacity/_planning_summary.html.haml
+++ b/app/views/miq_capacity/_planning_summary.html.haml
@@ -1,6 +1,6 @@
 - url = url_for(:action => 'planning_option_changed')
 #planning_summary_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+  = render :partial => "layouts/flash_msg"
   - if @perf_record
     %h3= _('Display Options')
     %dl.dl-horizontal

--- a/app/views/miq_capacity/_utilization_details.html.haml
+++ b/app/views/miq_capacity/_utilization_details.html.haml
@@ -1,5 +1,5 @@
 #utilization_details_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "2"}
+  = render :partial => "layouts/flash_msg"
   - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "details"}
     = render(:partial => "layouts/perf_charts",

--- a/app/views/miq_capacity/_utilization_report.html.haml
+++ b/app/views/miq_capacity/_utilization_report.html.haml
@@ -1,5 +1,5 @@
 #utilization_report_div
-  = render :partial => "layouts/flash_msg", :locals  => {:div_num => "3"}
+  = render :partial => "layouts/flash_msg"
   - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
     = render :partial => "utilization_options", :locals => {:cap_type => "report"}
     %hr

--- a/app/views/miq_capacity/_utilization_summary.html.haml
+++ b/app/views/miq_capacity/_utilization_summary.html.haml
@@ -1,5 +1,5 @@
 #utilization_summary_div
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "1"}
+  = render :partial => "layouts/flash_msg"
   - if @sb[:util] && @sb[:util][:trend_rpt] && @sb[:util][:summary]
     = render :partial => "utilization_options", :locals  => {:cap_type => "summ"}
     = render(:partial => "layouts/perf_charts",

--- a/app/views/ops/_diagnostics_cu_repair_tab.html.haml
+++ b/app/views/ops/_diagnostics_cu_repair_tab.html.haml
@@ -5,7 +5,7 @@
   :javascript
     ManageIQ.calendar.calDateFrom = null;
     ManageIQ.calendar.calDateTo = new Date();
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => "cu_repair"}
+  = render :partial => "layouts/flash_msg"
 
   %h3= _("Collection Options")
   .form-horizontal

--- a/app/views/ops/_ldap_server_entries.html.haml
+++ b/app/views/ops/_ldap_server_entries.html.haml
@@ -1,6 +1,5 @@
 #ldap_server_entries_div
-  = render :partial => "layouts/flash_msg",
-           :locals  => {:div_num => "_entries"}
+  = render :partial => "layouts/flash_msg"
   %fieldset
     %h3= _("LDAP Servers")
     %table.table.table-striped.table-bordered.table-hover

--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -8,7 +8,7 @@
                                'data-save-url'                       => "/#{controller_name}/log_depot_edit/",
                                'data-log-protocol-changed-url'       => "/#{controller_name}/log_protocol_changed/",
                                :novalidate                           => 1}
-  = render :partial => "layouts/flash_msg", :locals => {:div_num => div_num}
+  = render :partial => "layouts/flash_msg"
 
   %h3
     = _("Editing Log Depot Settings for %{class}: %{display}") % {:class   => Dictionary.gettext(@record.class.name,

--- a/app/views/ops/_log_collection.html.haml
+++ b/app/views/ops/_log_collection.html.haml
@@ -1,5 +1,4 @@
 - @angular_form = true
-- div_num ||= ""
 
 %form.form-horizontal#form_div{:name                                 => "angularForm",
                                'ng-controller'                       => "logCollectionFormController",

--- a/app/views/report/_report_info.html.haml
+++ b/app/views/report/_report_info.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+= render :partial => "layouts/flash_msg"
 - if @sb[:active_tab] == "report_info"
   - if @sb[:miq_report_id] && @miq_report
     .form-horizontal.static

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -3,7 +3,7 @@
     - if @in_a_form
       = render :partial => 'form'
     - elsif @report && !@report_result
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+      = render :partial => "layouts/flash_msg"
 
       - if @zgraph
         - width, height = @html ? [350, 250] : [700, 500]
@@ -25,7 +25,7 @@
       - if (nodes.length == 1 && @sb[:rpt_menu].blank?) || (nodes.length == 2 && @sb[:rpt_menu][nodes[1].to_i][1].blank?) || (nodes.length == 4 && @sb[:rpt_menu][nodes[1].to_i].present? && @sb[:rpt_menu][nodes[1].to_i][1][nodes[3].to_i][1].blank?)
         = render :partial => 'layouts/info_msg', :locals => {:message => _("No Reports available.")}
       - else
-        = render :partial => "layouts/flash_msg", :locals => {:div_num => "_report_list"}
+        = render :partial => "layouts/flash_msg"
         %table.table.table-striped.table-bordered.table-hover
           - if nodes.length == 1
             -# level1 folders list

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -1,7 +1,7 @@
 #menu_roles_div
   - if @sb[:active_accord] == :roles
     - if @menu_roles_tree
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}
+      = render :partial => "layouts/flash_msg"
       .col-sm-5
         %h3
           = _("Reports")
@@ -18,7 +18,7 @@
       = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
       = render :partial => "report/menu_form2"
     - elsif @sb[:menu]
-      = render :partial => "layouts/flash_msg", :locals => {:div_num => "_menu_list"}
+      = render :partial => "layouts/flash_msg"
       - if @sb[:menu].empty?
         = render :partial => 'layouts/info_msg', :locals => {:message => _("No Saved Reports available.")}
       - else

--- a/app/views/report/_show_schedule.html.haml
+++ b/app/views/report/_show_schedule.html.haml
@@ -1,4 +1,4 @@
-= render :partial => "layouts/flash_msg", :locals => {:div_num => "_schedule_list"}
+= render :partial => "layouts/flash_msg"
 %h3= _("Schedule Info")
 .form-horizontal.static
   .form-group


### PR DESCRIPTION
Purpose
--- 
Stop using `flash_msg_div` with `div_num`. Have a single DOM id for the flash message divs.

I went through the code and removed everything related. I expect bugs and this needs a detailed review and testing.

In particular, I suspect that there might be views where there actually are 2 `flash_msg_div` elements. E.g. on tabs that are displayed one by one. Such places need to be fixed (`flash_msg_div` moved to top and make sure there's only one).

@GregP : it would be cool, if you could take it from here or use this as an inspiration for your PRs.

Ping @AparnaKarve 

TODO Next:
---

 1. ~~this is some crazy partial that just renders a bit of javascript: `app/views/shared/ajax/_flash_msg_replace.js.haml`, used in few places --> replace with `javascript_flash(... :spinner_off => true)`~~
 1. bunch of `render :update do` blocks can be now replaced similarly to: https://github.com/ManageIQ/manageiq/pull/11318


Closes #11315 #11313 #11312 #11310 #11309