### PR TITLE
added JSON generation of chargeback report for service to api

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -35,6 +35,7 @@ class Service < ApplicationRecord
   virtual_has_one    :custom_action_buttons
   virtual_has_one    :provision_dialog
   virtual_has_one    :user
+  virtual_has_one    :chargeback_report
 
   before_validation :set_tenant_from_group
 
@@ -236,6 +237,12 @@ class Service < ApplicationRecord
     user = evm_owner
     user = User.super_admin.tap { |u| u.current_group = miq_group } if user.nil? || !user.miq_group_ids.include?(miq_group_id)
     user
+  end
+
+  def chargeback_report
+    miq_report = MiqReportResult.find_by(:name => chargeback_report_name)
+    raise "Chargeback report for service '#{name}' not found" if miq_report.nil?
+    {:results => miq_report.result_set}
   end
 
   def self.queue_chargeback_reports(options = {})

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -240,9 +240,9 @@ class Service < ApplicationRecord
   end
 
   def chargeback_report
-    miq_report = MiqReportResult.find_by(:name => chargeback_report_name)
-    raise "Chargeback report for service '#{name}' not found" if miq_report.nil?
-    {:results => miq_report.result_set}
+    report_result = MiqReportResult.find_by(:name => chargeback_report_name)
+    raise "Chargeback report for service '#{name}' not found" if report_result.nil?
+    {:results => report_result.result_set}
   end
 
   def self.queue_chargeback_reports(options = {})

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -242,7 +242,6 @@ class Service < ApplicationRecord
   def chargeback_report
     report_result = MiqReportResult.find_by(:name => chargeback_report_name)
     if report_result.nil?
-      _log.warn "Chargeback report for service '#{name}' not found"
       {:results => []}
     else
       {:results => report_result.result_set}

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -241,8 +241,12 @@ class Service < ApplicationRecord
 
   def chargeback_report
     report_result = MiqReportResult.find_by(:name => chargeback_report_name)
-    raise "Chargeback report for service '#{name}' not found" if report_result.nil?
-    {:results => report_result.result_set}
+    if report_result.nil?
+      _log.warn "Chargeback report for service '#{name}' not found"
+      {:results => []}
+    else
+      {:results => report_result.result_set}
+    end
   end
 
   def self.queue_chargeback_reports(options = {})

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -338,10 +338,6 @@ describe Service do
     end
 
     describe "#chargeback_report" do
-      it "raises error if chargeback report not found" do
-        expect { @service.chargeback_report }.to raise_error(RuntimeError)
-      end
-
       it "returns chargeback report" do
         EvmSpecHelper.local_miq_server
         @service.generate_chargeback_report

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -267,19 +267,19 @@ describe Service do
     before do
       @vm = FactoryGirl.create(:vm_vmware)
       @vm_1 = FactoryGirl.create(:vm_vmware)
-
       @service = FactoryGirl.create(:service)
       @service.name = "Test_Service_1"
-      @service_c1 = FactoryGirl.create(:service, :service => @service)
-      @service_c1.name = "Test_Service_2"
       @service << @vm
-      @service_c1 << @vm_1
       @service.save
-      @service_c1.save
     end
 
     describe ".queue_chargeback_reports" do
       it "queue request to generate chargeback report for each service" do
+        @service_c1 = FactoryGirl.create(:service, :service => @service)
+        @service_c1.name = "Test_Service_2"
+        @service_c1 << @vm_1
+        @service_c1.save
+
         expect(MiqQueue).to receive(:put).twice
         described_class.queue_chargeback_reports
       end
@@ -288,7 +288,6 @@ describe Service do
     describe "#chargeback_report_name" do
       it "creates chargeback report's name" do
         expect(@service.chargeback_report_name).to eq "Chargeback-Vm-Monthly-Test_Service_1"
-        expect(@service_c1.chargeback_report_name).to eq "Chargeback-Vm-Monthly-Test_Service_2"
       end
     end
 
@@ -335,6 +334,18 @@ describe Service do
         cols_from_data = report.table.column_names.to_set
         cols_from_yaml = report_yaml['col_order'].to_set
         expect(cols_from_yaml).to be_subset(cols_from_data)
+      end
+    end
+
+    describe "#chargeback_report" do
+      it "raises error if chargeback report not found" do
+        expect { @service.chargeback_report }.to raise_error(RuntimeError)
+      end
+
+      it "returns chargeback report" do
+        EvmSpecHelper.local_miq_server
+        @service.generate_chargeback_report
+        expect(@service.chargeback_report).to have_key(:results)
       end
     end
   end


### PR DESCRIPTION
Added ability to generate JSON of chargeback report for service.

https://www.pivotaltracker.com/story/show/128987465

**Usage** 
  URI:   /api/services/:id?attributes=chargeback_report
**return (report found):**
```
{
  "href": "http://localhost:3000/api/services/6",
  "id": 6,
  "name": "Test-Service_Item-20160921-180120",
  "description": "Test-Service_Item",
  "guid": "e74e1c68-8046-11e6-8b8d-f45c898eac77",
  "service_template_id": 2,
  "options": {
    "dialog": {
      "dialog_name": "Order-2"
    }
  },
  "display": true,
  "created_at": "2016-09-21T22:01:09Z",
  "updated_at": "2016-09-21T22:01:20Z",
  "evm_owner_id": 1,
  "miq_group_id": 2,
  "tenant_id": 1,
  "chargeback_report": {
    "results": [
      {
        "start_date": "2016-09-01T00:00:00.000Z",
        "display_range": "Sep 2016",
        "vm_name": "aab-ldap",
        "cpu_allocated_cost": 2.0,
        "cpu_used_metric": 107.9729654013167,
        "cpu_used_cost": 2.1594593080263342,
        "memory_allocated_cost": 2.0,
        "memory_used_metric": 354.440954083205,
        "memory_used_cost": 7.0888190816640995,
        "disk_io_used_metric": 0.0,
        "disk_io_used_cost": 0.0,
        "net_io_used_metric": 0.0,
        "net_io_used_cost": 1.0,
        "storage_allocated_metric": 42949672960.0,
        "storage_allocated_cost": 1.862645149230957e-09,
        "storage_used_metric": 42949672960.0,
        "storage_used_cost": 80.0
      }
    ]
  },
  "actions": [
    {
      "name": "edit",
      "method": "post",
      "href": "http://localhost:3000/api/services/6"
    },
    {
      "name": "retire",
      "method": "post",
      "href": "http://localhost:3000/api/services/6"
    },
    {
      "name": "set_ownership",
      "method": "post",
      "href": "http://localhost:3000/api/services/6"
    },
    {
      "name": "delete",
      "method": "delete",
      "href": "http://localhost:3000/api/services/6"
    }
  ]
}
```

**return (report not found):**
```
{
  "href": "http://localhost:3000/api/services/6",
  "id": 6,
  "name": "Test-Service_Item-20160921-180120",
  "description": "Yuri_test-Service_Item",
  "guid": "e74e1c68-8046-11e6-8b8d-f45c898eac77",
  "service_template_id": 2,
  "options": {
    "dialog": {
      "dialog_name": "Order-2"
    }
  },
  "display": true,
  "created_at": "2016-09-21T22:01:09Z",
  "updated_at": "2016-09-21T22:01:20Z",
  "evm_owner_id": 1,
  "miq_group_id": 2,
  "tenant_id": 1,
  "chargeback_report": {
    "results": [

    ]
  },
  "actions": [
    {
      "name": "edit",
      "method": "post",
      "href": "http://localhost:3000/api/services/6"
    },
    {
      "name": "retire",
      "method": "post",
      "href": "http://localhost:3000/api/services/6"
    },
    {
      "name": "set_ownership",
      "method": "post",
      "href": "http://localhost:3000/api/services/6"
    },
    {
      "name": "delete",
      "method": "delete",
      "href": "http://localhost:3000/api/services/6"
    }
  ]
}
```

**return (service not found):**
```
{
  "error": {
    "kind": "not_found",
    "message": "Couldn't find Service with 'id'=5",
    "klass": "ActiveRecord::RecordNotFound"
  }
}
```

@miq-bot add-label core, chargeback, enhancement, reporting

\cc @gtanzillo, @abellotti 