### PR TITLE
When automate method fails write to STDERR when running under Travis

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -187,6 +187,7 @@ module MiqAeEngine
         method_pid = nil
         threads = []
       rescue => err
+        STDERR.puts "** AUTOMATE ** Method exec failed because #{err.class}:#{err.message}" if ENV.key?("CI")
         $miq_ae_logger.error("Method exec failed because (#{err.class}:#{err.message})")
         rc = MIQ_ABORT
         msg = "Method execution failed"


### PR DESCRIPTION
Testing a sporadic Travis failure when launching Automate Methods. Write the error to stderr when running under Travis

