### PR TITLE
Create Picture API

### DIFF
--- a/app/controllers/api/pictures_controller.rb
+++ b/app/controllers/api/pictures_controller.rb
@@ -1,4 +1,11 @@
 module Api
   class PicturesController < BaseController
+    def create_resource(_type, _id, data)
+      data['content'] = Base64.decode64(data['content'])
+      picture = Picture.create(data)
+      raise BadRequestError,
+            "Failed to create Picture - #{picture.errors.full_messages.join(', ')}" unless picture.valid?
+      picture
+    end
   end
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -2,7 +2,7 @@ class Picture < ApplicationRecord
   has_one :binary_blob, :as => :resource, :dependent => :destroy, :autosave => true
 
   validates :extension,
-            :inclusion => { :in => %w(png jpg), :message => 'must be a png or jpg' },
+            :inclusion => { :in => %w(png jpg svg), :message => 'must be a png, jpg, or svg' },
             :if        => :extension
 
   virtual_has_one :image_href, :class_name => "String"

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,6 +1,10 @@
 class Picture < ApplicationRecord
   has_one :binary_blob, :as => :resource, :dependent => :destroy, :autosave => true
 
+  validates :extension,
+            :inclusion => { :in => %w(png jpg), :message => 'must be a png or jpg' },
+            :if        => :extension
+
   virtual_has_one :image_href, :class_name => "String"
 
   URL_ROOT          = Rails.root.join("public").to_s

--- a/config/api.yml
+++ b/config/api.yml
@@ -611,8 +611,12 @@
     :description: Pictures
     :options:
     - :collection
-    :verbs: *g
+    :verbs: *gp
     :klass: Picture
+    :collection_actions:
+      :post:
+      - :name: create
+        :identifier: picture_new
   :policies:
     :description: Policies
     :identifier: policy

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1457,6 +1457,17 @@
   :feature_type: node
   :identifier: rss
 
+# Pictures
+- :name: Pictures
+  :description: Everything under Pictures
+  :feature_type: admin
+  :identifier: pictures
+  :children:
+  - :name: Create new Picture
+    :description: Create a new picture
+    :feature_type: admin
+    :identifier: picture_new
+
 # Policy
 - :name: Explorer
   :description: Control Explorer

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -13,17 +13,20 @@ describe Picture do
   end
 
   context "#extension" do
-    it "accepts only png or jpb" do
+    it "accepts only png, jpg, or svg" do
       expect(subject.extension).to be_nil
       subject.extension = "foo"
 
       expect(subject.valid?).to be_falsey
-      expect(subject.errors.messages).to eq(:extension =>['must be a png or jpg'])
+      expect(subject.errors.messages).to eq(:extension =>['must be a png, jpg, or svg'])
 
       subject.extension = "png"
       expect(subject.valid?).to be_truthy
 
       subject.extension = "jpg"
+      expect(subject.valid?).to be_truthy
+
+      subject.extension = "svg"
       expect(subject.valid?).to be_truthy
     end
 

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -13,10 +13,24 @@ describe Picture do
   end
 
   context "#extension" do
+    it "accepts only png or jpb" do
+      expect(subject.extension).to be_nil
+      subject.extension = "foo"
+
+      expect(subject.valid?).to be_falsey
+      expect(subject.errors.messages).to eq(:extension =>['must be a png or jpg'])
+
+      subject.extension = "png"
+      expect(subject.valid?).to be_truthy
+
+      subject.extension = "jpg"
+      expect(subject.valid?).to be_truthy
+    end
+
     it "on new record" do
       expect(subject.extension).to be_nil
-      ext = "foo"
-      subject.extension         = ext.dup
+      ext = "png"
+      subject.extension = ext.dup
       expect(subject.extension).to eq(ext)
 
       subject.save
@@ -33,8 +47,8 @@ describe Picture do
 
       subject.reload
       expect(subject.extension).to be_nil
-      ext = "foo"
-      subject.extension         = ext.dup
+      ext = "jpg"
+      subject.extension = ext.dup
       expect(subject.extension).to eq(ext)
 
       subject.save

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -61,4 +61,35 @@ describe "Pictures" do
       expect_result_to_include_picture_href(service_request.id)
     end
   end
+
+  describe 'POST /api/pictures' do
+    it 'rejects create without an appropriate role' do
+      api_basic_authorize
+
+      run_post pictures_url, :extension => 'png', :content => 'content'
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'creates a new picture' do
+      api_basic_authorize collection_action_identifier(:pictures, :create)
+
+      expect do
+        run_post pictures_url, :extension => 'png', :content => 'content'
+      end.to change(Picture, :count).by(1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'creates multiple pictures' do
+      api_basic_authorize collection_action_identifier(:pictures, :create)
+
+      expect do
+        run_post(pictures_url, gen_request(:create, [
+                                             {:extension => 'png', :content => 'content'},
+                                             {:extension => 'jpg', :content => 'content'}
+                                           ]))
+      end.to change(Picture, :count).by(2)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -63,10 +63,26 @@ describe "Pictures" do
   end
 
   describe 'POST /api/pictures' do
+    # one pixel png image encoded in Base64
+    let(:content) do
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABGdBTUEAALGP\n"\
+      "C/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3Cc\n"\
+      "ulE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2Jl\n"\
+      "LnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIg\n"\
+      "eDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpy\n"\
+      "ZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1u\n"\
+      "cyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAg\n"\
+      "ICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYv\n"\
+      "MS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3Jp\n"\
+      "ZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpS\n"\
+      "REY+CjwveDp4bXBtZXRhPgpMwidZAAAADUlEQVQIHWNgYGCwBQAAQgA+3N0+\n"\
+      "xQAAAABJRU5ErkJggg==\n"
+    end
+
     it 'rejects create without an appropriate role' do
       api_basic_authorize
 
-      run_post pictures_url, :extension => 'png', :content => 'content'
+      run_post pictures_url, :extension => 'png', :content => content
 
       expect(response).to have_http_status(:forbidden)
     end
@@ -74,21 +90,31 @@ describe "Pictures" do
     it 'creates a new picture' do
       api_basic_authorize collection_action_identifier(:pictures, :create)
 
+      expected = {
+        'results' => [a_hash_including('id')]
+      }
+
       expect do
-        run_post pictures_url, :extension => 'png', :content => 'content'
+        run_post pictures_url, :extension => 'png', :content => content
       end.to change(Picture, :count).by(1)
+      expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
 
     it 'creates multiple pictures' do
       api_basic_authorize collection_action_identifier(:pictures, :create)
 
+      expected = {
+        'results' => [a_hash_including('id'), a_hash_including('id')]
+      }
+
       expect do
         run_post(pictures_url, gen_request(:create, [
-                                             {:extension => 'png', :content => 'content'},
-                                             {:extension => 'jpg', :content => 'content'}
+                                             {:extension => 'png', :content => content},
+                                             {:extension => 'jpg', :content => content}
                                            ]))
       end.to change(Picture, :count).by(2)
+      expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
Adds ability to create a Picture from the API

*POST /api/pictures*
```
{
  "extension": "jpg",
  "content": "<base 64 encoded image here>"
}
```

will have a follow up PR for assigning pictures to a resource. 

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 