### PR TITLE
Skip callbacks in Api::BaseController inherited from ApplicationController

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -36,6 +36,10 @@ module Api
                          :only => [:show, :update, :destroy, :handle_options_request, :options]
     end
     skip_before_action :get_global_session_data
+    skip_before_action :reset_toolbar
+    skip_before_action :set_session_tenant
+    skip_before_action :set_user_time_zone
+    skip_before_action :allow_websocket
     skip_after_action :set_global_session_data
     before_action :set_access_control_headers
     prepend_before_action :require_api_user_or_token, :except => [:handle_options_request]


### PR DESCRIPTION
* `reset_toolbar` sets the `@toolbars` variable back to `{}`, but it is
  never used in the API code
* `set_session_tenant` sets a value in the session which is never used
  in the API code. Besides, `current_user` will be `nil`
* `set_user_time_zone` sets a value in the session and `Time.zone` to
  the user timezone, but since `current_user` is `nil` it will just set
  it to the server timezone.
* ~~`set_gettext_locale` I believe is not needed, since we don't support
  `Accept-Language` in the JSON API~~
* `allow_websocket` - websockets are not utilized in JSON API calls

@abellotti @Fryguy I may be making some assumptions here, so please keep me honest.

This change comes from https://github.com/ManageIQ/manageiq/pull/11085 where I originally wanted to remove `ApplicationController` from the `Api::BaseController` inheritance tree. Since I removed that from that PR as it was too big a change, I'm laying out the first steps here in this separate PR

@miq-bot add-label api, technical debt
@miq-bot assign @abellotti 