### PR TITLE
Disable revert snapshot when VM is not down

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -33,6 +33,15 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     {:available => false, :message => "Removing all snapshots is currently not supported"}
   end
 
+  def validate_revert_to_snapshot
+    {:available => allowed_to_revert?,
+     :message   => "Revert is allowed only when vm is down. Current state is #{current_state}"}
+  end
+
+  def allowed_to_revert?
+    current_state == 'off'
+  end
+
   private
 
   def with_snapshots_service(vm_uid_ems)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1736,7 +1736,7 @@ describe ApplicationHelper do
           end
           context "when with snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'default case'
+            it_behaves_like 'record with error message', 'revert_to_snapshot'
           end
         end
       end


### PR DESCRIPTION
RHV provider allows to revert a VM to a snapshot only if it is powered off.

https://bugzilla.redhat.com/show_bug.cgi?id=1375544