### PR TITLE
Remove workaround for provider_object being an Array

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -21,13 +21,10 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
     end
 
     def remote_console_acquire_ticket(userid, console_type)
-      # FIXME: a temporary work-around for #8151 (provider_object being an Array)
-      provider = provider_object.kind_of?(Array) ? provider_object.first : provider_object
-
       validate_remote_console_acquire_ticket(console_type)
 
-      parsed_ticket = Nokogiri::XML(provider.ticket)
-      display = provider.attributes[:display]
+      parsed_ticket = Nokogiri::XML(provider_object.ticket)
+      display = provider_object.attributes[:display]
 
       SystemConsole.where(:vm_id => id).each(&:destroy)
       # TODO: non-blocking SSL support in the proxy


### PR DESCRIPTION
A workaround for the `provider_object` being an `Array` bug in `ManageIQ::Providers::Redhat::InfraManager::Vm::RemoteConsole` (#8151) was introduced as part of #8306.

Now that the issue is closed (fixed in #8483 - `darga/backported`), removing the workaround.