### PR TITLE
Delete passing along of div_num as local variable, used by old DHTMLX…

### DIFF
--- a/app/controllers/ops_controller/settings/ldap.rb
+++ b/app/controllers/ops_controller/settings/ldap.rb
@@ -147,10 +147,7 @@ module OpsController::Settings::Ldap
       else
         add_flash(_("Credential validation was successful"))
       end
-      render :update do |page|
-        page << javascript_prologue
-        page.replace("flash_msg_div_entries", :partial => "layouts/flash_msg", :locals => {:div_num => "entries"})
-      end
+      render_flash
     elsif params[:button] == "cancel"
       @ldap_domain = session[:edit][:ldap_domain] if session[:edit] && session[:edit][:ldap_domain]
       if !@ldap_domain || @ldap_domain.id.blank?
@@ -206,11 +203,7 @@ module OpsController::Settings::Ldap
         server = {}
         server[:hostname] = params[:entry][:hostname]
         if params[:entry][:hostname] == ""
-          add_flash(_("Hostname is required"), :error)
-          render :update do |page|
-            page << javascript_prologue
-            page.replace("flash_msg_div_entries", :partial => "layouts/flash_msg", :locals => {:div_num => "entries"})
-          end
+          render_flash(_("Hostname is required"), :error)
           return
         else
           server[:mode] = params[:entry_mode]


### PR DESCRIPTION
Delete passing along of div_num as local variable, used by old DHTMLX code base, when rendering layouts/_flash_msg partial view
flash_msg partial will now default to DOM ID of flash_msg_div 

Replace render :update blocks with render_flash

https://github.com/ManageIQ/manageiq/issues/11238
https://github.com/ManageIQ/manageiq/issues/11239
