### PR TITLE
Convert back to `#` based headers to underline style

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,13 @@ Guidelines:
 * Provide as much context/info in the description as necessary to get the reviewer up to the same domain knowledge level as yourself
 * Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
 
-## Links [Optional]
+Links [Optional]
+----------------
 
 * http://documentation.for/library/that/I/am/adding
 * [PR relevant issue or pull_request](#123)
 
-## Steps for Testing/QA [Optional]
+Steps for Testing/QA [Optional]
+-------------------------------
 
 If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.


### PR DESCRIPTION
Purpose
-------
Tools like `hub` use the `#` as a comment character (similar to `git` commits) to supply useful information to the author of the pull request when generating the description with the PR template.  Headers would be treated as comments if that style is used when building a pull request description using `hub`.

This is obviously a point of contention, and people's opinion on this varies.  Tried to document in the commit message that we should consider a broader discussion if this comes up again.


Links [Optional]
----------------

* https://github.com/ManageIQ/manageiq/pull/9168
* https://github.com/ManageIQ/manageiq/pull/11159
* https://github.com/ManageIQ/manageiq/commit/570b592d
* https://github.com/ManageIQ/manageiq/commit/5d76ffd9
* https://github.com/github/hub/issues/1247 (known issue about the `#` as comments issue in `hub`)