### PR TITLE
miqAjaxButton - make it possible to override sparkle

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -693,7 +693,7 @@ function miqRESTAjaxButton(url, button, dataType, data) {
 
 // Handle an ajax form button press (i.e. Submit) by starting the spinning Q,
 // then waiting for .7 seconds for observers to finish
-function miqAjaxButton(url, serialize_fields) {
+function miqAjaxButton(url, serialize_fields, options) {
   if (typeof serialize_fields == "undefined") {
     serialize_fields = false;
   }
@@ -702,23 +702,23 @@ function miqAjaxButton(url, serialize_fields) {
   }
 
   setTimeout(function () {
-    miqAjaxButtonSend(url, serialize_fields);
+    miqAjaxButtonSend(url, serialize_fields, options);
   }, 700);
 }
 
 // Send ajax url after any outstanding ajax requests, wait longer if needed
-function miqAjaxButtonSend(url, serialize_fields) {
+function miqAjaxButtonSend(url, serialize_fields, options) {
   if ($.active) {
     setTimeout(function () {
-      miqAjaxButtonSend(url);
+      miqAjaxButtonSend(url, serialize_fields, options);
     }, 700);
   } else {
-    miqAjax(url, serialize_fields);
+    miqAjax(url, serialize_fields, options);
   }
 }
 
 // Function to generate an Ajax request
-function miqAjax(url, serialize_fields) {
+function miqAjax(url, serialize_fields, options) {
   var data = undefined;
 
   if (serialize_fields === true) {
@@ -727,7 +727,12 @@ function miqAjax(url, serialize_fields) {
     data = serialize_fields;
   }
 
-  miqJqueryRequest(url, {beforeSend: true, complete: true, data: data});
+  var defaultOptions = {
+    beforeSend: true,
+    complete: true,
+  };
+
+  miqJqueryRequest(url, _.extend(defaultOptions, options || {}, { data: data }));
 }
 
 // Function to generate an Ajax request for EVM async processing

--- a/app/assets/javascripts/services/miq_service.js
+++ b/app/assets/javascripts/services/miq_service.js
@@ -16,8 +16,8 @@ ManageIQ.angular.app.service('miqService', ['$timeout', '$document', function($t
     miqBuildCalendar(true);
   };
 
-  this.miqAjaxButton = function(url, serializeFields) {
-    miqAjaxButton(url, serializeFields);
+  this.miqAjaxButton = function(url, serializeFields, options) {
+    miqAjaxButton(url, serializeFields, options);
   };
 
   this.miqAsyncAjaxButton = function(url, serializeFields) {

--- a/spec/javascripts/services/miq_service_spec.js
+++ b/spec/javascripts/services/miq_service_spec.js
@@ -41,7 +41,12 @@ describe('miqService', function() {
   describe('#miqAjaxButton', function() {
     it('calls the global miqAjaxButton with the correct arguments', function() {
       testService.miqAjaxButton('test_url');
-      expect(window.miqAjaxButton).toHaveBeenCalledWith('test_url', undefined);
+      expect(window.miqAjaxButton).toHaveBeenCalledWith('test_url', undefined, undefined);
+    });
+
+    it('calls the global miqAjaxButton with all the arguments', function() {
+      testService.miqAjaxButton('test_url', { test: 'data' }, { complete: false });
+      expect(window.miqAjaxButton).toHaveBeenCalledWith('test_url', { test: 'data' }, { complete: false });
     });
   });
 


### PR DESCRIPTION
Calling `miqAjaxButton` ends up calling `miqJqueryRequest` with `{ beforeSend: true, complete: true }` - which is equivalent to `miqSparkleOn()` before the request and `miqSparkleOff()` after.

Sometimes we do need to override this behaviour (for example, make it *not* `miqSparkleOff()` because you want to wait for a task).

This makes it possible to add a third (optional) argument to `miqAjaxButton` where you can override these (by passing `{ beforeSend: false }` for example).

Affected functions (added an optional options argument):

   * `miqService.miqAjaxButton`
   * `miqAjaxButton`
   * `miqAjaxButtonSend`
   * `miqAjax`

Cc: @martinpovolny , @tzumainn

(From gitter - :point_up: [October 5, 2016 2:49 PM](https://gitter.im/ManageIQ/manageiq/ui?at=57f512fe29403a416fcaf3a3))