### PR TITLE
Allow to add a containers provider with a port other than 8443

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -7,7 +7,9 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
 
   included do
     has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
-    default_value_for :port, DEFAULT_PORT
+    default_value_for :port do |provider|
+      provider.port || DEFAULT_PORT
+    end
   end
 
   # This is the API version that we use and support throughout the entire code

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -58,7 +58,7 @@ describe "Providers API" do
       "endpoint"       => {
         "role"     => "default",
         "hostname" => "sample_openshift_multi_end_point.provider.com",
-        "port"     => "8443"
+        "port"     => 8444
       },
       "authentication" => {
         "role"     => "bearer",
@@ -271,6 +271,10 @@ describe "Providers API" do
         connection["endpoint"]["hostname"]
       end
 
+      def port(connection)
+        connection["endpoint"]["port"]
+      end
+
       def token(connection)
         connection["authentication"]["auth_key"]
       end
@@ -292,6 +296,7 @@ describe "Providers API" do
 
       expect(provider.hostname).to eq(hostname(default_connection))
       expect(provider.authentication_token).to eq(token(default_connection))
+      expect(provider.port).to eq(port(default_connection))
       expect(provider.connection_configurations.hawkular.endpoint.hostname).to eq(hostname(hawkular_connection))
       expect(provider.connection_configurations.hawkular.authentication.auth_key).to eq(token(hawkular_connection))
     end


### PR DESCRIPTION
When adding a containers provider, port 8443 is being used for the "default" role endpoint, even if a different port was specified.
Fixes #11389