### PR TITLE
s/NotFound/NotFoundError/ in Api::BaseController

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -66,7 +66,7 @@ module Api
       def query_resource(type, id, data)
         unless id
           data_spec = data.collect { |key, val| "#{key}=#{val}" }.join(", ")
-          raise NotFound, "Invalid #{type} resource specified - #{data_spec}"
+          raise NotFoundError, "Invalid #{type} resource specified - #{data_spec}"
         end
         resource = resource_search(id, type, collection_class(type))
         opts = {


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/11085 conflicted with
https://github.com/ManageIQ/manageiq/pull/11372 when both were merged -
the former changed all `NotFound`s to `NotFoundError` while the latter
introduced a new `NotFound`.