### PR TITLE
[WIP] Fail gracefully if the smartproxy role is missing

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -46,6 +46,11 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     image = target_entity
     return queue_signal(:abort_job, "no image found", "error") unless image
     return queue_signal(:abort_job, "cannot analyze non docker images", "error") unless image.docker_id
+    return queue_signal(
+      :abort_job,
+      "smartproxy role missing",
+      "error"
+    ) unless MiqServer.my_server.has_active_role?("smartproxy")
 
     ems_configs = VMDB::Config.new('vmdb').config[:ems]
 


### PR DESCRIPTION
We have seen several bugs where a missing smatproxy role causes the job to fail.
Users don't know what went wrong.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1371896 

## Steps for Testing/QA [Optional]
- remove smartproxy role.
- scan an image.
- in the tasks screen the job error message should say smartproxy is missing. 
