### PR TITLE
Allow VMware provision without needing to specify a host

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -28,6 +28,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
   def prepare_for_clone_task
     raise MiqException::MiqProvisionError, "Provision Request's Destination VM Name=[#{dest_name}] cannot be blank" if dest_name.blank?
     raise MiqException::MiqProvisionError, "A VM with name: [#{dest_name}] already exists" if source.ext_management_system.vms.where(:name => dest_name).any?
+    raise MiqException::MiqProvisionError, "Neither Cluster nor Host selected for [#{dest_name}]" if dest_host.nil? && dest_cluster.nil?
 
     clone_options = {
       :name          => dest_name,
@@ -48,11 +49,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     validate_customization_spec(clone_options[:customization])
 
     clone_options
-  end
-
-  def dest_cluster
-    cluster_id = get_option(:placement_cluster_name)
-    EmsCluster.find(cluster_id) unless cluster_id.nil?
   end
 
   def dest_resource_pool
@@ -84,7 +80,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     _log.info("Provisioning [#{source.name}] to [#{clone_options[:name]}]")
     _log.info("Source Template:            [#{source.name}]")
     _log.info("Destination VM Name:        [#{clone_options[:name]}]")
-    _log.info("Destination Host:           [#{clone_options[:host].name} (#{clone_options[:host].ems_ref})]") if clone_options[:host]
+    _log.info("Destination Cluster:        [#{clone_options[:cluster].name} (#{clone_options[:cluster].ems_ref})]")   if clone_options[:cluster]
+    _log.info("Destination Host:           [#{clone_options[:host].name} (#{clone_options[:host].ems_ref})]")         if clone_options[:host]
     _log.info("Destination Datastore:      [#{clone_options[:datastore].name} (#{clone_options[:datastore].ems_ref})]")
     _log.info("Destination Folder:         [#{clone_options[:folder].name}] (#{clone_options[:folder].ems_ref})")
     _log.info("Destination Resource Pool:  [#{clone_options[:pool].name} (#{clone_options[:pool].ems_ref})]")

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -29,6 +29,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     raise MiqException::MiqProvisionError, "Provision Request's Destination VM Name=[#{dest_name}] cannot be blank" if dest_name.blank?
     raise MiqException::MiqProvisionError, "A VM with name: [#{dest_name}] already exists" if source.ext_management_system.vms.where(:name => dest_name).any?
     raise MiqException::MiqProvisionError, "Neither Cluster nor Host selected for [#{dest_name}]" if dest_host.nil? && dest_cluster.nil?
+    raise MiqException::MiqProvisionError, "A Host must be selected on a non-DRS enabled cluster" if dest_host.nil? && !dest_cluster.drs_enabled
 
     clone_options = {
       :name          => dest_name,

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -28,8 +28,6 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
   def prepare_for_clone_task
     raise MiqException::MiqProvisionError, "Provision Request's Destination VM Name=[#{dest_name}] cannot be blank" if dest_name.blank?
     raise MiqException::MiqProvisionError, "A VM with name: [#{dest_name}] already exists" if source.ext_management_system.vms.where(:name => dest_name).any?
-    raise MiqException::MiqProvisionError, "Neither Cluster nor Host selected for [#{dest_name}]" if dest_host.nil? && dest_cluster.nil?
-    raise MiqException::MiqProvisionError, "A Host must be selected on a non-DRS enabled cluster" if dest_host.nil? && !dest_cluster.drs_enabled
 
     clone_options = {
       :name          => dest_name,

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -57,15 +57,14 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     resource_pool = ResourcePool.find_by(:id => respool_id) unless respool_id.nil?
     return resource_pool unless resource_pool.nil?
 
-    cluster = dest_cluster
-    cluster ? cluster.default_resource_pool : dest_host.default_resource_pool
+    dest_cluster.try(:default_resource_pool) || dest_host.default_resource_pool
   end
 
   def dest_folder
     folder_id = get_option(:placement_folder_name)
     return EmsFolder.find_by(:id => folder_id) if folder_id
 
-    dc = dest_cluster.parent_datacenter
+    dc = dest_cluster.try(:parent_datacenter) || dest_host.parent_datacenter
 
     # Pick the parent folder in the destination datacenter
     find_folder("#{dc.folder_path}/vm", dc)

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
         vim_net_adapter = template_networks[idx]
 
         if net[:is_dvs] == true
-          #build_config_spec_dvs(net, vim_net_adapter, vmcs)
+          #TODO build_config_spec_dvs(net, vim_net_adapter, vmcs)
         else
           build_config_spec_vlan(net, vim_net_adapter, vmcs)
         end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Netw
         vim_net_adapter = template_networks[idx]
 
         if net[:is_dvs] == true
-          build_config_spec_dvs(net, vim_net_adapter, vmcs)
+          #build_config_spec_dvs(net, vim_net_adapter, vmcs)
         else
           build_config_spec_vlan(net, vim_net_adapter, vmcs)
         end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/placement.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/placement.rb
@@ -15,9 +15,16 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Placement
 
   def manual_placement
     _log.info("Manual placement...")
-    return selected_placement_obj(:placement_host_name, Host),
-           selected_placement_obj(:placement_cluster_name, EmsCluster),
-           selected_placement_obj(:placement_ds_name, Storage)
+
+    host      = selected_placement_obj(:placement_host_name, Host)
+    cluster   = selected_placement_obj(:placement_cluster_name, EmsCluster)
+    datastore = selected_placement_obj(:placement_ds_name, Storage)
+
+    if host && cluster.nil?
+      cluster = host.ems_cluster
+    end
+
+    return host, cluster, datastore
   end
 
   def automatic_placement

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/placement.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/placement.rb
@@ -16,6 +16,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Placement
   def manual_placement
     _log.info("Manual placement...")
     return selected_placement_obj(:placement_host_name, Host),
+           selected_placement_obj(:placement_cluster_name, EmsCluster),
            selected_placement_obj(:placement_ds_name, Storage)
   end
 
@@ -23,16 +24,20 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Placement
     # get most suitable host and datastore for new VM
     _log.info("Getting most suitable host and datastore for new VM from automate...")
     host, datastore = get_most_suitable_host_and_storage
+    cluster = host.ems_cluster
+
     _log.info("Host Name: [#{host.name}] Id: [#{host.id}]") if host
+    _log.info("Cluster Name: [#{cluster.name}] Id: [#{cluster.id}]") if cluster
     _log.info("Datastore Name: [#{datastore.name}] ID : [#{datastore.id}]") if datastore
     host ||= selected_placement_obj(:placement_host_name, Host)
+    cluster ||= selected_placement_obj(:placement_cluster_name, EmsCluster)
     datastore ||= selected_placement_obj(:placement_ds_name, Storage)
-    return host, datastore
+    return host, cluster, datastore
   end
 
   def selected_placement_obj(key, klass)
     klass.find_by(:id => get_option(key)).tap do |obj|
-      #raise MiqException::MiqProvisionError, "Destination #{key} not provided" unless obj
+      #TODO raise MiqException::MiqProvisionError, "Destination #{key} not provided" unless obj
       _log.info("Using selected #{key} : [#{obj.name}] id : [#{obj.id}]") if obj
     end
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/placement.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/placement.rb
@@ -32,8 +32,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Placement
 
   def selected_placement_obj(key, klass)
     klass.find_by(:id => get_option(key)).tap do |obj|
-      raise MiqException::MiqProvisionError, "Destination #{key} not provided" unless obj
-      _log.info("Using selected #{key} : [#{obj.name}] id : [#{obj.id}]")
+      #raise MiqException::MiqProvisionError, "Destination #{key} not provided" unless obj
+      _log.info("Using selected #{key} : [#{obj.name}] id : [#{obj.id}]") if obj
     end
   end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
   def determine_placement
     host, datastore = placement
 
-    options[:dest_host]    = [host.id, host.name]
+    options[:dest_host]    = [host.id, host.name] if host
     options[:dest_storage] = [datastore.id, datastore.name]
     signal :start_clone_task
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/state_machine.rb
@@ -4,9 +4,10 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::StateMachine
   end
 
   def determine_placement
-    host, datastore = placement
+    host, cluster, datastore = placement
 
-    options[:dest_host]    = [host.id, host.name] if host
+    options[:dest_host]    = [host.id, host.name]       if host
+    options[:dest_cluster] = [cluster.id, cluster.name] if cluster
     options[:dest_storage] = [datastore.id, datastore.name]
     signal :start_clone_task
   end


### PR DESCRIPTION
This will allow a user to provision a VM to a VMware DRS-enabled cluster without having to specify a specific host.  This aligns MIQ provision workflow with the VMware cloning workflow when you have a DRS cluster.

- [x] Lookup a host in the cluster to find the right storage ems_ref (https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb#L113)

- [x] Be able to use VDS switches/portgroups without having to lookup by host ems_ref (https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/network.rb#L83)

https://bugzilla.redhat.com/show_bug.cgi?id=1377975