### PR TITLE
Avoid displaying multiple Region dropdowns in Ems Cloud form

### DIFF
--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -50,6 +50,7 @@
           = select_tag('provider_region',
                        options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "emsCommonModel.provider_region",
+                       "ng-if"                       => "emsCommonModel.emstype == '#{name}'",
                        "ng-switch-when"              => name,
                        "required"                    => "",
                        "checkchange"                 => "",


### PR DESCRIPTION
Display only one dropdown based on `emstype`.

Issue introduced in https://github.com/ManageIQ/manageiq/pull/8783 

https://bugzilla.redhat.com/show_bug.cgi?id=1381192