### PR TITLE
Remove jquery-rails, explicitly add jquery 2.1 to bower

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   # Unmodified gems
   gem "angular-ui-bootstrap-rails",   "~>0.13.0"
   gem "jquery-hotkeys-rails"
-  gem "jquery-rails",                 "~>4.1.1"
   gem "lodash-rails",                 "~>3.10.0"
   gem "patternfly-sass",              "~>3.11.0"
   gem "sass-rails"

--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,8 @@
     "rxjs": "^4.1.0",
     "rx-angular": "rx.angular#^1.1.3",
     "manageiq-ui-components": "~0.0.7",
-    "patternfly-bootstrap-treeview": "~2.1.0"
+    "patternfly-bootstrap-treeview": "~2.1.0",
+    "jquery": "~2.1.4"
   },
   "resolutions": {
     "moment": ">=2.9.0",


### PR DESCRIPTION
We've been using jquery from bower for quite a while (depended upon by patternfly and others), this is just making it obvious.

jquery-rails provides jquery & jquery-ujs, and we already have ujs in bower.json as well - not needed, removing