### PR TITLE
Vm compliance history link fix

### DIFF
--- a/app/helpers/compliance_summary_helper.rb
+++ b/app/helpers/compliance_summary_helper.rb
@@ -19,7 +19,7 @@ module ComplianceSummaryHelper
                     {:time => time_ago_in_words(date.in_time_zone(Time.zone)).titleize}
                   end
       h[:title] = _("Show Details of Compliance Check on %{date}") % {:date => format_timezone(date)}
-      h[:explorer] = true
+      h[:explorer] = true if @explorer
       h[:link] = url_for(
         :controller => controller.controller_name,
         :action     => 'show',
@@ -39,6 +39,7 @@ module ComplianceSummaryHelper
       h[:value] = _("Available")
       h[:title] = _("Show Compliance History of this %{model} (Last 10 Checks)") %
                   {:model => ui_lookup(:model => controller.class.model.name)}
+      h[:explorer] = true if @explorer
       h[:link] = url_for(
         :controller => controller.controller_name,
         :action     => 'show',

--- a/spec/helpers/compliance_summary_helper_spec.rb
+++ b/spec/helpers/compliance_summary_helper_spec.rb
@@ -1,0 +1,64 @@
+describe ComplianceSummaryHelper do
+  before do
+    server  = FactoryGirl.build(:miq_server, :id => 0)
+    @record = FactoryGirl.build(:vm_vmware, :miq_server => server)
+    @compliance1 = FactoryGirl.build(:compliance)
+    @compliance2 = FactoryGirl.build(:compliance)
+    allow_any_instance_of(described_class).to receive(:role_allows?).and_return(true)
+  end
+
+  context "when @explorer is set" do
+    before do
+      allow(controller).to receive(:controller_name).and_return("vm_infra")
+      allow(controller.class).to receive(:model).and_return(VmOrTemplate)
+      @explorer = true
+    end
+
+    it "#textual_compliance_status" do
+      @record.compliances = [@compliance1]
+      date = @compliance1.timestamp
+      expect(helper.textual_compliance_status).to eq(:label    => "Status",
+                                                     :image    => "check",
+                                                     :value    => "Compliant as of #{time_ago_in_words(date.in_time_zone(Time.zone)).titleize} Ago",
+                                                     :title    => "Show Details of Compliance Check on #{format_timezone(date)}",
+                                                     :explorer => true,
+                                                     :link     => "/vm_infra/show?count=1&display=compliance_history")
+    end
+
+    it "#textual_compliance_history" do
+      @record.compliances = [@compliance1, @compliance2]
+      expect(helper.textual_compliance_history).to eq(:label    => "History",
+                                                      :image    => "compliance",
+                                                      :value    => "Available",
+                                                      :explorer => true,
+                                                      :title    => "Show Compliance History of this VM or Template (Last 10 Checks)",
+                                                      :link     => "/vm_infra/show?display=compliance_history")
+    end
+  end
+
+  context "for classic screens when @explorer is not set" do
+    before do
+      allow(controller).to receive(:controller_name).and_return("host")
+      allow(controller.class).to receive(:model).and_return(Host)
+    end
+
+    it "#textual_compliance_status" do
+      @record.compliances = [@compliance1]
+      date = @compliance1.timestamp
+      expect(helper.textual_compliance_status).to eq(:label => "Status",
+                                                     :image => "check",
+                                                     :value => "Compliant as of #{time_ago_in_words(date.in_time_zone(Time.zone)).titleize} Ago",
+                                                     :title => "Show Details of Compliance Check on #{format_timezone(date)}",
+                                                     :link  => "/host/show?count=1&display=compliance_history")
+    end
+
+    it "#textual_compliance_history" do
+      @record.compliances = [@compliance1, @compliance2]
+      expect(helper.textual_compliance_history).to eq(:label => "History",
+                                                      :image => "compliance",
+                                                      :value => "Available",
+                                                      :title => "Show Compliance History of this Host / Node (Last 10 Checks)",
+                                                      :link  => "/host/show?display=compliance_history")
+    end
+  end
+end


### PR DESCRIPTION
Fixed links to only add explorer key in returning hash for explorer style screens to get the links to be built correctly.

@dclarizio please review.

clicking on Compliance History link before:
![before](https://cloud.githubusercontent.com/assets/3450808/18921613/8304798c-8573-11e6-997b-7406ab4b7d2e.png)

clicking on Compliance History link after:
![after](https://cloud.githubusercontent.com/assets/3450808/18921607/7e48182c-8573-11e6-8041-73812e159d6b.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1375093