### PR TITLE
Rename and move calc_fixed_compute to MetricRollup in chargeback

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -47,6 +47,11 @@ class Chargeback < ActsAsArModel
           key, extra_fields = key_and_fields(perf, interval, tz)
           data[key] ||= extra_fields
 
+          if perf.chargeback_fields_present?
+            data[key]['fixed_compute_metric'] ||= 0
+            data[key]['fixed_compute_metric'] = data[key]['fixed_compute_metric'] + 1
+          end
+
           rates_to_apply = cb.get_rates(perf)
           chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
           data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')
@@ -118,14 +123,11 @@ class Chargeback < ActsAsArModel
       raise _("expected 'hourly' performance interval but got '%{interval}") % {:interval => perf.capture_interval_name}
     end
 
-    calc_fixed_compute = calc_fixed_compute?(perf)
-    h['fixed_compute_metric'] = (h['fixed_compute_metric'] || 0) + 1 if calc_fixed_compute
-
     rates.each do |rate|
       rate.chargeback_rate_details.each do |r|
         rec    = r.metric && perf.respond_to?(r.metric) ? perf : perf.resource
         metric = r.metric.nil? ? 0 : rec.send(r.metric) || 0
-        cost   = r.group == 'fixed' && !calc_fixed_compute ? 0 : r.cost(metric)
+        cost   = r.group == 'fixed' && !perf.chargeback_fields_present? ? 0 : r.cost(metric)
 
         reportable_metric_and_cost_fields(r.rate_name, r.group, metric, cost).each do |k, val|
           next unless attribute_names.include?(k)
@@ -152,18 +154,6 @@ class Chargeback < ActsAsArModel
     end
 
     col_hash
-  end
-
-  # check if at least one of these isnt empty\nil\zero
-  def self.calc_fixed_compute?(perf)
-    fixed_compute_fields = %w(
-      derived_vm_numvcpus cpu_usagemhz_rate_average
-      cpu_usage_rate_average disk_usage_rate_average
-      derived_memory_available derived_memory_used
-      net_usage_rate_average derived_vm_used_disk_storage
-      derived_vm_allocated_disk_storage
-    )
-    fixed_compute_fields.any? { |field| perf.send(field).present? && perf.send(field) != 0 }
   end
 
   def self.get_group_key_ts(perf, interval, tz)

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -1,6 +1,12 @@
 class MetricRollup < ApplicationRecord
   include Metric::Common
 
+  CHARGEBACK_METRIC_FIELDS = %w(derived_vm_numvcpus cpu_usagemhz_rate_average
+                                cpu_usage_rate_average disk_usage_rate_average
+                                derived_memory_available derived_memory_used
+                                net_usage_rate_average derived_vm_used_disk_storage
+                                derived_vm_allocated_disk_storage).freeze
+
   def self.with_interval_and_time_range(interval, timestamp)
     where(:capture_interval_name => interval, :timestamp => timestamp)
   end
@@ -48,5 +54,11 @@ class MetricRollup < ApplicationRecord
     metrics = metrics.where(:resource_id => resource_ids) if resource_ids
     metrics = metrics.order(:resource_id, :timestamp => :desc)
     metrics.select('DISTINCT ON (metric_rollups.resource_id) metric_rollups.*')
+  end
+
+  def chargeback_fields_present?
+    return @chargeback_fields_present if defined?(@chargeback_fields_present)
+
+    @chargeback_fields_present = CHARGEBACK_METRIC_FIELDS.any? { |field| send(field).present? && send(field).nonzero? }
   end
 end


### PR DESCRIPTION
- rename `calc_fixed_compute` to `chargeback_fields_present?` and memoize it
- move method to MetricRollup
- calculation moved outside of calculate_cost 

Future intension is make method on chargeback_rate_detail for getting cost and metric value 
and it will be dependent only on MetricRollup records.

@miq-bot add_label refactoring, chargeback
@miq-bot assign @gtanzillo 

fyi @zeari 


