### PR TITLE
Remove duplicate item of list in display_adv_search?

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -797,7 +797,7 @@ module ApplicationHelper
        load_balancer
        resource_pool ems_infra ontap_storage_system ontap_storage_volume
        ontap_file_share snia_local_file_system ontap_logical_disk
-       orchestration_stack cim_base_storage_extent storage storage_manager configuration_job).include?(@layout)
+       orchestration_stack cim_base_storage_extent storage_manager configuration_job).include?(@layout)
   end
 
   # Do we show or hide the clear_search link in the list view title


### PR DESCRIPTION
"storage" is removed from the list in display_adv_search? method
in application helper because it makes no sense to be there twice.