### PR TITLE
[UI] Cloud report task status 

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -10,8 +10,9 @@ class MiqReportResult < ApplicationRecord
 
   serialize :report
 
-  virtual_column :miq_group_description, :type => :string, :uses => :miq_group
-  virtual_column :status,                :type => :string, :uses => :miq_task
+  virtual_delegate :description, :to => :miq_group, :prefix => true, :allow_nil => true
+  virtual_delegate :state_or_status, :to => "miq_task", :allow_nil => true
+  virtual_attribute :status, :string, :uses => :state_or_status
   virtual_column :status_message,        :type => :string, :uses => :miq_task
 
   virtual_has_one :result_set,           :class_name => "Hash"
@@ -31,15 +32,11 @@ class MiqReportResult < ApplicationRecord
   end
 
   def status
-    miq_task.nil? ? "Unknown" : miq_task.human_status
+    MiqTask.human_status(state_or_status)
   end
 
   def status_message
     miq_task.nil? ? _("Report results are no longer available") : miq_task.message
-  end
-
-  def miq_group_description
-    miq_group.try(:description)
   end
 
   def report_results

--- a/app/presenters/tree_builder_report_saved_reports.rb
+++ b/app/presenters/tree_builder_report_saved_reports.rb
@@ -34,6 +34,6 @@ class TreeBuilderReportSavedReports < TreeBuilderReportReportsClass
 
   def x_get_tree_custom_kids(object, count_only, _options)
     scope = MiqReportResult.with_current_user_groups_and_report(from_cid(object[:id].split('-').last))
-    count_only ? scope.size : scope.order("last_run_on DESC").to_a
+    count_only ? scope.size : scope.order("last_run_on DESC").includes(:miq_task).to_a
   end
 end


### PR DESCRIPTION
summary
---------

`/report/explorer` has (a few) n+1 queries while loading the tree.

1. remove an N+1 query. (just one, there are others)
2. simplify node builder to be more similar to the other node builder calls in the same method.

The numbers are the same both before and after this PR. The session is empty and the tree is not expanded.

When a node is expanded, this PR kicks in:

|     ms |queries | query (ms) |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  18,908.9 |10,129 |  2,847.1 |   20,435 |`/report/explorer` **before**
|  5,689.9 |  130 |   384.3 |   20,435 |`/report/explorer` **after**
| 70% | 99% | 87% | |

Expanding the tree also triggers a partial tree refresh:

|     ms |queries | query (ms) |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  15,665.3 |10,005 |  1,436.5 |   20,004 |`/report/tree_autoload` **before**
|  4,636.8 |    6 |   317.4 |   20,004 |`/report/tree_autoload` **after**
| 70% | 99% | 78% | |

Alternative to https://github.com/ManageIQ/manageiq/pull/9728

before
---------

but clicking on a node, dynamically refreshing the tree slows it all down. (rendering time adds 25 seconds to this)

|     ms |queries | query (ms) |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  15,665.3 |10,005 |  1,436.5 |   20,004 |`/report/tree_autoload#master`
|     190.1 |    1 |     86.5 |   10,000 |`..SELECT "miq_report_results".* `
|   1,243.2 |10,000 |  1,102.0 |   10,000 |`..SELECT  "miq_tasks".* `

full page refresh displays:

|     ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  18,908.9 |10,129 |  2,847.1 |   20,435 |`/report/explorer#master`

after
-----

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  4,636.8 |    6 |   317.4 |   20,004 |`/report/tree_autoload#pr`
|  4,629.1 |    6 |   317.4 |   20,004 |`.Executing action: tree_autoload`
|    166.0 |    1 |    61.3 |   10,000 |`..SELECT "miq_report_results".* `
|    149.8 |    1 |    51.0 |   10,000 |`..SELECT "miq_tasks".* `

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  5,689.9 |  130 |   384.3 |   20,435 |`/report/explorer#pr`

