### PR TITLE
Restlike routes redirect for Notifications

### DIFF
--- a/app/controllers/restful_redirect_controller.rb
+++ b/app/controllers/restful_redirect_controller.rb
@@ -3,6 +3,14 @@ class RestfulRedirectController < ApplicationController
     case params[:model]
     when 'MiqRequest'
       redirect_to :controller => 'miq_request', :action => 'show', :id => params[:id]
+    when 'VmOrTemplate'
+      klass = VmOrTemplate.select(:id, :type).find(params[:id]).try(:class)
+      controller = if klass && (VmCloud > klass || TemplateCloud > klass)
+                     'vm_cloud'
+                   else
+                     'vm_infra'
+                   end
+      redirect_to :controller => controller, :action => 'show', :id => params[:id]
     else
       redirect_to :controller => 'dashboard', :flash_msg => _("Could not find #{params[:model]}[id=#{params[:id]}]")
     end

--- a/app/controllers/restful_redirect_controller.rb
+++ b/app/controllers/restful_redirect_controller.rb
@@ -1,0 +1,10 @@
+class RestfulRedirectController < ApplicationController
+  def index
+    case params[:model]
+    when 'MiqRequest'
+      redirect_to :controller => 'miq_request', :action => 'show', :id => params[:id]
+    else
+      redirect_to :controller => 'dashboard', :flash_msg => _("Could not find #{params[:model]}[id=#{params[:id]}]")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2364,6 +2364,12 @@ Vmdb::Application.routes.draw do
                save_post
     },
 
+    :restful_redirect => {
+      :get => %w(
+        index
+      )
+    },
+
     :service                  => {
       :get  => %w(
         download_data

--- a/spec/requests/restful_redirect_spec.rb
+++ b/spec/requests/restful_redirect_spec.rb
@@ -1,0 +1,30 @@
+describe RestfulRedirectController do
+  let(:user) { FactoryGirl.create(:user_with_email, :role => 'super_administrator', :password => 'x') }
+
+  before do
+    EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  before :each do
+    post '/dashboard/authenticate', :params => { :user_name => user.userid, :user_password => user.password }
+  end
+
+  context 'for MiqRequest' do
+    let(:ems)      { FactoryGirl.create(:ems_vmware_with_authentication) }
+    let(:template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+    let(:req) { FactoryGirl.create(:miq_provision_request, :requester => user, :source => template) }
+
+    before do
+      MiqDialog.seed
+    end
+
+    it 'redirects' do
+      get '/restful_redirect', :params => { :model => 'MiqRequest', :id => req.id }
+      expect(response).to redirect_to(:controller => 'miq_request', :action => 'show', :id => req.id)
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:show)
+      expect(response.body).to include(req.message)
+    end
+  end
+end


### PR DESCRIPTION
To support links from notifications we will need a generic way to link to an entity. The MiqRequest is one of the entities user will want to be notified about. More to come.

@miq-bot add_label enhancement, ui, euwe/yes
@miq-bot assign @martinpovolny