### PR TITLE
[WIP] [POC] Use Rake::Invoke to avoid forking and making system calls

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -10,6 +10,18 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
+def load_rakefile
+  chdir APP_ROOT do
+    load 'Rakefile'
+  end
+
+  Rake.application.in_namespace('db:migrate') do |namespace|
+    ([Rake::Task['db:migrate']] + namespace.tasks).each do |task|
+      task.prerequisites.delete "good_migrations:disable_autoload"
+    end
+  end
+end
+
 chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
@@ -28,18 +40,20 @@ chdir APP_ROOT do
   # If we need a "reset all the things" script, we should call it bin/reset.
   system! 'bundle update'
 
+  # load 'Rakefile'
+  load_rakefile
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  Rake::Task["db:migrate"].invoke
 
   puts "\n== Seeding database =="
-  system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
+  Rake::Task["db:seed"].invoke
 
   puts "\n== Resetting tests =="
   system! "bin/rails test:vmdb:setup"
 
   unless ENV["SKIP_AUTOMATE_RESET"]
     puts "\n== Resetting Automate Domains =="
-    system! "bin/rails evm:automate:reset"
+    Rake::Task["evm:automate:reset"].invoke
   end
 
   # Make sure bower is done before compiling assets
@@ -48,9 +62,10 @@ chdir APP_ROOT do
 
   if ENV['RAILS_ENV'] == 'production'
     puts "\n== Recompiling assets =="
-    system! "bin/rails evm:compile_assets"
+    Rake::Task["evm:compile_assets"].invoke
   end
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  Rake::Task["log:clear"].invoke
+  Rake::Task["tmp:clear"].invoke
 end


### PR DESCRIPTION
Purpose
-------
Propose an additional speed up `bin/update` by avoiding reloading the Rails environment multiple times with each system call.


You don't always have to fork it hard...
----------------------------------------
While it is true that forking processes (in case of `bin/update`,  using `system!`) on their own come with a cost, it is exacerbated in this case because we are loading the Rails environment for each call to `bin/rails` or `bin/rake`.  Rake is meant to be similar to `make` where it will only re-run what is needed with each tasks, and can be included and invoked directly with ruby.  This means the `environment` task (basically loads the Rails environment and codebase), will only be loaded once and not for each task.

The exception currently the `test:vmdb:setup` task, which errors out when a conflicting Rails environment is already loaded.  To avoid a complex solution for this, it has been left as a `system!` call for now.


Metrics
-------
The following were metrics gather after running `time bin/update 1> /dev/null` 5 times, with and without the changes from this PR.


```
           Forking       Rake Invoke
                                   
real      1m18.501s       1m27.507s
user      1m01.366s       1m03.772s 
sys       0m10.921s       0m07.689s 
                                   
real      1m31.489s       1m06.997s 
user      1m12.873s       0m52.699s
sys       0m11.381s       0m07.039s 
                                   
real      1m27.706s       1m12.850s
user      1m10.032s       0m59.474s
sys       0m11.233s       0m06.987s 
                                   
real      1m29.377s       1m02.597s 
user      1m11.318s       0m49.589s
sys       0m11.341s       0m06.703s 
                                   
real      1m27.696s       1m12.294s
user      1m10.528s       0m58.776s
sys       0m10.956s       0m06.913s 
```


Because we are running `bower update` in a seperate thread, this seems to add a bit of fluctuation in the times, so to see the saves, the `bower.thread` code was removed and the following metrics are recorded against that.

```
           Forking       Rake Invoke
                                   
real      1m30.935s       1m15.289s
user      1m05.726s       0m55.341s
sys       0m09.636s       0m05.767s
                                    
real      1m28.028s       1m03.358s
user      1m06.053s       0m45.669s
sys       0m09.650s       0m05.514s
                                    
real      1m26.096s       1m18.736s
user      1m04.857s       0m58.715s
sys       0m09.706s       0m06.177s
                                    
real      1m27.291s       1m05.380s
user      1m05.334s       0m47.128s
sys       0m09.619s       0m05.983s
                                    
real      1m27.423s       1m13.117s
user      1m05.264s       0m55.201s
sys       0m09.574s       0m05.628s
```


It is pretty clear that this saves at least 15 seconds in total run time, sometimes more.

![Rock On](http://25.media.tumblr.com/5e0fdb8e9a5bafa71291e21bc50bee53/tumblr_mhr9gayllQ1s45dzzo5_400.gif)


Considerations
--------------

* As part of loading the `Rakefile`, we are also removing the prerequisites of `good_migrations` when running `db:migrate` because we were previously removing it via the ENV variable in the `system!` call.  This probably could have been accomplished by loading the environment variable at the top of the script 
* This is less "vanilla rails" than the `system!` counter part, and that was very much a large movtivation the https://github.com/ManageIQ/manageiq/pull/11299 PR.  This workflow is probably also [going against the "Rails Way"](https://github.com/rails/rails/issues/18878) a bit as well, so that is something to consider
* Because we aren't starting with a clean rake env with each task, we could very much be affecting the outcome of each of the scripts now run, and this could have huge consequences, especially if this is used in a production environment.


Keep in mind, this is currently a proof of concept (for a reason), and definitely needs some testing and further evaluation from others.  This very well may be something that gets closed without merging, which is fine.  The intent was to propose some further speed ups to the script since that was recently something that we considered was a worthwhile effort.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/11299
* https://github.com/rails/rails/issues/18878
* https://github.com/testdouble/good-migrations/blob/master/tasks/good_migrations.rake


Testing/QA
----------

Essentially with this, we want to make sure that we end up in the same state as we did after running `bin/setup` from a similar state with these changes and without.  Since I am still unsure of the concequences of maintaining a single Rake ENV while running each of these tasks, a lot of vetting with this should be done.