### PR TITLE
Use https instead of git protocol in Gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ raise "Ruby versions less than 2.2.2 are unsupported!" if RUBY_VERSION < "2.2.2"
 
 # when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
 unless dependencies.detect { |d| d.name == "manageiq-providers-amazon" }
-  gem "manageiq-providers-amazon", :git => "git://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
+  gem "manageiq-providers-amazon", :git => "https://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
 end
 
 # Unmodified gems
@@ -68,9 +68,9 @@ gem "uglifier",                       "~>3.0.0"
 gem "websocket-driver",               "~>0.6.3"
 
 # Modified gems (forked on Github)
-gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "git://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
-gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
-gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"
+gem "foreman_api_client",             ">=0.1.0",   :require => false, :git => "https://github.com/ManageIQ/foreman_api_client.git", :branch => "master"
+gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
+gem "ziya",                           "=2.3.0",    :require => false, :git => "https://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-3"
 
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
 # american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.
@@ -92,7 +92,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "coffee-rails"
 
   # Modified gems (forked on Github)
-  gem "jquery-rjs",                   "=0.1.1",                       :git => "git://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"
+  gem "jquery-rjs",                   "=0.1.1",                       :git => "https://github.com/amatsuda/jquery-rjs.git", :ref => "1288c09"
 end
 
 ### Start of gems excluded from the appliances.

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -52,8 +52,8 @@ gem "winrm-elevated",          "~>0.4.0",           :require => false
 gem "zip-zip",                 "~>0.3.0",           :require => false
 
 # Modified gems (forked on github)
-gem "handsoap", "~>0.2.5", :require => false, :git => "git://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-4"
-gem "rubywbem",            :require => false, :git => "git://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
+gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-4"
+gem "rubywbem",            :require => false, :git => "https://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
 
 group :appliance do
   gem "highline", "~> 1.6.21", :require => false  # Needed for the appliance_console


### PR DESCRIPTION
Removes Bundler warnings: "The git source `git://github.com/...` uses the
`git` protocol, which transmits data without encryption. Disable this
warning with `bundle config git.allow_insecure true`, or switch to the
`https` protocol to keep your data secure."

See https://github.com/bundler/bundler/pull/2569 for more info.