### PR TITLE
fix vmware provision bug

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -80,8 +80,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
     _log.info("Destination VM Name:        [#{clone_options[:name]}]")
     _log.info("Destination Host:           [#{clone_options[:host].name} (#{clone_options[:host].ems_ref})]")
     _log.info("Destination Datastore:      [#{clone_options[:datastore].name} (#{clone_options[:datastore].ems_ref})]")
-    _log.info("Destination Folder:         [#{clone_options[:folder].name}] (#{clone_options[:folder].ems_ref})")
-    _log.info("Destination Resource Pool:  [#{clone_options[:pool].name} (#{clone_options[:pool].ems_ref})]")
+    _log.info("Destination Folder:         [#{clone_options[:folder].name}] (#{clone_options[:folder].ems_ref})") if clone_options[:folder]
+    _log.info("Destination Resource Pool:  [#{clone_options[:pool].name} (#{clone_options[:pool].ems_ref})]") if clone_options[:pool]
     _log.info("Power on after cloning:     [#{clone_options[:power_on].inspect}]")
     _log.info("Create Linked Clone:        [#{clone_options[:linked_clone].inspect}]")
     _log.info("Selected Source Snapshot:   [#{clone_options[:snapshot].name} (#{clone_options[:snapshot].ems_ref})]") if clone_options[:linked_clone]


### PR DESCRIPTION
This pull request fix a small bug in the vmware provisioning process. During the process, the folder and the pool is not requisite. So this cause a NoMethodError during the virtual machine provisioning from provider vmware vcenter if I do not fill in the folder and pool attributes in the provision dialog.
This fix just add a condition that the clone_options[:folder].name and clone_options[:pool].name would be access only if they exist in file app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb.

