### PR TITLE
Remove directories and file accidentally committed

### DIFF
--- a/lib/miq_automation_engine/service_models/home/agoldboi/git/manageiq/lib/miq_automation_engine/service_models/miq_ae_service_authentication_htpasswd.rb
+++ b/lib/miq_automation_engine/service_models/home/agoldboi/git/manageiq/lib/miq_automation_engine/service_models/miq_ae_service_authentication_htpasswd.rb
@@ -1,4 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceAuthenticationHtpasswd < MiqAeServiceModelBase
-  end
-end


### PR DESCRIPTION
As far as I can tell this directory should not be here and is a
duplicate of:

 `lib/miq_automation_engine/service_models/miq_ae_service_authentication_htpasswd.rb`

Removing because it doesn't seem to serve any purpose.