### PR TITLE
Include supports :reboot_guest to the Azure::CloudManager::Vm

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations.rb
@@ -1,4 +1,5 @@
 module ManageIQ::Providers::Azure::CloudManager::Vm::Operations
+  extend ActiveSupport::Concern
   include_concern 'Power'
 
   def raw_destroy

--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -1,4 +1,13 @@
 module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
+  extend ActiveSupport::Concern
+
+  included do
+    supports :reboot_guest do
+      unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
+      unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+    end
+  end
+
   def raw_suspend
     provider_service.stop(name, resource_group)
     update_attributes!(:raw_power_state => "VM stopping")


### PR DESCRIPTION
Azure instances were missing the 'Soft Reboot' button in Power operations toolbar. This PR is fixing the issue and getting back the soft reboot for Azure instances.

https://bugzilla.redhat.com/show_bug.cgi?id=1379071