### PR TITLE
Rename: API for AE git_refresh to refresh_from_source

### DIFF
--- a/app/controllers/api/automate_controller.rb
+++ b/app/controllers/api/automate_controller.rb
@@ -12,7 +12,7 @@ module Api
       render_resource :automate, :name => "automate", :subcount => resources.count, :resources => resources
     end
 
-    def git_refresh_resource(type, id = nil, data = nil)
+    def refresh_from_source_resource(type, id = nil, data = nil)
       api_action(type, id) do |klass|
         unless GitBasedDomainImportService.available?
           return action_result(false, 'Please enable the git owner role in order to import git repositories')

--- a/config/api.yml
+++ b/config/api.yml
@@ -63,7 +63,7 @@
       - :name: read
         :identifier: miq_ae_domain_view
       :post:
-      - :name: git_refresh
+      - :name: refresh_from_source
         :identifier: miq_ae_git_refresh
   :automation_requests:
     :description: Automation Requests

--- a/spec/requests/api/automate_spec.rb
+++ b/spec/requests/api/automate_spec.rb
@@ -86,21 +86,21 @@ describe "Automate API" do
     end
   end
 
-  describe 'git_refresh action' do
+  describe 'refresh_from_source action' do
     let(:git_domain) { FactoryGirl.create(:miq_ae_git_domain) }
     it 'forbids access for users without proper permissions' do
       api_basic_authorize
 
-      run_post(automate_url(git_domain.id), gen_request(:git_refresh))
+      run_post(automate_url(git_domain.id), gen_request(:refresh_from_source))
 
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'fails to refresh git when the region misses git_owner role' do
-      api_basic_authorize action_identifier(:automate, :git_refresh)
+      api_basic_authorize action_identifier(:automate, :refresh_from_source)
       expect(GitBasedDomainImportService).to receive(:available?).and_return(false)
 
-      run_post(automate_url(git_domain.id), gen_request(:git_refresh))
+      run_post(automate_url(git_domain.id), gen_request(:refresh_from_source))
       expect_single_action_result(:success => false,
                                   :message => 'Please enable the git owner role in order to import git repositories')
     end
@@ -112,19 +112,19 @@ describe "Automate API" do
       end
 
       it 'fails to refresh when domain did not originate from git' do
-        api_basic_authorize action_identifier(:automate, :git_refresh)
+        api_basic_authorize action_identifier(:automate, :refresh_from_source)
 
-        run_post(automate_url(non_git_domain.id), gen_request(:git_refresh))
+        run_post(automate_url(non_git_domain.id), gen_request(:refresh_from_source))
         expect_single_action_result(:success => false,
                                     :message => "Domain [id=#{non_git_domain.id}] did not originate from git repository"
                                    )
       end
 
       it 'refreshes domain from git_repository' do
-        api_basic_authorize action_identifier(:automate, :git_refresh)
+        api_basic_authorize action_identifier(:automate, :refresh_from_source)
 
         expect_any_instance_of(GitBasedDomainImportService).to receive(:import)
-        run_post(automate_url(git_domain.id), gen_request(:git_refresh))
+        run_post(automate_url(git_domain.id), gen_request(:refresh_from_source))
         expect_single_action_result(:success => true,
                                     :message => 'Domain refreshed from git repository',
                                     :href    => automate_url(git_domain.id)


### PR DESCRIPTION
As per Jason's comment, *the fact that it's git under the covers should be obscured from the caller. A more appropriate name might be refresh or refresh_from_source. That way you can have any number of backings, and they all refresh the same.*

I pick refresh_from_source over simple refresh. As it brings less ambiguity about what it does. I hope, users will be able to guess this does git fetch under the hood.

@miq-bot add_label api, euwe/yes
@miq-bot assign @abellotti 