### PR TITLE
Refactor: Clean-up interface of VimPerformanceState

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -224,4 +224,8 @@ module Metric::CiMixin::Capture
 
     perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
   end
+
+  def perf_tags
+    tag_list(:ns => '/managed').split.join("|")
+  end
 end

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -73,7 +73,7 @@ class VimPerformanceState < ApplicationRecord
     self.vm_allocated_disk_storage = VimPerformanceState.capture_vm_disk_storage(resource, :allocated_disk)
     self.tag_names = VimPerformanceState.capture_tag_names(resource)
     self.image_tag_names = VimPerformanceState.capture_image_tag_names(resource)
-    self.host_sockets = VimPerformanceState.capture_host_sockets(resource)
+    capture_host_sockets
   end
 
   def vm_count_on
@@ -235,13 +235,13 @@ class VimPerformanceState < ApplicationRecord
     hardware.try(:cpu_total_cores)
   end
 
-  def self.capture_host_sockets(obj)
-    if obj.kind_of?(Host)
-      obj.hardware.try(:cpu_sockets)
-    else
-      if obj.respond_to?(:hosts)
-        obj.hosts.includes(:hardware).collect { |h| h.hardware.try(:cpu_sockets) }.compact.sum
-      end
-    end
+  private
+
+  def capture_host_sockets
+    self.host_sockets = if resource.kind_of?(Host)
+                          resource.hardware.try(:cpu_sockets)
+                        elsif resource.respond_to?(:hosts)
+                          resource.hosts.includes(:hardware).collect { |h| h.hardware.try(:cpu_sockets) }.compact.sum
+                        end
   end
 end

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -69,7 +69,7 @@ class VimPerformanceState < ApplicationRecord
     self.reserve_cpu = VimPerformanceState.capture_reserve(resource, :cpu_reserve)
     self.reserve_mem = VimPerformanceState.capture_reserve(resource, :memory_reserve)
     capture_vm_disk_storage
-    self.tag_names = VimPerformanceState.capture_tag_names(resource)
+    capture_tag_names
     capture_image_tag_names
     capture_host_sockets
   end
@@ -208,11 +208,11 @@ class VimPerformanceState < ApplicationRecord
     obj.try(field)
   end
 
-  def self.capture_tag_names(obj)
-    obj.perf_tags
-  end
-
   private
+
+  def capture_tag_names
+    self.tag_names = resource.perf_tags
+  end
 
   def capture_image_tag_names
     self.image_tag_names = if resource.respond_to?(:container_image) && resource.container_image.present?

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -154,12 +154,6 @@ class VimPerformanceState < ApplicationRecord
   def capture_total(field)
     return resource.send("aggregate_#{field}") if resource.respond_to?("aggregate_#{field}")
 
-    hardware = if resource.respond_to?(:hardware)
-                 resource.hardware
-               elsif resource.respond_to?(:container_node)
-                 resource.container_node.hardware
-               end
-
     field == :memory ? hardware.try(:memory_mb) : hardware.try(:aggregate_cpu_speed)
   end
 
@@ -235,11 +229,6 @@ class VimPerformanceState < ApplicationRecord
   end
 
   def capture_cpu_total_cores
-    hardware = if resource.respond_to?(:hardware)
-                 resource.hardware
-               elsif resource.respond_to?(:container_node)
-                 resource.container_node.hardware
-               end
     # TODO: This is cpu_total_cores and needs to be renamed, but reports depend on the name :numvcpus
     self.numvcpus = hardware.try(:cpu_total_cores)
   end
@@ -250,5 +239,13 @@ class VimPerformanceState < ApplicationRecord
                         elsif resource.respond_to?(:hosts)
                           resource.hosts.includes(:hardware).collect { |h| h.hardware.try(:cpu_sockets) }.compact.sum
                         end
+  end
+
+  def hardware
+    if resource.respond_to?(:hardware)
+      resource.hardware
+    elsif resource.respond_to?(:container_node)
+      resource.container_node.hardware
+    end
   end
 end

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -60,7 +60,7 @@ class VimPerformanceState < ApplicationRecord
     self.capture_interval = 3600
     self.assoc_ids = VimPerformanceState.capture_assoc_ids(resource)
     self.parent_host_id = VimPerformanceState.capture_parent_host(resource)
-    self.parent_storage_id = VimPerformanceState.capture_parent_storage(resource)
+    capture_parent_storage
     capture_parent_ems
     self.parent_ems_cluster_id = VimPerformanceState.capture_parent_cluster(resource)
     capture_cpu_total_cores
@@ -195,11 +195,11 @@ class VimPerformanceState < ApplicationRecord
     obj.host_id if obj.kind_of?(VmOrTemplate)
   end
 
-  def self.capture_parent_storage(obj)
-    obj.storage_id if obj.kind_of?(VmOrTemplate)
-  end
-
   private
+
+  def capture_parent_storage
+    self.parent_storage_id = resource.storage_id if resource.kind_of?(VmOrTemplate)
+  end
 
   def capture_parent_ems
     self.parent_ems_id = resource.try(:ems_id)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -70,7 +70,7 @@ class VimPerformanceState < ApplicationRecord
     self.reserve_mem = VimPerformanceState.capture_reserve(resource, :memory_reserve)
     capture_vm_disk_storage
     self.tag_names = VimPerformanceState.capture_tag_names(resource)
-    self.image_tag_names = VimPerformanceState.capture_image_tag_names(resource)
+    capture_image_tag_names
     capture_host_sockets
   end
 
@@ -212,12 +212,15 @@ class VimPerformanceState < ApplicationRecord
     obj.tag_list(:ns => "/managed").split.join("|")
   end
 
-  def self.capture_image_tag_names(obj)
-    return '' unless obj.respond_to?(:container_image) && obj.container_image.present?
-    obj.container_image.tag_list(:ns => "/managed").split.join("|")
-  end
-
   private
+
+  def capture_image_tag_names
+    self.image_tag_names = if resource.respond_to?(:container_image) && resource.container_image.present?
+                             resource.container_image.tag_list(:ns => "/managed").split.join("|")
+                           else
+                             ''
+                           end
+  end
 
   def capture_vm_disk_storage
     if resource.kind_of?(VmOrTemplate)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -61,7 +61,7 @@ class VimPerformanceState < ApplicationRecord
     self.assoc_ids = VimPerformanceState.capture_assoc_ids(resource)
     self.parent_host_id = VimPerformanceState.capture_parent_host(resource)
     self.parent_storage_id = VimPerformanceState.capture_parent_storage(resource)
-    self.parent_ems_id = VimPerformanceState.capture_parent_ems(resource)
+    capture_parent_ems
     self.parent_ems_cluster_id = VimPerformanceState.capture_parent_cluster(resource)
     capture_cpu_total_cores
     self.total_cpu = VimPerformanceState.capture_total(resource, :cpu_speed)
@@ -199,11 +199,11 @@ class VimPerformanceState < ApplicationRecord
     obj.storage_id if obj.kind_of?(VmOrTemplate)
   end
 
-  def self.capture_parent_ems(obj)
-    obj.try(:ems_id)
-  end
-
   private
+
+  def capture_parent_ems
+    self.parent_ems_id = resource.try(:ems_id)
+  end
 
   def capture_reserve
     self.reserve_cpu = resource.try(:cpu_reserve)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -62,7 +62,7 @@ class VimPerformanceState < ApplicationRecord
     capture_parent_host
     capture_parent_storage
     capture_parent_ems
-    self.parent_ems_cluster_id = VimPerformanceState.capture_parent_cluster(resource)
+    capture_parent_cluster
     capture_cpu_total_cores
     self.total_cpu = VimPerformanceState.capture_total(resource, :cpu_speed)
     self.total_mem = VimPerformanceState.capture_total(resource, :memory)
@@ -187,11 +187,13 @@ class VimPerformanceState < ApplicationRecord
     result.presence
   end
 
-  def self.capture_parent_cluster(obj)
-    obj.parent_cluster.try(:id) if (obj.kind_of?(Host) || obj.kind_of?(VmOrTemplate))
-  end
-
   private
+
+  def capture_parent_cluster
+    if resource.kind_of?(Host) || resource.kind_of?(VmOrTemplate)
+      self.parent_ems_cluster_id = resource.parent_cluster.try(:id)
+    end
+  end
 
   def capture_parent_host
     self.parent_host_id = resource.host_id if resource.kind_of?(VmOrTemplate)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -48,29 +48,32 @@ class VimPerformanceState < ApplicationRecord
     state = obj.vim_performance_states.find_by_timestamp(ts)
     return state unless state.nil?
 
-    state = obj.vim_performance_states.build
-    state.state_data ||= {}
-    state.timestamp = ts
-    state.capture_interval = 3600
-    state.assoc_ids = capture_assoc_ids(obj)
-    state.parent_host_id = capture_parent_host(obj)
-    state.parent_storage_id = capture_parent_storage(obj)
-    state.parent_ems_id = capture_parent_ems(obj)
-    state.parent_ems_cluster_id = capture_parent_cluster(obj)
-    # TODO: This is cpu_total_cores and needs to be renamed, but reports depend on the name :numvcpus
-    state.numvcpus = capture_cpu_total_cores(obj)
-    state.total_cpu = capture_total(obj, :cpu_speed)
-    state.total_mem = capture_total(obj, :memory)
-    state.reserve_cpu = capture_reserve(obj, :cpu_reserve)
-    state.reserve_mem = capture_reserve(obj, :memory_reserve)
-    state.vm_used_disk_storage = capture_vm_disk_storage(obj, :used_disk)
-    state.vm_allocated_disk_storage = capture_vm_disk_storage(obj, :allocated_disk)
-    state.tag_names = capture_tag_names(obj)
-    state.image_tag_names = capture_image_tag_names(obj)
-    state.host_sockets = capture_host_sockets(obj)
+    state = obj.vim_performance_states.build(:timestamp => ts)
+    state.capture
     state.save
 
     state
+  end
+
+  def capture
+    self.state_data ||= {}
+    self.capture_interval = 3600
+    self.assoc_ids = VimPerformanceState.capture_assoc_ids(resource)
+    self.parent_host_id = VimPerformanceState.capture_parent_host(resource)
+    self.parent_storage_id = VimPerformanceState.capture_parent_storage(resource)
+    self.parent_ems_id = VimPerformanceState.capture_parent_ems(resource)
+    self.parent_ems_cluster_id = VimPerformanceState.capture_parent_cluster(resource)
+    # TODO: This is cpu_total_cores and needs to be renamed, but reports depend on the name :numvcpus
+    self.numvcpus = VimPerformanceState.capture_cpu_total_cores(resource)
+    self.total_cpu = VimPerformanceState.capture_total(resource, :cpu_speed)
+    self.total_mem = VimPerformanceState.capture_total(resource, :memory)
+    self.reserve_cpu = VimPerformanceState.capture_reserve(resource, :cpu_reserve)
+    self.reserve_mem = VimPerformanceState.capture_reserve(resource, :memory_reserve)
+    self.vm_used_disk_storage = VimPerformanceState.capture_vm_disk_storage(resource, :used_disk)
+    self.vm_allocated_disk_storage = VimPerformanceState.capture_vm_disk_storage(resource, :allocated_disk)
+    self.tag_names = VimPerformanceState.capture_tag_names(resource)
+    self.image_tag_names = VimPerformanceState.capture_image_tag_names(resource)
+    self.host_sockets = VimPerformanceState.capture_host_sockets(resource)
   end
 
   def vm_count_on

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -66,8 +66,7 @@ class VimPerformanceState < ApplicationRecord
     capture_cpu_total_cores
     self.total_cpu = VimPerformanceState.capture_total(resource, :cpu_speed)
     self.total_mem = VimPerformanceState.capture_total(resource, :memory)
-    self.reserve_cpu = VimPerformanceState.capture_reserve(resource, :cpu_reserve)
-    self.reserve_mem = VimPerformanceState.capture_reserve(resource, :memory_reserve)
+    capture_reserve
     capture_vm_disk_storage
     capture_tag_names
     capture_image_tag_names
@@ -204,11 +203,12 @@ class VimPerformanceState < ApplicationRecord
     obj.try(:ems_id)
   end
 
-  def self.capture_reserve(obj, field)
-    obj.try(field)
-  end
-
   private
+
+  def capture_reserve
+    self.reserve_cpu = resource.try(:cpu_reserve)
+    self.reserve_mem = resource.try(:memory_reserve)
+  end
 
   def capture_tag_names
     self.tag_names = resource.perf_tags

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -209,14 +209,14 @@ class VimPerformanceState < ApplicationRecord
   end
 
   def self.capture_tag_names(obj)
-    obj.tag_list(:ns => "/managed").split.join("|")
+    obj.perf_tags
   end
 
   private
 
   def capture_image_tag_names
     self.image_tag_names = if resource.respond_to?(:container_image) && resource.container_image.present?
-                             resource.container_image.tag_list(:ns => "/managed").split.join("|")
+                             resource.container_image.perf_tags
                            else
                              ''
                            end

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -59,7 +59,7 @@ class VimPerformanceState < ApplicationRecord
     self.state_data ||= {}
     self.capture_interval = 3600
     self.assoc_ids = VimPerformanceState.capture_assoc_ids(resource)
-    self.parent_host_id = VimPerformanceState.capture_parent_host(resource)
+    capture_parent_host
     capture_parent_storage
     capture_parent_ems
     self.parent_ems_cluster_id = VimPerformanceState.capture_parent_cluster(resource)
@@ -191,11 +191,11 @@ class VimPerformanceState < ApplicationRecord
     obj.parent_cluster.try(:id) if (obj.kind_of?(Host) || obj.kind_of?(VmOrTemplate))
   end
 
-  def self.capture_parent_host(obj)
-    obj.host_id if obj.kind_of?(VmOrTemplate)
-  end
-
   private
+
+  def capture_parent_host
+    self.parent_host_id = resource.host_id if resource.kind_of?(VmOrTemplate)
+  end
 
   def capture_parent_storage
     self.parent_storage_id = resource.storage_id if resource.kind_of?(VmOrTemplate)

--- a/spec/models/vim_performance_state_spec.rb
+++ b/spec/models/vim_performance_state_spec.rb
@@ -2,9 +2,10 @@ RSpec.describe VimPerformanceState do
   describe ".capture_host_sockets" do
     it "returns the host sockets when given a host" do
       hardware = FactoryGirl.build(:hardware, :cpu_sockets => 2)
-      host = FactoryGirl.build(:host, :hardware => hardware)
+      host = FactoryGirl.create(:host, :hardware => hardware)
+      state = VimPerformanceState.capture(host)
 
-      expect(described_class.capture_host_sockets(host)).to eq(2)
+      expect(state.host_sockets).to eq(2)
     end
 
     it "rolls up the total sockets when given something that has hosts" do
@@ -13,8 +14,9 @@ RSpec.describe VimPerformanceState do
       host_1 = FactoryGirl.build(:host, :hardware => hardware_1)
       host_2 = FactoryGirl.build(:host, :hardware => hardware_2)
       cluster = FactoryGirl.create(:ems_cluster, :hosts => [host_1, host_2])
+      state = VimPerformanceState.capture(cluster)
 
-      expect(described_class.capture_host_sockets(cluster)).to eq(6)
+      expect(state.host_sockets).to eq(6)
     end
   end
 

--- a/tools/metrics_populate_retro_tags.rb
+++ b/tools/metrics_populate_retro_tags.rb
@@ -26,7 +26,7 @@ vm_perf_recs = MetricRollup.where(time_cond).where(:capture_interval_name => 'ho
 vm_perf_recs.group_by(&:resource_id).sort.each do |resource_id, perfs|
   puts "Updating tags in performance data for VM: ID: #{resource_id} => #{perfs.first.resource_name}"
   MetricRollup.update_all(
-    {:tag_names => VimPerformanceState.capture_tag_names(perfs.first.vm)},
+    {:tag_names => perfs.first.vm.perf_tags},
     :id        => perfs.collect(&:id)
   )
 end


### PR DESCRIPTION
Drop VimPerformanceState class methods, reintroduce as private instance methods

@miq-bot add_label perf
