### PR TITLE
Remove the region api authentication when removing a subscription

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -60,6 +60,7 @@ class PglogicalSubscription < ActsAsArModel
 
   def delete
     pglogical.subscription_drop(id, true)
+    MiqRegion.find_by_region(provider_region).remove_auth_key
     MiqRegion.destroy_region(connection, provider_region)
     if self.class.count == 0
       pglogical.node_drop(MiqPglogical.local_node_name, true)


### PR DESCRIPTION
The authentication is useless once the data has been removed and it wont be removed when the region is destroyed because it has a primary key within the global region.

Requires https://github.com/ManageIQ/manageiq/pull/11646
/cc @lgalis 

@gtanzillo please review