### PR TITLE
Display asynchronous ActionCable notifications in the UI

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -4,9 +4,6 @@ var miqInitNotifications = function () {
   var cable = ActionCable.createConsumer('/ws/notifications');
 
   var notifications = cable.subscriptions.create("NotificationChannel", {
-    connected: function () {
-      console.log("Cable client connected!");
-    },
     disconnected: function () {
       var _this = this;
       // Try to request a new ws_token if disconnected, reconnecting will happen automatically
@@ -17,7 +14,7 @@ var miqInitNotifications = function () {
       });
     },
     received: function (data) {
-      console.log("Cable message received:", data);
+      sendDataWithRx({notification: data});
     }
   });
 }

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -28,6 +28,7 @@ function eventNotifications($timeout) {
 
   var state = ManageIQ.angular.eventNotificationsData.state;
   var observerCallbacks = ManageIQ.angular.eventNotificationsData.observerCallbacks;
+  var _this = this;
 
   var updateUnreadCount = function(group) {
     if (group) {
@@ -67,8 +68,6 @@ function eventNotifications($timeout) {
     state.toastNotifications = [];
 
     if (seed) {
-      var _this = this;
-
       API.get('/api/notifications?expand=resources&attributes=details')
       .then(function (data) {
         data.resources.forEach(function(resource) {
@@ -121,6 +120,7 @@ function eventNotifications($timeout) {
       type: type,
       message: message,
       data: notificationData,
+      href: id ? '/api/notifications/' + id : undefined,
       timeStamp: (new Date()).getTime()
     };
 
@@ -209,7 +209,6 @@ function eventNotifications($timeout) {
 
   this.markAllRead = function(group) {
     if (group) {
-      var _this = this;
       var resources = group.notifications.map(function(notification) {
         notification.unread = false;
         _this.removeToast(notification);
@@ -263,7 +262,6 @@ function eventNotifications($timeout) {
 
   this.clearAll = function(group) {
     if (group) {
-      var _this = this;
       var resources = group.notifications.map(function(notification) {
         _this.removeToast(notification);
         return { href: notification.href };
@@ -316,4 +314,11 @@ function eventNotifications($timeout) {
   };
 
   this.doReset(true);
+
+  ManageIQ.angular.rxSubject.subscribe(function (data) {
+    if (data.notification) {
+      var msg = miqFormatNotification(data.notification.text, data.notification.bindings);
+      _this.add('event', data.notification.level, msg, {message: msg}, data.notification.id);
+    }
+  });
 }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -29,8 +29,8 @@ class Notification < ApplicationRecord
   private
 
   def emit_message
-    notification_recipients.pluck(:user_id).each do |user|
-      ActionCable.server.broadcast("notifications_#{user}", to_h)
+    notification_recipients.pluck(:id, :user_id).each do |id, user|
+      ActionCable.server.broadcast("notifications_#{user}", to_h.merge!(:id => id))
     end
   end
 


### PR DESCRIPTION
This PR links together ActionCable with PatternFly's notification drawer powered by Angular. 

A new notification can be created in a `rails console` using:
```ruby
Notification.create(:type => :vm_powered_on, :subject => Vm.first)
```

If the user is logged in at the moment of the notification creation, he will receive a toast message:
![screenshot from 2016-09-22 13-30-12](https://cloud.githubusercontent.com/assets/649130/18746621/b68b9f88-80c8-11e6-9131-19b39ad3015d.png)

The notification will also appear in the drawer, even if the user was not logged in:
![screenshot from 2016-09-22 13-31-49](https://cloud.githubusercontent.com/assets/649130/18746654/f191aa64-80c8-11e6-9832-7ab859285cc6.png)

Summoning: :sparkles:  :pray: :sparkles:
* @isimluk for the changes in the model
* @himdel for the changes in the angular