### PR TITLE
Use checkboxes in VMware vApp provisioning

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter.rb
@@ -2,8 +2,8 @@ module ManageIQ::Providers
   class Vmware::CloudManager::OrchestrationServiceOptionConverter < ::ServiceOrchestration::OptionConverter
     def stack_create_options
       {
-        :deploy  => stack_parameters['deploy'] == 'yes',
-        :powerOn => stack_parameters['powerOn'] == 'yes',
+        :deploy  => stack_parameters['deploy'] == 't',
+        :powerOn => stack_parameters['powerOn'] == 't',
         :vdc_id  => @dialog_options['dialog_availability_zone']
       }
     end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -11,19 +11,19 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
       OrchestrationTemplate::OrchestrationParameter.new(
         :name          => "deploy",
         :label         => "Deploy vApp",
-        :data_type     => "string",
-        :default_value => "yes",
+        :data_type     => "boolean",
+        :default_value => true,
         :constraints   => [
-          OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(no yes))
+          OrchestrationTemplate::OrchestrationParameterBoolean.new
         ]
       ),
       OrchestrationTemplate::OrchestrationParameter.new(
         :name          => "powerOn",
         :label         => "Power On vApp",
-        :data_type     => "string",
-        :default_value => "no",
+        :data_type     => "boolean",
+        :default_value => false,
         :constraints   => [
-          OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(no yes))
+          OrchestrationTemplate::OrchestrationParameterBoolean.new
         ]
       )
     ]

--- a/app/models/orchestration_template/orchestration_parameter_boolean.rb
+++ b/app/models/orchestration_template/orchestration_parameter_boolean.rb
@@ -1,0 +1,4 @@
+class OrchestrationTemplate
+  class OrchestrationParameterBoolean < OrchestrationParameterConstraint
+  end
+end

--- a/app/services/orchestration_template_dialog_service.rb
+++ b/app/services/orchestration_template_dialog_service.rb
@@ -201,9 +201,12 @@ class OrchestrationTemplateDialogService
   def add_parameter_field(parameter, group, position)
     if parameter.constraints
       dropdown = parameter.constraints.detect { |c| c.kind_of? OrchestrationTemplate::OrchestrationParameterAllowed }
+      checkbox = parameter.constraints.detect { |c| c.kind_of? OrchestrationTemplate::OrchestrationParameterBoolean } unless dropdown
     end
     if dropdown
       create_parameter_dropdown_list(parameter, group, position, dropdown)
+    elsif checkbox
+      create_parameter_checkbox(parameter, group, position)
     else
       create_parameter_textbox(parameter, group, position)
     end
@@ -242,6 +245,22 @@ class OrchestrationTemplateDialogService
       :options        => {:protected => parameter.hidden?},
       :validator_type => pattern ? 'regex' : nil,
       :validator_rule => pattern.try(:pattern),
+      :label          => parameter.label,
+      :description    => parameter.description,
+      :reconfigurable => true,
+      :position       => position,
+      :dialog_group   => group
+    )
+  end
+
+  def create_parameter_checkbox(parameter, group, position)
+    group.dialog_fields.build(
+      :type           => "DialogFieldCheckBox",
+      :name           => "param_#{parameter.name}",
+      :data_type      => "boolean",
+      :display        => "edit",
+      :default_value  => parameter.default_value,
+      :options        => {:protected => parameter.hidden?},
       :label          => parameter.label,
       :description    => parameter.description,
       :reconfigurable => true,

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -126,8 +126,8 @@ describe OrchestrationTemplateDialogService do
     fields = group.dialog_fields
     expect(fields.size).to eq(2)
 
-    assert_field(fields[0], DialogFieldDropDownList, :name => "param_deploy",  :default_value => "yes", :values => [%w(no no), %w(yes yes)])
-    assert_field(fields[1], DialogFieldDropDownList, :name => "param_powerOn", :default_value => "no", :values => [%w(no no), %w(yes yes)])
+    assert_field(fields[0], DialogFieldCheckBox, :name => "param_deploy",  :default_value => "t", :data_type => "boolean")
+    assert_field(fields[1], DialogFieldCheckBox, :name => "param_powerOn", :default_value => "f", :data_type => "boolean")
   end
 
   def assert_field(field, clss, attributes)


### PR DESCRIPTION
Initial [PR](https://github.com/ManageIQ/manageiq/pull/11340) allowing provisioning of VMware vApps used dropdowns to
show true/false for boolean options (deploy and powerOn). This patch
adds a new `OrchestrationTemplate::OrchestrationParameterBoolean`
constraint indicating that the orchestration template parameter should
be displayed as a checkbox in the service dialog.

Changes in the orchestration logic reflect the change due to different
values returned by the checkbox field.

@miq-bot add_label providers/vmware/cloud, enhancement, orchestration