### PR TITLE
Cleanup rescues by removing redundant StandardError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -394,7 +394,7 @@ class ApplicationController < ActionController::Base
         msg = _('Depot Settings successfuly validated')
         MiqSchedule.new.verify_file_depot(settings)
       end
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during 'Validate': %{error_message}") % {:error_message => bang.message}, :error)
     else
       add_flash(msg)
@@ -2346,7 +2346,7 @@ class ApplicationController < ActionController::Base
       begin
         authrec = find_by_id_filtered(model.constantize, id)
       rescue ActiveRecord::RecordNotFound
-      rescue StandardError => @bang
+      rescue => @bang
       end
     end
     if rec.nil?

--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -267,7 +267,7 @@ module ApplicationController::Buttons
     else
       begin
         button.invoke(obj)    # Run the task
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error executing: \"%{task_description}\" %{error_message}") %
           {:task_description => params[:desc], :error_message => bang.message}, :error) # Push msg and error flag
       else

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -30,7 +30,7 @@ module ApplicationController::DialogRunner
       return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
       begin
         result = @edit[:wf].submit_request
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Provisioning': %{error_message}") % {:error_message => bang.message}, :error)
         javascript_flash
       else

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -108,7 +108,7 @@ module ApplicationController::Filter
       @edit[:edit_exp] = copy_hash(exp)
       begin
         exp_set_fields(@edit[:edit_exp])
-      rescue StandardError => bang
+      rescue => bang
         @exp_atom_errors = [_("There is an error in the selected expression element, perhaps it was imported or edited manually."),
                             _("This element should be removed and recreated or you can report the error to your %{product} administrator.") % {:product => I18n.t('product.name')},
                             _("Error details: %{message}") % {:message => bang}]
@@ -701,7 +701,7 @@ module ApplicationController::Filter
       sname = s.description
       begin
         s.destroy                                                   # Delete the record
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during 'delete': %{error_message}") %
           {:model => ui_lookup(:model => "MiqSearch"), :name => sname, :error_message => bang.message}, :error)
       else

--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -727,7 +727,7 @@ module ApplicationController::MiqRequestMethods
         end
         begin
           @edit[:wf].refresh_field_values(@edit[:new])
-        rescue StandardError => bang
+        rescue => bang
           add_flash(bang.message, :error)
           @edit[:new][f.to_sym] = val                                             # Save value
           return false                                                            # No need to refresh dialog divs

--- a/app/controllers/application_controller/sysprep_answer_file.rb
+++ b/app/controllers/application_controller/sysprep_answer_file.rb
@@ -11,7 +11,7 @@ class ApplicationController
           @edit[:new][:sysprep_upload_text] = SysprepFile.new(params[:upload][:file]).content
           msg = _('Sysprep "%{params}" upload was successful') % {:params => params[:upload][:file].original_filename}
           add_flash(msg)
-        rescue StandardError => bang
+        rescue => bang
           @edit[:new][:sysprep_upload_text] = nil
           msg = _("Error during Sysprep \"%{params}\" file upload: %{message}") %
                   {:params => params[:upload][:file].original_filename, :message => bang.message}

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -231,7 +231,7 @@ module ApplicationController::Tags
                                       :add_ids    => @edit[:new][:assignments] - @edit[:current][:assignments],
                                       :delete_ids => @edit[:current][:assignments] - @edit[:new][:assignments]
                                     })
-  rescue StandardError => bang
+  rescue => bang
     add_flash(_("Error during 'Save Tags': %{error_message}") % {:error_message => bang.message}, :error)
   else
     add_flash(_("Tag edits were successfully saved"))

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -584,7 +584,7 @@ class CatalogController < ApplicationController
       st_catalog_set_record_vars(@stc)
       begin
         @stc.save
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Catalog Edit': %{error_message}") % {:error_message => bang.message}, :error)
       else
         if @stc.errors.empty?
@@ -639,7 +639,7 @@ class CatalogController < ApplicationController
       model_name = ui_lookup(:model => "ServiceTemplate")  # Lookup friendly model name in dictionary
       begin
         st.public_send(task.to_sym) if st.respond_to?(task)    # Run the task
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{error_message}") %
           {:model => model_name, :name => st_name, :task => task, :error_message => bang.message}, :error)
       else
@@ -729,7 +729,7 @@ class CatalogController < ApplicationController
         begin
           ot.remote_proxy = true
           ot.destroy
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("Error during 'Orchestration Template Deletion': %{error_message}") %
             {:error_message => bang.message}, :error)
         else
@@ -1006,7 +1006,7 @@ class CatalogController < ApplicationController
       end
       begin
         ot.save_as_orderable!
-      rescue StandardError => bang
+      rescue => bang
         render_flash(_("Error during 'Orchestration Template Edit': %{error_message}") %
           {:error_message => bang.message}, :error)
       else
@@ -1059,7 +1059,7 @@ class CatalogController < ApplicationController
         :remote_proxy => true)
       begin
         ot.save_as_orderable!
-      rescue StandardError => bang
+      rescue => bang
         render_flash(_("Error during 'Orchestration Template Copy': %{error_message}") %
           {:error_message => bang.message}, :error)
       else
@@ -1105,7 +1105,7 @@ class CatalogController < ApplicationController
         :remote_proxy => true)
       begin
         ot.save_as_orderable!
-      rescue StandardError => bang
+      rescue => bang
         render_flash(_("Error during 'Orchestration Template creation': %{error_message}") %
           {:error_message => bang.message}, :error)
       else

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -326,7 +326,7 @@ class ChargebackController < ApplicationController
       rate_type = x_node.split('-').last
       begin
         ChargebackRate.set_assignments(rate_type, @edit[:set_assignments])
-      rescue StandardError => bang
+      rescue => bang
         render_flash(_("Error during 'Rate assignments': %{error_message}") % {:error_message => bang.message}, :error)
       else
         add_flash(_("Rate Assignments saved"))

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -410,7 +410,7 @@ class ConfigurationController < ApplicationController
       @timeprofile.rollup_daily_metrics = params[:rollup_daily]
       begin
         @timeprofile.save!
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("TimeProfile \"%{name}\": Error during 'save': %{error_message}") %
                       {:name => @timeprofile.description, :error_message => bang.message}, :error)
         @in_a_form = true

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -999,7 +999,7 @@ module EmsCommon
         end
         begin
           ems.send(task.to_sym) if ems.respond_to?(task)    # Run the task
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{error_message}") %
             {:model => model.to_s, :name => ems_name, :task => task, :error_message => bang.message}, :error)
           AuditEvent.failure(:userid => session[:userid], :event => "#{@table_name}_#{task}",

--- a/app/controllers/host_controller.rb
+++ b/app/controllers/host_controller.rb
@@ -294,7 +294,7 @@ class HostController < ApplicationController
       @in_a_form = true
       begin
         verify_host.verify_credentials(params[:type])
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
@@ -417,7 +417,7 @@ class HostController < ApplicationController
           page << "if (confirm('The Host SSH key has changed, do you want to accept the new key?')) miqAjax('#{new_url}');"
         end
         return
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -616,7 +616,7 @@ class MiqAeClassController < ApplicationController
           @ae_inst.ae_values.each { |v| v.value = nil if v.value == "" }
           @ae_inst.save!
         end   # end of transaction
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
         render :update do |page|
@@ -674,7 +674,7 @@ class MiqAeClassController < ApplicationController
           add_aeinst.ae_values.each { |v| v.value = nil if v.value == "" }
           add_aeinst.save!
         end  # end of transaction
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'add': %{message}") % {:message => bang.message}, :error)
         @in_a_form = true
         render :update do |page|
@@ -1022,7 +1022,7 @@ class MiqAeClassController < ApplicationController
         MiqAeClass.transaction do
           ae_class.save!
         end  # end of transaction
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         session[:changed] = @changed
         @changed = true
@@ -1069,7 +1069,7 @@ class MiqAeClassController < ApplicationController
           ae_class.ae_fields.each { |fld| fld.default_value = nil if fld.default_value == "" }
           ae_class.save!
         end  # end of transaction
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         session[:changed] = @changed = true
         render :update do |page|
@@ -1115,7 +1115,7 @@ class MiqAeClassController < ApplicationController
       ns_set_record_vars(ae_ns)                     # Set the record variables, but don't save
       begin
         ae_ns.save!
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'save': %{message}") % {:message => bang.message}, :error)
         session[:changed] = @changed
         @changed = true
@@ -1166,7 +1166,7 @@ class MiqAeClassController < ApplicationController
           ae_method.inputs.each { |fld| fld.default_value = nil if fld.default_value == "" }
           ae_method.save!
         end  # end of transaction
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         session[:changed] = @changed
         @changed = true
@@ -1241,7 +1241,7 @@ class MiqAeClassController < ApplicationController
         MiqAeClass.transaction do
           add_aeclass.save!
         end
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
         render :update do |page|
@@ -1279,7 +1279,7 @@ class MiqAeClassController < ApplicationController
           set_field_vars(add_aemethod)
           add_aemethod.save!
         end
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
         render :update do |page|
@@ -1733,7 +1733,7 @@ class MiqAeClassController < ApplicationController
 
     begin
       res = @edit[:typ].copy(options)
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during '%{record} copy': %{error_message}") %
         {:record => ui_lookup(:model => @edit[:typ].to_s), :error_message => bang.message}, :error)
       render :update do |page|

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -217,7 +217,7 @@ module MiqAeCustomizationController::Dialogs
 
       begin
         dialog_set_record_vars(dialog)
-      rescue StandardError => @bang
+      rescue => @bang
         add_flash(@bang.message, :error)
         @changed = true
         render_flash

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -108,7 +108,7 @@ class MiqAeToolsController < ApplicationController
   def automate_json
     begin
       automate_json = automate_import_json_serializer.serialize(ImportFileUpload.find(params[:import_file_upload_id]))
-    rescue StandardError => e
+    rescue => e
       add_flash(_("Error: import processing failed: %{message}") % {:message => e.message}, :error)
     end
 
@@ -263,7 +263,7 @@ Classes updated/added: %{class_stats}
 Instances updated/added: %{instance_stats}
 Methods updated/added: %{method_stats}") % stat_options)
         redirect_to :action => 'import_export', :flash_msg => @flash_array[0][:message]         # redirect to build the retire screen
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'upload': %{message}") % {:message => bang.message}, :error)
         redirect_to :action => 'import_export', :flash_msg => @flash_array[0][:message], :flash_error => true         # redirect to build the retire screen
       end

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -714,7 +714,7 @@ class MiqCapacityController < ApplicationController
 
       begin
         @sb[:bottlenecks][:report].generate_table(:userid => session[:userid])
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error building timeline %{error_message}") % {:error_message => bang.message}, :error)
       else
         bottleneck_tl_to_xml

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -58,7 +58,7 @@ class MiqPolicyController < ApplicationController
           end
           session[:export_data] = MiqPolicy.export_to_yaml(@sb[:new][:choices_chosen], db)
           javascript_redirect :action => 'fetch_yaml', :fname => filename, :escape => false
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("Error during export: %{error_message}") % {:error_message => bang.message}, :error)
           render :update do |page|
             page << javascript_prologue
@@ -181,7 +181,7 @@ class MiqPolicyController < ApplicationController
     if params[:commit] == "import"
       begin
         miq_policy_import_service.import_policy(@import_file_upload_id)
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during upload: %{messages}") % {:messages => bang.message}, :error)
       else
         @sb[:hide] = false

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -45,7 +45,7 @@ module MiqPolicyController::AlertProfiles
         begin
           alerts.each { |a| alert_profile.remove_member(MiqAlert.find(a)) unless mems.include?(a.id) }  # Remove any alerts no longer in the members list box
           mems.each_key { |m| alert_profile.add_member(MiqAlert.find(m)) unless current.include?(m) }   # Add any alerts not in the set
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("Error during 'Alert Profile %{params}': %{message}") %
             {:params => params[:button], :message => bang.message}, :error)
         end

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -501,7 +501,7 @@ module MiqPolicyController::Alerts
     alarms = {}
     begin
       alarms = MiqAlert.ems_alarms(@edit[:new][:db], @edit[:new][:expression][:options][:ems_id])
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during alarms: %{messages}") % {:messages => bang.message}, :error)
     end
     alarms

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -45,7 +45,7 @@ module MiqPolicyController::PolicyProfiles
         begin
           policies.each { |c| profile.remove_member(MiqPolicy.find(c)) unless mems.include?(c.id) } # Remove any policies no longer in the members list box
           mems.each_key { |m| profile.add_member(MiqPolicy.find(m)) unless current.include?(m) }    # Add any policies not in the set
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("Error during 'Policy Profile %{params}': %{messages}") %
             {:params => params[:button], :messages => bang.message}, :error)
         end

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -318,7 +318,7 @@ class MiqRequestController < ApplicationController
     begin
       method = WORKFLOW_METHOD_WHITELIST[params[:field]]
       @edit[:wf].send(method, @edit[:new]) unless method.nil?
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error retrieving LDAP info: %{error_message}") % {:error_message => bang.message}, :error)
       javascript_flash
     else
@@ -557,7 +557,7 @@ class MiqRequestController < ApplicationController
       end
       begin
         miq_request.public_send(task.to_sym) if miq_request.respond_to?(task)    # Run the task
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{message}") %
                       {:model   => ui_lookup(:model => "MiqRequest"),
                        :name    => request_name,

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -207,7 +207,7 @@ class MiqTaskController < ApplicationController
       end
       begin
         job.send(task.to_sym) if job.respond_to?(task)    # Run the task
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{message}") %
                     {:model   => ui_lookup(:model => "MiqTask"),
                      :name    => job_name,

--- a/app/controllers/mixins/containers_common_mixin.rb
+++ b/app/controllers/mixins/containers_common_mixin.rb
@@ -206,7 +206,7 @@ module ContainersCommonMixin
       image_name = image.name
       begin
         image.scan
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during 'Analysis': %{message}") %
                       {:model   => ui_lookup(:model => "ContainerImage"),
                        :name    => image_name,
@@ -222,7 +222,7 @@ module ContainersCommonMixin
     model.where(:id => ids).order("lower(name)").each do |entity|
       begin
         entity.check_compliance
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during 'Check Compliance': ") %
                   {:model => ui_lookup(:model => model),
                    :name  => entity.name} << bang.message,

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -24,7 +24,7 @@ module OpsController::Diagnostics
     begin
       svr = MiqServer.find(@sb[:selected_server_id])
       svr.restart_queue
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during 'Appliance restart': %{message}") % {:message => bang.message}, :error)
     else
       audit = {:event        => "restart_server",
@@ -48,7 +48,7 @@ module OpsController::Diagnostics
     # begin
     #   svr = MiqServer.find(@sb[:selected_server_id])
     #   Object.const_get("Miq#{wtype.capitalize}Worker").restart_workers(@sb[:selected_server_id])
-    # rescue StandardError => bang
+    # rescue => bang
     #   add_flash(_("Error during %s workers restart: ") % wtype << bang.message, :error)
     # else
     #   audit = {:event=>"restart_workers", :message=>"#{wtype} Workers on Server '#{svr.name}' restarted", :target_id=>svr.id, :target_class=>"MiqServer", :userid => session[:userid]}
@@ -61,7 +61,7 @@ module OpsController::Diagnostics
       begin
         svr = MiqServer.find(@sb[:selected_server_id])
         worker.restart
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'workers restart': %{message}") % {:message => bang.message}, :error)
       else
         audit = {:event        => "restart_workers",
@@ -121,7 +121,7 @@ module OpsController::Diagnostics
           depot.update_authentication(creds) if type.try(:requires_credentials?)
           @record.save!
         end
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Save': %{message}") % {:message => bang.message}, :error)
         @changed = true
         render :update do |page|
@@ -147,7 +147,7 @@ module OpsController::Diagnostics
       begin
         type = FileDepot.depot_description_to_class(params[:log_protocol])
         type.validate_settings(settings)
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Validate': %{message}") % {:message => bang.message}, :error)
       else
         add_flash(_("Log Depot Settings were validated"))
@@ -257,7 +257,7 @@ module OpsController::Diagnostics
       selected_zone = Zone.find_by_id(from_cid(x_node.split('-').last))
       begin
         Metric::Capture.perf_capture_gap_queue(from, to, selected_zone)
-      rescue StandardError => bang
+      rescue => bang
         # Push msg and error flag
         add_flash(_("Error during 'C & U Gap Collection': %{message}") % {:message => bang.message}, :error)
       else
@@ -282,7 +282,7 @@ module OpsController::Diagnostics
   def replication_reset
     begin
       MiqReplicationWorker.reset_replication
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during 'Reset/synchronization process': %{message}") % {:message => bang.message}, :error)
     else
       add_flash(_("Reset/synchronization process successfully initiated"))
@@ -410,7 +410,7 @@ module OpsController::Diagnostics
   def db_gc_collection
     begin
       MiqSchedule.run_adhoc_db_gc(:userid => session[:userid])
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during 'Database Garbage Collection': %{message}") % {:message => bang.message}, :error)
     else
       add_flash(_("Database Garbage Collection successfully initiated"))
@@ -425,7 +425,7 @@ module OpsController::Diagnostics
   # to delete orphaned records for user that was delete from db
   def orphaned_records_delete
     MiqReportResult.delete_by_userid(params[:userid])
-  rescue StandardError => bang
+  rescue => bang
     add_flash(_("Error during Orphaned Records delete for user %{id}: %{message}") % {:id      => params[:userid],
                                                                                       :message => bang.message}, :error)
     javascript_flash(:spinner_off => true)
@@ -605,7 +605,7 @@ module OpsController::Diagnostics
     ems.each do |ms|
       begin
         ms.reset_vim_cache_queue              # Run the task
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Clear Connection Broker cache': %{message}") % {:message => bang.message}, :error)
       else
         audit = {:event        => "reset_broker",
@@ -635,7 +635,7 @@ module OpsController::Diagnostics
       begin
         options[:context] = klass.name
         instance.synchronize_logs(session[:userid], options)
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Log collection error returned: %{error_message}") % {:error_message => bang.message}, :error)
       else
         add_flash(_("Log collection for %{product} %{object_type} %{name} has been initiated") % {:product => I18n.t('product.name'), :object_type => klass.name, :name => instance.display_name})
@@ -680,7 +680,7 @@ module OpsController::Diagnostics
       asr = AssignedServerRole.find(@sb[:diag_selected_id])
       begin
         asr.activate_in_role_scope
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang, :error)
       else
         add_flash(_("Start successfully initiated"))
@@ -697,7 +697,7 @@ module OpsController::Diagnostics
       asr = AssignedServerRole.find(@sb[:diag_selected_id])
       begin
         asr.deactivate_in_role_scope
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang, :error)
       else
         add_flash(_("Suspend successfully initiated"))
@@ -722,7 +722,7 @@ module OpsController::Diagnostics
 
   def process_server_deletion(server)
     server.destroy
-  rescue StandardError => bang
+  rescue => bang
     add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqServer"), :name => server.name, :task => "destroy"} << bang.message,
               :error)
   else
@@ -744,7 +744,7 @@ module OpsController::Diagnostics
       asr = AssignedServerRole.find(@sb[:diag_selected_id])
       begin
         asr.set_priority(asr.priority - 1)
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang, :error)
       else
         priority = asr.priority == 1 ? "primary" : (asr.priority == 2 ? "secondary" : "normal")
@@ -762,7 +762,7 @@ module OpsController::Diagnostics
       asr = AssignedServerRole.find(@sb[:diag_selected_id])
       begin
         asr.set_priority(asr.priority + 1)
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang, :error)
       else
         priority = asr.priority == 1 ? "primary" : (asr.priority == 2 ? "secondary" : "normal")

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -124,7 +124,7 @@ module OpsController::OpsRbac
 
       begin
         tenant.save!
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error when adding a new tenant: %{message}") % {:message => bang.message}, :error)
         javascript_flash
       else
@@ -199,7 +199,7 @@ module OpsController::OpsRbac
           tenant_quotas = params[:quotas].deep_symbolize_keys
           tenant.set_quotas(tenant_quotas.to_hash)
         end
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error when saving tenant quota: %{message}") % {:message => bang.message}, :error)
         javascript_flash
       else
@@ -543,7 +543,7 @@ module OpsController::OpsRbac
                                                                          @edit[:new][:user_id],
                                                                          @edit[:new][:user_pwd])
         end
-      rescue StandardError => bang
+      rescue => bang
         @edit[:ldap_groups_by_user] = []
         add_flash(_("Error during 'LDAP Group Look Up': %{message}") % {:message => bang.message}, :error)
         render :update do |page|

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -17,7 +17,7 @@ module OpsController::Settings
     if session[:imports]
       begin
         session[:imports].apply
-      rescue StandardError => bang
+      rescue => bang
         msg = _("Error during 'apply': %{error}") % {:error => bang}
         err = true
       else
@@ -153,7 +153,7 @@ module OpsController::Settings
       @edit[:region].description = @edit[:new][:description]
       begin
         @edit[:region].save!
-      rescue StandardError => bang
+      rescue => bang
         @edit[:region].errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -261,7 +261,7 @@ module OpsController::Settings::AnalysisProfiles
               # mems.each { |c| scanitemset.remove_member(ScanItem.find(c)) if !mems.include?(c.id) }
               # scanitemset.remove_all_members
               # scanitemset.add_member()
-            rescue StandardError => bang
+            rescue => bang
               title = params[:button] == "add" ? "add" : "update"
               add_flash(_("Error during '%{title}': %{message}") % {:title => title, :message => bang.message}, :error)
             end
@@ -512,7 +512,7 @@ module OpsController::Settings::AnalysisProfiles
             scanitemset.add_member(scanitem)
             # resetting flash_array to not show a message for each memmber that is saved for a scanitemset
             @flash_array = []
-          rescue StandardError => bang
+          rescue => bang
             add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{message}") %
                         {:model => ui_lookup(:model => "ScanItemSet"),
                          :name  => scanitem.name, :task => "update", :message => bang.message},

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -204,7 +204,7 @@ module OpsController::Settings::Common
     else
       begin
         MiqRegion.replication_type = replication_type
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during replication configuration save: %{message}") %
                     {:message => bang.message}, :error)
       else
@@ -431,7 +431,7 @@ module OpsController::Settings::Common
             begin
               server.name = @update.config[:server][:name]
               server.save!
-            rescue StandardError => bang
+            rescue => bang
               add_flash(_("Error when saving new server name: %{message}") % {:message => bang.message}, :error)
               javascript_flash
               return
@@ -626,7 +626,7 @@ module OpsController::Settings::Common
         server.vm_scan_storage_affinity = Storage.where(:id => children[:storages].to_a).to_a
       end
     end
-  rescue StandardError => bang
+  rescue => bang
     add_flash(_("Error during Analysis Affinity save: %{message}") % {:message => bang.message}, :error)
   else
     add_flash(_("Analysis Affinity was saved"))

--- a/app/controllers/ops_controller/settings/ldap.rb
+++ b/app/controllers/ops_controller/settings/ldap.rb
@@ -142,7 +142,7 @@ module OpsController::Settings::Ldap
       @in_a_form = true
       begin
         ldap_server.verify_credentials
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -132,7 +132,7 @@ module OpsController::Settings::RHN
 
     begin
       db.save!
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_(bang.message), :error)
       @in_a_form = true
       javascript_flash

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -66,7 +66,7 @@ module OpsController::Settings::Schedules
       schedule_validate?(schedule)
       begin
         schedule.save!
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error when adding a new schedule: %{message}") % {:message => bang.message}, :error)
         javascript_flash
       else
@@ -229,7 +229,7 @@ module OpsController::Settings::Schedules
     uri_settings = build_uri_settings(file_depot)
     begin
       MiqSchedule.new.verify_file_depot(uri_settings)
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during 'Validate': %{message}") % {:message => bang.message}, :error)
     else
       add_flash(_('Depot Settings successfuly validated'))

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -72,7 +72,7 @@ module OpsController::Settings::Tags
                                           :perf_by_tag  => @edit[:new][:perf_by_tag],
                                           :example_text => @edit[:new][:example_text],
                                           :show         => @edit[:new][:show])
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("Error during 'add': %{message}") % {:message => bang.message}, :error)
           javascript_flash
         else
@@ -88,7 +88,7 @@ module OpsController::Settings::Tags
         category_set_record_vars(update_category)
         begin
           update_category.save!
-        rescue StandardError => bang
+        rescue => bang
           update_category.errors.each do |field, msg|
             add_flash("#{field.to_s.capitalize} #{msg}", :error)
           end

--- a/app/controllers/ops_controller/settings/upload.rb
+++ b/app/controllers/ops_controller/settings/upload.rb
@@ -73,7 +73,7 @@ module OpsController::Settings::Upload
             imp = AssetTagImport.upload('VmOrTemplate', params[:upload][:file])
           end
         end
-      rescue StandardError => bang
+      rescue => bang
         msg = _("Error during 'upload': %{message}") % {:message => bang.message}
         err = true
       else

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -61,7 +61,7 @@ module OpsController::Settings::Zones
     zonename = zone.name
     begin
       zone.destroy
-    rescue StandardError => bang
+    rescue => bang
       add_flash(bang.to_s, :error)
       zone.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
       self.x_node = "z-#{zone.id}"

--- a/app/controllers/orchestration_stack_controller.rb
+++ b/app/controllers/orchestration_stack_controller.rb
@@ -190,7 +190,7 @@ class OrchestrationStackController < ApplicationController
     else
       begin
         template.save_as_orderable!
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("An error occured when changing orchestration template \"%{name}\" to orderable: %{err_msg}") %
           {:name => template.name, :err_msg => bang.message}, :error)
         render_flash
@@ -253,7 +253,7 @@ class OrchestrationStackController < ApplicationController
       )
       begin
         ot.save_as_orderable!
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Orchestration Template Copy': %{error_message}") %
           {:error_message => bang.message}, :error)
         render_flash

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -231,7 +231,7 @@ class ProviderForemanController < ApplicationController
 
     begin
       @provider_cfgmgmt.verify_credentials(params[:type])
-    rescue StandardError => error
+    rescue => error
       render_flash(_("Credential validation was not successful: %{details}") % {:details => error}, :error)
     else
       render_flash(_("Credential validation was successful"))

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -248,7 +248,7 @@ module PxeController::IsoDatastores
     begin
       @record = @isd = find_by_id_filtered(IsoDatastore, from_cid(params[:id]))
     rescue ActiveRecord::RecordNotFound
-    rescue StandardError => @bang
+    rescue => @bang
     end
   end
 

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -372,7 +372,7 @@ module PxeController::PxeServers
     begin
       @record = @ps = find_by_id_filtered(PxeServer, from_cid(params[:id]))
     rescue ActiveRecord::RecordNotFound
-    rescue StandardError => @bang
+    rescue => @bang
     end
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -71,7 +71,7 @@ class ReportController < ApplicationController
       @sb[:overwrite] = !params[:overwrite].nil?
       begin
         reps, mri = MiqReport.import(params[:upload][:file], :save => true, :overwrite => @sb[:overwrite], :userid => session[:userid])
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'upload': %{message}") % {:message => bang.message}, :error)
         @sb[:flash_msg] = @flash_array
         redirect_to :action => 'explorer'

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -95,7 +95,7 @@ module ReportController::Reports
         rpt_name = rpt.name
         audit = {:event => "report_record_delete", :message => "[#{rpt_name}] Record deleted", :target_id => rpt.id, :target_class => "MiqReport", :userid => session[:userid]}
         rpt.destroy
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("%{model} \"%{name}\": Error during 'miq_report_delete': %{message}") %
                     {:model => ui_lookup(:model => "MiqReport"), :name => rpt_name, :message =>  bang.message}, :error)
         render :update do |page|

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -112,7 +112,7 @@ module ReportController::Widgets
     w = MiqWidget.find_by_id(params[:id])
     begin
       w.queue_generate_content
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Widget content generation error: %{message}") % {:message => bang.message}, :error)
     else
       add_flash(_("Content generation for this Widget has been initiated"))

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -136,7 +136,7 @@ class ServiceController < ApplicationController
 
       begin
         service.save
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during 'Service Edit': %{message}") % {:message => bang.message}, :error)
       else
         add_flash(_("Service \"%{name}\" was saved") % {:name => service.name})

--- a/app/controllers/storage_manager_controller.rb
+++ b/app/controllers/storage_manager_controller.rb
@@ -113,7 +113,7 @@ class StorageManagerController < ApplicationController
       @in_a_form = true
       begin
         verify_sm.verify_credentials
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
@@ -200,7 +200,7 @@ class StorageManagerController < ApplicationController
       @changed = session[:changed]
       begin
         verify_sm.verify_credentials
-      rescue StandardError => bang
+      rescue => bang
         add_flash(bang.to_s, :error)
       else
         add_flash(_("Credential validation was successful"))
@@ -421,7 +421,7 @@ class StorageManagerController < ApplicationController
     if task == "refresh_inventory"
       begin
         StorageManager.refresh_inventory(sms, true)
-      rescue StandardError => bang
+      rescue => bang
         add_flash(_("Error during '%{task}': %{message}") % {:task => task, :message => bang.message},
                   :error)
         AuditEvent.failure(:userid => session[:userid], :event => "storage_manager_#{task}",
@@ -449,7 +449,7 @@ class StorageManagerController < ApplicationController
         end
         begin
           sm.send(task.to_sym) if sm.respond_to?(task)    # Run the task
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{message}") %
                       {:model   => ui_lookup(:model => "StorageManager"),
                        :name    => sm_name, :task => task,

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -585,7 +585,7 @@ module VmCommon
                            :name        => params[:name],
                            :description => params[:description],
                            :memory      => params[:snap_memory] == "1")
-        rescue StandardError => bang
+        rescue => bang
           puts bang.backtrace.join("\n")
           flash = _("Error during 'Create Snapshot': %{message}") % {:message => bang.message}
           flash_error = true
@@ -832,7 +832,7 @@ module VmCommon
       flash = _("%{model} \"%{name}\" successfully added to Service \"%{to_name}\"") % {:model => ui_lookup(:model => "Vm"), :name => @record.name, :to_name => Service.find(chosen).name}
       begin
         @record.add_to_vsc(Service.find(chosen).name)
-      rescue StandardError => bang
+      rescue => bang
         flash = _("Error during 'Add VM to service': %{message}") % {:message => bang}
       end
       redirect_to :action => @lastaction, :id => @record.id, :flash_msg => flash
@@ -845,7 +845,7 @@ module VmCommon
     begin
       @vervice_name = Service.find_by_name(@record.location).name
       @record.remove_from_vsc(@vervice_name)
-    rescue StandardError => bang
+    rescue => bang
       add_flash(_("Error during 'Remove VM from service': %{message}") % {:message => bang.message}, :error)
     else
       add_flash(_("VM successfully removed from service \"%{name}\"") % {:name => @vervice_name})
@@ -935,7 +935,7 @@ module VmCommon
           @record.save!
           vms.each { |v| @record.remove_child(v) unless kids.include?(v.id) }                                # Remove any VMs no longer in the kids list box
           kids.each_key { |k| @record.set_child(VmOrTemplate.find(k)) }                                             # Add all VMs in kids hash, dups will not be re-added
-        rescue StandardError => bang
+        rescue => bang
           add_flash(_("Error during '%{name} update': %{message}") % {:name    => @record.class.base_model.name,
                                                                       :message => bang.message}, :error)
           AuditEvent.failure(audit.merge(:message => "[#{@record.name} -- #{@record.location}] Update returned: #{bang}"))

--- a/app/models/manageiq/providers/azure/manager_mixin.rb
+++ b/app/models/manageiq/providers/azure/manager_mixin.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers::Azure::ManagerMixin
     raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - check your Azure Client ID and Client Key")
   rescue MiqException::MiqInvalidCredentialsError
     raise # Raise before falling into catch-all block below
-  rescue StandardError => err
+  rescue => err
     _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
     raise MiqException::MiqInvalidCredentialsError, _("Unexpected response returned from system: #{err.message}")
   else

--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture.rb
@@ -57,7 +57,7 @@ module ManageIQ::Providers
       Benchmark.realtime_block(:collect_data) do
         begin
           context.collect_metrics
-        rescue StandardError => e
+        rescue => e
           _log.error("Hawkular metrics service unavailable: #{e.message}")
           ems.update_attributes(:last_metrics_error       => :unavailable,
                                 :last_metrics_update_date => Time.now.utc) if ems

--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -55,7 +55,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
       "Remote error message: #{e.message}"
     rescue GSSAPI::GssApiError
       raise MiqException::MiqHostError, "Unable to reach any KDC in realm #{realm}"
-    rescue StandardError => e
+    rescue => e
       raise MiqException::MiqHostError, "Unable to connect: #{e.message}"
     end
 

--- a/app/models/manageiq/providers/microsoft/infra_manager/host.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/host.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
       "Remote error message: #{e.message}"
     rescue WinRM::WinRMAuthorizationError => e
       raise MiqException::MiqHostError, "Check credentials. Remote error message: #{e.message}"
-    rescue StandardError => e
+    rescue => e
       raise MiqException::MiqHostError, "Unable to connect: #{e.message}."
     end
     true

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -119,7 +119,7 @@ module ManageIQ
             cloud_ems.with_provider_connection do |connection|
               compute_hosts = connection.hosts.select { |x| x.service_name == "compute" }
             end
-          rescue StandardError => err
+          rescue => err
             _log.error "Error Class=#{err.class.name}, Message=#{err.message}"
             $log.error err.backtrace.join("\n")
             # Just log the error and continue the refresh, we don't want error in cloud side to affect infra refresh

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -68,7 +68,7 @@ module MiqServer::LogManagement
         )
 
         logfile.upload
-      rescue Timeout::Error => err
+      rescue StandardError, Timeout::Error => err
         logfile.update_attributes(:state => "error")
         _log.error("Posting of historical logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
         raise
@@ -189,7 +189,7 @@ module MiqServer::LogManagement
       )
 
       logfile.upload
-    rescue Timeout::Error => err
+    rescue StandardError, Timeout::Error => err
       _log.error("#{log_prefix} Posting of current logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
       logfile.update_attributes(:state => "error")
       raise

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -68,7 +68,7 @@ module MiqServer::LogManagement
         )
 
         logfile.upload
-      rescue StandardError, Timeout::Error => err
+      rescue Timeout::Error => err
         logfile.update_attributes(:state => "error")
         _log.error("Posting of historical logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
         raise
@@ -189,7 +189,7 @@ module MiqServer::LogManagement
       )
 
       logfile.upload
-    rescue StandardError, Timeout::Error => err
+    rescue Timeout::Error => err
       _log.error("#{log_prefix} Posting of current logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
       logfile.update_attributes(:state => "error")
       raise

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -47,7 +47,7 @@ class PglogicalSubscription < ActsAsArModel
     subscription_list.each do |s|
       begin
         s.save!
-      rescue StandardError => e
+      rescue => e
         errors << "Failed to save subscription to #{s.host}: #{e.message}"
       end
     end

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -28,7 +28,7 @@ class UserValidationService
     if user[:new_password].present?
       begin
         User.find_by_userid(user[:name]).change_password(user[:password], user[:new_password])
-      rescue StandardError => bang
+      rescue => bang
         return ValidateResult.new(:fail, "Error: " + bang.message)
       end
     end

--- a/gems/pending/VolumeManager/MiqVolumeManager.rb
+++ b/gems/pending/VolumeManager/MiqVolumeManager.rb
@@ -30,7 +30,7 @@ class MiqVolumeManager
 
       begin
         disk = MiqDisk.new(RawDisk, diskInfo, 0)
-      rescue StandardError, NoMemoryError, SignalException => err
+      rescue NoMemoryError, SignalException => err
         $log.warn "#{msg_pfx}: Could not open PV: #{bd}"
         $log.warn err.to_s
         $log.debug err.backtrace.join("\n")

--- a/gems/pending/VolumeManager/MiqVolumeManager.rb
+++ b/gems/pending/VolumeManager/MiqVolumeManager.rb
@@ -30,7 +30,7 @@ class MiqVolumeManager
 
       begin
         disk = MiqDisk.new(RawDisk, diskInfo, 0)
-      rescue NoMemoryError, SignalException => err
+      rescue StandardError, NoMemoryError, SignalException => err
         $log.warn "#{msg_pfx}: Could not open PV: #{bd}"
         $log.warn err.to_s
         $log.debug err.backtrace.join("\n")

--- a/gems/pending/postgres_ha_admin/database_yml.rb
+++ b/gems/pending/postgres_ha_admin/database_yml.rb
@@ -24,7 +24,7 @@ module PostgresHaAdmin
       FileUtils.copy(db_yml_file, new_name)
       begin
         File.write(db_yml_file, db_yml.to_yaml)
-      rescue StandardError
+      rescue
         FileUtils.mv(new_name, db_yml_file)
         raise
       end

--- a/gems/pending/postgres_ha_admin/failover_monitor.rb
+++ b/gems/pending/postgres_ha_admin/failover_monitor.rb
@@ -51,7 +51,7 @@ module PostgresHaAdmin
       loop do
         begin
           monitor
-        rescue StandardError => err
+        rescue => err
           @logger.error("#{err.class}: #{err}")
           @logger.error(err.backtrace.join("\n"))
         end

--- a/gems/pending/spec/coverage_helper.rb
+++ b/gems/pending/spec/coverage_helper.rb
@@ -6,6 +6,6 @@ Dir.glob(File.join(GEMS_PENDING_ROOT, "**", "*.rb")).each do |file|
   next if EXCLUSIONS_LIST.any? { |exclusion| file.include?(exclusion) }
   begin
     silence_warnings { require file }
-  rescue LoadError, MissingSourceFile
+  rescue StandardError, LoadError, MissingSourceFile
   end
 end

--- a/gems/pending/spec/coverage_helper.rb
+++ b/gems/pending/spec/coverage_helper.rb
@@ -6,6 +6,6 @@ Dir.glob(File.join(GEMS_PENDING_ROOT, "**", "*.rb")).each do |file|
   next if EXCLUSIONS_LIST.any? { |exclusion| file.include?(exclusion) }
   begin
     silence_warnings { require file }
-  rescue StandardError, LoadError, MissingSourceFile
+  rescue LoadError, MissingSourceFile
   end
 end

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -68,7 +68,7 @@ module VMDB
       begin
         config.config = Vmdb::Settings.decrypt_passwords!(YAML.load(contents))
         config.validate
-      rescue StandardError, Psych::SyntaxError => err
+      rescue Psych::SyntaxError => err
         config.errors = [[:contents, "File contents are malformed, '#{err.message}'"]]
       end
 

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -68,7 +68,7 @@ module VMDB
       begin
         config.config = Vmdb::Settings.decrypt_passwords!(YAML.load(contents))
         config.validate
-      rescue Psych::SyntaxError => err
+      rescue StandardError, Psych::SyntaxError => err
         config.errors = [[:contents, "File contents are malformed, '#{err.message}'"]]
       end
 

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/kernel/reporting'
     next if file.include?("/bin/") || file.include?("/spec/")
     begin
       silence_warnings { require file }
-    rescue LoadError, MissingSourceFile
+    rescue StandardError, LoadError, MissingSourceFile
     end
   end
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/kernel/reporting'
     next if file.include?("/bin/") || file.include?("/spec/")
     begin
       silence_warnings { require file }
-    rescue StandardError, LoadError, MissingSourceFile
+    rescue LoadError, MissingSourceFile
     end
   end
 end


### PR DESCRIPTION
I've replaced `rescue StandardError => ... ` with the preferred `rescue => ...`.

Fixes https://github.com/ManageIQ/manageiq/issues/11696