### PR TITLE
Remove raise_in_transactional_callbacks option

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,9 +43,6 @@ Vmdb::Application.configure do
   # on accessibility issues.
   config.assets.precompile << 'tota11y.js'
 
-  # Raise exceptions in transactional callbacks
-  config.active_record.raise_in_transactional_callbacks = true
-
   # Customize any additional options below...
 
   # Do not include all helpers for all views

--- a/config/environments/i18n.rb
+++ b/config/environments/i18n.rb
@@ -41,9 +41,6 @@ Vmdb::Application.configure do
   # on accessibility issues.
   config.assets.precompile << 'tota11y.js'
 
-  # Raise exceptions in transactional callbacks
-  config.active_record.raise_in_transactional_callbacks = true
-
   # Customize any additional options below...
 
   # Do not include all helpers for all views

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,9 +67,6 @@ Vmdb::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
-  # Raise exceptions in transactional callbacks
-  config.active_record.raise_in_transactional_callbacks = true
-
   # Customize any additional options below...
 
   # Do not include all helpers for all views

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,9 +46,6 @@ Vmdb::Application.configure do
   config.middleware.delete ::ActionDispatch::ShowExceptions
   config.middleware.delete ::ActionDispatch::DebugExceptions
 
-  # Raise exceptions in transactional callbacks
-  config.active_record.raise_in_transactional_callbacks = true
-
   # Customize any additional options below...
 
   # Do not include all helpers for all views


### PR DESCRIPTION
This option is deprecated in Rails 5. Now all callbacks just bubble up
anyway.

https://github.com/rails/rails/commit/07d3d402341e81ada0214f2cb2be1da69eadfe72

Another part of #8996 