### PR TITLE
Bump azure-armrest gem from version ~>0.3.5 to =0.3.7

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -8,7 +8,7 @@ gem "activerecord",            "~> 5.0.0" # used by appliance_console
 gem "activesupport",           "~> 5.0.0"
 gem "addressable",             "~> 2.4",            :require => false
 gem "awesome_spawn",           "~> 1.4",            :require => false
-gem "azure-armrest",           "~> 0.3.5",          :require => false
+gem "azure-armrest",           "=0.3.7",            :require => false
 gem "bcrypt",                  "~> 3.1.10",         :require => false
 gem "binary_struct",           "~> 2.1",            :require => false
 gem "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/


### PR DESCRIPTION
When an Azure storage account is not completely or not correctly provisioned, and is left in a dysfunctional state, an exception is thrown if we try to read the associated storage key.

This azure-armrest gem version includes PR: https://github.com/ManageIQ/azure-armrest/pull/213 which will catch any exception thrown when trying to read storage keys, ignore the storage account, then move on to the next one.

## Revert to using an explicit version
I am reverting back to the Gemfile specifier = instead of ~> 
Experience taught us to be explicit with the version of the azure-armrest gem that we use, this means we will not automatically pick up newly released versions of the azure-armrest gem; instead we will control the version we use.

## Links
https://msdn.microsoft.com/en-us/library/azure/mt163558.aspx
https://bugzilla.redhat.com/show_bug.cgi?id=1376468


## Steps for Testing/QA

Please pay particular attention to image inventory gathering and instance provisioning.