### PR TITLE
[WIP] Fix ems_ref for compute and volume Availability Zones

### DIFF
--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -49,6 +49,7 @@ module EmsRefresh::SaveInventoryCloud
       :cloud_tenants,
       :flavors,
       :availability_zones,
+      :availability_zone_volumes,
       :host_aggregates,
       :key_pairs,
       :orchestration_templates,
@@ -109,6 +110,20 @@ module EmsRefresh::SaveInventoryCloud
 
     save_inventory_multi(ems.availability_zones, hashes, deletes, [:ems_ref])
     store_ids_for_new_records(ems.availability_zones, hashes, :ems_ref)
+  end
+
+  def save_availability_zone_volumes_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+
+    ems.availability_zone_volumes.reset
+    deletes = if (target == ems)
+                :use_association
+              else
+                []
+              end
+
+    save_inventory_multi(ems.availability_zone_volumes, hashes, deletes, [:ems_ref])
+    store_ids_for_new_records(ems.availability_zone_volumes, hashes, :ems_ref)
   end
 
   def save_host_aggregates_inventory(ems, hashes, target = nil)

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   require_nested :AuthKeyPair
   require_nested :AvailabilityZone
   require_nested :AvailabilityZoneNull
+  require_nested :AvailabilityZoneVolume
   require_nested :CloudResourceQuota
   require_nested :CloudTenant
   require_nested :CloudVolume
@@ -32,6 +33,11 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   include CinderManagerMixin
   include SwiftManagerMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
+
+  has_many :availability_zones, :foreign_key => :ems_id,
+           :class_name => "ManageIQ::Providers::Openstack::CloudManager::AvailabilityZone", :dependent => :destroy
+  has_many :availability_zone_volumes, :foreign_key => :ems_id,
+           :class_name => "ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneVolume", :dependent => :destroy
 
   supports :provisioning
   supports :cloud_tenant_mapping do

--- a/app/models/manageiq/providers/openstack/cloud_manager/availability_zone_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/availability_zone_volume.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneVolume < ::AvailabilityZone
+  has_many   :cloud_volumes, :class_name => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -1,4 +1,9 @@
 class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
+
+  belongs_to :availability_zone,
+             #:foreign_key => :availability_zone_id,
+             :class_name => "ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneVolume"
+
   include_concern 'Operations'
 
   include SupportsFeatureMixin

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -362,7 +362,7 @@ module Openstack
       # standard openstack AZs have their ems_ref set to their name ("nova" in the test case)...
       # the "null" openstack AZ has a unique ems_ref and name
       expect(@nova_az).to have_attributes(
-        :ems_ref => "compute-#{@nova_az.name}"
+        :ems_ref => @nova_az.name
       )
     end
 


### PR DESCRIPTION
Openstack has different Availability zones (AZ) for compute-related inventory from Nova and
volume-related inventory from Cinder. AZ from Openstack Cloud provider had the same ID, what caused several issues.

This commit adds a new model AvailabilityZoneVolume in Openstack Cloud provider, so
compute and volume AZs were divided.
## Links
- https://bugzilla.redhat.com/show_bug.cgi?id=1377393 (BZ this PR should fix)
- previous links that could be somehow related:
  - https://bugzilla.redhat.com/show_bug.cgi?id=1352867
  - https://github.com/ManageIQ/manageiq/pull/9672 
## Steps for Testing/QA
- add Openstack Cloud provider, run refresh
- check availability zones (should contain _nova_ and _nova (Volume)_)
- provision instance (select _nova_ availability zone)
- provision should succeed, new instance should be visible in UI 
