### PR TITLE
Fix Group by tag in chargeback report

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -981,9 +981,10 @@ module ReportController::Reports::Editor
       elsif @edit[:new][:cb_show_typ] == "entity"
         options[:provider_id] = @edit[:new][:cb_provider_id]
         options[:entity_id] = @edit[:new][:cb_entity_id]
-        options[:groupby_tag] = @edit[:new][:cb_groupby_tag]
-        options[:groupby] = @edit[:new][:cb_groupby]
       end
+
+      options[:groupby] = @edit[:new][:cb_groupby]
+      options[:groupby_tag] = @edit[:new][:cb_groupby] == 'tag' ? @edit[:new][:cb_groupby_tag] : nil
 
       rpt.db_options[:options] = options
     end
@@ -1256,10 +1257,9 @@ module ReportController::Reports::Editor
         @edit[:new][:cb_show_typ] = "entity"
         @edit[:new][:cb_entity_id] = options[:entity_id]
         @edit[:new][:cb_provider_id] = options[:provider_id]
-        @edit[:new][:cb_groupby] = options[:groupby]
-        @edit[:new][:cb_groupby_tag] = options[:groupby_tag]
       end
 
+      @edit[:new][:cb_groupby_tag] = options[:groupby_tag] if options.key?(:groupby_tag)
       @edit[:new][:cb_model] = Chargeback.report_cb_model(@rpt.db)
       @edit[:new][:cb_interval] = options[:interval]
       @edit[:new][:cb_interval_size] = options[:interval_size]

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1601,6 +1601,11 @@ module ReportController::Reports::Editor
                 _("A specific #{ui_lookup(:model => @edit[:new][:cb_model])} or all must be selected")
               end
             end
+
+      if @edit[:new][:cb_groupby] == "tag" && !@edit[:new][:cb_groupby_tag].present?
+        msg = _('A Group by Tag must be selected')
+      end
+
       if msg
         add_flash(msg, :error)
         active_tab = 'edit_3'

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -276,7 +276,7 @@ class Chargeback < ActsAsArModel
     rpt.col_order.each do |c|
       if c == tag_col
         header = edit[:cb_cats][edit[:new][:cb_groupby_tag]]
-        rpt.headers.push(Dictionary.gettext(header, :type => :column, :notfound => :titleize))
+        rpt.headers.push(Dictionary.gettext(header, :type => :column, :notfound => :titleize)) if header
       else
         rpt.headers.push(Dictionary.gettext(c, :type => :column, :notfound => :titleize))
       end

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -264,7 +264,7 @@ class Chargeback < ActsAsArModel
       rpt.sortby = static_cols + ["start_date"]
     elsif edit[:new][:cb_groupby] == "tag"
       tag_col = report_tag_field
-      rpt.cols += tag_col
+      rpt.cols += [tag_col]
       rpt.col_order = [tag_col, "display_range"]
       rpt.sortby = [tag_col, "start_date"]
     elsif edit[:new][:cb_groupby] == "project"

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -63,6 +63,22 @@ describe ReportController do
         expect(chargeback_report.tz).to eq("Eastern Time (US & Canada)")
       end
 
+      it "should save the 'Tag Group' option" do
+        ApplicationController.handle_exceptions = true
+
+        report_edit_options[:new][:cb_groupby] = "tag"
+        report_edit_options[:new][:cb_groupby_tag] = "department"
+        report_edit_options[:cb_cats] = {'department' => 'Department'}
+
+        controller.instance_variable_set(:@edit, report_edit_options)
+        session[:edit] = assigns(:edit)
+
+        post :miq_report_edit, :params => { :id => chargeback_report.id, :button => 'save' }
+
+        chargeback_report.reload
+        expect(chargeback_report.db_options[:options][:groupby_tag]).to eq('department')
+      end
+
       describe '#reportable_models' do
         subject { controller.send(:reportable_models) }
         it 'does not contain duplicate items' do


### PR DESCRIPTION
Fixes option 'Group by tag' in form of chargeback report:
* when storing report
* populate the option when editing report
* validating the if option 'Group by Tag ' is selected

@miq-bot assign_label ui, reporting, chargeback, wip


Test scenario:
let's take any chargeback (Vm or Project) report and focus on option Group by (Tag) :

**Group by Tag is not stored:**
![chargetag](https://cloud.githubusercontent.com/assets/14937244/19069704/41e51d26-8a28-11e6-9376-499d3e50f9f5.gif)

**unselected Group by Tag doesn't display validation message**
![emshfdu5ne](https://cloud.githubusercontent.com/assets/14937244/19071601/35639f7e-8a31-11e6-8235-bada91d54d46.gif)



