### PR TITLE
Fix MW Operation params cleaning on operation

### DIFF
--- a/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
+++ b/app/assets/javascripts/controllers/middleware_server/middleware_server_controller.js
@@ -32,7 +32,7 @@ function MwServerController($scope, miqService) {
         operation = event.operation,
         timeout = event.timeout;
 
-    $scope.paramsModel = {};
+    $scope.paramsModel = $scope.paramsModel || {};
     if (eventType == 'mwServerOps'  && operation) {
       $scope.paramsModel.serverId = angular.element('#mw_param_server_id').val();
       $scope.paramsModel.operation = operation;


### PR DESCRIPTION
This fixes a bug which was causing errors in the operation parameters
dialog (required fields message and empty submit button text) after
submitting an operation.

@miq-bot add_label providers/hawkular, ui, bug

cc @theute @pilhuhn 