### PR TITLE
Disconnect container images

### DIFF
--- a/app/controllers/container_image_controller.rb
+++ b/app/controllers/container_image_controller.rb
@@ -6,6 +6,10 @@ class ContainerImageController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def show_list
+    process_show_list(:where_clause => 'container_images.deleted_on IS NULL')
+  end
+
   def guest_applications
     show_association('guest_applications', _('Packages'), 'guest_application', :guest_applications, GuestApplication)
   end

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -96,5 +96,15 @@ class ContainerImage < ApplicationRecord
     openscap_rule_results.where(:result => "fail").group(:severity).count.symbolize_keys
   end
 
+  def disconnect_inv
+    _log.info "Disconnecting Image [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
+    "id [#{ext_management_system.id}] "
+    self.container_image_registry = nil
+    self.old_ems_id = ems_id
+    self.ext_management_system = nil
+    self.deleted_on = Time.now.utc
+    save
+  end
+
   alias_method :perform_metadata_sync, :sync_stashed_metadata
 end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -316,7 +316,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_images, hashes, deletes, [:image_ref, :container_image_registry_id], [],
-                         :container_image_registry)
+                         :container_image_registry, true)
     store_ids_for_new_records(ems.container_images, hashes,
                               [:image_ref, :container_image_registry_id])
   end

--- a/app/services/container_dashboard_service.rb
+++ b/app/services/container_dashboard_service.rb
@@ -67,7 +67,7 @@ class ContainerDashboardService
         :href         => get_url_to_entity(:container_service)
       },
       :images     => {
-        :count        => @ems.present? ? @ems.container_images.count : ContainerImage.count,
+        :count        => @ems.present? ? @ems.container_images.count : ContainerImage.where.not(:ext_management_system => nil).count,
         :errorCount   => 0,
         :warningCount => 0,
         :href         => get_url_to_entity(:container_image)


### PR DESCRIPTION
Enable archiving for `ContainerImage` in the same manner as `ContainerGroup` or `ContainerProject`.

@Fryguy @simon3z @moolitayer @enoodle Please review

@miq-bot add_label providers/container, euwe/yes
