### PR TITLE
Deployment wizard: change API request function call for deployment data

### DIFF
--- a/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
+++ b/app/assets/javascripts/controllers/container_deployment/deploy-provider-controller.js
@@ -217,8 +217,8 @@ miqHttpInject(angular.module('miq.containers.providersModule', ['ui.bootstrap', 
     $scope.showDeploymentWizard = false;
     $scope.showListener = function() {
       if (!$scope.showDeploymentWizard) {
-        var url = '/api/container_deployments/container_deployment_data';
-        API.get(url).then(function (response) {
+        var url = '/api/container_deployments';
+        API.options(url).then(function (response) {
           'use strict';
           $scope.deploymentData = response.data;
           initializeDeploymentWizard();


### PR DESCRIPTION
change `API.get` to `API.options` and the request url, following #11563 and https://github.com/ManageIQ/manageiq/pull/11708