### PR TITLE
Fix the url depending on type of the action (follow-up fix for #11501 )

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -176,6 +176,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
         miqService.sparkleOff();
       });
     }
+    $scope.actionUrl = $scope.newRecord ? $scope.createUrl : $scope.updateUrl;
     $scope.currentTab = "default";
   };
 
@@ -457,7 +458,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
 
   $scope.validateClicked = function($event, authType, formSubmit) {
     $scope.authType = authType;
-    miqService.validateWithREST($event, authType, $scope.updateUrl, formSubmit)
+    miqService.validateWithREST($event, authType, $scope.actionUrl, formSubmit)
       .then(function success(data) {
         $scope.$apply(function() {
           if(data.level == "error") {

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -43,6 +43,10 @@ describe('emsCommonFormController', function() {
       $httpBackend.flush();
     }));
 
+    it('sets actionUrl to createUrl', function () {
+      expect($scope.actionUrl).toEqual($scope.createUrl);
+    });
+
     it('sets the name to blank', function () {
       expect($scope.emsCommonModel.name).toEqual('');
     });
@@ -102,6 +106,10 @@ describe('emsCommonFormController', function() {
         });
       $httpBackend.flush();
     }));
+
+    it('sets actionUrl to updateUrl', function () {
+      expect($scope.actionUrl).toEqual($scope.updateUrl);
+    });
 
     it('sets the name to the Amazon EC2 Cloud Provider', function () {
       expect($scope.emsCommonModel.name).toEqual('amz');


### PR DESCRIPTION
This is a follow-up fix for https://github.com/ManageIQ/manageiq/pull/11501 and should fix the url that gets eventually passed to `miqJqueryRequest` while validating credentials during a Create or an Update operation.

https://bugzilla.redhat.com/show_bug.cgi?id=1375699