### PR TITLE
Fixed issue with no history and refresh toolbar buttons displayed in UI

### DIFF
--- a/app/helpers/application_helper/button/button_without_rbac_check.rb
+++ b/app/helpers/application_helper/button/button_without_rbac_check.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::ButtonWithoutRbacCheck < ApplicationHelper::Button::Basic
+  def role_allows_feature?
+    true
+  end
+end

--- a/app/helpers/application_helper/button/button_without_rback_check.rb
+++ b/app/helpers/application_helper/button/button_without_rback_check.rb
@@ -1,5 +1,0 @@
-class ApplicationHelper::Button::ButtonWithoutRbackCheck < ApplicationHelper::Button::Basic
-  def role_allows_feature?
-    true
-  end
-end

--- a/app/helpers/application_helper/button/history_choice.rb
+++ b/app/helpers/application_helper/button/history_choice.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::HistoryChoice < ApplicationHelper::Button::ButtonWithoutRbackCheck
+class ApplicationHelper::Button::HistoryChoice < ApplicationHelper::Button::ButtonWithoutRbacCheck
   def calculate_properties
     super
     # Show disabled history button if no history

--- a/app/helpers/application_helper/button/history_choice.rb
+++ b/app/helpers/application_helper/button/history_choice.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::HistoryChoice < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::HistoryChoice < ApplicationHelper::Button::ButtonWithoutRbackCheck
   def calculate_properties
     super
     # Show disabled history button if no history

--- a/app/helpers/application_helper/button/history_item.rb
+++ b/app/helpers/application_helper/button/history_item.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::ButtonWithoutRbackCheck
+class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::ButtonWithoutRbacCheck
   def calculate_properties
     super
     if @view_context.x_tree_history.length > history_item_id

--- a/app/helpers/application_helper/button/history_item.rb
+++ b/app/helpers/application_helper/button/history_item.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::HistoryItem < ApplicationHelper::Button::ButtonWithoutRbackCheck
   def calculate_properties
     super
     if @view_context.x_tree_history.length > history_item_id

--- a/app/helpers/application_helper/button/separator.rb
+++ b/app/helpers/application_helper/button/separator.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::Separator < ApplicationHelper::Button::ButtonWithoutRbackCheck
+class ApplicationHelper::Button::Separator < ApplicationHelper::Button::ButtonWithoutRbacCheck
   def initialize(props)
     super(nil, nil, {}, props)
     self[:type] = :separator

--- a/app/helpers/application_helper/button/view.rb
+++ b/app/helpers/application_helper/button/view.rb
@@ -1,4 +1,4 @@
-class ApplicationHelper::Button::View < ApplicationHelper::Button::ButtonWithoutRbackCheck
+class ApplicationHelper::Button::View < ApplicationHelper::Button::ButtonWithoutRbacCheck
   def visible?
     # only hide gtl button if they are not in @gtl_buttons
     !@gtl_buttons || @gtl_buttons.include?(self[:id].to_s)

--- a/app/helpers/application_helper/toolbar/x_history.rb
+++ b/app/helpers/application_helper/toolbar/x_history.rb
@@ -22,6 +22,7 @@ class ApplicationHelper::Toolbar::XHistory < ApplicationHelper::Toolbar::Basic
       'fa fa-repeat fa-lg',
       N_('Reload current display'),
       nil,
-      :url => "reload"),
+      :url => "reload",
+      :klass => ApplicationHelper::Button::ButtonWithoutRbackCheck),
   ])
 end

--- a/app/helpers/application_helper/toolbar/x_history.rb
+++ b/app/helpers/application_helper/toolbar/x_history.rb
@@ -23,6 +23,6 @@ class ApplicationHelper::Toolbar::XHistory < ApplicationHelper::Toolbar::Basic
       N_('Reload current display'),
       nil,
       :url => "reload",
-      :klass => ApplicationHelper::Button::ButtonWithoutRbackCheck),
+      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck),
   ])
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -250,7 +250,7 @@ class ApplicationHelper::ToolbarBuilder
       :icon      => "product product-custom-#{input[:image]} fa-lg",
       :title     => input[:description].to_s,
       :enabled   => options[:enabled],
-      :klass     => ApplicationHelper::Button::ButtonWithoutRbackCheck,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "button",
       :url_parms => "?id=#{record.id}&button_id=#{button_id}&cls=#{record.class}&pressed=custom_button&desc=#{button_name}"
     }

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -68,7 +68,7 @@ describe ApplicationHelper do
           :title     => CGI.escapeHTML(@button1.description.to_s),
           :text      => escaped_button1_text,
           :enabled   => true,
-          :klass     => ApplicationHelper::Button::ButtonWithoutRbackCheck,
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
           :url       => "button",
           :url_parms => "?id=#{subject.id}&button_id=#{@button1.id}&cls=#{subject.class.name}&pressed=custom_button&desc=#{escaped_button1_text}"
         }
@@ -96,7 +96,7 @@ describe ApplicationHelper do
           :title     => CGI.escapeHTML(@button1.description.to_s),
           :text      => escaped_button1_text,
           :enabled   => true,
-          :klass     => ApplicationHelper::Button::ButtonWithoutRbackCheck,
+          :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
           :url       => "button",
           :url_parms => "?id=#{subject.id}&button_id=#{@button1.id}&cls=#{subject.class.name}&pressed=custom_button&desc=#{escaped_button1_text}"
         }


### PR DESCRIPTION
Fixed issue introduced in #10942.

The history and refresh buttons should not be checked for RBAC, we just forgot to change their parent class from `Basic` to the one introduced in ef409bbbb8dce0d3df0a4e697199775b1707fd71, when doing RBAC changes.

Before:
![screencapture-localhost-3000-vm_infra-explorer-1474441884407](https://cloud.githubusercontent.com/assets/1187051/18701166/81492248-7fdb-11e6-9330-c82abb9b5862.png)

After:
![screencapture-localhost-3000-vm_infra-explorer-1474441861044](https://cloud.githubusercontent.com/assets/1187051/18701165/80319804-7fdb-11e6-9a89-84b85d457f42.png)


## Links
Fixing: #11397
Fixing: #11323 
BZ ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1377757

@dclarizio @martinpovolny @PanSpagetka @jzigmund @karelhala