### PR TITLE
OpenStack Infra: Enable node start and stop

### DIFF
--- a/app/helpers/application_helper/button/host_feature_button.rb
+++ b/app/helpers/application_helper/button/host_feature_button.rb
@@ -1,8 +1,18 @@
 class ApplicationHelper::Button::HostFeatureButton < ApplicationHelper::Button::GenericFeatureButton
-  needs :@record
 
   def visible?
-    return false if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
-    super
+    unless @feature.nil? || @record.nil?
+      if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
+        return true if %w(start stop).include?(@feature.to_s)
+        return false
+      end
+
+      return @record.is_available?(@feature) if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)
+    end
+    true
+  end
+
+  def disabled?
+    false
   end
 end

--- a/app/helpers/application_helper/button/host_feature_button_with_disable.rb
+++ b/app/helpers/application_helper/button/host_feature_button_with_disable.rb
@@ -1,8 +1,14 @@
 class ApplicationHelper::Button::HostFeatureButtonWithDisable < ApplicationHelper::Button::GenericFeatureButtonWithDisable
-  needs :@record
 
   def visible?
-    return false if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
-    super
+    unless @feature.nil? || @record.nil?
+      return false if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
+      return @record.is_available?(@feature) if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager::Host)
+    end
+    true
+  end
+
+  def disabled?
+    false
   end
 end

--- a/app/helpers/application_helper/toolbar/hosts_center.rb
+++ b/app/helpers/application_helper/toolbar/hosts_center.rb
@@ -178,7 +178,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :confirm   => N_("Shutdown the selected items to Standy Mode?"),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::HostFeatureButton,
+          :options   => {:feature => :standby}),
         button(
           :host_shutdown,
           nil,
@@ -188,7 +190,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :url_parms => "main_div",
           :confirm   => N_("Shutdown the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::HostFeatureButtonWithDisable,
+          :options   => {:feature => :shutdown}),
         button(
           :host_reboot,
           nil,
@@ -198,7 +202,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           :url_parms => "main_div",
           :confirm   => N_("Restart the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::HostFeatureButton,
+          :options   => {:feature => :reboot}),
         separator,
         button(
           :host_start,
@@ -207,7 +213,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Power On'),
           :image     => "power_on",
           :url_parms => "main_div",
-          :confirm   => N_("Power On the selected items?")),
+          :confirm   => N_("Power On the selected items?"),
+          :klass     => ApplicationHelper::Button::HostFeatureButton,
+          :options   => {:feature => :start}),
         button(
           :host_stop,
           nil,
@@ -215,7 +223,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Power Off'),
           :image     => "power_off",
           :url_parms => "main_div",
-          :confirm   => N_("Power Off the selected items?")),
+          :confirm   => N_("Power Off the selected items?"),
+          :klass     => ApplicationHelper::Button::HostFeatureButton,
+          :options   => {:feature => :stop}),
         button(
           :host_reset,
           nil,
@@ -223,7 +233,9 @@ class ApplicationHelper::Toolbar::HostsCenter < ApplicationHelper::Toolbar::Basi
           N_('Reset'),
           :image     => "power_reset",
           :url_parms => "main_div",
-          :confirm   => N_("Reset the selected items?")),
+          :confirm   => N_("Reset the selected items?"),
+          :klass     => ApplicationHelper::Button::HostFeatureButtonWithDisable,
+          :options   => {:feature => :reset}),
       ]
     ),
   ])

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -144,4 +144,13 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
 
     [state, response.body.to_s]
   end
+
+  # unsupported Host operations, validate is called in hosts_center view
+  def validate_shutdown
+    {:available => false,   :message => nil}
+  end
+
+  def validate_reset
+    {:available => false,   :message => nil}
+  end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -1,6 +1,8 @@
 require 'openstack/openstack_configuration_parser'
 
 class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
+  include HostOperationsMixin
+
   belongs_to :availability_zone
 
   has_many :host_service_group_openstacks, :foreign_key => :host_id, :dependent => :destroy,
@@ -209,15 +211,15 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
     task = MiqTask.create(:name => "Setting node '#{name}' to manageable", :userid => userid)
 
-    $log.info("Requesting manageable of #{log_target}")
+    _log.info("Requesting manageable of #{log_target}")
     begin
       MiqEvent.raise_evm_job_event(self, :type => "manageable", :prefix => "request")
     rescue => err
-      $log.warn("Error raising request manageable for #{log_target}: #{err.message}")
+      _log.warn("Error raising request manageable for #{log_target}: #{err.message}")
       return
     end
 
-    $log.info("Queuing provide of #{log_target}")
+    _log.info("Queuing provide of #{log_target}")
     timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_manageable, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
     MiqQueue.put(
@@ -239,7 +241,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
     log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
 
-    $log.info("Setting to manageable #{log_target}...")
+    _log.info("Setting to manageable #{log_target}...")
 
     task.update_status("Active", "Ok", "Setting to manageable") if task
 
@@ -262,12 +264,12 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       begin
         MiqEvent.raise_evm_job_event(self, :type => "manageable", :suffix => "complete")
       rescue => err
-        $log.warn("Error raising complete manageable event for #{log_target}: #{err.message}")
+        _log.warn("Error raising complete manageable event for #{log_target}: #{err.message}")
       end
     end
 
     task.update_status("Finished", task_status, "Setting to Manageable Complete with #{status}") if task
-    $log.info("Setting to Manageable #{log_target}...Complete - Timings: #{t.inspect}")
+    _log.info("Setting to Manageable #{log_target}...Complete - Timings: #{t.inspect}")
   end
 
   def introspect_queue(userid = "system", _options = {})
@@ -275,15 +277,15 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
     task = MiqTask.create(:name => "Hardware Introspection for '#{name}' ", :userid => userid)
 
-    $log.info("Requesting Hardware Introspection of #{log_target}")
+    _log.info("Requesting Hardware Introspection of #{log_target}")
     begin
       MiqEvent.raise_evm_job_event(self, :type => "introspect", :prefix => "request")
     rescue => err
-      $log.warn("Error raising request introspection for #{log_target}: #{err.message}")
+      _log.warn("Error raising request introspection for #{log_target}: #{err.message}")
       return
     end
 
-    $log.info("Queuing introspection of #{log_target}")
+    _log.info("Queuing introspection of #{log_target}")
     timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_introspect, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
     MiqQueue.put(
@@ -305,7 +307,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
     log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
 
-    $log.info("Introspecting #{log_target}...")
+    _log.info("Introspecting #{log_target}...")
 
     task.update_status("Active", "Ok", "Introspecting") if task
 
@@ -337,12 +339,12 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       begin
         MiqEvent.raise_evm_job_event(self, :type => "introspect", :suffix => "complete")
       rescue => err
-        $log.warn("Error raising complete introspect event for #{log_target}: #{err.message}")
+        _log.warn("Error raising complete introspect event for #{log_target}: #{err.message}")
       end
     end
 
     task.update_status("Finished", task_status, "Introspecting Complete with #{workflow_state}") if task
-    $log.info("Introspecting #{log_target}...Complete - Timings: #{t.inspect}")
+    _log.info("Introspecting #{log_target}...Complete - Timings: #{t.inspect}")
   end
 
   def provide_queue(userid = "system", _options = {})
@@ -350,15 +352,15 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
     task = MiqTask.create(:name => "Providing node '#{name}' ", :userid => userid)
 
-    $log.info("Requesting Provide of #{log_target}")
+    _log.info("Requesting Provide of #{log_target}")
     begin
       MiqEvent.raise_evm_job_event(self, :type => "provide", :prefix => "request")
     rescue => err
-      $log.warn("Error raising request provide for #{log_target}: #{err.message}")
+      _log.warn("Error raising request provide for #{log_target}: #{err.message}")
       return
     end
 
-    $log.info("Queuing provide of #{log_target}")
+    _log.info("Queuing provide of #{log_target}")
     timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_provide, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
     MiqQueue.put(
@@ -380,7 +382,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
     log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
 
-    $log.info("Provide #{log_target}...")
+    _log.info("Provide #{log_target}...")
 
     task.update_status("Active", "Ok", "Provide") if task
 
@@ -412,12 +414,36 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       begin
         MiqEvent.raise_evm_job_event(self, :type => "provide", :suffix => "complete")
       rescue => err
-        $log.warn("Error raising complete provide event for #{log_target}: #{err.message}")
+        _log.warn("Error raising complete provide event for #{log_target}: #{err.message}")
       end
     end
 
     task.update_status("Finished", task_status, "Provide Complete with #{workflow_state}") if task
-    $log.info("Provide #{log_target}...Complete - Timings: #{t.inspect}")
+    _log.info("Provide #{log_target}...Complete - Timings: #{t.inspect}")
+  end
+
+  def validate_start
+    if state.casecmp("off") == 0
+      {:available => true,   :message => nil}
+    else
+      {:available => false,  :message => _("Cannot start. Already on.")}
+    end
+  end
+
+  def start(userid = "system")
+    ironic_set_power_state_queue(userid, "power on", "Starting", "start", :host_start)
+  end
+
+  def validate_stop
+    if state.casecmp("on") == 0
+      {:available => true,   :message => nil}
+    else
+      {:available => false,  :message => _("Cannot stop. Already off.")}
+    end
+  end
+
+  def stop(userid = "system")
+    ironic_set_power_state_queue(userid, "power off", "Stopping", "stop", :host_stop)
   end
 
   def validate_destroy

--- a/app/models/manageiq/providers/openstack/infra_manager/host_operations_mixin.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host_operations_mixin.rb
@@ -1,0 +1,79 @@
+module ManageIQ::Providers::Openstack::InfraManager::HostOperationsMixin
+  include Vmdb::Logging
+
+  def ironic_set_power_state_queue(userid = "system",
+                                   power_state = "power off",
+                                   power_state_text_verb = "Stopping",
+                                   power_state_text = "stop",
+                                   feature = :host_stop)
+    log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
+
+    task = MiqTask.create(:name => "#{power_state_text_verb} Ironic node '#{name}'", :userid => userid)
+
+    _log.info("#{power_state_text_verb} Ironic node #{log_target}")
+    begin
+      MiqEvent.raise_evm_job_event(self, :type => power_state_text, :prefix => "request")
+    rescue => err
+      _log.warn("Error raising request #{power_state_text} for #{log_target}: #{err.message}")
+      return
+    end
+
+    _log.info("Queuing #{power_state_text} for #{log_target}")
+    timeout = (VMDB::Config.new("vmdb").config.fetch_path(feature, :queue_timeout) || 20.minutes).to_i_with_method
+    cb = {:class_name  => task.class.name,
+          :instance_id => task.id,
+          :method_name => :queue_callback_on_exceptions,
+          :args        => ['Finished']}
+    MiqQueue.put(
+      :class_name   => self.class.name,
+      :instance_id  => id,
+      :args         => [task.id, power_state, power_state_text_verb, power_state_text],
+      :method_name  => "ironic_set_power_state",
+      :miq_callback => cb,
+      :msg_timeout  => timeout,
+      :zone         => my_zone
+    )
+  end
+
+  def ironic_set_power_state(taskid = nil,
+                             power_state = "power off",
+                             power_state_text_verb = "Stopping",
+                             power_state_text = "stop")
+    unless taskid.nil?
+      task = MiqTask.find_by_id(taskid)
+      task.state_active if task
+    end
+
+    log_target = "#{self.class.name} name: [#{name}], id: [#{id}]"
+
+    _log.info("#{power_state_text_verb} #{log_target}...")
+
+    task.update_status("Active", "Ok", power_state_text.capitalize) if task
+
+    status = "Fail"
+    task_status = "Ok"
+    _dummy, t = Benchmark.realtime_block(:total_time) do
+      begin
+        connection = ext_management_system.openstack_handle.detect_baremetal_service
+        response = connection.set_node_power_state(name, power_state)
+
+        if response.status == 202
+          status = "Success"
+          EmsRefresh.queue_refresh(ext_management_system)
+        end
+      rescue => err
+        task_status = "Error"
+        status = err
+      end
+
+      begin
+        MiqEvent.raise_evm_job_event(self, :type => power_state_text, :suffix => "complete")
+      rescue => err
+        _log.warn("Error raising complete #{power_state_text} event for #{log_target}: #{err.message}")
+      end
+    end
+
+    task.update_status("Finished", task_status, "#{power_state_text.capitalize} Complete with #{status}") if task
+    _log.info("#{power_state_text_verb} #{log_target}...Complete - Timings: #{t.inspect}")
+  end
+end

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
@@ -491,14 +491,17 @@ openstack-keystone:                     active
     end
 
     it "check task executes and queues refresh if success" do
-      allow_any_instance_of(ManageIQ::Providers::Openstack::InfraManager).to receive(:openstack_handle).and_return([])
-      allow_any_instance_of(Array).to receive(:detect_workflow_service).and_return([])
-      allow_any_instance_of(Array).to receive(:detect_baremetal_service).and_return([])
-
-      allow_any_instance_of(Array).to receive(:create_execution).and_return([])
-      allow_any_instance_of(Array).to receive(:set_node_provision_state).and_return([])
-      body = {"state" => "SUCCESS", "id" => '1'}
-      allow_any_instance_of(Array).to receive(:body).and_return(body)
+      response = double("response")
+      expect(response).to receive(:body).at_least(1).times { {"state" => "SUCCESS", "id" => 1} }
+      expect(response).to receive(:status).and_return(202)
+      workflow_service = double("workflow_service")
+      expect(workflow_service).to receive(:create_execution).at_least(1).times { response }
+      baremetal_service = double("baremetal_service")
+      expect(baremetal_service).to receive(:set_node_provision_state) { response }
+      openstack_handle = double("openstack handle")
+      expect(openstack_handle).to receive(:detect_workflow_service).at_least(1).times { workflow_service }
+      expect(openstack_handle).to receive(:detect_baremetal_service) { baremetal_service }
+      allow(ext_management_system).to receive(:openstack_handle).and_return(openstack_handle)
       expect(MiqQueue.where(:method_name => "refresh").count).to eq(0)
 
       task = FactoryGirl.create(:miq_task)
@@ -511,7 +514,6 @@ openstack-keystone:                     active
       host.provide(task.id)
       expect(MiqQueue.where(:method_name => "refresh").count).to eq(1)
 
-      allow_any_instance_of(Array).to receive(:status).and_return(202)
       MiqQueue.all.map(&:delete)
       expect(MiqQueue.where(:method_name => "refresh").count).to eq(0)
       task = FactoryGirl.create(:miq_task)
@@ -530,6 +532,24 @@ openstack-keystone:                     active
 
       host.destroy_ironic
       expect(MiqQueue.where(:method_name => "destroy").count).to eq(1)
+    end
+
+    it "check ironic_set_power_state is queued" do
+      expect(MiqQueue.where(:method_name => "ironic_set_power_state").count).to eq(0)
+      host.ironic_set_power_state_queue
+      expect(MiqQueue.where(:method_name => "ironic_set_power_state").count).to eq(1)
+    end
+
+    it "check ironic_set_power_state executes and queues refresh if success" do
+      baremetal_service = double("baremetal_service")
+      expect(baremetal_service).to receive(:set_node_power_state) { double(:status => 202) }
+      openstack_handle = double("openstack handle")
+      expect(openstack_handle).to receive(:detect_baremetal_service) { baremetal_service }
+      allow(ext_management_system).to receive(:openstack_handle).and_return(openstack_handle)
+      expect(MiqQueue.where(:method_name => "refresh").count).to eq(0)
+
+      host.ironic_set_power_state
+      expect(MiqQueue.where(:method_name => "refresh").count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Enables starting and stopping nodes through the Ironic API.

Previously, all node operations were disabled for OpenStack. For
now, we are enabling only start and stop.