### PR TITLE
Using the newly created icons for middleware domain and server group.

### DIFF
--- a/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
+++ b/app/assets/javascripts/controllers/middleware_topology/middleware_topology_controller.js
@@ -112,7 +112,7 @@ function MiddlewareTopologyCtrl($scope, $http, $interval, $location, topologySer
           .attr('class', 'glyph')
           .attr('style', 'font-family:' + iconInfo.fontfamily + ';')
           .attr('x', 0)
-          .attr('y', d.item.kind == 'MiddlewareDomain' ? 6 : 8);
+          .attr('y', 8);
       })
 
 

--- a/app/assets/stylesheets/middleware_topology.css
+++ b/app/assets/stylesheets/middleware_topology.css
@@ -4,6 +4,15 @@
 }
 
 .middleware .kube-topology g.MiddlewareDeployment text.glyph {
+    font-family: IcoMoon;
     font-size: 20px;
     fill: #555;
+}
+
+.middleware .kube-topology g.MiddlewareDomain text.glyph {
+    font-family: IcoMoon;
+}
+
+.middleware .kube-topology g.MiddlewareServerGroup text.glyph {
+    font-family: IcoMoon;
 }

--- a/app/decorators/middleware_domain_decorator.rb
+++ b/app/decorators/middleware_domain_decorator.rb
@@ -3,11 +3,11 @@ class MiddlewareDomainDecorator < Draper::Decorator
   include MiddlewareDecoratorMixin
 
   def fonticon
-    'fa fa-exchange'.freeze
+    'domain'.freeze
   end
 
   # Determine the icon
   def item_image
-    'placeholder'
+    'middleware_domain'
   end
 end

--- a/app/decorators/middleware_server_group_decorator.rb
+++ b/app/decorators/middleware_server_group_decorator.rb
@@ -3,11 +3,11 @@ class MiddlewareServerGroupDecorator < Draper::Decorator
   include MiddlewareDecoratorMixin
 
   def fonticon
-    'fa fa-exchange'.freeze
+    'server-group'.freeze
   end
 
   # Determine the icon
   def item_image
-    'placeholder'
+    'middleware_server_group'
   end
 end

--- a/app/models/mixins/ui_service_mixin.rb
+++ b/app/models/mixins/ui_service_mixin.rb
@@ -13,9 +13,9 @@ module UiServiceMixin
       :MiddlewareDeployment    => {:type => "glyph", :icon => "\uE603", :fontfamily => "icomoon"},                 # product-report
       :MiddlewareDeploymentEar => {:type => "glyph", :icon => "\uE626", :fontfamily => "icomoon"},                 # product-file-ear-o
       :MiddlewareDeploymentWar => {:type => "glyph", :icon => "\uE627", :fontfamily => "icomoon"},                 # product-file-war-o
-      :MiddlewareDomain        => {:type => "glyph", :icon => "\uF0E8", :fontfamily => "FontAwesome"},             # fa-sitemap
+      :MiddlewareDomain        => {:type => "glyph", :icon => "\uE639", :fontfamily => "icomoon"},
       :MiddlewareMessaging     => {:type => "glyph", :icon => "\uF0EC", :fontfamily => "FontAwesome"},             # fa-exchange (placeholder)
-      :MiddlewareServerGroup   => {:type => "glyph", :icon => "\uF00A", :fontfamily => "FontAwesome"},             # fa-th
+      :MiddlewareServerGroup   => {:type => "glyph", :icon => "\uE638", :fontfamily => "icomoon"},
       :Kubernetes              => {:type => "image", :icon => provider_icon(:Kubernetes)},
       :Openshift               => {:type => "image", :icon => provider_icon(:Openshift)},
       :OpenshiftEnterprise     => {:type => "image", :icon => provider_icon(:OpenshiftEnterprise)},

--- a/app/views/middleware_topology/show.html.haml
+++ b/app/views/middleware_topology/show.html.haml
@@ -49,14 +49,14 @@
         %svg.kube-topology
           %g.MiddlewareDomain{:transform => "translate(21, 21)"}
             %circle{:r => "17"}
-            %text{:x => "0", :y => "6", :class => "fa fa-sitemap glyph"} &#xF0E8;
+            %text{:x => "0", :y => "8", :class => "domain glyph"} &#xE639;
         %label
           = _("Domains")
       %kubernetes-topology-icon{tooltipOptions, :kind => "MiddlewareServerGroup"}
         %svg.kube-topology
           %g.MiddlewareServerGroup{:transform => "translate(21, 21)"}
             %circle{:r => "17"}
-            %text{:x => "0", :y => "8", :class => "fa fa-th glyph"} &#xF00A;
+            %text{:x => "0", :y => "8", :class => "server-group glyph"} &#xE638;
         %label
           = _("Server Groups")
 


### PR DESCRIPTION
This PR use the icons that were created in #11614 for middleware domain and middleware server group. It addresses both, topology and normal ui.

Together with PR #11614 it fixes: issue #10480, #10481 and #10948

![screenshot from 2016-10-03 14-51-44](https://cloud.githubusercontent.com/assets/535866/19037902/0e6bd2dc-8979-11e6-8fda-d050bb3d8a88.png)

![screenshot from 2016-10-03 14-51-58](https://cloud.githubusercontent.com/assets/535866/19037906/1a6fd5d8-8979-11e6-92d9-e7fad56f8c7b.png)

@miq-bot add_label ui, providers/hawkular, topology, euwe/yes

@dclarizio could you please look?