### PR TITLE
Update the migration order spec for the new euwe branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ public/stylesheets/jmaki-3column-footer.css
 public/stylesheets/jmaki-standard-no-sidebars.css
 public/stylesheets/jmaki-standard-right-sidebar.css
 
+# spec/
+spec/replication/util/data/euwe_migrations
+
 # tmp/
 tmp/*
 

--- a/lib/tasks/test_replication.rake
+++ b/lib/tasks/test_replication.rake
@@ -52,13 +52,13 @@ class EvmTestSetupReplication
 
   def write_released_migrations
     file_contents = released_migrations.sort.join("\n")
-    File.write(Rails.root.join("spec/replication/util/data/darga_migrations"), file_contents)
+    File.write(Rails.root.join("spec/replication/util/data/euwe_migrations"), file_contents)
   end
 
   private
 
   def released_migrations
-    unless system("git fetch --depth=1 http://github.com/ManageIQ/manageiq.git refs/heads/darga:#{TEST_BRANCH}")
+    unless system("git fetch --depth=1 http://github.com/ManageIQ/manageiq.git refs/heads/euwe:#{TEST_BRANCH}")
       return []
     end
     files = `git ls-tree -r --name-only #{TEST_BRANCH} db/migrate/`

--- a/spec/replication/util/migration_order_spec.rb
+++ b/spec/replication/util/migration_order_spec.rb
@@ -1,6 +1,6 @@
 describe "migration order" do
   let(:current_release_migrations) do
-    File.read(File.join(__dir__, 'data/darga_migrations')).split.map(&:to_i).sort
+    File.read(File.join(__dir__, 'data/euwe_migrations')).split.map(&:to_i).sort
   end
 
   let(:migrations_now) do


### PR DESCRIPTION
This spec will now check for migrations which are dated earlier than the last one in the euwe branch to prevent us from running them out of order.

This includes adding the euwe_migrations file to the .gitignore because I forgot that we still print the file when I opened #10776

@Fryguy please review