### PR TITLE
Retrieve productization info via /api

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,13 +2,14 @@ module Api
   class ApiController < Api::BaseController
     def index
       res = {
-        :name        => Settings.base.name,
-        :description => Settings.base.description,
-        :version     => Settings.base.version,
-        :versions    => entrypoint_versions,
-        :settings    => user_settings,
-        :identity    => auth_identity,
-        :server_info => server_info,
+        :name         => Settings.base.name,
+        :description  => Settings.base.description,
+        :version      => Settings.base.version,
+        :versions     => entrypoint_versions,
+        :settings     => user_settings,
+        :identity     => auth_identity,
+        :server_info  => server_info,
+        :product_info => product_info
       }
       res[:authorization] = auth_authorization if attribute_selection.include?("authorization")
       res[:collections]   = entrypoint_collections
@@ -41,6 +42,16 @@ module Api
         :version   => vmdb_build_info(:version),
         :build     => vmdb_build_info(:build),
         :appliance => appliance_name,
+      }
+    end
+
+    def product_info
+      {
+        :name                 => I18n.t("product.name"),
+        :name_full            => I18n.t("product.name_full"),
+        :copyright            => I18n.t("product.copyright"),
+        :support_website      => I18n.t("product.support_website"),
+        :support_website_text => I18n.t("product.support_website_text"),
       }
     end
   end

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -50,4 +50,20 @@ RSpec.describe "API entrypoint" do
       )
     )
   end
+
+  it "returns product_info" do
+    api_basic_authorize
+
+    run_get entrypoint_url
+
+    expect(response.parsed_body).to include(
+      "product_info" => a_hash_including(
+        "name"                 => I18n.t("product.name"),
+        "name_full"            => I18n.t("product.name_full"),
+        "copyright"            => I18n.t("product.copyright"),
+        "support_website"      => I18n.t("product.support_website"),
+        "support_website_text" => I18n.t("product.support_website_text"),
+      )
+    )
+  end
 end


### PR DESCRIPTION
The newly added About modal/dropdown in SUI displays incorrect company website and copyright info for downstream as shown in the screenshots --

<img width="1424" alt="screen shot 2016-09-27 at 3 55 18 pm" src="https://cloud.githubusercontent.com/assets/1538216/18895133/0f0a04b8-84cc-11e6-90ce-108f02996987.png">

<img width="1420" alt="screen shot 2016-09-27 at 3 53 27 pm" src="https://cloud.githubusercontent.com/assets/1538216/18894980/08476496-84cb-11e6-92b8-3defefc45990.png">

We need the API `/api` to provide us with productization info that can be used by SUI to show correct info for downstream.
