### PR TITLE
Remove commented code circa pre-2011

### DIFF
--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -82,9 +82,6 @@ module MiqPolicyController::Alerts
     @edit[:new][:repeat_time] = params[:repeat_time].to_i if params[:repeat_time]
     @edit[:new][:event_name] = params[:event_name] if params[:event_name]
 
-    # Removed following line, not allowing this option to be changed in the UI at this time (v3.3, sprint 66)
-    #   @edit[:new][:expression][:mode] = params[:use_automate_cb] == "1" ? "automate" : "internal" if params.has_key?(:use_automate_cb)
-
     if params[:miq_alert_db]
       @edit[:new][:db] = params[:miq_alert_db]
       @edit[:expression_types] = MiqAlert.expression_types(@edit[:new][:db])
@@ -459,11 +456,6 @@ module MiqPolicyController::Alerts
       5.minutes.to_i => _("5 Minutes"), 10.minutes.to_i => _("10 Minutes"), 15.minutes.to_i => "15 Minutes", 30.minutes.to_i => "30 Minutes",
       1.hour.to_i => "1 Hour", 2.hours.to_i => "2 Hours", 3.hours.to_i => "3 Hours", 4.hours.to_i => "4 Hours", 6.hours.to_i => "6 Hours", 12.hours.to_i => "12 Hours",
       1.day.to_i => "1 Day"
-      # Stopping this at 1 day for now - Sprint 53
-      #     , 2.days.to_i=>"2 Days", 3.days.to_i=>"3 Days", 4.days.to_i=>"4 Days", 5.days.to_i=>"5 Days", 6.days.to_i=>"6 Days",
-      #     1.week.to_i=>"1 Week", 2.weeks.to_i=>"2 Weeks", 3.weeks.to_i=>"3 Weeks",
-      #     1.month.to_i=>"1 Month", 2.months.to_i=>"2 Months", 3.months.to_i=>"3 Months", 6.months.to_i=>"6 Months",
-      #     1.year.to_i=>"1 Year"
     }
 
     # :hourly_time_thresholds
@@ -477,9 +469,6 @@ module MiqPolicyController::Alerts
       1.minutes.to_i => "1 Minute", 2.minutes.to_i => "2 Minutes", 3.minutes.to_i => "3 Minutes", 4.minutes.to_i => "4 Minutes",
       5.minutes.to_i => "5 Minutes", 10.minutes.to_i => "10 Minutes", 15.minutes.to_i => "15 Minutes", 30.minutes.to_i => "30 Minutes",
       1.hour.to_i => "1 Hour", 2.hours.to_i => "2 Hours"
-      # Stopping this at 2 hours now - Sprint 65
-      #     , 3.hours.to_i=>"3 Hours", 4.hours.to_i=>"4 Hours", 6.hours.to_i=>"6 Hours", 12.hours.to_i=>"12 Hours",
-      #     1.day.to_i=>"1 Day"
     }
 
     # hourly_performance repeat times for Notify Every pull down


### PR DESCRIPTION
 went back to when they were extracted to smaller modules.  These "at this time"
and "for now" comments are clearly never going to change.

```

commit b1d3d5ba86865a93cfae7f159c49150b76222417
Date:   Fri Dec 2 18:47:09 2011 +0000

    Broke miq_policy_controller up into smaller modules.
    BugzID:13624
```

[skip ci]