### PR TITLE
Fix for a Dialog with Tag Control Failure

### DIFF
--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -93,7 +93,7 @@ class DialogFieldSortedItem < DialogField
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : self[:values].to_miq_a
     unless @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value)
-      self.default_value = sort_data(@raw_values).first.first
+      self.default_value = sort_data(@raw_values).first.try(:first)
     end
     self.value ||= default_value
 

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -238,11 +238,27 @@ describe DialogFieldDropDownList do
 
       context "when the raw values are not already set" do
         before do
-          dialog_field.values = %w(original values)
+          dialog_field.values = [%w(original values)]
         end
 
         it "returns the values" do
-          expect(dialog_field.trigger_automate_value_updates).to eq(%w(original values))
+          expect(dialog_field.trigger_automate_value_updates).to eq([%w(original values)])
+        end
+
+        it "sets up the default value" do
+          dialog_field.trigger_automate_value_updates
+          expect(dialog_field.default_value).to eq("original")
+        end
+      end
+
+      context "when the raw values are nil" do
+        before do
+          dialog_field.values = nil
+        end
+
+        it "sets the default value to nil without blowing up" do
+          dialog_field.trigger_automate_value_updates
+          expect(dialog_field.default_value).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
The "raw_values" method for tag control got removed because I was consolidating similar functionality in commit c16275b9480efd3d9b74053460d241af0dfa3bd2. However, tag control values in the db are not set (they're calculated at runtime as they're based on a category), and thus when `self[:values].to_miq_a` was ran, it was only returning a single array, not a multidimensional one as expected. I believe this issue can happen as well with regular drop downs and radio buttons, so this should fix those too.

Steps for Testing/QA
-------------------------------
Steps are included in the BZ, but I will include them here as well:

Attempt to order a service catalog with dialog that contains a tag control field attached.  Before this fix, clicking order will cause a server error but no indication anything happened, and after, it should work as expected and show the tag control field.

https://bugzilla.redhat.com/show_bug.cgi?id=1382765

/cc @gmcculloug 