### PR TITLE
Enable My Filters in Datastores

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1161,7 +1161,8 @@ module ApplicationHelper
          ems_infra host miq_template offline orchestration_stack persistent_volume ems_middleware
          middleware_server middleware_deployment middleware_datasource middleware_domain middleware_server_group
          middleware_messaging ems_network security_group floating_ip cloud_subnet network_router network_port
-         cloud_network resource_pool retired service templates vm configuration_job).include?(@layout) && !@in_a_form
+         cloud_network resource_pool retired service storage templates vm
+         configuration_job).include?(@layout) && !@in_a_form
       "show_list"
     elsif @compare
       "compare_sections"


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1361224

Make My Filters in Datastores clickable
when reaching Compute -> Infrastructure -> Datastores.

Before:
![datastores_before](https://cloud.githubusercontent.com/assets/13417815/18750852/247ea1ac-80dd-11e6-8ea9-ec237a7cdf73.png)

After:
![datastores_after](https://cloud.githubusercontent.com/assets/13417815/18750856/2959edda-80dd-11e6-9ef0-24bc0154e94a.png)

