### PR TITLE
[Relationship]: skip unneeded is_isolated_root?

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -184,11 +184,12 @@ module RelationshipMixin
     rel.nil? ? true : rel.is_root?
   end
 
-  # Returns true if the record is a root node and does not have a corresponding
-  #   relationship record, meaning it is an isolated root node; false otherwise
-  def is_isolated_root?(*_args)
-    relationship.nil?
+  # Returns a relationship for a record that is a root node with no corresponding
+  #   relationship record, meaning it is an isolated root node
+  def relationship_for_isolated_root
+    Relationship.new(:resource => self)
   end
+  private :relationship_for_isolated_root
 
   # Returns a list of ancestor relationships, starting with the root relationship
   #   and ending with the parent relationship
@@ -221,27 +222,24 @@ module RelationshipMixin
   def path_rels(*args)
     options = args.extract_options!
     rel = relationship(:raise_on_multiple => true) # TODO: Handle multiple nodes with a way to detect which node you want
-    rels = rel.nil? ? [] : rel.path
+    rels = rel.nil? ? [relationship_for_isolated_root] : rel.path
     Relationship.filter_by_resource_type(rels, options)
   end
 
   # Returns a list of the path records, starting with the root record and ending
   #   with the node's own record
   def path(*args)
-    return [self] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in an Array?
     Relationship.resources(path_rels(*args)) # TODO: Prevent preload of self which is in the list
   end
 
   # Returns a list of the path class/id pairs, starting with the root class/id
   #   and ending with the node's own class/id
   def path_ids(*args)
-    return [[self.class.base_class.name, id]] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Array?
     Relationship.resource_pairs(path_rels(*args))
   end
 
   # Returns the number of records in the path
   def path_count(*args)
-    return 1 if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new?
     path_rels(*args).size
   end
 
@@ -352,25 +350,25 @@ module RelationshipMixin
   # Returns a list of all relationships in the record's subtree
   def subtree_rels(*args)
     options = args.extract_options!
+    # TODO: make this a single query (vs 3)
+    # thus making filter_by_resource_type into a query
     rels = relationships.flat_map(&:subtree).uniq
+    rels = [relationship_for_isolated_root] if rels.empty?
     Relationship.filter_by_resource_type(rels, options)
   end
 
   # Returns a list of all records in the record's subtree
   def subtree(*args)
-    return [self] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in an Array?
     Relationship.resources(subtree_rels(*args)) # TODO: Prevent preload of self which is in the list
   end
 
   # Returns a list of all class/id pairs in the record's subtree
   def subtree_ids(*args)
-    return [[self.class.base_class.name, id]] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in an Array?
     Relationship.resource_pairs(subtree_rels(*args))
   end
 
   # Returns the number of records in the record's subtree
   def subtree_count(*args)
-    return 1 if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new?
     subtree_rels(*args).size
   end
 
@@ -378,19 +376,17 @@ module RelationshipMixin
   def subtree_rels_arranged(*args)
     options = args.extract_options!
     rel = relationship(:raise_on_multiple => true)
-    return {} if rel.nil?  # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
+    return {relationship_for_isolated_root => {}} if rel.nil?
     Relationship.filter_arranged_rels_by_resource_type(rel.subtree.arrange, options)
   end
 
   # Returns the subtree class/id pairs arranged in a tree
   def subtree_ids_arranged(*args)
-    return {[self.class.base_class.name, id] => {}} if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
     Relationship.arranged_rels_to_resource_pairs(subtree_rels_arranged(*args))
   end
 
   # Returns the subtree records arranged in a tree
   def subtree_arranged(*args)
-    return {self => {}} if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
     Relationship.arranged_rels_to_resources(subtree_rels_arranged(*args))
   end
 
@@ -460,48 +456,42 @@ module RelationshipMixin
   # Returns a list of all relationships in the tree from the root
   def fulltree_rels(*args)
     options = args.extract_options!
-    return [] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in an Array?
-    root_id = relationship.root_id
-    rels = Relationship.subtree_of(root_id).uniq
+    root_id = relationship.try(:root_id)
+    rels = root_id ? Relationship.subtree_of(root_id).uniq : [relationship_for_isolated_root]
     Relationship.filter_by_resource_type(rels, options)
   end
 
   # Returns a list of all records in the tree from the root
   def fulltree(*args)
-    return [self] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in an Array?
     Relationship.resources(fulltree_rels(*args)) # TODO: Prevent preload of self which is in the list
   end
 
   # Returns a list of all class/id pairs in the tree from the root
   def fulltree_ids(*args)
-    return [[self.class.base_class.name, id]] if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in an Array?
     Relationship.resource_pairs(fulltree_rels(*args))
   end
 
   # Returns the number of records in the tree from the root
   def fulltree_count(*args)
-    return 1 if self.is_isolated_root?
     fulltree_rels(*args).size
   end
 
   # Returns the relationships in the tree from the root arranged in a tree
   def fulltree_rels_arranged(*args)
     options = args.extract_options!
-    return {} if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
-    root_id = relationship.root_id
+    root_id = relationship.try(:root_id)
+    return {Relationship.new(:resource => self) => {}} if root_id.nil?
     rels = Relationship.subtree_of(root_id).arrange
     Relationship.filter_arranged_rels_by_resource_type(rels, options)
   end
 
   # Returns the class/id pairs in the tree from the root arranged in a tree
   def fulltree_ids_arranged(*args)
-    return {[self.class.base_class.name, id] => {}} if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
     Relationship.arranged_rels_to_resource_pairs(fulltree_rels_arranged(*args))
   end
 
   # Returns the records in the tree from the root arranged in a tree
   def fulltree_arranged(*args)
-    return {self => {}} if self.is_isolated_root? # TODO: Should this return nil or init_relationship or Relationship.new in a Hash?
     Relationship.arranged_rels_to_resources(fulltree_rels_arranged(*args))
   end
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -39,7 +39,7 @@ class Relationship < ApplicationRecord
   #
 
   def self.resource(relationship)
-    relationship.nil? ? nil : relationship.resource
+    relationship.try!(:resource)
   end
 
   def self.resources(relationships)

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :relationship do
-    resource_type  "VmOrTemplate"
+    # passed in resource will determine resource_type
   end
 
   factory :relationship_vm_vmware, :parent => :relationship do

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -283,18 +283,41 @@ describe RelationshipMixin do
 
   describe "#root" do
     it "is self with with no relationships" do
-      nodes = host.with_relationship_type(test_rel_type, &:root)
-      expect(nodes).to eq(host)
+      host # execute the query
+      expect do
+        nodes = host.with_relationship_type(test_rel_type, &:root)
+        expect(nodes).to eq(host)
+      end.to match_query_limit_of(1) # lookup the relationship node
     end
 
     it "is a self with a tree's root node" do
-      nodes = vms[0].with_relationship_type(test_rel_type, &:root)
-      expect(nodes).to eq(vms[0])
+      vms # execute the lookup query
+      expect do
+        nodes = vms[0].with_relationship_type(test_rel_type, &:root)
+        expect(nodes).to eq(vms[0])
+      end.to match_query_limit_of(1) # lookup the relationship node
     end
 
     it "is a parent with a tree's child node" do
       nodes = vms[7].with_relationship_type(test_rel_type, &:root)
       expect(nodes).to eq(vms[0])
+    end
+  end
+
+  describe "#root_id" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:root_id)
+      expect(nodes).to eq(["Host", host.id])
+    end
+
+    it "is a self with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:root_id)
+      expect(nodes).to eq(["VmOrTemplate", vms[0].id])
+    end
+
+    it "is a parent with a tree's child node" do
+      nodes = vms[7].with_relationship_type(test_rel_type, &:root_id)
+      expect(nodes).to eq(["VmOrTemplate", vms[0].id])
     end
   end
 

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -6,6 +6,8 @@ describe RelationshipMixin do
   #             8 9
   let(:vms_rel_tree) { {0 => [{1 => [3, 4]}, {2 => [5, 6, {7 => [8, 9]}]}]} }
   let(:vms) { build_relationship_tree(vms_rel_tree) }
+  # host with no tree
+  let(:host) { FactoryGirl.create(:host) }
 
   context "tree with relationship" do
     it "#with_relationship_type and #relationship_type" do
@@ -251,22 +253,6 @@ describe RelationshipMixin do
     end
   end
 
-  context "tree with no relationships" do
-    before(:each) { @host = FactoryGirl.create(:host) }
-
-    it('#root') { expect(@host.root).to eq(@host) }
-
-    it('#ancestors')   { expect(@host.ancestors).to eq([]) }
-    it('#path')        { expect(@host.path).to eq([@host]) }
-    it('#descendants') { expect(@host.descendants).to eq([]) }
-    it('#subtree')     { expect(@host.subtree).to eq([@host]) }
-    it('#fulltree')    { expect(@host.fulltree).to eq([@host]) }
-
-    it('#descendants_arranged') { expect(@host.descendants_arranged).to eq({}) }
-    it('#subtree_arranged')     { expect(@host.subtree_arranged).to eq({@host => {}}) }
-    it('#fulltree_arranged')    { expect(@host.fulltree_arranged).to eq({@host => {}}) }
-  end
-
   context "tree with relationship type 'ems_metadata'" do
     let(:vms) { build_relationship_tree(vms_rel_tree, "ems_metadata") }
 
@@ -295,15 +281,462 @@ describe RelationshipMixin do
     end
   end
 
+  describe "#root" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:root)
+      expect(nodes).to eq(host)
+    end
+
+    it "is a self with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:root)
+      expect(nodes).to eq(vms[0])
+    end
+
+    it "is a parent with a tree's child node" do
+      nodes = vms[7].with_relationship_type(test_rel_type, &:root)
+      expect(nodes).to eq(vms[0])
+    end
+  end
+
+  # VMs override path, so we will work with host trees
+  describe "#path" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:path)
+      expect(nodes).to eq([host])
+    end
+
+    it "is a self with a tree's root node" do
+      hosts = build_relationship_tree({0 => [1, 2]}, test_rel_type, :host_vmware)
+      nodes = hosts[0].with_relationship_type(test_rel_type, &:path)
+      expect(nodes).to eq([hosts[0]])
+    end
+
+    it "is a parent with a tree's child node" do
+      hosts = build_relationship_tree({0 => [{1 => [3, 4]}, 2]}, test_rel_type, :host_vmware)
+      nodes = hosts[3].with_relationship_type(test_rel_type, &:path)
+      expect(nodes).to eq([hosts[0], hosts[1], hosts[3]])
+    end
+  end
+
+  describe "#path_id" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:path_ids)
+      expect(nodes).to eq([["Host", host.id]])
+    end
+
+    it "is a self with a tree's root node" do
+      hosts = build_relationship_tree({0 => [1, 2]}, test_rel_type, :host_vmware)
+      nodes = hosts[0].with_relationship_type(test_rel_type, &:path_ids)
+      expect(nodes).to eq([["Host", hosts[0].id]])
+    end
+
+    it "is a parent with a tree's child node" do
+      hosts = build_relationship_tree({0 => [{1 => [3, 4]}, 2]}, test_rel_type, :host_vmware)
+      nodes = hosts[3].with_relationship_type(test_rel_type, &:path_ids)
+      expect(nodes).to eq([["Host", hosts[0].id], ["Host", hosts[1].id], ["Host", hosts[3].id]])
+    end
+  end
+
+  describe "#path_count" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:path_count)
+      expect(nodes).to eq(1)
+    end
+
+    it "is a self with a tree's root node" do
+      hosts = build_relationship_tree({0 => [1, 2]}, test_rel_type, :host_vmware)
+      nodes = hosts[0].with_relationship_type(test_rel_type, &:path_count)
+      expect(nodes).to eq(1)
+    end
+
+    it "is a parent with a tree's child node" do
+      hosts = build_relationship_tree({0 => [{1 => [3, 4]}, 2]}, test_rel_type, :host_vmware)
+      nodes = hosts[3].with_relationship_type(test_rel_type, &:path_count)
+      expect(nodes).to eq(3)
+    end
+  end
+
+  describe "#ancestors" do
+    it "is empty with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:ancestors)
+      expect(nodes).to eq([])
+    end
+
+    it "is empty with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:ancestors)
+      expect(nodes).to eq([])
+    end
+
+    it "is an ancestor with child nodes" do
+      nodes = vms[7].with_relationship_type(test_rel_type, &:ancestors)
+      expect(nodes).to eq([vms[0], vms[2]])
+    end
+  end
+
+  describe "#subtree" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:subtree)
+      expect(nodes).to eq([host])
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:subtree)
+      expect(nodes).to match_array(vms.values)
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:subtree)
+      expect(nodes).to match_array([vms[2], vms[5], vms[6], vms[7], vms[8], vms[9]])
+    end
+  end
+
+  describe "#subtree_arranged" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:subtree_arranged)
+      expect(nodes).to eq(host => {})
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:subtree_arranged)
+      expect(nodes).to eq(
+        vms[0] => {
+          vms[1] => {
+            vms[3] => {},
+            vms[4] => {}
+          },
+          vms[2] => {
+            vms[5] => {},
+            vms[6] => {},
+            vms[7] => {
+              vms[8] => {},
+              vms[9] => {}
+            }
+          }
+        }
+      )
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:subtree_arranged)
+      expect(nodes).to eq(
+        vms[2] => {
+          vms[5] => {},
+          vms[6] => {},
+          vms[7] => {
+            vms[8] => {},
+            vms[9] => {}
+          }
+        }
+      )
+    end
+  end
+
+  describe "#subtree_ids" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:subtree_ids)
+      expect(nodes).to eq([["Host", host.id]])
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:subtree_ids)
+      expect(nodes).to match_array(vms.values.map { |vm| ["VmOrTemplate", vm.id] })
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:subtree_ids)
+      expect(nodes).to match_array(
+        [["VmOrTemplate", vms[2].id], ["VmOrTemplate", vms[5].id], ["VmOrTemplate", vms[6].id],
+         ["VmOrTemplate", vms[7].id], ["VmOrTemplate", vms[8].id], ["VmOrTemplate", vms[9].id]]
+      )
+    end
+  end
+
+  describe "#subtree_ids_arranged" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:subtree_ids_arranged)
+      expect(nodes).to eq([host.class.name, host.id] => {})
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:subtree_ids_arranged)
+      expect(nodes).to eq(
+        ["VmOrTemplate", vms[0].id] => {
+          ["VmOrTemplate", vms[1].id] => {
+            ["VmOrTemplate", vms[3].id] => {},
+            ["VmOrTemplate", vms[4].id] => {}
+          },
+          ["VmOrTemplate", vms[2].id] => {
+            ["VmOrTemplate", vms[5].id] => {},
+            ["VmOrTemplate", vms[6].id] => {},
+            ["VmOrTemplate", vms[7].id] => {
+              ["VmOrTemplate", vms[8].id] => {},
+              ["VmOrTemplate", vms[9].id] => {}
+            }
+          }
+        }
+      )
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:subtree_ids_arranged)
+      expect(nodes).to eq(
+        ["VmOrTemplate", vms[2].id] => {
+          ["VmOrTemplate", vms[5].id] => {},
+          ["VmOrTemplate", vms[6].id] => {},
+          ["VmOrTemplate", vms[7].id] => {
+            ["VmOrTemplate", vms[8].id] => {},
+            ["VmOrTemplate", vms[9].id] => {}
+          }
+        }
+      )
+    end
+  end
+
+  describe "#subtree_count" do
+    it "is 1 with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:subtree_count)
+      expect(nodes).to eq(1)
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:subtree_count)
+      expect(nodes).to eq(10)
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:subtree_count)
+      expect(nodes).to eq(6)
+    end
+  end
+
+  describe "#descendants" do
+    it "is empty with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:descendants)
+      expect(nodes).to eq([])
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:descendants)
+      expect(nodes).to match_array([vms[1], vms[3], vms[4], vms[2], vms[5], vms[6], vms[7], vms[8], vms[9]])
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:descendants)
+      expect(nodes).to match_array([vms[5], vms[6], vms[7], vms[8], vms[9]])
+    end
+  end
+
+  describe "#descendants_arranged" do
+    it "is empty with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:descendants_arranged)
+      expect(nodes).to eq({})
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:descendants_arranged)
+      expect(nodes).to eq(
+        vms[1] => {
+          vms[3] => {},
+          vms[4] => {}
+        },
+        vms[2] => {
+          vms[5] => {},
+          vms[6] => {},
+          vms[7] => {
+            vms[8] => {},
+            vms[9] => {}
+          }
+        }
+      )
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:descendants_arranged)
+      expect(nodes).to eq(
+        vms[5] => {},
+        vms[6] => {},
+        vms[7] => {
+          vms[8] => {},
+          vms[9] => {}
+        }
+      )
+    end
+  end
+
+  describe "#descendant_ids_arranged" do
+    it "is empty with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:descendant_ids_arranged)
+      expect(nodes).to eq({})
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:descendant_ids_arranged)
+      expect(nodes).to eq(
+        ["VmOrTemplate", vms[1].id] => {
+          ["VmOrTemplate", vms[3].id] => {},
+          ["VmOrTemplate", vms[4].id] => {}
+        },
+        ["VmOrTemplate", vms[2].id] => {
+          ["VmOrTemplate", vms[5].id] => {},
+          ["VmOrTemplate", vms[6].id] => {},
+          ["VmOrTemplate", vms[7].id] => {
+            ["VmOrTemplate", vms[8].id] => {},
+            ["VmOrTemplate", vms[9].id] => {}
+          }
+        }
+      )
+    end
+
+    it "is a subtree with a tree's child node" do
+      nodes = vms[2].with_relationship_type(test_rel_type, &:descendant_ids_arranged)
+      expect(nodes).to eq(
+        ["VmOrTemplate", vms[5].id] => {},
+        ["VmOrTemplate", vms[6].id] => {},
+        ["VmOrTemplate", vms[7].id] => {
+          ["VmOrTemplate", vms[8].id] => {},
+          ["VmOrTemplate", vms[9].id] => {}
+        }
+      )
+    end
+  end
+
+  describe "#fulltree" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:fulltree)
+      expect(nodes).to eq([host])
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:fulltree)
+      expect(nodes).to match_array([vms[0], vms[1], vms[3], vms[4], vms[2], vms[5], vms[6], vms[7], vms[8], vms[9]])
+    end
+
+    it "is the full tree with a tree's child node" do
+      nodes = vms[8].with_relationship_type(test_rel_type, &:fulltree)
+      expect(nodes).to match_array([vms[0], vms[1], vms[3], vms[4], vms[2], vms[5], vms[6], vms[7], vms[8], vms[9]])
+    end
+  end
+
+  describe "#fulltree_arranged" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:fulltree_arranged)
+      expect(nodes).to eq(host => {})
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:fulltree_arranged)
+      expect(nodes).to eq(
+        vms[0] => {
+          vms[1] => {
+            vms[3] => {},
+            vms[4] => {}
+          },
+          vms[2] => {
+            vms[5] => {},
+            vms[6] => {},
+            vms[7] => {
+              vms[8] => {},
+              vms[9] => {}
+            }
+          }
+        }
+      )
+    end
+
+    it "is the full tree with a tree's child node" do
+      nodes = vms[8].with_relationship_type(test_rel_type, &:fulltree_arranged)
+      expect(nodes).to eq(
+        vms[0] => {
+          vms[1] => {
+            vms[3] => {},
+            vms[4] => {}
+          },
+          vms[2] => {
+            vms[5] => {},
+            vms[6] => {},
+            vms[7] => {
+              vms[8] => {},
+              vms[9] => {}
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "#fulltree_ids_arranged" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:fulltree_ids_arranged)
+      expect(nodes).to eq([host.class.name, host.id] => {})
+    end
+
+    it "is the full tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:fulltree_ids_arranged)
+      expect(nodes).to eq(
+        ["VmOrTemplate", vms[0].id] => {
+          ["VmOrTemplate", vms[1].id] => {
+            ["VmOrTemplate", vms[3].id] => {},
+            ["VmOrTemplate", vms[4].id] => {}
+          },
+          ["VmOrTemplate", vms[2].id] => {
+            ["VmOrTemplate", vms[5].id] => {},
+            ["VmOrTemplate", vms[6].id] => {},
+            ["VmOrTemplate", vms[7].id] => {
+              ["VmOrTemplate", vms[8].id] => {},
+              ["VmOrTemplate", vms[9].id] => {}
+            }
+          }
+        }
+      )
+    end
+
+    it "is the full tree with a tree's child node" do
+      nodes = vms[8].with_relationship_type(test_rel_type, &:fulltree_ids_arranged)
+      expect(nodes).to eq(
+        ["VmOrTemplate", vms[0].id] => {
+          ["VmOrTemplate", vms[1].id] => {
+            ["VmOrTemplate", vms[3].id] => {},
+            ["VmOrTemplate", vms[4].id] => {}
+          },
+          ["VmOrTemplate", vms[2].id] => {
+            ["VmOrTemplate", vms[5].id] => {},
+            ["VmOrTemplate", vms[6].id] => {},
+            ["VmOrTemplate", vms[7].id] => {
+              ["VmOrTemplate", vms[8].id] => {},
+              ["VmOrTemplate", vms[9].id] => {}
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "#fulltree_count" do
+    it "is self with with no relationships" do
+      nodes = host.with_relationship_type(test_rel_type, &:fulltree_count)
+      expect(nodes).to eq(1)
+    end
+
+    it "is the tree with a tree's root node" do
+      nodes = vms[0].with_relationship_type(test_rel_type, &:fulltree_count)
+      expect(nodes).to eq(10)
+    end
+
+    it "is the full tree with a tree's child node" do
+      nodes = vms[8].with_relationship_type(test_rel_type, &:fulltree_count)
+      expect(nodes).to eq(10)
+    end
+  end
+
   protected
 
-  def build_relationship_tree(tree, rel_type = test_rel_type)
+  def build_relationship_tree(tree, rel_type = test_rel_type, base_factory = :vm_vmware)
     # temp list of the relationships
     # allows easy access while building
     # can map to the resource to return all the resources created
     rels = Hash.new do |hash, key|
-      hash[key] = FactoryGirl.create(:relationship_vm_vmware,
-                                     :resource     => FactoryGirl.create(:vm_vmware),
+      hash[key] = FactoryGirl.create(:relationship,
+                                     :resource     => FactoryGirl.create(base_factory),
                                      :relationship => rel_type)
     end
 


### PR DESCRIPTION
**High Level:**

- Remove `TODO:` items around one edge case: A node passed in has no tree. `+10/-20`
- This removes extra queries to the database (1+ per tree)
- Adds tests `+454/-20`

**Details:**

Don't call `is_isloated_root?` to short circuit the calls.

The methods calls `is_isolated_root?` to ensure `relationship` is not `null`,
but the very next call it looks up the `relationship`. Best to just fetch
the `relationship` once and then react accordingly.

This short circuit often makes an additional query. Sometimes the code
could have chained query through to rbac, but instead it forces a
load and database queries.

A cache was needed to alleviate the extra `is_isolated_root?` query.

Also, the short circuit is skipping the filtering in the `_rel_` methods.

after
----

- added tests for all method modified (and more)
- tests are based upon method (not data scenario) so you can see if each method is tested to your satisfaction.
- added test cases for no tree, accessing root node, and accessing child node in the tree.
- removed `TODO` item around the `_rels_` methods not short circuiting correctly.
- `build_relationship_tree` helper now builds trees for any model type.

|        ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  23,982.2 |  143 |  8,514.8 |   89,703 |before
|  22,743.7 |  131 |  8,315.1 |   89,691 |after
| N/A | 8% | N/A | minimal |

I think those numbers are misleading. It is executing 1 fewer queries per ems: It is querying the relationships table (1.0ms, 1 row) x 12 fewer == (12.0ms, 12 rows, 12 queries)
/cc @Fryguy FYI