### PR TITLE
The object in the hash reference should be as small as possible

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -111,7 +111,7 @@ module EmsRefresh::SaveInventory
 
         found.save!
         h[:id] = found.id
-        found.reload # reload to clear caches and lower memory usage
+        found.send(:clear_association_cache)
         h[:_object] = found
       rescue => err
         # If a vm failed to process, mark it as invalid and log an error

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -112,6 +112,7 @@ module EmsRefresh::SaveInventoryHelper
     hashes.each do |h|
       r = records.detect { |r| keys.all? { |k| r.send(k) == r.class.type_for_attribute(k.to_s).cast(h[k]) } }
       h[:id]      = r.id
+      r.send(:clear_association_cache)
       h[:_object] = r
     end
   end


### PR DESCRIPTION
The object in the hash reference should be as small as possible,
so we don't need to store that many data in memory.

An object having :id and :type is usable for relation assignment,
which is the only reason we keep this reference.

---
so now the object stored looks like
h[:_object]
```
#<ManageIQ::Providers::Amazon::CloudManager::Flavor id: 505, type: "ManageIQ::Providers::Amazon::CloudManager::Flavor">
```
but with the reload, we are storing
```
h[:_object].reload
#<ManageIQ::Providers::Amazon::CloudManager::Flavor id: 505, ems_id: 35, name: "t2.nano", description: "T2 Nano", cpus: 1, cpu_cores: 1, memory: 536870912, ems_ref: "t2.nano", type: "ManageIQ::Providers::Amazon::CloudManager::Flavor", supports_32_bit: true, supports_64_bit: true, enabled: true, supports_hvm: true, supports_paravirtual: false, block_storage_based_only: true, cloud_subnet_required: true, ephemeral_disk_size: 0, ephemeral_disk_count: 0, root_disk_size: nil, swap_disk_size: nil, publicly_available: nil>
```

(I hope the object internal representation is really smaller, maybe some rails guru knows that?)