### PR TITLE
Toolbar button refactoring server role

### DIFF
--- a/app/helpers/application_helper/button/role_power_options.rb
+++ b/app/helpers/application_helper/button/role_power_options.rb
@@ -1,7 +1,10 @@
 class ApplicationHelper::Button::RolePowerOptions < ApplicationHelper::Button::Basic
-  needs :@record
+  needs :@record, :@sb
 
   def visible?
-    @record.class == AssignedServerRole && @record.miq_server.started?
+    x_active_tree == :diagnostics_tree &&
+      %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab]) &&
+      @record.class == AssignedServerRole &&
+      @record.miq_server.started?
   end
 end

--- a/app/helpers/application_helper/button/role_power_options.rb
+++ b/app/helpers/application_helper/button/role_power_options.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::RolePowerOptions < ApplicationHelper::Button::B
   needs :@record, :@sb
 
   def visible?
-    x_active_tree == :diagnostics_tree &&
+    @view_context.x_active_tree == :diagnostics_tree &&
       %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab]) &&
       @record.class == AssignedServerRole &&
       @record.miq_server.started?

--- a/app/helpers/application_helper/button/role_power_options.rb
+++ b/app/helpers/application_helper/button/role_power_options.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::RolePowerOptions < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.class == AssignedServerRole && @record.miq_server.started?
+  end
+end

--- a/app/helpers/application_helper/button/role_start.rb
+++ b/app/helpers/application_helper/button/role_start.rb
@@ -12,7 +12,7 @@ class ApplicationHelper::Button::RoleStart < ApplicationHelper::Button::RolePowe
                          N_("This Role is already active on this Server")
                        elsif !@record.miq_server.started?
                          N_("Only available Roles on active Servers can be started")
-                       elsif x_node != "root" && @record.server_role.regional_role?
+                       elsif @view_context.x_node != "root" && @record.server_role.regional_role?
                          N_("This role can only be managed at the Region level")
                        end
                      end

--- a/app/helpers/application_helper/button/role_start.rb
+++ b/app/helpers/application_helper/button/role_start.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::RoleStart < ApplicationHelper::Button::RolePowerOptions
-  needs :@record
+  needs :@record, :@sb
 
   def calculate_properties
     super

--- a/app/helpers/application_helper/button/role_start.rb
+++ b/app/helpers/application_helper/button/role_start.rb
@@ -1,0 +1,21 @@
+class ApplicationHelper::Button::RoleStart < ApplicationHelper::Button::RolePowerOptions
+  needs :@record
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if disabled?
+  end
+
+  def disabled?
+    @error_message = if @record.class == AssignedServerRole
+                       if @record.active
+                         N_("This Role is already active on this Server")
+                       elsif !@record.miq_server.started?
+                         N_("Only available Roles on active Servers can be started")
+                       elsif x_node != "root" && @record.server_role.regional_role?
+                         N_("This role can only be managed at the Region level")
+                       end
+                     end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/role_suspend.rb
+++ b/app/helpers/application_helper/button/role_suspend.rb
@@ -1,0 +1,26 @@
+class ApplicationHelper::Button::RoleSuspend < ApplicationHelper::Button::RolePowerOptions
+  needs :@record
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if disabled?
+  end
+
+  def disabled?
+    @error_message = if x_node != "root" && @record.server_role.regional_role?
+                       N_("This role can only be managed at the Region level")
+                     else
+                       if @record.active
+                         unless @record.server_role.max_concurrent != 1
+                           N_("Activate the %{server_role_description} Role on another Server to suspend it on %{server_name} [%{server_id}]") %
+                             {:server_role_description => @record.server_role.description,
+                              :server_name             => @record.miq_server.name,
+                              :server_id               => @record.miq_server.id}
+                         end
+                       else
+                         N_("Only active Roles on active Servers can be suspended")
+                       end
+                     end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/role_suspend.rb
+++ b/app/helpers/application_helper/button/role_suspend.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::RoleSuspend < ApplicationHelper::Button::RolePowerOptions
-  needs :@record
+  needs :@record, :@sb
 
   def calculate_properties
     super

--- a/app/helpers/application_helper/button/role_suspend.rb
+++ b/app/helpers/application_helper/button/role_suspend.rb
@@ -7,7 +7,7 @@ class ApplicationHelper::Button::RoleSuspend < ApplicationHelper::Button::RolePo
   end
 
   def disabled?
-    @error_message = if x_node != "root" && @record.server_role.regional_role?
+    @error_message = if @view_context.x_node != "root" && @record.server_role.regional_role?
                        N_("This role can only be managed at the Region level")
                      else
                        if @record.active

--- a/app/helpers/application_helper/button/server_demote.rb
+++ b/app/helpers/application_helper/button/server_demote.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Button::ServerDemote < ApplicationHelper::Button::Serve
   def disabled?
     @error_message = if @record.master_supported?
                        if @record.priority == 1 || @record.priority == 2
-                         if x_node != "root" && @record.server_role.regional_role?
+                         if @view_context.x_node != "root" && @record.server_role.regional_role?
                            N_("This role can only be managed at the Region level")
                          end
                        end

--- a/app/helpers/application_helper/button/server_demote.rb
+++ b/app/helpers/application_helper/button/server_demote.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Button::ServerDemote < ApplicationHelper::Button::ServerLevelOptions
+  needs :@record
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if disabled?
+  end
+
+  def disabled?
+    @error_message = if @record.master_supported?
+                       if @record.priority == 1 || @record.priority == 2
+                         if x_node != "root" && @record.server_role.regional_role?
+                           N_("This role can only be managed at the Region level")
+                         end
+                       end
+                     end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/server_demote.rb
+++ b/app/helpers/application_helper/button/server_demote.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::ServerDemote < ApplicationHelper::Button::ServerLevelOptions
-  needs :@record
+  needs :@record, :@sb
 
   def calculate_properties
     super

--- a/app/helpers/application_helper/button/server_level_options.rb
+++ b/app/helpers/application_helper/button/server_level_options.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::ServerLevelOptions < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    @record.class == AssignedServerRole && @record.master_supported?
+  end
+end

--- a/app/helpers/application_helper/button/server_level_options.rb
+++ b/app/helpers/application_helper/button/server_level_options.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::ServerLevelOptions < ApplicationHelper::Button:
   needs :@record, :@sb
 
   def visible?
-    x_active_tree == :diagnostics_tree &&
+    @view_context.x_active_tree == :diagnostics_tree &&
       %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab]) &&
       @record.class == AssignedServerRole &&
       @record.master_supported?

--- a/app/helpers/application_helper/button/server_level_options.rb
+++ b/app/helpers/application_helper/button/server_level_options.rb
@@ -1,7 +1,10 @@
 class ApplicationHelper::Button::ServerLevelOptions < ApplicationHelper::Button::Basic
-  needs :@record
+  needs :@record, :@sb
 
   def visible?
-    @record.class == AssignedServerRole && @record.master_supported?
+    x_active_tree == :diagnostics_tree &&
+      %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab]) &&
+      @record.class == AssignedServerRole &&
+      @record.master_supported?
   end
 end

--- a/app/helpers/application_helper/button/server_promote.rb
+++ b/app/helpers/application_helper/button/server_promote.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::ServerPromote < ApplicationHelper::Button::ServerLevelOptions
-  needs :@record
+  needs :@record, :@sb
 
   def calculate_properties
     super

--- a/app/helpers/application_helper/button/server_promote.rb
+++ b/app/helpers/application_helper/button/server_promote.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Button::ServerPromote < ApplicationHelper::Button::ServerLevelOptions
+  needs :@record
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if disabled?
+  end
+
+  def disabled?
+    @error_message = if @record.master_supported?
+                       if (@record.priority != 1 && @record.priority != 2) || @record.priority == 2
+                         if x_node != "root" && @record.server_role.regional_role?
+                           N_("This role can only be managed at the Region level")
+                         end
+                       end
+                     end
+    @error_message.present?
+  end
+end

--- a/app/helpers/application_helper/button/server_promote.rb
+++ b/app/helpers/application_helper/button/server_promote.rb
@@ -9,7 +9,7 @@ class ApplicationHelper::Button::ServerPromote < ApplicationHelper::Button::Serv
   def disabled?
     @error_message = if @record.master_supported?
                        if (@record.priority != 1 && @record.priority != 2) || @record.priority == 2
-                         if x_node != "root" && @record.server_role.regional_role?
+                         if @view_context.x_node != "root" && @record.server_role.regional_role?
                            N_("This role can only be managed at the Region level")
                          end
                        end

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -58,7 +58,8 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
                           :server_role_description => @record.server_role.description,
                           :server_name             => @record.miq_server.name,
                           :server_id               => @record.miq_server.id}
-                      end
+                      end,
+          :klass => ApplicationHelper::Button::RoleSuspend
         ),
         button(
           :demote_server,

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -71,7 +71,8 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
               :server_id               => @record.miq_server.id}
           end,
           N_('Demote Server'),
-          :confirm => N_("Do you want to demote this Server to secondary?  This will leave no primary Server for this Role.")),
+          :confirm => N_("Do you want to demote this Server to secondary?  This will leave no primary Server for this Role."),
+          :klass => ApplicationHelper::Button::ServerDemote),
         button(
           :promote_server,
           'product product-migrate fa-lg',

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -40,7 +40,9 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
                           :server_role_description => @record.server_role.description,
                           :server_name             => @record.miq_server.name,
                           :server_id               => @record.miq_server.id}
-                      end),
+                      end,
+          :klass => ApplicationHelper::Button::RoleStart
+        ),
         button(
           :role_suspend,
           'fa fa-pause-circle-o fa-lg',

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -82,7 +82,8 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
               :server_id               => @record.miq_server.id}
           end,
           N_('Promote Server'),
-          :confirm => N_("Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role.")),
+          :confirm => N_("Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role."),
+          :klass => ApplicationHelper::Button::ServerPromote),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -78,7 +78,9 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
             }
           end,
           N_('Demote Server'),
-          :confirm => N_("Do you want to demote this Server to secondary?  This will leave no primary Server for this Role.")),
+          :confirm => N_("Do you want to demote this Server to secondary?  This will leave no primary Server for this Role."),
+          :klass => ApplicationHelper::Button::ServerLevelOptions
+        ),
         button(
           :zone_promote_server,
           'product product-migrate fa-lg',
@@ -90,7 +92,9 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
             }
           end,
           N_('Promote Server'),
-          :confirm => N_("Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role.")),
+          :confirm => N_("Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role."),
+          :klass => ApplicationHelper::Button::ServerLevelOptions
+        ),
       ]
     ),
     select(

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -44,7 +44,8 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
                           :server_name             => @record.miq_server.name,
                           :server_id               => @record.miq_server.id
                         }
-                      end
+                      end,
+          :klass => ApplicationHelper::Button::RolePowerOptions
         ),
         button(
           :zone_role_suspend,
@@ -63,7 +64,8 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
                           :server_name             => @record.miq_server.name,
                           :server_id               => @record.miq_server.id
                         }
-                      end
+                      end,
+          :klass => ApplicationHelper::Button::RolePowerOptions
         ),
         button(
           :zone_demote_server,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,8 +425,10 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
+        when "zone_collect_current_logs", "zone_collect_logs", "zone_log_depot_edit"
+          return true
         end
-        return true
+        return false
       when "diagnostics_summary"
         return !["refresh_server_summary", "restart_server"].include?(id)
       when "diagnostics_workers"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,7 +425,7 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
-        when "role_start", "role_suspend", "zone_role_start", "zone_role_suspend"
+        when "role_suspend", "zone_role_start", "zone_role_suspend"
           return !(@record.class == AssignedServerRole && @record.miq_server.started?)
         when "demote_server", "promote_server", "zone_demote_server", "zone_promote_server"
           return !(@record.class == AssignedServerRole && @record.master_supported?)
@@ -707,12 +707,12 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "MiqServer", "MiqRegion"
       case id
-      when "role_start", "role_suspend", "promote_server", "demote_server"
+      when "role_suspend", "promote_server", "demote_server"
         return true
       end
     when "ServerRole"
       case id
-      when "role_start", "role_suspend", "promote_server", "demote_server"
+      when "role_suspend", "promote_server", "demote_server"
         return true
       end
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
@@ -754,14 +754,6 @@ class ApplicationHelper::ToolbarBuilder
     case get_record_cls(@record)
     when "AssignedServerRole"
       case id
-      when "role_start"
-        if x_node != "root" && @record.server_role.regional_role?
-          return N_("This role can only be managed at the Region level")
-        elsif @record.active
-          return N_("This Role is already active on this Server")
-        elsif !@record.miq_server.started? && !@record.active
-          return N_("Only available Roles on active Servers can be started")
-        end
       when "role_suspend"
         if x_node != "root" && @record.server_role.regional_role?
           return N_("This role can only be managed at the Region level")

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,8 +425,6 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
-        when "demote_server"
-          return !(@record.class == AssignedServerRole && @record.master_supported?)
         end
         return true
       when "diagnostics_summary"
@@ -703,16 +701,6 @@ class ApplicationHelper::ToolbarBuilder
       else
         return true unless editable_domain?(@record)
       end
-    when "MiqServer", "MiqRegion"
-      case id
-      when "demote_server"
-        return true
-      end
-    when "ServerRole"
-      case id
-      when "demote_server"
-        return true
-      end
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
       case id
       when "configured_system_provision"
@@ -750,16 +738,6 @@ class ApplicationHelper::ToolbarBuilder
     end
 
     case get_record_cls(@record)
-    when "AssignedServerRole"
-      case id
-      when "demote_server"
-        if @record.master_supported?
-          if @record.priority == 1 || @record.priority == 2
-            if x_node != "root" && @record.server_role.regional_role?
-              return N_("This role can only be managed at the Region level")
-            end
-          end
-        end
     when "AvailabilityZone"
       case id
       when "availability_zone_perf"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -712,7 +712,7 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "ServerRole"
       case id
-      when "server_delete", "role_start", "role_suspend", "promote_server", "demote_server"
+      when "role_start", "role_suspend", "promote_server", "demote_server"
         return true
       end
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,8 +425,6 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
-        when "zone_role_start", "zone_role_suspend"
-          return !(@record.class == AssignedServerRole && @record.miq_server.started?)
         when "demote_server", "promote_server", "zone_demote_server", "zone_promote_server"
           return !(@record.class == AssignedServerRole && @record.master_supported?)
         end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,7 +425,7 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
-        when "demote_server", "promote_server"
+        when "demote_server"
           return !(@record.class == AssignedServerRole && @record.master_supported?)
         end
         return true
@@ -705,12 +705,12 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "MiqServer", "MiqRegion"
       case id
-      when "promote_server", "demote_server"
+      when "demote_server"
         return true
       end
     when "ServerRole"
       case id
-      when "promote_server", "demote_server"
+      when "demote_server"
         return true
       end
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
@@ -760,15 +760,6 @@ class ApplicationHelper::ToolbarBuilder
             end
           end
         end
-      when "promote_server"
-        if @record.master_supported?
-          if (@record.priority != 1 && @record.priority != 2) || @record.priority == 2
-            if x_node != "root" && @record.server_role.regional_role?
-              return N_("This role can only be managed at the Region level")
-            end
-          end
-        end
-      end
     when "AvailabilityZone"
       case id
       when "availability_zone_perf"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,7 +425,7 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
-        when "role_suspend", "zone_role_start", "zone_role_suspend"
+        when "zone_role_start", "zone_role_suspend"
           return !(@record.class == AssignedServerRole && @record.miq_server.started?)
         when "demote_server", "promote_server", "zone_demote_server", "zone_promote_server"
           return !(@record.class == AssignedServerRole && @record.master_supported?)
@@ -707,12 +707,12 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "MiqServer", "MiqRegion"
       case id
-      when "role_suspend", "promote_server", "demote_server"
+      when "promote_server", "demote_server"
         return true
       end
     when "ServerRole"
       case id
-      when "role_suspend", "promote_server", "demote_server"
+      when "promote_server", "demote_server"
         return true
       end
     when "ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfiguredSystem", "ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem"
@@ -754,21 +754,6 @@ class ApplicationHelper::ToolbarBuilder
     case get_record_cls(@record)
     when "AssignedServerRole"
       case id
-      when "role_suspend"
-        if x_node != "root" && @record.server_role.regional_role?
-          return N_("This role can only be managed at the Region level")
-        else
-          if @record.active
-            unless @record.server_role.max_concurrent != 1
-              return N_("Activate the %{server_role_description} Role on another Server to suspend it on %{server_name} [%{server_id}]") %
-                {:server_role_description => @record.server_role.description,
-                 :server_name             => @record.miq_server.name,
-                 :server_id               => @record.miq_server.id}
-            end
-          else
-            return N_("Only active Roles on active Servers can be suspended")
-          end
-        end
       when "demote_server"
         if @record.master_supported?
           if @record.priority == 1 || @record.priority == 2

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -425,7 +425,7 @@ class ApplicationHelper::ToolbarBuilder
           return false
         when "delete_server", "zone_delete_server"
           return @record.class != MiqServer
-        when "demote_server", "promote_server", "zone_demote_server", "zone_promote_server"
+        when "demote_server", "promote_server"
           return !(@record.class == AssignedServerRole && @record.master_supported?)
         end
         return true

--- a/spec/helpers/application_helper/buttons/role_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_start_spec.rb
@@ -1,0 +1,92 @@
+describe ApplicationHelper::Button::RoleStart do
+  describe '#visible?' do
+    context "record is assigned server role and miq server is started" do
+      before do
+        @record = FactoryGirl.create(
+          :assigned_server_role,
+          :miq_server => FactoryGirl.create(:miq_server)
+        )
+        allow(@record.miq_server).to receive(:started?).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "record is server role" do
+      before do
+        @record = FactoryGirl.create(:server_role, :name => "biggus_dickus")
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+
+    context "record is miq server" do
+      before do
+        @record = FactoryGirl.create(:miq_server)
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "record is active assigned server role" do
+      before do
+        @record = FactoryGirl.create(:assigned_server_role)
+        allow(@record).to receive(:active?).and_return(true)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("This Role is already active on this Server")
+      end
+    end
+
+    context "record is inactive assigned server role" do
+      before do
+        @record = FactoryGirl.create(
+          :assigned_server_role,
+          :active => false,
+          :miq_server => FactoryGirl.create(:miq_server)
+        )
+        allow(@record.miq_server).to receive(:started?).and_return(false)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("Only available Roles on active Servers can be started")
+      end
+    end
+
+    context "record is inactive assigned server role" do
+      before do
+        @record = FactoryGirl.create(
+          :assigned_server_role,
+          :active => false,
+          :miq_server => FactoryGirl.create(:miq_server),
+          :server_role => FactoryGirl.create(
+            :server_role,
+            :name => "dr_fetus"
+          )
+        )
+        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+        allow(@record.miq_server).to receive(:started?).and_return(true)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("This role can only be managed at the Region level")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/role_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_start_spec.rb
@@ -9,7 +9,13 @@ describe ApplicationHelper::Button::RoleStart do
         allow(@record.miq_server).to receive(:started?).and_return(true)
       end
 
-      it_behaves_like "will not be skipped for this record"
+      it "will not be skipped for this record" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
+        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        expect(button.visible?).to be_truthy
+      end
     end
 
     context "record is server role" do
@@ -17,7 +23,13 @@ describe ApplicationHelper::Button::RoleStart do
         @record = FactoryGirl.create(:server_role, :name => "biggus_dickus")
       end
 
-      it_behaves_like "will be skipped for this record"
+      it "will be skipped for this record" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
+        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        expect(button.visible?).to be_falsey
+      end
     end
 
     context "record is miq server" do
@@ -25,7 +37,13 @@ describe ApplicationHelper::Button::RoleStart do
         @record = FactoryGirl.create(:miq_server)
       end
 
-      it_behaves_like "will be skipped for this record"
+      it "will be skipped for this record" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
+        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        expect(button.visible?).to be_falsey
+      end
     end
   end
 

--- a/spec/helpers/application_helper/buttons/role_start_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_start_spec.rb
@@ -13,7 +13,7 @@ describe ApplicationHelper::Button::RoleStart do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
-        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:diagnostics_tree)
         expect(button.visible?).to be_truthy
       end
     end
@@ -27,7 +27,7 @@ describe ApplicationHelper::Button::RoleStart do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
-        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:diagnostics_tree)
         expect(button.visible?).to be_falsey
       end
     end
@@ -41,7 +41,7 @@ describe ApplicationHelper::Button::RoleStart do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
-        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:diagnostics_tree)
         expect(button.visible?).to be_falsey
       end
     end
@@ -100,7 +100,7 @@ describe ApplicationHelper::Button::RoleStart do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_truthy
         button.calculate_properties
         expect(button[:title]).to eq("This role can only be managed at the Region level")

--- a/spec/helpers/application_helper/buttons/role_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_suspend_spec.rb
@@ -1,0 +1,83 @@
+describe ApplicationHelper::Button::RoleSuspend do
+  describe '#disabled?' do
+    context "record has regional role" do
+      before do
+        @record = FactoryGirl.create(
+          :assigned_server_role,
+          :server_role => FactoryGirl.create(
+              :server_role,
+              :name => "terminator",
+          )
+        )
+        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("This role can only be managed at the Region level")
+      end
+    end
+
+    context "record is active and max_concurrent is 1" do
+      before do
+        @record = FactoryGirl.create(
+          :assigned_server_role,
+          :active => true,
+          :server_role => FactoryGirl.create(
+            :server_role,
+            :name => "terminator",
+            :description => "cyborg"
+          ),
+          :miq_server => FactoryGirl.create(
+            :miq_server,
+            :name => "ratman"
+          )
+        )
+        allow(@record.server_role).to receive(:regional_role?).and_return(false)
+        allow(@record.server_role).to receive(:max_concurrent).and_return(1)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to match(/Activate the cyborg Role on another Server to suspend it on ratman \[\w+]/)
+      end
+    end
+
+    context "record is inactive" do
+      before do
+        @record = FactoryGirl.create(
+          :assigned_server_role,
+          :active => false,
+          :server_role => FactoryGirl.create(
+            :server_role,
+            :name => "terminator",
+            :description => "cyborg"
+          ),
+          :miq_server => FactoryGirl.create(
+            :miq_server,
+            :name => "ratman"
+          )
+        )
+        allow(@record.server_role).to receive(:regional_role?).and_return(false)
+        allow(@record.server_role).to receive(:max_concurrent).and_return(1)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("Only active Roles on active Servers can be suspended")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/role_suspend_spec.rb
+++ b/spec/helpers/application_helper/buttons/role_suspend_spec.rb
@@ -15,7 +15,7 @@ describe ApplicationHelper::Button::RoleSuspend do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_truthy
         button.calculate_properties
         expect(button[:title]).to eq("This role can only be managed at the Region level")
@@ -44,7 +44,7 @@ describe ApplicationHelper::Button::RoleSuspend do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_truthy
         button.calculate_properties
         expect(button[:title]).to match(/Activate the cyborg Role on another Server to suspend it on ratman \[\w+]/)
@@ -73,7 +73,7 @@ describe ApplicationHelper::Button::RoleSuspend do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_truthy
         button.calculate_properties
         expect(button[:title]).to eq("Only active Roles on active Servers can be suspended")

--- a/spec/helpers/application_helper/buttons/server_demote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_demote_spec.rb
@@ -6,7 +6,13 @@ describe ApplicationHelper::Button::ServerDemote do
         allow(@record).to receive(:master_supported?).and_return(true)
       end
 
-      it_behaves_like "will not be skipped for this record"
+      it "will not be skipped for this record" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
+        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        expect(button.visible?).to be_truthy
+			end
     end
 
     context "record is server role" do
@@ -14,7 +20,13 @@ describe ApplicationHelper::Button::ServerDemote do
         @record = FactoryGirl.create(:server_role, :name => "pooh")
       end
 
-      it_behaves_like "will be skipped for this record"
+      it "will be skipped for this record" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
+        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        expect(button.visible?).to be_falsey
+      end
     end
   end
 

--- a/spec/helpers/application_helper/buttons/server_demote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_demote_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::ServerDemote do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
-        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:diagnostics_tree)
         expect(button.visible?).to be_truthy
 			end
     end
@@ -24,7 +24,7 @@ describe ApplicationHelper::Button::ServerDemote do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tab => "diagnostics_roles_servers"})
-        allow(button).to receive(:x_active_tree).and_return(:diagnostics_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:diagnostics_tree)
         expect(button.visible?).to be_falsey
       end
     end
@@ -41,7 +41,7 @@ describe ApplicationHelper::Button::ServerDemote do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_truthy
         button.calculate_properties
         expect(button[:title]).to eq("This role can only be managed at the Region level")

--- a/spec/helpers/application_helper/buttons/server_demote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_demote_spec.rb
@@ -1,0 +1,39 @@
+describe ApplicationHelper::Button::ServerDemote do
+  describe '#visible?' do
+    context "is assigned server role and master is supported" do
+      before do
+        @record = FactoryGirl.create(:assigned_server_role)
+        allow(@record).to receive(:master_supported?).and_return(true)
+      end
+
+      it_behaves_like "will not be skipped for this record"
+    end
+
+    context "record is server role" do
+      before do
+        @record = FactoryGirl.create(:server_role, :name => "pooh")
+      end
+
+      it_behaves_like "will be skipped for this record"
+    end
+  end
+
+  describe '#disabled?' do
+    context "record has priority == 2" do
+      before do
+        @record = FactoryGirl.create(:assigned_server_role, :priority => 2)
+        allow(@record).to receive(:master_supported?).and_return(true)
+        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("This role can only be managed at the Region level")
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/server_promote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_promote_spec.rb
@@ -1,0 +1,37 @@
+describe ApplicationHelper::Button::ServerPromote do
+  describe '#disabled?' do
+    context "record has priority == 2" do
+      before do
+        @record = FactoryGirl.create(:assigned_server_role, :priority => 2)
+        allow(@record).to receive(:master_supported?).and_return(true)
+        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_truthy
+        button.calculate_properties
+        expect(button[:title]).to eq("This role can only be managed at the Region level")
+      end
+    end
+
+    context "record has priority == 1" do
+      before do
+        @record = FactoryGirl.create(:assigned_server_role, :priority => 1)
+        allow(@record).to receive(:master_supported?).and_return(true)
+        allow(@record.server_role).to receive(:regional_role?).and_return(true)
+      end
+
+      it "disables the button and returns the error message" do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(button).to receive(:x_node).and_return('z-1r23')
+        expect(button.disabled?).to be_falsey
+        button.calculate_properties
+        expect(button[:title]).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/server_promote_spec.rb
+++ b/spec/helpers/application_helper/buttons/server_promote_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::ServerPromote do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_truthy
         button.calculate_properties
         expect(button[:title]).to eq("This role can only be managed at the Region level")
@@ -27,7 +27,7 @@ describe ApplicationHelper::Button::ServerPromote do
       it "disables the button and returns the error message" do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        allow(button).to receive(:x_node).and_return('z-1r23')
+        allow(view_context).to receive(:x_node).and_return('z-1r23')
         expect(button.disabled?).to be_falsey
         button.calculate_properties
         expect(button[:title]).to eq(nil)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -730,44 +730,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when with MiqServer" do
-      before do
-        @record = MiqServer.new
-        stub_user(:features => :all)
-      end
-
-      %w(role_start role_suspend promote_server demote_server).each do |id|
-        it "and id = #{id}" do
-          @id = id
-          expect(subject).to be_truthy
-        end
-      end
-
-      it "otherwise" do
-        @id = 'xx'
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "when with ServerRole" do
-      before do
-        @record = ServerRole.new
-        stub_user(:features => :all)
-      end
-
-      ["server_delete", "role_start", "role_suspend", "promote_server", "demote_server"].each do |id|
-        it "and id = #{id}" do
-          @id = id
-          expect(subject).to be_truthy
-        end
-      end
-
-      it "otherwise" do
-        @id = 'xx'
-        expect(subject).to be_falsey
-      end
-    end
-
     context "ServiceTemplate" do
       before do
         @record = ServiceTemplate.new
@@ -895,62 +857,6 @@ describe ApplicationHelper do
       @id = "iso_datastore_new"
 
       expect(subject).to match(/No.*are available/)
-    end
-
-    context "when record class = AssignedServerRole" do
-      before { @record = AssignedServerRole.new }
-
-      before do
-        @sb = {:active_tree => :diagnostics_tree,
-               :trees       => {:diagnostics_tree => {:tree => :diagnostics_tree}}}
-        @server_role = ServerRole.new(:description => "some description")
-      end
-
-      context "and id = role_start" do
-        before :each do
-          @message = "This Role is already active on this Server"
-          @id = "role_start"
-
-          allow(@record).to receive_messages(:miq_server => double(:started? => true), :active => true, :server_role => @server_role)
-        end
-
-        it "when miq server not started" do
-          allow(@record).to receive_messages(:miq_server => double(:started? => false))
-          expect(subject).to eq(@message)
-        end
-
-        it "when miq server started but not active" do
-          allow(@record).to receive_messages(:active => false)
-          allow(@record).to receive_messages(:miq_server => double(:started? => false))
-          expect(subject).to eq("Only available Roles on active Servers can be started")
-        end
-
-        it_behaves_like 'default true_case'
-      end
-
-      context "and id = role_suspend" do
-        before do
-          @id = "role_suspend"
-          @miq_server = MiqServer.new(:name => "xx miq server", :id => "xx server id")
-          allow(@miq_server).to receive_messages(:started? => true)
-          allow(@record).to receive_messages(:miq_server => @miq_server, :active => true,
-                          :server_role => @server_role)
-          @server_role.max_concurrent = 1
-        end
-
-        context "when miq server started and active" do
-          it "and server_role.max_concurrent == 1" do
-            allow(@record).to receive_messages(:miq_server => @miq_server)
-            expect(subject).to eq("Activate the #{@record.server_role.description} Role on another Server to suspend it on #{@record.miq_server.name} [#{@record.miq_server.id}]")
-          end
-          it_behaves_like 'default true_case'
-        end
-
-        it "when miq_server not started or not active" do
-          allow(@record).to receive_messages(:miq_server => double(:started? => false), :active => false)
-          expect(subject).to eq("Only active Roles on active Servers can be suspended")
-        end
-      end
     end
 
     context "when record class = OntapStorageSystem" do


### PR DESCRIPTION
Toolbar buttons for ServerRole class moved from toolbar builder to separate button class

| Toolbar buttons id | Toolbar buttons class |
| --- | --- |
| `zone_role_start`, `zone_role_suspend` | `RolePowerOptions` |
| `role_start` | `RoleStart < RolePowerOptions` |
| `role_suspend` | `RoleSuspend < RolePowerOptions` |
| `zone_promote_server`, `zone_demote_server` | `ServerLevelOptions` |
| `promote_server` | `ServerPromote < ServerLevelOptions` |
| `demote_server` | `ServerDemote < ServerLevelOptions` |
| `server_delete` | :x: |
## Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/126786645
