### PR TITLE
fix bug in vm pxe provision from rhev

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::StateMachine
   def configure_destination
     signal :create_pxe_configuration_file
   end
-  
+
   def customize_destination
     if destination_image_locked?
       _log.info("Destination image locked; re-queuing")
@@ -14,7 +14,7 @@ module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::StateMachine
       configure_container
       signal :create_pxe_configuration_file
     end
-  end  
+  end
 
   def create_pxe_configuration_file
     message = "Generating PXE and Customization Files on PXE Server"

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
@@ -2,6 +2,19 @@ module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::StateMachine
   def configure_destination
     signal :create_pxe_configuration_file
   end
+  
+  def customize_destination
+    if destination_image_locked?
+      _log.info("Destination image locked; re-queuing")
+      requeue_phase
+    else
+      message = "Starting New #{destination_type} Customization"
+      _log.info("#{message} #{for_destination}")
+      update_and_notify_parent(:message => message)
+      configure_container
+      signal :create_pxe_configuration_file
+    end
+  end  
 
   def create_pxe_configuration_file
     message = "Generating PXE and Customization Files on PXE Server"


### PR DESCRIPTION
This pull request is for fixing bug in vm pxe provision from rhevm. The source code i use is release darga-2 in branch darga.
When i am trying vm pxe provision, I found that the steps that generate ks.cfg and pxe configuration files ware not called during the provision through reviewing the evm.log. And this is the reason why i can not provisoning a vm with os determined by pxe config and custom script.
So, i add a function customize_destination in module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::StateMachine. After this, pxe provision works fine for me. 
