### PR TITLE
Remove the extra "default" authentication created when editing a container provider.

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -425,17 +425,19 @@ module Mixins
       configurations = []
 
       [:default, :ceilometer, :amqp, :ssh_keypair, :metrics, :hawkular].each do |role|
-        configurations << build_configuration(authentications, endpoints, role)
+        configurations << build_configuration(ems, authentications, endpoints, role)
       end
 
       ems.connection_configurations = configurations
     end
 
-    def build_configuration(authentications, endpoints, role)
-      return {:endpoint => endpoints[role], :authentication => nil} unless authentications[role]
+    def build_configuration(ems, authentications, endpoints, role)
+      authtype = role == :default ? ems.default_authentication_type.to_sym : role
+      return {:endpoint => endpoints[role], :authentication => nil} unless authentications[authtype]
 
-      authentication = authentications.delete(role)
-      authentication[:role] = role
+      authentication = authentications.delete(authtype)
+      authentication[:role] = authtype.to_s
+      authentication[:authtype] = authtype.to_s
       {:endpoint => endpoints[role], :authentication => authentication}
     end
 
@@ -472,12 +474,11 @@ module Mixins
                          :save          => (mode != :validate)}
         session[:oauth_response] = nil
       end
-      if ems.kind_of?(ManageIQ::Providers::ContainerManager) &&
-         ems.supports_authentication?(:bearer) && !params[:default_password].blank?
-        creds[:hawkular] = {:auth_key => params[:default_password], :userid => "_"}
-        creds[:bearer] = {:auth_key => params[:default_password]}
+      if ems.kind_of?(ManageIQ::Providers::ContainerManager)
+        default_key = params[:default_password] ? params[:default_password] : ems.authentication_key
+        creds[:hawkular] = {:auth_key => default_key, :save => (mode != :validate)}
+        creds[:bearer] = {:auth_key => default_key, :save => (mode != :validate)}
         creds.delete(:default)
-        ems.update_authentication(creds, :save => (mode != :validate))
       end
       creds
     end

--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -81,7 +81,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   def verify_credentials(auth_type = nil, options = {})
     options = options.merge(:auth_type => auth_type)
-    if options[:auth_type] == "hawkular"
+    if options[:auth_type].to_s == "hawkular"
       verify_hawkular_credentials
     else
       with_provider_connection(options, &:api_valid?)

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -259,11 +259,11 @@ module AuthenticationMixin
 
   def authentication_check_types(*args)
     options = args.extract_options!
-    types = args.first
 
     # Let the individual classes determine what authentication(s) need to be checked
-    types = authentications_to_validate if self.respond_to?(:authentications_to_validate) && types.nil?
-    types = [nil] if types.blank?
+    types = authentications_to_validate if respond_to?(:authentications_to_validate)
+    types = args.first                  if types.blank?
+    types = [nil]                       if types.blank?
     Array(types).each do |t|
       success = authentication_check(t, options).first
       retry_scheduled_authentication_check(t, options) unless success

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -191,6 +191,12 @@ describe EmsContainerController do
           expect(@ems.authentication_token("bearer")).to eq('valid-token')
           expect(@ems.authentication_type("default")).to be_nil
           expect(@ems.hostname).to eq('10.10.10.11')
+
+          controller.remove_instance_variable(:@_params)
+          controller.instance_variable_set(:@_params, :name => 'EMS 3', :default_userid => '_')
+          controller.send(:set_ems_record_vars, @ems)
+          expect(@ems.authentication_token("bearer")).to eq('valid-token')
+          expect(@ems.authentication_type("default")).to be_nil
         end
 
         it "when adding kubernetes EMS" do


### PR DESCRIPTION
**Description**
1. Remove the extra "default" authentication created when editing a container provider.
2. This also solves the Bearer Authentication show as None problem.

PR #9947 solved the removal of the extra "default" authentications only in cases where the
`params[:default_password]` was not blank (this is not always true), this PR fixes that,
and remove the extra authentication in all the cases where the external management system
is container manager.

(*) The bug is for Darga, but this bug exist also in master.

**Bugzilla**
(extra default authentication)
https://bugzilla.redhat.com/show_bug.cgi?id=1370576
https://bugzilla.redhat.com/show_bug.cgi?id=1361012
(not queuing authentication for all authentication types, result in status not authenticated)
https://bugzilla.redhat.com/show_bug.cgi?id=1389278