### PR TITLE
Keep pod-container relationship after disconnection

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -6,6 +6,7 @@ class Container < ApplicationRecord
   has_one    :container_node, :through => :container_group
   has_one    :container_replicator, :through => :container_group
   has_one    :container_project, :through => :container_group
+  has_one    :old_container_project, :through => :container_group
   belongs_to :container_definition
   belongs_to :container_image
   has_one    :container_image_registry, :through => :container_image

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -12,7 +12,6 @@ class ContainerDefinition < ApplicationRecord
     _log.info "Disconnecting Container definition [#{name}] id [#{id}]"
     self.container.try(:disconnect_inv)
     self.deleted_on = Time.now.utc
-    self.container_group = nil
     self.old_ems_id = self.ems_id
     self.ems_id = nil
     save


### PR DESCRIPTION
We need to keep this relationship for chargeback reports since we would like to know the project that an archived container belonged to

@simon3z @moolitayer @Fryguy Please review