### PR TITLE
Domain only attributes should be missing in namespace yaml files

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -6,7 +6,7 @@ class MiqAeNamespace < ApplicationRecord
   EXPORT_EXCLUDE_KEYS = [/^id$/, /_id$/, /^created_on/, /^updated_on/,
                          /^updated_by/, /^reserved$/, /^commit_message/,
                          /^commit_time/, /^commit_sha/, /^ref$/, /^ref_type$/,
-                         /^last_import_on/].freeze
+                         /^last_import_on/, /^source/, /^top_level_namespace/].freeze
 
   belongs_to :parent,        :class_name => "MiqAeNamespace",  :foreign_key => :parent_id
   has_many   :ae_namespaces, :class_name => "MiqAeNamespace",  :foreign_key => :parent_id,    :dependent => :destroy

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_export_spec.rb
@@ -176,6 +176,19 @@ describe MiqAeDatastore do
     end
   end
 
+  context "domain_only_attributes" do
+    it "namespace should not contain domain only attributes" do
+      domain_only_attrs = %w(source top_level_namespace)
+      export_model(@manageiq_domain.name)
+      namespace_file = File.join(@export_dir, @manageiq_domain.name, @aen1.name, '__namespace__.yaml')
+      data = YAML.load_file(namespace_file)
+      hash = data.fetch_path('object', 'attributes')
+      domain_only_attrs.each do |attr|
+        expect(hash.key?(attr)).to be_falsey
+      end
+    end
+  end
+
   context "export import roundtrip" do
     context "export all domains" do
       before do


### PR DESCRIPTION
The newly added attributes 
* source
* top_level_namespace
are for domains only, they should get filtered out when creating out the namespace yaml files.

Without this change in place during export/import of ManageIQ domains we will see lot of noise around these attributes being missing in the YAML files when creating a PR