### PR TITLE
[DARGA] Re-enable Amazon provisioning

### DIFF
--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -43,6 +43,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   before_validation :ensure_managers
 
+  supports :provisioning
+
   def ensure_managers
     build_network_manager unless network_manager
     network_manager.name            = "#{name} Network Manager"


### PR DESCRIPTION
Re-enabling Amazon provisioning, was added to the manageiq-providers-amazon repo per https://github.com/ManageIQ/manageiq-providers-amazon/pull/16.  Duplicating the effort for the previous version of the repo in the gems directory.

## Links [Optional]
https://bugzilla.redhat.com/show_bug.cgi?id=1376010
