### PR TITLE
Update Service Aggregation Methods to use SQL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2196,7 +2196,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Following 3 methods moved here to ensure they are loaded at the right time and will be available to all controllers
-  def find_by_id_filtered(db, id)
+  def find_by_id_filtered(db, id, options = {})
     raise _("Invalid input") unless is_integer?(id)
 
     db_obj = db.find_by(:id => from_cid(id))
@@ -2205,7 +2205,7 @@ class ApplicationController < ActionController::Base
       raise msg
     end
 
-    Rbac.filtered_object(db_obj, :user => current_user) ||
+    Rbac.filtered_object(db_obj, :user => current_user, :named_scope => options[:named_scope]) ||
       raise(_("User '%{user_id}' is not authorized to access '%{model}' record id '%{record_id}'") %
               {:user_id   => current_userid,
                :record_id => id,

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -61,6 +61,7 @@ class ServiceController < ApplicationController
     build_accordions_and_trees
 
     if params[:id]  # If a tree node id came in, show in one of the trees
+      @find_with_aggregates = true
       nodetype, id = params[:id].split("-")
       self.x_node = "#{nodetype}-#{to_cid(id)}"
       get_node_info(x_node)
@@ -343,6 +344,14 @@ class ServiceController < ApplicationController
     return if record_no_longer_exists?(@record)
 
     get_tagdata(@record)
+  end
+
+  # Overwriting from application controller
+  #
+  # FIXME:  Find a more graceful way of adding .with_aggregates to the @record
+  def find_by_id_filtered(db, id)
+    options = @find_with_aggregates ? { :named_scope => :with_aggregates } : {}
+    super(db, id, options)
   end
 
   def tagging_explorer_controller?

--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -9,12 +9,143 @@ module Service::Aggregation
     virtual_column :aggregate_direct_vm_disk_space_used,      :type => :integer
     virtual_column :aggregate_direct_vm_memory_on_disk,       :type => :integer
 
-    virtual_column :aggregate_all_vm_cpus,                    :type => :integer
-    virtual_column :aggregate_all_vm_memory,                  :type => :integer
-    virtual_column :aggregate_all_vm_disk_count,              :type => :integer
-    virtual_column :aggregate_all_vm_disk_space_allocated,    :type => :integer
-    virtual_column :aggregate_all_vm_disk_space_used,         :type => :integer
-    virtual_column :aggregate_all_vm_memory_on_disk,          :type => :integer
+    virtual_attribute :aggregate_all_vm_cpus,   :integer,
+                      :arel => aggregate_service_hardware_arel('cpus', :cpu_total_cores)
+    virtual_attribute :aggregate_all_vm_memory, :integer,
+                      :arel => aggregate_service_hardware_arel('memory', :memory_mb)
+    virtual_attribute :aggregate_all_vm_disk_count, :integer,
+                      :arel => aggregate_all_vms_disk_count_arel
+    virtual_attribute :aggregate_all_vm_disk_space_allocated, :integer,
+                      :arel => aggregate_all_vms_disk_space_allocated_arel
+    virtual_attribute :aggregate_all_vm_disk_space_used, :integer,
+                      :arel => aggregate_all_vms_disk_space_used_arel
+    virtual_attribute :aggregate_all_vm_memory_on_disk, :integer,
+                      :arel => aggregate_service_hardware_arel('memory_on_disk', :memory_mb, :on_vms_only => true)
+
+    AGGREGATE_ALL_VM_ATTRS = [
+      :aggregate_all_vm_cpus,
+      :aggregate_all_vm_memory,
+      :aggregate_all_vm_disk_count,
+      :aggregate_all_vm_disk_space_allocated,
+      :aggregate_all_vm_disk_space_used,
+      :aggregate_all_vm_memory_on_disk
+    ].freeze
+
+    scope :with_aggregates, -> { select(Arel.star, *AGGREGATE_ALL_VM_ATTRS) }
+  end
+
+  module ClassMethods
+    def aggregate_service_hardware_arel(aggregate_alias, hardware_column, options = {})
+      virtual_column_name = "aggregate_all_vm_#{aggregate_alias}"
+      aggregation_sql = hardwares_tbl[hardware_column].sum
+      aggregate_hardware_arel(virtual_column_name, aggregation_sql, options)
+    end
+
+    def aggregate_all_vms_disk_count_arel
+      virtual_column_name = "aggregate_all_vm_disk_count"
+      aggregation_sql = disks_tbl[:id].count
+      aggregate_hardware_arel(virtual_column_name, aggregation_sql, :include_disks => true)
+    end
+
+    def aggregate_all_vms_disk_space_allocated_arel
+      column_name     = "aggregate_all_vm_disk_space_allocated"
+      coalesce_values = [disks_tbl[:size], zero]
+      aggregation_sql = Arel::Nodes::NamedFunction.new('SUM',
+                                                       [Arel::Nodes::NamedFunction.new('COALESCE', coalesce_values)])
+      aggregate_hardware_arel(column_name, aggregation_sql, :include_disks => true)
+    end
+
+    def aggregate_all_vms_disk_space_used_arel
+      column_name     = "aggregate_all_vm_disk_space_used"
+      coalesce_values = [disks_tbl[:size_on_disk], disks_tbl[:size], zero]
+      aggregation_sql = Arel::Nodes::NamedFunction.new('SUM',
+                                                       [Arel::Nodes::NamedFunction.new('COALESCE', coalesce_values)])
+      aggregate_hardware_arel(column_name, aggregation_sql, :include_disks => true)
+    end
+
+    def aggregate_hardware_arel(virtual_column_name, aggregation_sql, options = {})
+      lambda do |t|
+        subtree_services             = Arel::Table.new(:services)
+        subtree_services.table_alias = "#{virtual_column_name}_services"
+
+        subselect = subtree_services.project(aggregation_sql)
+        subselect = base_service_aggregation_join(subselect, subtree_services, options)
+        join_on_disks(subselect) if options[:include_disks]
+
+        subselect.where(aggregation_where_clause(t, subtree_services))
+      end
+    end
+
+    def aggregation_where_clause(arel, subtree_services)
+      arel.grouping(
+        subtree_services[:id].eq(arel[:id])
+         .or(subtree_services[:ancestry].matches(ancestry_ilike))
+      ).or(subtree_services[:ancestry].eq(service_id_cast))
+    end
+
+    def base_service_aggregation_join(arel, services_tbl, options = {})
+      arel.join(service_resources_tbl).on(service_resources_tbl[:service_id].eq(services_tbl[:id])
+                                  .and(service_resources_tbl[:resource_type].eq(vm_or_template_type)))
+          .join(vms_tbl).on(vm_join_clause(options))
+          .join(hardwares_tbl).on(hardwares_tbl[:vm_or_template_id].eq(vms_tbl[:id]))
+    end
+
+    def vm_join_clause(options = {})
+      clause = vms_tbl[:id].eq(service_resources_tbl[:resource_id])
+      if options[:on_vms_only] # meaning VMs that are powered "on"
+        clause = clause.and(vms_tbl[:power_state].lower.eq('on'))
+      end
+      clause
+    end
+
+    def join_on_disks(arel)
+      arel.join(disks_tbl).on(disks_tbl[:hardware_id].eq(hardwares_tbl[:id]))
+    end
+
+    # NOTE: The following class methods are technically "constants", but to
+    # make sure they are not triggered when the class is first loaded and cause
+    # requests to the DB (can break building the appliance), we are making them
+    # memoized class methods.
+
+    def service_resources_tbl
+      @service_resources_tbl ||= ServiceResource.arel_table
+    end
+
+    def vms_tbl
+      @vms_tbl ||= Vm.arel_table
+    end
+
+    def hardwares_tbl
+      @hardwares_tbl ||= Hardware.arel_table
+    end
+
+    def disks_tbl
+      @disks_tbl ||= Disk.arel_table
+    end
+
+    def partitions_tbl
+      @partitions_tbl ||= Partition.arel_table
+    end
+
+    def zero
+      @zero ||= Arel::Nodes::SqlLiteral.new("0")
+    end
+
+    def vm_or_template_type
+      @vm_or_template_type ||= Arel::Nodes::SqlLiteral.new("'VmOrTemplate'")
+    end
+
+    def ancestry_match
+      @ancestry_match ||= Arel::Nodes::SqlLiteral.new("'/%'")
+    end
+
+    def ancestry_ilike
+      @ancestry_ilike ||= Arel::Nodes::NamedFunction.new("CONCAT", [Service.arel_table[:id], ancestry_match])
+    end
+
+    def service_id_cast
+      @service_id_cast ||= Arel::Nodes::NamedFunction.new("CAST", [Service.arel_table[:id].as("VARCHAR")])
+    end
   end
 
   def aggregate_direct_vm_cpus
@@ -42,26 +173,51 @@ module Service::Aggregation
   end
 
   def aggregate_all_vm_cpus
-    all_vms.inject(0) { |aggregate, vm| aggregate + vm.cpu_total_cores.to_i }
+    if has_attribute?("aggregate_all_vm_cpus")
+      self["aggregate_all_vm_cpus"]
+    else
+      all_vms.inject(0) { |aggregate, vm| aggregate + vm.cpu_total_cores.to_i }
+    end
   end
 
   def aggregate_all_vm_memory
-    all_vms.inject(0) { |aggregate, vm| aggregate + vm.ram_size.to_i }
+    if has_attribute?("aggregate_all_vm_memory")
+      self["aggregate_all_vm_memory"]
+    else
+      all_vms.inject(0) { |aggregate, vm| aggregate + vm.ram_size.to_i }
+    end
   end
 
   def aggregate_all_vm_disk_count
-    all_vms.inject(0) { |aggregate, vm| aggregate + vm.num_disks.to_i }
+    if has_attribute?("aggregate_all_vm_disk_count")
+      self["aggregate_all_vm_disk_count"]
+    else
+      all_vms.inject(0) { |aggregate, vm| aggregate + vm.num_disks.to_i }
+    end
   end
 
   def aggregate_all_vm_disk_space_allocated
-    all_vms.inject(0) { |aggregate, vm| aggregate + vm.allocated_disk_storage.to_i }
+    if has_attribute?("aggregate_all_vm_disk_space_allocated")
+      self["aggregate_all_vm_disk_space_allocated"]
+    else
+      all_vms.inject(0) { |aggregate, vm| aggregate + vm.allocated_disk_storage.to_i }
+    end
   end
 
   def aggregate_all_vm_disk_space_used
-    all_vms.inject(0) { |aggregate, vm| aggregate + vm.used_disk_storage.to_i }
+    if has_attribute?("aggregate_all_vm_disk_space_used")
+      self["aggregate_all_vm_disk_space_used"]
+    else
+      all_vms.inject(0) { |aggregate, vm| aggregate + vm.used_disk_storage.to_i }
+    end
   end
 
   def aggregate_all_vm_memory_on_disk
-    all_vms.inject(0) { |aggregate, vm| aggregate + vm.ram_size_in_bytes_by_state.to_i }
+    if has_attribute?("aggregate_all_vm_memory_on_disk")
+      # Avoids (poorly) "ERROR:  integer out of range" in postgres
+      self["aggregate_all_vm_memory_on_disk"] * 1.megabyte
+    else
+      all_vms.inject(0) { |aggregate, vm| aggregate + vm.ram_size_in_bytes_by_state.to_i }
+    end
   end
 end


### PR DESCRIPTION
## Purpose

Displaying the number "Totals for Service VMs" on the `/service/explorer/:id` page is expensive at scale.  The following table rows:
- CPU
- Memory
- Disk Count
- Disk Space Allocated
- Disk Space Used
- Memory on Disk

Currently requiring load in each hardware record for each vm record, and sometimes each disk record for those hardware records, causing a huge `N*N(N)? + 1`™ when a service has a lot of VMs.
## Overview (aka: WTF is even going on here...)

This is going to be a long, almost blog-post like, explanation here, so hold on to your butts...
### How we currently aggregate these stats...

Taking a step back and looking a particular example from one of the table rows above, to calculate (aggregate) the number of CPUs for a given service currently, you would call `my_service.aggregate_all_vm_cpus` and get returned the number of CPUs that are used by ALL VMs that were created using this service.  What happens under the hood is the following:
- `my_service.all_vms`
  - This is a `virtual_has_many`, but basically is makes use of `ancestry` on services to return all of the VMs that are associated with this service , and any other service that is a descendant of this one (uses the `.direct_vms` method on each service and child service in `app/models/service.rb` to do this).
- `.map(&:hardware)`
  - In reality, we are using a `virtual_column` here, but because it isn't making use of any arel, we are effectively doing a map.
- `.inject(0) {|sum, hw| sum += hw.cpu_total_cores.to_i`

With anything having to do with `Disks`, we are also effectively adding another `.flat_map(&:disks)` following the `.map(&:hardware)` step, which then totals up the values from the disk records.  As you probably can probably guess, this is extremely expensive with a service with many VMs.
### Representing the same thing with SQL

To represent the `aggregate_all_vm_cpus` as a column in SQL, you can represent `Service.select(:id, :aggregate_all_vm_cpus).first` as the following:

``` SQL
SELECT id,
      (
       --- Return only the SUM of all of the CPU cores to the main query (`.inject(0) { ... }`)
       SELECT SUM(hardwares.cpu_total_cores)

       --- Make sure we alias the table name so it doesn't conflict with the outer one
       FROM services aggregate_all_vm_cpus_services

       --- Join on services_resources that have a type of 'VmOrTemplate' (part of `.direct_vms`)
       JOIN service_resources ON service_resources.service_id = aggregate_all_vm_cpus_services.id
                             AND service_resources.resource_type = 'VmOrTemplate' 

       --- Include vms and their associated hardware (`.map(&:hardware)`)
       JOIN vms               ON vms.id = service_resources.resource_id
       JOIN hardwares         ON hardwares.vm_or_template_id = vms.id

       --- Include services that are the current service, and descendants of that service (`.all_vms`)
       WHERE (("aggregate_all_vm_cpus_services"."id" = services.id 
               OR "aggregate_all_vm_cpus_services"."ancestry" ILIKE CONCAT(services.id, '/%'))
              OR "aggregate_all_vm_cpus_services"."ancestry" = CAST(services.id AS VARCHAR))) AS aggregate_all_vm_cpus
FROM services
WHERE id = <my_service.id>;
```

This is not ideal, and should not be used when against a index action, as this nested `SELECT` would be run individually for each service, but for a show, it is about a 20ms nested select in the query for a service with 1800 VMs associated with it and it's children.

To do this for `Disk Count`, another join would need to be done for disks against the `hardware` records.
### Moving this into `virtual_attributes`

Part the reasoning behind doing this as a nested `SELECT` statement is it allows it to be used as a `virtual_attribute`/`virtual_column`.  This allows it to be queried against and selected as if it were a column on the `services` table:

``` ruby
irb> Service.select(:id, :aggregate_all_vm_cpus).where(:id => 123).first.attributes["aggregate_all_vm_cpus"]
=> 12345
```

And multiple of these can also then be used together in a single query:

``` ruby
irb> Service.select(:id, :aggregate_all_vm_cpus, :aggregate_all_vm_disk_count).where(:id => 123).first.attributes
  Service Load (146.1ms)  SELECT  "services"."id", ((SELECT ...
=> {"id" => 123, "aggregate_all_vm_cpus" => 12345, "aggregate_all_vm_disk_count" => 4321}
```

Which now takes a fraction of a second instead of multiple seconds when grabbing each record individually.  This did require modifying the underlying methods in order to check for the existence of the attribute before aggregating in ruby.
### Working it into `/service/explorer/:id`

For any of these new `virtual_attribute` arel methods to actually have an affect, they need to be included in the select in some way, otherwise they will just default to the original `N+1` method of aggregating the data.  This is done when calling `get_node_info` in the `if params[:id]` of the `explorer` action, which then calls `show_record`, then `identify_service`, then `identify_record` (defined in `ApplicationController::CiProcessing`), and finally calling `find_by_id_filtered` (defined in the main `ApplicationController`.

For simplicity, the `with_aggregates` scope was created to make including the columns easier.  This needed to be added to the query that returned the record that was acted against in the views so the aggregates aren't recalculated, so modifying `find_by_id_filtered` was necessary to prevent this.
## Metrics

The following metrics should be a clear indication of the improvements provided by this change.

**Before**

| ms | queries | query (ms) | rows |
| --: | --: | --: | --: |
| 32,534.7 | 278 | 2,922.5 | 74,540 |

**After**

| ms | queries | query (ms) | rows |
| --: | --: | --: | --: |
| 15,958.3 | 44 | 1,304.6 | 36,626 |
## Considerations and Mentionables
- Truth be told, we are technically moving the N+1 here from the application into the database, it just so happens that the DB is much more efficient at running this kind of stuff than the application is, and doesn't have nearly the object overhead that comes with running this in the DB.  That said, there will be probably a bit more stress put on the DB to execute these queries, but nothing in the sense of "multi second table locking", and overall it should be less of an impact on resources.
- These are DEFINITELY not queries that you want to run in a index type fashion, as they will not scale. This is because the nested selects will individually run for each service record returned.  In this case, it will end up in a tying up a process, so these methods need to be used with care.
- Optimally, sharing the `JOIN`s here would be ideal as they would prevent making multiple loops in the database for each aggregate column.  I was originally under the impression that the current UI doesn't facilitate for something like that easily, but it might be possible based on how I have implemented the scopes for this and the changes to the controller.  This would be a minor improvement at this point, and the `virtual_column` arel improvements might still want to be included regardless.
- The overwriting/modifications of `find_by_id_filtered` is ugly at best.  Unfortunately, we are inheriting a lot from the ApplicationController when finding records for "show" routes.  I was mostly going for allowing for additions (scopes on the finder), and overriding as few methods as possible when doing so.  `find_by_id_filtered` should still be the method that is used though at the end of the day and make sure we are finding only what the user has access to, and splitting it up would cause more chances for this filtering to be done incorrectly.
  - Something I noticed while working on that method is it makes two calls to the same record.  One for the `find_by`, and the other when tossed into `Rbac.filtered`.  Furthermore, this also blows away any scopes that might have been applied in the first finder `find_by` when tossed into Rbac, meaning I had to apply the `:named_scope` to Rbac or it wouldn't take.  Since normally this is used with just a model's class and an ID passed in, this is fine, but I found it confusing myself when trying to apply the scope originally to the first query.
