### PR TITLE
Removed validate_vm_control method and calls as it is already replaced by supports_control

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -71,28 +71,19 @@ module VmOrTemplate::Operations
   #
 
   def validate_vm_control_shelve_action
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    unless supports_control?
+      return {:available => false, :message => unsupported_reason(:control)}
+    end
     return {:available => true,   :message => nil}  if %w(on off suspended paused).include?(current_state)
     {:available => false,  :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused"}
   end
 
   def validate_vm_control_shelve_offload_action
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    unless supports_control?
+      return {:available => false, :message => unsupported_reason(:control)}
+    end
     return {:available => true,   :message => nil}  if %w(shelved).include?(current_state)
     {:available => false,  :message => "The VM can't be shelved offload, current state has to be shelved"}
-  end
-
-  def validate_vm_control
-    # Check the basic require to interact with a VM.
-    return [false, 'The VM is retired'] if self.retired?
-    return [false, 'The VM is a template'] if self.template?
-    return [false, 'The VM is terminated'] if self.terminated?
-    return [true,  'The VM is not connected to a Host'] unless self.has_required_host?
-    return [true,  'The VM does not have a valid connection state'] if !connection_state.nil? && !self.connected_to_ems?
-    return [true,  "The VM is not connected to an active #{ui_lookup(:table => "ext_management_systems")}"] unless self.has_active_ems?
-    nil
   end
 
   included do
@@ -129,8 +120,9 @@ module VmOrTemplate::Operations
   end
 
   def validate_vm_control_power_state(check_powered_on)
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    unless supports_control?
+      return {:available => false, :message => unsupported_reason(:control)}
+    end
     return {:available => true,   :message => nil}  if current_state.send(check_powered_on ? "==" : "!=", "on")
     {:available => false,  :message => "The VM is#{" not" if check_powered_on} powered on"}
   end

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -1,8 +1,9 @@
 module VmOrTemplate::Operations::Snapshot
   def validate_create_snapshot
     return {:available => false, :message => "Create Snapshot operation not supported for #{self.class.model_suffix} VM"} unless self.supports_snapshots?
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    unless supports_control?
+      return {:available => false, :message => unsupported_reason(:control)}
+    end
     msg = {:available => true, :message => nil}
     msg[:message] = 'At least one snapshot has to be active to create a new snapshot for this VM' if !snapshots.blank? && snapshots.first.get_current_snapshot.nil?
     msg
@@ -11,8 +12,9 @@ module VmOrTemplate::Operations::Snapshot
   def validate_remove_snapshot(task = 'Remove')
     return {:available => false, :message => "#{task} Snapshot operation not supported for #{self.class.model_suffix} VM"} unless self.supports_snapshots?
     return {:available => false, :message => "There are no snapshots available for this VM"} if snapshots.size <= 0
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
+    unless supports_control?
+      return {:available => false, :message => unsupported_reason(:control)}
+    end
     {:available => true, :message => nil}
   end
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1545,7 +1545,7 @@ describe ApplicationHelper do
           end
           context "when with snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'default case'
+            it_behaves_like 'record with error message', 'remove_snapshot'
           end
         end
 
@@ -1561,7 +1561,7 @@ describe ApplicationHelper do
           end
           context "when with snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'default case'
+            it_behaves_like 'record with error message', 'remove_all_snapshots'
           end
         end
 
@@ -1577,7 +1577,7 @@ describe ApplicationHelper do
           end
           context "when with snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'default case'
+            it_behaves_like 'record with error message', 'revert_to_snapshot'
           end
         end
       end
@@ -1627,7 +1627,7 @@ describe ApplicationHelper do
           end
           context "when with snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'default case'
+            it_behaves_like 'record with error message', 'remove_snapshot'
           end
         end
 


### PR DESCRIPTION
The method validate_vm_control was replaced by supports_control method long back, still few functions were calling the old method. Replaced all such methods to call the new method instead of old method and removed the old method to have consistency.
