### PR TITLE
For external auth configure kerberos to do dns_lookups

### DIFF
--- a/gems/pending/appliance_console/external_httpd_authentication.rb
+++ b/gems/pending/appliance_console/external_httpd_authentication.rb
@@ -108,6 +108,7 @@ module ApplianceConsole
       say("\nConfiguring IPA (may take a minute) ...")
       ipa_client_unconfigure if ipa_client_configured?
       ipa_client_configure(realm, @domain, @ipaserver, @principal, @password)
+      enable_kerberos_dns_lookups
     end
 
     def configure_pam

--- a/gems/pending/appliance_console/external_httpd_configuration.rb
+++ b/gems/pending/appliance_console/external_httpd_configuration.rb
@@ -6,31 +6,33 @@ module ApplianceConsole
       #
       # External Authentication Definitions
       #
-      IPA_COMMAND         = "/usr/bin/ipa"
-      IPA_INSTALL_COMMAND = "/usr/sbin/ipa-client-install"
-      IPA_GETKEYTAB       = "/usr/sbin/ipa-getkeytab"
+      IPA_COMMAND          = "/usr/bin/ipa".freeze
+      IPA_INSTALL_COMMAND  = "/usr/sbin/ipa-client-install".freeze
+      IPA_GETKEYTAB        = "/usr/sbin/ipa-getkeytab".freeze
 
-      SSSD_CONFIG         = "/etc/sssd/sssd.conf"
-      PAM_CONFIG          = "/etc/pam.d/httpd-auth"
-      HTTP_KEYTAB         = "/etc/http.keytab"
-      HTTP_REMOTE_USER    = "/etc/httpd/conf.d/manageiq-remote-user.conf"
-      HTTP_EXTERNAL_AUTH  = "/etc/httpd/conf.d/manageiq-external-auth.conf"
-      HTTP_EXTERNAL_AUTH_TEMPLATE = "#{HTTP_EXTERNAL_AUTH}.erb"
+      KERBEROS_CONFIG_FILE = "/etc/krb5.conf".freeze
 
-      GETSEBOOL_COMMAND   = "/usr/sbin/getsebool"
-      SETSEBOOL_COMMAND   = "/usr/sbin/setsebool"
-      GETENFORCE_COMMAND  = "/usr/sbin/getenforce"
+      SSSD_CONFIG          = "/etc/sssd/sssd.conf".freeze
+      PAM_CONFIG           = "/etc/pam.d/httpd-auth".freeze
+      HTTP_KEYTAB          = "/etc/http.keytab".freeze
+      HTTP_REMOTE_USER     = "/etc/httpd/conf.d/manageiq-remote-user.conf".freeze
+      HTTP_EXTERNAL_AUTH   = "/etc/httpd/conf.d/manageiq-external-auth.conf".freeze
+      HTTP_EXTERNAL_AUTH_TEMPLATE = "#{HTTP_EXTERNAL_AUTH}.erb".freeze
 
-      APACHE_USER         = "apache"
+      GETSEBOOL_COMMAND    = "/usr/sbin/getsebool".freeze
+      SETSEBOOL_COMMAND    = "/usr/sbin/setsebool".freeze
+      GETENFORCE_COMMAND   = "/usr/sbin/getenforce".freeze
 
-      TIMESTAMP_FORMAT    = "%Y%m%d_%H%M%S"
+      APACHE_USER          = "apache".freeze
 
-      LDAP_ATTRS          = {
+      TIMESTAMP_FORMAT     = "%Y%m%d_%H%M%S".freeze
+
+      LDAP_ATTRS           = {
         "mail"        => "REMOTE_USER_EMAIL",
         "givenname"   => "REMOTE_USER_FIRSTNAME",
         "sn"          => "REMOTE_USER_LASTNAME",
         "displayname" => "REMOTE_USER_FULLNAME"
-      }
+      }.freeze
 
       def template_directory
         Pathname.new(ENV.fetch("APPLIANCE_TEMPLATE_DIRECTORY"))
@@ -79,6 +81,17 @@ module ApplianceConsole
       def unconfigure_httpd_application
         rm_file(HTTP_EXTERNAL_AUTH)
         rm_file(HTTP_REMOTE_USER)
+      end
+
+      #
+      # Kerberos KRB5 File Methods
+      #
+      def enable_kerberos_dns_lookups
+        FileUtils.copy(KERBEROS_CONFIG_FILE, "#{KERBEROS_CONFIG_FILE}.miqbkp")
+        krb5config = File.read(KERBEROS_CONFIG_FILE)
+        krb5config[/(\s*)dns_lookup_kdc(\s*)=(\s*)(.*)/, 4] = 'true'
+        krb5config[/(\s*)dns_lookup_realm(\s*)=(\s*)(.*)/, 4] = 'true'
+        File.write(KERBEROS_CONFIG_FILE, krb5config)
       end
 
       #


### PR DESCRIPTION
The appliance_console uses the command ipa-client-install to configure external authentication.
The ipa-client-install command uses a somewhat complex decision matrix to determine how
to configure kerberos. To be precise the appliance_console passes the  `ipa server` argument
to ipa-client-install, which results in kerberos being configured to not do dns_lookups for KDC.

The end result is that password validation for IPA-AD/Trust configurations fail.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1380873
* See also: ipa-client-install man pager

Steps for Testing/QA [Optional]
-------------------------------

To test this configure external authentication with IPA/AD Trust as described here:
https://github.com/ManageIQ/manageiq_docs/blob/master/auth/ipa_ad_trust.adoc

Even when correctly configured, without this change login using an AD username will fail. With this change login can succeed.
