### PR TITLE
Add coverage for some API subcollection actions

### DIFF
--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -259,4 +259,61 @@ describe "Groups API" do
       expect(MiqGroup.exists?(g2_id)).to be_falsey
     end
   end
+
+  describe "tags subcollection" do
+    it "can list a group's tags" do
+      group = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:classification_department_with_tags)
+      Classification.classify(group, "department", "finance")
+      api_basic_authorize
+
+      run_get("#{groups_url(group.id)}/tags")
+
+      expect(response.parsed_body).to include("subcount" => 1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can assign a tag to a group" do
+      group = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:classification_department_with_tags)
+      api_basic_authorize(subcollection_action_identifier(:groups, :tags, :assign))
+
+      run_post("#{groups_url(group.id)}/tags", :action => "assign", :category => "department", :name => "finance")
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"      => true,
+            "message"      => a_string_matching(/assigning tag/i),
+            "tag_category" => "department",
+            "tag_name"     => "finance"
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can unassign a tag from a group" do
+      group = FactoryGirl.create(:miq_group)
+      FactoryGirl.create(:classification_department_with_tags)
+      Classification.classify(group, "department", "finance")
+      api_basic_authorize(subcollection_action_identifier(:groups, :tags, :unassign))
+
+      run_post("#{groups_url(group.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"      => true,
+            "message"      => a_string_matching(/unassigning tag/i),
+            "tag_category" => "department",
+            "tag_name"     => "finance"
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -171,4 +171,31 @@ describe "Service Templates API" do
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe "service requests subcollection" do
+    it "can list a service template's service requests" do
+      service_template = FactoryGirl.create(:service_template)
+      service_request = FactoryGirl.create(:service_template_provision_request,
+                                           :requester => @user,
+                                           :source    => service_template)
+      api_basic_authorize(action_identifier(:service_requests, :read, :subcollection_actions, :get))
+
+      run_get("#{service_templates_url(service_template.id)}/service_requests")
+
+      expected = {
+        "count"     => 1,
+        "subcount"  => 1,
+        "name"      => "service_requests",
+        "resources" => [
+          {
+            "href" => a_string_matching(
+              "#{service_templates_url(service_template.id)}/service_requests/#{service_request.id}"
+            )
+          }
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -9,25 +9,12 @@ describe "Tags API" do
 
   let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
   let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
-
-  let(:vm1) { FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems.id, :raw_power_state => "poweredOn") }
-  let(:vm1_url)      { vms_url(vm1.id) }
-  let(:vm1_tags_url) { "#{vm1_url}/tags" }
-
-  let(:vm2) { FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems.id, :raw_power_state => "poweredOn") }
-  let(:vm2_url)      { vms_url(vm2.id) }
-  let(:vm2_tags_url) { "#{vm2_url}/tags" }
-
   let(:invalid_tag_url) { tags_url(999_999) }
-
   let(:tag_count)    { Tag.count }
 
   before(:each) do
     FactoryGirl.create(:classification_department_with_tags)
     FactoryGirl.create(:classification_cost_center_with_tags)
-
-    Classification.classify(vm2, tag1[:category], tag1[:name])
-    Classification.classify(vm2, tag2[:category], tag2[:name])
   end
 
   context "Tag collection" do
@@ -322,145 +309,6 @@ describe "Tags API" do
 
       expect_query_result(:tags, :tag_count, :tag_count)
       expect_result_resources_to_include_keys("resources", %w(id name categorization))
-    end
-  end
-
-  context "Vm Tag subcollection" do
-    it "query all tags of a Vm with no tags" do
-      api_basic_authorize
-
-      run_get vm1_tags_url
-
-      expect_empty_query_result(:tags)
-    end
-
-    it "query all tags of a Vm" do
-      api_basic_authorize
-
-      run_get vm2_tags_url
-
-      expect_query_result(:tags, 2, :tag_count)
-    end
-
-    it "query all tags of a Vm and verify tag category and names" do
-      api_basic_authorize
-
-      run_get vm2_tags_url, :expand => "resources"
-
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => [tag1[:path], tag2[:path]])
-    end
-
-    it "assigns a tag to a Vm without appropriate role" do
-      api_basic_authorize
-
-      run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it "assigns a tag to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
-      )
-    end
-
-    it "assigns a tag to a Vm by name path" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      run_post(vm1_tags_url, gen_request(:assign, :name => tag1[:path]))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
-      )
-    end
-
-    it "assigns a tag to a Vm by href" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      run_post(vm1_tags_url, gen_request(:assign, :href => tags_url(Tag.find_by_name(tag1[:path]).id)))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
-      )
-    end
-
-    it "assigns an invalid tag by href to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      run_post(vm1_tags_url, gen_request(:assign, :href => invalid_tag_url))
-
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "assigns an invalid tag to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      run_post(vm1_tags_url, gen_request(:assign, :name => "/managed/bad_category/bad_name"))
-
-      expect_tagging_result(
-        [{:success => false, :href => vm1_url, :tag_category => "bad_category", :tag_name => "bad_name"}]
-      )
-    end
-
-    it "assigns multiple tags to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      run_post(vm1_tags_url, gen_request(:assign, [{:name => tag1[:path]}, {:name => tag2[:path]}]))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]},
-         {:success => true, :href => vm1_url, :tag_category => tag2[:category], :tag_name => tag2[:name]}]
-      )
-    end
-
-    it "assigns tags by mixed specification to a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
-
-      tag = Tag.find_by_name(tag2[:path])
-      run_post(vm1_tags_url, gen_request(:assign, [{:name => tag1[:path]}, {:href => tags_url(tag.id)}]))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]},
-         {:success => true, :href => vm1_url, :tag_category => tag2[:category], :tag_name => tag2[:name]}]
-      )
-    end
-
-    it "unassigns a tag from a Vm without appropriate role" do
-      api_basic_authorize
-
-      run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    it "unassigns a tag from a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :unassign)
-
-      run_post(vm2_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm2_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
-      )
-      expect(vm2.tags.count).to eq(1)
-      expect(vm2.tags.first.name).to eq(tag2[:path])
-    end
-
-    it "unassigns multiple tags from a Vm" do
-      api_basic_authorize subcollection_action_identifier(:vms, :tags, :unassign)
-
-      tag = Tag.find_by_name(tag2[:path])
-      run_post(vm2_tags_url, gen_request(:unassign, [{:name => tag1[:path]}, {:href => tags_url(tag.id)}]))
-
-      expect_tagging_result(
-        [{:success => true, :href => vm2_url, :tag_category => tag1[:category], :tag_name => tag1[:name]},
-         {:success => true, :href => vm2_url, :tag_category => tag2[:category], :tag_name => tag2[:name]}]
-      )
-      expect(vm2.tags.count).to eq(0)
     end
   end
 end

--- a/spec/requests/api/templates_spec.rb
+++ b/spec/requests/api/templates_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe "Templates API" do
       Classification.classify(template, "department", "finance")
       api_basic_authorize(subcollection_action_identifier(:templates, :tags, :unassign))
 
-      run_post("#{templates_url(template.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
+      run_post("#{templates_url(template.id)}/tags",
+               :action   => "unassign",
+               :category => "department",
+               :name     => "finance")
 
       expected = {
         "results" => [

--- a/spec/requests/api/templates_spec.rb
+++ b/spec/requests/api/templates_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe "Templates API" do
+  describe "tags subcollection" do
+    it "can list a template's tags" do
+      template = FactoryGirl.create(:template)
+      FactoryGirl.create(:classification_department_with_tags)
+      Classification.classify(template, "department", "finance")
+      api_basic_authorize
+
+      run_get("#{templates_url(template.id)}/tags")
+
+      expect(response.parsed_body).to include("subcount" => 1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can assign a tag to a template" do
+      template = FactoryGirl.create(:template)
+      FactoryGirl.create(:classification_department_with_tags)
+      api_basic_authorize(subcollection_action_identifier(:templates, :tags, :assign))
+
+      run_post("#{templates_url(template.id)}/tags", :action => "assign", :category => "department", :name => "finance")
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"      => true,
+            "message"      => a_string_matching(/assigning tag/i),
+            "tag_category" => "department",
+            "tag_name"     => "finance"
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "can unassign a tag from a template" do
+      template = FactoryGirl.create(:template)
+      FactoryGirl.create(:classification_department_with_tags)
+      Classification.classify(template, "department", "finance")
+      api_basic_authorize(subcollection_action_identifier(:templates, :tags, :unassign))
+
+      run_post("#{templates_url(template.id)}/tags", :action => "unassign", :category => "department", :name => "finance")
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "success"      => true,
+            "message"      => a_string_matching(/unassigning tag/i),
+            "tag_category" => "department",
+            "tag_name"     => "finance"
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -1149,4 +1149,164 @@ describe "Vms API" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  context "Vm Tag subcollection" do
+    let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
+    let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
+    let(:tag_count)    { Tag.count }
+
+    let(:vm1) { FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems.id, :raw_power_state => "poweredOn") }
+    let(:vm1_url)      { vms_url(vm1.id) }
+    let(:vm1_tags_url) { "#{vm1_url}/tags" }
+
+    let(:vm2) { FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems.id, :raw_power_state => "poweredOn") }
+    let(:vm2_url)      { vms_url(vm2.id) }
+    let(:vm2_tags_url) { "#{vm2_url}/tags" }
+
+    let(:invalid_tag_url) { tags_url(999_999) }
+
+    before do
+      FactoryGirl.create(:classification_department_with_tags)
+      FactoryGirl.create(:classification_cost_center_with_tags)
+      Classification.classify(vm2, tag1[:category], tag1[:name])
+      Classification.classify(vm2, tag2[:category], tag2[:name])
+    end
+
+    it "query all tags of a Vm with no tags" do
+      api_basic_authorize
+
+      run_get vm1_tags_url
+
+      expect_empty_query_result(:tags)
+    end
+
+    it "query all tags of a Vm" do
+      api_basic_authorize
+
+      run_get vm2_tags_url
+
+      expect_query_result(:tags, 2, :tag_count)
+    end
+
+    it "query all tags of a Vm and verify tag category and names" do
+      api_basic_authorize
+
+      run_get vm2_tags_url, :expand => "resources"
+
+      expect_query_result(:tags, 2, :tag_count)
+      expect_result_resources_to_include_data("resources", "name" => [tag1[:path], tag2[:path]])
+    end
+
+    it "assigns a tag to a Vm without appropriate role" do
+      api_basic_authorize
+
+      run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "assigns a tag to a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+      )
+    end
+
+    it "assigns a tag to a Vm by name path" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      run_post(vm1_tags_url, gen_request(:assign, :name => tag1[:path]))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+      )
+    end
+
+    it "assigns a tag to a Vm by href" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      run_post(vm1_tags_url, gen_request(:assign, :href => tags_url(Tag.find_by_name(tag1[:path]).id)))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+      )
+    end
+
+    it "assigns an invalid tag by href to a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      run_post(vm1_tags_url, gen_request(:assign, :href => invalid_tag_url))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "assigns an invalid tag to a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      run_post(vm1_tags_url, gen_request(:assign, :name => "/managed/bad_category/bad_name"))
+
+      expect_tagging_result(
+        [{:success => false, :href => vm1_url, :tag_category => "bad_category", :tag_name => "bad_name"}]
+      )
+    end
+
+    it "assigns multiple tags to a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      run_post(vm1_tags_url, gen_request(:assign, [{:name => tag1[:path]}, {:name => tag2[:path]}]))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]},
+         {:success => true, :href => vm1_url, :tag_category => tag2[:category], :tag_name => tag2[:name]}]
+      )
+    end
+
+    it "assigns tags by mixed specification to a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :assign)
+
+      tag = Tag.find_by_name(tag2[:path])
+      run_post(vm1_tags_url, gen_request(:assign, [{:name => tag1[:path]}, {:href => tags_url(tag.id)}]))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm1_url, :tag_category => tag1[:category], :tag_name => tag1[:name]},
+         {:success => true, :href => vm1_url, :tag_category => tag2[:category], :tag_name => tag2[:name]}]
+      )
+    end
+
+    it "unassigns a tag from a Vm without appropriate role" do
+      api_basic_authorize
+
+      run_post(vm1_tags_url, gen_request(:assign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "unassigns a tag from a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :unassign)
+
+      run_post(vm2_tags_url, gen_request(:unassign, :category => tag1[:category], :name => tag1[:name]))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm2_url, :tag_category => tag1[:category], :tag_name => tag1[:name]}]
+      )
+      expect(vm2.tags.count).to eq(1)
+      expect(vm2.tags.first.name).to eq(tag2[:path])
+    end
+
+    it "unassigns multiple tags from a Vm" do
+      api_basic_authorize subcollection_action_identifier(:vms, :tags, :unassign)
+
+      tag = Tag.find_by_name(tag2[:path])
+      run_post(vm2_tags_url, gen_request(:unassign, [{:name => tag1[:path]}, {:href => tags_url(tag.id)}]))
+
+      expect_tagging_result(
+        [{:success => true, :href => vm2_url, :tag_category => tag1[:category], :tag_name => tag1[:name]},
+         {:success => true, :href => vm2_url, :tag_category => tag2[:category], :tag_name => tag2[:name]}]
+      )
+      expect(vm2.tags.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
* Moves the existing tags subcollection tests (which were based on vms) under the vms specs
* Adds some tests for tags subcollections of groups, users and templates
* Adds a test for service request subcollection of service templates

These tests describe the behavior affected by https://github.com/ManageIQ/manageiq/pull/11694

@miq-bot assign @abellotti 
@miq-bot add-label api, test
