### PR TITLE
Create a regex without an encoding (fixes a codeclimate/flog parsing issue)

### DIFF
--- a/gems/pending/fs/fat32/directory_entry.rb
+++ b/gems/pending/fs/fat32/directory_entry.rb
@@ -404,12 +404,12 @@ module Fat32
         LFN_NAME_COMPONENTS.each {|comp|
           chStart = (ent_num - 1) * CHARS_PER_LFN + comp[LFN_NC_OFFSET]
           if chStart > name.length
-            ent["#{comp[LFN_NC_HASHNAME]}"] = "\377" * (comp[LFN_NC_LENGTH] * 2)
+            ent["#{comp[LFN_NC_HASHNAME]}"] = "\377".b * (comp[LFN_NC_LENGTH] * 2)
           else
             ptName = name[chStart, comp[LFN_NC_LENGTH]]
             ptName.Utf8ToUnicode!
             if ptName.length < comp[LFN_NC_LENGTH] * 2
-              ptName += "\377" * (comp[LFN_NC_LENGTH] * 2 - ptName.length)
+              ptName += "\377".b * (comp[LFN_NC_LENGTH] * 2 - ptName.length)
             end
             ent["#{comp[LFN_NC_HASHNAME]}"] = ptName
           end

--- a/gems/pending/fs/fat32/directory_entry.rb
+++ b/gems/pending/fs/fat32/directory_entry.rb
@@ -342,7 +342,12 @@ module Fat32
       pre_name = ""; hashNames = %w(name name2 name3)
       hashNames.each {|name|
         n = ent["#{name}"]
-        pre_name += n.gsub(/\377/, "").UnicodeToUtf8.gsub(/\000/, "")
+
+        # Regexp.new options used below:
+        #   nil (default options: not case insensitive, extended, multiline, etc.)
+        #   'n' - No encoding on the regexp
+        regex = Regexp.new('\377', nil, 'n')
+        pre_name += n.gsub(regex, "").UnicodeToUtf8.gsub(/\000/, "")
       }
       return pre_name
     end


### PR DESCRIPTION
Fixes the following error that trips up codeclimate and flog:
`WARNING: invalid multibyte escape: /\377/ for "\\377" ""`


**Flog before**
```
WARNING: invalid multibyte escape: /\377/ for "\\377" ""
WARNING: trying to recover with ENC_UTF8
WARNING: trying to recover with ENC_NONE
   600.6: flog total
    14.3: flog/method average

   105.8: Fat32::DirectoryEntry#dump       gems/pending/fs/fat32/directory_entry.rb:501
    75.7: Fat32::DirectoryEntry#initialize gems/pending/fs/fat32/directory_entry.rb:106
    65.5: Fat32::DirectoryEntry#mkLfn      gems/pending/fs/fat32/directory_entry.rb:386
    36.1: Fat32::DirectoryEntry#dosToRubyTime gems/pending/fs/fat32/directory_entry.rb:472
    31.7: Fat32::DirectoryEntry#mkLegalSfn gems/pending/fs/fat32/directory_entry.rb:443
    28.7: Fat32::DirectoryEntry#rubyToDosTime gems/pending/fs/fat32/directory_entry.rb:486
    23.1: Fat32::DirectoryEntry#writeEntry gems/pending/fs/fat32/directory_entry.rb:274
```

**Flog after**

```
   602.3: flog total
    14.3: flog/method average

   105.8: Fat32::DirectoryEntry#dump       gems/pending/fs/fat32/directory_entry.rb:506
    75.7: Fat32::DirectoryEntry#initialize gems/pending/fs/fat32/directory_entry.rb:106
    65.5: Fat32::DirectoryEntry#mkLfn      gems/pending/fs/fat32/directory_entry.rb:391
    36.1: Fat32::DirectoryEntry#dosToRubyTime gems/pending/fs/fat32/directory_entry.rb:477
    31.7: Fat32::DirectoryEntry#mkLegalSfn gems/pending/fs/fat32/directory_entry.rb:448
    28.7: Fat32::DirectoryEntry#rubyToDosTime gems/pending/fs/fat32/directory_entry.rb:491
    23.1: Fat32::DirectoryEntry#writeEntry gems/pending/fs/fat32/directory_entry.rb:274
```

**Code climate**
![image](https://cloud.githubusercontent.com/assets/19339/18756846/6c768876-80bf-11e6-97d7-c7e9a7a628aa.png)
