### PR TITLE
Add GUI with inputs for VMware vCloud event monitoring

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -329,6 +329,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.default_api_port = "8443";
     } else if ($scope.emsCommonModel.emstype === 'vmware_cloud') {
       $scope.emsCommonModel.default_api_port = "443";
+      $scope.emsCommonModel.event_stream_selection = "none";
+      $scope.emsCommonModel.amqp_security_protocol = 'non-ssl';
     }
   };
 
@@ -482,7 +484,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
   };
 
   $scope.radioSelectionChanged = function() {
-    if ($scope.emsCommonModel.event_stream_selection === "ceilometer") {
+    if ($scope.emsCommonModel.event_stream_selection === "ceilometer" ||
+        $scope.emsCommonModel.event_stream_selection === "none") {
       if (angular.isDefined($scope.postValidationModel)) {
         $scope.emsCommonModel.amqp_hostname = $scope.postValidationModel.amqp.amqp_hostname;
         $scope.emsCommonModel.amqp_api_port = $scope.postValidationModel.amqp.amqp_api_port;

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -810,7 +810,7 @@ module EmsCommon
     @provider_regions = retrieve_provider_regions
     @openstack_infra_providers = retrieve_openstack_infra_providers
     @openstack_security_protocols = retrieve_openstack_security_protocols
-    @openstack_amqp_security_protocols = retrieve_openstack_amqp_security_protocols
+    @amqp_security_protocols = retrieve_amqp_security_protocols
     @nuage_security_protocols = retrieve_nuage_security_protocols
     @scvmm_security_protocols = [[_('Basic (SSL)'), 'ssl'], ['Kerberos', 'kerberos']]
     @openstack_api_versions = retrieve_openstack_api_versions
@@ -858,7 +858,7 @@ module EmsCommon
     retrieve_security_protocols
   end
 
-  def retrieve_openstack_amqp_security_protocols
+  def retrieve_amqp_security_protocols
     # OSP8 doesn't support SSL for AMQP
     [[_('Non-SSL'), 'non-ssl']]
   end

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -383,6 +383,9 @@ module Mixins
 
       if ems.kind_of?(ManageIQ::Providers::Vmware::CloudManager)
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
+        if params[:event_stream_selection] == "amqp"
+          amqp_endpoint = {:role => :amqp, :hostname => amqp_hostname, :port => amqp_port, :security_protocol => amqp_security_protocol}
+        end
       end
 
       if ems.kind_of?(ManageIQ::Providers::Azure::CloudManager)

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -76,19 +76,4 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   rescue => err
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
-
-  def translate_exception(err)
-    case err
-    when Fog::Compute::VcloudDirector::Unauthorized
-      MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
-    when Excon::Errors::Timeout
-      MiqException::MiqUnreachableError.new "Login attempt timed out"
-    when Excon::Errors::SocketError
-      MiqException::MiqHostError.new "Socket error: #{err.message}"
-    when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError
-      err
-    else
-      MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
-    end
-  end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher/stream.rb
@@ -12,15 +12,13 @@ class ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream
       connection.start
       return true
     rescue Bunny::AuthenticationFailureError => e
-      _log.info("Failed testing rabbit amqp connection: #{e.message}")
-      raise MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
-    rescue Bunny::TCPConnectionFailedForAllHosts => e
-      raise MiqException::MiqHostError.new "Socket error: #{e.message}"
+      raise MiqException::MiqInvalidCredentialsError.new "bad username or password for #{options[:hostname]}"
+    rescue Bunny::TCPConnectionFailed, Bunny::TCPConnectionFailedForAllHosts
+      raise MiqException::MiqHostError.new "cannot reach #{options[:hostname]}:#{options[:port]}"
     rescue
-      _log.info("Failed testing rabbit amqp connection for #{options[:hostname]}. ")
       raise
     ensure
-      connection.close if connection.respond_to? :close
+      connection.close if connection.respond_to?(:close) && connection.open?
     end
   end
 

--- a/app/models/manageiq/providers/vmware/cloud_manager/manager_events_mixin.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/manager_events_mixin.rb
@@ -7,16 +7,17 @@ module ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
         :ems          => self,
         :virtual_host => "/",
       }
-      amqp = connection_configuration_by_role("amqp")
-      if (endpoint = amqp.try(:endpoint))
-        opts[:hostname]          = endpoint.hostname
-        opts[:port]              = endpoint.port
-        opts[:security_protocol] = endpoint.security_protocol
-      end
+      if (amqp = connection_configuration_by_role("amqp"))
+        if (endpoint = amqp.try(:endpoint))
+          opts[:hostname]          = endpoint.hostname
+          opts[:port]              = endpoint.port
+          opts[:security_protocol] = endpoint.security_protocol
+        end
 
-      if (authentication = amqp.try(:authentication))
-        opts[:username] = authentication.userid
-        opts[:password] = authentication.password
+        if (authentication = amqp.try(:authentication))
+          opts[:username] = authentication.userid
+          opts[:password] = authentication.password
+        end
       end
       opts
     end
@@ -24,7 +25,5 @@ module ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
 
   def verify_amqp_credentials(_options = {})
     ManageIQ::Providers::Vmware::CloudManager::EventCatcher::Stream.test_amqp_connection(event_monitor_options)
-  rescue => err
-    raise translate_exception(err)
   end
 end

--- a/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
+++ b/app/models/manageiq/providers/vmware/manager_auth_mixin.rb
@@ -1,3 +1,5 @@
+require 'fog/vcloud_director'
+
 module ManageIQ::Providers::Vmware::ManagerAuthMixin
   extend ActiveSupport::Concern
 
@@ -6,20 +8,21 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
     raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
 
     options[:auth_type] = auth_type
-    case auth_type.to_s
+    begin
+      case auth_type.to_s
       when 'default' then
-        begin
-          with_provider_connection(options) do |vcd|
-            vcd.organizations.all
-          end
-        rescue => err
-          miq_exception = translate_exception(err)
-          _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-          raise miq_exception
+        with_provider_connection(options) do |vcd|
+          vcd.organizations.all
         end
-      when 'amqp' then verify_amqp_credentials(options)
+      when 'amqp' then
+        verify_amqp_credentials(options)
       else
         raise "Invalid Vmware vCloud Authentication Type: #{auth_type.inspect}"
+      end
+    rescue => err
+      miq_exception = translate_exception(err)
+      _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+      raise miq_exception
     end
 
     true
@@ -36,10 +39,23 @@ module ManageIQ::Providers::Vmware::ManagerAuthMixin
     self.class.raw_connect(server, port, username, password)
   end
 
+  def translate_exception(err)
+    case err
+    when Fog::Compute::VcloudDirector::Unauthorized
+      MiqException::MiqInvalidCredentialsError.new "Login failed due to a bad username or password."
+    when Excon::Errors::Timeout
+      MiqException::MiqUnreachableError.new "Login attempt timed out"
+    when Excon::Errors::SocketError
+      MiqException::MiqHostError.new "Socket error: #{err.message}"
+    when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError
+      err
+    else
+      MiqException::MiqHostError.new "Unexpected response returned from system: #{err.message}"
+    end
+  end
+
   module ClassMethods
     def raw_connect(server, port, username, password)
-      require 'fog/vcloud_director'
-
       params = {
         :vcloud_director_username      => username,
         :vcloud_director_password      => password,

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -78,14 +78,15 @@
 
 %div{"ng-if" => defined?(security_protocol_hide) ? false : true}
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_security_protocol.$invalid}",
-              "ng-if"    => "emsCommonModel.emstype == 'openstack' || " +       |
-                            "emsCommonModel.emstype == 'openstack_infra' || " + |
-                            "emsCommonModel.emstype == 'nuage_network' || " +   |
-                            "emsCommonModel.emstype == 'scvmm'"}                |
+              "ng-if"    => "emsCommonModel.emstype == 'openstack' || " +                              |
+                            "emsCommonModel.emstype == 'openstack_infra' || " +                        |
+                            "emsCommonModel.emstype == 'nuage_network' || " +                          |
+                            "(emsCommonModel.emstype == 'vmware_cloud' && '#{prefix}' === 'amqp') || " |
+                            "emsCommonModel.emstype == 'scvmm'"}                                       |
     %label.col-md-2.control-label{"for" => "#{prefix}_security_protocol"}
       = _('Security Protocol')
-    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
-      - prefix == "amqp" ? security_protocols = @openstack_amqp_security_protocols : security_protocols = @openstack_security_protocols
+    .col-md-8{"ng-if" => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra' || emsCommonModel.emstype == 'vmware_cloud'"}
+      - prefix == "amqp" ? security_protocols = @amqp_security_protocols : security_protocols = @openstack_security_protocols
       = select_tag("#{prefix}_security_protocol",
                        options_for_select([["<#{_('Choose')}>", nil]] + security_protocols, disabled: ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "#{ng_model}.#{prefix}_security_protocol",

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -152,8 +152,18 @@
               = _("Used to gather Capacity & Utilization metrics.")
       = miq_tab_content('amqp', 'default') do
         .form-group
-          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra'"}
-            %label.radio-inline.control-label{"for" => "ceilometer_radio"}
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra' || #{ng_model}.emstype == 'vmware_cloud'"}
+            %label.radio-inline.control-label{"for" => "none_radio", "ng-show" => "#{ng_model}.emstype == 'vmware_cloud'"}
+              %input{:type         => "radio",
+                     :name         => "event_stream_selection",
+                     :id           => "none_radio",
+                     "ng-checked"  => "emsCommonModel.event_stream_selection == none",
+                     :value        => "none",
+                     "ng-model"    => "emsCommonModel.event_stream_selection",
+                     "ng-change"   => "radioSelectionChanged()",
+                     "checkchange" => ""}
+                = _("None")
+            %label.radio-inline.control-label{"for" => "ceilometer_radio", "ng-show" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra'"}
               %input{:type         => "radio",
                      :name         => "event_stream_selection",
                      :id           => "ceilometer_radio",
@@ -190,12 +200,18 @@
                                     :prefix            => "amqp",
                                     :basic_info_needed => true}
         .form-group
-          .col-md-12
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'openstack_infra'"}
             %span{:style => "color:black"}
               %div{"ng-if" => "emsCommonModel.event_stream_selection == 'amqp'"}
                 = _("Used to authenticate with OpenStack AMQP Messaging Bus for event handling. Configure AMQP if eventing is not enabled on Ceilometer.")
               %div{"ng-if" => "emsCommonModel.event_stream_selection == 'ceilometer'"}
                 = _("Select Ceilometer if eventing is not enabled on AMQP.")
+          .col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'vmware_cloud'"}
+            %span{:style => "color:black"}
+              %div{"ng-if" => "emsCommonModel.event_stream_selection == 'amqp'"}
+                = _("Enable event monitoring. Used to automatically resync state when changes are performed on VMware vCloud Director directly.")
+              %div{"ng-if" => "emsCommonModel.event_stream_selection == 'none'"}
+                = _("Disable event monitoring.")
       = miq_tab_content('ssh_keypair', 'default') do
         .form-group
           .col-md-12.col-md-12{"ng-if" => "#{ng_model}" == "emsCommonModel" && "#{ng_model}.emstype == 'openstack_infra'"}
@@ -293,12 +309,11 @@
 %div{"ng-if" => "#{ng_model}.emstype == ''"}
   :javascript
     $('#auth_tabs').hide();
-%div{"ng-if" => "#{ng_model}.emstype == 'ec2' || "          + |
-                "#{ng_model}.emstype == 'gce' || "          + |
-                "#{ng_model}.emstype == 'scvmm' || "        + |
-                "#{ng_model}.emstype == 'vmwarews' || "     + |
-                "#{ng_model}.emstype == 'vmware_cloud' || " + |
-                "#{ng_model}.emstype == 'hawkular'"}          |
+%div{"ng-if" => "#{ng_model}.emstype == 'ec2' || "      + |
+                "#{ng_model}.emstype == 'gce' || "      + |
+                "#{ng_model}.emstype == 'scvmm' || "    + |
+                "#{ng_model}.emstype == 'vmwarews' || " + |
+                "#{ng_model}.emstype == 'hawkular'"}      |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);
     miq_tabs_show_hide("#metrics_tab", false);
@@ -312,7 +327,7 @@
     miq_tabs_show_hide("#ssh_keypair_tab", false);
     miq_tabs_init('#auth_tabs');
     $('#auth_tabs').show();
-%div{"ng-if" => "#{ng_model}.emstype == 'openstack'"}
+%div{"ng-if" => "#{ng_model}.emstype == 'openstack' || #{ng_model}.emstype == 'vmware_cloud'"}
   :javascript
     miq_tabs_show_hide("#amqp_tab", true);
     miq_tabs_show_hide("#metrics_tab", false);


### PR DESCRIPTION
User had to input her RabbitMQ credentials using Rails console.
Not any more - it can be done via GUI at ems cloud provider form (see screenshots below).

User can opt-in to avoid AMQP:
![event_gui_1](https://cloud.githubusercontent.com/assets/8102426/19350687/0b670c40-9159-11e6-9898-25c86685af6c.PNG)

Or she can provide AMQP credentials:
![event_gui_2](https://cloud.githubusercontent.com/assets/8102426/19350686/0b6093ba-9159-11e6-953b-7a0d77536eb8.PNG)


