### PR TITLE
[EUWE] point amazon provider gem to euwe branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ raise "Ruby versions less than 2.2.2 are unsupported!" if RUBY_VERSION < "2.2.2"
 
 # when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
 unless dependencies.detect { |d| d.name == "manageiq-providers-amazon" }
-  gem "manageiq-providers-amazon", :git => "https://github.com/ManageIQ/manageiq-providers-amazon", :branch => "master"
+  gem "manageiq-providers-amazon", :git => "https://github.com/ManageIQ/manageiq-providers-amazon", :branch => "euwe"
 end
 
 # Unmodified gems


### PR DESCRIPTION
for now point to euwe branch of the amazon provider repo

once we start finalizing and release a version of the gem we can point it to that release
of course we can do this asap - but this is to make `bin/setup` work on euwe again

note that naming the branch 'euwe' on amazon is just for starters and to minimize developer confusion.
we can give the amazon release any number we want and further down the road we can name the branches what we want. 

@miq-bot assign @chessbyte 
cc @Fryguy @blomquisg 