### PR TITLE
Consider single digit to be valid compressed_id?

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -83,8 +83,7 @@ module ArRegion
 
     def split_id(id)
       return [my_region_number, nil] if id.nil?
-      id = uncompress_id(id) if compressed_id?(id)
-      id = id.to_i
+      id = uncompress_id(id)
 
       region_number = id_to_region(id)
       short_id      = (region_number == 0) ? id : id % (region_number * rails_sequence_factor)
@@ -97,7 +96,7 @@ module ArRegion
     #
 
     def compressed_id?(id)
-      id.to_s =~ RE_COMPRESSED_ID
+      id.to_s =~ /^#{CID_OR_ID_MATCHER}$/
     end
 
     def compress_id(id)

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -22,24 +22,16 @@ describe "AR Regions extension" do
   end
 
   it ".compressed_id?" do
-    expect(base_class.compressed_id?(5)).to     be_falsey
-    expect(base_class.compressed_id?(15)).to    be_falsey
-    expect(base_class.compressed_id?(25)).to    be_falsey
-    expect(base_class.compressed_id?("5")).to   be_falsey
-    expect(base_class.compressed_id?("1r5")).to be_truthy
-    expect(base_class.compressed_id?("2r5")).to be_truthy
-  end
-
-  describe 'CID_OR_ID_MATCHER' do
-    subject { /^#{ArRegion::CID_OR_ID_MATCHER}$/ }
-    it { is_expected.to match('1') }
-    it { is_expected.to match('100023') }
-    it { is_expected.to match('1r23') }
-    it { is_expected.to match('10r10') }
-    it { is_expected.not_to match('hello') }
-    it { is_expected.not_to match('r1') }
-    it { is_expected.not_to match('1r') }
-    it { is_expected.not_to match('1rr1') }
+    expect(base_class.compressed_id?(5)).to        be_truthy
+    expect(base_class.compressed_id?(15)).to       be_truthy
+    expect(base_class.compressed_id?("5")).to      be_truthy
+    expect(base_class.compressed_id?('100023')).to be_truthy
+    expect(base_class.compressed_id?('1r23')).to   be_truthy
+    expect(base_class.compressed_id?('10r10')).to  be_truthy
+    expect(base_class.compressed_id?('hello')).to  be_falsey
+    expect(base_class.compressed_id?('r1')).to     be_falsey
+    expect(base_class.compressed_id?('1r')).to     be_falsey
+    expect(base_class.compressed_id?('1rr1')).to   be_falsey
   end
 
   it ".split_id" do


### PR DESCRIPTION
When region is 0 we compress_id("00007") to 7. Thus, "7" is valid compressed ID.

We discussed this a minute ago on gitter, @imtayadeway @abellotti @Fryguy 

@miq-bot add_label euwe/yes
