### PR TITLE
[WIP] Updated API container_deployments/container_deployment_data to be returned with OPTIONS

### DIFF
--- a/app/controllers/api/container_deployments_controller.rb
+++ b/app/controllers/api/container_deployments_controller.rb
@@ -1,16 +1,12 @@
 module Api
   class ContainerDeploymentsController < BaseController
-    def show
-      if @req.c_id == "container_deployment_data"
-        render_resource :container_deployments, :data => ContainerDeploymentService.new.all_data
-      else
-        super
-      end
-    end
-
     def create_resource(_type, _id, data)
       deployment = ContainerDeployment.new
       deployment.create_deployment(data, @auth_user_obj)
+    end
+
+    def options
+      render_options(:container_deployments, ContainerDeploymentService.new.all_data)
     end
   end
 end

--- a/spec/requests/api/container_deployments_spec.rb
+++ b/spec/requests/api/container_deployments_spec.rb
@@ -1,8 +1,8 @@
 describe "Container Deployments API" do
-  it "supports collect-data with GET" do
+  it "supports collect-data with OPTIONS" do
     allow_any_instance_of(ContainerDeploymentService).to receive(:cloud_init_template_id).and_return(1)
-    api_basic_authorize collection_action_identifier(:container_deployments, :read, :get)
-    run_get container_deployments_url + "/container_deployment_data"
+    api_basic_authorize
+    run_options container_deployments_url
     expect(response).to have_http_status(:ok)
     expect_hash_to_have_only_keys(response.parsed_body["data"], %w(deployment_types providers provision))
   end


### PR DESCRIPTION
- Leveraging the new OPTIONS support to return the container_deployment_data.
- Was obtained via a named resource id GET /api/container_deployments/container_deployment_data
- Now returned in the data section of an OPTIONS /api/container_deployments
- Updated rspec