### PR TITLE
Replication: Fix typo preventing full error msg, when saving region replication role

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -211,7 +211,7 @@ module OpsController::Settings::Common
       begin
         MiqRegion.replication_type = replication_type
       rescue StandardError => bang
-        add_flash(_("Error during replication configuration save: ") %
+        add_flash(_("Error during replication configuration save: %{message}") %
                     {:message => bang.message}, :error)
       else
         add_flash(_("Replication configuration save was successful"))


### PR DESCRIPTION
This is related to https://bugzilla.redhat.com/show_bug.cgi?id=1378400

@miq-bot add_label replication, bug, euwe/yes
/cc @carbonin 