### PR TITLE
[EUWE] Remove shallow fetch from replication migration spec setup

### DIFF
--- a/lib/tasks/test_replication.rake
+++ b/lib/tasks/test_replication.rake
@@ -58,7 +58,7 @@ class EvmTestSetupReplication
   private
 
   def released_migrations
-    unless system("git fetch --depth=1 http://github.com/ManageIQ/manageiq.git refs/heads/darga:#{TEST_BRANCH}")
+    unless system("git fetch http://github.com/ManageIQ/manageiq.git refs/heads/darga:#{TEST_BRANCH}")
       return []
     end
     files = `git ls-tree -r --name-only #{TEST_BRANCH} db/migrate/`

--- a/lib/tasks/test_replication.rake
+++ b/lib/tasks/test_replication.rake
@@ -58,7 +58,7 @@ class EvmTestSetupReplication
   private
 
   def released_migrations
-    unless system("git fetch http://github.com/ManageIQ/manageiq.git refs/heads/darga:#{TEST_BRANCH}")
+    unless system(fetch_command)
       return []
     end
     files = `git ls-tree -r --name-only #{TEST_BRANCH} db/migrate/`
@@ -73,6 +73,10 @@ class EvmTestSetupReplication
     migrations.keep_if { |timestamp| timestamp =~ /\d+/ }
   ensure
     `git branch -D #{TEST_BRANCH}`
+  end
+
+  def fetch_command
+    "git fetch #{'--depth=1 ' if ENV['CI']}http://github.com/ManageIQ/manageiq.git refs/heads/darga:#{TEST_BRANCH}"
   end
 
   def prepare_slave_database


### PR DESCRIPTION
This was causing the local repo to become a shallow checkout which needed to be fixed by running `git fetch --unshallow`

This may take a bit longer to run and take up some more space, but the idea is that we don't care that much for the automated tests and most developers should have the stable branch locally already.

This is a backport for #11769 

/cc @jrafanie @chessbyte 