### PR TITLE
Conversion of Middleware Provider form to Angular

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -223,7 +223,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.metrics_password != '' && $scope.angularForm.metrics_password.$valid &&
       $scope.emsCommonModel.metrics_verify != '' && $scope.angularForm.metrics_verify.$valid)) {
       return true;
-    } else if(($scope.currentTab == "default" && $scope.emsCommonModel.ems_controller == "ems_container") &&
+    } else if(($scope.currentTab == "default" &&
+      ($scope.emsCommonModel.ems_controller == "ems_container" || $scope.emsCommonModel.ems_controller == "ems_middleware")) &&
       ($scope.emsCommonModel.emstype) &&
       ($scope.emsCommonModel.default_hostname != '' && $scope.emsCommonModel.default_api_port) &&
       ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid) &&

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -1,5 +1,6 @@
 class EmsMiddlewareController < ApplicationController
   include EmsCommon
+  include Mixins::EmsCommonAngular
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -38,5 +38,10 @@ class EmsMiddlewareController < ApplicationController
   def restful?
     true
   end
+
+  def ems_middleware_form_fields
+    ems_form_fields
+  end
+
   public :restful?
 end

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -293,14 +293,14 @@ module Mixins
                        :hawkular_auth_status      => hawkular_auth_status.nil? ? true : hawkular_auth_status,
       } if controller_name == "ems_container"
 
-      render :json => {:name                      => @ems.name,
-                       :emstype                   => @ems.emstype,
-                       :zone                      => zone,
-                       :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
-                       :default_api_port          => @ems.connection_configurations.default.endpoint.port,
-                       :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
-                       :ems_controller            => controller_name,
-                       :default_auth_status       => default_auth_status,
+      render :json => {:name                => @ems.name,
+                       :emstype             => @ems.emstype,
+                       :zone                => zone,
+                       :default_hostname    => @ems.connection_configurations.default.endpoint.hostname,
+                       :default_api_port    => @ems.connection_configurations.default.endpoint.port,
+                       :default_userid      => @ems.authentication_userid ? @ems.authentication_userid : "",
+                       :ems_controller      => controller_name,
+                       :default_auth_status => default_auth_status,
       } if controller_name == "ems_middleware"
     end
 

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -292,6 +292,16 @@ module Mixins
                        :default_auth_status       => default_auth_status,
                        :hawkular_auth_status      => hawkular_auth_status.nil? ? true : hawkular_auth_status,
       } if controller_name == "ems_container"
+
+      render :json => {:name                      => @ems.name,
+                       :emstype                   => @ems.emstype,
+                       :zone                      => zone,
+                       :default_hostname          => @ems.connection_configurations.default.endpoint.hostname,
+                       :default_api_port          => @ems.connection_configurations.default.endpoint.port,
+                       :default_userid            => @ems.authentication_userid ? @ems.authentication_userid : "",
+                       :ems_controller            => controller_name,
+                       :default_auth_status       => default_auth_status,
+      } if controller_name == "ems_middleware"
     end
 
     private ############################

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -399,6 +399,10 @@ module Mixins
         hawkular_endpoint = {:role => :hawkular, :hostname => hawkular_hostname, :port => hawkular_api_port}
       end
 
+      if ems.kind_of?(ManageIQ::Providers::Hawkular::MiddlewareManager)
+        default_endpoint = {:role => :default, :hostname => hostname, :port => port}
+      end
+
       endpoints = {:default     => default_endpoint,
                    :ceilometer  => ceilometer_endpoint,
                    :amqp        => amqp_endpoint,

--- a/app/views/ems_middleware/_form.html.haml
+++ b/app/views/ems_middleware/_form.html.haml
@@ -1,0 +1,69 @@
+- @angular_form = true
+
+.form-horizontal{:id => "start_form_div", :style => "display:none"}
+  = render :partial => "layouts/flash_msg"
+  %div
+    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_name"}
+        = _('Name')
+      .col-md-8
+        %input.form-control{"type"           => "text",
+                            "id"             => "ems_name",
+                            "name"           => "name",
+                            "ng-model"       => "emsCommonModel.name",
+                            "maxlength"      => "#{MAX_NAME_LEN}",
+                            "required"       => "",
+                            "checkchange"    => "",
+                            "auto-focus"     => "",
+                            "start-form-div" => "start_form_div"}
+        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.emstype.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_type"}
+        = _('Type')
+      .col-md-8
+        = select_tag('emstype',
+                     options_for_select([["<#{_('Choose')}>", nil]] + @ems_types, disabled: ["<#{_('Choose')}>", nil]),
+                     "ng-if"                       => "newRecord",
+                     "ng-model"                    => "emsCommonModel.emstype",
+                     "ng-change"                   => "providerTypeChanged()",
+                     "required"                    => "",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
+        %div{"ng-if" => "!newRecord"}
+          %label.form-control{"type"        => "text",
+                              "id"          => "ems_type",
+                              "name"        => "emstype",
+                              "ng-if"       => "!newRecord",
+                              "readonly"    => true,
+                              "style"       => "color: black; font-weight: normal;"}
+            = @emstype_display
+
+    .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_zone"}
+        = _("Zone")
+      .col-md-8
+        - if @server_zones.length <= 1
+          %input.form-control{"type"        => "text",
+                              "id"          => "ems_zone",
+                              "name"        => "zone",
+                              "ng-model"    => "emsCommonModel.zone",
+                              "maxlength"   => 15,
+                              "required"    => "",
+                              "checkchange" => "",
+                              "readonly"    => true,
+                              "style"       => "color: black;"}
+        - else
+          = select_tag('zone',
+                       options_for_select(@server_zones.sort_by { |name, _name| name }),
+                       "ng-model"                    => "emsCommonModel.zone",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+
+
+  %hr
+    = render :partial => "/layouts/angular/multi_auth_credentials", :locals  => {:record => @ems, :ng_model => "emsCommonModel"}
+
+    = render :partial => "layouts/angular/x_edit_buttons_angular", :locals => {:record => @ems, :restful => true}

--- a/app/views/ems_middleware/edit.html.haml
+++ b/app/views/ems_middleware/edit.html.haml
@@ -1,1 +1,17 @@
-= render :partial => 'shared/views/ems_common/form'
+= form_for(@ems,
+           :url    => ems_middleware_path(@ems),
+           :method => :patch,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "update-url"      => "#{ems_middleware_path(@ems)}",
+                       "form-fields-url" => "/#{controller_name}/ems_middleware_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "save"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+  = render :partial => "form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());

--- a/app/views/ems_middleware/new.html.haml
+++ b/app/views/ems_middleware/new.html.haml
@@ -1,1 +1,19 @@
-= render :partial => 'shared/views/ems_common/form'
+- url = @ems.persisted? ? ems_middlewares_path(@ems) : ems_middlewares_path
+= form_for(@ems,
+           :url    => url,
+           :method => :post,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "create-url"      => "#{url}",
+                       "form-fields-url" => "/#{controller_name}/ems_middleware_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "add"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+
+  = render :partial => "form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -1,4 +1,4 @@
-- return unless %w(ems_cloud ems_infra ems_container).include?(controller_name)
+- return unless %w(ems_cloud ems_infra ems_container ems_middleware).include?(controller_name)
 - prefix ||= "default"
 - ng_reqd_hostname ||= true
 - ng_reqd_api_port ||= true
@@ -30,6 +30,7 @@
                          "emsCommonModel.emstype == 'openstack_infra' || " + |
                          "emsCommonModel.emstype == 'rhevm' || " +           |
                          "emsCommonModel.emstype == 'vmware_cloud' || " +    |
+                         "emsCommonModel.emstype == 'hawkular' || " +        |
                          "emsCommonModel.ems_controller == 'ems_container'"} |
     %label.col-md-2.control-label{"for" => "#{prefix}_api_port"}
       = _('API Port')

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -22,7 +22,7 @@
       = miq_tab_header('hawkular') do
         %i{"error-on-tab" => "hawkular", :style => "color:#cc0000"}
         = _("Hawkular")
-    - else
+    - elsif controller_name == "host"
       = miq_tab_header('remote') do
         = _("Remote Login")
       = miq_tab_header('ws') do
@@ -33,7 +33,8 @@
   .tab-content
     = miq_tab_content('default', 'default') do
       .form-group
-        .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container'"}
+        .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container' || " +  |
+                              "#{ng_model}.ems_controller == 'ems_middleware'"}      |
           = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                => true,
                                                 :ng_model               => "#{ng_model}",
@@ -243,7 +244,7 @@
           .col-md-12
             %span{:style => "color:black"}
               = _("Used to gather Capacity & Utilization metrics.")
-    - else
+    - elsif controller_name == "host"
       = miq_tab_content('remote', 'default') do
         .form-group
           .col-md-12
@@ -291,7 +292,12 @@
 %div{"ng-if" => "#{ng_model}.emstype == ''"}
   :javascript
     $('#auth_tabs').hide();
-%div{"ng-if" => "#{ng_model}.emstype == 'ec2' || #{ng_model}.emstype == 'gce' || #{ng_model}.emstype == 'scvmm' || #{ng_model}.emstype == 'vmwarews' || #{ng_model}.emstype == 'vmware_cloud'"}
+%div{"ng-if" => "#{ng_model}.emstype == 'ec2' || "          + |
+                "#{ng_model}.emstype == 'gce' || "          + |
+                "#{ng_model}.emstype == 'scvmm' || "        + |
+                "#{ng_model}.emstype == 'vmwarews' || "     + |
+                "#{ng_model}.emstype == 'vmware_cloud' || " + |
+                "#{ng_model}.emstype == 'hawkular'"}          |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1065,6 +1065,7 @@ Vmdb::Application.routes.draw do
     :ems_middleware            => {
       :get  => %w(
         download_data
+        ems_middleware_form_fields
         show_list
         tagging_edit
         tag_edit_form_field_changed

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -47,15 +47,15 @@ describe EmsMiddlewareController do
     it 'creates on post' do
       expect do
         post :create, :params => {
-            "button"           => "add",
-            "name"             => "SeaHawks",
-            "emstype"          => "hawkular",
-            "zone"             => zone.name,
-            "cred_type"        => "default",
-            "default_hostname" => "foo.com",
-            "default_userid"   => "foo",
-            "default_password" => "[FILTERED]",
-            "default_verify"   => "[FILTERED]"
+          "button"           => "add",
+          "name"             => "SeaHawks",
+          "emstype"          => "hawkular",
+          "zone"             => zone.name,
+          "cred_type"        => "default",
+          "default_hostname" => "foo.com",
+          "default_userid"   => "foo",
+          "default_password" => "[FILTERED]",
+          "default_verify"   => "[FILTERED]"
         }
       end.to change { ManageIQ::Providers::Hawkular::MiddlewareManager.count }.by(1)
     end
@@ -63,15 +63,15 @@ describe EmsMiddlewareController do
     it 'creates and updates an authentication record on post' do
       expect do
         post :create, :params => {
-            "button"           => "add",
-            "name"             => "SeaHawks",
-            "emstype"          => "hawkular",
-            "zone"             => zone.name,
-            "cred_type"        => "default",
-            "default_hostname" => "foo.com",
-            "default_userid"   => "foo",
-            "default_password" => "[FILTERED]",
-            "default_verify"   => "[FILTERED]"
+          "button"           => "add",
+          "name"             => "SeaHawks",
+          "emstype"          => "hawkular",
+          "zone"             => zone.name,
+          "cred_type"        => "default",
+          "default_hostname" => "foo.com",
+          "default_userid"   => "foo",
+          "default_password" => "[FILTERED]",
+          "default_verify"   => "[FILTERED]"
         }
       end.to change { Authentication.count }.by(1)
 
@@ -81,14 +81,14 @@ describe EmsMiddlewareController do
 
       expect do
         post :update, :params => {
-            "id"               => hawkular.id,
-            "button"           => "save",
-            "default_hostname" => "host_hawkular_updated",
-            "name"             => "SeaHawks",
-            "emstype"          => "hawkular",
-            "default_userid"   => "bar",
-            "default_password" => "[FILTERED]",
-            "default_verify"   => "[FILTERED]"
+          "id"               => hawkular.id,
+          "button"           => "save",
+          "default_hostname" => "host_hawkular_updated",
+          "name"             => "SeaHawks",
+          "emstype"          => "hawkular",
+          "default_userid"   => "bar",
+          "default_password" => "[FILTERED]",
+          "default_verify"   => "[FILTERED]"
         }
       end.not_to change { Authentication.count }
 

--- a/spec/controllers/ems_middleware_controller_spec.rb
+++ b/spec/controllers/ems_middleware_controller_spec.rb
@@ -1,4 +1,6 @@
 describe EmsMiddlewareController do
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.build(:zone) }
   before(:each) do
     stub_user(:features => :all)
   end
@@ -30,6 +32,68 @@ describe EmsMiddlewareController do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_ems_middleware")
       end
+    end
+  end
+
+  describe "Hawkular - create, update" do
+    before do
+      allow(controller).to receive(:check_privileges).and_return(true)
+      allow(controller).to receive(:assert_privileges).and_return(true)
+      login_as FactoryGirl.create(:user, :features => "ems_middleware_new")
+    end
+
+    render_views
+
+    it 'creates on post' do
+      expect do
+        post :create, :params => {
+            "button"           => "add",
+            "name"             => "SeaHawks",
+            "emstype"          => "hawkular",
+            "zone"             => zone.name,
+            "cred_type"        => "default",
+            "default_hostname" => "foo.com",
+            "default_userid"   => "foo",
+            "default_password" => "[FILTERED]",
+            "default_verify"   => "[FILTERED]"
+        }
+      end.to change { ManageIQ::Providers::Hawkular::MiddlewareManager.count }.by(1)
+    end
+
+    it 'creates and updates an authentication record on post' do
+      expect do
+        post :create, :params => {
+            "button"           => "add",
+            "name"             => "SeaHawks",
+            "emstype"          => "hawkular",
+            "zone"             => zone.name,
+            "cred_type"        => "default",
+            "default_hostname" => "foo.com",
+            "default_userid"   => "foo",
+            "default_password" => "[FILTERED]",
+            "default_verify"   => "[FILTERED]"
+        }
+      end.to change { Authentication.count }.by(1)
+
+      expect(response.status).to eq(200)
+      hawkular = ManageIQ::Providers::Hawkular::MiddlewareManager.where(:name => "SeaHawks").first
+      expect(hawkular.authentications.size).to eq(1)
+
+      expect do
+        post :update, :params => {
+            "id"               => hawkular.id,
+            "button"           => "save",
+            "default_hostname" => "host_hawkular_updated",
+            "name"             => "SeaHawks",
+            "emstype"          => "hawkular",
+            "default_userid"   => "bar",
+            "default_password" => "[FILTERED]",
+            "default_verify"   => "[FILTERED]"
+        }
+      end.not_to change { Authentication.count }
+
+      expect(response.status).to eq(200)
+      expect(hawkular.authentications.first).to have_attributes(:userid => "bar", :password => "[FILTERED]")
     end
   end
 end

--- a/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
+++ b/spec/javascripts/controllers/ems_common/ems_common_form_controller_spec.js
@@ -653,3 +653,120 @@ describe('emsCommonFormController in the context of ems infra provider', functio
     });
   });
 });
+
+describe('emsCommonFormController in the context of ems middleware provider', function () {
+  var $scope, $controller, $httpBackend, miqService, compile;
+
+  beforeEach(module('ManageIQ'));
+
+  beforeEach(inject(function (_$httpBackend_, $rootScope, _$controller_, _miqService_, _$compile_) {
+    miqService = _miqService_;
+    compile = _$compile_;
+    spyOn(miqService, 'miqAjaxButton');
+    spyOn(miqService, 'restAjaxButton');
+    spyOn(miqService, 'sparkleOn');
+    spyOn(miqService, 'sparkleOff');
+    $scope = $rootScope.$new();
+
+    var emsCommonFormResponse = {
+      name: '',
+      emstype: '',
+      zone: 'default',
+      emstype_vm: false,
+      openstack_infra_providers_exist: false,
+      default_api_port: '',
+      api_version: 'v2'
+    };
+    $httpBackend = _$httpBackend_;
+    $httpBackend.whenGET('/ems_middleware/ems_middleware_form_fields/new').respond(emsCommonFormResponse);
+    $controller = _$controller_('emsCommonFormController',
+      {
+        $scope: $scope,
+        $attrs: {
+          'formFieldsUrl': '/ems_middleware/ems_middleware_form_fields/',
+          'createUrl': '/ems_middleware',
+          'updateUrl': '/ems_middleware/12345'
+        },
+        emsCommonFormId: 'new',
+        miqService: miqService
+      });
+  }));
+
+  afterEach(function () {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('when the emsCommonFormId is new', function () {
+    beforeEach(inject(function () {
+      $httpBackend.flush();
+    }));
+
+    it('sets the name to blank', function () {
+      expect($scope.emsCommonModel.name).toEqual('');
+    });
+
+    it('sets the type to blank', function () {
+      expect($scope.emsCommonModel.emstype).toEqual('');
+    });
+
+    it('sets the zone to default', function () {
+      expect($scope.emsCommonModel.zone).toEqual('default');
+    });
+
+    it('sets the api_port to blank', function () {
+      expect($scope.emsCommonModel.default_api_port).toEqual('');
+    });
+  });
+
+  describe('when the emsCommonFormId is an Hawkular Id', function () {
+    var emsCommonFormResponse = {
+      id: 12345,
+      name: 'SeaHawks',
+      emstype: 'hawkular',
+      zone: 'default',
+      default_userid: "default_user"
+    };
+
+    beforeEach(inject(function (_$controller_) {
+      $httpBackend.whenGET('/ems_middleware/ems_middleware_form_fields/12345').respond(emsCommonFormResponse);
+
+      $controller = _$controller_('emsCommonFormController',
+        {
+          $scope: $scope,
+          $attrs: {
+            'formFieldsUrl': '/ems_middleware/ems_middleware_form_fields/',
+            'createUrl': '/ems_middleware',
+            'updateUrl': '/ems_middleware/12345'
+          },
+          emsCommonFormId: 12345,
+          miqService: miqService
+        });
+      $httpBackend.flush();
+    }));
+
+    it('sets the name to the Hawkular Middleware Provider', function () {
+      expect($scope.emsCommonModel.name).toEqual('SeaHawks');
+    });
+
+    it('sets the type to hawkular', function () {
+      expect($scope.emsCommonModel.emstype).toEqual('hawkular');
+    });
+
+    it('sets the zone to default', function () {
+      expect($scope.emsCommonModel.zone).toEqual('default');
+    });
+
+    it('sets the default_userid', function () {
+      expect($scope.emsCommonModel.default_userid).toEqual("default_user");
+    });
+
+    it('sets the default_password', function () {
+      expect($scope.emsCommonModel.default_password).toEqual(miqService.storedPasswordPlaceholder);
+    });
+
+    it('sets the default_verify', function () {
+      expect($scope.emsCommonModel.default_verify).toEqual(miqService.storedPasswordPlaceholder);
+    });
+  });
+});

--- a/spec/routing/ems_middleware_routing_spec.rb
+++ b/spec/routing/ems_middleware_routing_spec.rb
@@ -1,0 +1,68 @@
+require "routing/shared_examples"
+
+describe EmsMiddlewareController do
+  let(:controller_name) { "ems_middleware" }
+
+  it_behaves_like "A controller that has advanced search routes", true
+  it_behaves_like "A controller that has compare routes"
+  it_behaves_like "A controller that has download_data routes"
+  it_behaves_like "A controller that has tagging routes"
+  it_behaves_like "A controller that has timeline routes"
+
+  %w(
+    ems_middleware_form_fields
+    new
+    show_list
+  ).each do |task|
+    describe "##{task}" do
+      it 'routes with GET' do
+        expect(get("/#{controller_name}/#{task}")).to route_to("#{controller_name}##{task}")
+      end
+    end
+  end
+
+  %w(
+    button
+    listnav_search_selected
+    save_default_search
+    show
+    show_list
+    update
+  ).each do |task|
+    describe "##{task}" do
+      it 'routes with POST' do
+        expect(post("/#{controller_name}/#{task}")).to route_to("#{controller_name}##{task}")
+      end
+    end
+  end
+
+  describe "#index" do
+    it "routes with GET" do
+      expect(get("/#{controller_name}")).to route_to("#{controller_name}#index")
+    end
+  end
+
+  describe "#create" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}")).to route_to("#{controller_name}#create")
+    end
+  end
+
+  describe "#edit" do
+    it "routes with GET" do
+      expect(get("/#{controller_name}/123/edit")).to route_to("#{controller_name}#edit", :id => "123")
+    end
+  end
+
+  describe "#show" do
+    it "routes with GET" do
+      expect(get("/#{controller_name}/123")).to route_to("#{controller_name}#show", :id => "123")
+    end
+  end
+
+  describe "#update" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/update/123")).to route_to("#{controller_name}#update", :id => "123")
+    end
+  end
+end


### PR DESCRIPTION
Convert the Middleware Provider form to Angular and leverage the validation directives that are currently used by the other providers.
PR includes specs  for `ems_middleware` routing, controller actions like `create` and `update` and also jasmine specs.

<img width="1361" alt="screen shot 2016-10-03 at 4 43 30 pm" src="https://cloud.githubusercontent.com/assets/1538216/19058017/072e532c-8989-11e6-853d-dfb703561138.png">

Fixes https://github.com/ManageIQ/manageiq/issues/9789
Fixes https://github.com/ManageIQ/manageiq/issues/11296