### PR TITLE
Introduce service for sharing resources across tenants

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
   has_many   :miq_reports, :dependent => :nullify
   has_many   :service_orders, :dependent => :nullify
-  has_many   :shares
+  has_many   :owned_shares, :class_name => "Share"
   has_many   :notification_recipients, :dependent => :delete_all
   has_many   :notifications, :through => :notification_recipients
   has_many   :unseen_notification_recipients, -> { unseen }, :class_name => 'NotificationRecipient'

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -128,6 +128,7 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :service_resources, :as => :resource
   has_many                  :direct_services, :through => :service_resources, :source => :service
   belongs_to                :tenant
+  has_many                  :connected_shares, -> { where(:resource_type => "VmOrTemplate") }, :foreign_key => :resource_id, :class_name => "Share"
 
   acts_as_miq_taggable
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,7 @@ module Vmdb
     config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models", "mixins")
     config.autoload_paths << Rails.root.join("app", "controllers", "mixins")
     config.autoload_paths << Rails.root.join("lib")
+    config.autoload_paths << Rails.root.join("lib", "services")
 
     config.autoload_once_paths << Rails.root.join("lib", "vmdb", "console_methods.rb")
 

--- a/lib/services/resource_sharer.rb
+++ b/lib/services/resource_sharer.rb
@@ -1,0 +1,69 @@
+class ResourceSharer
+  WHITELISTED_RESOURCE_TYPES = %w(
+    MiqTemplate
+    ServiceTemplate
+  ).freeze
+
+  include ActiveModel::Model
+
+  attr_accessor :user, :resource, :tenants, :features
+
+  with_options :presence => true do
+    validates :user
+    validates :resource
+    validates :tenants
+    validates :features
+  end
+
+  validate :allowed_resource_type
+  validate :rbac_visibility
+  validate :valid_tenants
+
+  ##
+  # Creates shares from the user with +features+ to +tenants+ with the given +resource+
+  # @param user - The user sharing the resource
+  # @param resource - The resource to be shared
+  # @param tenants - The tenants to share the resource with
+  # @param features - The product features to be associated with the share. Features must
+  #   be a subset of the user's accessible miq_product_features or :all if you wish to
+  #   share all the user's accessible features. Defaults to :all.
+  def initialize(attributes={})
+    attributes = attributes.reverse_merge(:features => :all)
+    if attributes[:user] && attributes[:features] == :all
+      attributes[:features] = attributes[:user].miq_user_role.miq_product_features
+    end
+    super
+  end
+
+  def share
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      tenants.map do |tenant|
+        Share.create!(:user => user, :resource => resource, :tenant => tenant, :miq_product_features => features)
+      end
+    end
+  end
+
+  private
+
+  def rbac_visibility
+    return unless user && resource
+    unless Rbac::Filterer.search(:targets => [resource], :user => user)[0].include?(resource)
+      errors.add(:user, "is not authorized to share this resource")
+    end
+  end
+
+  def allowed_resource_type
+    unless WHITELISTED_RESOURCE_TYPES.any? { |type| resource.is_a?(type.constantize) }
+      errors.add(:resource, "is not sharable. Supported resource types: #{WHITELISTED_RESOURCE_TYPES.join(' ')}")
+    end
+  end
+
+  def valid_tenants
+    return unless tenants
+    unless tenants.respond_to?(:all?) && tenants.all? { |t| t.is_a?(Tenant) }
+      errors.add(:tenants, "must be an array of Tenant objects")
+    end
+  end
+end

--- a/lib/services/resource_sharer.rb
+++ b/lib/services/resource_sharer.rb
@@ -50,7 +50,7 @@ class ResourceSharer
 
   def rbac_visibility
     return unless user && resource
-    unless Rbac::Filterer.search(:targets => [resource], :user => user)[0].include?(resource)
+    unless Rbac::Filterer.filtered_object(resource, :user => user).present?
       errors.add(:user, "is not authorized to share this resource")
     end
   end

--- a/lib/services/resource_sharer.rb
+++ b/lib/services/resource_sharer.rb
@@ -27,10 +27,10 @@ class ResourceSharer
   # @param features - The product features to be associated with the share. Features must
   #   be a subset of the user's accessible miq_product_features or :all if you wish to
   #   share all the user's accessible features. Defaults to :all.
-  def initialize(attributes={})
-    attributes = attributes.reverse_merge(:features => :all)
-    if attributes[:user] && attributes[:features] == :all
-      attributes[:features] = attributes[:user].miq_user_role.miq_product_features
+  def initialize(args={})
+    args = args.reverse_merge(:features => :all)
+    if args[:user] && args[:features] == :all
+      args[:features] = args[:user].miq_user_role.miq_product_features
     end
     super
   end

--- a/lib/services/resource_sharer.rb
+++ b/lib/services/resource_sharer.rb
@@ -28,7 +28,7 @@ class ResourceSharer
   # @param features - The product features to be associated with the share. Features must
   #   be a subset of the user's accessible miq_product_features or :all if you wish to
   #   share all the user's accessible features. Defaults to :all.
-  def initialize(args={})
+  def initialize(args = {})
     args = args.reverse_merge(:features => :all)
     if args[:user] && args[:features] == :all
       args[:features] = args[:user].miq_user_role.miq_product_features
@@ -63,7 +63,9 @@ class ResourceSharer
     # TODO:  This is bad. Need feature API to fetch Set of allowed features
     # based on parent and check if the requested features are all in the Set.
     Array(features).each do |feature|
-      rejected_features << "#{feature.identifier}: #{feature.name}" unless user.miq_user_role.allows?(:identifier => feature.identifier)
+      unless user.miq_user_role.allows?(:identifier => feature.identifier)
+        rejected_features << "#{feature.identifier}: #{feature.name}"
+      end
     end
 
     unless rejected_features.empty?
@@ -72,14 +74,14 @@ class ResourceSharer
   end
 
   def allowed_resource_type
-    unless WHITELISTED_RESOURCE_TYPES.any? { |type| resource.is_a?(type.constantize) }
+    unless WHITELISTED_RESOURCE_TYPES.any? { |type| resource.kind_of?(type.constantize) }
       errors.add(:resource, "is not sharable. Supported resource types: #{WHITELISTED_RESOURCE_TYPES.join(' ')}")
     end
   end
 
   def valid_tenants
     return unless tenants
-    unless tenants.respond_to?(:all?) && tenants.all? { |t| t.is_a?(Tenant) }
+    unless tenants.respond_to?(:all?) && tenants.all? { |t| t.kind_of?(Tenant) }
       errors.add(:tenants, "must be an array of Tenant objects")
     end
   end

--- a/spec/factories/miq_template.rb
+++ b/spec/factories/miq_template.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
   factory :miq_template do
+    name "ubuntu-16.04-stable"
+    location "Minneapolis, MN"
+    vendor "openstack"
   end
 end

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -11,15 +11,53 @@ describe ResourceSharer do
 
     let(:user) { FactoryGirl.create(:user,
                                     :role     => "user",
-                                    :features => "service") }
+                                    :features => user_allowed_feature) }
+    let(:user_allowed_feature) { "service"}
     let(:resource_to_be_shared) { FactoryGirl.create(:miq_template) }
     let(:tenants) { [FactoryGirl.create(:tenant)] }
     let(:features) { :all }
 
-    context "with the :all option" do
-      it "uses the user's current features" do
-        shares = subject.share
-        expect(shares.first.miq_product_features).to match_array(user.miq_user_role.miq_product_features)
+    context "product features" do
+      context "with the :all option on initialization" do
+        it "uses the user's current features" do
+          shares = subject.share
+          expect(shares.first.miq_product_features).to match_array(user.miq_user_role.miq_product_features)
+        end
+      end
+
+      context "with an unauthorized product feature (across tree)" do
+        let(:features) { MiqProductFeature.find_by(:identifier => "host") }
+        let(:user_allowed_feature) { "service"}
+
+        before { EvmSpecHelper.seed_specific_product_features(%w(host service)) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors.full_messages).to include(a_string_including("Features not permitted"))
+        end
+      end
+
+      context "with an unauthorized product feature (up tree)" do
+        let(:features) { MiqProductFeature.find_by(:identifier => "host") }
+        let(:user_allowed_feature) { "host_edit"}
+
+        before { EvmSpecHelper.seed_specific_product_features(%w(host)) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors.full_messages).to include(a_string_including("Features not permitted"))
+        end
+      end
+
+      context "with a 'sees everything' product feature user" do
+        let(:features) { MiqProductFeature.find_by(:identifier => "host_edit") }
+        let(:user_allowed_feature) { "everything" }
+
+        before { EvmSpecHelper.seed_specific_product_features(%w(host_edit everything)) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
       end
     end
 

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -70,8 +70,22 @@ describe ResourceSharer do
       end
     end
 
-    context "attempting to share a resource the user doesn't have access to" do
-      pending "is invalid"
+    context "attempting to share a resource the user doesn't have access to via RBAC" do
+      let(:user) { FactoryGirl.create(:user,
+                                      :role     => "user",
+                                      :features => user_allowed_feature,
+                                      :tenant   => FactoryGirl.create(:tenant, :name => "Tenant under root")) }
+      let(:resource_to_be_shared) { FactoryGirl.create(:miq_template,
+                                                       :tenant => FactoryGirl.create(:tenant,
+                                                                                     :name => "Sibling tenant")) }
+      let(:tenants) { [user.current_tenant] } # Attempt to share a resource in Sibling tenant to one's own tenant
+
+      before { Tenant.seed }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages).to include(a_string_including("is not authorized to share this resource"))
+      end
     end
 
     context "with tenants that aren't tenants" do

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -1,0 +1,49 @@
+describe ResourceSharer do
+  before { allow(User).to receive_messages(:server_timezone => "UTC") }
+
+  describe "#share" do
+    subject do
+      described_class.new(:user => user,
+                          :resource => resource_to_be_shared,
+                          :tenants => tenants,
+                          :features => features)
+    end
+
+    let(:user) { FactoryGirl.create(:user,
+                                    :role     => "user",
+                                    :features => "service") }
+    let(:resource_to_be_shared) { FactoryGirl.create(:miq_template) }
+    let(:tenants) { [FactoryGirl.create(:tenant)] }
+    let(:features) { :all }
+
+    context "with the :all option" do
+      it "uses the user's current features" do
+        shares = subject.share
+        expect(shares.first.miq_product_features).to match_array(user.miq_user_role.miq_product_features)
+      end
+    end
+
+    context "with an invalid resource" do
+      let(:resource_to_be_shared) { FactoryGirl.build(:miq_group) }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages).to include(a_string_including("Resource is not sharable"))
+      end
+    end
+
+    context "attempting to share a resource the user doesn't have access to" do
+      pending "is invalid"
+    end
+
+    context "with tenants that aren't tenants" do
+      let(:tenants) { [FactoryGirl.build(:miq_group)] }
+
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages)
+          .to include(a_string_including("Tenants must be an array of Tenant objects"))
+      end
+    end
+  end
+end

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -17,11 +17,22 @@ describe ResourceSharer do
     let(:tenants) { [FactoryGirl.create(:tenant)] }
     let(:features) { :all }
 
+    context "with valid arguments" do
+      before do
+        expect(user.owned_shares.count).to eq(0)
+        expect(subject).to be_valid
+        subject.share
+      end
+
+      it "creates a share from the user to the tenant" do
+        expect(user.owned_shares.count).to eq(1)
+      end
+    end
+
     context "product features" do
       context "with the :all option on initialization" do
         it "uses the user's current features" do
-          shares = subject.share
-          expect(shares.first.miq_product_features).to match_array(user.miq_user_role.miq_product_features)
+          expect(subject.features).to match_array(user.miq_user_role.miq_product_features)
         end
       end
 

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -3,16 +3,18 @@ describe ResourceSharer do
 
   describe "#share" do
     subject do
-      described_class.new(:user => user,
+      described_class.new(:user     => user,
                           :resource => resource_to_be_shared,
-                          :tenants => tenants,
+                          :tenants  => tenants,
                           :features => features)
     end
 
-    let(:user) { FactoryGirl.create(:user,
-                                    :role     => "user",
-                                    :features => user_allowed_feature) }
-    let(:user_allowed_feature) { "service"}
+    let(:user) do
+      FactoryGirl.create(:user,
+                         :role     => "user",
+                         :features => user_allowed_feature)
+    end
+    let(:user_allowed_feature) { "service" }
     let(:resource_to_be_shared) { FactoryGirl.create(:miq_template) }
     let(:tenants) { [FactoryGirl.create(:tenant)] }
     let(:features) { :all }
@@ -38,7 +40,7 @@ describe ResourceSharer do
 
       context "with an unauthorized product feature (across tree)" do
         let(:features) { MiqProductFeature.find_by(:identifier => "host") }
-        let(:user_allowed_feature) { "service"}
+        let(:user_allowed_feature) { "service" }
 
         before { EvmSpecHelper.seed_specific_product_features(%w(host service)) }
 
@@ -50,7 +52,7 @@ describe ResourceSharer do
 
       context "with an unauthorized product feature (up tree)" do
         let(:features) { MiqProductFeature.find_by(:identifier => "host") }
-        let(:user_allowed_feature) { "host_edit"}
+        let(:user_allowed_feature) { "host_edit" }
 
         before { EvmSpecHelper.seed_specific_product_features(%w(host)) }
 
@@ -82,13 +84,17 @@ describe ResourceSharer do
     end
 
     context "attempting to share a resource the user doesn't have access to via RBAC" do
-      let(:user) { FactoryGirl.create(:user,
-                                      :role     => "user",
-                                      :features => user_allowed_feature,
-                                      :tenant   => FactoryGirl.create(:tenant, :name => "Tenant under root")) }
-      let(:resource_to_be_shared) { FactoryGirl.create(:miq_template,
-                                                       :tenant => FactoryGirl.create(:tenant,
-                                                                                     :name => "Sibling tenant")) }
+      let(:user) do
+        FactoryGirl.create(:user,
+                           :role     => "user",
+                           :features => user_allowed_feature,
+                           :tenant   => FactoryGirl.create(:tenant, :name => "Tenant under root"))
+      end
+      let(:resource_to_be_shared) do
+        FactoryGirl.create(:miq_template,
+                           :tenant => FactoryGirl.create(:tenant,
+                                                         :name => "Sibling tenant"))
+      end
       let(:tenants) { [user.current_tenant] } # Attempt to share a resource in Sibling tenant to one's own tenant
 
       before { Tenant.seed }


### PR DESCRIPTION
Summary
----------------

Adds a ResourceSharer service object for adding ad-hoc Shares from users to tenants, with tests and a newly named `User#owned_shares` association for fetching shares you're shared with tenants. Fulfills all tasks outlined in the pivotal story (see below). 

Notes
----------------

This is a great example of composability over inheritance, as we're not just strapping more methods on to existing ActiveRecord models. I'd really like to persuade us to write more code this way and less hacking across multiple spots in the app to do the same action. This class is the authority for ad-hoc sharing, what's valid, what's not, etc, and can be utilized anywhere, replaced as needed, tested in its own environment, etc. As is a bit of a convention these days, I've added `lib/services` to especially mark that, as our current `/lib` is a bucket of *many* different things.

Links
----------------

* https://www.pivotaltracker.com/story/show/131005225