### PR TITLE
Re-initialize accordions when replacing the right cell

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -254,6 +254,7 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
   }
 
   miqInitMainContent();
+  miqInitAccordions();
 
   if (data.hideModal) { $('#quicksearchbox').modal('hide'); }
   if (data.initAccords) { miqInitAccordions(); }


### PR DESCRIPTION
Right cell replace can display a previously hidden toolbar.
This cause issues with accessing the last elements in an accordion.
Forcing the miqInitAccordions() fixes this issue...

https://bugzilla.redhat.com/show_bug.cgi?id=1381643
https://bugzilla.redhat.com/show_bug.cgi?id=1381638