### PR TITLE
Remove system attribute from namespace yaml files in ManageIQ domain

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Operations/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Operations
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Reconfiguration/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Reconfiguration/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Reconfiguration/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Reconfiguration
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Retirement
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Orchestration
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Operations/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Operations/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Operations
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Retirement
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: VM
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Cloud
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Operations
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Service
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: AnsibleTower
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: ConfigurationManagement
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Control/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Control/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Control
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Deployment/ContainerProvider/System/StateMachine/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Deployment/ContainerProvider/System/StateMachine/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachine
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Deployment/ContainerProvider/System/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Deployment/ContainerProvider/System/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: System
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Deployment/ContainerProvider/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Deployment/ContainerProvider/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: ContainerProvider
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Deployment/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Deployment/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Deployment
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Cluster/Operations/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Cluster/Operations/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Operations
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Cluster/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Cluster/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Cluster
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Configured_System/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Configured_System
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Operations/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Operations/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Operations
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/Host/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Host
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Migrate/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Migrate/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Migrate/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Migrate/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Migrate
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Operations/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Operations/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Operations
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Reconfigure/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Reconfigure/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Reconfigure
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Retirement
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: VM
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Infrastructure
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Provisioning
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: StateMachines
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Retirement
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/Service/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Service
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: CommonMethods
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/CustomEvent/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/CustomEvent/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: CustomEvent
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: EmsEvent
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/MiqEvent/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/MiqEvent/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: MiqEvent
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/RequestEvent/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/RequestEvent/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: RequestEvent
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: Event
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/System/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/__namespace__.yaml
@@ -6,6 +6,5 @@ object:
     name: System
     description: 
     display_name: 
-    system: 
     priority: 
     enabled: 

--- a/db/fixtures/ae_datastore/ManageIQ/__domain__.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/__domain__.yaml
@@ -6,6 +6,8 @@ object:
     name: ManageIQ
     description: Base domain
     display_name: 
-    system: true
     priority: 0
     enabled: true
+    tenant_id: 1
+    source: system
+    top_level_namespace: 


### PR DESCRIPTION
We have removed the system attribute from the
miq_ae_namespace table. Remove references to system
from all the namespace yaml file in ManageIQ domain

Links
----------------

* https://github.com/ManageIQ/manageiq/pull/10213
