### PR TITLE
Replaced validate_shutdown_guest by supports_shutdown_guest

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
@@ -1,4 +1,6 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations
+  extend ActiveSupport::Concern
+
   include_concern 'Guest'
   include_concern 'Power'
   include_concern 'Snapshot'

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/guest.rb
@@ -1,6 +1,11 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Guest
-  def validate_shutdown_guest
-    validate_vm_control_powered_on
+  extend ActiveSupport::Concern
+
+  included do
+    supports :shutdown_guest do
+      unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:shutdown_guest, _("The VM is not powered on")) unless current_state == "on"
+    end
   end
 
   def raw_shutdown_guest

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -6,14 +6,15 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
       unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
       unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
     end
-  end
 
-  def validate_shutdown_guest
-    msg = validate_vm_control
-    return {:available => msg[0], :message => msg[1]} unless msg.nil?
-    return {:available => true, :message => ''} if tools_status && tools_status == 'toolsNotInstalled'
-    return {:available => true, :message => nil} if current_state == 'on'
-    {:available => false, :message => 'The VM is not powered on'}
+    supports :shutdown_guest do
+      unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports_control?
+      unless tools_status && tools_status == 'toolsNotInstalled'
+        if current_state != "on"
+          unsupported_reason_add(:shutdown_guest, _("The VM is not powered on"))
+        end
+      end
+    end
   end
 
   def validate_standby_guest

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -19,10 +19,6 @@ module MiqTemplate::Operations
     validate_invalid_for_template(_("Pause Operation"))
   end
 
-  def validate_shutdown_guest
-    validate_invalid_for_template(_("Shutdown Guest Operation"))
-  end
-
   def validate_standby_guest
     validate_invalid_for_template(_("Standby Guest Operation"))
   end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -88,6 +88,7 @@ module SupportsFeatureMixin
     :retire                     => 'Retirement',
     :smartstate_analysis        => 'Smartstate Analaysis',
     :snapshots                  => 'Snapshots',
+    :shutdown_guest             => 'Shutdown Guest Operation',
     :terminate                  => 'Terminate a VM',
     :update_aggregate           => 'Host Aggregate Update',
     :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -7,10 +7,6 @@ module Vm::Operations::Guest
     api_relay_method :reset
   end
 
-  def validate_shutdown_guest
-    validate_unsupported("Shutdown Guest Operation")
-  end
-
   def validate_standby_guest
     validate_unsupported("Standby Guest Operation")
   end


### PR DESCRIPTION
As a part of efforts to replace old validate_* methods by supports_* methods provided by the SupportsFeatureMixin, replaced validate_shutdown_guest methods by supports_shutdown_guest.
