### PR TITLE
wait_for_task action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -232,6 +232,10 @@ class ApplicationController < ActionController::Base
   end
   private :browser_refresh_task
 
+  #
+  # :task_id => id of task to wait for
+  # :action  => 'action_to_call' -- action to be called when the task finishes
+  #
   def initiate_wait_for_task(options = {})
     task_id = options[:task_id]
     session[:async] ||= {}
@@ -240,6 +244,9 @@ class ApplicationController < ActionController::Base
 
     session[:async][:params]           = copy_hash(params)  # Save the incoming parms
     session[:async][:params][:task_id] = task_id
+
+    # override method to be called, when the task is done
+    session[:async][:params][:action] = options[:action] if options.key?(:action)
 
     browser_refresh_task(task_id)
   end


### PR DESCRIPTION
`initiate_wait_for_task` can be called:
```
 initiate_wait_for_task(:task_id => task_id, :action => :done_action)
```
specifying the action that has to be called when the task is done.

That way the method does not need to contain logic to differentiate if it's called before or after the wait for task call as seen here: https://github.com/ManageIQ/manageiq/blob/master/app/controllers/vm_common.rb#L85

Used in https://github.com/ManageIQ/manageiq/pull/10118 and  https://github.com/ManageIQ/manageiq/pull/11428