### PR TITLE
ArbitrationProfile API bug fix

### DIFF
--- a/app/controllers/api/arbitration_profiles_controller.rb
+++ b/app/controllers/api/arbitration_profiles_controller.rb
@@ -4,7 +4,10 @@ module Api
       validate_profile_data(data)
       attributes = build_arbitration_attributes(data)
       arbitration_profile = ArbitrationProfile.create(attributes)
-      raise BadRequestError, arbitration_profile.errors.full_messages.join(', ') unless arbitration_profile.valid?
+      unless arbitration_profile.valid?
+        raise BadRequestError,
+              "Failed to add new arbitration profile - #{arbitration_profile.errors.full_messages.join(', ')}"
+      end
       arbitration_profile
     end
 

--- a/app/controllers/api/arbitration_profiles_controller.rb
+++ b/app/controllers/api/arbitration_profiles_controller.rb
@@ -3,8 +3,8 @@ module Api
     def create_resource(_type, _id, data)
       validate_profile_data(data)
       attributes = build_arbitration_attributes(data)
-      arbitration_profile = collection_class(:arbitration_profiles).create(attributes)
-      validate_profile(arbitration_profile)
+      arbitration_profile = ArbitrationProfile.create(attributes)
+      raise BadRequestError, arbitration_profile.errors.full_messages.join(', ') unless arbitration_profile.valid?
       arbitration_profile
     end
 
@@ -33,13 +33,6 @@ module Api
       if data.key?('provider') && data.key?('ext_management_system')
         raise BadRequestError, 'Only one of provider or ext_management_system may be specified'
       end
-    end
-  end
-
-  def validate_profile(profile)
-    if profile.invalid?
-      raise BadRequestError, "Failed to add new arbitration profile -
-            #{profile.errors.full_messages.join(', ')}"
     end
   end
 end

--- a/spec/requests/api/arbitration_profile_spec.rb
+++ b/spec/requests/api/arbitration_profile_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_body)
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation via action' do
@@ -39,6 +40,8 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, gen_request(:create, request_body))
       end.to change(ArbitrationProfile, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation with provider id' do
@@ -48,6 +51,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_body.merge(:provider => {:id => provider.id}))
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation with provider href ' do
@@ -59,6 +63,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_json.merge(:provider => {:href => provider_href}))
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation with ext_management_system id' do
@@ -69,6 +74,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_json.merge(:ext_management_system => {:id => provider.id}))
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation with ext_management_system href' do
@@ -80,6 +86,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_json.merge(:ext_management_system => {:href => provider_href}))
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation with availability_zone id' do
@@ -89,6 +96,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_body.merge(:availability_zone => {:id => availability_zone.id}))
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'supports arbitration_default creation with availability_zone href' do
@@ -99,6 +107,7 @@ RSpec.describe 'Arbitration Profile API' do
       expect do
         run_post(arbitration_profiles_url, request_body.merge(:availability_zone => {:href => availability_zone_href}))
       end.to change(ArbitrationProfile, :count).by(1)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'rejects a request with an invalid availability zone' do


### PR DESCRIPTION
When creating an ArbitrationProfile via the API, the Profile was being created successfully but was throwing the following error:

```
{
"error":{
"kind":"internal_server_error",
"message":"undefined method `validate_profile' for #\u003cApi::ArbitrationProfilesController:0x007fda2a8defd0\u003e",
"klass":"NoMethodError"
}
}
```
as reported by @jeff-phillips-18.

Ended up simplifying and doing the validation within the `create_resource`. Also added in http status checks into the tests to make sure this issue can be caught in the future.

@miq-bot add_label service broker, api 