### PR TITLE
Create new service model to fix test failure

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-network_manager-load_balancer.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-azure-network_manager-load_balancer.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Azure_NetworkManager_LoadBalancer < MiqAeServiceLoadBalancer
+  end
+end


### PR DESCRIPTION
ManageIQ::Providers::Azure::NetworkManager::LoadBalancer was created without a corresponding service model