### PR TITLE
Fetch config for entities under domain server

### DIFF
--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -25,16 +25,17 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
     expect(@ems_hawkular.middleware_datasources.count).to be > 0
     expect(@ems_hawkular.middleware_messagings.count).to be > 0
     expect(@ems_hawkular.middleware_deployments.first).to have_attributes(:status => 'Enabled')
-    assert_specific_datasource
+    assert_specific_datasource('Local~/subsystem=datasources/data-source=ExampleDS')
+    assert_specific_datasource('Local~/host=master/server=server-one/subsystem=datasources/data-source=ExampleDS')
     assert_specific_server_group(domain)
     assert_specific_domain
   end
 
-  def assert_specific_datasource
-    datasource = @ems_hawkular.middleware_datasources.find_by_name('Datasource [ExampleDS]')
+  def assert_specific_datasource(nativeid)
+    datasource = @ems_hawkular.middleware_datasources.find_by_nativeid(nativeid)
     expect(datasource).to have_attributes(
       :name     => 'Datasource [ExampleDS]',
-      :nativeid => 'Local~/subsystem=datasources/data-source=ExampleDS'
+      :nativeid => nativeid
     )
     expect(datasource.properties).not_to be_nil
     expect(datasource.properties).to have_attributes(

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
@@ -4882,4 +4882,342 @@ http_interactions:
         Status~Deployment Status","data":[{"timestamp":1472598684000,"value":"up"}]}]'
     http_version: 
   recorded_at: Tue, 30 Aug 2016 23:12:21 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Sep 2016 13:57:55 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '682'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "properties" : {
+            "__identityHash" : "db85f6b08996789d6b315151197ef115897dc12"
+          },
+          "name" : "configuration",
+          "identityHash" : "db85f6b08996789d6b315151197ef115897dc12",
+          "value" : {
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:jboss/datasources/ExampleDS",
+            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "Enabled" : "true",
+            "Password" : "sa"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Sep 2016 13:57:55 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '718'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-two/r;Local~%2Fhost=master%2Fserver=server-two%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Sep 2016 13:57:55 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '702'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=datasources%2Fdata-source=ExampleDS/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Sep 2016 13:57:55 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '682'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "properties" : {
+            "__identityHash" : "db85f6b08996789d6b315151197ef115897dc12"
+          },
+          "name" : "configuration",
+          "identityHash" : "db85f6b08996789d6b315151197ef115897dc12",
+          "value" : {
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:jboss/datasources/ExampleDS",
+            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "Enabled" : "true",
+            "Password" : "sa"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=DLQ/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Sep 2016 13:57:55 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '702'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DDLQ/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/entity/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost=master/r;Local~%2Fhost=master%2Fserver=server-one/r;Local~%2Fhost=master%2Fserver=server-one%2Fsubsystem=messaging-activemq%2Fserver=default%2Fjms-queue=ExpiryQueue/d;configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.2.3p173
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Sep 2016 13:57:55 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '718'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "errorMsg" : "No DataEntity found on any of the following paths: [[CanonicalPaths[/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration]]]",
+          "details" : {
+            "entityType" : "DataEntity",
+            "path" : [ [ {
+              "paths" : [ "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault%2Fjms-queue%3DExpiryQueue/d;configuration" ]
+            } ] ]
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
The config for Datasources and JMS Topic/Queues was not fetched for those entites that were owned by the domain server, because it had a different canonical path in the Hawkular inventory.

There were two almost identical methods, so I made the code dry. One for datasources and the second one for messagings.

It fixes [BZ 1378480](https://bugzilla.redhat.com/show_bug.cgi?id=1378480).
@miq-bot add_labels providers/hawkular, bug, euwe/yes

@josejulio could you please review?
@miq-bot assign @josejulio 