### PR TITLE
Make LiveMetrics configuration accessible at class level

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
@@ -60,10 +60,14 @@ module ManageIQ::Providers
       end
     end
 
+    def mw_server_metrics_by_column
+      MiddlewareServer.live_metrics_config['middleware_server']['supported_metrics_by_column']
+    end
+
     def generate_mw_gc_condition(eval_method, options)
       c = ::Hawkular::Alerts::Trigger::Condition.new({})
       c.trigger_mode = :FIRING
-      c.data_id = MiddlewareServer.supported_metrics_by_column[eval_method]
+      c.data_id = mw_server_metrics_by_column[eval_method]
       c.type = :RATE
       c.operator = convert_operator(options[:mw_operator])
       c.threshold = options[:value_mw_garbage_collector].to_i
@@ -71,8 +75,8 @@ module ManageIQ::Providers
     end
 
     def generate_mw_jvm_conditions(eval_method, options)
-      data_id = MiddlewareServer.supported_metrics_by_column[eval_method]
-      data2_id = MiddlewareServer.supported_metrics_by_column["mw_heap_max"]
+      data_id = mw_server_metrics_by_column[eval_method]
+      data2_id = mw_server_metrics_by_column["mw_heap_max"]
       c = []
       c[0] = generate_mw_compare_condition(data_id, data2_id, :GT, options[:value_mw_greater_than].to_f / 100)
       c[1] = generate_mw_compare_condition(data_id, data2_id, :LT, options[:value_mw_less_than].to_f / 100)

--- a/app/models/middleware_messaging.rb
+++ b/app/models/middleware_messaging.rb
@@ -21,4 +21,8 @@ class MiddlewareMessaging < ApplicationRecord
   def chart_layout_path
     "#{self.class.name.gsub(/::/, '_')}_#{messaging_type.parameterize(:separator => '_')}"
   end
+
+  def self.supported_models
+    @supported_models ||= %w(queue topic).collect { |model| name.demodulize.underscore + "_jms_#{model}" }
+  end
 end

--- a/app/models/mixins/live_metrics_mixin.rb
+++ b/app/models/mixins/live_metrics_mixin.rb
@@ -52,34 +52,40 @@ module LiveMetricsMixin
     end
 
     def included_children
-      self.class.live_metrics_config ||= {}
-      self.class.live_metrics_config[live_metrics_name] ||= load_live_metrics_config
       self.class.live_metrics_config[live_metrics_name]['included_children']
     end
 
     def supported_metrics
-      self.class.live_metrics_config ||= {}
-      self.class.live_metrics_config[live_metrics_name] ||= load_live_metrics_config
       self.class.live_metrics_config[live_metrics_name]['supported_metrics']
     end
 
     def supported_metrics_by_column
-      self.class.supported_metrics_by_column ||= {}
-      self.class.supported_metrics_by_column[live_metrics_name] ||= supported_metrics.invert
+      self.class.live_metrics_config[live_metrics_name]['supported_metrics_by_column']
+    end
+  end
+
+  module ClassMethods
+    def supported_models
+      @supported_models ||= [name.demodulize.underscore]
     end
 
-    def load_live_metrics_config
-      live_metrics_file = File.join(LIVE_METRICS_DIR, "#{live_metrics_name}.yaml")
+    def live_metrics_config
+      @live_metrics_config ||= {}
+      supported_models.each do |model_name|
+        @live_metrics_config[model_name] ||= load_live_metrics_config(model_name)
+        @live_metrics_config[model_name]['supported_metrics_by_column'] =
+          @live_metrics_config[model_name]['supported_metrics'].invert
+      end
+      @live_metrics_config
+    end
+
+    def load_live_metrics_config(config_file)
+      live_metrics_file = File.join(LIVE_METRICS_DIR, "#{config_file}.yaml")
       live_metrics_config = File.exist?(live_metrics_file) ? YAML.load_file(live_metrics_file) : {}
       if live_metrics_config['supported_metrics']
         live_metrics_config['supported_metrics'] = live_metrics_config['supported_metrics'].reduce({}, :merge)
       end
       live_metrics_config
     end
-  end
-
-  module ClassMethods
-    attr_accessor :live_metrics_config
-    attr_accessor :supported_metrics_by_column
   end
 end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource_spec.rb
@@ -98,5 +98,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareDatasource 
     }.freeze
     supported_metrics = ds.supported_metrics
     expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
+
+    _model, model_config = MiddlewareDatasource.live_metrics_config.first
+    supported_metrics = model_config['supported_metrics']
+    expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
   end
 end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_messaging_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_messaging_spec.rb
@@ -122,6 +122,10 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareMessaging d
       it "#supported_metrics for #{ms_model}" do
         supported_metrics = ms.supported_metrics
         expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
+
+        model_config = MiddlewareMessaging.live_metrics_config["middleware_messaging_jms_#{ms_model}"]
+        supported_metrics = model_config['supported_metrics']
+        expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
       end
     end
   end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/middleware_server_spec.rb
@@ -102,6 +102,10 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer do
   it "#supported_metrics" do
     supported_metrics = eap.supported_metrics
     expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
+
+    _model, model_config = MiddlewareServer.live_metrics_config.first
+    supported_metrics = model_config['supported_metrics']
+    expected_metrics.each { |k, v| expect(supported_metrics[k]).to eq(v) }
   end
 
   it "#metrics_available" do


### PR DESCRIPTION
With the inclusion of MiddlewareMessaging, LiveMetrics config was moved from class to instance.
MiddlewareMessaging is used for queues and topics so at class level there was not enough info to determine the supported metrics.
But in Middleware Alerts use cases the supported metrics are needed at class info.
So, this PR combines both approaches, let that an entity that support multiple models can load all metrics at class level and get specific ones at instance level.
Added additional specs to protect this use case in future modifications.