### PR TITLE
Stop appending the "_" character as part of the enforced VM naming.

### DIFF
--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -29,7 +29,6 @@ module MiqProvision::Naming
 
       # Check if we need to force a unique target name
       if prov_obj.get_option(:miq_force_unique_name) == true && unresolved_vm_name !~ NAME_SEQUENCE_REGEX
-        unresolved_vm_name += '_' unless unresolved_vm_name.ends_with?('_')
         unresolved_vm_name += '$n{4}'
         _log.info "Forced unique provision name to #{unresolved_vm_name} for #{prov_obj.class}:#{prov_obj.id}"
       end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -309,6 +309,23 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           expect(result).to eq(task_mor)
         end
       end
+
+      describe '#get_next_vm_name' do
+        before do
+          @vm_prov.update_attributes(:options => @options.merge(:miq_force_unique_name => true))
+          allow(MiqRegion).to receive_message_chain('my_region.next_naming_sequence').and_return(123)
+        end
+
+        it 'does not add "_" in name' do
+          allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(double(:root => 'myvm'))
+          expect(@vm_prov.get_next_vm_name).to eq('myvm0123')
+        end
+
+        it 'keeps "_" in name' do
+          allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(double(:root => 'myvm_'))
+          expect(@vm_prov.get_next_vm_name).to eq('myvm_0123')
+        end
+      end
     end
   end
 end

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -76,10 +76,10 @@ describe MiqProvisionRequestTemplate do
 
     it 'should create sequenced VM names' do
       task1 = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
-      expect(task1.options[:vm_target_name]).to eq('miq_0001')
+      expect(task1.options[:vm_target_name]).to eq('miq0001')
 
       task2 = provision_request_template.create_tasks_for_service(service_task, parent_svc).first
-      expect(task2.options[:vm_target_name]).to eq('miq_0002')
+      expect(task2.options[:vm_target_name]).to eq('miq0002')
     end
 
     it 'assign task to a request' do


### PR DESCRIPTION
Some providers don't allow the "_" character in the VM name.

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1379476

cc @gmcculloug 