### PR TITLE
[WIP] Use $azure_log for logging Azure things

### DIFF
--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -41,6 +41,14 @@ module ManageIQ::Providers::Azure::ManagerMixin
         :subscription_id => subscription,
         :proxy           => proxy_uri
       )
+
+      if Rails.env == 'development'
+        if ::Azure::Armrest::ArmrestService.respond_to?(:log)
+          ::Azure::Armrest::ArmrestService.log = $azure_log
+        else
+          ::Azure::Armrest::Configuration.log = $azure_log
+        end
+      end
     end
 
     # Discovery


### PR DESCRIPTION
This replaces all instances of `_log` with `$azure_log` for all the Azure provider code.

This should make debugging any Azure issues easier and reduce the clutter of the evm.log.
