### PR TITLE
Always verify a dest_resource_pool exists in the db before setting it

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/cloning.rb
@@ -52,9 +52,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Cloning
   end
 
   def dest_resource_pool
-    respool_id = get_option(:placement_rp_name)
-    resource_pool = ResourcePool.find_by(:id => respool_id) unless respool_id.nil?
-    return resource_pool unless resource_pool.nil?
+    resource_pool = ResourcePool.find_by(:id => get_option(:placement_rp_name))
+    return resource_pool if resource_pool
 
     dest_cluster.try(:default_resource_pool) || dest_host.default_resource_pool
   end

--- a/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/provision_spec.rb
@@ -194,6 +194,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Provision do
           expect(@vm_prov.dest_resource_pool).to eq(resource_pool)
         end
 
+        it "returns a resource_pool if one is passed in" do
+          expect(ResourcePool).to receive(:find_by).and_return(:resource_pool)
+          expect(@vm_prov).to receive(:default_resource_pool).never
+          @vm_prov.dest_resource_pool
+        end
+
         it "uses the resource pool from the cluster" do
           @vm_prov.options[:dest_host]    = [dest_host_with_cluster.id, dest_host_with_cluster.name]
           @vm_prov.options[:dest_cluster] = [cluster.id, cluster.name]


### PR DESCRIPTION
We want to validate that the passed in resource pool exists. This mitigates the possibility of returning on a value the database doesn't know about - and furthermore causing errors down the provisioning road.

Links
----------------

* [PT 131830133](https://www.pivotaltracker.com/story/show/131830133)
