### PR TITLE
[DARGA] Bump Azure-armrest gem version from 0.2.9 to 0.2.10

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -16,7 +16,7 @@ gem "activerecord",            "~> 5.0.0"
 # Not locally modified and not required
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.3",            :require => false
-gem "azure-armrest",           "=0.2.9",            :require => false
+gem "azure-armrest",           "=0.2.10",           :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "excon",                   "~>0.40",            :require => false


### PR DESCRIPTION
When an Azure storage account is not completely or correctly provisioned, and is left in a dysfunctional state, an exception is thrown if we try to read the associated storage key.

This armrest gem version includes PR: https://github.com/ManageIQ/azure-armrest/pull/212 which will catch any exception thrown when trying to read storage keys, ignore the storage account, then move on to the next one.

## Links 
https://msdn.microsoft.com/en-us/library/azure/mt163558.aspx
https://bugzilla.redhat.com/show_bug.cgi?id=1377416

## Steps for Testing/QA

Please pay particular attention to image inventory gathering and instance provisioning.