### PR TITLE
Prevent deployment/delete operations in hawkular provider itself.

### DIFF
--- a/app/controllers/middleware_datasource_controller.rb
+++ b/app/controllers/middleware_datasource_controller.rb
@@ -9,7 +9,8 @@ class MiddlewareDatasourceController < ApplicationController
 
   OPERATIONS = {
     :middleware_datasource_remove => { :op   => :remove_middleware_datasource,
-                                       :hawk => N_('Not removed datasources'),
+                                       :skip => true,
+                                       :hawk => N_('removed datasources for'),
                                        :msg  => N_('The selected datasources were removed')
     }
   }.freeze

--- a/app/controllers/middleware_deployment_controller.rb
+++ b/app/controllers/middleware_deployment_controller.rb
@@ -9,19 +9,23 @@ class MiddlewareDeploymentController < ApplicationController
 
   OPERATIONS = {
     :middleware_deployment_restart  => {:op   => :restart_middleware_deployment,
-                                        :hawk => N_('Not restarting deployment'),
+                                        :skip => true,
+                                        :hawk => N_('restarting deployment for'),
                                         :msg  => N_('Restart initiated for selected deployment(s)')
     },
     :middleware_deployment_disable  => {:op   => :disable_middleware_deployment,
-                                        :hawk => N_('Not disabling deployment'),
+                                        :skip => true,
+                                        :hawk => N_('disabling deployment for'),
                                         :msg  => N_('Disable initiated for selected deployment(s)')
     },
     :middleware_deployment_enable   => {:op   => :enable_middleware_deployment,
-                                        :hawk => N_('Not enabling deployment'),
+                                        :skip => true,
+                                        :hawk => N_('enabling deployment for'),
                                         :msg  => N_('Enable initiated for selected deployment(s)')
     },
     :middleware_deployment_undeploy => {:op   => :undeploy_middleware_deployment,
-                                        :hawk => N_('Not undeploying deployment'),
+                                        :skip => true,
+                                        :hawk => N_('undeploying deployment for'),
                                         :msg  => N_('Undeployment initiated for selected deployment(s)')
     }
   }.freeze

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -105,12 +105,19 @@ module MiddlewareCommonMixin
     end
   end
 
+  def skip_operation?(item_record, operation_info)
+    provider_name = 'Hawkular'
+    if operation_info.fetch(:skip)
+      item_record.try(:product) == provider_name || item_record.try(:middleware_server).try(:product) == provider_name
+    end
+  end
+
   def run_operation_batch(operation_info, items)
     operation_triggered = false
     items.split(/,/).each do |item|
       item_record = identify_record item
-      if item_record.has_attribute?('product') && item_record.product == 'Hawkular' && operation_info.fetch(:skip)
-        add_flash(_("Not %{hawkular_info} the provider") % {:hawkular_info => operation_info.fetch(:hawk)})
+      if skip_operation?(item_record, operation_info)
+        add_flash(_("Not %{hawkular_info} the provider itself") % {:hawkular_info => operation_info.fetch(:hawk)})
       else
         run_operation_on_record(operation_info, item_record)
         operation_triggered = true


### PR DESCRIPTION
The intent of this PR is for preventing the user for deploy/undeploy something on the provider server.

for instance: this prevents undeploy of hawkular-rest-api.war, hawkular-inventory-dist.war etc..

Fixes #10967
