### PR TITLE
Remove unnecessary files created by locale:plugin:find

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -175,5 +175,9 @@ namespace :locale do
                                 :ignore_fuzzy   => true,
                                 :report_warning => false)
     Rake::Task['gettext:find'].invoke
+
+    Dir["#{@engine.root}/locale/**/*.edit.po", "#{@engine.root}/locale/**/*.po.time_stamp"].each do |file|
+      File.unlink(file)
+    end
   end
 end


### PR DESCRIPTION
`*.edit.po` and `*.po.time_stamp` files are not needed