### PR TITLE
Include SupportsFeatureMixin for Hosts

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -16,6 +16,7 @@ class Host < ApplicationRecord
   include NewWithTypeStiMixin
   include VirtualTotalMixin
   include TenantIdentityMixin
+  include SupportsFeatureMixin
 
   VENDOR_TYPES = {
     # DB            Displayed


### PR DESCRIPTION
This is to fix an issue while trying to access Host summary screen, need to include supportsfeaturemixin to be able to enable/disable Power reset & shutdown buttons.

@durandom @dclarizio please review/merge. This issue is causing an error while trying to access Host summary screens.