### PR TITLE
OpenStack Infra node destroy should delete node from Ironic

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1858,4 +1858,8 @@ class Host < ApplicationRecord
     return power_state unless power_state.nil?
     "unknown"
   end
+
+  def validate_destroy
+    {:available => true, :message => nil}
+  end
 end

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
@@ -484,6 +484,10 @@ openstack-keystone:                     active
       expect(MiqQueue.where(:method_name => "manageable").count).to eq(0)
       host.manageable_queue
       expect(MiqQueue.where(:method_name => "manageable").count).to eq(1)
+
+      expect(MiqQueue.where(:method_name => "destroy_ironic").count).to eq(0)
+      host.destroy_ironic_queue
+      expect(MiqQueue.where(:method_name => "destroy_ironic").count).to eq(1)
     end
 
     it "check task executes and queues refresh if success" do
@@ -514,6 +518,18 @@ openstack-keystone:                     active
       host.manageable(task.id)
       expect(task.status).to eq("Ok")
       expect(MiqQueue.where(:method_name => "refresh").count).to eq(1)
+    end
+
+    it "check task executes and queues destroy_queue if success" do
+      baremetal_service = double("baremetal_service")
+      expect(baremetal_service).to receive(:delete_node) { double(:status => 204) }
+      openstack_handle = double("openstack handle")
+      expect(openstack_handle).to receive(:detect_baremetal_service) { baremetal_service }
+      allow(ext_management_system).to receive(:openstack_handle).and_return(openstack_handle)
+      expect(MiqQueue.where(:method_name => "destroy").count).to eq(0)
+
+      host.destroy_ironic
+      expect(MiqQueue.where(:method_name => "destroy").count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Deleting an OpenStack Infrastructure node now generates a call to
Ironic to delete the node first. If the delete is successful, the
node is then removed locally from ManageIQ.