### PR TITLE
Fix saving MiqSearch with same name

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -603,7 +603,7 @@ module ApplicationController::Filter
   private :adv_search_new
 
   def adv_search_set_details(search, type, user=nil)
-    search.update_attributes!(
+    search.update_attributes(
       :search_key => user,
       :name => "#{type == "global" ? "global" : "user_#{user}"}_#{@edit[:new_search_name]}",
       :search_type => type


### PR DESCRIPTION
fixes https://github.com/ManageIQ/manageiq/issues/10844

update_attributes! is throwing error validation will fails
changed to update_attributes and then error handle later
when MiqSearch is saved :
https://github.com/ManageIQ/manageiq/blob/master/app/controllers/application_controller/filter.rb#L655

@miq-bot assign_label ui, bug
