### PR TITLE
Add unread notifications indicator and toolitp

### DIFF
--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -10,6 +10,7 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
   vm.newNotifications = false;
   vm.notificationsDrawerShown = sessionStorage.getItem(cookieId + "-shown") == 'true';
   eventNotifications.setDrawerShown(vm.notificationsDrawerShown);
+  updateTooltip();
 
   vm.toggleNotificationsList = function () {
     vm.notificationsDrawerShown = !vm.notificationsDrawerShown;
@@ -20,12 +21,23 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
   var refresh = function() {
     $timeout(function() {
       vm.newNotifications = eventNotifications.state().unreadNotifications;
+      updateTooltip();
     });
   };
 
   var destroy = function() {
     eventNotifications.unregisterObserverCallback(refresh);
   };
+
+  function updateTooltip() {
+    var unreadNotificationCount = 0;
+    if (angular.isArray(vm.notificationGroups)) {
+      angular.forEach(vm.notificationGroups, function(group) {
+        unreadNotificationCount += group.unreadCount;
+      });
+    }
+    vm.notificationsIndicatorTooltip = __(unreadNotificationCount + " unread notifications");
+  }
 
   eventNotifications.registerObserverCallback(refresh);
 

--- a/app/assets/javascripts/controllers/header/header_controller.js
+++ b/app/assets/javascripts/controllers/header/header_controller.js
@@ -21,7 +21,7 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
   var refresh = function() {
     $timeout(function() {
       vm.newNotifications = eventNotifications.state().unreadNotifications;
-      updateTooltip();
+      updateTooltip(eventNotifications.state().groups);
     });
   };
 
@@ -29,14 +29,19 @@ function HeaderCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.unregisterObserverCallback(refresh);
   };
 
-  function updateTooltip() {
-    var unreadNotificationCount = 0;
-    if (angular.isArray(vm.notificationGroups)) {
-      angular.forEach(vm.notificationGroups, function(group) {
-        unreadNotificationCount += group.unreadCount;
+  function updateTooltip(groups) {
+    var notificationCount = {
+      text: 0
+    };
+
+    if (angular.isArray(groups)) {
+      angular.forEach(groups, function(group) {
+        notificationCount.text += group.unreadCount;
       });
     }
-    vm.notificationsIndicatorTooltip = __(unreadNotificationCount + " unread notifications");
+
+    vm.notificationsIndicatorTooltip = miqFormatNotification(__("%{count} unread notifications"),
+                                                             {count: notificationCount});
   }
 
   eventNotifications.registerObserverCallback(refresh);

--- a/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
+++ b/app/assets/javascripts/controllers/notifications/notifications_drawer_controller.js
@@ -37,10 +37,6 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
     });
   };
 
-  vm.markAllRead = function (group) {
-    eventNotifications.markAllRead(group);
-  };
-
   var updatePosition = function() {
     var hasVerticalScrollbar,
         scrollContent = angular.element('#main-content'),
@@ -110,7 +106,7 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
         retClass = "pficon pficon-error-circle-o";
       } else if (notification.data.type == 'warning') {
         retClass = "pficon pficon-warning-triangle-o";
-      } else if ((notification.data.type == 'success') || (notification.data.type == 'success')) {
+      } else if ((notification.data.type == 'success') || (notification.data.type == 'ok')) {
         retClass = "pficon pficon-ok";
       }
     }
@@ -126,6 +122,9 @@ function NotificationsDrawerCtrl($scope, eventNotifications, $timeout) {
     eventNotifications.clear(notification, group);
   };
 
+  vm.customScope.markAllRead = function(group) {
+    eventNotifications.markAllRead(group);
+  };
   vm.customScope.clearAllNotifications = function(group) {
     eventNotifications.clearAll(group);
   };

--- a/app/assets/javascripts/services/event_notifications_service.js
+++ b/app/assets/javascripts/services/event_notifications_service.js
@@ -24,7 +24,7 @@ function eventNotifications($timeout) {
   this.ERROR = 'danger';
   this.WARNING = 'warning';
   this.INFO = 'info';
-  this.SUCCESS = 'ok';
+  this.SUCCESS = 'success';
 
   var state = ManageIQ.angular.eventNotificationsData.state;
   var observerCallbacks = ManageIQ.angular.eventNotificationsData.observerCallbacks;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,6 +11,7 @@
  *= require dialog_fields
  *= require angular
  *= require miq_timeline
+ *= require notifications
  *= require angular-patternfly-sass/dist/styles/angular-patternfly
  *= require schedule_editor
  *= require miq_tree

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -1,0 +1,17 @@
+.drawer-pf-action.footer-actions {
+  width: 100%;
+
+  .footer-button-left {
+    display: inline-block;
+    width: calc(50% - 25px);
+    text-align: right;
+    margin: 0 10px;
+  }
+
+  .footer-button-right {
+    display: inline-block;
+    width: calc(50% - 35px);
+    text-align: left;
+    margin: 0 10px;
+  }
+}

--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -593,6 +593,26 @@ body#dashboard {
   }
 }
 
+// Navbar item badge position and color
+.navbar-pf-vertical .nav .nav-item-iconic {
+  &.drawer-pf-trigger-icon {
+    width: 40px;
+  }
+  .badge {
+    position: relative;
+    top: -23px;
+    right : -10px;
+    margin: 0px;
+    min-width: 13px;
+    background-color: #0088ce;
+  }
+}
+
+// Toast notifications positioning
+.toast-notifications-list-pf {
+  top: 65px
+}
+
 // Notifications drawer positioning
 .drawer-pf {
   bottom: 20px;

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -13,8 +13,9 @@
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
       %li{:class => "drawer-pf-trigger dropdown"}
         %a{:class => "nav-item-iconic drawer-pf-trigger-icon", :title => "{{vm.notificationsIndicatorTooltip}}", "ng-click" => "vm.toggleNotificationsList()"}
-          %span{"ng-class" => "{'fa fa-bell': vm.newNotifications, 'fa fa-bell-o': !vm.newNotifications}"}
+          %span.fa{"ng-class" => "{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"}
           %span.badge.info{"ng-show" => "vm.newNotifications"}
+            -# Small circle
             &#8226
       %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
       %li.dropdown

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -12,8 +12,10 @@
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
       %li{:class => "drawer-pf-trigger dropdown"}
-        %a{:class => "nav-item-iconic drawer-pf-trigger-icon", "ng-click" => "vm.toggleNotificationsList()"}
-          %span{:title => _("Notifications"), "ng-class" => "{'fa fa-bell': vm.newNotifications, 'fa fa-bell-o': !vm.newNotifications}"}
+        %a{:class => "nav-item-iconic drawer-pf-trigger-icon", :title => "{{vm.notificationsIndicatorTooltip}}", "ng-click" => "vm.toggleNotificationsList()"}
+          %span{"ng-class" => "{'fa fa-bell': vm.newNotifications, 'fa fa-bell-o': !vm.newNotifications}"}
+          %span.badge.info{"ng-show" => "vm.newNotifications"}
+            &#8226
       %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
       %li.dropdown
         %a{:class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu1",  "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "true"}

--- a/app/views/layouts/_notifications_drawer.html.haml
+++ b/app/views/layouts/_notifications_drawer.html.haml
@@ -4,8 +4,6 @@
        "drawer-hidden" => "!vm.notificationsDrawerShown",
        "drawer-title" => _("Notifications"),
        "allow-expand" => "true",
-       "action-button-title" => _("Mark All Read"),
-       "action-button-callback" => "vm.markAllRead",
        "notification-groups" => "vm.notificationGroups",
        "heading-include" => "/static/notification_drawer/notification-heading.html",
        "subheading-include" => "/static/notification_drawer/notification-subheading.html",

--- a/app/views/static/notification_drawer/notification-footer.html.haml
+++ b/app/views/static/notification_drawer/notification-footer.html.haml
@@ -1,11 +1,11 @@
-%div.drawer-pf-action.footer-actions
-  %div.footer-button-left
+.drawer-pf-action.footer-actions
+  .footer-button-left
     %a.btn.btn-link{"role" => "button",
                     "ng-class" => "{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}",
                     "ng-click" => "customScope.markAllRead(notificationGroup)"}
       %span
         = _('Mark All Read')
-  %div.footer-button-right
+  .footer-button-right
     %a.btn.btn-link{"role" => "button",
                     "ng-class" => "{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}",
                     "ng-click" => "customScope.clearAllNotifications(notificationGroup)"}

--- a/app/views/static/notification_drawer/notification-footer.html.haml
+++ b/app/views/static/notification_drawer/notification-footer.html.haml
@@ -1,7 +1,13 @@
-.drawer-pf-action
-  %a.btn.btn-link.btn-block{"role" => "button",
-    "ng-class" => "{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}",
-    "ng-click" => "customScope.clearAllNotifications(notificationGroup)"}
-    %span.pficon.pficon-close
-    %span
-      = _("Clear All")
+%div.drawer-pf-action.footer-actions
+  %div.footer-button-left
+    %a.btn.btn-link{"role" => "button",
+                    "ng-class" => "{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}",
+                    "ng-click" => "customScope.markAllRead(notificationGroup)"}
+      %span
+        = _('Mark All Read')
+  %div.footer-button-right
+    %a.btn.btn-link{"role" => "button",
+                    "ng-class" => "{'disabled': !notificationGroup.notifications || notificationGroup.notifications.length === 0}",
+                    "ng-click" => "customScope.clearAllNotifications(notificationGroup)"}
+      %span
+        = _('Clear All')


### PR DESCRIPTION
This PR adds an indicator to the notifications drawer trigger to better notify the user when there are unread notifications. The notification badge differs from the patternfly design but has been approved by Patternfly UXD team members and visual designers.

A tooltip with the current unread notification count has also been added.

The list for the toast notifications has been moved down below the nav bar so as not to obstruct the notifications indicator.

Links
----------------
Jira Story: https://patternfly.atlassian.net/browse/CFUX-114
