### PR TITLE
add /etc/redhat-access-insights/machine-id to the sample VM analysis …

### DIFF
--- a/product/scan_items/scan_item_file.yaml
+++ b/product/scan_items/scan_item_file.yaml
@@ -6,6 +6,7 @@
   - target: c:/windows/system32/msi*.*
   - target: /etc/*.conf
   - target: /etc/hosts
+  - target: /etc/redhat-access-insights/machine-id
   - target: c:/windows/system32/netapi32.dll
 :name: sample_file
 :description: Sample File Scan


### PR DESCRIPTION
The /etc/redhat-access-insights/machined-id  file required to link Red Hat Insights and CloudForms should be included as part of the sample Analysis Profile in CloudForms. Currently it is not and requires a manual configuration.

This is regards to:
https://bugzilla.redhat.com/show_bug.cgi?id=1349663
