### PR TITLE
Automate - Service provision pending email not being sent.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvisionRequestApproval.class/__methods__/approve_request.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvisionRequestApproval.class/__methods__/approve_request.rb
@@ -8,4 +8,7 @@ approval_type = $evm.object['approval_type'].downcase
 if approval_type == 'auto'
   $evm.log("info", "AUTO-APPROVING")
   $evm.root["miq_request"].approve("admin", "Auto-Approved")
+else
+  $evm.log("info", "Not Auto-Approved")
+  exit MIQ_ABORT
 end


### PR DESCRIPTION
Added logic for abort with log message when approval_type was 'manual'.

This will now run pending_request method and send the pending email(s).

https://bugzilla.redhat.com/show_bug.cgi?id=1380197