### PR TITLE
Remove unused var assignments and raise wrapped error message

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -11,7 +11,7 @@ class MiqRequest < ApplicationRecord
 
   alias_attribute :state, :request_state
 
-  serialize   :options, Hash
+  serialize :options, Hash
 
   default_value_for(:message)       { |r| "#{r.class::TASK_DESCRIPTION} - Request Created" }
   default_value_for :options,       {}
@@ -147,9 +147,8 @@ class MiqRequest < ApplicationRecord
     MiqAeEvent.raise_evm_event(event_name, self, build_request_event(event_name))
     _log.info("Raised  event [#{event_name}] to Automate")
   rescue MiqAeException::Error => err
-    message = _("Error returned from %{name} event processing in Automate: %{error_message}") %
-                {:name => event_name, :error_message => err.message}
-    raise
+    raise err, _("Error returned from %{name} event processing in Automate: %{error_message}") %
+               { :name => event_name, :error_message => err.message }
   end
 
   def call_automate_event_sync(event_name)
@@ -158,9 +157,8 @@ class MiqRequest < ApplicationRecord
     _log.info("Raised event [#{event_name}] to Automate")
     return ws
   rescue MiqAeException::Error => err
-    message = _("Error returned from %{name} event processing in Automate: %{error_message}") %
-                {:name => event_name, :error_message => err.message}
-    raise
+    raise err, _("Error returned from %{name} event processing in Automate: %{error_message}") %
+               { :name => event_name, :error_message => err.message }
   end
 
   def automate_event_failed?(event_name)

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -85,8 +85,9 @@ describe MiqRequest do
 
       it "re-raises exceptions" do
         allow(MiqAeEvent).to receive(:raise_evm_event).and_raise(MiqAeException::AbortInstantiation.new("bogus automate error"))
-
-        expect { request.call_automate_event_sync(event_name) }.to raise_error(MiqAeException::Error, "bogus automate error")
+        expect do
+          request.call_automate_event_sync(event_name)
+        end.to raise_error(MiqAeException::AbortInstantiation, /#{event_name}.*bogus automate error/)
       end
     end
 
@@ -98,7 +99,9 @@ describe MiqRequest do
 
       it "re-raises exceptions" do
         allow(MiqAeEvent).to receive(:raise_evm_event).and_raise(MiqAeException::AbortInstantiation.new("bogus automate error"))
-        expect { request.call_automate_event(event_name) }.to raise_error(MiqAeException::Error, "bogus automate error")
+        expect do
+          request.call_automate_event(event_name)
+        end.to raise_error(MiqAeException::AbortInstantiation, /#{event_name}.*bogus automate error/)
       end
     end
 


### PR DESCRIPTION
These `message` variables were assigned but not used when re-raising
the caught exception. This change will wrap the original error message
with information including the `event_name`.

Alternatively, I could see this as being intended to update the `message`
column for the request but I am not sure.

@ZitaNemeckova @matthewd @Fryguy 
@miq-bot add_label cleanup/rubocop
