### PR TITLE
Set the User.current_user in Automation Engine

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -229,6 +229,9 @@ module MiqAeMethodService
     end
 
     def execute(m, *args)
+      # Since each request from DRb client could run in a separate thread
+      # We have to set the current_user in every thread.
+      User.current_user = @workspace.ae_user
       MiqAeServiceMethods.send(m, *args)
     rescue NoMethodError => err
       raise MiqAeException::MethodNotFound, err.message

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -61,6 +61,7 @@ module MiqAeEngine
     end
 
     def self.instantiate(uri, user, attrs = {})
+      User.current_user = user
       workspace = MiqAeWorkspaceRuntime.new(attrs)
       workspace.instantiate(uri, user, nil)
       workspace

--- a/spec/lib/miq_automation_engine/engine/miq_ae_workspace_runtime_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_workspace_runtime_spec.rb
@@ -1,0 +1,14 @@
+describe MiqAeEngine::MiqAeWorkspaceRuntime do
+  let(:root_tenant) { Tenant.seed }
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  before do
+    EvmSpecHelper.local_miq_server
+  end
+
+  it "sets current_user" do
+    allow_any_instance_of(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:instantiate)
+    MiqAeEngine::MiqAeWorkspaceRuntime.instantiate("/a/b/c", user)
+
+    expect(User.current_user).to eq(user)
+  end
+end


### PR DESCRIPTION
Set the User.current_user in the Automation Engine so that the objects can be created for the correct user.

* https://bugzilla.redhat.com/show_bug.cgi?id=1322983

Testing steps are mentioned in the bugzilla