### PR TITLE
Bundle power ops: pass in the correct delay_for_action depending on the action

### DIFF
--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -131,16 +131,39 @@ describe Service do
       expect(@service.group_has_resources?(0)).to be_falsey
     end
 
+    it "last_index" do
+      @service.add_resource(Vm.first, :group_idx => 1, :start_delay => 60)
+      expect(@service.last_index).to eq 1
+    end
+
     it "start" do
+      @service.add_resource(Vm.first, :group_idx => 0, :start_delay => 60)
       expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_start)
+      expect(@service).to receive(:queue_group_action).with(:start, 0, 1, 60)
 
       @service.start
     end
 
     it "stop" do
+      @service.add_resource(Vm.first, :group_idx => 1, :stop_delay => 60)
       expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_stop)
+      expect(@service).to receive(:queue_group_action).with(:stop, 1, -1, 60)
 
       @service.stop
+    end
+
+    it "suspend" do
+      @service.add_resource(Vm.first, :group_idx => 1, :stop_delay => 60)
+      expect(@service).to receive(:queue_group_action).with(:suspend, 1, -1, 60)
+
+      @service.suspend
+    end
+
+    it "shutdown_guest" do
+      @service.add_resource(Vm.first, :group_idx => 1, :stop_delay => 60)
+      expect(@service).to receive(:queue_group_action).with(:shutdown_guest, 1, -1, 60)
+
+      @service.shutdown_guest
     end
 
     context "with VM resources" do


### PR DESCRIPTION
The service#start action requires a delay for first action (including all subsequent queued actions.)
The #stop action requires the same, except we pass in the delay_action for the last index as opposed to the first for the start action.

This allows the first service in each bundle to pass the correct delay as opposed to defaulting to 0 in all cases.

Links
----------------

* [PT #128461221](https://www.pivotaltracker.com/story/show/128461221)

Steps for Testing/QA
-------------------------------
1. Create a bundled service with at least 3 services.
2. Set the power options and delay for the start and stop actions (as below.)

<img width="1221" alt="screen shot 2016-09-29 at 3 42 09 pm" src="https://cloud.githubusercontent.com/assets/697347/18969474/56f04946-865b-11e6-8c1f-a4992c5fdbfb.png">

3. After provisioning the VMS - call `service.start` and `service.stop` from the rails console.  The order of operations will be reversed on stop.  The actions should be run within their delay_start, delay_stop parameters.

