### PR TITLE
Add .missing for Azure EmsEvent.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/_missing.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/Azure.class/_missing.yaml
@@ -1,0 +1,10 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: ".missing"
+    inherits: 
+    description: 
+  fields: []


### PR DESCRIPTION
Add .missing instance under System/Event/EmsEvent/AZURE.

.missing is missing in System/Event/EmsEvent/AZURE, causing the following error when events are received with no corresponding handler:
```
ERROR -- : Class [System/Event/EmsEvent/AZURE] not found in MiqAeDatastore
```

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1379435