### PR TITLE
[Automate] Remove to_a at core 

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -121,12 +121,7 @@ module MiqAeMethodService
           method = options[:method] || method_name
           ret = object_send(method, *params)
           return options[:override_return] if options.key?(:override_return)
-          reflection = @object.class.reflection_with_virtual(method)
-          if reflection && reflection.collection?
-            wrap_results(ret.to_a)
-          else
-            wrap_results(ret)
-          end
+          wrap_results(ret)
         end
       end
     end

--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -128,22 +128,16 @@ module MiqAeMethodService
     private_class_method :expose
 
     def self.wrap_results(results)
-      ret = nil
       ar_method do
-        if results.nil?
-          ret = nil
-        elsif results.kind_of?(Array)
-          ret = results.collect { |r| wrap_results(r) }
-        elsif results.kind_of?(ActiveRecord::Relation)
-          ret = results.collect { |r| wrap_results(r) }
+        if results.kind_of?(Array) || results.kind_of?(ActiveRecord::Relation)
+          results.collect { |r| wrap_results(r) }
         elsif results.kind_of?(ActiveRecord::Base)
           klass = MiqAeMethodService.const_get("MiqAeService#{results.class.name.gsub(/::/, '_')}")
-          ret = klass.new(results)
+          klass.new(results)
         else
-          ret = results
+          results
         end
       end
-      ret
     end
 
     def wrap_results(results)


### PR DESCRIPTION
This came up in #11549 - When calling rbac, there is no need to convert a relation to a collection (aka `to_a`) for results passed into `wrap`.

And a more basic question is: "Do our tests pass if we remove that `to_a`?

I also noticed some extra code in wrap. I can pull out into another PR if we do indeed want to move forward with this.

/cc @mkanoor 