### PR TITLE
Change the invalid migration message to live in a method

### DIFF
--- a/spec/replication/util/migration_order_spec.rb
+++ b/spec/replication/util/migration_order_spec.rb
@@ -17,22 +17,29 @@ describe "migration order" do
     current_release_migrations.last
   end
 
+  def invalid_migrations_message(incorrect_migration_time_stamps, last_released_migration)
+    <<-EOS
+The following migration timestamps are too early to be included in the next release:
+
+#{incorrect_migration_time_stamps.join("\n")}
+
+These migrations must be regenerated so that they will run after the latest
+released migration, #{last_released_migration}.
+
+This is done to prevent schema differences between migrated databases and
+newly created ones where all the migrations are run in timestamp order.
+EOS
+  end
+
   it "is correct" do
     incorrect_migration_time_stamps = []
     new_migrations.each do |m|
       incorrect_migration_time_stamps << m if m < last_released_migration
     end
 
-    expect(incorrect_migration_time_stamps).to be_empty, <<-EOS.gsub!(/^ +/, "")
-      The following migration timestamps are too early to be included in the next release:
-
-      #{incorrect_migration_time_stamps.join("\n")}
-
-      These migrations must be regenerated so that they will run after the latest
-      released migration, #{last_released_migration}.
-
-      This is done to prevent schema differences between migrated databases and
-      newly created ones where all the migrations are run in timestamp order.
-    EOS
+    expect(incorrect_migration_time_stamps).to(
+      be_empty,
+      invalid_migrations_message(incorrect_migration_time_stamps, last_released_migration)
+    )
   end
 end


### PR DESCRIPTION
The reasoning for this is that RSpec spits out the failing line in
addition to the message.  Since the long string is part of the line, it
appears "twice" in the RSpec message which is confusing.  By moving it
into a method, then the output won't contain the first of the 2
messages.

Example of the "double" RSpec message (before):

```
  1) migration order is correct
     Failure/Error:
           expect(incorrect_migration_time_stamps).to be_empty, <<-EOS.gsub!(/^ +/, "")
             The following migration timestamps are too early to be included in the next release:
       
             #{incorrect_migration_time_stamps.join("\n")}
       
             These migrations must be regenerated so that they will run after the latest
             released migration, #{last_released_migration}.
       
             This is done to prevent schema differences between migrated databases and
             newly created ones where all the migrations are run in timestamp order.
     
       The following migration timestamps are too early to be included in the next release:
     
       20160922090347
     
       These migrations must be regenerated so that they will run after the latest
       released migration, 20160922171248.
     
       This is done to prevent schema differences between migrated databases and
       newly created ones where all the migrations are run in timestamp order.
```

after:

```
  1) migration order is correct
     Failure/Error:
       expect(incorrect_migration_time_stamps).to(
         be_empty,
         invalid_migrations_message(incorrect_migration_time_stamps, last_released_migration)
       )
     
       The following migration timestamps are too early to be included in the next release:
     
       20160922090347
     
       These migrations must be regenerated so that they will run after the latest
       released migration, 20160922171248.
     
       This is done to prevent schema differences between migrated databases and
       newly created ones where all the migrations are run in timestamp order.
```


@carbonin Please review.