### PR TITLE
Include missing subcollection mixins

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -2,6 +2,8 @@ module Api
   class GroupsController < BaseController
     INVALID_GROUP_ATTRS = %w(id href group_type).freeze
 
+    include Subcollections::Tags
+
     def groups_search_conditions
       ["group_type != ?", MiqGroup::TENANT_GROUP]
     end

--- a/app/controllers/api/service_templates_controller.rb
+++ b/app/controllers/api/service_templates_controller.rb
@@ -3,5 +3,6 @@ module Api
     include Subcollections::ServiceDialogs
     include Subcollections::Tags
     include Subcollections::ResourceActions
+    include Subcollections::ServiceRequests
   end
 end

--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -2,5 +2,6 @@ module Api
   class TemplatesController < BaseController
     include Subcollections::Policies
     include Subcollections::PolicyProfiles
+    include Subcollections::Tags
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,6 +3,8 @@ module Api
     INVALID_USER_ATTRS = %w(id href current_group_id settings).freeze # Cannot update other people's settings
     INVALID_SELF_USER_ATTRS = %w(id href current_group_id).freeze
 
+    include Subcollections::Tags
+
     skip_before_action :validate_api_action, :only => :update
 
     def update


### PR DESCRIPTION
In refactoring the API code into separate controllers for each
collection, some controllers were left missing the necessary methods for
subcollections they were configured (and documented) to support. Since
this was not picked up by the test suite I'll add tests to ensure this
does not happen again, but I'll do this in a follow up as this revision
represents more of a hotfix for this issue.

I've gone through the configuration and checked off each subcollection
in turn:

* automation_requests
  * [x] request_tasks
  * [x] tasks
* blueprints
  * [x] tags
* categories
  * [x] tags
* chargebacks
  * [x] rates
* clusters
  * [x] tags
  * [x] policies
  * [x] policy_profiles
* data_stores
  * [x] tags
* groups
  * [x] tags
* hosts
  * [x] tags
  * [x] policies
  * [x] policy_profiles
* policies
  * [x] conditions
  * [x] policy_actions
  * [x] events
* policy_profiles
  * [x] policies
* providers
  * [x] tags
  * [x] policies
  * [x] policy_profiles
  * [x] cloud_networks
* provision_requests
  * [x] request_tasks
  * [x] tasks
* reports
  * [x] results
  * [x] schedules
* resource_pools
  * [x] tags
  * [x] policies
  * [x] policy_profiles
* roles
  * [x] features
* service_catalogs
  * [x] service_templates
* service_orders
  * [x] service_requests
* service_requests
  * [x] request_tasks
  * [x] tasks
* service_templates
  * [x] resource_actions
  * [x] tags
  * [x] service_requests
  * [x] service_dialogs
* services
  * [x] tags
  * [x] service_dialogs
  * [x] vms
* templates
  * [x] tags
  * [x] policies
  * [x] policy_profiles
* tenants
  * [x] tags
  * [x] quotas
* users
  * [x] tags
* vms
  * [x] tags
  * [x] policies
  * [x] policy_profiles
  * [x] accounts
  * [x] custom_attributes
  * [x] software

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1381715

@miq-bot add-label api, bug
@miq-bot assign @abellotti 