### PR TITLE
Disable same origin as host matching in development

### DIFF
--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -38,9 +38,7 @@ class WebsocketServer
   end
 
   def call(env)
-    proto = Rack::Request.new(env).ssl? ? 'https' : 'http'
-    # Same-origin policy checking for WebSockets
-    if WebSocket::Driver.websocket?(env) && env['HTTP_ORIGIN'] == "#{proto}://#{env['HTTP_HOST']}"
+    if WebSocket::Driver.websocket?(env) && same_origin_as_host?(env)
 
       # ActionCable causes live reload crashes
       if env['REQUEST_URI'] =~ %r{^/ws/notifications}
@@ -96,5 +94,11 @@ class WebsocketServer
 
   def not_found
     [404, {'Content-Type' => 'text/plain'}, ['Not found']]
+  end
+
+  # Primitive same-origin policy checking in production
+  def same_origin_as_host?(env)
+    proto = Rack::Request.new(env).ssl? ? 'https' : 'http'
+    Rails.env.development? || env['HTTP_ORIGIN'] == "#{proto}://#{env['HTTP_HOST']}"
   end
 end


### PR DESCRIPTION
Matching the HOST with the ORIGIN header causes the websocket server to reject connections from the SSUI when it's started using `gulp serve-dev`.