### PR TITLE
Add list of applied chargeback rate names as field in chargeback reports

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1,7 +1,7 @@
 module ReportController::Reports::Editor
   extend ActiveSupport::Concern
 
-  CHARGEBACK_ALLOWED_FIELD_SUFFIXES = %w(_cost -owner_name _metric -provider_name -provider_uid -project_uid -archived).freeze
+  CHARGEBACK_ALLOWED_FIELD_SUFFIXES = %w(_cost -owner_name _metric -provider_name -provider_uid -project_uid -archived -chargeback_rates).freeze
 
   def miq_report_new
     assert_privileges("miq_report_new")

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -55,14 +55,16 @@ class Chargeback < ActsAsArModel
           if data[key].nil?
             start_ts, end_ts, display_range = get_time_range(perf, interval, tz)
             data[key] = {
-              "start_date"    => start_ts,
-              "end_date"      => end_ts,
-              "display_range" => display_range,
-              "interval_name" => interval,
+              "start_date"       => start_ts,
+              "end_date"         => end_ts,
+              "display_range"    => display_range,
+              "interval_name"    => interval,
+              "chargeback_rates" => ''
             }.merge(extra_fields)
           end
 
           rates_to_apply = cb.get_rates(perf)
+          data[key]["chargeback_rates"] = (data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)).uniq.join(', ')
           calculate_costs(perf, data[key], rates_to_apply)
         end
       end

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -4,6 +4,7 @@ class ChargebackContainerProject < Chargeback
     :end_date              => :datetime,
     :interval_name         => :string,
     :display_range         => :string,
+    :chargeback_rates      => :string,
     :project_name          => :string,
     :tag_name              => :string,
     :project_uid           => :string,

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -4,6 +4,7 @@ class ChargebackVm < Chargeback
     :end_date                 => :datetime,
     :interval_name            => :string,
     :display_range            => :string,
+    :chargeback_rates         => :string,
     :vm_name                  => :string,
     :tag_name                 => :string,
     :vm_uid                   => :string,


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1369442
Add applied chargeback rate names to chargeback report
![screencapture-localhost-3000-report-explorer-1474912813629](https://cloud.githubusercontent.com/assets/11256940/18846001/b2f1ac48-842c-11e6-86a4-63c9e7e1381b.png)

@gtanzillo @enoodle Please review
cc @simon3z 