### PR TITLE
Update tools/purge_archived_vms.rb to Rails 5 querying

### DIFF
--- a/tools/purge_archived_vms.rb
+++ b/tools/purge_archived_vms.rb
@@ -16,7 +16,11 @@ else
   $log.warn "Will delete any matching records." unless REPORT_ONLY
 end
 
-Vm.find_in_batches(:conditions => ["vms.updated_on IS NULL OR vms.updated_on < ?", ARCHIVE_CUTOFF], :include => [:ext_management_system, :storage]) do |vms|
+query = Vm.where(:updated_on => nil)
+          .or(Vm.where("updated_on < ?", ARCHIVE_CUTOFF))
+          .includes(:ext_management_system, :storage)
+
+query.find_in_batches do |vms|
   vms.each do |vm|
     begin
       if vm.archived?


### PR DESCRIPTION
The tool was using the old hash based querying which no longer works in Rails 5, so this PR updates it.

cc @carnott-redhat 