### PR TITLE
Allow Vm to show floating and fixed ip addresses

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -29,7 +29,9 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
 
   default_value_for :cloud, true
 
-  virtual_column :ipaddresses,   :type => :string_set, :uses => {:network_ports => :ipaddresses}
+  virtual_column :ipaddresses, :type => :string_set, :uses => {:network_ports => :ipaddresses}
+  virtual_column :floating_ip_addresses, :type => :string_set, :uses => {:network_ports => :floating_ip_addresses}
+  virtual_column :fixed_ip_addresses, :type => :string_set, :uses => {:network_ports => :fixed_ip_addresses}
   virtual_column :mac_addresses, :type => :string_set, :uses => :network_ports
   virtual_column :load_balancer_health_check_state,
                  :type => :string,
@@ -64,6 +66,14 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
 
   def ipaddresses
     @ipaddresses ||= network_ports.collect(&:ipaddresses).flatten.compact.uniq
+  end
+
+  def floating_ip_addresses
+    @floating_ip_addresses ||= network_ports.collect(&:floating_ip_addresses).flatten.compact.uniq
+  end
+
+  def fixed_ip_addresses
+    @fixed_ip_addresses ||= network_ports.collect(&:fixed_ip_addresses).flatten.compact.uniq
   end
 
   def cloud_network

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -420,6 +420,11 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :name => "miq-azure-test1").first
     cloud_subnet  = cloud_network.cloud_subnets.first
     expect(v.floating_ip).to eql(floating_ip)
+    expect(v.floating_ips.first).to eql(floating_ip)
+    expect(v.floating_ip_addresses.first).to eql(floating_ip.address)
+    expect(v.fixed_ip_addresses).to match_array(v.ipaddresses - [floating_ip.address])
+    expect(v.fixed_ip_addresses.count).to be > 0
+
     expect(v.cloud_network).to eql(cloud_network)
     expect(v.cloud_subnet).to eql(cloud_subnet)
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -752,6 +752,9 @@ module Openstack
         expect(vm.public_networks.count).to be > 0
         expect(vm.public_networks.first).to be_kind_of(ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public)
 
+        expect(vm.fixed_ip_addresses.count).to    be > 0
+        expect(vm.floating_ip_addresses.count).to be > 0
+
         expect(vm.private_networks.map(&:name)).to match_array vm_expected[:__network_names]
         expect(vm.public_networks.first.floating_ips).to include vm.floating_ips.first
         vm.network_ports.each do |network_port|


### PR DESCRIPTION
Allow Vm to show floating and fixed ip addresses, since it is
a virtual column, it's also usable in the API.

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1375639