### PR TITLE
Remove Warnings regarding constants being already defined in tests

### DIFF
--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -2,11 +2,11 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
   describe "dispatch embedded" do
     include Spec::Support::JobProxyDispatcherHelper
 
-    NUM_VMS = 5
-    NUM_REPO_VMS = 0
-    NUM_HOSTS = 3
-    NUM_SERVERS = 3
-    NUM_STORAGES = 3
+    NUM_OF_VMS = 5
+    NUM_OF_REPO_VMS = 0
+    NUM_OF_HOSTS = 3
+    NUM_OF_SERVERS = 3
+    NUM_OF_STORAGES = 3
 
     def assert_at_most_x_scan_jobs_per_y_resource(x_scans, y_resource)
       vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND agent_class = ? AND target_class = ?", "active", "finished", "MiqServer", "VmOrTemplate"]).select("target_id").collect(&:target_id).compact.uniq
@@ -40,7 +40,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
     context "With a zone, server, ems, hosts, vmware vms" do
       before(:each) do
         server = EvmSpecHelper.local_miq_server(:is_master => true, :name => "test_server_main_server")
-        (NUM_SERVERS - 1).times do |i|
+        (NUM_OF_SERVERS - 1).times do |i|
           FactoryGirl.create(:miq_server, :zone => server.zone, :name => "test_server_#{i}")
         end
 
@@ -52,10 +52,10 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
         allow_any_instance_of(Host).to receive_messages(:authentication_status_ok? => true)
 
         @hosts, @proxies, @storages, @vms, @repo_vms = build_entities(
-          :hosts    => NUM_HOSTS,
-          :storages => NUM_STORAGES,
-          :vms      => NUM_VMS,
-          :repo_vms => NUM_REPO_VMS
+          :hosts    => NUM_OF_HOSTS,
+          :storages => NUM_OF_STORAGES,
+          :vms      => NUM_OF_VMS,
+          :repo_vms => NUM_OF_REPO_VMS
         )
       end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb
@@ -190,11 +190,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     end
 
     context 'when create pod throws exception' do
-      CODE = 0
-      CLIENT_MESSAGE = 'error'.freeze
       before(:each) do
         allow_any_instance_of(MockKubeClient).to receive(:create_pod) do |_instance, *_args|
-          raise KubeException.new(CODE, CLIENT_MESSAGE, nil)
+          raise KubeException.new(0, 'error', nil)
         end
       end
 
@@ -207,11 +205,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job do
     end
 
     context 'when getting the service account throws exception' do
-      CODE = 0
-      CLIENT_MESSAGE = 'error'.freeze
       before(:each) do
         allow_any_instance_of(MockKubeClient).to receive(:get_service_account) do |_instance, *_args|
-          raise KubeException.new(CODE, CLIENT_MESSAGE, nil)
+          raise KubeException.new(0, 'error', nil)
         end
       end
 


### PR DESCRIPTION
Reduces the clutter from the output of our test suite by fixing warnings caused by constants being defined more than once inside specs.

* **job_proxy_dispatcher_embedded_scan_spec.rb:**  Just renamed the constants to something that didn't conflict.  We could probably use something besides constants, but avoided that refactor for the time being
* **manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb:**  Removed the constants entirely since I didn't see there being a need for them in the first place.


Fixes #11700


Links 
-----
* #11700

Steps for Testing/QA [Optional]
-------------------------------

Check the travis output and see if the following errors have gone away:

```ruby
$ bin/rake test:vmdb
./spec/models/job_proxy_dispatcher_spec.rb:12: warning: already initialized constant NUM_VMS
./spec/models/job_proxy_dispatcher_embedded_scan_spec.rb:5: warning: previous definition of NUM_VMS was here
./spec/models/job_proxy_dispatcher_spec.rb:13: warning: already initialized constant NUM_REPO_VMS
./spec/models/job_proxy_dispatcher_embedded_scan_spec.rb:6: warning: previous definition of NUM_REPO_VMS was here
./spec/models/job_proxy_dispatcher_spec.rb:14: warning: already initialized constant NUM_HOSTS
./spec/models/job_proxy_dispatcher_embedded_scan_spec.rb:7: warning: previous definition of NUM_HOSTS was here
./spec/models/job_proxy_dispatcher_spec.rb:15: warning: already initialized constant NUM_SERVERS
./spec/models/job_proxy_dispatcher_embedded_scan_spec.rb:8: warning: previous definition of NUM_SERVERS was here
./spec/models/job_proxy_dispatcher_spec.rb:16: warning: already initialized constant NUM_STORAGES
./spec/models/job_proxy_dispatcher_embedded_scan_spec.rb:9: warning: previous definition of NUM_STORAGES was here
./spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb:210: warning: already initialized constant CODE
./spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb:193: warning: previous definition of CODE was here
./spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb:211: warning: already initialized constant CLIENT_MESSAGE
./spec/models/manageiq/providers/kubernetes/container_manager/scanning/job_spec.rb:194: warning: previous definition of CLIENT_MESSAGE was here

Randomized with seed 13522
...
```