### PR TITLE
Validate either a host or cluster is selected when provisioning on VMware

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow < ManageIQ::Providers::InfraManager::ProvisionWorkflow
+  include_concern "DialogFieldValidation"
+
   def self.default_dialog_file
     'miq_provision_dialogs'
   end

--- a/app/models/manageiq/providers/vmware/infra_manager/provision_workflow/dialog_field_validation.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision_workflow/dialog_field_validation.rb
@@ -1,0 +1,15 @@
+# These methods are available for dialog field validation, do not erase.
+module ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow::DialogFieldValidation
+  def validate_placement_host_name(field, values, dlg, fld, value)
+    result = validate_placement(field, values, dlg, fld, value)
+    return result if result.nil?
+
+    ems_cluster = EmsCluster.find_by(:id => get_value(values[:placement_cluster_name]))
+
+    if ems_cluster.nil?
+      _("Either Host Name or Cluster Name is required")
+    elsif !ems_cluster.drs_enabled
+      _("%{field_required} for Non-DRS enabled cluster") % {:field_required => result}
+    end
+  end
+end

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_template.yaml
@@ -434,8 +434,8 @@
             :method: :allowed_hosts
           :auto_select_single: false
           :description: Name
-          :required_method: :validate_placement
-          :required: true
+          :validation_method: :validate_placement_host_name
+          :required: false
           :display: :edit
           :data_type: :integer
           :required_description: Host Name


### PR DESCRIPTION
VMware allows you to select just a cluster (and not a host) if that cluster supports DRS, this updates the validation method to check that:
1. A host or a cluster is explicitly selected
2. The selected cluster has DRS enabled if no host is selected

![screenshot from 2016-10-04 19-13-07](https://cloud.githubusercontent.com/assets/12851112/19095912/c23ab8da-8a66-11e6-8491-0a13d14dbf19.png)
![screenshot from 2016-10-04 19-12-49](https://cloud.githubusercontent.com/assets/12851112/19095916/c4d52652-8a66-11e6-886e-4e08373579a5.png)
