### PR TITLE
Remove shallow fetch from replication migration spec setup

### DIFF
--- a/lib/tasks/test_replication.rake
+++ b/lib/tasks/test_replication.rake
@@ -58,7 +58,7 @@ class EvmTestSetupReplication
   private
 
   def released_migrations
-    unless system("git fetch --depth=1 http://github.com/ManageIQ/manageiq.git refs/heads/euwe:#{TEST_BRANCH}")
+    unless system("git fetch http://github.com/ManageIQ/manageiq.git refs/heads/euwe:#{TEST_BRANCH}")
       return []
     end
     files = `git ls-tree -r --name-only #{TEST_BRANCH} db/migrate/`


### PR DESCRIPTION
This was causing the local repo to become a shallow checkout which needed to be fixed by running `git fetch --unshallow`

This may take a bit longer to run and take up some more space, but the idea is that we don't care that much for the automated tests and most developers should have the stable branch locally already.

@jrafanie please review