### PR TITLE
No need to seed/set secret token in API specs

### DIFF
--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -87,8 +87,6 @@ module Spec
       end
 
       def init_api_spec_env
-        MiqDatabase.seed
-        Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
         @guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
 
         define_user


### PR DESCRIPTION
This may have been needed because of session-related callbacks that were
registered in ApplicationController, but since skipped in
4e0da8205fdfb10bd499bdbc11171c3f58b876f1.

/cc @Fryguy 
@miq-bot add-label api, test
@miq-bot assign @abellotti 