### PR TITLE
Fix the flash msg of suspending a role

### DIFF
--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -700,7 +700,7 @@ module OpsController::Diagnostics
       rescue StandardError => bang
         add_flash(bang, :error)
       else
-        add_flash(_("Suspend successfully initiated"), :error)
+        add_flash(_("Suspend successfully initiated"))
       end
     end
     refresh_screen


### PR DESCRIPTION
Configuration > Diagnostics > Zone > Roles by Servers
When I suspend a role, the flash msg type is "error", but the text is "sucessfully".
![image](https://cloud.githubusercontent.com/assets/21187701/18862867/1e8a1da2-84c1-11e6-852f-7d269ae0b33e.png)

So I fix the little bug.
![image](https://cloud.githubusercontent.com/assets/21187701/18862915/54cd687e-84c1-11e6-82d1-4f99dd7f60f7.png)
