### PR TITLE
[WIP] Fix for strange toolbar behavior when flash message appears in the URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1044,10 +1044,28 @@ module ApplicationHelper
   end
 
   def javascript_redirect(args)
+    args = encode_query_string(args)
     render :update do |page|
       page << javascript_prologue
       page.redirect_to args
     end
+  end
+
+  def encode_query_string(args)
+    if args.kind_of?(String) && args.include?("?")
+      uri = URI(args)
+      query_string = Rack::Utils.parse_nested_query(uri.query)
+      query_string.each { |k, v| query_string[k] = URI.encode(v) }
+      args = "#{uri.path}?#{query_string.to_query}"
+    elsif args.kind_of?(Hash) && args[:flash_msg]
+      encode_flash(args)
+    end
+    args
+  end
+
+  def encode_flash(args)
+    args[:flash_msg] = URI.encode(args[:flash_msg])
+    args
   end
 
   def javascript_flash(**args)

--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -9,6 +9,7 @@
   - if @flash_array
     %div{:id      => "flash_text_div#{div_num}"}
       - @flash_array.each do |fl|
+        - fl[:message] = URI.decode(fl[:message])
         - case fl[:level]
         - when :error
           .alert.alert-danger.alert-dismissable


### PR DESCRIPTION
After conversion of the toolbars to angular, a strange behavior/bug has been introduced where the toolbar does not react to the first user click if the URL in the browser address bar contains a flash message with +'s. What happens instead is, the first user click “auto-corrects” the browser url by encoding the + signs in the url after which the toolbar becomes functional.

Example of a flash message(with +'s )which will make the issue visible -
`"Edit+of+Cloud+Provider+"Amazon"+was+cancelled+by+the+user"`

Although this bug is not exactly a show-stopper, it hampers the user experience to some extent and hence should not be overlooked.

Things to note for this PR:
- The current fix in the PR is to encode the query parameters in the URL
- Chances are that a fix on the JS side might be needed and most likely in the new Toolbar UI component itself (https://github.com/ManageIQ/ui-components), but hard to say at this point. 
The current fix, however, could be considered an interim fix until we know more

Fixes #11394
