### PR TITLE
Set the @active flag when initially rendering a snapshot tree

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -256,6 +256,7 @@ module VmCommon
       drop_breadcrumb(:name => @record.name + _(" (Snapshots)"),
                       :url  => "/#{rec_cls}/show/#{@record.id}?display=#{@display}")
       @snapshot_tree = TreeBuilderSnapshots.new(:snapshot_tree, :snapshot, @sb, true, :root => @record)
+      @active = !['root', nil].include?(@snapshot_tree.selected_node)
       @button_group = "snapshot"
     elsif @display == "devices"
       drop_breadcrumb(:name => @record.name + _(" (Devices)"),


### PR DESCRIPTION
Some toolbar buttons were not accessible on the snapshots page of a VM. This was because the toolbar builder was not informed properly about the node selection status in the snapshots tree. This PR passes this information using the `@active` instance variable.

https://bugzilla.redhat.com/show_bug.cgi?id=1378042