### PR TITLE
TreeBuilder Rbac - use ems.vms vs building the list

### DIFF
--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -51,20 +51,10 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
   end
 
   def prune_rbac(tree)
-    vms = extract_vms(tree).uniq
-
-    allowed_vm_ids = Set.new(Rbac.filtered(vms).map(&:id)) # results_format == :ids
+    allowed_vm_ids = Set.new(Rbac.filtered(@root_ems.vms).pluck(:id))
 
     prune_filtered_vms(tree, allowed_vm_ids)
     prune_empty_folders(tree)
-  end
-
-  def extract_vms(tree)
-    tree.collect do |object, children|
-      child_vms = extract_vms(children)
-      child_vms.unshift(object) if object.kind_of?(VmOrTemplate)
-      child_vms
-    end.flatten
   end
 
   def prune_filtered_vms(tree, allowed_vm_ids)


### PR DESCRIPTION
- If the rbac results don't need an `order`, don't sort them locally. (It is being converted into a `Set` anyway)
- The Tree Builder holds vms from a root Ems. Use the basic `ems.vms` query to filter out the tree. `Rbac` only runs on database queries.
- pluck the id from rbac rather than bringing back all the vms to turn into a 

|        ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  22,027.7 |  143 |  9,024.8 |   89,703 |master
|  19,209.4 |  143 |  5,837.6 |   68,434 |skip sort
| 13% | 0% | N/A | N/A

- We're saving from not building the unique vms list and just passing a scope to `Rbac`.
- The `pluck` allocates fewer objects (see `rows` above) but there are potentially still those rows coming back from the db. Granted it now only has `id` vs `*`. So the numbers are not pure apple to apples. But what it can tell you is we are allocating ~24% fewer objects.

/cc @chrisarcand adding onto rbac
/cc @Fryguy think we have a number of rbac calls that take a list of ids that do not need to be sorted on the way out