### PR TITLE
fix a typo in remove_from_provider

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/remove_from_provider.rb
@@ -13,6 +13,6 @@ if stack
     $evm.set_state_var('stack_exists_in_provider', true)
   else
     $evm.log('info', "Stack <#{stack.name}> no longer exists in provider:<#{ems.try(:name)}>")
-    $evm.set_state_var('stack_existes_in_provider', false)
+    $evm.set_state_var('stack_exists_in_provider', false)
   end
 end


### PR DESCRIPTION
Obvious a typo

## Steps for Testing/QA [Optional]
This code is rarely hit. It might occur when attempting to retire an orchestration stack created through manageiq service but the stack had been deleted on the provider by other means. The bug is very benign. When it exists the only impact is it will try to wait on the stack to be deleted from the provider. In reality it does not need to wait, so the retirement will continue.

There is no obvious different before and after the fix.

https://bugzilla.redhat.com/show_bug.cgi?id=1378512