### PR TITLE
Fix automate

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -6,7 +6,7 @@
 prov = $evm.root['service_template_provision_task']
 
 unless prov
-  $evm.log(:error, "miq_provision object not provided")
+  $evm.log(:error, "service_template_provision_task object not provided")
   exit(MIQ_STOP)
 end
 

--- a/product/scan_items/scan_item_file.yaml
+++ b/product/scan_items/scan_item_file.yaml
@@ -6,6 +6,7 @@
   - target: c:/windows/system32/msi*.*
   - target: /etc/*.conf
   - target: /etc/hosts
+  - target: /etc/redhat-access-insights/machine-id
   - target: c:/windows/system32/netapi32.dll
 :name: sample_file
 :description: Sample File Scan


### PR DESCRIPTION
The automate method incorrectly states 

$evm.log(:error, "**miq_provision** object not provided") 

when the object is actually service_template_provision_task

$evm.log(:error, "**service_template_provision_task** object not provided")
