### PR TITLE
Fix for Azure Orchestration template no longer defaults to Default

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -2,7 +2,6 @@ class DialogField < ApplicationRecord
   include NewWithTypeStiMixin
   attr_accessor :value
   attr_accessor :dialog
-  attr_accessor :default_value
 
   belongs_to :dialog_group
   has_one :resource_action, :as => :resource, :dependent => :destroy
@@ -77,7 +76,7 @@ class DialogField < ApplicationRecord
   end
 
   def initialize_with_values(dialog_values)
-    @value = value_from_dialog_fields(dialog_values) || get_default_value
+    @value = value_from_dialog_fields(dialog_values) || default_value
   end
 
   def update_values(_dialog_values)
@@ -132,10 +131,6 @@ class DialogField < ApplicationRecord
 
   def value_from_dialog_fields(dialog_values)
     dialog_values[automate_key_name] || dialog_values[name]
-  end
-
-  def get_default_value
-    default_value
   end
 
   def values_from_automate

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -6,25 +6,4 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def initial_values
     [[nil, "<None>"]]
   end
-
-  def refresh_json_value(checked_value)
-    @raw_values = @default_value = nil
-
-    refreshed_values = values
-
-    if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
-      @value = checked_value
-    else
-      @value = @default_value
-    end
-
-    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?, :visible => visible?}
-  end
-
-  private
-
-  def load_values_on_init?
-    return true unless show_refresh_button
-    load_values_on_init
-  end
 end

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -6,25 +6,4 @@ class DialogFieldRadioButton < DialogFieldSortedItem
   def initial_values
     [["", "<None>"]]
   end
-
-  def refresh_json_value(checked_value)
-    @raw_values = @default_value = nil
-
-    refreshed_values = values
-
-    if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
-      @value = checked_value
-    else
-      @value = @default_value
-    end
-
-    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?, :visible => visible?}
-  end
-
-  private
-
-  def load_values_on_init?
-    return true unless show_refresh_button
-    load_values_on_init
-  end
 end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -57,9 +57,24 @@ class DialogFieldSortedItem < DialogField
   end
 
   def trigger_automate_value_updates
-    @default_value = nil if dynamic
+    self.default_value = nil if dynamic
     @raw_values = nil
     raw_values
+  end
+
+  def refresh_json_value(checked_value)
+    self.default_value = nil
+    @raw_values = nil
+
+    refreshed_values = values
+
+    @value = if refreshed_values.collect { |value_pair| value_pair[0].to_s }.include?(checked_value)
+               checked_value
+             else
+               default_value
+             end
+
+    {:refreshed_values => refreshed_values, :checked_value => @value, :read_only => read_only?, :visible => visible?}
   end
 
   private
@@ -77,15 +92,20 @@ class DialogFieldSortedItem < DialogField
 
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : self[:values].to_miq_a
-    unless @raw_values.collect { |value_pair| value_pair[0] }.include?(@default_value)
-      @default_value = sort_data(@raw_values).first.first
+    unless @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
+      self.default_value = sort_data(@raw_values).first.first
     end
-    self.value ||= @default_value
+    self.value ||= default_value
 
     @raw_values
   end
 
   def initial_values
     [[nil, "<None>"]]
+  end
+
+  def load_values_on_init?
+    return true unless show_refresh_button
+    load_values_on_init
   end
 end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -1,6 +1,163 @@
 describe DialogFieldSortedItem do
   let(:df) { FactoryGirl.build(:dialog_field_sorted_item, :label => 'dialog_field', :name => 'dialog_field') }
 
+  describe "#initialize_with_values" do
+    let(:dialog_field) do
+      described_class.new(
+        :name                => "potato_name",
+        :default_value       => default_value,
+        :load_values_on_init => load_values_on_init,
+        :show_refresh_button => show_refresh_button,
+        :values              => [%w(test test), %w(test2 test2)]
+      )
+    end
+    let(:default_value) { "test2" }
+
+    context "when show_refresh_button is true" do
+      let(:show_refresh_button) { true }
+
+      context "when load_values_on_init is true" do
+        let(:load_values_on_init) { true }
+
+        context "when the dialog values match the automate key name" do
+          let(:dialog_values) { {"dialog_potato_name" => "dialog potato value"} }
+
+          it "uses the values given" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq("dialog potato value")
+          end
+        end
+
+        context "when the dialog values match the dialog name" do
+          let(:dialog_values) { {"potato_name" => "potato value"} }
+
+          it "uses the values given" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq("potato value")
+          end
+        end
+
+        context "when the values from the passed in dialog values do not match either the automate or dialog name" do
+          let(:dialog_values) { {"not_potato_name" => "not potato value"} }
+
+          context "when the default value does not exist in the list of options" do
+            let(:default_value) { "default value" }
+
+            it "uses the default value of the dialog field" do
+              dialog_field.initialize_with_values(dialog_values)
+              expect(dialog_field.value).to eq("test")
+            end
+          end
+
+          context "when the default value does exist in the list of options" do
+            it "uses the default value of the dialog field" do
+              dialog_field.initialize_with_values(dialog_values)
+              expect(dialog_field.value).to eq("test2")
+            end
+          end
+        end
+      end
+
+      context "when load_values_on_init is false" do
+        let(:load_values_on_init) { false }
+        let(:dialog_values) { "potato" }
+
+        it "sets the raw values to the initial values" do
+          dialog_field.initialize_with_values(dialog_values)
+          expect(dialog_field.instance_variable_get(:@raw_values)).to eq([[nil, "<None>"]])
+        end
+      end
+    end
+
+    context "when show_refresh_button is false" do
+      let(:show_refresh_button) { false }
+
+      context "when load_values_on_init is true" do
+        let(:load_values_on_init) { true }
+
+        context "when the dialog values match the automate key name" do
+          let(:dialog_values) { {"dialog_potato_name" => "dialog potato value"} }
+
+          it "uses the values given" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq("dialog potato value")
+          end
+        end
+
+        context "when the dialog values match the dialog name" do
+          let(:dialog_values) { {"potato_name" => "potato value"} }
+
+          it "uses the values given" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq("potato value")
+          end
+        end
+
+        context "when the values from the passed in dialog values do not match either the automate or dialog name" do
+          let(:dialog_values) { {"not_potato_name" => "not potato value"} }
+
+          context "when the default value does not exist in the list of options" do
+            let(:default_value) { "default value" }
+
+            it "uses the default value of the dialog field" do
+              dialog_field.initialize_with_values(dialog_values)
+              expect(dialog_field.value).to eq("test")
+            end
+          end
+
+          context "when the default value does exist in the list of options" do
+            it "uses the default value of the dialog field" do
+              dialog_field.initialize_with_values(dialog_values)
+              expect(dialog_field.value).to eq("test2")
+            end
+          end
+        end
+      end
+
+      context "when load_values_on_init is false" do
+        let(:load_values_on_init) { false }
+
+        context "when the dialog values match the automate key name" do
+          let(:dialog_values) { {"dialog_potato_name" => "dialog potato value"} }
+
+          it "uses the values given" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq("dialog potato value")
+          end
+        end
+
+        context "when the dialog values match the dialog name" do
+          let(:dialog_values) { {"potato_name" => "potato value"} }
+
+          it "uses the values given" do
+            dialog_field.initialize_with_values(dialog_values)
+            expect(dialog_field.value).to eq("potato value")
+          end
+        end
+
+        context "when the values from the passed in dialog values do not match either the automate or dialog name" do
+          let(:dialog_values) { {"not_potato_name" => "not potato value"} }
+
+          context "when the default value does not exist in the list of options" do
+            let(:default_value) { "default value" }
+
+            it "uses the default value of the dialog field" do
+              dialog_field.initialize_with_values(dialog_values)
+              expect(dialog_field.value).to eq("test")
+            end
+          end
+
+          context "when the default value does exist in the list of options" do
+            it "uses the default value of the dialog field" do
+              dialog_field.initialize_with_values(dialog_values)
+              expect(dialog_field.value).to eq("test2")
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "#get_default_value" do
     it "returns the first value when no default and only a single value is available" do
       df.values = [%w(value1 text1)]

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -175,7 +175,7 @@ describe DialogField do
     end
   end
 
-  it "has default_value as an accessible attribute" do
-    expect(described_class.new).to have_attr_accessor(:default_value)
+  it "does not use attr_accessor for default_value" do
+    expect(described_class.new(:default_value => "test")[:default_value]).to eq("test")
   end
 end

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -87,6 +87,7 @@ describe OrchestrationTemplateDialogService do
     mode_values = [["Complete",    "Complete (Delete other resources in the group)"],
                    ["Incremental", "Incremental (Default)"]]
     assert_field(fields[4], DialogFieldDropDownList, :name => "deploy_mode", :values => mode_values)
+    expect(fields[4].default_value).to eq("Incremental")
   end
 
   def assert_field(field, clss, attributes)


### PR DESCRIPTION
This PR removes the `attr_accessor` for `default_value` because I didn't realize that rails handles this for columns (makes sense now but didn't cross my mind when I implemented the original fix). The issue before when I implemented that change was that we were referencing `@default_value` instead of `default_value`.

https://bugzilla.redhat.com/show_bug.cgi?id=1376603

@gmcculloug I'm guessing you'd suggest @bzwei to review, but please tag someone else if not :).
@miq-bot assign @gmcculloug 