### PR TITLE
Support provider name & template name to uniquely identify a template

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -92,7 +92,8 @@ class LaunchAnsibleJob
   end
 
   def job_template_by_provider
-    provider_name = var_search(@handle.object, 'ansible_provider_name')
+    provider_name = var_search(@handle.object, 'ansible_tower_provider_name') ||
+                    var_search(@handle.object, 'dialog_ansible_tower_provider_name')
     provider = @handle.vmdb(MANAGER_CLASS).where('lower(name) = ?', provider_name.downcase).first if provider_name
     provider.configuration_scripts.detect { |s| s.name.casecmp(job_template_name) == 0 } if provider && job_template_name
   end

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Operations/StateMachines/Job.class/__methods__/launch_ansible_job.rb
@@ -9,6 +9,7 @@ class LaunchAnsibleJob
   ANSIBLE_DIALOG_VAR_REGEX = Regexp.new(/dialog_param_(.*)/)
   SCRIPT_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript'.freeze
   JOB_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager_Job'.freeze
+  MANAGER_CLASS = 'ManageIQ_Providers_AnsibleTower_ConfigurationManager'.freeze
 
   def initialize(handle)
     @handle = handle
@@ -64,7 +65,10 @@ class LaunchAnsibleJob
   end
 
   def job_template
-    job_template = var_search(@handle.object, 'job_template') || job_template_by_name || job_template_by_id
+    job_template = var_search(@handle.object, 'job_template') ||
+                   job_template_by_id ||
+                   job_template_by_provider ||
+                   job_template_by_name
 
     if job_template.nil?
       raise "Job Template not specified"
@@ -72,16 +76,25 @@ class LaunchAnsibleJob
     job_template
   end
 
+  def job_template_name
+    @job_template_name ||= var_search(@handle.object, 'job_template_name') ||
+                           var_search(@handle.object, 'dialog_job_template_name')
+  end
+
   def job_template_by_name
-    name = var_search(@handle.object, 'job_template_name') ||
-           var_search(@handle.object, 'dialog_job_template_name')
-    @handle.vmdb(SCRIPT_CLASS).where('lower(name) = ?', name.downcase).first if name
+    @handle.vmdb(SCRIPT_CLASS).where('lower(name) = ?', job_template_name.downcase).first if job_template_name
   end
 
   def job_template_by_id
     job_template_id = var_search(@handle.object, 'job_template_id') ||
                       var_search(@handle.object, 'dialog_job_template_id')
     @handle.vmdb(SCRIPT_CLASS).where(:id => job_template_id).first if job_template_id
+  end
+
+  def job_template_by_provider
+    provider_name = var_search(@handle.object, 'ansible_provider_name')
+    provider = @handle.vmdb(MANAGER_CLASS).where('lower(name) = ?', provider_name.downcase).first if provider_name
+    provider.configuration_scripts.detect { |s| s.name.casecmp(job_template_name) == 0 } if provider && job_template_name
   end
 
   def extra_variables

--- a/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
+++ b/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
@@ -65,7 +65,21 @@ describe LaunchAnsibleJob do
     ext_vars['y'] = 'Y'
     root_object['vm'] = svc_vm
     current_object = Spec::Support::MiqAeMockObject.new(:job_template_name => job_template.name)
-    current_object['ansible_provider_name'] = manager.name
+    current_object['ansible_tower_provider_name'] = manager.name
+    current_object.parent = root_object
+    service.object = current_object
+    job_args[:limit] = vm.name
+    expect(job_class).to receive(:create_job).with(anything, job_args).and_return(svc_job)
+    LaunchAnsibleJob.new(service).main
+    expect(service.get_state_var(:ansible_job_id)).to eq(job.id)
+  end
+
+  it "run a job using job template name and dialog provider name" do
+    ext_vars['x'] = 'X'
+    ext_vars['y'] = 'Y'
+    root_object['vm'] = svc_vm
+    current_object = Spec::Support::MiqAeMockObject.new(:job_template_name => job_template.name)
+    current_object['dialog_ansible_tower_provider_name'] = manager.name
     current_object.parent = root_object
     service.object = current_object
     job_args[:limit] = vm.name

--- a/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
+++ b/spec/automation/unit/method_validation/launch_ansible_job_spec.rb
@@ -5,8 +5,11 @@ describe LaunchAnsibleJob do
   let(:jt_class) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfigurationScript }
   let(:user) { FactoryGirl.create(:user_with_group) }
   let(:vm) { FactoryGirl.create(:vm) }
+  let(:manager) { FactoryGirl.create(:configuration_manager_ansible_tower, :name => "AT1") }
   let(:svc_vm) { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
-  let(:job_template) { FactoryGirl.create(:ansible_configuration_script) }
+  let(:job_template) do
+    FactoryGirl.create(:ansible_configuration_script, :manager_id => manager.id)
+  end
   let(:svc_job_template) { jt_class.find(job_template.id) }
   let(:ip_addr) { '1.1.1.1' }
   let(:job) { FactoryGirl.create(:ansible_tower_job) }
@@ -49,6 +52,20 @@ describe LaunchAnsibleJob do
     ext_vars['y'] = 'Y'
     root_object['vm'] = svc_vm
     current_object = Spec::Support::MiqAeMockObject.new(:job_template_name => job_template.name)
+    current_object.parent = root_object
+    service.object = current_object
+    job_args[:limit] = vm.name
+    expect(job_class).to receive(:create_job).with(anything, job_args).and_return(svc_job)
+    LaunchAnsibleJob.new(service).main
+    expect(service.get_state_var(:ansible_job_id)).to eq(job.id)
+  end
+
+  it "run a job using job template name and provider name" do
+    ext_vars['x'] = 'X'
+    ext_vars['y'] = 'Y'
+    root_object['vm'] = svc_vm
+    current_object = Spec::Support::MiqAeMockObject.new(:job_template_name => job_template.name)
+    current_object['ansible_provider_name'] = manager.name
     current_object.parent = root_object
     service.object = current_object
     job_args[:limit] = vm.name


### PR DESCRIPTION
Optionally support 'ansible_provider_name' to uniquely identify a
job template. This is needed where you might have multiple Ansible
Towers with the same named templates.

Links
- https://bugzilla.redhat.com/show_bug.cgi?id=1378606

Testing:
Bugzilla provides the details
