### PR TITLE
Extract factories to provider gems

### DIFF
--- a/spec/factories/floating_ip.rb
+++ b/spec/factories/floating_ip.rb
@@ -3,8 +3,6 @@ FactoryGirl.define do
     sequence(:address) { |n| ip_from_seq(n) }
   end
 
-  factory :floating_ip_amazon, :parent => :floating_ip,
-                               :class  => "ManageIQ::Providers::Amazon::NetworkManager::FloatingIp"
   factory :floating_ip_azure, :parent => :floating_ip,
                               :class  => "ManageIQ::Providers::Azure::NetworkManager::FloatingIp"
   factory :floating_ip_openstack, :parent => :floating_ip,

--- a/spec/support/factory_girl_helper.rb
+++ b/spec/support/factory_girl_helper.rb
@@ -20,4 +20,8 @@ end
 require 'factory_girl'
 # in case we are running as an engine, the factories are located in the dummy app
 FactoryGirl.definition_file_paths << 'spec/manageiq/spec/factories'
+# also add factories from provider gems until miq codebase does not use any provider specific factories anymore
+Rails::Engine.subclasses.select { |e| e.name.starts_with?("ManageIQ::Providers") }.each do |engine|
+  FactoryGirl.definition_file_paths << File.join(engine.root, 'spec', 'factories')
+end
 FactoryGirl.find_definitions


### PR DESCRIPTION
Provider specific factories should be located in the provider repository.
Since the manageiq codebase still uses provider specific factories a lot, we include all factories from providers. This can be undone once we are clean.

once https://github.com/ManageIQ/manageiq/pull/11083 is merged we can use `Vmdb::Plugins` instead of looking at `Rails::Engine`

Depends on https://github.com/ManageIQ/manageiq-providers-amazon/pull/48 
Unfortunately this is a :chicken: :egg: PR - Without this being merged amazon will fail with `Factory already registered` and without the amazon PR being merged, this one will fail with `Unknown Factory :floating_ip_amazon`. I suggest merging the amazon PR first.

That this is only the first PR in making the specs more loosely coupled from the providers :smile: 

@miq-bot add_labels test, refactoring, pluggable providers
@miq-bot assign chrisarcand 

@jrafanie @chrisarcand pls review
