### PR TITLE
Corrected method name in toolbar button specs

### DIFF
--- a/spec/helpers/application_helper/buttons/miq_request_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_request_copy_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::MiqRequestCopy do
-  describe '#skip?' do
+  describe '#visible?' do
 
     let(:button) do
       described_class.new(

--- a/spec/helpers/application_helper/buttons/policy_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/policy_copy_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::PolicyCopy do
-  describe '#skip?' do
+  describe '#visible?' do
 
     let(:button) do
       described_class.new(

--- a/spec/helpers/application_helper/buttons/policy_delete_spec.rb
+++ b/spec/helpers/application_helper/buttons/policy_delete_spec.rb
@@ -1,5 +1,5 @@
 describe ApplicationHelper::Button::PolicyDelete do
-  describe '#skip?' do
+  describe '#visible?' do
 
     let(:button) do
       described_class.new(


### PR DESCRIPTION
It seems that I have missed few spec files in PR #10814.

