### PR TITLE
Add MiqServer#reload_settings back

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -15,6 +15,10 @@ module MiqServer::ConfigurationManagement
     add_settings_for_resource(config)
   end
 
+  def reload_settings
+    Vmdb::Settings.reload! if is_local?
+  end
+
   def servers_for_settings_reload
     [self]
   end

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -36,6 +36,19 @@ describe MiqServer, "::ConfigurationManagement" do
     end
   end
 
+  describe "#reload_settings" do
+    let(:miq_server) { EvmSpecHelper.local_miq_server }
+
+    it "reloads the new changes into the settings for the resource" do
+      Vmdb::Settings.save!(miq_server, :some_test_setting => 2)
+      expect(Settings.some_test_setting).to be_nil
+
+      miq_server.reload_settings
+
+      expect(Settings.some_test_setting).to eq(2)
+    end
+  end
+
   context "ConfigurationManagementMixin" do
     let(:miq_server) { FactoryGirl.create(:miq_server) }
 


### PR DESCRIPTION
This was mistakenly removed in commit 742caa27047cf0215fc9df62348af8b284587dbc

@Fryguy please review

/cc @roliveri 
@miq-bot add_label bug, core, darga/no