### PR TITLE
support virtual attributes for aggregation

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -610,6 +610,14 @@ module ActiveRecord
 
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
+        # work around 1 until https://github.com/rails/rails/pull/25304 gets merged
+        # This allows attribute_name to be a virtual_attribute
+        if (arel = klass.arel_attribute(attribute_name)) && virtual_attribute?(attribute_name)
+          attribute_name = arel
+        end
+        # end work around 1
+
+        # allow calculate to work when including a virtual attribute
         real = without_virtual_includes
         return super if real.equal?(self)
 

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -685,6 +685,23 @@ describe VirtualFields do
         expect(tc.parent_col1).to eq("def")
       end
     end
+
+    describe "#sum" do
+      it "supports virtual attributes" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(arel_attribute(:col1)) })
+          def col2
+            col1
+          end
+        end
+
+        TestClass.create(:id => 1, :col1 => nil)
+        TestClass.create(:id => 2, :col1 => 20)
+        TestClass.create(:id => 3, :col1 => 30)
+
+        expect(TestClass.sum(:col2)).to eq(50)
+      end
+    end
   end
 
   describe "#follow_associations" do


### PR DESCRIPTION
We are starting to use more aggregates for speeding up the performance of pages.
This teaches aggregates how to use virtual attributes.

In order to support `includes(virtual_attribute_name)`, @matthewd already patched `calculate` - this is extending it.

Getting this into rails has been slow going, but recently updated it and hoping this new version will be an easier sell. ref: rails/rails#25304 [merged, waiting for next version of rails]

```ruby
ems = Ems.first
ems.hardware.disks.sum(:used_disk_storage)
```
