### PR TITLE
Add features based on supported_api_versions to RedHat provider

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
 
     # Create the underlying connection according to the version of the oVirt API requested by
     # the caller:
-    connect_method = version == 4 ? :raw_connect_v4 : :raw_connect_v3
+    connect_method = "raw_connect_v#{version}".to_sym
     connection = self.class.public_send(connect_method, server, port, path, username, password, service)
 
     # Copy the API path to the endpoints table:
@@ -30,12 +30,12 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     true
   end
 
-  def supported_auth_types
-    %w(default metrics)
+  def supports_api_version?(version)
+    supported_api_versions.include?(version)
   end
 
-  def supports_authentication?(authtype)
-    supported_auth_types.include?(authtype.to_s)
+  def supported_auth_types
+    %w(default metrics)
   end
 
   def rhevm_service

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -39,6 +39,12 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     true
   end
 
+  def supported_api_versions
+    with_provider_connection do |connection|
+      connection.supported_api_versions
+    end
+  end
+
   def supports_api_version?(version)
     supported_api_versions.include?(version)
   end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -58,8 +58,9 @@ module SupportsFeatureMixin
   extend ActiveSupport::Concern
 
   QUERYABLE_FEATURES = {
-    :associate_floating_ip        => 'Associate a Floating IP',
-    :control                      => 'Basic control operations', # FIXME: this is just a internal helper and should be refactored
+    :associate_floating_ip    => 'Associate a Floating IP',
+    # FIXME: this is just a internal helper and should be refactored
+    :control                      => 'Basic control operations',
     :cloud_tenant_mapping         => 'CloudTenant mapping',
     :backup_create                => 'CloudVolume backup creation',
     :backup_restore               => 'CloudVolume backup restore',
@@ -81,7 +82,8 @@ module SupportsFeatureMixin
     :resize                       => 'Resizing',
     :retire                       => 'Retirement',
     :smartstate_analysis          => 'Smartstate Analaysis',
-    :terminate                => 'Terminate a VM'
+    :snapshots                    => 'Snapshots',
+    :terminate                    => 'Terminate a VM',
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -631,6 +631,8 @@ describe EmsInfraController do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
       login_as FactoryGirl.create(:user, :features => "ems_infra_new")
+      allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager)
+        .to receive(:supported_api_versions).and_return([3, 4])
     end
 
     render_views

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/configuration/network_spec.rb
@@ -31,6 +31,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::Configuration::Ne
 
     allow(rhevm_vm).to receive_messages(:nics => [rhevm_nic1, rhevm_nic2])
     allow(Ovirt::Cluster).to receive_messages(:find_by_href => rhevm_cluster)
+    allow_any_instance_of(ManageIQ::Providers::Redhat::InfraManager).to receive(:supported_api_versions)
+      .and_return([3, 4])
   end
 
   context "#configure_network_adapters" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_0_spec.rb
@@ -3,6 +3,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.252.231", :ipaddress => "192.168.252.231", :port => 8443)
     @ems.update_authentication(:default => {:userid => "evm@manageiq.com", :password => "password"})
+    allow(@ems).to receive(:supported_api_versions).and_return([3])
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_3_1_spec.rb
@@ -3,6 +3,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
     guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_redhat, :zone => zone, :hostname => "192.168.252.230", :ipaddress => "192.168.252.230", :port => 443)
     @ems.update_authentication(:default => {:userid => "evm@manageiq.com", :password => "password"})
+    allow(@ems).to receive(:supported_api_versions).and_return([3])
   end
 
   it ".ems_type" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresher_target_vm_spec.rb
@@ -20,6 +20,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::Refresher do
                              :ems_id  => @ems.id,
                              :uid_ems => "00000002-0002-0002-0002-0000000001e9_respool")
     @cluster.with_relationship_type("ems_metadata") { @cluster.add_child @rp }
+    allow(@ems).to receive(:supported_api_versions).and_return([3, 4])
   end
 
   it "should refresh a vm" do

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -95,4 +95,49 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       end
     end
   end
+
+  context "supported features" do
+    let(:ems) { FactoryGirl.create(:ems_redhat) }
+    let(:supported_api_versions) { [3, 4]  }
+    context "#process_api_features_support" do
+      before(:each) do
+        allow(described_class).to receive(:api_features).and_return({ 3 => ['feature1'], 4 => ['feature2'] })
+        described_class.process_api_features_support
+        allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
+      end
+
+      context "no versions supported" do
+        let(:supported_api_versions) { [] }
+        it 'supports the reight features' do
+          expect(ems.supports_feature1?).to be_falsey
+          expect(ems.supports_feature2?).to be_falsey
+        end
+      end
+
+      context "version 3 supported" do
+        let(:supported_api_versions) { [3] }
+        it 'supports the reight features' do
+          expect(ems.supports_feature1?).to be_truthy
+          expect(ems.supports_feature2?).to be_falsey
+        end
+      end
+
+      context "version 4 supported" do
+        let(:supported_api_versions) { [4] }
+        it 'supports the reight features' do
+          expect(ems.supports_feature1?).to be_falsey
+          expect(ems.supports_feature2?).to be_truthy
+        end
+      end
+
+      context "all versions supported" do
+        let(:supported_api_versions) { [3, 4] }
+        it 'supports the reight features' do
+          expect(ems.supports_feature1?).to be_truthy
+          expect(ems.supports_feature2?).to be_truthy
+        end
+      end
+    end
+  end
 end
+

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -78,4 +78,21 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       expect(described_class.extract_ems_ref_id("/ovirt-engine/api/vms/123")).to eq("123")
     end
   end
+
+  context "api versions" do
+    let(:ems) { FactoryGirl.create(:ems_redhat) }
+    context "#supported_api_versions" do
+      it "returns the supported api versions" do
+        expect(ems.supported_api_versions).to match_array([3])
+      end
+    end
+
+    context "#supports_api_version?" do
+      it "returns the supported api versions" do
+        allow(ems).to receive(:supported_api_versions).and_return([3])
+        expect(ems.supports_api_version?(3)).to eq(true)
+        expect(ems.supports_api_version?(6)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -101,40 +101,44 @@ describe ManageIQ::Providers::Redhat::InfraManager do
     let(:supported_api_versions) { [3, 4]  }
     context "#process_api_features_support" do
       before(:each) do
-        allow(described_class).to receive(:api_features).and_return({ 3 => ['feature1'], 4 => ['feature2'] })
+        allow(described_class).to receive(:api_features).and_return({ 3 => ['feature1', 'feature3'], 4 => ['feature2', 'feature3'] })
         described_class.process_api_features_support
         allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
       end
 
       context "no versions supported" do
         let(:supported_api_versions) { [] }
-        it 'supports the reight features' do
+        it 'supports the right features' do
           expect(ems.supports_feature1?).to be_falsey
           expect(ems.supports_feature2?).to be_falsey
+          expect(ems.supports_feature3?).to be_falsey
         end
       end
 
       context "version 3 supported" do
         let(:supported_api_versions) { [3] }
-        it 'supports the reight features' do
+        it 'supports the right features' do
           expect(ems.supports_feature1?).to be_truthy
           expect(ems.supports_feature2?).to be_falsey
+          expect(ems.supports_feature3?).to be_truthy
         end
       end
 
       context "version 4 supported" do
         let(:supported_api_versions) { [4] }
-        it 'supports the reight features' do
+        it 'supports the right features' do
           expect(ems.supports_feature1?).to be_falsey
           expect(ems.supports_feature2?).to be_truthy
+          expect(ems.supports_feature3?).to be_truthy
         end
       end
 
       context "all versions supported" do
         let(:supported_api_versions) { [3, 4] }
-        it 'supports the reight features' do
+        it 'supports the right features' do
           expect(ems.supports_feature1?).to be_truthy
           expect(ems.supports_feature2?).to be_truthy
+          expect(ems.supports_feature3?).to be_truthy
         end
       end
     end


### PR DESCRIPTION
Using the SupportedFeaturesMixin to set features that are supported by the RedHat provider based on the  API versions.
Using the OvirtSDK4 Probe to find which API versions are supported by the server.
This patch is dependant on OvirtSDK4 4.0.2