### PR TITLE
Allow dynamic properties to be bind into notification by ui

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -40,15 +40,23 @@ class Notification < ApplicationRecord
   end
 
   def text_bindings
-    [:initiator, :subject, :cause].each_with_object({}) do |key, result|
+    [:initiator, :subject, :cause].each_with_object(text_bindings_dynamic) do |key, result|
       value = public_send(key)
       result[key] = {
         :link => {
           :id    => value.id,
           :model => value.class.name,
         },
-        :text => value.name
+        :text => value.try(:name) || value.try(:description)
       } if value
+    end
+  end
+
+  def text_bindings_dynamic
+    options.each_with_object({}) do |(key, value), result|
+      result[key] = {
+        :text => value
+      }
     end
   end
 end


### PR DESCRIPTION
The expectation is that at same point we will emit notification with supplementary information to the currect `[initiator, :subject, :cause]` trinity.

This is follow-up on #11410 and it finishes: https://www.pivotaltracker.com/n/projects/1608513/stories/130092529

/cc @skateman 
@miq-bot add_label core, enhancement, euwe/yes
@miq-bot assign @gtanzillo 