### PR TITLE
Refactor typed actions rendering in the API

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -72,7 +72,6 @@ module Api
         opts = {
           :name             => type.to_s,
           :is_subcollection => false,
-          :resource_actions => "resource_actions_#{type}",
           :expand_resources => true
         }
         resource_to_jbuilder(type, type, resource, opts).attributes!

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -6,12 +6,7 @@ module Api
       #
       def render_collection_type(type, id, is_subcollection = false)
         klass = collection_class(type)
-        opts  = {
-          :name               => type.to_s,
-          :is_subcollection   => is_subcollection,
-          :resource_actions   => "resource_actions_#{type}",
-          :collection_actions => "collection_actions_#{type}"
-        }
+        opts  = {:name => type.to_s, :is_subcollection => is_subcollection}
         if id
           render_resource type, resource_search(id, type, klass), opts
         else
@@ -65,7 +60,7 @@ module Api
               json.href normalize_href(reftype, resource["id"])
             end
           end
-          aspecs = get_aspecs(type, opts[:collection_actions], :collection,
+          aspecs = get_aspecs(type, :collection,
                               :is_subcollection => opts[:is_subcollection], :ref => reftype)
           add_actions(json, aspecs, reftype)
         end
@@ -106,23 +101,14 @@ module Api
 
       #
       # type is the collection type we need to get actions specifications for
-      # typed_actions is the optional type specific method to return actions
       # item_type is :collection or :resource
       #
       # opts[:is_subcollection] is true if accessing as subcollection or subresource
       # opts[:ref] is how to identify item, either the reftype of the collection or href of resource
       # opts[:resource] is the object to get action specs for the specific resource
       #
-      def get_aspecs(type, typed_actions, item_type, opts = {})
-        aspecs = []
-        if typed_actions
-          aspecs = if respond_to?(typed_actions)
-                     send(typed_actions, opts[:is_subcollection], opts[:ref])
-                   else
-                     gen_action_specs(type, item_type, opts[:is_subcollection], opts[:ref], opts[:resource])
-                   end
-        end
-        aspecs
+      def get_aspecs(type, item_type, opts = {})
+        gen_action_specs(type, item_type, opts[:is_subcollection], opts[:ref], opts[:resource])
       end
 
       #
@@ -325,7 +311,7 @@ module Api
         return unless render_actions(resource)
 
         href   = json.attributes!["href"]
-        aspecs = get_aspecs(type, opts[:resource_actions], :resource,
+        aspecs = get_aspecs(type, :resource,
                             :is_subcollection => opts[:is_subcollection], :ref => href, :resource => resource)
         add_actions(json, aspecs, type)
       end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -60,8 +60,8 @@ module Api
               json.href normalize_href(reftype, resource["id"])
             end
           end
-          aspecs = get_aspecs(type, :collection,
-                              :is_subcollection => opts[:is_subcollection], :ref => reftype)
+          cspec = collection_config[type]
+          aspecs = gen_action_spec_for_collections(type, cspec, opts[:is_subcollection], reftype) if cspec
           add_actions(json, aspecs, reftype)
         end
       end
@@ -97,18 +97,6 @@ module Api
           matched_type = collection_config.name_for_klass(rclass)
         end
         matched_type || reftype
-      end
-
-      #
-      # type is the collection type we need to get actions specifications for
-      # item_type is :collection or :resource
-      #
-      # opts[:is_subcollection] is true if accessing as subcollection or subresource
-      # opts[:ref] is how to identify item, either the reftype of the collection or href of resource
-      # opts[:resource] is the object to get action specs for the specific resource
-      #
-      def get_aspecs(type, item_type, opts = {})
-        gen_action_specs(type, item_type, opts[:is_subcollection], opts[:ref], opts[:resource])
       end
 
       #
@@ -311,8 +299,8 @@ module Api
         return unless render_actions(resource)
 
         href   = json.attributes!["href"]
-        aspecs = get_aspecs(type, :resource,
-                            :is_subcollection => opts[:is_subcollection], :ref => href, :resource => resource)
+        cspec = collection_config[type]
+        aspecs = gen_action_spec_for_resources(cspec, opts[:is_subcollection], href, resource) if cspec
         add_actions(json, aspecs, type)
       end
 
@@ -371,24 +359,6 @@ module Api
                 js.child! { |jsc| jsc.href normalize_href(sctype, scr["id"]) }
               end
             end
-          end
-        end
-      end
-
-      #
-      # Let's create the action specs for the different collections
-      #
-      # type is :collection or :resource
-      # subcollection set to true, if accessing collection or resource as subcollection
-      # href is the optional href for the action specs, required for resources
-      #
-      def gen_action_specs(collection, type, is_subcollection, href = nil, resource = nil)
-        cspec = collection_config[collection]
-        if cspec
-          if type == :collection
-            gen_action_spec_for_collections(collection, cspec, is_subcollection, href)
-          else
-            gen_action_spec_for_resources(cspec, is_subcollection, href, resource)
           end
         end
       end


### PR DESCRIPTION
* Remove support for typed actions rendering

The JSON API has either ceased to need support for these, or was never
needed. If it is needed again in the future it can easily be re-added,
while removing them a) eliminates a source of dynamic method sending,
and b) reduces the overall complexity.

To be extra sure, grepping for these:

```
ag --color --color-match 30\;43 --literal --line-number --smart-case --nogroup --column --stats -- collection_actions_ .
0 matches
```

```
ag --color --color-match 30\;43 --literal --line-number --smart-case --nogroup --column --stats -- resource_actions_ .
app/controllers/api/subcollections/resource_actions.rb:4:11:      def resource_actions_query_resource(object)
1 matches
```

yields one match, which is called successfully from `collection_search`,
not from `get_aspecs`

* Remove middlemen get_aspecs and gen_actions_specs

These methods just serve to forward messages to other methods, switching
on type (and adding two layers of indirection). Since the callers know
which type they need, this revision has them call the target themselves,
eliminating the need for these methods.

:fire:: :scissors: :sparkles: :tophat: :sparkles: :scissors: :fire: 

/cc @jrafanie 
@miq-bot add-label api, refactoring, technical debt
@miq-bot assign @abellotti 
