### PR TITLE
Service power operations API

### DIFF
--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -25,6 +25,57 @@ module Api
       end
     end
 
+    def start_resource(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        service = resource_search(id, type, klass)
+        api_log_info("Starting #{service_ident(service)}")
+
+        begin
+          description = "#{service_ident(service)} starting"
+          task_id = queue_object_action(service, description, :method_name => "start", :role => "ems_operations")
+          action_result(true, description, :task_id => task_id)
+        rescue => e
+          action_result(false, e.to_s)
+        end
+      end
+    end
+
+    def stop_resource(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        service = resource_search(id, type, klass)
+        api_log_info("Stopping #{service_ident(service)}")
+
+        begin
+          description = "#{service_ident(service)} stopping"
+          task_id = queue_object_action(service, description, :method_name => "stop", :role => "ems_operations")
+          action_result(true, description, :task_id => task_id)
+        rescue => e
+          action_result(false, e.to_s)
+        end
+      end
+    end
+
+    def suspend_resource(type, id = nil, _data = nil)
+      raise BadRequestError, "Must specify an id for starting a #{type} resource" unless id
+
+      api_action(type, id) do |klass|
+        service = resource_search(id, type, klass)
+        api_log_info("Suspending #{service_ident(service)}")
+
+        begin
+          description = "#{service_ident(service)} suspending"
+          task_id = queue_object_action(service, description, :method_name => "suspend", :role => "ems_operations")
+          action_result(true, description, :task_id => task_id)
+        rescue => e
+          action_result(false, e.to_s)
+        end
+      end
+    end
+
     private
 
     def build_service_attributes(data)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -179,10 +179,14 @@ class Service < ApplicationRecord
       :args        => [action, group_idx, direction]
     }
     nh[:deliver_on] = deliver_delay.seconds.from_now.utc if deliver_delay > 0
-    first_vm = vms.first
-    nh[:zone] = first_vm.ext_management_system.zone.name unless first_vm.nil?
+    nh[:zone] = my_zone if my_zone
     MiqQueue.put(nh)
     true
+  end
+
+  def my_zone
+    first_vm = vms.first
+    first_vm.ext_management_system.zone.name unless first_vm.nil?
   end
 
   def service_action(requested, service_resource)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1332,6 +1332,12 @@
         :identifier: service_ownership
       - :name: delete
         :identifier: service_delete
+      - :name: start
+        :identifier: service_admin
+      - :name: stop
+        :identifier: service_admin
+      - :name: suspend
+        :identifier: service_admin
     :resource_actions:
       :get:
       - :name: read
@@ -1347,6 +1353,12 @@
         :identifier: service_reconfigure
         :options:
         - :validate_action
+      - :name: start
+        :identifier: service_admin
+      - :name: stop
+        :identifier: service_admin
+      - :name: suspend
+        :identifier: service_admin
       :delete:
       - :name: delete
         :identifier: service_delete

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -354,4 +354,156 @@ describe "Services API" do
       expect_bad_request("Cannot expand subcollection vms by name and virtual attribute")
     end
   end
+
+  describe "Power Operations" do
+    describe "start" do
+      it "will start a service for a user with appropriate role" do
+        service = FactoryGirl.create(:service)
+        api_basic_authorize(action_identifier(:services, :start))
+
+        run_post(services_url(service.id), :action => "start")
+
+        expected = {
+          "href"    => a_string_matching(services_url(service.id)),
+          "success" => true,
+          "message" => a_string_matching("starting")
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "can start multiple services for a user with appropriate role" do
+        service_1, service_2 = FactoryGirl.create_list(:service, 2)
+        api_basic_authorize(collection_action_identifier(:services, :start))
+
+        run_post(services_url, :action => "start", :resources => [{:id => service_1.id}, {:id => service_2.id}])
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including("success"   => true,
+                             "message"   => a_string_matching("starting"),
+                             "task_id"   => anything,
+                             "task_href" => anything,
+                             "href"      => a_string_matching(services_url(service_1.id))),
+            a_hash_including("success"   => true,
+                             "message"   => a_string_matching("starting"),
+                             "task_id"   => anything,
+                             "task_href" => anything,
+                             "href"      => a_string_matching(services_url(service_2.id))),
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not start a service for a user without an appropriate role" do
+        service = FactoryGirl.create(:service)
+        api_basic_authorize
+
+        run_post(services_url(service.id), :action => "start")
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "stop" do
+      it "will stop a service for a user with appropriate role" do
+        service = FactoryGirl.create(:service)
+        api_basic_authorize(action_identifier(:services, :stop))
+
+        run_post(services_url(service.id), :action => "stop")
+
+        expected = {
+          "href"    => a_string_matching(services_url(service.id)),
+          "success" => true,
+          "message" => a_string_matching("stopping")
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "can stop multiple services for a user with appropriate role" do
+        service_1, service_2 = FactoryGirl.create_list(:service, 2)
+        api_basic_authorize(collection_action_identifier(:services, :stop))
+
+        run_post(services_url, :action => "stop", :resources => [{:id => service_1.id}, {:id => service_2.id}])
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including("success"   => true,
+                             "message"   => a_string_matching("stopping"),
+                             "task_id"   => anything,
+                             "task_href" => anything,
+                             "href"      => a_string_matching(services_url(service_1.id))),
+            a_hash_including("success"   => true,
+                             "message"   => a_string_matching("stopping"),
+                             "task_id"   => anything,
+                             "task_href" => anything,
+                             "href"      => a_string_matching(services_url(service_2.id))),
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not stop a service for a user without an appropriate role" do
+        service = FactoryGirl.create(:service)
+        api_basic_authorize
+
+        run_post(services_url(service.id), :action => "stop")
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "suspend" do
+      it "will suspend a service for a user with appropriate role" do
+        service = FactoryGirl.create(:service)
+        api_basic_authorize(action_identifier(:services, :suspend))
+
+        run_post(services_url(service.id), :action => "suspend")
+
+        expected = {
+          "href"    => a_string_matching(services_url(service.id)),
+          "success" => true,
+          "message" => a_string_matching("suspending")
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "can suspend multiple services for a user with appropriate role" do
+        service_1, service_2 = FactoryGirl.create_list(:service, 2)
+        api_basic_authorize(collection_action_identifier(:services, :suspend))
+
+        run_post(services_url, :action => "suspend", :resources => [{:id => service_1.id}, {:id => service_2.id}])
+
+        expected = {
+          "results" => a_collection_containing_exactly(
+            a_hash_including("success"   => true,
+                             "message"   => a_string_matching("suspending"),
+                             "task_id"   => anything,
+                             "task_href" => anything,
+                             "href"      => a_string_matching(services_url(service_1.id))),
+            a_hash_including("success"   => true,
+                             "message"   => a_string_matching("suspending"),
+                             "task_id"   => anything,
+                             "task_href" => anything,
+                             "href"      => a_string_matching(services_url(service_2.id))),
+          )
+        }
+        expect(response.parsed_body).to include(expected)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "will not suspend a service for a user without an appropriate role" do
+        service = FactoryGirl.create(:service)
+        api_basic_authorize
+
+        run_post(services_url(service.id), :action => "suspend")
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds support for start, stop and suspend for services.

Resolves https://www.pivotaltracker.com/story/show/128432915