### PR TITLE
Fix Parent EMS Cloud Title on Storage Pages

### DIFF
--- a/app/helpers/cloud_object_store_container_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_container_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module CloudObjectStoreContainerHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_key

--- a/app/helpers/cloud_object_store_container_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_container_helper/textual_summary.rb
@@ -11,7 +11,8 @@ module CloudObjectStoreContainerHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
+    label = ui_lookup(:model => "ManageIQ::Providers::CloudManager")
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent #{label}"))
   end
 
   def textual_key

--- a/app/helpers/cloud_object_store_object_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_object_helper/textual_summary.rb
@@ -10,7 +10,8 @@ module CloudObjectStoreObjectHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
+    label = ui_lookup(:model => "ManageIQ::Providers::CloudManager")
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent #{label}"))
   end
 
   def textual_ems

--- a/app/helpers/cloud_object_store_object_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_object_helper/textual_summary.rb
@@ -10,7 +10,7 @@ module CloudObjectStoreObjectHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_ems

--- a/app/helpers/cloud_volume_backup_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_backup_helper/textual_summary.rb
@@ -24,7 +24,7 @@ module CloudVolumeBackupHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_ems_storage

--- a/app/helpers/cloud_volume_backup_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_backup_helper/textual_summary.rb
@@ -24,7 +24,8 @@ module CloudVolumeBackupHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
+    label = ui_lookup(:model => "ManageIQ::Providers::CloudManager")
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent #{label}"))
   end
 
   def textual_ems_storage

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -20,7 +20,8 @@ module CloudVolumeHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
+    label = ui_lookup(:model => "ManageIQ::Providers::CloudManager")
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent #{label}"))
   end
 
   def textual_ems

--- a/app/helpers/cloud_volume_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_helper/textual_summary.rb
@@ -20,7 +20,7 @@ module CloudVolumeHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_ems

--- a/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
@@ -32,7 +32,8 @@ module CloudVolumeSnapshotHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
+    label = ui_lookup(:model => "ManageIQ::Providers::CloudManager")
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent #{label}"))
   end
 
   def textual_ems

--- a/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
+++ b/app/helpers/cloud_volume_snapshot_helper/textual_summary.rb
@@ -32,7 +32,7 @@ module CloudVolumeSnapshotHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.ext_management_system.try(:parent_manager)
+    textual_link(@record.ext_management_system.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_ems

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -53,7 +53,8 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    textual_link(@record.try(:parent_manager), :label => _("Parent Cloud Provider"))
+    label = ui_lookup(:model => "ManageIQ::Providers::CloudManager")
+    textual_link(@record.try(:parent_manager), :label => _("Parent #{label}"))
   end
 
   def textual_zone

--- a/app/helpers/ems_storage_helper/textual_summary.rb
+++ b/app/helpers/ems_storage_helper/textual_summary.rb
@@ -53,7 +53,7 @@ module EmsStorageHelper::TextualSummary
   end
 
   def textual_parent_ems_cloud
-    @record.try(:parent_manager)
+    textual_link(@record.try(:parent_manager), :label => _("Parent Cloud Provider"))
   end
 
   def textual_zone


### PR DESCRIPTION
Six pages added or modified recently for Cloud Storage and Storage Manager pages
mis-titled the link to the Cloud Manager.  It defaulted to "Parent ems cloud" and
should be "Parent Cloud Provider".

Here is an image of the relevant relationship field for a Cloud Object Store Object.

![screen shot 2016-10-05 at 4 30 43 pm](https://cloud.githubusercontent.com/assets/6118503/19130454/3332e636-8b19-11e6-90ea-994da4c9c3b6.png)

The pages changed were:
1) Cinder and Swift Storage Managers
2) Cloud Volumes
3) Cloud Volume Backups
4) Cloud Volume Snapshots
5) Cloud Object Store Containers
6) Cloud Object Store Objects

@h-kataria @dclarizio @roliveri please review and merge.  Thanks.

