### PR TITLE
Show shared networks in the OpenStack provisioning dialog

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -7,4 +7,8 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
 
   has_many :private_networks,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private"
+
+  def all_private_networks
+    private_networks + (try(:ext_management_system).try(:private_networks).try(:where, :shared => true) || [])
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -54,7 +54,7 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     # We want only non external networks to be connectable directly to the Vm
     return {} unless (src_obj = provider_or_tenant_object)
 
-    src_obj.private_networks.each_with_object({}) do |cn, hash|
+    src_obj.all_private_networks.each_with_object({}) do |cn, hash|
       hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
     end
   end

--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -19,6 +19,7 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"
   has_many :private_networks, :foreign_key => :ems_id, :dependent => :destroy,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Private"
+  alias_method :all_private_networks, :private_networks
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -16,6 +16,7 @@ module HasNetworkManagerMixin
              :network_routers,
              :public_networks,
              :private_networks,
+             :all_private_networks,
              :all_cloud_networks,
              :to        => :network_manager,
              :allow_nil => true

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -263,17 +263,28 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
             @cn3 = FactoryGirl.create(:cloud_network_public_openstack,
                                       :cloud_tenant          => @ct2,
                                       :ext_management_system => provider.network_manager)
+
+            @cn_shared = FactoryGirl.create(:cloud_network_private_openstack,
+                                            :shared                => true,
+                                            :cloud_tenant          => @ct2,
+                                            :ext_management_system => provider.network_manager)
           end
 
           it "#allowed_cloud_networks with tenant selected" do
             workflow.values.merge!(:cloud_tenant => @ct2.id)
             cns = workflow.allowed_cloud_networks
-            expect(cns.keys).to match_array [@cn2.id]
+            expect(cns.keys).to match_array [@cn2.id, @cn_shared.id]
+          end
+
+          it "#allowed_cloud_networks with another tenant selected" do
+            workflow.values[:cloud_tenant] = @ct1.id
+            cns = workflow.allowed_cloud_networks
+            expect(cns.keys).to match_array [@cn1.id, @cn_shared.id]
           end
 
           it "#allowed_cloud_networks with tenant not selected" do
             cns = workflow.allowed_cloud_networks
-            expect(cns.keys).to match_array [@cn2.id, @cn1.id]
+            expect(cns.keys).to match_array [@cn2.id, @cn1.id, @cn_shared.id]
           end
         end
 


### PR DESCRIPTION
Show shared networks in the OpenStack provisioning dialog.
Shared networks were lost during refactoring, adding specs
to make sure shared private networks show under all tenants.

Steps for Testing/QA [Optional]
-------------------------------

Create shared network in the OpenStack, that network should be available when choosing any tenant. 

Public networks should not be affected, only connection through router and right tenant association to floating IP is checked.

Fixes:
http://talk.manageiq.org/t/cannot-select-shared-openstacck-networks-for-instance-provisioning/1753

