### PR TITLE
Add monthly/hourly/weekly in rates for 'per time' types

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -565,7 +565,7 @@ class ChargebackController < ApplicationController
       @edit[:new][:details].push(temp)
     end
 
-    @edit[:new][:per_time_types] = {"hourly" => _("Hourly")}
+    @edit[:new][:per_time_types] = ChargebackRateDetail::PER_TIME_TYPES
 
     if params[:typ] == "copy"
       @rate.id = nil

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -10,6 +10,7 @@ class ChargebackRateDetail < ApplicationRecord
   validate :contiguous_tiers?
 
   FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric).freeze
+  PER_TIME_TYPES = {"hourly" => _("Hourly"), "weekly" => _("Weekly"), "monthly" => _("Monthly")}.freeze
 
   # Set the rates according to the tiers
   def find_rate(value)

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -9,9 +9,8 @@
   %td{:rowspan => n.to_s}
     = r[:description]
   %td{:rowspan => n.to_s}
-    - per_time_types = {"hourly" => _("Hourly")}
     = select_tag("per_time_#{i}",
-      options_for_select(per_time_types.invert, @edit[:new][:details][i.to_i][:per_time]),
+      options_for_select(ChargebackRateDetail::PER_TIME_TYPES.invert, @edit[:new][:details][i.to_i][:per_time]),
       "data-miq_observe" => {:url => url}.to_json)
   - measure = @edit[:new][:details][i.to_i][:detail_measure]
   - if measure.nil?


### PR DESCRIPTION
basically revert of https://github.com/ManageIQ/manageiq/pull/9298/files

as we are doing new calculations for chargeback we can also support
chargeback rates in monthly/hourly/weekly time frame (Per Time in UI)

@miq-bot add_label ui, chargeback
@miq-bot assign @gtanzillo 

cc @mzazrivec 


<img width="1434" alt="screen shot 2016-10-06 at 07 38 07" src="https://cloud.githubusercontent.com/assets/14937244/19141712/f4d28214-8b97-11e6-9f93-95a4cdb9a6eb.png">
