### PR TITLE
Correct format of columns for MiqExpression

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -60,7 +60,7 @@ module ReportController::Schedules
     @schedule.towhat = "MiqReport"
     if @sb[:tree_typ] == "reports"
       exp                   = {}
-      exp["="]              = {"field" => "MiqReport.id", "value" => @sb[:miq_report_id]}
+      exp["="]              = {"field" => "MiqReport-id", "value" => @sb[:miq_report_id]}
       @_params.delete :id   # incase add schedule button was pressed from report show screen.
       @schedule.filter      = MiqExpression.new(exp)
       miq_report            = MiqReport.find(@sb[:miq_report_id])
@@ -486,7 +486,7 @@ module ReportController::Schedules
 
     unless !@edit[:new][:repfilter] || @edit[:new][:repfilter] == ""
       record = MiqReport.find(@edit[:new][:repfilter].to_i)
-      exp["="] = {"field" => "MiqReport.id", "value" => record.id} if record
+      exp["="] = {"field" => "MiqReport-id", "value" => record.id} if record
       schedule.filter = MiqExpression.new(exp)
     end
   end

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -65,7 +65,7 @@ module ReportController::Widgets
         params[:id] = @widget.id.to_s   # reset id in params for show
         # Build the filter expression and attach widget to schedule filter
         exp = {}
-        exp["="] = {"field" => "MiqWidget.id", "value" => @widget.id}
+        exp["="] = {"field" => "MiqWidget-id", "value" => @widget.id}
         @edit[:schedule].filter = MiqExpression.new(exp)
         @edit[:schedule].save
         @edit = session[:edit] = nil    # clean out the saved info

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -145,7 +145,7 @@ class MiqReport < ApplicationRecord
   end
 
   def list_schedules
-    exp = MiqExpression.new("=" => {"field" => "MiqReport.id",
+    exp = MiqExpression.new("=" => {"field" => "MiqReport-id",
                                     "value" => id})
     MiqSchedule.filter_matches_with exp
   end
@@ -155,7 +155,7 @@ class MiqReport < ApplicationRecord
     params['name'] ||= name
     params['description'] ||= title
 
-    params['filter'] = MiqExpression.new("=" => {"field" => "MiqReport.id",
+    params['filter'] = MiqExpression.new("=" => {"field" => "MiqReport-id",
                                                  "value" => id})
     params['towhat'] = "MiqReport"
     params['prod_default'] = "system"

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -557,7 +557,7 @@ class MiqWidget < ApplicationRecord
       :name         => title,
       :description  => description,
       :sched_action => {:method => "generate_widget"},
-      :filter       => MiqExpression.new("=" => {"field" => "MiqWidget.id", "value" => id}),
+      :filter       => MiqExpression.new("=" => {"field" => "MiqWidget-id", "value" => id}),
       :towhat       => self.class.name,
       :run_at       => {
         :interval   => {:value => value, :unit  => unit},

--- a/spec/models/miq_schedule_filter_spec.rb
+++ b/spec/models/miq_schedule_filter_spec.rb
@@ -46,7 +46,7 @@ describe "MiqSchedule Filter" do
         @report_schedule = FactoryGirl.create(:miq_schedule,
                                               :towhat       => "MiqReport",
                                               :sched_action => {:method => "run_report"},
-                                              :filter       => MiqExpression.new("=" => {"field" => "MiqReport.id", "value" => @report.id})
+                                              :filter       => MiqExpression.new("=" => {"field" => "MiqReport-id", "value" => @report.id})
                                              )
       end
 

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "reports API" do
     report = FactoryGirl.create(:miq_report)
 
     exp = {}
-    exp["="] = {"field" => "MiqReport.id", "value" => report.id}
+    exp["="] = {"field" => "MiqReport-id", "value" => report.id}
     exp = MiqExpression.new(exp)
 
     schedule_1 = FactoryGirl.create(:miq_schedule, :filter => exp)
@@ -127,7 +127,7 @@ RSpec.describe "reports API" do
     report = FactoryGirl.create(:miq_report)
 
     exp = {}
-    exp["="] = {"field" => "MiqReport.id", "value" => report.id}
+    exp["="] = {"field" => "MiqReport-id", "value" => report.id}
     exp = MiqExpression.new(exp)
 
     schedule = FactoryGirl.create(:miq_schedule, :name => 'unit_test', :filter => exp)


### PR DESCRIPTION
On some places we are using columns in bad format- for separation of columns is correct to use "-". 
I need this for https://github.com/ManageIQ/manageiq/pull/11369
 because there is used for parsing column Field.parse and in this case is specs were failing.

I guess that it was ok because method MiqExpression#to_ruby had correct behaviour but MiqExpression#to_sql - but it seems that it was not needed.


```ruby
with "."

 MiqExpression.new({"=" => {"field" => "MiqWidget.id", "value" => 444}}).to_sql
=>
[
    [0] nil,
    [1] nil,
    [2] {
        :supported_by_sql => false
    }
]


MiqExpression.new({"=" => {"field" => "MiqWidget.id", "value" => 444}}).to_ruby
=>
"<value ref=miqwidget, type=string>/virtual/id</value> == \"444\""




with "-"


MiqExpression.new({"=" => {"field" => "MiqWidget-id", "value" => 444}}).to_sql
=>
[
    [0] "\"miq_widgets\".\"id\" = 444",
    [1] {},
    [2] {
        :supported_by_sql => true
    }
]

MiqExpression.new({"=" => {"field" => "MiqWidget-id", "value" => 444}}).to_ruby
=>
"<value ref=miqwidget, type=integer>/virtual/id</value> == 444"


```

 
cc @imtayadeway  @alongoldboim 

@miq-bot assign @gtanzillo 


