### PR TITLE
[DARGA] C&U - WEB UI crashes when moving from calendar to daily/hourly selection

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -203,12 +203,12 @@ module ApplicationController::Performance
     edate_daily = edate.hour < 23 ? edate - 1.day : edate
     options[:edate_daily] = edate_daily
 
-    if options[:hourly_date].present? && # Need to clear hourly date if not nil so it will be reset below if
+    if options[:hourly_date].blank? || # Need to clear hourly date if not nil so it will be reset below if
        (options[:hourly_date].to_date < sdate.to_date || options[:hourly_date].to_date > edate.to_date || # it is out of range
          (options[:typ] == "Hourly" && options[:time_profile] && !options[:time_profile_days].include?(options[:hourly_date].to_date.wday))) # or not in profile
       options[:hourly_date] = nil
     end
-    if options[:daily_date].present? &&
+    if options[:daily_date].blank? ||
        (options[:daily_date].to_date < sdate_daily.to_date || options[:daily_date].to_date > edate_daily.to_date)
       options[:daily_date] = nil
     end

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -21,4 +21,54 @@ describe ApplicationController do
       controller.send(:perf_planning_gen_data)
     end
   end
+
+  context "#perf_set_or_fix_dates" do
+    def push_metric(prov, timestamp, interval = "daily")
+      prov.metric_rollups << MetricRollup.create(
+        :capture_interval_name => interval,
+        :timestamp             => timestamp,
+        :time_profile          => TimeProfile.first
+      )
+    end
+
+    before(:each) do
+      allow(MiqServer).to receive(:my_zone).and_return("default")
+      ems = FactoryGirl.create(:ems_kubernetes)
+      controller.instance_variable_set(:@perf_record, ems)
+      push_metric(ems, DateTime.parse('1/1/2016 00:00').utc, "hourly")
+      push_metric(ems, DateTime.parse('1/30/2016 23:00').utc, "hourly")
+    end
+
+    it "shoud not change the dates" do
+      options = {
+        :typ         => 'Daily',
+        :hourly_date => '1/15/2016',
+        :daily_date  => '1/15/2016'
+      }
+      controller.send(:perf_set_or_fix_dates, options)
+      expect(options[:hourly_date]).to eq('1/15/2016')
+      expect(options[:daily_date]).to eq('1/15/2016')
+    end
+
+    it "should fix empty dates" do
+      options = {
+        :typ         => 'Daily',
+        :hourly_date => ''
+      }
+      controller.send(:perf_set_or_fix_dates, options)
+      expect(options[:hourly_date]).to eq('1/30/2016')
+      expect(options[:daily_date]).to eq('1/30/2016')
+    end
+
+    it "should fix wrong dates" do
+      options = {
+        :typ         => 'Daily',
+        :hourly_date => '2/15/2016',
+        :daily_date  => '2/15/2016'
+      }
+      controller.send(:perf_set_or_fix_dates, options)
+      expect(options[:hourly_date]).to eq('1/30/2016')
+      expect(options[:daily_date]).to eq('1/30/2016')
+    end
+  end
 end


### PR DESCRIPTION
**Description**
In Darga It is posible to send an empty string as a date from the UI,  we need to reset the date when an empty string is present.

PR #10458 did not reset the date in cases where the date was empty, it only protected the sanity checks.
This PR also reset the date in cases where the date string is emepty.

**Bugzilla**
https://bugzilla.redhat.com/show_bug.cgi?id=1370570