### PR TITLE
Report Editor - Do not store perf interval options in session

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -281,7 +281,7 @@ module ReportController::Reports::Editor
     end
   end
 
-  def build_perf_interval_arrays
+  def ensure_perf_interval_defaults
     case @edit[:new][:perf_interval]
     when "hourly"
       @edit[:new][:perf_end] ||= "0"
@@ -519,7 +519,7 @@ module ReportController::Reports::Editor
         @edit[:new][:perf_interval] ||= "daily"                 # Default to Daily
         @edit[:new][:perf_avgs] ||= "time_interval"
         @edit[:new][:tz] = session[:user_tz]
-        build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
+        ensure_perf_interval_defaults
       end
       if Chargeback.db_is_chargeback?(@edit[:new][:model])
         @edit[:new][:cb_model] = Chargeback.report_cb_model(@edit[:new][:model])
@@ -553,12 +553,11 @@ module ReportController::Reports::Editor
           @edit[:percent_col] = false
           @edit[:new][:perf_limit_val] = nil
         end
-        build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
+        ensure_perf_interval_defaults
         @edit[:limit_cols] = VimPerformanceTrend.trend_limit_cols(@edit[:new][:perf_trend_db], @edit[:new][:perf_trend_col], @edit[:new][:perf_interval])
       end
       @refresh_div = "columns_div"
       @refresh_partial = "form_columns"
-      # build_perf_interval_arrays  # Build the start and end arrays for the performance interval chooser
       # @edit[:limit_cols] = VimPerformanceTrend.trend_limit_cols(@edit[:new][:perf_trend_db], @edit[:new][:perf_trend_col], @edit[:new][:perf_interval])
     elsif params[:chosen_limit_col]
       if params[:chosen_limit_col] == "<None>"
@@ -585,7 +584,7 @@ module ReportController::Reports::Editor
       @edit[:new][:perf_interval] = params[:chosen_interval]
       @edit[:new][:perf_start] = nil  # Clear start/end offsets
       @edit[:new][:perf_end] = nil
-      build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
+      ensure_perf_interval_defaults
       reset_report_col_fields
       @refresh_div = "form_div"
       @refresh_partial = "form"
@@ -1431,9 +1430,8 @@ module ReportController::Reports::Editor
       @edit[:limit_cols] = VimPerformanceTrend.trend_limit_cols(@edit[:new][:perf_trend_db], @edit[:new][:perf_trend_col], @edit[:new][:perf_interval])
     end
 
-    # Build performance interval select arrays, if needed
     if [:performance, :trend].include?(model_report_type(@rpt.db))
-      build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
+      ensure_perf_interval_defaults
     end
 
     expkey = :record_filter

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -292,10 +292,6 @@ module ReportController::Reports::Editor
       5.times { |i| end_array.push(["#{i + 2} days ago", (i + 2).days.to_s]) }
       4.times { |i| end_array.push(["#{pluralize(i + 1, "week")} ago", (i + 1).weeks.to_s]) }
       5.times { |i| end_array.push(["#{pluralize(i + 2, "month")} ago", (i + 1).months.to_s]) }
-      start_array = []
-      6.times { |i| start_array.push([pluralize(i + 1, "day").to_s, (i + 1).days.to_s]) }
-      4.times { |i| start_array.push([pluralize(i + 1, "week").to_s, (i + 1).weeks.to_s]) }
-      5.times { |i| start_array.push([pluralize(i + 2, "month").to_s, (i + 1).months.to_s]) }
       @edit[:new][:perf_end] ||= "0"
       @edit[:new][:perf_start] ||= 1.day.to_s
     when "daily"
@@ -305,15 +301,9 @@ module ReportController::Reports::Editor
       5.times  { |i| end_array.push(["#{i + 2} days ago", (i + 1).days.to_s]) }
       3.times  { |i| end_array.push(["#{pluralize((i + 1), "week")} ago", ((i + 1).weeks - 1.day).to_s]) }
       6.times  { |i| end_array.push(["#{pluralize((i + 1), "month")} ago", ((i + 1).months - 1.day).to_s]) }
-      start_array = []
-      5.times  { |i| start_array.push([pluralize(i + 2, "day").to_s, (i + 2).days.to_s]) }
-      3.times  { |i| start_array.push([pluralize((i + 1), "week").to_s, (i + 1).weeks.to_s]) }
-      11.times { |i| start_array.push([pluralize((i + 1), "month").to_s, (i + 1).months.to_s]) }
-      start_array.push(["1 year", 1.year.to_i.to_s])  # For some reason, 1.year is a float, so use to_i to get rid of decimals
       @edit[:new][:perf_end] ||= "0"
       @edit[:new][:perf_start] ||= 2.days.to_s
     end
-    @edit[:start_array] = start_array
     @edit[:end_array] = end_array
   end
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -281,30 +281,15 @@ module ReportController::Reports::Editor
     end
   end
 
-  # Create the arrays for the start/end interval pulldowns
   def build_perf_interval_arrays
     case @edit[:new][:perf_interval]
     when "hourly"
-      end_array = [
-        ["Today", "0"],
-        ["Yesterday", 1.day.to_s]
-      ]
-      5.times { |i| end_array.push(["#{i + 2} days ago", (i + 2).days.to_s]) }
-      4.times { |i| end_array.push(["#{pluralize(i + 1, "week")} ago", (i + 1).weeks.to_s]) }
-      5.times { |i| end_array.push(["#{pluralize(i + 2, "month")} ago", (i + 1).months.to_s]) }
       @edit[:new][:perf_end] ||= "0"
       @edit[:new][:perf_start] ||= 1.day.to_s
     when "daily"
-      end_array = [
-        ["Yesterday", "0"]    # Start with yesterday, since we only allow full 24 hour days in daily trending
-      ]
-      5.times  { |i| end_array.push(["#{i + 2} days ago", (i + 1).days.to_s]) }
-      3.times  { |i| end_array.push(["#{pluralize((i + 1), "week")} ago", ((i + 1).weeks - 1.day).to_s]) }
-      6.times  { |i| end_array.push(["#{pluralize((i + 1), "month")} ago", ((i + 1).months - 1.day).to_s]) }
       @edit[:new][:perf_end] ||= "0"
       @edit[:new][:perf_start] ||= 2.days.to_s
     end
-    @edit[:end_array] = end_array
   end
 
   # This method figures out what to put in each band unit pulldown array

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -282,8 +282,8 @@ module ReportController::Reports::Editor
   end
 
   # Create the arrays for the start/end interval pulldowns
-  def build_perf_interval_arrays(interval)
-    case interval
+  def build_perf_interval_arrays
+    case @edit[:new][:perf_interval]
     when "hourly"
       end_array = [
         ["Today", "0"],
@@ -544,7 +544,7 @@ module ReportController::Reports::Editor
         @edit[:new][:perf_interval] ||= "daily"                 # Default to Daily
         @edit[:new][:perf_avgs] ||= "time_interval"
         @edit[:new][:tz] = session[:user_tz]
-        build_perf_interval_arrays(@edit[:new][:perf_interval]) # Build the start and end arrays for the performance interval chooser
+        build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
       end
       if Chargeback.db_is_chargeback?(@edit[:new][:model])
         @edit[:new][:cb_model] = Chargeback.report_cb_model(@edit[:new][:model])
@@ -578,12 +578,12 @@ module ReportController::Reports::Editor
           @edit[:percent_col] = false
           @edit[:new][:perf_limit_val] = nil
         end
-        build_perf_interval_arrays(@edit[:new][:perf_interval]) # Build the start and end arrays for the performance interval chooser
+        build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
         @edit[:limit_cols] = VimPerformanceTrend.trend_limit_cols(@edit[:new][:perf_trend_db], @edit[:new][:perf_trend_col], @edit[:new][:perf_interval])
       end
       @refresh_div = "columns_div"
       @refresh_partial = "form_columns"
-      # build_perf_interval_arrays(@edit[:new][:perf_interval])  # Build the start and end arrays for the performance interval chooser
+      # build_perf_interval_arrays  # Build the start and end arrays for the performance interval chooser
       # @edit[:limit_cols] = VimPerformanceTrend.trend_limit_cols(@edit[:new][:perf_trend_db], @edit[:new][:perf_trend_col], @edit[:new][:perf_interval])
     elsif params[:chosen_limit_col]
       if params[:chosen_limit_col] == "<None>"
@@ -610,7 +610,7 @@ module ReportController::Reports::Editor
       @edit[:new][:perf_interval] = params[:chosen_interval]
       @edit[:new][:perf_start] = nil  # Clear start/end offsets
       @edit[:new][:perf_end] = nil
-      build_perf_interval_arrays(@edit[:new][:perf_interval]) # Build the start and end arrays for the performance interval chooser
+      build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
       reset_report_col_fields
       @refresh_div = "form_div"
       @refresh_partial = "form"
@@ -1458,7 +1458,7 @@ module ReportController::Reports::Editor
 
     # Build performance interval select arrays, if needed
     if [:performance, :trend].include?(model_report_type(@rpt.db))
-      build_perf_interval_arrays(@edit[:new][:perf_interval]) # Build the start and end arrays for the performance interval chooser
+      build_perf_interval_arrays # Build the start and end arrays for the performance interval chooser
     end
 
     expkey = :record_filter

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -52,6 +52,23 @@ module ReportHelper
     end
   end
 
+  def filter_performance_start_options
+    start_array = []
+    case @edit[:new][:perf_interval]
+    when 'hourly'
+      6.times { |i| start_array.push([pluralize(i + 1, 'day').to_s, (i + 1).days.to_s]) }
+      4.times { |i| start_array.push([pluralize(i + 1, 'week').to_s, (i + 1).weeks.to_s]) }
+      5.times { |i| start_array.push([pluralize(i + 2, 'month').to_s, (i + 1).months.to_s]) }
+    when 'daily'
+      5.times  { |i| start_array.push([pluralize(i + 2, 'day').to_s, (i + 2).days.to_s]) }
+      3.times  { |i| start_array.push([pluralize((i + 1), 'week').to_s, (i + 1).weeks.to_s]) }
+      11.times { |i| start_array.push([pluralize((i + 1), 'month').to_s, (i + 1).months.to_s]) }
+      # For some reason, 1.year is a float, so use to_i to get rid of decimals
+      start_array.push(['1 year', 1.year.to_i.to_s])
+    end
+    start_array
+  end
+
   # We allow value-based charts when we have aggregations or
   # simple charts w/o summary.
   def chart_mode_values_allowed?

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -68,6 +68,28 @@ module ReportHelper
     start_array
   end
 
+  def filter_performance_end_options
+    end_array = []
+    case @edit[:new][:perf_interval]
+    when 'hourly'
+      end_array += [
+        ['Today', '0'],
+        ['Yesterday', 1.day.to_s]
+      ]
+      5.times { |i| end_array.push(["#{i + 2} days ago", (i + 2).days.to_s]) }
+      4.times { |i| end_array.push(["#{pluralize(i + 1, 'week')} ago", (i + 1).weeks.to_s]) }
+      5.times { |i| end_array.push(["#{pluralize(i + 2, 'month')} ago", (i + 1).months.to_s]) }
+    when 'daily'
+      end_array += [
+        ['Yesterday', '0'] # Start with yesterday, since we only allow full 24 hour days in daily trending
+      ]
+      5.times { |i| end_array.push(["#{i + 2} days ago", (i + 1).days.to_s]) }
+      3.times { |i| end_array.push(["#{pluralize((i + 1), 'week')} ago", ((i + 1).weeks - 1.day).to_s]) }
+      6.times { |i| end_array.push(["#{pluralize((i + 1), 'month')} ago", ((i + 1).months - 1.day).to_s]) }
+    end
+    end_array
+  end
+
   # We allow value-based charts when we have aggregations or
   # simple charts w/o summary.
   def chart_mode_values_allowed?

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -63,8 +63,7 @@ module ReportHelper
       5.times  { |i| start_array.push([pluralize(i + 2, 'day').to_s, (i + 2).days.to_s]) }
       3.times  { |i| start_array.push([pluralize((i + 1), 'week').to_s, (i + 1).weeks.to_s]) }
       11.times { |i| start_array.push([pluralize((i + 1), 'month').to_s, (i + 1).months.to_s]) }
-      # For some reason, 1.year is a float, so use to_i to get rid of decimals
-      start_array.push(['1 year', 1.year.to_i.to_s])
+      start_array.push(['1 year', 1.year.to_s])
     end
     start_array
   end

--- a/app/views/report/_form_filter_performance.html.haml
+++ b/app/views/report/_form_filter_performance.html.haml
@@ -18,7 +18,7 @@
         miqSelectPickerEvent('chosen_end', '#{url}')
       = _('going back')
       = select_tag('chosen_start',
-        options_for_select(@edit[:start_array], @edit[:new][:perf_start]),
+        options_for_select(filter_performance_start_options, @edit[:new][:perf_start]),
         :multiple => false,
         :class => "selectpicker")
       :javascript

--- a/app/views/report/_form_filter_performance.html.haml
+++ b/app/views/report/_form_filter_performance.html.haml
@@ -10,7 +10,7 @@
         = _("Show daily data from")
     .col-md-8
       = select_tag('chosen_end',
-        options_for_select(@edit[:end_array], @edit[:new][:perf_end]),
+        options_for_select(filter_performance_end_options, @edit[:new][:perf_end]),
         :multiple => false,
         :class => "selectpicker")
       :javascript

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -135,7 +135,6 @@ describe ReportController do
           expect(edit_new[:perf_interval]).to eq("daily")
           expect(edit_new[:perf_avgs]).to eq("time_interval")
           expect(edit_new[:tz]).to eq(session[:user_tz])
-          expect(assigns(:edit)[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("form_div")
           expect(assigns(:refresh_partial)).to eq("form")
         end
@@ -171,7 +170,6 @@ describe ReportController do
           expect(edit_new[:perf_target_pct1]).to eq(100)
           expect(edit_new[:perf_limit_val]).to be_nil
           expect(edit[:percent_col]).to be_falsey
-          expect(edit[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("columns_div")
           expect(assigns(:refresh_partial)).to eq("form_columns")
         end
@@ -191,7 +189,6 @@ describe ReportController do
           expect(edit_new[:perf_limit_val]).to eq(100)
           expect(edit_new[:perf_limit_col]).to be_nil
           expect(edit[:percent_col]).to be_truthy
-          expect(edit[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("columns_div")
           expect(assigns(:refresh_partial)).to eq("form_columns")
         end
@@ -268,7 +265,6 @@ describe ReportController do
           expect(edit_new[:perf_interval]).to eq(perf_int)
           expect(edit_new[:perf_start]).to eq(1.day.to_s)
           expect(edit_new[:perf_end]).to eq("0")
-          expect(edit[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("form_div")
           expect(assigns(:refresh_partial)).to eq("form")
         end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -135,7 +135,6 @@ describe ReportController do
           expect(edit_new[:perf_interval]).to eq("daily")
           expect(edit_new[:perf_avgs]).to eq("time_interval")
           expect(edit_new[:tz]).to eq(session[:user_tz])
-          expect(assigns(:edit)[:start_array]).to be_an_instance_of(Array)
           expect(assigns(:edit)[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("form_div")
           expect(assigns(:refresh_partial)).to eq("form")
@@ -172,7 +171,6 @@ describe ReportController do
           expect(edit_new[:perf_target_pct1]).to eq(100)
           expect(edit_new[:perf_limit_val]).to be_nil
           expect(edit[:percent_col]).to be_falsey
-          expect(edit[:start_array]).to be_an_instance_of(Array)
           expect(edit[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("columns_div")
           expect(assigns(:refresh_partial)).to eq("form_columns")
@@ -193,7 +191,6 @@ describe ReportController do
           expect(edit_new[:perf_limit_val]).to eq(100)
           expect(edit_new[:perf_limit_col]).to be_nil
           expect(edit[:percent_col]).to be_truthy
-          expect(edit[:start_array]).to be_an_instance_of(Array)
           expect(edit[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("columns_div")
           expect(assigns(:refresh_partial)).to eq("form_columns")
@@ -271,7 +268,6 @@ describe ReportController do
           expect(edit_new[:perf_interval]).to eq(perf_int)
           expect(edit_new[:perf_start]).to eq(1.day.to_s)
           expect(edit_new[:perf_end]).to eq("0")
-          expect(edit[:start_array]).to be_an_instance_of(Array)
           expect(edit[:end_array]).to be_an_instance_of(Array)
           expect(assigns(:refresh_div)).to eq("form_div")
           expect(assigns(:refresh_partial)).to eq("form")


### PR DESCRIPTION
 Do not store performance interval options in session

Calculate them in helper instead. As a side effect the options are calculated only when really needed (when form_filter_performance is rendered).

@miq-bot add_label technical debt, reporting, ui
@miq-bot assign @martinpovolny 