### PR TITLE
Fixed miqJqueryRequest call for RESTful urls with ipv6 address

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -455,9 +455,9 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     }
   };
 
-  $scope.validateClicked = function($event, authType, url, formSubmit) {
+  $scope.validateClicked = function($event, authType, formSubmit) {
     $scope.authType = authType;
-    miqService.validateWithREST($event, authType, url, formSubmit)
+    miqService.validateWithREST($event, authType, $scope.updateUrl, formSubmit)
       .then(function success(data) {
         $scope.$apply(function() {
           if(data.level == "error") {

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -680,7 +680,7 @@ function miqRESTAjaxButton(url, button, dataType, data) {
     } else {
       formData = $(form).serialize();
     }
-    return miqJqueryRequest(form.action, {
+    return miqJqueryRequest(url, {
       beforeSend: true,
       complete: true,
       data: formData,

--- a/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
+++ b/app/views/layouts/angular/_form_buttons_verify_angular.html.haml
@@ -5,7 +5,7 @@
   - verify_title_on = _("Validate the credentials by logging into the Server")
   - verify_title_off ||= _("Server information, Username and matching password fields are needed to perform verification of credentials")
 - if controller.send(:restful?)
-  - validate = "validateClicked($event, '#{valtype}', '#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}', true)"
+  - validate = "validateClicked($event, '#{valtype}', true)"
 - else
   - validate = "validateClicked('#{url_for(:action => validate_url, :id => id, :type => valtype, :button => "validate")}')"
 %div{"ng-show" => ng_show, "ng-controller" => "buttonGroupController"}


### PR DESCRIPTION
`miqJqueryRequest` does not support URLs that contain an ipv6 address.

For e.g. This URL `https://[fc00:beef::7]/ems_cloud/1000000000010?button=validate` would fail to send a request to the server.

In forms like Cloud Providers/Infrastructure Providers (that use RESTful routing), the url was obtained from the property `form.action` which would return an absolute URL: 
`http://192.168.1.1/foo/bar.html`         for ipv4 and
`http://[fc00:beef::7]/foo/bar.html`    for ipv6

The ipv4 absolute URLs seem to work fine with `miqJqueryRequest`, but not the ipv6.

However, to successfully execute a `miqJqueryRequest`, a relative path like `ems_cloud/1000000000010?button=validate` should suffice and I would say also recommended, in order to avoid issues related to ipv6.

This PR precisely addresses that. The faulty `miqJqueryRequest` call was fixed to use a relative path.

*Steps to reproduce*
-------------------
Issue currently visible on a QE appliance. Ping me if you need the appliance details.

https://bugzilla.redhat.com/show_bug.cgi?id=1375699
