### PR TITLE
Fixing misleading title for button edit dialog.

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -594,7 +594,6 @@ module ApplicationController::Buttons
     drop_breadcrumb(:name => title, :url => "/miq_ae_customization/button_new")
     @lastaction = "automate_button"
     @layout = "miq_ae_automate_button"
-    @custom_button = nil
     @sb[:buttons] = nil
     @sb[:button_groups] = nil
     replace_right_cell("button_edit")

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -109,11 +109,11 @@
               = obj[:name]
             %td
               = obj[:description]
-- elsif @custom_button
-  = render :partial => 'shared/buttons/ab_show'
 - elsif %w(ab_group_edit ab_group_new).include?(params[:pressed]) || (params[:button] == "reset" && params[:action] == "group_update")
   = render :partial => 'shared/buttons/group_form'
 - elsif %w(ab_button_edit ab_button_new).include?(params[:pressed]) || (params[:button] == "reset" && params[:action] == "button_update") || (params[:button] == "paste" && params[:action] == "resolve")
   = render :partial => 'shared/buttons/ab_form'
 - elsif params[:pressed] == "ab_group_reorder" || (params[:button] == "reset" && params[:action] == "ab_group_reorder")
   = render :partial => 'shared/buttons/group_order_form'
+- elsif @custom_button
+  = render :partial => 'shared/buttons/ab_show'


### PR DESCRIPTION
Purpose or Intent
----------------------
This fix is based on BZ below, it changes the misleading title for button edit dialog from `'Adding a new Button'` to `'Editing Button "name_of_the_button"'`.

Links
-------
https://bugzilla.redhat.com/show_bug.cgi?id=1379348
