### PR TITLE
MiqPolicies REST API support

### DIFF
--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -316,6 +316,13 @@ module Api
           raise BadRequestError, "Resource id or href should not be specified for creating a new #{type}"
         end
       end
+
+      def assert_all_required_fields_exists(data, type, required_fields)
+        missing_fields = required_fields - data.keys
+        unless missing_fields.empty?
+          raise BadRequestError, "Resource #{missing_fields.join(", ")} needs be specified for creating a new #{type}"
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/policies_controller.rb
+++ b/app/controllers/api/policies_controller.rb
@@ -3,5 +3,61 @@ module Api
     include Subcollections::Conditions
     include Subcollections::Events
     include Subcollections::PolicyActions
+    REQUIRED_FIELDS = %w(name description towhat conditions_ids policy_contents).freeze
+
+    def create_resource(type, _id, data = {})
+      assert_id_not_specified(data, type)
+      assert_all_required_fields_exists(data, type, REQUIRED_FIELDS)
+      create_policy(data)
+    end
+
+    def edit_resource(type, id = nil, data = {})
+      raise BadRequestError, "Must specify an id for editing a #{type} resource" unless id
+      assert_all_required_fields_exists(data, type, %w(conditions_ids policy_contents))
+      policy = resource_search(id, type, collection_class(:policies))
+      begin
+        add_policies_content(data, policy)
+        policy.conditions = Condition.where(:id => data.delete("conditions_ids")) if data["conditions_ids"]
+        policy.update_attributes(data)
+      rescue => err
+        raise BadRequestError, "Could not edit the policy - #{err}"
+      end
+      policy
+    end
+
+    private
+
+    def create_policy(data)
+      policy = MiqPolicy.create!(:name        => data.delete("name"),
+                                 :description => data.delete("description"),
+                                 :towhat      => data.delete("towhat")
+                                )
+      add_policies_content(data, policy)
+      policy.conditions = Condition.where(:id => data.delete("conditions_ids")) if data["conditions_ids"]
+      policy
+    rescue => err
+      policy.destroy if policy
+      raise BadRequestError, "Could not create the new policy - #{err}"
+    end
+
+    def add_policies_content(data, policy)
+      policy.miq_policy_contents.destroy_all
+      data.delete("policy_contents").each do |policy_content|
+        add_policy_content(policy_content, policy)
+      end if data["policy_contents"]
+    end
+
+    def add_policy_content(policy_content, policy)
+      actions_list = []
+      policy_content["actions"].each do |action|
+        actions_list << [MiqAction.find(action["action_id"]), action["opts"]]
+      end
+      policy.replace_actions_for_event(MiqEventDefinition.find(policy_content["event_id"]), actions_list)
+      policy.save!
+    end
+
+    def policy_ident(policy)
+      "Policy id:#{policy.id} name:'#{policy.name}'"
+    end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -636,15 +636,12 @@
       :post:
       - :name: query
         :identifier: policy_view
-      - :name: add
+      - :name: create
         :identifier: policy_new
-        :disabled: true
       - :name: edit
         :identifier: policy_edit
-        :disabled: true
       - :name: delete
         :identifier: policy_delete
-        :disabled: true
     :resource_actions:
       :get:
       - :name: read
@@ -652,11 +649,11 @@
       :post:
       - :name: edit
         :identifier: policy_edit
-        :disabled: true
+      - :name: delete
+        :identifier: policy_delete
       :delete:
       - :name: delete
         :identifier: policy_delete
-        :disabled: true
     :subcollection_actions:
       :post:
       - :name: assign


### PR DESCRIPTION
Adding CRUD actions to policies API endpoint.
Current api example:
add/update

``` json
{
    "action": "create",
    "resource": {
        "description": "sample policy",
        "name": "sample policy",
        "towhat": "ManageIQ::Providers::Redhat::InfraManager",
        "conditions_ids": [
            2,
            3
        ],
        "policy_contents": [{
            "event_id": 2,
            "actions": [ {"action_id": 1, "opts": { "qualifier": "failure" }} ]
        }]
    }
}
```
