### PR TITLE
Fix QE JS helpers' debounce not preserving this

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,7 @@
 //= require miq_browser_detect
 //= require miq_application
 //= require miq_change_stored_password
+//= require miq_qe
 //= require automate_import_export
 //= require dialog_field_refresh
 //= require excanvas

--- a/app/assets/javascripts/miq_qe.js
+++ b/app/assets/javascripts/miq_qe.js
@@ -3,7 +3,7 @@ ManageIQ.qe.get_debounce_index = function () {
     ManageIQ.qe.debounce_counter = 0;
   }
   return ManageIQ.qe.debounce_counter++;
-}
+};
 
 if (typeof _ !== 'undefined' && typeof _.debounce !== 'undefined') {
   var orig_debounce = _.debounce;
@@ -14,21 +14,21 @@ if (typeof _ !== 'undefined' && typeof _.debounce !== 'undefined') {
     // We make sure that once this fn is actually run, it decreases the counter
     var new_func = function() {
       try {
-        return func.apply({}, arguments);
+        return func.apply(this, arguments);
       } finally {
         // this is run before the return above, always
         delete ManageIQ.qe.debounced[debounce_index];
       }
-    }
+    };
     // Override the newly-created fn (prepended wait + original fn)
     // We have to increase the counter before the waiting is initiated
     var debounced_func = orig_debounce.call(this, new_func, wait, options);
     var new_debounced_func = function() {
       ManageIQ.qe.debounced[debounce_index] = 1;
       return debounced_func.apply(this, arguments);
-    }
+    };
     return new_debounced_func;
-  }
+  };
 }
 
 ManageIQ.qe.xpath = function(root, xpath) {


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq/pull/11390, we introduced helper functions to make the QE's life easier. But there was a bug where the modified `_.debounce` would not preserve the value of `this` all the way to the callback.

It got disabled in https://github.com/ManageIQ/manageiq/pull/11697, so this PR is re-enabling the functionality, and fixing the `this` bug..

Now, assuming `new_debounced_func` is called with the right `this`, it's passed to `debounced_func`, then `orig_debounce` preserves that so it gets passed to `new_func`, which means that with this change, it gets propagated to `func` too.

Re-added `euwe/yes` to #11390, adding here as well..

Cc @martinpovolny, @h-kataria 