### PR TITLE
Fix the issue that user can't add alerts.

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -274,8 +274,7 @@ module MiqPolicyController::Alerts
 
     # Build hash of arrays of all events by event type
     @edit[:events] = {}
-    MiqEventDefinition.all_events.each do |e|
-      next if e.name.ends_with?("compliance_check")
+    MiqEventDefinition.all_control_events.each do |e|
       @edit[:events][e.id] = (e.etype.description + ": " + e.description)
     end
 

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -21,6 +21,10 @@ class MiqEventDefinition < ApplicationRecord
     where(:event_type => "Default")
   end
 
+  def self.all_control_events
+    all_events.where.not("name like ?", "%compliance_check").select { |e| e.etype }
+  end
+
   def miq_policies
     p_ids = MiqPolicyContent.where(:miq_event_definition_id => id).uniq.pluck(:miq_policy_id)
     MiqPolicy.where(:id => p_ids).to_a
@@ -63,9 +67,7 @@ class MiqEventDefinition < ApplicationRecord
   end
 
   def etype
-    set = memberof.first
-    raise "unexpected error, no type found for event #{name}" if set.nil?
-    set
+    memberof.first.tap { |set| _log.error("No type found for event #{name}") if set.nil? }
   end
 
   def self.etypes

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -55,4 +55,48 @@ describe MiqEventDefinition do
       end
     end
   end
+
+  describe '#etype' do
+    it "returns event set type" do
+      set_type = 'set_testing'
+      set = MiqEventDefinitionSet.create(:name => set_type, :description => "Set testing")
+      event = FactoryGirl.create(:miq_event_definition, :name => "vm_start")
+      set.add_member(event)
+
+      expect(event.etype.name).to eq(set_type)
+    end
+
+    it "returns nil when not belong to any event set" do
+      event = FactoryGirl.create(:miq_event_definition, :name => "test_event")
+      expect(event.etype).to be_nil
+    end
+  end
+
+  describe '.all_control_events' do
+    subject { MiqEventDefinition.all_control_events }
+
+    before do
+      com_set = MiqEventDefinitionSet.create(:name => "compliance", :description => "Compliance Events")
+      FactoryGirl.create(:miq_event_definition,
+                         :name       => "host_compliance_check",
+                         :event_type => "Default").tap { |e| com_set.add_member(e) }
+    end
+
+    it 'has all default control policy events with set type' do
+      event = FactoryGirl.create(:miq_event_definition, :name => "some_event", :event_type => "Default")
+      set   = MiqEventDefinitionSet.create(:name => "evm_operations", :description => "EVM Events")
+      set.add_member(event)
+
+      expect(subject.include?(event)).to be true
+    end
+
+    it 'has not the events for compliance policy' do
+      expect(subject.any? { |e| e.name.ends_with?("compliance_check") }).to be false
+    end
+
+    it 'has not the events without a set type' do
+      event = FactoryGirl.create(:miq_event_definition, :name => "test_event", :event_type => "Default")
+      expect(subject.include?(event)).to be false
+    end
+  end
 end


### PR DESCRIPTION
When seeded from the fixture file, default events in miq_event_definitions table always belong to certain event set. However there are some appliances from 5.6 fresh installation that have some deleted old events showed up in the DB and not belong to any event set. UI for Add a New Alert would not open due to these ghost and orphaned events.

So far we can't find out why these deleted events still showed up in a fresh appliance. It is strange.
This commit would skip these orphaned events so users can access the Add a New Alert page.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1379854

cc @gmcculloug @h-kataria 