### PR TITLE
Add API for import of VMs from Vmware to RHEV infra provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "omniauth",                       "~>1.3.1",       :require => false
 gem "omniauth-google-oauth2",         "~>0.2.6"
 gem "open4",                          "~>1.3.0",       :require => false
 gem "outfielding-jqplot-rails",       "= 1.0.8"
-gem "ovirt-engine-sdk",               "~>4.0.5",       :require => false # Required by the oVirt provider
+gem "ovirt-engine-sdk",               "~>4.0.6",       :require => false # Required by the oVirt provider
 gem "ovirt_metrics",                  "~>1.3.0",       :require => false
 gem "paperclip",                      "~>4.3.0"
 gem "puma",                           "~>3.3.0"

--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -61,6 +61,27 @@ module Api
       super(object, type, id, formatted_data)
     end
 
+    def import_vm_resource(type, id = nil, data = {})
+      raise BadRequestError, "Must specify an id for import of VM to a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        provider = resource_search(id, type, klass)
+
+        vm_id = parse_id(data['source'], :vms)
+        # check if user can access the VM
+        resource_search(vm_id, :vms, Vm)
+
+        api_log_info("Importing VM to #{provider_ident(provider)}")
+        target_params = {
+          :name       => data.fetch_path('target', 'name'),
+          :cluster_id => parse_id(data.fetch_path('target', 'cluster'), :clusters),
+          :storage_id => parse_id(data.fetch_path('target', 'data_store'), :data_stores),
+          :sparse     => data.fetch_path('target', 'sparse')
+        }
+        import_vm_to_provider(provider, vm_id, target_params)
+      end
+    end
+
     private
 
     def format_provider_custom_attributes(attribute)
@@ -122,6 +143,16 @@ module Api
     def destroy_provider(provider)
       desc = "#{provider_ident(provider)} deleting"
       task_id = queue_object_action(provider, desc, :method_name => "destroy")
+      action_result(true, desc, :task_id => task_id)
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def import_vm_to_provider(provider, source_vm_id, target_params)
+      desc = "#{provider_ident(provider)} importing vm"
+      task_id = queue_object_action(provider, desc,
+                                    :method_name => 'import_vm',
+                                    :args        => [source_vm_id, target_params])
       action_result(true, desc, :task_id => task_id)
     rescue => err
       action_result(false, err.to_s)

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -51,5 +51,9 @@ module ManageIQ::Providers
     def validate_authentication_status
       {:available => true, :message => nil}
     end
+
+    def validate_import_vm
+      false
+    end
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   require_nested  :Template
   require_nested  :Vm
   include_concern :ApiIntegration
+  include_concern :VmImport
 
   supports :provisioning
   supports :refresh_new_target

--- a/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm_import.rb
@@ -1,0 +1,89 @@
+module ManageIQ::Providers::Redhat::InfraManager::VmImport
+  extend ActiveSupport::Concern
+
+  # source_params {
+  #   vm_id
+  # }
+  #
+  # target_params {
+  #   name (optional)
+  #   cluster_id
+  #   storage_id
+  #   sparse
+  # }
+  def import_vm(source_vm_id, target_params)
+    vm = Vm.includes(:ext_management_system).find(source_vm_id)
+    source_provider = vm.ext_management_system
+
+    check_import_supported! source_provider
+
+    auth = password_auth(source_provider)
+    perform_vmware_to_ovirt_import(
+      :source_vm_name    => vm.name,
+      :target_vm_name    => target_params[:name],
+      :username          => auth.userid,
+      :password          => auth.password,
+      :url               => vmware_import_url(source_provider, vm),
+      :cluster_id        => EmsCluster.find(target_params[:cluster_id]).uid_ems,
+      :storage_domain_id => Storage.find(target_params[:storage_id]).ems_ref_obj.split('/').last,
+      :sparse            => target_params[:sparse]
+    )
+  end
+
+  def validate_import_vm
+    api_version >= '4.0'
+  end
+
+  private
+
+  def check_import_supported!(source_provider)
+    raise _('Cannot import archived VMs') if source_provider.nil?
+
+    raise _('Cannot import to a RHEV provider of version < 4.0') unless api_version >= '4.0'
+    unless source_provider.type == ManageIQ::Providers::Vmware::InfraManager.name
+      raise _('Source provider must be of type Vmware')
+    end
+  end
+
+  def perform_vmware_to_ovirt_import(params)
+    with_provider_connection :version => 4 do |conn|
+      conn.system_service.external_vm_imports_service.add(
+        OvirtSDK4::ExternalVmImport.new(
+          :name           => params[:source_vm_name],
+          :vm             => { :name => params[:target_vm_name] || params[:source_vm_name] },
+          :provider       => OvirtSDK4::ExternalVmProviderType::VMWARE,
+          :username       => params[:username],
+          :password       => params[:password],
+          :url            => params[:url],
+          :cluster        => { :id => params[:cluster_id] },
+          :storage_domain => { :id => params[:storage_domain_id] },
+          :sparse         => params[:sparse],
+        )
+      )
+    end
+  end
+
+  def vmware_import_url(provider, vm)
+    username = password_auth(provider).userid
+    host = select_host(vm)
+    cluster = vm.parent_resource_pool.absolute_path(:exclude_ems => true, :exclude_hidden => true)
+    vcenter = provider.endpoints.first.hostname
+    "vpx://#{escape_username(username)}@#{vcenter}/#{escape_cluster(cluster)}/#{host.ipaddress}?no_verify=1"
+  end
+
+  def escape_username(username)
+    username.sub('@', '%40')
+  end
+
+  def escape_cluster(cluster)
+    URI.escape cluster, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
+  end
+
+  def select_host(vm)
+    vm.ems_cluster.hosts.first # any host from the VM's cluster
+  end
+
+  def password_auth(provider)
+    provider.authentication_userid_passwords.first
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -773,6 +773,10 @@
         :identifier: ems_infra_refresh
       - :name: delete
         :identifier: ems_infra_delete
+      - :name: import_vm
+        :identifier: ems_infra_import_vm
+        :options:
+        - :validate_action
       :delete:
       - :name: delete
         :identifier: ems_infra_delete

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -913,6 +913,10 @@
       :description: Re-check Authentication Status of Infrastructure Providers
       :feature_type: control
       :identifier: ems_infra_recheck_auth_status
+    - :name: Import VM
+      :description: Import Virtual Machine from other Infrastructure Provider
+      :feature_type: admin
+      :identifier: ems_infra_import_vm
   - :name: Modify
     :description: Modify Infrastructure Providers
     :feature_type: admin

--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -11,6 +11,10 @@ FactoryGirl.define do
     store_type "NFS"
   end
 
+  factory :storage_redhat, :parent => :storage_nfs do
+    sequence(:ems_ref_obj) { |n| "/api/storagedomains/#{n}" }
+  end
+
   factory :storage_block, :parent => :storage do
     store_type "FCP"
   end

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
@@ -1,0 +1,57 @@
+describe ManageIQ::Providers::Redhat::InfraManager::VmImport do
+  let(:target_ems)  { FactoryGirl.create(:ems_redhat_with_authentication) }
+  let(:source_ems)  { FactoryGirl.create(:ems_vmware_with_authentication) }
+  let(:source_vm)   { FactoryGirl.create(:vm_with_ref, :ext_management_system => source_ems) }
+  let(:pool)        { FactoryGirl.create(:resource_pool) }
+  let(:source_host) { FactoryGirl.create(:host) }
+  let(:cluster)     { FactoryGirl.create(:ems_cluster) }
+  let(:storage)     { FactoryGirl.create(:storage_redhat) }
+
+  let(:cluster_path)          { 'Folder1/Folder @#$*2/Compute 3/Folder4/Cluster 5' }
+  let(:cluster_path_escaped)  { 'Folder1%2FFolder%20%40%23%24*2%2FCompute%203%2FFolder4%2FCluster%205' }
+
+  let(:new_name) { 'created-vm' }
+
+  context 'import url encoding' do
+    describe '#escape_cluster' do
+      it 'properly escapes Vmware cluster path' do
+        expect(target_ems.send(:escape_cluster, cluster_path)).to eq(cluster_path_escaped)
+      end
+    end
+  end
+
+  require 'ovirtsdk4'
+
+  describe '#import_vm' do
+    before(:each) do
+      allow_any_instance_of(Vm).to receive_message_chain(:parent_resource_pool, :absolute_path) { cluster_path }
+      allow(target_ems).to receive(:check_import_supported!).and_return(true)
+      allow(target_ems).to receive(:select_host).and_return(source_host)
+      allow(OvirtSDK4::Probe).to receive(:probe).and_return([OvirtSDK4::ProbeResult.new(:version => '4')])
+    end
+
+    it 'passes the proper params to oVirt API' do
+      vcenter = source_ems.endpoints.first.hostname
+      url = "vpx://testuser@#{vcenter}/#{cluster_path_escaped}/#{source_host.ipaddress}?no_verify=1"
+      import_params = OvirtSDK4::ExternalVmImport.new(
+        :name           => source_vm.name,
+        :vm             => { :name => new_name },
+        :provider       => OvirtSDK4::ExternalVmProviderType::VMWARE,
+        :username       => 'testuser',
+        :password       => 'secret',
+        :url            => url,
+        :cluster        => { :id => cluster.uid_ems },
+        :storage_domain => { :id => storage.ems_ref_obj.split('/').last },
+        :sparse         => true
+      )
+      expect_any_instance_of(OvirtSDK4::ExternalVmImportsService).to receive(:add).with(eq(import_params))
+      target_ems.import_vm(
+        source_vm.id,
+        :name       => new_name,
+        :cluster_id => cluster.id,
+        :storage_id => storage.id,
+        :sparse     => true
+      )
+    end
+  end
+end


### PR DESCRIPTION
Added a new action to the `providers` REST resource that allows for importing vms.
`POST /api/providers/:id`
```json
{
  "action" : "import_vm", 
  "resource" : {
      "source": { "href": "http://localhost:3000/api/vms/:source_vm_id" },
      "target": {
          "name": "<name of newly created VM in RHEV>",
          "data_store": { "href": "http://localhost:3000/api/:target_data_store_id" },
          "cluster": { "href": "http://localhost:3000/api/:target_cluster_id" },
          "sparse": "[true|false]"
      }
  }
}
```
For now only the combination of a Vmware source VM and a RHEV as the target provider is supported.