### PR TITLE
Enable the previously disabled ActionCable

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -44,7 +44,7 @@
         ManageIQ.browser = "#{j browser_info(:name_ui)}";
         ManageIQ.controller = "#{j controller_name}";
         API.autorenew();
-        // miqInitNotifications(); // ActionCable causes live reload crashes
+        miqInitNotifications(); // ActionCable causes live reload crashes
 
     - id = %w(configuration policy).include?(@layout) ? @config_tab : @layout
     %body{:id => id, :onload => is_browser_ie? ? '' : 'miqOnLoad();', 'data-controller' => controller_name}

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,11 @@ module Vmdb
     # Set the manifest file name so that we are sure it gets overwritten on updates
     config.assets.manifest = Rails.root.join("public/assets/.sprockets-manifest.json").to_s
 
+    # Disable ActionCable's request forgery protection
+    # This is basically matching a set of allowed origins which is not good for us
+    # Our own origin-host forgery protection is implemented in lib/websocket_server.rb
+    Rails.application.config.action_cable.disable_request_forgery_protection = true
+
     # Customize any additional options below...
 
     # HACK: By default, Rails.configuration.eager_load_paths contains all of the directories

--- a/config/initializers/action_cable_patch.rb
+++ b/config/initializers/action_cable_patch.rb
@@ -1,0 +1,52 @@
+if Gem::Version.new(ActionCable::VERSION::STRING) < Gem::Version.new("5.0.1")
+  ActiveSupport.on_load(:action_cable) do
+    require 'action_cable/subscription_adapter/postgresql'
+    ActionCable::SubscriptionAdapter::PostgreSQL.class_eval do
+      def new_connection
+        ar_conn = ActiveRecord::Base.connection_pool.checkout
+        ActiveRecord::Base.connection_pool.remove ar_conn
+
+        pg_conn = ar_conn.raw_connection
+
+        unless pg_conn.is_a?(PG::Connection)
+          raise 'ActiveRecord database must be Postgres in order to use the Postgres ActionCable storage adapter'
+        end
+
+        yield pg_conn
+      end
+    end
+
+    ActionCable::SubscriptionAdapter::PostgreSQL::Listener.class_eval do
+      def listen
+        @adapter.new_connection do |pg_conn|
+          catch :shutdown do
+            loop do
+              until @queue.empty?
+                action, channel, callback = @queue.pop(true)
+
+                case action
+                when :listen
+                  pg_conn.exec("LISTEN #{pg_conn.escape_identifier channel}")
+                  @event_loop.post(&callback) if callback
+                when :unlisten
+                  pg_conn.exec("UNLISTEN #{pg_conn.escape_identifier channel}")
+                when :shutdown
+                  throw :shutdown
+                end
+              end
+
+              pg_conn.wait_for_notify(1) do |chan, pid, message|
+                broadcast(chan, message)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+elsif Rails.env.development?
+  errstr = "ActionCable version is 5.0.1 or newer, please see if we still need this patch: #{__FILE__}!"
+  # Display errors in both development.log and STDOUT
+  Rails.logger.warn(errstr)
+  warn(errstr)
+end

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -41,13 +41,13 @@ class WebsocketServer
     if WebSocket::Driver.websocket?(env)
 
       # ActionCable causes live reload crashes
-      # if env['REQUEST_URI'] =~ %r{^/ws/notifications}
-      #   ActionCable.server.call(env)
-      # else
-      exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
-      return not_found if exp.nil?
-      init_proxy(env, exp[1])
-      # end
+      if env['REQUEST_URI'] =~ %r{^/ws/notifications}
+        ActionCable.server.call(env)
+      else
+        exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
+        return not_found if exp.nil?
+        init_proxy(env, exp[1])
+      end
 
       [-1, {}, []]
     else

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -38,7 +38,9 @@ class WebsocketServer
   end
 
   def call(env)
-    if WebSocket::Driver.websocket?(env)
+    proto = Rack::Request.new(env).ssl? ? 'https' : 'http'
+    # Same-origin policy checking for WebSockets
+    if WebSocket::Driver.websocket?(env) && env['HTTP_ORIGIN'] == "#{proto}://#{env['HTTP_HOST']}"
 
       # ActionCable causes live reload crashes
       if env['REQUEST_URI'] =~ %r{^/ws/notifications}


### PR DESCRIPTION
Thanks to @matthewd the code-reloading issue has been fixed in a1ff151 and to @jrafanie with the monkey-patching help. ActionCable's default request forgery protection was disabled and I implemented our own check that will [eventually land](https://github.com/rails/rails/pull/26568) in rails.

You need to run `bin/setup` or `cp config/cable.yml.sample config/cable.yml` before testing this PR!