### PR TITLE
Added missing routes for Network Ports

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1501,6 +1501,7 @@ Vmdb::Application.routes.draw do
       :post => %w(
         button
         quick_search
+        listnav_search_selected
         show
         show_list
         tag_edit_form_field_changed
@@ -1508,6 +1509,7 @@ Vmdb::Application.routes.draw do
       ) +
         adv_search_post +
         compare_post +
+        save_post +
         exp_post
     },
 

--- a/spec/routing/network_ports_routing_spec.rb
+++ b/spec/routing/network_ports_routing_spec.rb
@@ -1,0 +1,16 @@
+describe "routes for Network Ports" do
+  let(:controller_name) { "network_port" }
+  describe "#listnav_search_selected" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/listnav_search_selected")).to route_to(
+        "#{controller_name}#listnav_search_selected")
+    end
+  end
+
+  describe "#save_default_search" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/save_default_search")).to route_to(
+        "#{controller_name}#save_default_search")
+    end
+  end
+end


### PR DESCRIPTION
Added routes for advanced search in Network Ports
Previous PR that's fixing missing routes for Network* resources:https://github.com/ManageIQ/manageiq/pull/10324

https://bugzilla.redhat.com/show_bug.cgi?id=1364089