### PR TITLE
Add helper methods for generic object.

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -8,8 +8,8 @@ class GenericObject < ApplicationRecord
   delegate :property_attribute_defined?,
            :property_defined?,
            :type_cast,
-           :defined_property_associations, :property_association_defined?,
-           :defined_property_methods, :property_method_defined?,
+           :property_associations, :property_association_defined?,
+           :property_methods, :property_method_defined?,
            :to => :generic_object_definition, :allow_nil => true
 
   def initialize(attributes = {})
@@ -41,8 +41,8 @@ class GenericObject < ApplicationRecord
     end
 
     attributes_as_string += ["attributes: #{property_attributes}"]
-    attributes_as_string += ["associations: #{defined_property_associations.keys}"]
-    attributes_as_string += ["methods: #{defined_property_methods}"]
+    attributes_as_string += ["associations: #{property_associations.keys}"]
+    attributes_as_string += ["methods: #{property_methods}"]
 
     prefix = Kernel.instance_method(:inspect).bind(self).call.split(' ', 2).first
     "#{prefix} #{attributes_as_string.join(", ")}>"
@@ -89,7 +89,7 @@ class GenericObject < ApplicationRecord
         type_cast(name, value)
       elsif property_association_defined?(name)
         # property association is of multiple values
-        value.select { |v| v.kind_of?(defined_property_associations[name].constantize) }.uniq.map(&:id)
+        value.select { |v| v.kind_of?(property_associations[name].constantize) }.uniq.map(&:id)
       end
 
     self.properties = properties.merge(name => val)

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -18,7 +18,8 @@ class GenericObjectDefinition < ApplicationRecord
   validates :name, :presence => true, :uniqueness => true
   validate  :validate_property_attributes,
             :validate_property_associations,
-            :validate_property_name_unique
+            :validate_property_name_unique,
+            :validate_supported_property_features
 
   before_validation :set_default_properties
   before_validation :normalize_property_attributes,
@@ -109,6 +110,12 @@ class GenericObjectDefinition < ApplicationRecord
     all = properties[:attributes].keys + properties[:associations].keys + properties[:methods]
     common = all.group_by(&:to_s).select { |_k, v| v.size > 1 }.collect(&:first)
     errors[:properties] << "property name has to be unique: [#{common.join(",")}]" unless common.blank?
+  end
+
+  def validate_supported_property_features
+    if properties.keys.any? { |f| !f.to_s.singularize.in?(FEATURES) }
+      errors[:properties] << "only these features are supported: [#{FEATURES.join(", ")}]"
+    end
   end
 
   def check_not_in_use

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -63,6 +63,44 @@ class GenericObjectDefinition < ApplicationRecord
     super
   end
 
+  def add_property_attribute(name, type)
+    properties[:attributes][name.to_s] = type.to_sym
+    save
+  end
+
+  def delete_property_attribute(name)
+    transaction do
+      properties[:attributes].delete(name.to_s)
+      save!
+
+      generic_objects.find_each { |o| o.delete_property(name) }
+    end
+  end
+
+  def add_property_association(name, type)
+    properties[:associations][name.to_s] = type.to_s.classify
+    save
+  end
+
+  def delete_property_association(name)
+    transaction do
+      properties[:associations].delete(name.to_s)
+      save!
+
+      generic_objects.find_each { |o| o.delete_property(name) }
+    end
+  end
+
+  def add_property_method(name)
+    properties[:methods] << name.to_s unless properties[:methods].include?(name.to_s)
+    save
+  end
+
+  def delete_property_method(name)
+    properties[:methods].delete(name.to_s)
+    save
+  end
+
   private
 
   def get_objects_of_association(attr, values)

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -32,14 +32,15 @@ class GenericObjectDefinition < ApplicationRecord
   end
 
   FEATURES.each do |feature|
-    define_method("defined_property_#{feature}s") do
+    define_method("property_#{feature}s") do
       return errors[:properties] if properties_changed? && !valid?
       properties["#{feature}s".to_sym]
     end
 
     define_method("property_#{feature}_defined?") do |attr|
-      return defined_property_methods.include?(attr.to_s) if feature == 'method'
-      send("defined_property_#{feature}s").try(:key?, attr.to_s)
+      attr = attr.to_s
+      return property_methods.include?(attr) if feature == 'method'
+      send("property_#{feature}s").key?(attr)
     end
   end
 
@@ -53,7 +54,7 @@ class GenericObjectDefinition < ApplicationRecord
   end
 
   def type_cast(attr, value)
-    TYPE_MAP.fetch(defined_property_attributes[attr]).cast(value)
+    TYPE_MAP.fetch(property_attributes[attr]).cast(value)
   end
 
   def properties=(props)
@@ -64,7 +65,7 @@ class GenericObjectDefinition < ApplicationRecord
   private
 
   def get_associations(attr, values)
-    defined_property_associations[attr].constantize.where(:id => values).to_a
+    property_associations[attr].constantize.where(:id => values).to_a
   end
 
   def normalize_property_attributes

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -51,7 +51,7 @@ class GenericObjectDefinition < ApplicationRecord
 
   def property_getter(attr, val)
     return type_cast(attr, val) if property_attribute_defined?(attr)
-    return get_associations(attr, val) if property_association_defined?(attr)
+    return get_objects_of_association(attr, val) if property_association_defined?(attr)
   end
 
   def type_cast(attr, value)
@@ -65,7 +65,7 @@ class GenericObjectDefinition < ApplicationRecord
 
   private
 
-  def get_associations(attr, values)
+  def get_objects_of_association(attr, values)
     property_associations[attr].constantize.where(:id => values).to_a
   end
 

--- a/spec/models/generic_object_spec.rb
+++ b/spec/models/generic_object_spec.rb
@@ -149,7 +149,7 @@ describe GenericObject do
       expect(go_assoc.reload.vms.count).to eq(2)
     end
 
-    it 'skips non-exist object when retrieving from DB' do
+    it 'skips non-existing object when retrieving from DB' do
       vm2.destroy
       expect(go_assoc.vms.count).to eq(1)
     end


### PR DESCRIPTION
Add methods to make it easier to add/delete the generic object's attributes, associations and methods.

cc @gmcculloug @bzwei 