### PR TITLE
Reset domain priorities at startup and restore

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -171,6 +171,7 @@ module MiqAeDatastore
 
     restore_attrs_for_domains(saved_attrs)
     reset_default_namespace
+    MiqAeDomain.reset_priorities
   end
 
   def self.default_domain_names

--- a/lib/miq_automation_engine/models/miq_ae_datastore.rb
+++ b/lib/miq_automation_engine/models/miq_ae_datastore.rb
@@ -191,6 +191,8 @@ module MiqAeDatastore
         _log.info "Seeding... Complete"
       end
     end
+    _log.info "Reseting domain priorities at startup..."
+    MiqAeDomain.reset_priorities
   end
 
   def self.get_homonymic_across_domains(user, arclass, fqname, enabled = nil)

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -55,7 +55,10 @@ class MiqAeYamlImport
       @domain_name = directory.split("/").last
       import_domain(directory, @domain_name)
     end
-    MiqAeDatastore.reset_default_namespace if @restore && !@preview
+    if @restore && !@preview
+      MiqAeDatastore.reset_default_namespace
+      MiqAeDomain.reset_priorities
+    end
     domains
   end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -269,6 +269,21 @@ describe MiqAeDomain do
     end
   end
 
+  context "reset priority" do
+    it "#reset_priorites" do
+      FactoryGirl.create(:miq_ae_system_domain, :name => 'ManageIQ', :tenant => @user.current_tenant, :priority => 0)
+      FactoryGirl.create(:miq_ae_system_domain, :name => 'B', :tenant => @user.current_tenant)
+      FactoryGirl.create(:miq_ae_system_domain, :name => 'A', :tenant => @user.current_tenant)
+      FactoryGirl.create(:miq_ae_system_domain, :name => 'Z', :tenant => @user.current_tenant)
+      FactoryGirl.create(:miq_ae_domain, :name => 'U1', :tenant => @user.current_tenant)
+      FactoryGirl.create(:miq_ae_domain, :name => 'U2', :tenant => @user.current_tenant)
+
+      ordered_names = %w(ManageIQ Z B A U1 U2)
+      MiqAeDomain.reset_priorities
+      expect(MiqAeDomain.all.order('priority').collect(&:name)).to eq(ordered_names)
+    end
+  end
+
   context "git enabled domains" do
     let(:commit_time) { Time.now.utc }
     let(:commit_time_new) { Time.now.utc + 1.hour }


### PR DESCRIPTION
With the multiple pluggable provider system domains, we need
to sort these based on the name and also adjust the priority of
existing user domains. This way the user domains would be listed
above the ManageIQ and pluggable provider domains.

https://www.pivotaltracker.com/n/projects/1613499/stories/131394235