### PR TITLE
Add automate engine support for array elements containing text values.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -283,8 +283,7 @@ module MiqAeEngine
       objects_str.split(',').collect do |element|
         if element.include?(CLASS_SEPARATOR)
           klass, str_value = element.split(CLASS_SEPARATOR)
-          value = MiqAeObject.convert_value_based_on_datatype(str_value, klass)
-          value if value.kind_of?(MiqAeMethodService::MiqAeServiceModelBase)
+          MiqAeObject.convert_value_based_on_datatype(str_value.strip, klass.strip)
         else
           element.presence
         end
@@ -535,6 +534,8 @@ module MiqAeEngine
          (service_model = "MiqAeMethodService::MiqAeService#{SM_LOOKUP[datatype]}".safe_constantize)
         return service_model.find(value)
       end
+
+      (raise MiqAeException::InvalidClass unless MiqAeField.available_datatypes.include?(datatype)) if datatype
 
       # default datatype => 'string'
       value

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -280,10 +280,14 @@ module MiqAeEngine
     end
 
     def load_array_objects_from_string(objects_str)
-      objects_str.split(',').collect do |o|
-        klass, str_value = o.split(CLASS_SEPARATOR)
-        value = MiqAeObject.convert_value_based_on_datatype(str_value, klass)
-        value if value.kind_of?(MiqAeMethodService::MiqAeServiceModelBase)
+      objects_str.split(',').collect do |element|
+        if element.include?(CLASS_SEPARATOR)
+          klass, str_value = element.split(CLASS_SEPARATOR)
+          value = MiqAeObject.convert_value_based_on_datatype(str_value, klass)
+          value if value.kind_of?(MiqAeMethodService::MiqAeServiceModelBase)
+        else
+          element.presence
+        end
       end.compact
     end
 

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -91,30 +91,81 @@ describe MiqAeEngine::MiqAeObject do
     expect(result["vms"].length).to eq(2)
   end
 
-  it "#process_args_as_attributes with an array containing invalid entries" do
-    vm2 = FactoryGirl.create(:vm_vmware)
-    result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id},fred::12,,VmOrTemplate::#{vm2.id}"})
-    expect(result["vms"]).to be_kind_of(Array)
-    expect(result["vms"].length).to eq(2)
-  end
+  describe "#process_args_as_attributes" do
+    let(:result) { @miq_obj.process_args_as_attributes("Array::my_values" => my_values) }
 
-  it "#process_args_as_attributes with an array containing disparate objects" do
-    host    = FactoryGirl.create(:host)
-    ems     = FactoryGirl.create(:ems_vmware)
-    result  = @miq_obj.process_args_as_attributes({"Array::my_objects" => "VmOrTemplate::#{@vm.id},Host::#{host.id},ExtManagementSystem::#{ems.id}"})
-    expect(result["my_objects"]).to be_kind_of(Array)
-    expect(result["my_objects"].length).to eq(3)
-  end
+    context "with an array containing invalid entries" do
+      let(:my_values) { "VmOrTemplate::#{@vm.id},fred::12,VmOrTemplate::#{FactoryGirl.create(:vm_vmware).id}" }
 
-  it "#process_args_as_attributes with an array containing strings" do
-    result = @miq_obj.process_args_as_attributes("Array::my_values" => "abc,xyz,,1")
-    expect(result["my_values"]).to eq(%w(abc xyz 1))
-  end
+      it "raises an exception" do
+        expect { @miq_obj.process_args_as_attributes("Array::vms" => my_values) }.to raise_exception MiqAeException::InvalidClass
+      end
+    end
 
-  it "#process_args_as_attributes with an array containing string and objects" do
-    result = @miq_obj.process_args_as_attributes("Array::my_values" => "abc,VmOrTemplate::#{@vm.id}")
-    expect(result["my_values"].first).to eq("abc")
-    expect(result["my_values"].second).to be_kind_of(MiqAeMethodService::MiqAeServiceVmOrTemplate)
+    context "with an array containing empty entries" do
+      let(:my_values) { "VmOrTemplate::#{@vm.id},,,VmOrTemplate::#{FactoryGirl.create(:vm_vmware).id}" }
+
+      it "ignores empty values and returns everything else" do
+        expect(result["my_values"].size).to eq 2
+        expect(result["my_values"][0].id).to eq @vm.id
+      end
+    end
+
+    context "with an array including spaces after the commas" do
+      let(:my_values) { "integer::1, integer::3, integer::10" }
+
+      it "stores the values as an array of strings" do
+        expect(result["my_values"]).to eq([1, 3, 10])
+      end
+    end
+
+    context "with an array including no spaces after the commas" do
+      let(:my_values) { "integer::1,integer::3,integer::10" }
+
+      it "stores the values as an array of strings" do
+        expect(result["my_values"]).to eq([1, 3, 10])
+      end
+    end
+
+    context "with an array containing disparate objects" do
+      let!(:my_values) do
+        host    = FactoryGirl.create(:host)
+        ems     = FactoryGirl.create(:ems_vmware)
+        "VmOrTemplate::#{@vm.id},Host::#{host.id},ExtManagementSystem::#{ems.id}"
+      end
+
+      it "stores the first value as a VM object" do
+        expect(result["my_values"].first).to be_kind_of(MiqAeMethodService::MiqAeServiceVm)
+      end
+
+      it "stores the second value as a Host object" do
+        expect(result["my_values"].second).to be_kind_of(MiqAeMethodService::MiqAeServiceHost)
+      end
+
+      it "stores the third value as a ExtManagementSystem object" do
+        expect(result["my_values"].third).to be_kind_of(MiqAeMethodService::MiqAeServiceExtManagementSystem)
+      end
+    end
+
+    context "with an array containing strings" do
+      let(:my_values) { "abc,xyz,,1" }
+
+      it "stores the values as an array of strings" do
+        expect(result["my_values"]).to eq(%w(abc xyz 1))
+      end
+    end
+
+    context "with an array containing strings and objects" do
+      let(:my_values) { "abc,VmOrTemplate::#{@vm.id}" }
+
+      it "stores the first value as a string" do
+        expect(result["my_values"].first).to eq("abc")
+      end
+
+      it "stores the second value as an MiqAeMethodService::MiqAeServiceVmOrTemplate" do
+        expect(result["my_values"].second).to be_kind_of(MiqAeMethodService::MiqAeServiceVmOrTemplate)
+      end
+    end
   end
 
   it "disabled inheritance" do

--- a/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_object_spec.rb
@@ -106,6 +106,17 @@ describe MiqAeEngine::MiqAeObject do
     expect(result["my_objects"].length).to eq(3)
   end
 
+  it "#process_args_as_attributes with an array containing strings" do
+    result = @miq_obj.process_args_as_attributes("Array::my_values" => "abc,xyz,,1")
+    expect(result["my_values"]).to eq(%w(abc xyz 1))
+  end
+
+  it "#process_args_as_attributes with an array containing string and objects" do
+    result = @miq_obj.process_args_as_attributes("Array::my_values" => "abc,VmOrTemplate::#{@vm.id}")
+    expect(result["my_values"].first).to eq("abc")
+    expect(result["my_values"].second).to be_kind_of(MiqAeMethodService::MiqAeServiceVmOrTemplate)
+  end
+
   it "disabled inheritance" do
     @user = FactoryGirl.create(:user_with_group)
     create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/C', :instance_name => 'FRED')


### PR DESCRIPTION
Automate supports passing an array of objects on the URL to the engine.  This PR modifies that logic to allow strings to be passed as well.  This functionality supports the multi-select drop-down being added to the Service Dialogs in PR #10270.
## Links
- Backend support for PR #10270
## Steps for Testing/QA

Test using the multi-select control from the service dialog wired to a custom button.  Configure the button to call the `System/Request/InspectMe` method.  Logging will show the array containing each selected key passed from the dialog field.
