### PR TITLE
Replaced validate_reset methods by supports_reset

### DIFF
--- a/app/helpers/application_helper/button/instance_reset.rb
+++ b/app/helpers/application_helper/button/instance_reset.rb
@@ -3,6 +3,6 @@ class ApplicationHelper::Button::InstanceReset < ApplicationHelper::Button::Basi
 
   def visible?
     return true if @display == "instances"
-    @record.is_available?(:reset)
+    @record.supports_reset?
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
@@ -6,10 +6,11 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Guest
       unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
       unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
     end
-  end
 
-  def validate_reset
-    validate_vm_control_powered_on
+    supports :reset do
+      unsupported_reason_add(:reset, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reset, _("The VM is not powered on")) unless current_state == "on"
+    end
   end
 
   def raw_reboot_guest

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -156,8 +156,4 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
   def validate_shutdown
     {:available => false,   :message => nil}
   end
-
-  def validate_reset
-    {:available => false,   :message => nil}
-  end
 end

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/operations/guest.rb
@@ -15,13 +15,14 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Operations::Guest
         end
       end
     end
+
+    supports :reset do
+      unsupported_reason_add(:reset, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reset, _("The VM is not powered on")) unless current_state == "on"
+    end
   end
 
   def validate_standby_guest
-    validate_vm_control_powered_on
-  end
-
-  def validate_reset
     validate_vm_control_powered_on
   end
 end

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -25,10 +25,6 @@ module MiqTemplate::Operations
     validate_invalid_for_template(_("Standby Guest Operation"))
   end
 
-  def validate_reset
-    validate_invalid_for_template(_("Reset Operation"))
-  end
-
   private
 
   def validate_invalid_for_template(message_prefix)

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -88,6 +88,7 @@ module SupportsFeatureMixin
     :refresh_new_target         => 'Refresh non-existing record',
     :regions                    => 'Regions of a Provider',
     :remove_host                => 'Remove Host',
+    :reset                      => 'Reset',
     :resize                     => 'Resizing',
     :retire                     => 'Retirement',
     :smartstate_analysis        => 'Smartstate Analaysis',

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -11,10 +11,6 @@ module Vm::Operations::Guest
     validate_unsupported("Standby Guest Operation")
   end
 
-  def validate_reset
-    validate_unsupported("Reset Guest Operation")
-  end
-
   def raw_shutdown_guest
     unless has_active_ems?
       raise _("VM has no %{table}, unable to shutdown guest OS") %

--- a/spec/helpers/application_helper/buttons/instance_reset_spec.rb
+++ b/spec/helpers/application_helper/buttons/instance_reset_spec.rb
@@ -3,7 +3,7 @@ describe ApplicationHelper::Button::InstanceReset do
     context "when record is resetable" do
       before do
         @record = FactoryGirl.create(:vm_openstack)
-        allow(@record).to receive(:is_available?).with(:reset).and_return(true)
+        allow(@record).to receive(:supports_reset?).and_return(true)
       end
 
       it_behaves_like "will not be skipped for this record"
@@ -12,7 +12,7 @@ describe ApplicationHelper::Button::InstanceReset do
     context "when record is not resetable" do
       before do
         @record = FactoryGirl.create(:vm_openstack)
-        allow(@record).to receive(:is_available?).with(:reset).and_return(false)
+        allow(@record).to receive(:supports_reset?).and_return(false)
       end
 
       it_behaves_like "will be skipped for this record"

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -594,9 +594,9 @@ describe Host do
       end
     end
 
-    describe "#validate_reset" do
-      it "returns available true" do
-        expect(host_with_ipmi.validate_reset).to eq(:available => true, :message => nil)
+    describe "#supports_reset" do
+      it "returns true for supports_reset?" do
+        expect(host_with_ipmi.supports_reset?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Replaced all instanced of validate_reset method by supports_reset in order to make use supportsFeatureMixin.

It's not yet mergeable because it has changes of another commit which is not pushed in yet.
