### PR TITLE
API: Fix creation of Foreman provider

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -6,7 +6,7 @@ module Api
     AUTH_TYPE_ATTR    = "auth_type"
     DEFAULT_AUTH_TYPE = "default"
     CONNECTION_ATTRS  = %w(connection_configurations).freeze
-    ENDPOINT_ATTRS    = %w(hostname ipaddress port security_protocol).freeze
+    ENDPOINT_ATTRS    = %w(hostname url ipaddress port security_protocol).freeze
     RESTRICTED_ATTRS  = [TYPE_ATTR, CREDENTIALS_ATTR, ZONE_ATTR, "zone_id"]
 
     include Subcollections::Policies

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -183,7 +183,7 @@ describe "Providers API" do
       ems = ExtManagementSystem.find(provider_id)
       expect(ems.authentications.size).to eq(1)
       ENDPOINT_ATTRS.each do |attr|
-        expect(ems.send(attr)).to eq(sample_openshift[attr])
+        expect(ems.send(attr)).to eq(sample_openshift[attr]) if sample_openshift.key? attr
       end
     end
 


### PR DESCRIPTION
The foreman provider uses `:url` column of its endpoint. Without allowing :url attribute, the working foreman provider cannot be created by API.

Note that, our reference documentation already advises users to pass in the `:url` attribute. (See https://github.com/ManageIQ/manageiq_docs/blob/master/api/reference/providers.adoc#foreman-support)

@miq-bot add_label api, bug, providers/foreman
@miq-bot assign @abellotti 