### PR TITLE
Remove dependency on ApplicationRecord in migration 

### DIFF
--- a/db/migrate/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets.rb
+++ b/db/migrate/20160308165211_move_network_port_cloud_subnet_id_to_network_ports_cloud_subnets.rb
@@ -1,5 +1,7 @@
 class MoveNetworkPortCloudSubnetIdToNetworkPortsCloudSubnets < ActiveRecord::Migration[5.0]
-  class NetworkPort < ApplicationRecord
+  class NetworkPort < ActiveRecord::Base
+    include ArRegion
+
     self.inheritance_column = :_type_disabled
   end
 


### PR DESCRIPTION
to keep migrations as much as possible independent on app code

cc @jrafanie @Fryguy 