### PR TITLE
rubocop issues: section.rb

### DIFF
--- a/app/presenters/menu/section.rb
+++ b/app/presenters/menu/section.rb
@@ -1,7 +1,10 @@
 module Menu
   Section = Struct.new(:id, :name, :icon, :items, :placement, :before, :type, :href) do
-    def initialize(an_id, name, icon, items = [], placement = :default, before = nil, type = :default, href = nil)
+    def initialize(an_id, name, icon, *args)
       super
+      self.items ||= []
+      self.placement ||= :default
+      self.type ||= :default
     end
 
     def features
@@ -36,9 +39,9 @@ module Menu
     end
 
     def contains_item_id?(item_id)
-     items.detect do |el|
-       el.id == item_id || (el.kind_of?(Section) && el.contains_item_id?(item_id))
-     end.present?
+      items.detect do |el|
+        el.id == item_id || (el.kind_of?(Section) && el.contains_item_id?(item_id))
+      end.present?
     end
 
     def default_redirect_url


### PR DESCRIPTION
== app/presenters/menu/section.rb ==
    R:  3: 19: Avoid parameter lists longer than 5 parameters.
    C: 39:  5: Use 2 (not 1) spaces for indentation.