### PR TITLE
Automate - Added checks and logging for amazon retirement.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_pre_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/amazon_pre_retirement.rb
@@ -4,12 +4,27 @@
 #
 
 vm = $evm.root['vm']
-if vm && vm.attributes['power_state'] == 'on'
-  ems = vm.ext_management_system
+ems = vm.ext_management_system if vm
+
+if vm.nil? || ems.nil?
+  $evm.log('info', "Skipping Amazon pre retirement for Instance:<#{vm.try(:name)}> on EMS:<#{ems.try(:name)}> "\
+              "with instance store type <#{vm.hardware.root_device_type}>")
+  exit MIQ_OK
+end
+
+power_state = vm.power_state
+if power_state == "on"
+  if vm.hardware.root_device_type.blank?
+    $evm.log('error', "Aborting Amazon pre retirement, empty root_device_type."\
+                      "  Instance <#{vm.name}> may have been provisioned externally.")
+    exit MIQ_ABORT
+  end
+
   if vm.hardware.root_device_type == "ebs"
-    $evm.log('info', "Stopping Amazon Instance <#{vm.name}> in EMS <#{ems.try(:name)}>")
-    vm.stop if ems
+    $evm.log('info', "Stopping EBS Amazon Instance <#{vm.name}> in EMS <#{ems.name}>")
+    vm.stop
   else
-    $evm.log('info', "Skipping stopping of non EBS Amazon Instance <#{vm.name}> in EMS <#{ems.try(:name)}>")
+    $evm.log('info', "Skipping stopping of non EBS Amazon Instance <#{vm.name}> in EMS <#{ems.name}> "\
+              "with instance store type <#{vm.hardware.root_device_type}>")
   end
 end

--- a/spec/automation/unit/method_validation/amazon_pre_retirement_spec.rb
+++ b/spec/automation/unit/method_validation/amazon_pre_retirement_spec.rb
@@ -2,7 +2,7 @@ describe "amazon_pre_retirement Method Validation" do
   before(:each) do
     @user = FactoryGirl.create(:user_with_group)
     @zone = FactoryGirl.create(:zone)
-    @ems  = FactoryGirl.create(:ems_vmware, :zone => @zone)
+    @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
     @ebs_hardware = FactoryGirl.create(:hardware, :bitness             => 64,
                                                   :virtualization_type => 'paravirtual',
                                                   :root_device_type    => 'ebs')
@@ -25,5 +25,11 @@ describe "amazon_pre_retirement Method Validation" do
     @vm.hardware = @is_hardware
     MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user)
     expect(MiqQueue.exists?(:method_name => 'stop', :instance_id => @vm.id, :role => 'ems_operations')).to be_falsey
+  end
+
+  it "calls abort for nil instances" do
+    @vm.hardware = nil
+    expect { MiqAeEngine.instantiate("#{@ins}?Vm::vm=#{@vm.id}#amazon", @user) }.to raise_error(
+      MiqAeException::AbortInstantiation)
   end
 end


### PR DESCRIPTION
Added checks for amazon retirement for nil vm, ems nil and root_device_type nil.

Added messages when one of these occur.

Abort and message if type is nil.

Added spec for nil type.

https://www.pivotaltracker.com/story/show/131399819