### PR TITLE
Label based Auto-Tagging UI

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -382,6 +382,9 @@ class OpsController < ApplicationController
       elsif @sb[:active_tab] == "settings_co_categories" && @in_a_form
         action_url = "category_edit"
         record_id = @category.try(:id)
+      elsif @sb[:active_tab] == "settings_label_tag_mapping" && @in_a_form
+        action_url = "label_tag_mapping_edit"
+        record_id = @lt_map.try(:id)
       elsif @sb[:active_tab] == 'settings_rhn_edit'
         locals[:no_cancel] = false
         action_url = "settings_update"
@@ -545,6 +548,14 @@ class OpsController < ApplicationController
         @right_cell_text = _("Adding a new Category")
       else
         @right_cell_text = _("Editing %{model} \"%{name}\"") % {:name => @category.description, :model => "Category"}
+      end
+    when "ltme" # label tag mapping edit
+      # when editing/adding label tag mapping in settings tree
+      presenter.update(:settings_label_tag_mapping, r[:partial => "label_tag_mapping_form"])
+      if !@lt_map
+        @right_cell_text = _("Adding a new Mapping")
+      else
+        @right_cell_text = _("Editing tag mapping from label \"%{name}\"") % {:name  => @lt_map.label_name}
       end
     when "sie"        # scanitemset edit
       #  editing/adding scanitem in settings tree

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -9,6 +9,7 @@ module OpsController::Settings
   include_concern 'Schedules'
   include_concern 'AutomateSchedules'
   include_concern 'Tags'
+  include_concern 'LabelTagMapping'
   include_concern 'Upload'
   include_concern 'Zones'
   include_concern 'RHN'

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -1150,6 +1150,8 @@ module OpsController::Settings::Common
         @sb[:good] = nil unless @sb[:show_button]
         add_flash(_("Choose the type of custom variables to be imported"))
         @in_a_form = true
+      when "settings_label_tag_mapping"
+        label_tag_mapping_get_all
       when "settings_rhn"
         @edit = session[:edit] || {}
         @edit[:new] ||= {}

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -1,0 +1,207 @@
+module OpsController::Settings::LabelTagMapping
+  extend ActiveSupport::Concern
+
+  def label_tag_mapping_edit
+    case params[:button]
+    when "cancel"
+      @lt_map = session[:edit][:lt_map] if session[:edit] && session[:edit][:lt_map]
+      if !@lt_map || @lt_map.id.blank?
+        add_flash(_("Add of new %{model} was cancelled by the user") %
+                    {:model => ui_lookup(:model => "ContainerLabelTagMapping")})
+      else
+        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
+                    {:model => ui_lookup(:model => "ContainerLabelTagMapping"), :name => @lt_map.label_name})
+      end
+      get_node_info(x_node)
+      @lt_map = @edit = session[:edit] = nil # clean out the saved info
+      replace_right_cell(@nodetype)
+    when "save", "add"
+      id = params[:id] ? params[:id] : "new"
+      return unless load_edit("label_tag_mapping_edit__#{id}", "replace_cell__explorer")
+      @lt_map = @edit[:lt_map] if @edit && @edit[:lt_map]
+      if @edit[:new][:label_name].blank?
+        add_flash(_("Label is required"), :error)
+      end
+      if @edit[:new][:category].blank?
+        add_flash(_("Category is required"), :error)
+      end
+      unless @flash_array.nil?
+        javascript_flash
+        return
+      end
+      if params[:button] == "add"
+        label_tag_mapping_add(@edit[:new][:entity], @edit[:new][:label_name], @edit[:new][:category])
+      else # save
+        label_tag_mapping_update(@lt_map.id, @edit[:new][:category])
+      end
+    when "reset", nil # Reset or first time in
+      if params[:id]
+        @lt_map = ContainerLabelTagMapping.find(params[:id])
+        lt_map_set_form_vars
+      else
+        lt_map_set_new_form_vars
+      end
+      @in_a_form = true
+      session[:changed] = false
+      if params[:button] == "reset"
+        add_flash(_("All changes have been reset"), :warning)
+      end
+      replace_right_cell("ltme")
+    end
+  end
+
+  def entity_ui_name_or_all(entity)
+    if entity.nil?
+      _("<All>")
+    else
+      ui_lookup(:model => entity)
+    end
+  end
+
+  def label_tag_mapping_get_all
+    # Current UI only supports any-value -> category mappings
+    mapping = ContainerLabelTagMapping.in_my_region.where(:label_value => nil)
+    @lt_mapping = []
+    mapping.each do |m|
+      lt_map = {}
+      lt_map[:id] = m.id
+      lt_map[:entity] = entity_ui_name_or_all(m.labeled_resource_type)
+      lt_map[:label_name] = m.label_name
+      lt_map[:category] = m.tag.category.description
+      @lt_mapping.push(lt_map)
+    end
+  end
+
+  # Set form variables for mapping edit (initially or after reset)
+  def lt_map_set_form_vars
+    @edit = {}
+    @edit[:lt_map] = @lt_map
+    @edit[:new] = {}
+    @edit[:key] = "label_tag_mapping_edit__#{@lt_map.id || "new"}"
+    @edit[:new][:entity] = @lt_map.labeled_resource_type.nil? ? "<All>" : @lt_map.labeled_resource_type
+    @edit[:new][:label_name] = @lt_map.label_name
+    @edit[:new][:category] = @lt_map.tag.category.description
+    @edit[:current] = copy_hash(@edit[:new])
+    @edit[:new][:options] = ContainerLabelTagMapping::MAPPABLE_ENTITIES.collect do |name|
+      [entity_ui_name_or_all(name), name]
+    end
+    session[:edit] = @edit
+  end
+
+  # Set form variables for mapping add
+  def lt_map_set_new_form_vars
+    @edit = {}
+    # no :lt_map
+    @edit[:new] = {}
+    @edit[:key] = "label_tag_mapping_edit__new"
+    @edit[:new][:entity] = nil
+    @edit[:new][:label_name] = nil
+    @edit[:new][:category] = nil
+    @edit[:current] = copy_hash(@edit[:new])
+    @edit[:new][:options] = ContainerLabelTagMapping::MAPPABLE_ENTITIES.collect do |name|
+      [entity_ui_name_or_all(name), name]
+    end
+    session[:edit] = @edit
+  end
+
+  # AJAX driven routine to check for changes in ANY field on the user form
+  def label_tag_mapping_field_changed
+    return unless load_edit("label_tag_mapping_edit__#{params[:id]}", "replace_cell__explorer")
+    lt_map_get_form_vars
+    @changed = (@edit[:new] != @edit[:current])
+    render :update do |page|
+      page << javascript_prologue
+      page.replace(@refresh_div,
+                   :partial => @refresh_partial,
+                   :locals  => {:type       => "container_label_tag_mapping",
+                                :action_url => 'label_tag_mapping_field_changed'}) if @refresh_div
+      page << javascript_for_miq_button_visibility_changed(@changed)
+    end
+  end
+
+  # Get variables from label_tag_mapping edit form
+  def lt_map_get_form_vars
+    @lt_map = @edit[:lt_map]
+    @edit[:new][:entity] = params[:entity] if params[:entity]
+    @edit[:new][:label_name] = params[:label_name] if params[:label_name]
+    @edit[:new][:category] = params[:category] if params[:category]
+  end
+
+  def label_tag_mapping_add(entity, label_name, cat_description)
+    prefix = ContainerLabelTagMapping::AUTOTAG_PREFIX
+    entity_str = entity.nil? ? "" : entity.underscore
+    cat_name = "#{prefix}:#{entity_str}:" + Classification.sanitize_name(label_name.tr("/", ":"))
+
+    # UI currently can't allow 2 mappings for same (entity, label).
+    if Classification.find_by_name(cat_name)
+      add_flash(_("Mapping for %{entity}, %{label} already exists") %
+                  {:entity => entity_ui_name_or_all(entity), :label => label_name}, :error)
+      javascript_flash
+      return
+    end
+
+    begin
+      ActiveRecord::Base.transaction do
+        category = Classification.create_category!(:name         => cat_name,
+                                                   :description  => cat_description,
+                                                   :single_value => true,
+                                                   :read_only    => true)
+        ContainerLabelTagMapping.create!(:labeled_resource_type => entity, :label_name => label_name,
+                                         :tag => category.tag)
+      end
+    rescue StandardError => bang
+      add_flash(_("Error during 'add': %{message}") % {:message => bang.message}, :error)
+      javascript_flash
+    else
+      add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "ContainerLabelTagMapping"),
+                                                       :name  => label_name})
+      get_node_info(x_node)
+      @lt_map = @edit = session[:edit] = nil # clean out the saved info
+      replace_right_cell("root")
+    end
+  end
+
+  def label_tag_mapping_update(id, cat_description)
+    mapping = ContainerLabelTagMapping.find(id)
+    update_category = mapping.tag.classification
+    update_category.description = cat_description
+    begin
+      update_category.save!
+    rescue StandardError => bang
+      add_flash(_("Error during 'save': %{message}") % {:message => bang.message}, :error)
+      javascript_flash
+    else
+      add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "ContainerLabelTagMapping"),
+                                                       :name  => mapping.label_name})
+      get_node_info(x_node)
+      @lt_map = @edit = session[:edit] = nil # clean out the saved info
+      replace_right_cell("root")
+    end
+  end
+
+  def label_tag_mapping_delete
+    mapping = ContainerLabelTagMapping.find(params[:id])
+    category = mapping.tag.category
+    label_name = mapping.label_name
+
+    deleted = false
+    # delete mapping and category - will indirectly delete tags
+    ActiveRecord::Base.transaction do
+      deleted = mapping.destroy && category.destroy
+    end
+
+    if deleted
+      add_flash(_("%{model} \"%{name}\": Delete successful") %
+                  {:model => ui_lookup(:model => "ContainerLabelTagMapping"), :name => label_name})
+      label_tag_mapping_get_all
+      render :update do |page|
+        page << javascript_prologue
+        page.replace_html 'settings_label_tag_mapping', :partial => 'settings_label_tag_mapping_tab'
+      end
+    else
+      mapping.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      category.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
+      javascript_flash
+    end
+  end
+end

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -12,6 +12,15 @@ class ContainerLabelTagMapping < ApplicationRecord
   #
   # All involved tags must also have a Classification.
 
+  AUTOTAG_PREFIX = "kubernetes".freeze
+  MAPPABLE_ENTITIES = [nil,
+                       "ContainerProject",
+                       "ContainerRoute",
+                       "ContainerNode",
+                       "ContainerReplicator",
+                       "ContainerService",
+                       "ContainerGroup",
+                       "ContainerBuild"].freeze
   belongs_to :tag
 
   # Pass the data this returns to map_* methods.

--- a/app/views/layouts/_edit_form_buttons.html.haml
+++ b/app/views/layouts/_edit_form_buttons.html.haml
@@ -8,7 +8,7 @@
 - serialize            ||= false
 - continue_button      ||= nil
 - restful              ||= false
-- show_cancel_button = %w(user_edit user_update menu_tree zone_edit zone_update ldap_seq_edit rbac_group_edit rbac_group_update rbac_group_field_changed category_edit category_update timeprofile_edit timeprofile_update timeprofile_copy)
+- show_cancel_button = %w(user_edit user_update menu_tree zone_edit zone_update ldap_seq_edit rbac_group_edit rbac_group_update rbac_group_field_changed category_edit category_update label_tag_mapping_edit label_tag_mapping_update timeprofile_edit timeprofile_update timeprofile_copy)
 - force_cancel_button ||= false
 &nbsp;
 %table{:width => "100%"}

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -60,6 +60,8 @@
             = _("Import Tags")
           = miq_tab_header("settings_import", @sb[:active_tab]) do
             = _("Import Variables")
+          = miq_tab_header("settings_label_tag_mapping", @sb[:active_tab]) do
+            = _("Map Tags")
           = miq_tab_header("settings_rhn", @sb[:active_tab]) do
             = _("Red Hat Updates")
           = miq_tab_header("settings_replication", @sb[:active_tab]) do
@@ -77,6 +79,8 @@
             = render :partial => "settings_import_tags_tab"
           = miq_tab_content("settings_import", @sb[:active_tab]) do
             = render :partial => "settings_import_tab"
+          = miq_tab_content("settings_label_tag_mapping", @sb[:active_tab]) do
+            = render :partial => "settings_label_tag_mapping_tab"
           = miq_tab_content("settings_rhn", @sb[:active_tab]) do
             = render :partial => "settings_rhn_tab"
           = miq_tab_content("settings_replication", @sb[:active_tab]) do

--- a/app/views/ops/_label_tag_mapping_form.html.haml
+++ b/app/views/ops/_label_tag_mapping_form.html.haml
@@ -1,0 +1,47 @@
+- url = url_for(:action => 'label_tag_mapping_field_changed', :id => @lt_map && @lt_map.id ? @lt_map.id.to_s : "new")
+#main_div
+  = render :partial => "layouts/flash_msg"
+  = form_tag({:action => 'label_tag_mapping_update'},
+             {:id     => "label_tag_mapping_form",
+              :class  => "form-horizontal",
+              :method => :post}) do
+    - disabled = !@lt_map.nil?
+    - if disabled
+      %h3= _("Container entity and label")
+    - else
+      %h3= _("Choose a container entity and label")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Entity")
+      .col-md-8
+        = select_tag('entity',
+                     options_for_select(@edit[:new][:options],
+                                        @edit[:new][:entity]),
+                                        :class    => "selectpicker",
+                                        :disabled => disabled)
+      :javascript
+        miqInitSelectPicker();
+        miqSelectPickerEvent('entity', "#{url}")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Label")
+      .col-md-8
+        = text_field_tag("label_name", @edit[:new][:label_name],
+                         :maxlength         => 25,
+                         :class             => "form-control",
+                         :disabled          => disabled,
+                         "data-miq_observe" => {:interval => '.5',
+                                                :url      => url}.to_json)
+    %h3= _("Choose a tag category to map to")
+    .form-group
+      %label.col-md-2.control-label
+        = _("Category")
+      .col-md-8
+        = text_field_tag("category", @edit[:new][:category],
+                         :maxlength         => 50,
+                         :class             => "form-control",
+                         "data-miq_observe" => {:interval => '.5',
+                                                :url      => url}.to_json)
+    .form-group
+      %label.col-md-2.control-label
+      .col-md-8

--- a/app/views/ops/_settings_label_tag_mapping_tab.html.haml
+++ b/app/views/ops/_settings_label_tag_mapping_tab.html.haml
@@ -1,0 +1,32 @@
+- if @sb[:active_tab] == "settings_label_tag_mapping"
+  = render :partial => "layouts/flash_msg"
+  %table.table.table-striped.table-bordered.table-hover
+    %thead
+      %tr
+        %th= _("Container Entity")
+        %th= _("Container Label")
+        %th= _("Tag Category")
+        %th= _("Actions")
+    %tbody
+      %tr#new_tr{:onclick => remote_function(:url => {:action => 'label_tag_mapping_edit', :id => nil}), :title => _("map a new label to tag")}
+        %td{:colspan => 3}
+          = _("<Click on this row to create a new mapping rule>")
+
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
+      - @lt_mapping.each do |lt_map|
+        %tr
+          - t = _("Click to edit this mapping rule")
+          %td{:onclick => remote_function(:url => {:action => 'label_tag_mapping_edit', :id => lt_map[:id]}), :title => t}
+            = h(lt_map[:entity])
+          %td{:onclick => remote_function(:url => {:action => 'label_tag_mapping_edit', :id => lt_map[:id]}), :title => t}
+            = h(lt_map[:label_name])
+          %td{:onclick => remote_function(:url => {:action => 'label_tag_mapping_edit', :id => lt_map[:id]}), :title => t}
+            = h(lt_map[:category])
+          %td.action-cell{:onclick => remote_function(:url => {:action => 'label_tag_mapping_delete',
+            :id      => lt_map[:id]},
+            :confirm => _("Are you sure you want to delete mapping '%{label_name}'?") % {:label_name => lt_map[:label_name]}),
+            :title   => _("Click to delete this mapping")}
+            %button.btn.btn-default.btn-block.btn-sm
+              = _("Delete")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2270,6 +2270,10 @@ Vmdb::Application.routes.draw do
         forest_delete
         forest_form_field_changed
         forest_select
+        label_tag_mapping_delete
+        label_tag_mapping_edit
+        label_tag_mapping_update
+        label_tag_mapping_field_changed
         log_depot_edit
         log_depot_field_changed
         log_depot_validate

--- a/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
+++ b/spec/controllers/ops_controller/settings/label_tag_mapping_spec.rb
@@ -1,0 +1,59 @@
+describe OpsController do
+  include_context "valid session"
+
+  describe '#label_tag_mapping_edit' do
+    it "initilizes form for new mapping" do
+      post :label_tag_mapping_edit
+      expect(assigns(:edit)[:new]).to include(:entity => nil, :label_name => nil, :category => nil)
+    end
+
+    def use_form_to_create_mapping
+      post :label_tag_mapping_edit
+      post :label_tag_mapping_field_changed, :id => 'new', :entity => 'ContainerProject'
+      post :label_tag_mapping_field_changed, :id => 'new', :label_name => 'my-label'
+      post :label_tag_mapping_field_changed, :id => 'new', :category => 'My Cat'
+      post :label_tag_mapping_edit, :button => 'add'
+    end
+
+    it "creates new mapping on save" do
+      use_form_to_create_mapping
+      mapping = ContainerLabelTagMapping.last
+      expect(mapping.labeled_resource_type).to eq('ContainerProject')
+      expect(mapping.label_name).to eq('my-label')
+      expect(mapping.label_value).to be nil
+      expect(mapping.tag.classification.category?).to be true
+      expect(mapping.tag.classification.description).to eq('My Cat')
+    end
+
+    it "can edit existing mapping" do
+      use_form_to_create_mapping
+      mapping = ContainerLabelTagMapping.last
+
+      post :label_tag_mapping_edit, :id => mapping.id.to_s
+      expect(assigns(:edit)[:new]).to include(:entity     => 'ContainerProject',
+                                              :label_name => 'my-label',
+                                              :category   => 'My Cat')
+
+      post :label_tag_mapping_field_changed, :id => mapping.id.to_s, :category => 'Edited Cat'
+      expect(assigns(:edit)[:new]).to include(:entity     => 'ContainerProject',
+                                              :label_name => 'my-label',
+                                              :category   => 'Edited Cat')
+
+      post :label_tag_mapping_edit, :id => mapping.id.to_s, :button => 'reset'
+      expect(assigns(:edit)[:new]).to include(:entity     => 'ContainerProject',
+                                              :label_name => 'my-label',
+                                              :category   => 'My Cat')
+
+      post :label_tag_mapping_field_changed, :id => mapping.id.to_s, :category => 'Edited Again Cat'
+      expect(assigns(:edit)[:new]).to include(:entity     => 'ContainerProject',
+                                              :label_name => 'my-label',
+                                              :category   => 'Edited Again Cat')
+
+      # Kludge: @flash_array contains "was added" from previous actions since
+      # we're reusing one controller in the test.
+      controller.instance_variable_set :@flash_array, nil
+      post :label_tag_mapping_edit, :id => mapping.id.to_s, :button => 'save'
+      expect(mapping.tag.classification.description).to eq('Edited Again Cat')
+    end
+  end
+end

--- a/spec/routing/ops_routing_spec.rb
+++ b/spec/routing/ops_routing_spec.rb
@@ -58,6 +58,10 @@ describe "routing for OpsController" do
     forest_delete
     forest_form_field_changed
     forest_select
+    label_tag_mapping_delete
+    label_tag_mapping_edit
+    label_tag_mapping_update
+    label_tag_mapping_field_changed
     log_depot_edit
     log_depot_field_changed
     log_depot_validate

--- a/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
+++ b/spec/views/ops/_label_tag_mapping_form.html.haml_spec.rb
@@ -1,0 +1,65 @@
+describe 'ops/_label_tag_mapping_form.html.haml' do
+  before do
+    assign(:sb, :active_tab => 'settings_label_tag_mapping')
+  end
+
+  context 'add new mapping' do
+    before(:each) do
+      @lt_map = nil
+      @edit = {:id  => nil,
+               :new => {:options    => [["<All>", nil]],
+                        :entity     => nil,
+                        :label_name => nil,
+                        :category   => nil}}
+      render :partial => "ops/label_tag_mapping_form"
+    end
+
+    it 'renders the entity select box' do
+      expect(render).to have_selector('select#entity')
+    end
+
+    it 'renders the label name text box' do
+      expect(render).to have_selector('input#label_name')
+    end
+
+    it 'renders the category name text box' do
+      expect(render).to have_selector('input#category')
+    end
+
+    it 'entity should be enabled when adding a new mapping' do
+      expect(response.body).to include('<select name="entity" id="entity" class="selectpicker">')
+    end
+
+    it 'label should be enabled when adding a new mapping' do
+      expect(response.body).to include('<input type="text" name="label_name" id="label_name" maxlength="25" class="form-control" data-miq_observe')
+    end
+
+    it 'category should be enabled when adding a new mapping' do
+      expect(response.body).to include('<input type="text" name="category" id="category" maxlength="50" class="form-control" data-miq_observe')
+    end
+  end
+
+  context 'edit existing mapping' do
+    before(:each) do
+      @lt_map = FactoryGirl.create(:container_label_tag_mapping)
+      @edit = {:id  => nil,
+               :new => {:options    => [["<All>", nil]],
+                        :entity     => nil,
+                        :label_name => nil,
+                        :category   => nil}}
+      render :partial => "ops/label_tag_mapping_form"
+    end
+
+    it 'entity should be disabled when editing an existing mapping' do
+      expect(response.body).to include('<select name="entity" id="entity" class="selectpicker" disabled="disabled">')
+    end
+
+    it 'label should be disabled when editing an existing mapping' do
+      expect(response.body).to include('<input type="text" name="label_name" id="label_name" maxlength="25" class="form-control" disabled="disabled" data-miq_observe')
+    end
+
+    it 'category should be enabled when editing an existing mapping' do
+      expect(response.body).to include('<input type="text" name="category" id="category" maxlength="50" class="form-control" data-miq_observe')
+    end
+  end
+end

--- a/spec/views/ops/_settings_label_tag_mapping_tab.html.haml_spec.rb
+++ b/spec/views/ops/_settings_label_tag_mapping_tab.html.haml_spec.rb
@@ -1,0 +1,23 @@
+describe 'ops/_settings_label_tag_mapping_tab.html.haml' do
+  before { assign(:sb, :active_tab => 'settings_label_tag_mapping') }
+
+  context 'table view' do
+    it 'renders the table with zero mappings' do
+      @lt_mapping = []
+      render
+      expect(response.body).to include('Click on this row to create a new mapping rule')
+      expect(response.body).to have_selector('button', :text => 'Add')
+    end
+
+    it 'renders the table with mappings' do
+      @lt_mapping = [{:entity => 'Node', :label_name => 'my-label', :category => 'My Cat'}]
+      render
+      expect(response.body).to include('Click on this row to create a new mapping rule')
+      expect(response.body).to have_selector('button', :text => 'Add')
+      expect(response.body).to include('Node')
+      expect(response.body).to include('my-label')
+      expect(response.body).to include('My Cat')
+      expect(response.body).to have_selector('button', :text => 'Delete')
+    end
+  end
+end


### PR DESCRIPTION
Adding UI to allow configuration of auto tagging based on kubernetes/openshift labels
bz: https://bugzilla.redhat.com/show_bug.cgi?id=1383405

This PR is continuing the work done in  PRs:
https://github.com/ManageIQ/manageiq/pull/7957
https://github.com/ManageIQ/manageiq/pull/7605
https://github.com/ManageIQ/manageiq/pull/7771
and issue https://github.com/ManageIQ/manageiq/issues/7460

Feature Allows viewing, adding, updating and removing mapping rules.

# Map Tags tab showing configured mappings
![container_label_tag_mapping_tab](https://cloud.githubusercontent.com/assets/20948594/19891621/9623ff56-a049-11e6-96ff-8bd471db687f.png)

# Add a new mapping
![container_label_tag_mapping_add](https://cloud.githubusercontent.com/assets/20948594/19891630/a6504088-a049-11e6-8db4-c8400df30ca3.png)

# Edit an existing mapping
![container_label_tag_mapping_edit](https://cloud.githubusercontent.com/assets/20948594/19891642/b1252532-a049-11e6-92f5-fdc663fcc204.png)
