### PR TITLE
Changed the heading 'Container Groups' to 'Pods' - Fix for bug #1377434

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -78,7 +78,7 @@ module EmsCommon
       'containers'                    => [Container,              _('Containers')],
       'container_replicators'         => [ContainerReplicator,    _('Container Replicators')],
       'container_nodes'               => [ContainerNode,          _('Container Nodes')],
-      'container_groups'              => [ContainerGroup,         _('Container Groups')],
+      'container_groups'              => [ContainerGroup,         _('Pods')],
       'container_services'            => [ContainerService,       _('Container Services')],
       'container_images'              => [ContainerImage,         _('Container Images')],
       'container_routes'              => [ContainerRoute,         _('Container Routes')],

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -81,7 +81,7 @@ class ContainerGroup < ApplicationRecord
   end
 
   def disconnect_inv
-    _log.info "Disconnecting Container group [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
+    _log.info "Disconnecting Pod [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.container_definitions.each(&:disconnect_inv)
     self.old_ems_id = ems_id

--- a/spec/presenters/tree_builder_containers_spec.rb
+++ b/spec/presenters/tree_builder_containers_spec.rb
@@ -8,7 +8,7 @@ describe TreeBuilderContainers do
     MiqRegion.seed
     EvmSpecHelper.local_miq_server
 
-    @container_group = FactoryGirl.create(:container_group, :name => "Container group", :id => 42)
+    @container_group = FactoryGirl.create(:container_group, :name => "Pod", :id => 42)
     @tagged_container = FactoryGirl.create(:container,
                                            :name            => "Tagged Container",
                                            :tags            => [tag],


### PR DESCRIPTION
bz:https://bugzilla.redhat.com/show_bug.cgi?id=1377434
Changes the heading on Provider>Pods from 'Container Group' to 'Pods'.
before:
![container_groups](https://cloud.githubusercontent.com/assets/8366181/18835857/ee2adc98-8405-11e6-9827-d2bee80f6f61.png)
after:
![pods](https://cloud.githubusercontent.com/assets/8366181/18835870/fa9d4998-8405-11e6-9c89-269f6c1e0cdd.png)

@zeari @alongoldboim 
@simon3z 

