### PR TITLE
Add more ChargebackRate factories

### DIFF
--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -188,7 +188,7 @@ describe ChargebackController do
 
     render_views
 
-    let(:chargeback_rate) { FactoryGirl.create(:chargeback_rate_with_details, :description => "foo") }
+    let(:chargeback_rate) { FactoryGirl.create(:chargeback_rate, :with_details, :description => "foo") }
 
     # this index represent first rate detail( "Allocated Memory in MB") chargeback_rate
     let(:index_to_rate_type) { "0" }

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -4,10 +4,51 @@ FactoryGirl.define do
     sequence(:description) { |n| "Chargeback Rate ##{n}" }
     rate_type 'Compute'
 
+    transient do
+      per_time 'hourly'
+    end
+
     trait :with_details do
       chargeback_rate_details do
         [FactoryGirl.create(:chargeback_rate_detail_memory_allocated, :tiers_with_three_intervals),
          FactoryGirl.create(:chargeback_rate_detail_memory_used, :tiers)]
+      end
+    end
+
+    trait :with_compute_details do
+      after(:create) do |chargeback_rate, evaluator|
+        %i(
+          chargeback_rate_detail_cpu_used
+          chargeback_rate_detail_cpu_allocated
+          chargeback_rate_detail_cpu_cores_used
+          chargeback_rate_detail_disk_io_used
+          chargeback_rate_detail_fixed_compute_cost
+          chargeback_rate_detail_fixed_compute_cost
+          chargeback_rate_detail_memory_allocated
+          chargeback_rate_detail_memory_used
+          chargeback_rate_detail_net_io_used
+        ).each do |factory_name|
+          chargeback_rate.chargeback_rate_details << FactoryGirl.create(factory_name,
+                                                                        :tiers_with_three_intervals,
+                                                                        :per_time => evaluator.per_time)
+        end
+      end
+    end
+
+    trait :with_storage_details do
+      rate_type 'Storage'
+
+      after(:create) do |chargeback_rate, evaluator|
+        %i(
+          chargeback_rate_detail_storage_used
+          chargeback_rate_detail_storage_allocated
+          chargeback_rate_detail_fixed_storage_cost
+          chargeback_rate_detail_fixed_storage_cost
+        ).each do |factory_name|
+          chargeback_rate.chargeback_rate_details << FactoryGirl.create(factory_name,
+                                                                        :tiers_with_three_intervals,
+                                                                        :per_time => evaluator.per_time)
+        end
       end
     end
   end

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -2,13 +2,13 @@ FactoryGirl.define do
   factory :chargeback_rate do
     guid                   { MiqUUID.new_guid }
     sequence(:description) { |n| "Chargeback Rate ##{n}" }
-    rate_type              'Compute'
-  end
+    rate_type 'Compute'
 
-  factory :chargeback_rate_with_details, :parent => :chargeback_rate do
-    after(:create) do |chargeback_rate|
-      chargeback_rate.chargeback_rate_details << FactoryGirl.create(:chargeback_rate_detail_memory_used_with_tiers)
-      chargeback_rate.chargeback_rate_details << FactoryGirl.create(:chargeback_rate_detail_memory_allocated_with_tiers)
+    trait :with_details do
+      chargeback_rate_details do
+        [FactoryGirl.create(:chargeback_rate_detail_memory_allocated, :tiers_with_three_intervals),
+         FactoryGirl.create(:chargeback_rate_detail_memory_used, :tiers)]
+      end
     end
   end
 end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -31,8 +31,20 @@ FactoryGirl.define do
     source "used"
   end
 
+  trait :fixed do
+    group "fixed"
+  end
+
   trait :allocated do
     source "allocated"
+  end
+
+  trait :cpu do
+    group "cpu"
+  end
+
+  trait :storage_group do
+    group "storage"
   end
 
   trait :memory do
@@ -43,12 +55,40 @@ FactoryGirl.define do
     per_unit "megabytes"
   end
 
+  trait :kbps do
+    per_unit "kbps"
+  end
+
+  trait :gigabytes do
+    per_unit "gigabytes"
+  end
+
   trait :daily do
     per_time "daily"
   end
 
   trait :hourly do
     per_time "hourly"
+  end
+
+  factory :chargeback_rate_detail_cpu_used, :traits => [:used, :cpu], :parent => :chargeback_rate_detail do
+    description "Used CPU in MHz"
+    metric      "cpu_usagemhz_rate_average"
+    per_unit    "megahertz"
+  end
+
+  factory :chargeback_rate_detail_cpu_cores_used, :traits => [:used], :parent => :chargeback_rate_detail do
+    description "Used CPU in Cores"
+    metric      "cpu_usage_rate_average"
+    group       "cpu_cores"
+    per_unit    "cores"
+  end
+
+  factory :chargeback_rate_detail_cpu_allocated, :traits => [:allocated, :cpu, :daily],
+                                                 :parent => :chargeback_rate_detail do
+    description "Allocated CPU Count"
+    metric      "derived_vm_numvcpus"
+    per_unit    "cpu"
   end
 
   factory :chargeback_rate_detail_memory_allocated, :traits => [:allocated, :memory, :megabytes, :daily],
@@ -61,5 +101,39 @@ FactoryGirl.define do
                                                :parent => :chargeback_rate_detail do
     description "Used Memory in MB"
     metric      "derived_memory_used"
+  end
+
+  factory :chargeback_rate_detail_disk_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
+    description "Used Disk I/O in KBps"
+    group       "disk_io"
+    metric      "disk_usage_rate_average"
+  end
+
+  factory :chargeback_rate_detail_net_io_used, :traits => [:used, :kbps], :parent => :chargeback_rate_detail do
+    description "Used Network I/O in KBps"
+    group       "net_io"
+    metric      "net_usage_rate_average"
+  end
+
+  factory :chargeback_rate_detail_storage_used, :traits => [:used, :storage_group, :gigabytes],
+                                                :parent => :chargeback_rate_detail do
+    description "Used Disk Storage in Bytes"
+    metric      "derived_vm_used_disk_storage"
+  end
+
+  factory :chargeback_rate_detail_storage_allocated, :traits => [:allocated, :storage_group, :gigabytes],
+                                                     :parent => :chargeback_rate_detail do
+    description "Allocated Disk Storage in Bytes"
+    metric      "derived_vm_allocated_disk_storage"
+  end
+
+  factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
+    sequence(:description) { |n| "Fixed Compute Cost #{n}" }
+    sequence(:source)      { |n| "compute_#{n}" }
+  end
+
+  factory :chargeback_rate_detail_fixed_storage_cost, :traits => [:fixed, :daily], :parent => :chargeback_rate_detail do
+    sequence(:description) { |n| "Fixed Storage Cost #{n}" }
+    sequence(:source)      { |n| "storage_#{n}" }
   end
 end

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :chargeback_rate_detail do
+  factory :chargeback_rate_detail, :traits => [:euro, :bytes] do
     group   "unknown"
     source  "unknown"
     chargeback_rate
@@ -27,91 +27,39 @@ FactoryGirl.define do
     end
   end
 
-  factory :chargeback_rate_detail_cpu_used, :parent => :chargeback_rate_detail do
-    description "Used CPU in MHz"
-    group       "cpu"
-    source      "used"
-    metric      "cpu_usagemhz_rate_average"
-    per_unit    "megahertz"
+  trait :used do
+    source "used"
   end
 
-  factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
-    description "Used CPU in Cores"
-    group       "cpu_cores"
-    source      "used"
-    metric      "cpu_usage_rate_average"
-    per_unit    "cores"
+  trait :allocated do
+    source "allocated"
   end
 
-  factory :chargeback_rate_detail_cpu_allocated, :parent => :chargeback_rate_detail do
-    description "Allocated CPU Count"
-    group       "cpu"
-    source      "allocated"
-    metric      "derived_vm_numvcpus"
-    per_unit    "cpu"
-    per_time    "daily"
+  trait :memory do
+    group "memory"
   end
 
-  factory :chargeback_rate_detail_memory_allocated, :parent => :chargeback_rate_detail do
+  trait :megabytes do
+    per_unit "megabytes"
+  end
+
+  trait :daily do
+    per_time "daily"
+  end
+
+  trait :hourly do
+    per_time "hourly"
+  end
+
+  factory :chargeback_rate_detail_memory_allocated, :traits => [:allocated, :memory, :megabytes, :daily],
+                                                    :parent => :chargeback_rate_detail do
     description "Allocated Memory in MB"
-    group       "memory"
-    source      "allocated"
     metric      "derived_memory_available"
-    per_unit    "megabytes"
-    per_time    "daily"
   end
 
-  factory :chargeback_rate_detail_memory_used, :parent => :chargeback_rate_detail do
-    per_unit    "megabytes"
-    per_time    "hourly"
+  factory :chargeback_rate_detail_memory_used, :traits => [:used, :memory, :megabytes, :hourly],
+                                               :parent => :chargeback_rate_detail do
     description "Used Memory in MB"
-    group       "memory"
-    source      "used"
     metric      "derived_memory_used"
   end
-
-  factory :chargeback_rate_detail_disk_io_used, :parent => :chargeback_rate_detail do
-    description "Used Disk I/O in KBps"
-    group       "disk_io"
-    source      "used"
-    metric      "disk_usage_rate_average"
-    per_unit    "kbps"
-  end
-
-  factory :chargeback_rate_detail_net_io_used, :parent => :chargeback_rate_detail do
-    description "Used Network I/O in KBps"
-    group       "net_io"
-    source      "used"
-    metric      "net_usage_rate_average"
-    per_unit    "kbps"
-  end
-
-  factory :chargeback_rate_detail_storage_used, :parent => :chargeback_rate_detail do
-    description "Used Disk Storage in Bytes"
-    group       "storage"
-    source      "used"
-    metric      "derived_vm_used_disk_storage"
-    per_unit    "gigabytes"
-  end
-
-  factory :chargeback_rate_detail_storage_allocated, :parent => :chargeback_rate_detail do
-    description "Allocated Disk Storage in Bytes"
-    group       "storage"
-    source      "allocated"
-    metric      "derived_vm_allocated_disk_storage"
-    per_unit    "gigabytes"
-  end
-
-  factory :chargeback_rate_detail_fixed_compute_cost, :parent => :chargeback_rate_detail do
-    description "Fixed Compute Cost 1"
-    group       "fixed"
-    source      "compute_1"
-    per_time    "daily"
-  end
-
-  factory :chargeback_rate_detail_memory_allocated_with_tiers, :parent => :chargeback_rate_detail_memory_allocated,
-                                                               :traits => [:euro, :bytes, :tiers_with_three_intervals]
-
-  factory :chargeback_rate_detail_memory_used_with_tiers, :parent => :chargeback_rate_detail_memory_used,
-                                                          :traits => [:euro, :bytes, :tiers]
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -79,6 +79,7 @@ describe ChargebackContainerImage do
     }
     let!(:cbrd) {
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :source             => "compute_1",
                          :chargeback_rate_id => @cbr.id,
                          :per_time           => "hourly",
                          :chargeback_tiers   => [cbt])
@@ -134,6 +135,7 @@ describe ChargebackContainerImage do
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
                          :chargeback_rate_id => @cbr.id,
                          :per_time           => "hourly",
+                         :source             => "compute_1",
                          :chargeback_tiers   => [cbt])
     }
     it "fixed_compute" do

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -119,10 +119,14 @@ describe ChargebackContainerProject do
                                    :finish                    => Float::INFINITY,
                                    :fixed_rate                => 0.0,
                                    :variable_rate             => @hourly_rate.to_s) }
-    let!(:cbrd) {FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
-                                   :chargeback_rate_id => @cbr.id,
-                                   :per_time           => "hourly",
-                                   :chargeback_tiers   => [cbt]) }
+    let!(:cbrd) do
+      FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :source             => "compute_1",
+                         :chargeback_rate_id => @cbr.id,
+                         :per_time           => "hourly",
+                         :chargeback_tiers   => [cbt])
+    end
+
     it "fixed_compute" do
       expect(subject.fixed_compute_1_cost).to eq(@hourly_rate * hours_in_day)
       expect(subject.fixed_compute_metric).to eq(@metric_size)
@@ -218,10 +222,14 @@ describe ChargebackContainerProject do
                                    :finish                    => Float::INFINITY,
                                    :fixed_rate                => 0.0,
                                    :variable_rate             => @hourly_rate.to_s) }
-    let!(:cbrd) {FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
-                                    :chargeback_rate_id => @cbr.id,
-                                    :per_time           => "hourly",
-                                    :chargeback_tiers   => [cbt]) }
+    let!(:cbrd) do
+      FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :source             => "compute_1",
+                         :chargeback_rate_id => @cbr.id,
+                         :per_time           => "hourly",
+                         :chargeback_tiers   => [cbt])
+    end
+
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
       expect(subject.fixed_compute_1_cost).to be_within(0.01).of(@hourly_rate * @hours_in_month)
@@ -377,10 +385,12 @@ describe ChargebackContainerProject do
                                    :finish                    => Float::INFINITY,
                                    :fixed_rate                => 0.0,
                                    :variable_rate             => @hourly_rate.to_s) }
-    let!(:cbrd) {FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
-                                    :chargeback_rate_id => @cbr.id,
-                                    :per_time           => "hourly",
-                                    :chargeback_tiers   => [cbt]) }
+    let!(:cbrd) do
+      FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
+                         :chargeback_rate_id => @cbr.id,
+                         :per_time           => "hourly",
+                         :chargeback_tiers   => [cbt])
+    end
 
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -118,13 +118,14 @@ describe ChargebackRateDetail do
     cbd.update(:chargeback_tiers => [cbt])
     expect(cbd.friendly_rate).to eq("3.0 Monthly")
 
-    cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => 'cpu', :per_time => 'monthly')
+    cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => 'cpu', :per_time => 'monthly', :detail_measure => nil)
     cbt = FactoryGirl.create(:chargeback_tier, :start => 0, :chargeback_rate_detail_id => cbd.id,
                              :finish => Float::INFINITY, :fixed_rate => 1.0, :variable_rate => 2.0)
     cbd.update(:chargeback_tiers => [cbt])
     expect(cbd.friendly_rate).to eq("Monthly @ 1.0 + 2.0 per Cpu from 0.0 to Infinity")
 
-    cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => 'megabytes', :per_time => 'monthly')
+    cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => 'megabytes', :per_time => 'monthly',
+                            :detail_measure => nil)
     cbt1 = FactoryGirl.create(:chargeback_tier, :start => 0.0, :chargeback_rate_detail_id => cbd.id,
                              :finish => 5.0, :fixed_rate => 1.0, :variable_rate => 2.0)
     cbt2 = FactoryGirl.create(:chargeback_tier, :start => 5.0, :chargeback_rate_detail_id => cbd.id,
@@ -139,7 +140,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
       'cpu',       'Cpu',
       'ohms',      'Ohms'
     ].each_slice(2) do |per_unit, per_unit_display|
-      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit)
+      cbd = FactoryGirl.build(:chargeback_rate_detail, :per_unit => per_unit, :detail_measure => nil)
       expect(cbd.per_unit_display).to eq(per_unit_display)
     end
   end
@@ -201,7 +202,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     cbm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
     cbc = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
 
-    cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost_1,
+    cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost,
                             :chargeback_rate_detail_measure_id  => cbm.id,
                             :chargeback_rate_detail_currency_id => cbc.id
                            )

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -201,7 +201,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     cbm = FactoryGirl.create(:chargeback_rate_detail_measure_bytes)
     cbc = FactoryGirl.create(:chargeback_rate_detail_currency_EUR)
 
-    cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost,
+    cbd = FactoryGirl.build(:chargeback_rate_detail_fixed_compute_cost_1,
                             :chargeback_rate_detail_measure_id  => cbm.id,
                             :chargeback_rate_detail_currency_id => cbc.id
                            )


### PR DESCRIPTION
Factories for ChargebackRate with rate_type and 'Compute' and 'Storage'
ChargebackRate have ChargebackRateDetails and each ChargebackRateDetail is defining for some metric some rate. ChargebackRateDetail have also ChargebackTier and basically rates are defined in ChargebackTier.

**For better imagination:**
this is one ChargebackRate with rate_type  'Compute' 
each line is ChargebackRateDetail and each ChargebackRateDetail have one ChargebackTier
<img width="898" alt="screen shot 2016-10-07 at 14 49 15" src="https://cloud.githubusercontent.com/assets/14937244/19190337/47e1835a-8c9d-11e6-91a7-308510498450.png">

* for testing new chargeback calculations

@miq-bot add_label chargeback,test 