### PR TITLE
Network related events need to follow create vm flow

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -16,7 +16,7 @@ class EmsEvent
       ems = ext_management_system
       if ems.supports_refresh_new_target?
         ep_class = ems.class::EventParser
-        target_hash = ep_class.parse_new_target(full_data, message, ems)
+        target_hash = ep_class.parse_new_target(full_data, message, ems, event_type)
 
         EmsRefresh.queue_refresh_new_target(target_hash, ems)
       else

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/network_add_vm_interface.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/network_add_vm_interface.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=src_vm"
+      value: "/System/event_handlers/event_action_refresh_new_target?target=src_vm"

--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/network_interface_plugged_into_vm.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/network_interface_plugged_into_vm.yaml
@@ -9,4 +9,4 @@ object:
     description: 
   fields:
   - rel4:
-      value: "/System/event_handlers/event_action_refresh?target=ems"
+      value: "/System/event_handlers/event_action_refresh_new_target?target=src_vm"


### PR DESCRIPTION
When we create a vm and we attach a nic to it this would trigger two events:
- vm creation
- network attached

The second event is processed first which would end up with full refresh without this PR.