### PR TITLE
Fixed accordion max-height issue when the screen width < 768px

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1542,9 +1542,14 @@ function miqInitAccordions() {
   var panel = $('#left_div .panel-heading').outerHeight();
   var count = $('#accordion:visible > .panel .panel-body').length;
   $('#accordion:visible > .panel .panel-body').each(function (_k, v) {
-    $(v).css('max-height', (height - count * panel) + 'px');
-    $(v).css('overflow-y', 'auto')
-    $(v).css('overflow-x', 'hidden')
+    if (window.matchMedia("(max-width: 768px)").matches) {
+      $(v).css('max-height', '');
+      $(v).css('overflow-y', 'none');
+    } else {
+      $(v).css('max-height', (height - count * panel) + 'px');
+      $(v).css('overflow-y', 'auto');
+    }
+    $(v).css('overflow-x', 'hidden');
   });
 }
 


### PR DESCRIPTION
There is no need for the secondary scrollbar in mobile view. Also the `max-height` calculation is unnecessary and it made the accordions small.

**Before:**
![screenshot from 2016-09-21 15-37-50](https://cloud.githubusercontent.com/assets/649130/18713174/a3708b1e-8011-11e6-84d0-e6705516250d.png)

**After:**
![screenshot from 2016-09-21 15-37-09](https://cloud.githubusercontent.com/assets/649130/18713181/aa800f56-8011-11e6-9c11-588333a62a64.png)

@miq-bot assign @epwinchell 

\cc @himdel for the JS
