### PR TITLE
Save inventory for Physical Infra Managers

### DIFF
--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -1,0 +1,52 @@
+#
+# Calling order for EmsPhysicalInfra:
+# - ems
+#   - physical_servers
+#
+
+module EmsRefresh::SaveInventoryPhysicalInfra
+  def save_ems_physical_infra_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+    log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
+
+    # Check if the data coming in reflects a complete removal from the ems
+    if hashes.blank?
+      target.disconnect_inv
+      return
+    end
+
+    _log.info("#{log_header} Saving EMS Inventory...")
+    if debug_trace
+      require 'yaml'
+      _log.debug "#{log_header} hashes:\n#{YAML.dump(hashes)}"
+    end
+
+    child_keys = [
+      :physical_servers,
+    ]
+
+    # Save and link other subsections
+    save_child_inventory(ems, hashes, child_keys, target)
+
+    ems.save!
+    hashes[:id] = ems.id
+
+    _log.info("#{log_header} Saving EMS Inventory...Complete")
+
+    ems
+  end
+
+  def save_physical_servers_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+
+    ems.physical_servers.reset
+    deletes = if (target == ems)
+                :use_association
+              else
+                []
+              end
+
+    save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref])
+    store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
+  end
+end

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -40,7 +40,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
     target = ems if target.nil?
 
     ems.physical_servers.reset
-    deletes = if (target == ems)
+    deletes = if target == ems
                 :use_association
               else
                 []

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -1,0 +1,15 @@
+class PhysicalServer < ApplicationRecord
+  include NewWithTypeStiMixin
+
+  acts_as_miq_taggable
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhyicalInfrManager"
+
+  default_value_for :enabled, true
+
+  def name_with_details
+    details % {
+      :name => name,
+    }
+  end
+end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -3,7 +3,7 @@ class PhysicalServer < ApplicationRecord
 
   acts_as_miq_taggable
 
-  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhyicalInfrManager"
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhysicalInfraManager"
 
   default_value_for :enabled, true
 


### PR DESCRIPTION
Adding Save inventory for Physical Infra Managers.

- Added Physical Server

This links to the PR https://github.com/juliancheal/manageiq-providers-lenovo/pull/3 on the Lenovo XClarity provider