### PR TITLE
Summary Screen styling updates

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -239,6 +239,7 @@ table.table-hover tbody tr:nth-child(even).no-hover:hover td {
 .table-summary-screen .label {
   display: table-cell;
   width: 20% !important;
+  padding-top: 6px;
   min-width: 200px;
   font: normal 12px OpenSansSemibold,Arial,Helvetica,sans-serif;
   cursor: default;

--- a/app/views/vm_common/_config.html.haml
+++ b/app/views/vm_common/_config.html.haml
@@ -2,7 +2,7 @@
 - case @display
 - when "devices"
   - unless @devices.empty?
-    %table.table.table-bordered.table-striped
+    %table.table.table-bordered.table-striped.table-summary-screen
       %thead
         %tr
           %th{:colspan => "2"}= _('Devices')
@@ -16,7 +16,7 @@
               = h(item[:description])
 - when "os_info"
   - if @osinfo
-    %table.table.table-bordered.table-striped
+    %table.table.table-bordered.table-striped.table-summary-screen
       %thead
         %tr
           %th{:colspan => "2"}= _('Basic Information')
@@ -52,7 +52,7 @@
 
 - when "hv_info"
   - if @vmminfo
-    %table.table.table-bordered.table-striped
+    %table.table.table-bordered.table-striped.table-summary-screen
       %thead
         %tr
           %th{:colspan => "2"}= _('Basic Information')
@@ -65,7 +65,7 @@
               = h(item[:description])
 
     %hr
-    %table.table.table-bordered.table-striped
+    %table.table.table-bordered.table-striped.table-summary-screen
       %thead
         %tr
           %th{:colspan => "2"}= _('Devices')
@@ -93,7 +93,7 @@
 - when "networks"
   - if @vmminfo
     - @record.hardware.networks.each do |adapter|
-      %table.table.table-bordered.table-striped
+      %table.table.table-bordered.table-striped.table-summary-screen
         %thead
           %tr
             %th{:colspan => "2"}= _('Network Adapter')
@@ -112,7 +112,7 @@
               %td
                 = adapter.send(sym)
 - when "resources_info"
-  %table.table.table-bordered.table-striped
+  %table.table.table-bordered.table-striped.table-summary-screen
     %thead
       %tr
         %th{:colspan => "2"}= _('Account Policies')


### PR DESCRIPTION
* Add "table-summary-screen" class to additional screens
* Add top padding to summary screen labels

This bug was caused by the following PR: #11288

Issue #11388
https://bugzilla.redhat.com/show_bug.cgi?id=1342787
Depends on: #11288 and #11420