### PR TITLE
Remove unused helper resources_include?

### DIFF
--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -59,10 +59,6 @@ module Spec
         resources.any? { |r| r.key?(key) && r[key].match("#{suffix}$") }
       end
 
-      def resources_include?(resources, key, value)
-        resources.any? { |r| r[key] == value }
-      end
-
       def api_config(param)
         @api_config = {
           :user       => "api_user_id",


### PR DESCRIPTION
This was added in 5e1b91e602f14ca82d59123e15c0e3d32cc8e7c1 but looks
like it was never used.

@miq-bot add-label api, test, technical debt
@miq-bot assign @abellotti 

:scissors: 