### PR TITLE
Need to keep and pass along the EmsEvent that triggers vm_clone_start

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -795,15 +795,16 @@ class MiqAction < ApplicationRecord
       return
     end
 
-    task_mor = inputs[:ems_event].full_data['info']['task']
+    source_event = inputs[:source_event]
+    task_mor = source_event.full_data.try(:fetch_path, 'info', 'task')
     unless task_mor
       MiqPolicy.logger.warn("MIQ(action_cancel_task): Event record does not have a task reference, no action will be taken")
       return
     end
 
-    MiqPolicy.logger.info("MIQ(action_cancel_task): Now executing Cancel of task [#{inputs[:ems_event].event_type}] on VM [#{inputs[:ems_event].vm_name}]")
-    ems = ExtManagementSystem.find_by_id(inputs[:ems_event].ems_id)
-    raise _("unable to find vCenter with id [%{id}]") % {:id => inputs[:ems_event].ems_id} if ems.nil?
+    MiqPolicy.logger.info("MIQ(action_cancel_task): Now executing Cancel of task [#{source_event.event_type}] on VM [#{source_event.vm_name}]")
+    ems = ExtManagementSystem.find_by_id(source_event.ems_id)
+    raise _("unable to find vCenter with id [%{id}]") % {:id => source_event.ems_id} if ems.nil?
 
     vim = ems.connect
     vim.cancelTask(task_mor)
@@ -813,7 +814,7 @@ class MiqAction < ApplicationRecord
     ae_hash = action.options[:ae_hash] || {}
     automate_attrs = ae_hash.reject { |key, _value| MiqAeEngine::DEFAULT_ATTRIBUTES.include?(key) }
     automate_attrs[:request] = action.options[:ae_request]
-    MiqAeEngine.set_automation_attributes_from_objects([inputs[:policy], inputs[:ems_event]], automate_attrs)
+    MiqAeEngine.set_automation_attributes_from_objects([inputs[:policy], inputs[:source_event]], automate_attrs)
 
     user = rec.tenant_identity
     unless user

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -43,6 +43,9 @@ class MiqEvent < EventStream
     inputs.merge!('MiqEvent::miq_event' => event_obj.id, :miq_event_id => event_obj.id)
     inputs.merge!('EventStream::event_stream' => event_obj.id, :event_stream_id => event_obj.id)
 
+    # save the EmsEvent that are required by some actions later in policy resolution
+    event_obj.update_attributes(:full_data => {:source_event_id => inputs[:ems_event].id}) if inputs[:ems_event]
+
     MiqAeEvent.raise_evm_event(raw_event, target, inputs, options)
     event_obj
   end
@@ -56,6 +59,7 @@ class MiqEvent < EventStream
 
     results = {}
     inputs[:type] ||= target.class.name
+    inputs[:source_event] = source_event if source_event
 
     _log.info("Event Raised [#{event_type}]")
     begin
@@ -153,5 +157,14 @@ class MiqEvent < EventStream
 
   def self.event_name_for_target(target, event_suffix)
     "#{target.class.base_model.name.underscore}_#{event_suffix}"
+  end
+
+  # return the event that triggered the policy event
+  def source_event
+    return @source_event if @source_event
+    return unless full_data
+
+    source_event_id = full_data.fetch_path(:source_event_id)
+    @source_event = EventStream.find_by(:id => source_event_id) if source_event_id
   end
 end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -52,6 +52,14 @@ describe MiqAction do
       expect(MiqQueue).to receive(:put).with(q_options).once
       @action.action_custom_automation(@action, @vm, :synchronous => false)
     end
+
+    it "passes source event to automate if set" do
+      ems_event = FactoryGirl.create(:ems_event, :event_type => "CloneVM_Task")
+      args = {:attrs => {:request => "test_custom_automation", "EventStream::event_stream" => ems_event.id}}
+      expect(MiqAeEngine).to receive(:deliver).with(hash_including(args)).once
+
+      @action.action_custom_automation(@action, @vm, :synchronous => true, :source_event => ems_event)
+    end
   end
 
   context "#action_evm_event" do

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -145,6 +145,28 @@ describe MiqEvent do
         expect(MiqPolicy).to receive(:enforce_policy).with(ems, event, :type => ems.class.name)
         MiqEvent.first.process_evm_event
       end
+
+      it"will pass EmsEvent to policy if set" do
+        event = 'vm_clone_start'
+        vm = FactoryGirl.create(:vm_vmware)
+        ems_event = FactoryGirl.create(
+          :ems_event,
+          :event_type => "CloneVM_Task",
+          :full_data  => { "info" => {"task" => "task-5324"}})
+        FactoryGirl.create(:miq_event_definition, :name => event)
+        FactoryGirl.create(
+          :miq_event,
+          :event_type => event,
+          :target     => vm,
+          :full_data  => {:source_event_id => ems_event.id})
+
+        expect(MiqPolicy).to receive(:enforce_policy).with(
+          vm,
+          event,
+          :type         => vm.class.name,
+          :source_event => ems_event)
+        MiqEvent.first.process_evm_event
+      end
     end
 
     context ".raise_event_for_children" do


### PR DESCRIPTION
To be able to cancel a vCenter task, we need to get the vCenter task id that is saved in CloneVM_Task event which triggers vm_clone_start event.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1381255

cc @gmcculloug @gtanzillo 