### PR TITLE
Removed leftover rubyrep passowrd checking code.

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -140,15 +140,9 @@ module OpsController::Settings::Common
           end
         end
       when 'settings_workers'
-        if @edit[:default_verify_status] != session[:log_depot_default_verify_status]
-          session[:log_depot_default_verify_status] = @edit[:default_verify_status]
-          verb = @edit[:default_verify_status] ? 'show' : 'hide'
-          page << "miqValidateButtons('#{verb}', 'default_');"
-        end
         if @edit[:new].config[:workers][:worker_base][:ui_worker][:count] != @edit[:current].config[:workers][:worker_base][:ui_worker][:count]
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
-        page.replace_html('pwd_note', @edit[:default_verify_status] ? '' : _("* Passwords don't match."))
       end
 
       page << javascript_for_miq_button_visibility(@changed || @login_text_changed)
@@ -483,9 +477,6 @@ module OpsController::Settings::Common
       end
     elsif @sb[:active_tab] == "settings_workers" &&
           x_node.split("-").first != "z"
-      unless @edit[:default_verify_status]
-        add_flash(_("Password/Verify Password do not match"), :error)
-      end
       unless @flash_array.nil?
         session[:changed] = @changed = true
         javascript_flash


### PR DESCRIPTION
Removed leftover checks that were causing a flash error message to display on worlkers settings screen, introduced in https://github.com/ManageIQ/manageiq/pull/9696

https://bugzilla.redhat.com/show_bug.cgi?id=1381330

before:
![before](https://cloud.githubusercontent.com/assets/3450808/19055409/c053c5e6-8991-11e6-86ce-cd3198cdff17.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/19055386/a4b51e48-8991-11e6-895b-00f9ad46868a.png)
