### PR TITLE
Specs for compressed ids support in API

### DIFF
--- a/spec/requests/api/notifications_spec.rb
+++ b/spec/requests/api/notifications_spec.rb
@@ -72,6 +72,21 @@ describe 'Notifications API' do
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { notification2_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      context 'compressed id' do
+        let(:notification_id) { ApplicationRecord.compress_id(notification_recipient.id) }
+        it 'deletes notifications specified by compressed id in href' do
+          api_basic_authorize
+          run_post(notifications_url, gen_request(:delete, :href => notifications_url(notification_id)))
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'deletes notifications specified by compressed id' do
+          api_basic_authorize
+          run_post(notifications_url, gen_request(:delete, :id => notification_id))
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
   end
 

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -63,6 +63,14 @@ describe "Queries API" do
       expect_single_resource_query("id" => vm1.id, "href" => vm1_url, "guid" => vm1.guid)
     end
 
+    it 'supports compressed ids' do
+      api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
+
+      run_get vms_url(ApplicationRecord.compress_id(vm1.id))
+
+      expect_single_resource_query("id" => vm1.id, "href" => vm1_url, "guid" => vm1.guid)
+    end
+
     it 'returns 404 on url with trailing garbage' do
       api_basic_authorize action_identifier(:vms, :read, :resource_actions, :get)
       vm1   # create resource
@@ -113,6 +121,14 @@ describe "Queries API" do
       expect_result_resources_to_include_keys("resources", %w(id href))
       expect_result_resources_to_include_hrefs("resources", :vm1_accounts_url_list)
       expect_result_resources_to_include_data("resources", "id" => [acct1.id, acct2.id])
+    end
+
+    it 'supports compressed ids' do
+      api_basic_authorize
+
+      run_get vms_url(ApplicationRecord.compress_id(vm1.id)) + "/accounts/#{acct1.id}"
+
+      expect_single_resource_query("id" => acct1.id, "href" => acct1_url, "name" => acct1.name)
     end
 
     it 'returns 404 on url with trailing garbage' do


### PR DESCRIPTION
This pr just brings missing specs for compressed IDs in the API.

Recently, we have introduced compressed ids on input. User can input compressed ID anywhere when talking to API.

@miq-bot add_label test, api, euwe/yes
@miq-bot assign @abellotti 

