### PR TITLE
Add missing Searchbar and Advanced Search button

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -788,7 +788,8 @@ module ApplicationHelper
   end
 
   def display_adv_search?
-    %w(availability_zone cloud_volume container_group container_node container_service
+    %w(auth_key_pair_cloud availability_zone cloud_object_store_container cloud_tenant cloud_volume
+       container_group container_node container_service
        container_route container_project container_replicator container_image
        container_image_registry persistent_volume container_build
        ems_container vm miq_template offline retired templates
@@ -1185,7 +1186,8 @@ module ApplicationHelper
   end
 
   def show_adv_search?
-    show_search = %w(availability_zone cim_base_storage_extent cloud_volume cloud_volume_snapshot container_group container_node container_service
+    show_search = %w(auth_key_pair_cloud availability_zone cim_base_storage_extent cloud_object_store_container
+                     cloud_tenant cloud_volume cloud_volume_snapshot container_group container_node container_service
                      container_route container_project container_replicator container_image container_image_registry
                      persistent_volume container_build
                      ems_cloud ems_cluster ems_container ems_infra flavor host miq_template offline

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,6 +345,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         protect
+        quick_search
         sections_field_changed
         show
         show_list
@@ -352,7 +353,7 @@ Vmdb::Application.routes.draw do
         tag_edit_form_field_changed
         update
       ) +
-               compare_post
+               compare_post + adv_search_post + exp_post
     },
 
     :cloud_object_store_object => {


### PR DESCRIPTION
fixing https://github.com/ManageIQ/manageiq/issues/11189

Add missing Searchbar and Advanced Search button
to Cloud Tenants, Object Stores and Key Pairs,
when reaching Compute -> Clouds -> Tenants/Object Stores/Key Pairs.

https://github.com/ManageIQ/manageiq/pull/11065 has to be merged first.

Before:
![searchbar_before](https://cloud.githubusercontent.com/assets/13417815/18677199/505a0090-7f58-11e6-8174-8c0d48978090.png)

After:
![searchbar_after](https://cloud.githubusercontent.com/assets/13417815/18677202/5518ddd6-7f58-11e6-8d3e-037516e94f27.png)
