### PR TITLE
/api/automate to combine restful and ae_browser like routes

### DIFF
--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -1,10 +1,14 @@
 module Api
   class AutomateController < BaseController
     def show
-      resources = collection_search
-      attributes = params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
-      resources = resources.collect { |resource| resource.slice(*attributes) } if attributes.present?
-      render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
+      if browser_requested?
+        resources = collection_search
+        attributes = params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
+        resources = resources.collect { |resource| resource.slice(*attributes) } if attributes.present?
+        render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
+      else
+        super
+      end
     end
 
     def git_refresh_resource(type, id = nil, data = nil)
@@ -23,6 +27,10 @@ module Api
     end
 
     private
+
+    def browser_requested?
+      @req.c_suffix !~ /^#{CID_OR_ID_MATCHER}$/
+    end
 
     def collection_search
       ae_browser = MiqAeBrowser.new(@auth_user_obj)

--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -1,12 +1,7 @@
 module Api
   class AutomateController < BaseController
     def show
-      ae_browser = MiqAeBrowser.new(@auth_user_obj)
-      begin
-        resources = ae_browser.search(@req.c_suffix, ae_search_options)
-      rescue => err
-        raise BadRequestError, err.to_s
-      end
+      resources = collection_search
       attributes = params['attributes'] ? %w(fqname) | params['attributes'].to_s.split(',') : nil
       resources = resources.collect { |resource| resource.slice(*attributes) } if attributes.present?
       render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
@@ -28,6 +23,15 @@ module Api
     end
 
     private
+
+    def collection_search
+      ae_browser = MiqAeBrowser.new(@auth_user_obj)
+      begin
+        ae_browser.search(@req.c_suffix, ae_search_options)
+      rescue => err
+        raise BadRequestError, err.to_s
+      end
+    end
 
     def ae_search_options
       # For /api/automate (discovering domains, scope is 1 if unspecified)

--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -32,6 +32,16 @@ module Api
       @req.c_suffix !~ /^#{CID_OR_ID_MATCHER}$/
     end
 
+    def resource_search(id, type, klass)
+      if browser_requested?
+        domains = collection_search
+        raise "Ambiguous #{@req.c_suffix} domain specification, please use id" if domains.count != 1
+        super(domains.first["id"], type, klass)
+      else
+        super
+      end
+    end
+
     def collection_search
       ae_browser = MiqAeBrowser.new(@auth_user_obj)
       begin

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -144,6 +144,16 @@ describe "Automate API" do
                                     :href    => automate_url(git_domain.id)
                                    )
       end
+      it 'refreshes domain from git_repository specified by name' do
+        api_basic_authorize action_identifier(:automate, :git_refresh)
+
+        expect_any_instance_of(GitBasedDomainImportService).to receive(:import)
+        run_post(automate_url(git_domain.name), gen_request(:git_refresh))
+        expect_single_action_result(:success => true,
+                                    :message => 'Domain refreshed from git repository',
+                                    :href    => automate_url(git_domain.name)
+                                   )
+      end
     end
   end
 end

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -2,7 +2,21 @@
 # REST API Request Tests - /api/automate
 #
 describe "Automate API" do
-  context "Automate Queries" do
+  context 'Crud-like queries' do
+    let(:domain) { FactoryGirl.create(:miq_ae_domain) }
+
+    it 'reads single resource' do
+      api_basic_authorize action_identifier(:automate, :read, :resource_actions, :get)
+
+      run_get automate_url(domain.id)
+
+      expect_single_resource_query('href' => automate_url(domain.id),
+                                   'id'   => domain.id,
+                                   'name' => domain.name)
+    end
+  end
+
+  context 'Browser-like queries' do
     before(:each) do
       MiqAeDatastore.reset
       FactoryGirl.create(:miq_ae_domain, :name => "ManageIQ", :tenant_id => @group.tenant.id)


### PR DESCRIPTION
The `/api/automate` is special as it allows to browse automate objects by `ae_browser`. On the other hand we want to allow CRUD-like restful actions for sake of consistency with other endpoints.

This pr brings
 * `GET /api/automate/:id`
 * `POST /api/automate/:browser_like_string` for `{ "action" : "git_refresh" }`

@miq-bot add_label api, euwe/yes
@miq-bot assign @abellotti 
