### PR TITLE
Add options hash to notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -9,6 +9,9 @@ class Notification < ApplicationRecord
   accepts_nested_attributes_for :notification_recipients
   before_create :set_notification_recipients
 
+  serialize :options, Hash
+  default_value_for(:options) { Hash.new }
+
   def type=(typ)
     self.notification_type = NotificationType.find_by_name!(typ)
   end

--- a/db/migrate/20160921072726_add_options_to_notifications.rb
+++ b/db/migrate/20160921072726_add_options_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddOptionsToNotifications < ActiveRecord::Migration[5.0]
+  def change
+    add_column :notifications, :options, :text
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5406,6 +5406,7 @@ notifications:
 - cause_id
 - created_at
 - updated_at
+- options
 ontap_aggregate_derived_metrics:
 - id
 - statistic_time


### PR DESCRIPTION
This could be needed for notifying about custom states of custom state machines.

@miq-bot add_label core, enhancement, sql migration
/cc @gtanzillo @gmcculloug 