### PR TITLE
Some small edits to the api.yml

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1959,4 +1959,3 @@
       :delete:
       - :name: edit
         :identifier: arbitration_rule_delete
-

--- a/config/api.yml
+++ b/config/api.yml
@@ -590,7 +590,7 @@
       - :name: reset
         :identifier: instance_reset
   :notifications:
-    :description: User's past notifications
+    :description: "User's past notifications"
     :options:
     - :collection
     :verbs: *gpd


### PR DESCRIPTION
* My editor is set up to kill trailing whitespace on save, so I have to remember not to commit that every time I make a change. So I'm fixing it here in a separate commit
* Though the description for notifications is parsed correctly by Ruby, it breaks my editor's parsing without surrounding quotes. Wouldn't normally insist on a change like this, but I don't really fancy fixing yaml-mode today, so hopefully no one minds this change?

@miq-bot add-label api
@miq-bot assign @abellotti 