### PR TITLE
Fix Summary Screen label color issue

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -236,12 +236,13 @@ table.table-hover tbody tr:nth-child(even).no-hover:hover td {
 
 /* summary screen formatting */
 
-table .label {
+.table-summary-screen .label {
   display: table-cell;
   width: 20% !important;
   min-width: 200px;
   font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;
   cursor: default;
+  color: #333;
   text-align: left;
   white-space: normal
 }

--- a/app/views/shared/summary/_textual.html.haml
+++ b/app/views/shared/summary/_textual.html.haml
@@ -1,6 +1,6 @@
 - items = expand_textual_group(items, @record)
 - if items.present?
-  %table.table.table-bordered.table-hover.table-striped
+  %table.table.table-bordered.table-hover.table-striped.table-summary-screen
     %thead
       %tr
         %th{:colspan => "2", :align => "left"}

--- a/app/views/shared/summary/_textual_firewall_rules.html.haml
+++ b/app/views/shared/summary/_textual_firewall_rules.html.haml
@@ -1,5 +1,5 @@
 - if items
-  %table.table.table-bordered.table-striped
+  %table.table.table-bordered.table-striped.table-summary-screen
     %thead
       %tr
         %th{:colspan => 6, :align => "left"}

--- a/app/views/shared/summary/_textual_listview.html.haml
+++ b/app/views/shared/summary/_textual_listview.html.haml
@@ -2,7 +2,7 @@
 #fieldset
   %h3
     = title
-  %table.table.table-bordered.table-striped.table-hover
+  %table.table.table-bordered.table-striped.table-hover.table-summary-screen
     - items.each do |item|
       %thead
         %tr

--- a/app/views/shared/summary/_textual_multilabel.html.haml
+++ b/app/views/shared/summary/_textual_multilabel.html.haml
@@ -1,5 +1,5 @@
 - if items && items[:values].present?
-  %table.table.table-bordered.table-striped{:class => items[:additional_table_class] || ""}
+  %table.table.table-bordered.table-striped.table-summary-screen{:class => items[:additional_table_class] || ""}
     %thead
       %tr
         %th{:colspan => items[:labels].count, :align => "left"}

--- a/app/views/shared/summary/_textual_multilink.html.haml
+++ b/app/views/shared/summary/_textual_multilink.html.haml
@@ -1,5 +1,5 @@
 - if items
-  %table.table.table-bordered.table-hover.table-striped
+  %table.table.table-bordered.table-hover.table-striped.table-summary-screen
     %thead
       %tr
         %th{:colspan => "100"}

--- a/app/views/shared/summary/_textual_normal_operating_ranges.html.haml
+++ b/app/views/shared/summary/_textual_normal_operating_ranges.html.haml
@@ -1,6 +1,6 @@
 - items = expand_textual_group(items)
 - if items.present?
-  %table.table.table-bordered.table-striped
+  %table.table.table-bordered.table-striped.table-summary-screen
     %thead
       %tr
         %th{:colspan => "3"}

--- a/app/views/shared/summary/_textual_tags.html.haml
+++ b/app/views/shared/summary/_textual_tags.html.haml
@@ -1,7 +1,7 @@
 - items = expand_textual_group(items)
 - if items.present?
   #table_div
-    %table.table.table-bordered.table-striped
+    %table.table.table-bordered.table-striped.table-summary-screen
       %thead
         %tr
           %th{:colspan => "2", :align => "left"}


### PR DESCRIPTION
Labels in Patternfly are colored white by default. The summary screen tables use a label that needs to be colorized. This PR creates a new "table-summary-screen" class and overrides the default label styling.

This bug was caused by the following PR: https://github.com/ManageIQ/manageiq/pull/11288

Issue #11388 
https://bugzilla.redhat.com/show_bug.cgi?id=1342787
Depends on:  https://github.com/ManageIQ/manageiq/pull/11288

Old
![screen shot 2016-09-21 at 10 30 00 am](https://cloud.githubusercontent.com/assets/1287144/18715189/658b0e6c-7fe6-11e6-99e1-551cdb7dc41d.png)

New
![screen shot 2016-09-21 at 10 23 48 am](https://cloud.githubusercontent.com/assets/1287144/18715056/daeb438a-7fe5-11e6-9b16-5794665c0444.png)