### PR TITLE
RBAC ops cleanup

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1068,15 +1068,19 @@ module OpsController::OpsRbac
   # Set form variables for user add/edit
   def rbac_group_set_form_vars
     @assigned_filters = []
-    @edit = {}
     @group = @record
+    @edit = {
+      :new => {
+        :filters => {},
+        :belongsto => {},
+        :description => @group.description,
+      },
+      :ldap_groups_by_user => [],
+      :projects_tenants => [],
+      :roles => {},
+    }
     @edit[:group_id] = @record.id
-    @edit[:new] = {}
     @edit[:key] = "rbac_group_edit__#{@edit[:group_id] || "new"}"
-    @edit[:new][:filters] = {}
-    @edit[:new][:belongsto] = {}
-    @edit[:ldap_groups_by_user] = []
-    @edit[:new][:description] = @group.description
 
     # Build the managed filters hash
     [@group.get_managed_filters].flatten.each do |f|
@@ -1090,10 +1094,8 @@ module OpsController::OpsRbac
     end
 
     # Build roles hash
-    all_roles = MiqUserRole.all
-    @edit[:roles] = {}
     @edit[:roles]["<Choose a Role>"] = nil if @record.id.nil?
-    all_roles.each do |r|
+    MiqUserRole.all.each do |r|
       @edit[:roles][r.name] = r.id
     end
     if @group.miq_user_role.nil? # If adding, set to first role
@@ -1102,7 +1104,6 @@ module OpsController::OpsRbac
       @edit[:new][:role] = @group.miq_user_role.id
     end
 
-    @edit[:projects_tenants] = []
     all_tenants, all_projects = Tenant.tenant_and_project_names
     @edit[:projects_tenants].push(["", [[_("<Choose a Project/Tenant>"),
                                          :selected => _("<Choose a Project/Tenant>"),

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -1031,14 +1031,14 @@ module OpsController::OpsRbac
       move_cols_up   if params[:button] == "up"
       move_cols_down if params[:button] == "down"
     else
-      @edit[:new][:description]  = params[:ldap_groups_user]  if params[:ldap_groups_user]
-      @edit[:new][:description]  = params[:description]       if params[:description]
-      @edit[:new][:role]         = params[:group_role]        if params[:group_role]
-      @edit[:new][:group_tenant] = params[:group_tenant].to_i if params[:group_tenant]
-      @edit[:new][:lookup]       = (params[:lookup] == "1")   if params[:lookup]
-      @edit[:new][:user]         = params[:user]              if params[:user]
-      @edit[:new][:user_id]      = params[:user_id]           if params[:user_id]
-      @edit[:new][:user_pwd]     = params[:password]          if params[:password]
+      @edit[:new][:ldap_groups_user] = params[:ldap_groups_user]  if params[:ldap_groups_user]
+      @edit[:new][:description]      = params[:description]       if params[:description]
+      @edit[:new][:role]             = params[:group_role]        if params[:group_role]
+      @edit[:new][:group_tenant]     = params[:group_tenant].to_i if params[:group_tenant]
+      @edit[:new][:lookup]           = (params[:lookup] == "1")   if params[:lookup]
+      @edit[:new][:user]             = params[:user]              if params[:user]
+      @edit[:new][:user_id]          = params[:user_id]           if params[:user_id]
+      @edit[:new][:user_pwd]         = params[:password]          if params[:password]
     end
 
     if params[:check]                               # User checked/unchecked a tree node


### PR DESCRIPTION
The main goal of this PR is to substitute `send()` with calling by full method names, for example:

```diff
-    send("rbac_#{what}_set_form_vars")
+    # set form fields according to what is copied
+    case key
+    when :user  then rbac_user_set_form_vars
+    when :group then rbac_group_set_form_vars
+    when :role  then rbac_role_set_form_vars
+    end
```

It's not necessary to use `send()`, if there are only three methods to be called by it, and also it makes code more searchable.