### PR TITLE
Require config environment over rails runner

### DIFF
--- a/tools/db_ping_remote.rb
+++ b/tools/db_ping_remote.rb
@@ -1,10 +1,10 @@
+require File.expand_path('../config/environment', __dir__)
 require 'io/console'
 
 def usage
   <<-USAGE
     Usage:
-      `bin/rails r tools/db_ping_remote.rb <host> <port> <username> [database] [adapter]`
-      Must be executed from the rails root directory
+      `ruby tools/db_ping_remote.rb <host> <port> <username> [database] [adapter]`
 
       host, port, username, and password are required
       database and adapter will be defaulted to the local configuration if not provided

--- a/tools/purge_metrics.rb
+++ b/tools/purge_metrics.rb
@@ -1,16 +1,17 @@
+require File.expand_path('../config/environment', __dir__)
+require 'trollop'
+
 MODES = %w(count purge)
 
-require 'trollop'
-ARGV.shift if ARGV[0] == '--'
+ARGV.shift if ARGV[0] == '--' # if invoked with rails runner
 opts = Trollop.options do
-  banner "Purge metrics records.\n\nUsage: rails runner #{$0} [-- options]\n\nOptions:\n\t"
+  banner "Purge metrics records.\n\nUsage: ruby #{$0} [options]\n\nOptions:\n\t"
   opt :mode,     "Mode (#{MODES.join(", ")})", :default => "count"
   opt :realtime, "Realtime range", :default => "4.hours"
   opt :hourly,   "Hourly range",   :default => "6.months"
   opt :daily,    "Daily range",    :default => "6.months"
   opt :window,   "Window of records to delete at once", :default => 1000
 end
-Trollop.die "script must be run with bin/rails runner" unless Object.const_defined?(:Rails)
 Trollop.die :mode,     "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
 Trollop.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
 Trollop.die :hourly,   "must be a number with method (e.g. 6.months)" unless opts[:hourly].number_with_method?

--- a/tools/purge_metrics.rb
+++ b/tools/purge_metrics.rb
@@ -16,7 +16,7 @@ Trollop.die :mode,     "must be one of #{MODES.join(", ")}" unless MODES.include
 Trollop.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
 Trollop.die :hourly,   "must be a number with method (e.g. 6.months)" unless opts[:hourly].number_with_method?
 Trollop.die :daily,    "must be a number with method (e.g. 6.months)" unless opts[:daily].number_with_method?
-Trollop.die :window,   "must be a number grater than 0" if opts[:window] <= 0
+Trollop.die :window,   "must be a number greater than 0" if opts[:window] <= 0
 
 def log(msg)
   $log.info "MIQ(#{__FILE__}) #{msg}"

--- a/tools/purge_miq_report_results.rb
+++ b/tools/purge_miq_report_results.rb
@@ -1,15 +1,16 @@
+require File.expand_path('../config/environment', __dir__)
+require 'trollop'
+
 MODES = %w(count purge)
 
-require 'trollop'
-ARGV.shift if ARGV[0] == '--'
+ARGV.shift if ARGV[0] == '--' # if invoked with rails runner
 opts = Trollop.options do
-  banner "Purge miq_report_results records.\n\nUsage: rails runner #{$0} [-- options]\n\nOptions:\n\t"
+  banner "Purge miq_report_results records.\n\nUsage: ruby #{$0} [options]\n\nOptions:\n\t"
   opt :mode,      "Mode (#{MODES.join(", ")})",          :default => "count"
   opt :window,    "Window of records to delete at once", :default => 100
   opt :date,      "Range of reports to keep by date (default: VMDB configuration)",     :type => :string
   opt :remaining, "Number of results to keep per report (default: VMDB configuration)", :type => :int
 end
-Trollop.die "script must be run with bin/rails runner"    unless Object.const_defined?(:Rails)
 Trollop.die :mode,   "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
 Trollop.die :window, "must be a number greater than 0"    if opts[:window] <= 0
 if opts[:remaining_given]

--- a/tools/purge_orphaned_tag_values.rb
+++ b/tools/purge_orphaned_tag_values.rb
@@ -7,8 +7,8 @@ opts = Trollop.options do
   opt :search_window, "Window of records to scan when finding orpahns", :default => 1000
   opt :delete_window, "Window of orphaned records to delete at once",   :default => 50
 end
-Trollop.die :search_window, "must be a number grater than 0" if opts[:search_window] <= 0
-Trollop.die :delete_window, "must be a number grater than 0" if opts[:delete_window] <= 0
+Trollop.die :search_window, "must be a number greater than 0" if opts[:search_window] <= 0
+Trollop.die :delete_window, "must be a number greater than 0" if opts[:delete_window] <= 0
 
 def log(msg)
   $log.info "MIQ(#{__FILE__}) #{msg}"

--- a/tools/purge_orphaned_tag_values.rb
+++ b/tools/purge_orphaned_tag_values.rb
@@ -1,11 +1,12 @@
+require File.expand_path('../config/environment', __dir__)
 require 'trollop'
-ARGV.shift if ARGV[0] == '--'
+
+ARGV.shift if ARGV[0] == '--' # if invoked with rails runner
 opts = Trollop.options do
-  banner "Purge orphaned vim_performance_tag_values records.\n\nUsage: rails runner #{$0} [-- options]\n\nOptions:\n\t"
+  banner "Purge orphaned vim_performance_tag_values records.\n\nUsage: ruby #{$0} [options]\n\nOptions:\n\t"
   opt :search_window, "Window of records to scan when finding orpahns", :default => 1000
   opt :delete_window, "Window of orphaned records to delete at once",   :default => 50
 end
-Trollop.die "script must be run with bin/rails runner" unless Object.const_defined?(:Rails)
 Trollop.die :search_window, "must be a number grater than 0" if opts[:search_window] <= 0
 Trollop.die :delete_window, "must be a number grater than 0" if opts[:delete_window] <= 0
 

--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../config/environment', __dir__)
 require 'trollop'
 require 'rest-client'
 #
@@ -9,16 +10,10 @@ require 'rest-client'
 #
 #
 
-PROGRAM_STRING = "rails runner #{$PROGRAM_NAME}".freeze
-
-unless Object.const_defined?(:Rails)
-  print "\nScript must be run with bin/rails runner\n"
-  print "\ne.g. #{PROGRAM_STRING} -- --help\n\n"
-  exit
-end
+PROGRAM_STRING = "ruby #{$PROGRAM_NAME}".freeze
 
 if ARGV.empty?
-  print "\n#{PROGRAM_STRING} -- --help\n\n"
+  print "\n#{PROGRAM_STRING} --help\n\n"
   exit
 end
 
@@ -46,7 +41,7 @@ Show a list of 5 recent requests
 
   #{PROGRAM_STRING} --last-requests
 
-Help! #{PROGRAM_STRING} -- --help
+Help! #{PROGRAM_STRING} --help
 
 Usage: #{PROGRAM_STRING} [--options]\n\nOptions:\n\t
 


### PR DESCRIPTION
Benefits:
* rails runner is for shebang lines or inline ruby, see #4307
* We don't have to check if rails is loaded.
* Can be run outside rails root directory via ruby.
* We don't need -- to avoid rails runner modifying our args.
* Less typing.
* Existing bin/rails runner callers with args just work:

`ruby tools/purge_orphaned_tag_values.rb -s 100`

Or, the old way:
`bin/rails runner tools/purge_orphaned_tag_values.rb -- -s 100`

Discovered while reviewing: #11281