### PR TITLE
Resolves selection of a node after edit in Automate tree

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -473,7 +473,8 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    tree = TreeBuilderAutomate.new(name, type, @sb)
+    tree_klass = name == :ae_tree ? TreeBuilderAeClass : TreeBuilderAutomate
+    tree = tree_klass.new(name, type, @sb)
     @automate_tree = tree if name == :automate_tree
     tree
   end


### PR DESCRIPTION
Automate -> Explorer -> Select a Method node -> Configuration -> Edit this Method -> Save changes -> Select another node

Before: couldn't select a node after editing a method
After: can select a node after editing a method
 
Closes #11301 

@miq-bot  add_label ui, bug
