### PR TITLE
Set the :number_of_sockets in SCVMM provisioning dialogs

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -64,7 +64,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
   end
 
   def cpu_count
-    get_option(:number_of_cpus)
+    get_option(:number_of_sockets)
   end
 
   def dynamic_mem_min

--- a/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -449,7 +449,7 @@
           :display: :edit
           :data_type: :integer
           :notes_display: :show
-        :number_of_cpus:
+        :number_of_sockets:
           :values:
             1: "1"
             2: "2"

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
@@ -92,7 +92,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
 
     context "#no cpu limit or reservation set" do
       before do
-        @options[:number_of_cpus] = 2
+        @options[:number_of_sockets] = 2
         @options[:cpu_limit]      = nil
         @options[:cpu_reserve]    = nil
       end
@@ -106,7 +106,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
       before do
         @options[:cpu_limit]      = 40
         @options[:cpu_reserve]    = nil
-        @options[:number_of_cpus] = 2
+        @options[:number_of_sockets] = 2
       end
 
       it "set vm" do
@@ -118,7 +118,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
       before do
         @options[:cpu_reserve]    = 15
         @options[:cpu_limit]      = nil
-        @options[:number_of_cpus] = 2
+        @options[:number_of_sockets] = 2
       end
 
       it "set vm" do


### PR DESCRIPTION
SCVMM provisioning quota checking reads the **:number_of_sockets** dialog property which was not set in SCVMM, instead **:number_of_cpus** was set.

This PR fixes this by renaming this dialog property accordingly. In turn, the cloning functionality had to be updated to read **:number_of_sockets** instead of **:number_of_cpus**.

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1364381



## Steps for Testing/QA
1. Add an SCVMM provider.
2. Set a tenant quota.
3. Provision a VM requesting a higher quota than the enforced quota.

