### PR TITLE
Support virtual attributes for select

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -608,6 +608,23 @@ module ActiveRecord
         recs
       end
 
+      # From ActiveRecord::QueryMethods
+      def select(*fields)
+        return super if block_given? || fields.empty?
+        # support virtual attributes by adding an alias to the sql phrase for the column
+        # this code is based upon _select()
+        fields.flatten!
+        fields.map! do |field|
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field))
+            arel.as(field.to_s)
+          else
+            field
+          end
+        end
+        # end support virtual attributes
+        super
+      end
+
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
         real = without_virtual_includes

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -554,7 +554,7 @@ describe VirtualFields do
         it "delegates to child (sql)" do
           TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
           TestClass.create(:id => 2, :ref2 => child)
-          tcs = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:child_col1).as("child_col1")).to_a
+          tcs = TestClass.all.select(:id, :col1, :child_col1).to_a
           expect { expect(tcs.map(&:child_col1)).to match_array([nil, 2]) }.to match_query_limit_of(0)
         end
 
@@ -562,7 +562,7 @@ describe VirtualFields do
         # just want to make sure it changed due to intentional changes
         it "uses table alias for subquery" do
           TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
-          sql = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:child_col1).as("x")).to_sql
+          sql = TestClass.all.select(:id, :col1, :child_col1).to_sql
           expect(sql).to match(/"test_classes_[^"]*"."col1"/i)
         end
       end
@@ -637,6 +637,27 @@ describe VirtualFields do
         TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
+      end
+    end
+
+    describe "#select" do
+      it "supports virtual attributes" do
+        class TestClass
+          virtual_attribute :col2, :integer, :arel => (-> (t) { t.grouping(arel_attribute(:col1)) })
+          def col2
+            if has_attribute?("col2")
+              col2
+            else
+              # typically we'd return col1
+              # but we're testing that virtual columns are working
+              # col1
+              raise "NOPE"
+            end
+          end
+        end
+
+        TestClass.create(:id => 2, :col1 => 20)
+        expect(TestClass.select(:col2).first[:col2]).to eq(20)
       end
     end
 

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -6,7 +6,7 @@ describe VirtualTotalMixin do
       ems2 = model_with_children(2)
       ems1 = model_with_children(1)
 
-      expect(base_model.order(base_model.arel_attribute(:total_vms)).pluck(:id))
+      expect(base_model.order(:total_vms).pluck(:id))
         .to eq([ems0, ems1, ems2].map(&:id))
     end
 


### PR DESCRIPTION
We are starting to push more virtual attributes into the select clauses.
This teaches `select` how to use virtual attributes.

Have not found an elegant way to introduce this to rails. Working on it.

```ruby
class Disk
  virtual_delegate :used_disk_storage, :arel => (-> { ... })
end

ems = ExtManagementSystem.first
ems.hardware.disks.select(:id, :used_disk_storage).map(&:used_disk_storage)
```