### PR TITLE
Time threshold for real time performance has to be a required field

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -572,6 +572,9 @@ module MiqPolicyController::Alerts
           add_flash(_("Trend Steepness must be an integer"), :error)
         end
       end
+      unless @edit.fetch_path(:new, :expression, :options, :rt_time_threshold)
+        add_flash(_("Time threshold for the field criteria must be selected"), :error)
+      end
     end
     if %w(mw_heap_used mw_non_heap_used).include?(@edit.fetch_path(:new, :expression, :eval_method))
       value_greater_than = @edit.fetch_path(:new, :expression, :options, :value_mw_greater_than)


### PR DESCRIPTION
To reproduce:
1. create a new alert
2. what to evaluate needs to be set to real time performance
3. performance field can be set to e.g. cpu - usage rate for collected intervals
4. don't enter anything into "field meets criteria for"

Before, the form would allow creation of an alert with the time threshold set to nothing. With
this fix in place, the form create would return a flash message.

https://bugzilla.redhat.com/show_bug.cgi?id=1379078