### PR TITLE
Added Automate $evm.create_notification method and added tests.

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -34,3 +34,23 @@
   :expires_in: 14.days
   :level: :warning
   :audience: tenant
+- :name: automate_user_success
+  :message: Automate user success
+  :expires_in: 24.hours
+  :level: :success
+  :audience: user
+- :name: automate_user_error
+  :message: Automate user error
+  :expires_in: 24.hours
+  :level: :error
+  :audience: user
+- :name: automate_user_info
+  :message: Automate user info
+  :expires_in: 24.hours
+  :level: :info
+  :audience: user
+- :name: automate_user_warning
+  :message: Automate user warning
+  :expires_in: 24.hours
+  :level: :warning
+  :audience: user

--- a/lib/miq_automation_engine/service_models/miq_ae_service_notification.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_notification.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceNotification < MiqAeServiceModelBase
+    expose :notification_type, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_notification_type.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_notification_type.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceNotificationType < MiqAeServiceModelBase
+    expose :notifications, :association => true
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -152,5 +152,72 @@ module MiqAeServiceSpec
         miq_ae_service.prepend_namespace = ns
       end
     end
+    context "create notifications" do
+      before { NotificationType.seed }
+
+      let(:options) { {} }
+      let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
+      let(:miq_ae_service) { MiqAeService.new(workspace) }
+      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:vm) { FactoryGirl.create(:vm) }
+
+      context "#create_notification!" do
+        it "invalid type" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          expect { miq_ae_service.create_notification!(:type => :invalid_type, :subject => vm) }
+            .to raise_error(ArgumentError, "Invalid notification type specified")
+        end
+
+        it "invalid subject" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          allow(workspace).to receive(:ae_user).and_return(user)
+          expect { miq_ae_service.create_notification!(:type => :vm_provisioned, :subject => 'fred') }
+            .to raise_error(ArgumentError, "Subject must be a valid Active Record object")
+        end
+
+        it "default type of automate_user_info" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          allow(workspace).to receive(:ae_user).and_return(user)
+          result = miq_ae_service.create_notification!(:message => 'mary had a little lamb')
+          expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
+        end
+
+        it "type of automate_user_info" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          allow(workspace).to receive(:ae_user).and_return(user)
+          result = miq_ae_service.create_notification!(:level => 'success', :audience => 'user', :message => 'test')
+          expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
+        end
+      end
+
+      context "#create_notification" do
+        it "invalid type" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          expect { miq_ae_service.create_notification(:type => :invalid_type, :subject => vm) }
+            .not_to raise_error
+        end
+
+        it "invalid subject" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          allow(workspace).to receive(:ae_user).and_return(user)
+          expect { miq_ae_service.create_notification(:type => :vm_provisioned, :subject => 'fred') }
+            .not_to raise_error
+        end
+
+        it "default type of automate_user_info" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          allow(workspace).to receive(:ae_user).and_return(user)
+          result = miq_ae_service.create_notification(:message => 'mary had a little lamb')
+          expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
+        end
+
+        it "type of automate_user_info" do
+          allow(workspace).to receive(:persist_state_hash).and_return({})
+          allow(workspace).to receive(:ae_user).and_return(user)
+          result = miq_ae_service.create_notification(:level => 'success', :audience => 'user', :message => 'test')
+          expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow Automate methods to generate notifications with new $evm.create_notification method.

Notification creation requires valid notification types to be used. There are predefined notification types and messages where the user only needs to pass the subject. 
Since Automate users can create their own methods and workflows, it's important that they're able to generate custom notification messages.  We've added the first set of automate specific notification types for this purpose: automate_user_success, automate_user_info, automate_user_warning, automate_user_error.  These are valid notification types and can be used as such, but the $evm.create_notification method constructs these types based on the "level and "audience" user input. 

Users can create notifications by:

1. Not specifying a "type" and only passing a "message". 
$evm.create_notification(:message => 'My custom provisioning job has started')"
When no type, level, or audience is specified, the default level is "info" and the default audience is "user" which generates a notification type of "automate_user_info".  The user has the ability to specify an object for the "subject" and if not specified, the "subject" is set to the Automate workspace user.

2. Specifying a type:
$evm.create_notification(:type => :vm_provisioned, :subject => vm, :message => 'testing123')
The user can create a notification using a predefined "type" and can specify a "subject" and "message".

3. Specifying level and/or audience:
$evm.create_notification(:level => 'warning', :subject => vm, :message => 'automate message')
This would generate a "automate_user_warning" notification type. 
$evm.create_notification(:audience => 'user', :subject => vm, :message => 'automate message') 
"tenant" and "global" audiences to be added. 

Type would be used in the case where "type", "level" and "audience" are specified:
$evm.create_notification(:type => :vm_provisioned, :level => 'warning', :audience => 'user')
The "vm_provisioned" type would be used here. 

The "subject" and "message" arguments can be used in all cases. The "subject" will default to the workspace user object if not specified.
