### PR TITLE
Add additional cloud objects to RBAC filter

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -72,6 +72,9 @@ module Rbac
     #   :descendant_ids
     #   ...
     TENANT_ACCESS_STRATEGY = {
+      'CloudSnapshot'          => :descendant_ids,
+      'CloudTenant'            => :descendant_ids,
+      'CloudVolume'            => :descendant_ids,
       'ExtManagementSystem'    => :ancestor_ids,
       'MiqAeNamespace'         => :ancestor_ids,
       'MiqGroup'               => :descendant_ids,


### PR DESCRIPTION
Now that cloud tenants are mapped to tenants, we can apply the tenant RBAC filter to additional cloud objects.