### PR TITLE
Don't auto-reload ConsoleMethods

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -71,13 +71,6 @@ module Vmdb
 
     # Customize any additional options below...
 
-    # HACK: By default, Rails.configuration.eager_load_paths contains all of the directories
-    # in app and Rails.configuration.autoload_paths is empty.  Sometime during initialization,
-    # these two arrays are combined and placed into ActiveSupport::Dependencies.autoload_paths,
-    # which is what is used for autoloading.  Since we do not want to eager load anything due
-    # to memory bloat, we clear out eager_load_paths down below.  This ends up leaving the
-    # ActiveSupport::Dependencies.autoload_paths empty, thus breaking autoloading.  Thus, in
-    # order to prevent eager loading, but still populate autoload_paths, we copy them.
     config.autoload_paths += config.eager_load_paths
     config.autoload_paths << Rails.root.join("app", "models", "aliases")
     config.autoload_paths << Rails.root.join("app", "models", "mixins")

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,6 +86,8 @@ module Vmdb
     config.autoload_paths << Rails.root.join("app", "controllers", "mixins")
     config.autoload_paths << Rails.root.join("lib")
 
+    config.autoload_once_paths << Rails.root.join("lib", "vmdb", "console_methods.rb")
+
     # config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled.
     # Defaults to every folder in the app directory of the application.
 


### PR DESCRIPTION
Fixes #8894

Before:

```
> simulate_queue_worker  (works)
> reload! (works)
> simulate_queue_worker (fails)

A copy of Vmdb::ConsoleMethods has been removed from the module tree but is
still active!
```

The ConsoleMethods module that defines these commands is in autoload_paths,
but you cannot auto-reload ConsoleMethods as these are mixed in to the
TOPLEVEL_BINDING for pry/irb. So only load that once.