### PR TITLE
Update openSCAP results styling

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -12,6 +12,7 @@ $img-bg-navbar:                             "navbar.png"; // sets a custom backg
 $color-success:                             #3f9c35;
 $color-warning:                             #ec7a08;
 $color-critical:                            #cc0000;
+$color-low-severity:                        #f0ab00;  //(pf-gold-200)
 
 // Product overrides for 'About' Modal
 

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -612,3 +612,13 @@ body#dashboard {
     margin-bottom: 0px;
   }
 }
+
+table .label {  // Adds margin to the label to vertically align with text
+  margin-top: 3px;
+}
+
+//  openSCAP result styling
+
+.label-low-severity {
+  background-color: $color-low-severity;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -940,22 +940,22 @@ class ApplicationController < ActionController::Base
   def result_span_class(value)
     case value.downcase
     when "pass"
-      "label label-success"
+      "label label-success center-block"
     when "fail"
-      "label label-danger"
+      "label label-danger center-block"
     else
-      "label label-primary"
+      "label label-primary center-block"
     end
   end
 
   def severity_span_class(value)
     case value.downcase
     when "high"
-      "label label-danger"
+      "label label-danger center-block"
     when "medium"
-      "label label-warning"
+      "label label-warning center-block"
     else
-      "label label-primary"
+      "label label-low-severity center-block"
     end
   end
 


### PR DESCRIPTION
This is an update to the styling in: https://github.com/ManageIQ/manageiq/pull/11288

* created "low-severity" label class using color-pf-gold-200
* added "center-block" class to label instead of fixed width
* removed left alignment (using default PF label center alignment)

https://bugzilla.redhat.com/show_bug.cgi?id=1342787
https://www.pivotaltracker.com/n/projects/1613907/stories/130217447

Old
![screen shot 2016-09-21 at 4 07 46 pm](https://cloud.githubusercontent.com/assets/1287144/18727198/93f57a42-8015-11e6-8c80-2f9e8451b800.png)

After
![screen shot 2016-09-21 at 4 01 26 pm](https://cloud.githubusercontent.com/assets/1287144/18727157/711011f4-8015-11e6-87bd-c9b8b1f79daf.png)