### PR TITLE
Bundle power ops

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,6 +2,9 @@ require 'ancestry'
 
 class Service < ApplicationRecord
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
+  ACTION_RESPONSE = { "Power On"    => :start, "Power Off" => :stop, "Shutdown" => :stop, "Suspend" => :suspend,
+                      "Do Nothing"  => nil
+                    }.freeze
 
   include VirtualTotalMixin
 
@@ -177,10 +180,7 @@ class Service < ApplicationRecord
     method = "#{requested}_action"
     response = service_resource.try(method)
 
-    action_response = { "Power On"    => :start, "Power Off" => :stop, "Shutdown" => :stop, "Suspend" => :suspend,
-                        "Do Nothing"  => nil
-                      }
-    response.nil? ? requested : action_response[response]
+    response.nil? ? requested : ACTION_RESPONSE[response]
   end
 
   def validate_reconfigure

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,9 +2,14 @@ require 'ancestry'
 
 class Service < ApplicationRecord
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
-  ACTION_RESPONSE = { "Power On"    => :start, "Power Off" => :stop, "Shutdown" => :stop, "Suspend" => :suspend,
-                      "Do Nothing"  => nil
-                    }.freeze
+
+  ACTION_RESPONSE = {
+    "Power On"   => :start,
+    "Power Off"  => :stop,
+    "Shutdown"   => :shutdown_guest,
+    "Suspend"    => :suspend,
+    "Do Nothing" => nil
+  }.freeze
 
   include VirtualTotalMixin
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -133,12 +133,15 @@ class Service < ApplicationRecord
     each_group_resource(group_idx) do |svc_rsc|
       begin
         rsc = svc_rsc.resource
+        rsc_action = service_action(action, svc_rsc)
         rsc_name =  "#{rsc.class.name}:#{rsc.id}" + (rsc.respond_to?(:name) ? ":#{rsc.name}" : "")
-        if rsc.respond_to?(action)
-          _log.info "Processing action <#{action}> for Service:<#{name}:#{id}>, RSC:<#{rsc_name}}> in Group Idx:<#{group_idx}>"
-          rsc.send(action)
+        if rsc_action.nil?
+          _log.info "Not Processing action for Service:<#{name}:#{id}>, RSC:<#{rsc_name}}> in Group Idx:<#{group_idx}>"
+        elsif rsc.respond_to?(rsc_action)
+          _log.info "Processing action <#{rsc_action}> for Service:<#{name}:#{id}>, RSC:<#{rsc_name}}> in Group Idx:<#{group_idx}>"
+          rsc.send(rsc_action)
         else
-          _log.info "Skipping action <#{action}> for Service:<#{name}:#{id}>, RSC:<#{rsc.class.name}:#{rsc.id}> in Group Idx:<#{group_idx}>"
+          _log.info "Skipping action <#{rsc_action}> for Service:<#{name}:#{id}>, RSC:<#{rsc.class.name}:#{rsc.id}> in Group Idx:<#{group_idx}>"
         end
       rescue => err
         _log.error "Error while processing Service:<#{name}> Group Idx:<#{group_idx}>  Resource<#{rsc_name}>.  Message:<#{err}>"
@@ -168,6 +171,16 @@ class Service < ApplicationRecord
     nh[:zone] = first_vm.ext_management_system.zone.name unless first_vm.nil?
     MiqQueue.put(nh)
     true
+  end
+
+  def service_action(requested, service_resource)
+    method = "#{requested}_action"
+    response = service_resource.try(method)
+
+    action_response = { "Power On"    => :start, "Power Off" => :stop, "Shutdown" => :stop, "Suspend" => :suspend,
+                        "Do Nothing"  => nil
+                      }
+    response.nil? ? requested : action_response[response]
   end
 
   def validate_reconfigure

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -134,7 +134,10 @@ class ServiceTemplate < ApplicationRecord
       svc.add_resource(sr.resource, nh) unless sr.resource.nil?
     end
 
-    parent_svc.add_resource!(svc) unless parent_svc.nil?
+    if parent_svc
+      service_resource = ServiceResource.find_by(:id => service_task.options[:service_resource_id])
+      parent_svc.add_resource!(svc, service_resource)
+    end
 
     svc.save
     svc

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -347,6 +347,45 @@ describe Service do
     end
   end
 
+  describe "#service_action" do
+    let(:service) { FactoryGirl.create(:service) }
+    let(:service_resource_nil) { double(:service_resource) }
+    let(:service_resource_power) do
+      instance_double("ServiceResource", :start_action => "Power On",
+                                         :stop_action  => "Suspend")
+    end
+    let(:service_resource_power_off) { instance_double("ServiceResource", :stop_action => "Power Off") }
+    let(:service_resource_shutdown) { instance_double("ServiceResource", :stop_action => "Shutdown") }
+    let(:service_resource_nothing) do
+      instance_double("ServiceResource", :start_action => "Do Nothing",
+                                         :stop_action  => "Do Nothing")
+    end
+
+    context "service_resource start_action stop_action is nil" do
+      it "returns the original action" do
+        expect(service.service_action(:start, service_resource_nil)).to eq(:start)
+        expect(service.service_action(:suspend, service_resource_nil)).to eq(:suspend)
+        expect(service.service_action(:stop, service_resource_nil)).to eq(:stop)
+        expect(service.service_action(nil, service_resource_nil)).to eq(nil)
+      end
+    end
+
+    context "service_resource start_action stop_action is not nil" do
+      it "returns :start for 'Power On'" do
+        expect(service.service_action(:start, service_resource_power)).to eq(:start)
+      end
+
+      it "returns :stop for Shutdown, Power Off" do
+        expect(service.service_action(:stop, service_resource_power_off)).to eq(:stop)
+      end
+
+      it "returns nil for Do Nothing" do
+        expect(service.service_action(:stop, service_resource_nothing)).to be_nil
+        expect(service.service_action(:start, service_resource_nothing)).to be_nil
+      end
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -375,9 +375,13 @@ describe Service do
         expect(service.service_action(:start, service_resource_power)).to eq(:start)
       end
 
-      it "returns :stop for Shutdown, Power Off" do
+      it "returns :stop for Power Off" do
         expect(service.service_action(:stop, service_resource_power_off)).to eq(:stop)
-        expect(service.service_action(:stop, service_resource_shutdown)).to eq(:stop)
+      end
+
+      it "returns :shutdown_guest for Shutdown" do
+        expect(service.service_action(:stop, service_resource_power_off)).to eq(:stop)
+        expect(service.service_action(:stop, service_resource_shutdown)).to eq(:shutdown_guest)
       end
 
       it "returns nil for Do Nothing" do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -377,6 +377,7 @@ describe Service do
 
       it "returns :stop for Shutdown, Power Off" do
         expect(service.service_action(:stop, service_resource_power_off)).to eq(:stop)
+        expect(service.service_action(:stop, service_resource_shutdown)).to eq(:stop)
       end
 
       it "returns nil for Do Nothing" do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -157,6 +157,20 @@ describe ServiceTemplate do
       expect(sub_svc).to include(@svc_d)
     end
 
+    it "should add_resource! only if a parent_svc exists" do
+      sub_svc = instance_double("service_task", :options => {:dialog => {}})
+      parent_svc = instance_double("service_task", :options => {:dialog => {}})
+      expect(parent_svc).to receive(:add_resource!).once
+
+      @svc_a.create_service(sub_svc, parent_svc)
+    end
+
+    it "should not call add_resource! if no parent_svc exists" do
+      sub_svc = instance_double("service_task", :options => {:dialog => {}})
+      expect(sub_svc).to receive(:add_resource!).never
+
+      @svc_a.create_service(sub_svc)
+    end
     it "should return all parent services for a service" do
       add_and_save_service(@svc_a, @svc_b)
       add_and_save_service(@svc_a, @svc_c)


### PR DESCRIPTION
## Apply service power operations to a bundle

>In the case where bundle services can respond to
'Power On', 'Power Off', 'Stop', 'Start', 'Suspend' or 
'Do Nothing' we now override the default start or stop 
actions with the above power operations.

>In the case of a 'Do Nothing' start or stop action
we ignore the start, or stop passed into the service
and move on to any if other services.

## Links

* [Pivotal #128432825](https://www.pivotaltracker.com/story/show/128432825)