### PR TITLE
virtual_aggregates for hardware 

### DIFF
--- a/app/models/disk.rb
+++ b/app/models/disk.rb
@@ -11,7 +11,9 @@ class Disk < ApplicationRecord
   virtual_column :unallocated_space_percent,   :type => :float,   :uses => :unallocated_space
   virtual_column :used_percent_of_provisioned, :type => :float
   virtual_column :partitions_aligned,          :type => :string,  :uses => {:partitions => :aligned}
-
+  virtual_column :used_disk_storage, :type => :integer, :arel => (lambda do |t|
+    t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [t[:size_on_disk], t[:size], 0]))
+  end)
   virtual_has_many  :base_storage_extents, :class_name => "CimStorageExtent"
   virtual_has_many  :storage_systems,      :class_name => "CimComputerSystem"
 
@@ -74,5 +76,9 @@ class Disk < ApplicationRecord
 
   def storage_systems
     miq_cim_instance.nil? ? [] : miq_cim_instance.storage_systems
+  end
+
+  def used_disk_storage
+    size_on_disk || size || 0
   end
 end

--- a/app/models/mixins/virtual_total_mixin.rb
+++ b/app/models/mixins/virtual_total_mixin.rb
@@ -5,24 +5,59 @@ module VirtualTotalMixin
     private
 
     # define an attribute to calculating the total of a child
+    def virtual_total(name, relation, options = {})
+      virtual_aggregate(name, relation, :size, nil, options)
+    end
+
+    # define an attribute to calculating the total of a child
+    #
+    #  example 1:
+    #
     #   virtual_total :total_vms, :vms
     #
     #   def total_vms
     #     vms.count
     #   end
-    #   virtual_attribute :total_vms, :integer, :uses => :vms
     #
-    #   It also defines the necessary arel so it will sort by the total in the database
+    #   virtual_attribute :total_vms, :integer, :uses => :vms, :arel => ...
     #
-    def virtual_total(name, relation, options = {})
-      define_method(name) do
-        (attribute_present?(name) ? self[name] : nil) || send(relation).try(:size) || 0
+    #  example 2:
+    #
+    #   virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+    #
+    #   def allocated_disk_storage
+    #     if disks.loaded?
+    #       disks.blank? ? nil : disks.map { |t| t.size.to_i }.sum
+    #     else
+    #       disks.sum(:size) || 0
+    #     end
+    #   end
+    #   virtual_attribute :allocated_disk_storage, :integer, :uses => :disks, :arel => ...
+    #
+    def virtual_aggregate(name, relation, method_name = :sum, column = nil, options = {})
+      if method_name == :size
+        define_method(name) do
+          (attribute_present?(name) ? self[name] : nil) || send(relation).try(:size) || 0
+        end
+      else
+        define_method(name) do
+          (attribute_present?(name) ? self[name] : nil) ||
+            rel = send(relation)
+            if rel.loaded?
+              rel.blank? ? nil : rel.map { |t| t.send(column).to_i }.send(method_name)
+            else
+              # aggregates are not smart enough to handle virtual attributes
+              arel_column = rel.klass.arel_attribute(column)
+              rel.try(method_name, arel_column) || 0
+            end
+        end
       end
 
       reflection = reflect_on_association(relation)
 
       if options.key?(:arel)
         arel = options.dup.delete(:arel)
+        # if there is no relation to get to the arel, have to throw it away
         arel = nil if !arel || !reflection
       elsif reflection && reflection.macro == :has_many && !reflection.options[:through]
         arel = lambda do |t|
@@ -30,8 +65,12 @@ module VirtualTotalMixin
           # need db access for the keys, so delaying all this lookup until call time
           local_key = reflection.active_record_primary_key
           foreign_key = reflection.foreign_key
-          # assuming has_many
-          Arel::Nodes::Grouping.new(foreign_table.project(Arel.star.count)
+          arel_column = if method_name == :size
+                          Arel.star.count
+                        else
+                          reflection.klass.arel_attribute(column).send(method_name)
+                        end
+          Arel::Nodes::Grouping.new(foreign_table.project(arel_column)
                                                  .where(t[local_key].eq(foreign_table[foreign_key])))
         end
       end

--- a/app/models/mixins/virtual_total_mixin.rb
+++ b/app/models/mixins/virtual_total_mixin.rb
@@ -13,28 +13,62 @@ module VirtualTotalMixin
     #
     #  example 1:
     #
-    #   virtual_total :total_vms, :vms
+    #    class ExtManagementSystem
+    #      has_many :vms
+    #      virtual_total :total_vms, :vms
+    #    end
     #
-    #   def total_vms
-    #     vms.count
-    #   end
+    #    generates:
     #
-    #   virtual_attribute :total_vms, :integer, :uses => :vms, :arel => ...
+    #    def total_vms
+    #      vms.count
+    #    end
+    #
+    #    virtual_attribute :total_vms, :integer, :uses => :vms, :arel => ...
+    #
+    #   # arel == (SELECT COUNT(*) FROM vms where ems.id = vms.ems_id)
     #
     #  example 2:
     #
-    #   virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+    #    class Hardware
+    #      has_many :disks
+    #      virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+    #    end
     #
-    #   def allocated_disk_storage
-    #     if disks.loaded?
-    #       disks.blank? ? nil : disks.map { |t| t.size.to_i }.sum
-    #     else
-    #       disks.sum(:size) || 0
-    #     end
-    #   end
-    #   virtual_attribute :allocated_disk_storage, :integer, :uses => :disks, :arel => ...
+    #    generates:
     #
+    #    def allocated_disk_storage
+    #      if disks.loaded?
+    #        disks.blank? ? nil : disks.map { |t| t.size.to_i }.sum
+    #      else
+    #        disks.sum(:size) || 0
+    #      end
+    #    end
+    #
+    #    virtual_attribute :allocated_disk_storage, :integer, :uses => :disks, :arel => ...
+    #
+    #    # arel => (SELECT sum("disks"."size") where "hardware"."id" = "disks"."hardware_id")
+
     def virtual_aggregate(name, relation, method_name = :sum, column = nil, options = {})
+      define_virtual_aggregate_method(name, relation, method_name, column)
+      reflection = reflect_on_association(relation)
+
+      if options.key?(:arel)
+        arel = options.dup.delete(:arel)
+        # if there is no relation to get to the arel, have to throw it away
+        arel = nil if !arel || !reflection
+      else
+        arel = virtual_aggregate_arel(reflection, method_name, column)
+      end
+
+      if arel
+        virtual_attribute name, :integer, :uses => options[:uses] || relation, :arel => arel
+      else
+        virtual_attribute name, :integer, **options
+      end
+    end
+
+    def define_virtual_aggregate_method(name, relation, method_name, column)
       if method_name == :size
         define_method(name) do
           (attribute_present?(name) ? self[name] : nil) || send(relation).try(:size) || 0
@@ -42,43 +76,34 @@ module VirtualTotalMixin
       else
         define_method(name) do
           (attribute_present?(name) ? self[name] : nil) ||
-            rel = send(relation)
-            if rel.loaded?
-              rel.blank? ? nil : rel.map { |t| t.send(column).to_i }.send(method_name)
-            else
-              # aggregates are not smart enough to handle virtual attributes
-              arel_column = rel.klass.arel_attribute(column)
-              rel.try(method_name, arel_column) || 0
+            begin
+              rel = send(relation)
+              if rel.loaded?
+                rel.blank? ? nil : (rel.map { |t| t.send(column).to_i } || 0).send(method_name)
+              else
+                # aggregates are not smart enough to handle virtual attributes
+                arel_column = rel.klass.arel_attribute(column)
+                rel.try(method_name, arel_column) || 0
+              end
             end
         end
       end
+    end
 
-      reflection = reflect_on_association(relation)
-
-      if options.key?(:arel)
-        arel = options.dup.delete(:arel)
-        # if there is no relation to get to the arel, have to throw it away
-        arel = nil if !arel || !reflection
-      elsif reflection && reflection.macro == :has_many && !reflection.options[:through]
-        arel = lambda do |t|
-          foreign_table = reflection.klass.arel_table
-          # need db access for the keys, so delaying all this lookup until call time
-          local_key = reflection.active_record_primary_key
-          foreign_key = reflection.foreign_key
-          arel_column = if method_name == :size
-                          Arel.star.count
-                        else
-                          reflection.klass.arel_attribute(column).send(method_name)
-                        end
-          Arel::Nodes::Grouping.new(foreign_table.project(arel_column)
-                                                 .where(t[local_key].eq(foreign_table[foreign_key])))
-        end
-      end
-
-      if arel
-        virtual_attribute name, :integer, :uses => options[:uses] || relation, :arel => arel
-      else
-        virtual_attribute name, :integer, **options
+    def virtual_aggregate_arel(reflection, method_name, column)
+      return unless reflection && reflection.macro == :has_many && !reflection.options[:through]
+      lambda do |t|
+        foreign_table = reflection.klass.arel_table
+        # need db access for the keys, so delaying all this lookup until call time
+        local_key = reflection.active_record_primary_key
+        foreign_key = reflection.foreign_key
+        arel_column = if method_name == :size
+                        Arel.star.count
+                      else
+                        reflection.klass.arel_attribute(column).send(method_name)
+                      end
+        t.grouping(foreign_table.project(arel_column)
+                                .where(t[local_key].eq(foreign_table[foreign_key])))
       end
     end
   end

--- a/spec/models/disk_spec.rb
+++ b/spec/models/disk_spec.rb
@@ -1,0 +1,44 @@
+describe Disk do
+  include Spec::Support::ArelHelper
+
+  describe ".used_disk_storage" do
+    context "with nothing" do
+      let(:disk) { FactoryGirl.build(:disk) }
+
+      it "calculates in ruby" do
+        expect(disk.used_disk_storage).to eq(0)
+      end
+
+      it "calculates in the database" do
+        disk.save!
+        expect(virtual_column_sql_value(Disk, "used_disk_storage")).to eq(0)
+      end
+    end
+
+    context "with size" do
+      let(:disk) { FactoryGirl.build(:disk, :size => 1024) }
+
+      it "calculates in ruby" do
+        expect(disk.used_disk_storage).to eq(1024)
+      end
+
+      it "calculates in the database" do
+        disk.save!
+        expect(virtual_column_sql_value(Disk, "used_disk_storage")).to eq(1024)
+      end
+    end
+
+    context "with size_on_disk" do
+      let(:disk) { FactoryGirl.build(:disk, :size_on_disk => 1024, :size => 10240) }
+
+      it "calculates in ruby" do
+        expect(disk.used_disk_storage).to eq(1024)
+      end
+
+      it "calculates in the database" do
+        disk.save!
+        expect(virtual_column_sql_value(Disk, "used_disk_storage")).to eq(1024)
+      end
+    end
+  end
+end

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -115,4 +115,68 @@ describe Hardware do
       end
     end
   end
+
+  describe ".allocated_disk_storage" do
+    let(:hardware) { FactoryGirl.create(:hardware) }
+
+    context "with no disks" do
+      it "bails ruby calculation" do
+        expect(hardware.allocated_disk_storage).to eq(0) # TODO
+      end
+
+      it "bails database calculation" do
+        hardware
+        expect(virtual_column_sql_value(Hardware, "allocated_disk_storage")).to be_nil
+      end
+    end
+
+    context "with disks" do
+      before do
+        FactoryGirl.create(:disk, :size_on_disk => 1024, :size => 10240, :hardware => hardware)
+        FactoryGirl.create(:disk, :size => 1024, :hardware => hardware)
+        FactoryGirl.create(:disk, :hardware => hardware)
+      end
+
+      it "calculates in ruby" do
+        expect(hardware.allocated_disk_storage).to eq(11264)
+      end
+
+      it "calculates in the database" do
+        hardware
+        expect(virtual_column_sql_value(Hardware, "allocated_disk_storage")).to eq(11264)
+      end
+    end
+  end
+
+  describe ".used_disk_storage" do
+    let(:hardware) { FactoryGirl.create(:hardware) }
+
+    context "with no disks" do
+      it "bails ruby calculation" do
+        expect(hardware.used_disk_storage).to eq(0) # TODO
+      end
+
+      it "bails database calculation" do
+        hardware
+        expect(virtual_column_sql_value(Hardware, "used_disk_storage")).to be_nil
+      end
+    end
+
+    context "with disks" do
+      before do
+        FactoryGirl.create(:disk, :size_on_disk => 1024, :size => 10240, :hardware => hardware)
+        FactoryGirl.create(:disk, :size => 1024, :hardware => hardware)
+        FactoryGirl.create(:disk, :hardware => hardware)
+      end
+
+      it "calculates in ruby" do
+        expect(hardware.used_disk_storage).to eq(2048)
+      end
+
+      it "calculates in the database" do
+        hardware
+        expect(virtual_column_sql_value(Hardware, "used_disk_storage")).to eq(2048)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**existing:**

`ems.total_vms` uses `virtual_total` to count the number of `vms` belonging to an `ems`.

```ruby
class ExtManagementSystem
  has_many :vms
  virtual_total :total_vms, :vms

  # which defines"
  def total_vms
    vms.size
    # equivalent to:
    # if vms.loaded?
    #   vms.size
    # else
    #   vms.count
    # end
  end
end
```

```SQL
SELECT COUNT(*)
FROM vms
WHERE vms.ems_id = $EMS_ID
```

**introducing:**

`hardware.allocated_disk_storage` uses `virtual_aggregate` to sum the `size` of all `disk` belonging to a piece of `hardware`. This is essentially the count example, but using `sum(size)` instead of `count(*)`

```ruby
class Hardware
  has_many :disks
  virtual_aggregate :allocated_disk_storage, :disks, :sum, :size

  # which defines:
  def allocated_disk_storage
    if disks.loaded?
      disks.map { |d| d.size }.sum
    else
      disks.sum(:size)
    end
  end
end
```

```SQL
SELECT sum(size)
FROM disks
WHERE disks.hardware_id = $HARDWARE_ID
```
