### PR TITLE
Handle the case that a parameter group does not have label

### DIFF
--- a/app/services/orchestration_template_dialog_service.rb
+++ b/app/services/orchestration_template_dialog_service.rb
@@ -48,7 +48,7 @@ class OrchestrationTemplateDialogService
 
     tab.dialog_groups.build(
       :display  => "edit",
-      :label    => parameter_group.label,
+      :label    => parameter_group.label || "Parameter Group#{position}",
       :position => position
     ).tap do |dialog_group|
       parameter_group.parameters.each_with_index { |param, index| add_parameter_field(param, dialog_group, index) }

--- a/spec/fixtures/orchestration_templates/hot_parameters.yml
+++ b/spec/fixtures/orchestration_templates/hot_parameters.yml
@@ -9,9 +9,7 @@ parameter_groups:
   - flavor
   - image_id
   - cartridges
-- label: DB parameters
-  description: Database related parameters
-  parameters:
+- parameters:
   - admin_pass
   - db_port
   - metadata

--- a/spec/models/orchestration_template_hot_spec.rb
+++ b/spec/models/orchestration_template_hot_spec.rb
@@ -29,8 +29,8 @@ describe OrchestrationTemplateHot do
   end
 
   def assert_db_group(group)
-    expect(group.label).to eq("DB parameters")
-    expect(group.description).to eq("Database related parameters")
+    expect(group.label).to be_nil
+    expect(group.description).to be_nil
 
     assert_hidden_length_patterns(group.parameters[0])
     assert_min_max_value(group.parameters[1])

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -111,7 +111,7 @@ describe OrchestrationTemplateDialogService do
 
   def assert_parameter_group2(group)
     expect(group).to have_attributes(
-      :label   => "DB parameters",
+      :label   => "Parameter Group2",
       :display => "edit",
     )
 


### PR DESCRIPTION
According to the spec the heat template (HOT) parameter group should have a label and description. Our service dialog generation tool uses the label for a tab label.

Here is the spec requirement:
```
parameter_groups:
- label: <human-readable label of parameter group>
  description: <description of the parameter group>
  parameters:
  - <param name>
  - <param name>
```

However our customer has a template without label and description which causes the dialog generation failure.
```
parameter_groups:
- parameters:
  - key_name
- parameters:
  - flavor
  - image
```
The fix is to automatic create a label for non-labeled parameter group.

In order to test the fix we purposely deleted the label and description from the sample template.

Links [Optional]
----------------

* http://docs.openstack.org/developer/heat/template_guide/hot_spec.html#parameter-groups-section
* https://bugzilla.redhat.com/show_bug.cgi?id=1378976

Steps for Testing/QA [Optional]
-------------------------------

Use a heat template that has parameter group but does not have label and description. You manually delete them like the our test sample.