### PR TITLE
Set appliance "system" memory/swap information

### DIFF
--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -3,14 +3,28 @@ require 'miq-system'
 module MiqServer::StatusManagement
   extend ActiveSupport::Concern
 
+  def status_update
+    assign_attributes(process_status)
+    save!
+  end
+
+  def process_status
+    require 'miq-process'
+    pinfo = MiqProcess.processInfo
+    # Ensure the hash only contains the values we want to store in the table
+    pinfo.keep_if { |k, _v| MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
+    pinfo[:os_priority] = pinfo.delete(:priority)
+    pinfo
+  end
+
   module ClassMethods
+    # TODO: Delegate class methods to instance methods.
+    # 1. Create instance methods
+    # 2. Delegate and/or deprecate these class methods
+    # 3. Change callers (app/models/miq_schedule_worker/jobs.rb) to use an instance.
+    # 4. Cleanup any existing queue messages.
     def status_update
-      require 'miq-process'
-      pinfo = MiqProcess.processInfo
-      # Ensure the hash only contains the values we want to store in the table
-      pinfo.keep_if { |k, _v| MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
-      pinfo[:os_priority] = pinfo.delete(:priority)
-      my_server.update_attributes!(pinfo)
+      my_server.status_update
     end
 
     def log_status

--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -4,8 +4,19 @@ module MiqServer::StatusManagement
   extend ActiveSupport::Concern
 
   def status_update
+    assign_attributes(system_status)
     assign_attributes(process_status)
     save!
+  end
+
+  def system_status
+    sys = MiqSystem.memory
+    {
+      :system_memory_free => sys.fetch(:MemFree, 0),
+      :system_memory_used => sys.fetch(:MemTotal, 0) - sys.fetch(:MemFree, 0),
+      :system_swap_free   => sys.fetch(:SwapFree, 0),
+      :system_swap_used   => sys.fetch(:SwapTotal, 0) - sys.fetch(:SwapFree, 0)
+    }
   end
 
   def process_status

--- a/spec/models/miq_server/status_management_spec.rb
+++ b/spec/models/miq_server/status_management_spec.rb
@@ -12,6 +12,7 @@ describe MiqServer do
 
     it ".status_update" do
       require 'miq-process'
+      require 'miq-system'
       allow(MiqProcess).to receive(:processInfo).and_return(
         :pid                   => 94_660,
         :memory_usage          => 246_824_960,
@@ -24,14 +25,27 @@ describe MiqServer do
         :proportional_set_size => 198_721_987
       )
 
+      allow(MiqSystem).to receive(:memory).and_return(
+        :MemFree   => 118_706_176,
+        :MemTotal  => 2_967_281_664,
+        :SwapFree  => 6_291_300_352,
+        :SwapTotal => 6_291_451_904
+      )
+
       described_class.status_update
       @miq_server.reload
+
       expect(@miq_server.os_priority).to eq 31
       expect(@miq_server.memory_usage).to eq 246_824_960
       expect(@miq_server.percent_memory).to eq 1.4
       expect(@miq_server.percent_cpu).to eq 1.0
       expect(@miq_server.memory_size).to eq 2_792_611_840
       expect(@miq_server.proportional_set_size).to eq 198_721_987
+
+      expect(@miq_server.system_memory_free).to eq 118_706_176
+      expect(@miq_server.system_memory_used).to eq(2_967_281_664 - 118_706_176)
+      expect(@miq_server.system_swap_free).to eq 6_291_300_352
+      expect(@miq_server.system_swap_used).to eq(6_291_451_904 - 6_291_300_352)
     end
   end
 end


### PR DESCRIPTION
Now that #11660 is in, we can set the appliance system memory and swap values as part of the existing status_update.  Note, this information is already logged in `MiqServer.log_system_status`

* MiqServer#status_update learned to set system used/free memory/swap information

Followup to #11660
https://bugzilla.redhat.com/show_bug.cgi?id=1274557

Note, it's easier to follow commit by commit since I moved a class method to an instance method in the first commit.