### PR TITLE
Store the workspace in the DRb front object

### DIFF
--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -32,7 +32,7 @@ module MiqAeEngine
     def setup
       require 'drb/timeridconv'
       global_id_conv = DRb::TimerIdConv.new(drb_cache_timeout)
-      drb_front = MiqAeMethodService::MiqAeServiceFront.new
+      drb_front = MiqAeMethodService::MiqAeServiceFront.new(@workspace)
       self.drb_server = DRb::DRbServer.new("druby://127.0.0.1:0", drb_front, :idconv => global_id_conv)
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -10,6 +10,11 @@ module MiqAeMethodService
 
   class MiqAeServiceFront
     include DRbUndumped
+    attr_accessor :workspace
+    def initialize(workspace)
+      @workspace = workspace
+    end
+
     def find(id)
       MiqAeService.find(id)
     end


### PR DESCRIPTION
This is necessary to access the user that started the Automation
Request. The user is stored in the workspace. Each DRb request
runs in a separate thread and the workspace and user should be
accessible from these threads.

These changes were pulled out from the RBAC PR #6395 to help with PR #10922