### PR TITLE
Reconnect orchestration stack with its template at post-provisioning

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -79,7 +79,7 @@ class ServiceOrchestration < Service
   # This is called when provision is completed and stack is added to VMDB through a refresh
   def post_provision_configure
     add_stack_to_resource
-
+    link_orchestration_template
     assign_vms_owner
   end
 
@@ -91,6 +91,12 @@ class ServiceOrchestration < Service
       :ems_id  => options.fetch_path(:orchestration_stack, 'ems_id')
     )
     add_resource!(@orchestration_stack) if @orchestration_stack
+  end
+
+  def link_orchestration_template
+    # some orchestration stacks do not have associations with their templates in their provider, we can link them here
+    return if @orchestration_stack.nil? || @orchestration_stack.orchestration_template
+    @orchestration_stack.update_attributes(:orchestration_template => orchestration_template)
   end
 
   def assign_vms_owner

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -243,9 +243,18 @@ describe ServiceOrchestration do
       end
     end
 
-    it 'add the provisioned stack to service resources' do
+    it 'adds the provisioned stack to service resources' do
       service.post_provision_configure
       expect(service.service_resources.find_by(:resource_type => 'OrchestrationStack').resource).to eq(@resulting_stack)
+    end
+
+    it 'reconnects cataloged stack with the orchestration template' do
+      # purposely disconnect the template
+      @resulting_stack.update_attributes!(:orchestration_template => nil)
+
+      service.post_provision_configure
+      @resulting_stack.reload
+      expect(@resulting_stack.orchestration_template).to eq(template_in_st)
     end
   end
 end


### PR DESCRIPTION
This is a follow-up PR for #11203. For some providers like Azure and vApp there might be no linkage between an orchestration stack and its template. We can however link them if the stack is provisioned through manageiq catalog service. At post-provisioning step we will reassure this linkage is still there, otherwise relink them. 

~~This PR has a dependency on #11598 because of the refactoring of the spec test.~~

/cc @gmcculloug 