### PR TITLE
Move the postgresql mountpoint up

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -134,7 +134,7 @@ module MiqServer::EnvironmentManagement
                          when '/var/log/audit'   then 'evm_server_var_log_audit_disk_high_usage'
                          when '/var/www/miq_tmp' then 'evm_server_miq_tmp_disk_high_usage'
                          when '/tmp'             then 'evm_server_tmp_disk_high_usage'
-                         when %r{pgsql/data}     then 'evm_server_db_disk_high_usage'
+                         when %r{lib/pgsql}      then 'evm_server_db_disk_high_usage'
                          end
 
       next unless disk_usage_event

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -71,7 +71,7 @@ module ApplianceConsole
 
     def initialize_postgresql
       log_and_feedback(__method__) do
-        prep_data_directory
+        PostgresAdmin.prep_data_directory
         run_initdb
         relabel_postgresql_dir
         configure_postgres
@@ -159,14 +159,6 @@ module ApplianceConsole
 
       fstab.entries << entry
       fstab.write!  # Test this more, whitespace is removed
-    end
-
-    def prep_data_directory
-      # initdb will fail if the database directory is not empty or not owned by the PostgresAdmin.user
-      FileUtils.mkdir(PostgresAdmin.data_directory) unless Dir.exist?(PostgresAdmin.data_directory)
-      FileUtils.chown_R(PostgresAdmin.user, PostgresAdmin.user, PostgresAdmin.data_directory)
-      FileUtils.rm_rf(PostgresAdmin.data_directory.join("pg_log"))
-      FileUtils.rm_rf(PostgresAdmin.data_directory.join("lost+found"))
     end
 
     def run_initdb

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -163,7 +163,7 @@ module ApplianceConsole
 
     def prep_data_directory
       # initdb will fail if the database directory is not empty or not owned by the PostgresAdmin.user
-      # May need to create the data dir here?
+      FileUtils.mkdir(PostgresAdmin.data_directory) unless Dir.exist?(PostgresAdmin.data_directory)
       FileUtils.chown_R(PostgresAdmin.user, PostgresAdmin.user, PostgresAdmin.data_directory)
       FileUtils.rm_rf(PostgresAdmin.data_directory.join("pg_log"))
       FileUtils.rm_rf(PostgresAdmin.data_directory.join("lost+found"))

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -66,8 +66,10 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
   end
 
   context "#update_fstab (private)" do
+    let(:pg_mount_point) { "/var/lib/pgsql" }
+
     before do
-      allow(PostgresAdmin).to receive_messages(:data_directory => "/var/lib/pgsql")
+      allow(ENV).to receive(:fetch).with("APPLIANCE_PG_MOUNT_POINT").and_return(pg_mount_point)
     end
 
     it "adds database disk entry" do
@@ -85,7 +87,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
 
     it "skips update if mount point is in fstab" do
       fstab = double
-      allow(fstab).to receive_messages(:entries => [double(:mount_point => PostgresAdmin.data_directory)])
+      allow(fstab).to receive_messages(:entries => [double(:mount_point => Pathname.new(pg_mount_point))])
       expect(fstab).to receive(:write!).never
       allow(LinuxAdmin::FSTab).to receive_messages(:instance => fstab)
       expect(fstab.entries.count).to eq(1)

--- a/gems/pending/util/postgres_admin.rb
+++ b/gems/pending/util/postgres_admin.rb
@@ -85,6 +85,14 @@ class PostgresAdmin
     result.match(/^\s+([0-9]+)\n/)[1].to_i
   end
 
+  def self.prep_data_directory
+    # initdb will fail if the database directory is not empty or not owned by the PostgresAdmin.user
+    FileUtils.mkdir(PostgresAdmin.data_directory) unless Dir.exist?(PostgresAdmin.data_directory)
+    FileUtils.chown_R(PostgresAdmin.user, PostgresAdmin.user, PostgresAdmin.data_directory)
+    FileUtils.rm_rf(PostgresAdmin.data_directory.join("pg_log"))
+    FileUtils.rm_rf(PostgresAdmin.data_directory.join("lost+found"))
+  end
+
   def self.backup(opts)
     before_backup(opts)
     backup_pg_compress(opts)

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -98,7 +98,7 @@ describe "Server Environment Management" do
     end
 
     it "database disk exceeds usage" do
-      disks = [{:used_bytes_percent => 85, :mount_point => '/var/lib/pgsql/data'}]
+      disks = [{:used_bytes_percent => 85, :mount_point => '/var/lib/pgsql'}]
       expect(@miq_server.check_disk_usage(disks))
       queue = MiqQueue.first
 


### PR DESCRIPTION
This will allow us to upgrade more easily by creating a data directory next to the existing one for the new version and using hard links to do the upgrade.

This will save space and allow us to reuse the existing disk in a sane way.

This PR goes with https://github.com/ManageIQ/manageiq-appliance-build/pull/165 which creates the disk at the new location on the appliance and requires https://github.com/ManageIQ/manageiq-appliance/pull/91 which creates the `APPLIANCE_PG_MOUNT_POINT` environment variable.

@jrafanie please review
/cc @gtanzillo @Fryguy 