### PR TITLE
Add method to determine if a remote region has an authentication key configured

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -40,6 +40,7 @@ class MiqRegion < ApplicationRecord
   alias_method :all_storages,           :storages
 
   PERF_ROLLUP_CHILDREN = [:ext_management_systems, :storages]
+  AUTHENTICATION_TYPE  = "system_api".freeze
 
   def database_backups
     DatabaseBackup.in_region(region_number)
@@ -267,7 +268,7 @@ class MiqRegion < ApplicationRecord
     auth.auth_key = key
     auth.name = "Region #{region} API Key"
     auth.resource = self
-    auth.authtype = "system_api"
+    auth.authtype = AUTHENTICATION_TYPE
     auth.save!
   end
 
@@ -277,11 +278,11 @@ class MiqRegion < ApplicationRecord
   end
 
   def auth_key_configured?
-    authentication_token("system_api").present?
+    authentication_token(AUTHENTICATION_TYPE).present?
   end
 
   def api_system_auth_token(userid)
-    region_v2_key = authentication_token("system_api")
+    region_v2_key = authentication_token(AUTHENTICATION_TYPE)
 
     token_hash = {
       :server_guid => remote_ws_miq_server.guid,

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -276,6 +276,10 @@ class MiqRegion < ApplicationRecord
     true
   end
 
+  def auth_key_configured?
+    authentication_token("system_api").present?
+  end
+
   def api_system_auth_token(userid)
     region_v2_key = authentication_token("system_api")
 

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -106,4 +106,13 @@ FactoryGirl.define do
   factory :authentication_redhat_metric, :parent => :authentication do
     authtype "metrics"
   end
+
+  factory :auth_token do
+    type "AuthToken"
+  end
+
+  factory :api_auth_token, :parent => :auth_token do
+    name     "API Auth Token"
+    authtype "system_api"
+  end
 end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -170,6 +170,28 @@ describe MiqRegion do
     end
   end
 
+  describe "#auth_key_configured?" do
+    let(:remote_region) { FactoryGirl.create(:miq_region) }
+    let(:remote_key)    { "this is the encryption key!" }
+
+    before { EvmSpecHelper.create_guid_miq_server_zone }
+
+    it "returns true if a key is configured" do
+      FactoryGirl.create(
+        :api_auth_token,
+        :resource_id   => remote_region.id,
+        :resource_type => "MiqRegion",
+        :auth_key      => remote_key
+      )
+
+      expect(remote_region.auth_key_configured?).to be true
+    end
+
+    it "returns false if a key is not configured" do
+      expect(remote_region.auth_key_configured?).to be false
+    end
+  end
+
   describe "#api_system_auth_token" do
     let(:region) { FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number) }
 


### PR DESCRIPTION
This method will be used by the UI in order to display which regions are already configured to do API authentication for central admin.

@gtanzillo please review
@miq-bot add_label enhancement, core

/cc @lgalis 