### PR TITLE
Fixed treeview node conversion in all open_parent_nodes calls

### DIFF
--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -33,12 +33,12 @@ module ApplicationController::TreeSupport
 
   def tree_autoload
     @edit ||= session[:edit] # Remember any previous @edit
-    nodes = tree_add_child_nodes(params[:id])
-    render :json => TreeBuilder.convert_bs_tree(nodes)
+    render :json => tree_add_child_nodes(params[:id])
   end
 
   def tree_add_child_nodes(id)
-    TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], id, controller_name)
+    nodes = TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], id, controller_name)
+    TreeBuilder.convert_bs_tree(nodes)
   end
 
   private ############################

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1798,11 +1798,7 @@ class CatalogController < ApplicationController
         end
       end
     end
-    add_nodes = {:key      => existing_node,
-                 :children => TreeBuilder.tree_add_child_nodes(@sb,
-                                                               x_tree[:klass_name],
-                                                               existing_node,
-                                                               controller_name)} if existing_node
+    add_nodes = {:key => existing_node, :nodes => tree_add_child_nodes(existing_node)} if existing_node
     self.x_node = if params[:rec_id]
                     "stc-#{to_cid(record.service_template_catalog_id)}_st-#{to_cid(record.id)}"
                   elsif record.kind_of?(OrchestrationTemplate)

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -244,7 +244,7 @@ class MiqAeClassController < ApplicationController
   def build_and_add_nodes(parents)
     existing_node = find_existing_node(parents)
     return nil if existing_node.nil?
-    children = TreeBuilder.tree_add_child_nodes(@sb, x_tree[:klass_name], existing_node, controller_name)
+    children = tree_add_child_nodes(existing_node)
     # set x_node after building tree nodes so parent node of new nodes can be selected in the tree.
     unless params[:action] == "x_show"
       if @record.kind_of?(MiqAeClass)
@@ -253,7 +253,7 @@ class MiqAeClassController < ApplicationController
         self.x_node = "aec-#{to_cid(@record.class_id)}"
       end
     end
-    {:key => existing_node, :children => children}
+    {:key => existing_node, :nodes => children}
   end
 
   def find_existing_node(parents)

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -623,8 +623,7 @@ class ReportController < ApplicationController
       end
     end
 
-    add_nodes = {:key      => existing_node,
-                 :children => tree_add_child_nodes(existing_node)} if existing_node
+    add_nodes = {:key => existing_node, :nodes => tree_add_child_nodes(existing_node)} if existing_node
     self.x_node = params[:id]
     add_nodes
   end

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1177,7 +1177,7 @@ module VmCommon
       end
     end
 
-    add_nodes = {:key => existing_node, :children => tree_add_child_nodes(existing_node)} if existing_node
+    add_nodes = {:key => existing_node, :nodes => tree_add_child_nodes(existing_node)} if existing_node
     add_nodes
   end
 

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -110,10 +110,11 @@ describe ReportController do
       TreeBuilderReportWidgets.new('widgets_tree', 'widgets', {})
       nodes = controller.send(:tree_add_child_nodes, 'xx-r')
       expected = [{:key     => "-#{controller.to_cid(widget.id)}",
-                   :title   => "Foo",
-                   :icon    => ActionController::Base.helpers.image_path('100/report_widget.png'),
+                   :text    => "Foo",
+                   :image   => ActionController::Base.helpers.image_path('100/report_widget.png'),
                    :tooltip => "Foo",
-                   :expand  => false}]
+                   :state   => {:expanded => false},
+                   :class   => ""}]
       expect(nodes).to eq(expected)
     end
   end


### PR DESCRIPTION
- Moved the treeview conversion to TreeSupport#tree_add_child_nodes
- Calling add_child_nodes in all open_parent_nodes definition
- This conversion will be removed upon the final refactoring

https://bugzilla.redhat.com/show_bug.cgi?id=1380485