### PR TITLE
Remove MiqWidget title unique validation

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -18,7 +18,7 @@ class MiqWidget < ApplicationRecord
   has_many   :miq_shortcuts, :through => :miq_widget_shortcuts
 
   validates_presence_of   :title, :description
-  validates_uniqueness_of :description, :title
+  validates_uniqueness_of :description
   VALID_CONTENT_TYPES = %w( report chart rss menu )
   validates_inclusion_of :content_type, :in => VALID_CONTENT_TYPES, :message => "should be one of #{VALID_CONTENT_TYPES.join(", ")}"
 
@@ -554,7 +554,7 @@ class MiqWidget < ApplicationRecord
     end
 
     sched = MiqSchedule.create!(
-      :name         => title,
+      :name         => description,
       :description  => description,
       :sched_action => {:method => "generate_widget"},
       :filter       => MiqExpression.new("=" => {"field" => "MiqWidget-id", "value" => id}),

--- a/app/services/widget_import_service.rb
+++ b/app/services/widget_import_service.rb
@@ -15,7 +15,7 @@ class WidgetImportService
   end
 
   def import_widget_from_hash(widget)
-    new_or_existing_widget = MiqWidget.where(:title => widget["title"]).first_or_create
+    new_or_existing_widget = MiqWidget.where(:description => widget["description"]).first_or_create
     new_or_existing_widget.title ||= widget["title"]
     new_or_existing_widget.content_type ||= "rss"
     new_or_existing_widget.resource = build_report_contents(widget)


### PR DESCRIPTION
This validation was causing issues when someone deleted a default widget then created a new widget with the same title as the default one, but a different description.

When we restart the server (on an update, for example) we attempt to recreate the default widgets if we can't find them by description, this leads to a unique validation error on the title.

This PR removes the validation and changes one additional lookup by title to a lookup by description.
Also we had to change how the schedule for a widget was created because schedule has a unique validation on `name` which would cause a similar problem during seeding (the widget would get created, but fail to create the schedule).

https://bugzilla.redhat.com/show_bug.cgi?id=1375313

@miq-bot add_label bug
@gtanzillo please review

## Some alternatives
I'm okay going either of these ways as well

- If there is a good reason we had a unique constraint on the widget title, another option is to not allow users to remove the default widgets in the first place (especially as they will be recreated anyway).
- Yet another option is to look up the existing widget by title or description, but I feel like calling two widgets *the same widget* because their titles are the same isn't quite right.
