### PR TITLE
Dump errors from log files after travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ script:
 - bundle exec rake ${TEST_SUITE+test:$TEST_SUITE}
 after_script:
 - source ${TRAVIS_BUILD_DIR}/tools/ci/after_script.sh
+after_failure:
+- source ${TRAVIS_BUILD_DIR}/tools/ci/after_failure.sh
 notifications:
   webhooks:
     urls:

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -39,7 +39,7 @@ module Vmdb
     private
 
     def self.create_loggers
-      if ENV.key?("CI")
+      if false && ENV.key?("CI")
         $log       = $rails_log = $audit_log = $fog_log = $policy_log = $vim_log = $rhevm_log = Vmdb.null_logger
         $aws_log   = $kube_log = $mw_log = $scvmm_log = $api_log = $miq_ae_logger = $websocket_log = Vmdb.null_logger
         $azure_log = Vmdb.null_logger

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -39,6 +39,8 @@ module Vmdb
     private
 
     def self.create_loggers
+      # Intentionally setting false to enable logging so we can
+      # diagnose an Automate method failure
       if false && ENV.key?("CI")
         $log       = $rails_log = $audit_log = $fog_log = $policy_log = $vim_log = $rhevm_log = Vmdb.null_logger
         $aws_log   = $kube_log = $mw_log = $scvmm_log = $api_log = $miq_ae_logger = $websocket_log = Vmdb.null_logger

--- a/tools/ci/after_failure.sh
+++ b/tools/ci/after_failure.sh
@@ -1,0 +1,7 @@
+set -v
+
+echo "Errors and warnings in log files"
+echo log/*
+egrep -i "warn|error" log/*.log
+
+set +v


### PR DESCRIPTION
Testing sporadic failures and capturing the logs from the travis run.

Enable logging
Search for warnings and errors in log files and write it to STDERR