### PR TITLE
Disable extension when stopping replication

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -61,7 +61,10 @@ class PglogicalSubscription < ActsAsArModel
   def delete
     pglogical.subscription_drop(id, true)
     MiqRegion.destroy_region(connection, provider_region)
-    pglogical.node_drop(MiqPglogical.local_node_name, true) if self.class.count == 0
+    if self.class.count == 0
+      pglogical.node_drop(MiqPglogical.local_node_name, true)
+      pglogical.disable
+    end
   end
 
   def self.delete_all

--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -25,6 +25,11 @@ class PgLogicalRaw
     connection.enable_extension("pglogical_origin") if connection.postgresql_version < 90_500
   end
 
+  def disable
+    connection.disable_extension("pglogical")
+    connection.disable_extension("pglogical_origin") if connection.postgresql_version < 90_500
+  end
+
   # Monitoring
   #
 

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -52,6 +52,7 @@ class MiqPglogical
     return unless provider?
     pglogical.replication_set_drop(REPLICATION_SET_NAME)
     drop_node
+    pglogical.disable
   end
 
   # Lists the tables currently being replicated by pglogical

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -354,6 +354,7 @@ describe PglogicalSubscription do
       expect(MiqRegion).to receive(:destroy_region)
         .with(instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter), 0)
       expect(pglogical).to receive(:node_drop).with("region_#{MiqRegion.my_region_number}", true)
+      expect(pglogical).to receive(:disable)
 
       sub.delete
     end

--- a/spec/replication/util/ar_pglogical_spec.rb
+++ b/spec/replication/util/ar_pglogical_spec.rb
@@ -12,6 +12,12 @@ describe "ar_pglogical extension" do
     end
   end
 
+  describe "#enabled?" do
+    it "detects that the extensions are not enabled" do
+      expect(connection.pglogical.enabled?).to be false
+    end
+  end
+
   context "with the extensions enabled" do
     let(:node_name) { "test-node" }
     let(:node_dsn)  { "host=host.example.com dbname=vmdb_test" }
@@ -23,6 +29,13 @@ describe "ar_pglogical extension" do
     describe "#enabled?" do
       it "detects that the extensions are enabled" do
         expect(connection.pglogical.enabled?).to be true
+      end
+    end
+
+    describe "#disable" do
+      it "disables the pglogical extension" do
+        connection.pglogical.disable
+        expect(connection.extensions).not_to include("pglogical")
       end
     end
 

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -23,10 +23,9 @@ describe MiqPglogical do
   describe "#destroy_provider" do
     it "removes the provider configuration" do
       subject.destroy_provider
-      expect(pglogical.nodes.num_tuples).to eq(0)
-      expect(pglogical.replication_sets).not_to include(described_class::REPLICATION_SET_NAME)
       expect(subject.provider?).to be false
       expect(subject.node?).to be false
+      expect(connection.extension_enabled?("pglogical")).to be false
     end
   end
 


### PR DESCRIPTION
Remove the pglogical extensions when disabling replication on a node.

This will allow us to be sure that all data from the previous installation was properly removed (disabling the extensions actually removes the tables associated with running pglogical and the data within them).

@gtanzillo please review.
