### PR TITLE
Move handle_options_request into ApiController

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,5 +1,9 @@
 module Api
   class ApiController < Api::BaseController
+    def options
+      head(:ok)
+    end
+
     def index
       res = {
         :name         => Settings.base.name,

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -48,10 +48,6 @@ module Api
     respond_to :json
     rescue_from_api_errors
 
-    def handle_options_request
-      head(:ok)
-    end
-
     private
 
     def validate_response_format

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2849,9 +2849,7 @@ Vmdb::Application.routes.draw do
 
   namespace :api, :path => "api(/:version)", :version => API_VERSION_REGEX, :defaults => {:format => "json"} do
     root :to => "api#index"
-
-    # OPTIONS requests for REST API pre-flight checks
-    match '/' => 'base#handle_options_request', :via => :options
+    match "/", :to => "api#options", :via => :options
 
     unless defined?(API_ACTIONS)
       API_ACTIONS = {


### PR DESCRIPTION
Moves this action into the ApiController (since it is only matched
against `OPTIONS /api/`) and renames to simply `options`, making it
polymorphic with other API controllers' options actions.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 