### PR TITLE
fixed typo in update_serviceprovision_status.rb

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -6,7 +6,7 @@
 prov = $evm.root['service_template_provision_task']
 
 unless prov
-  $evm.log(:error, "miq_provision object not provided")
+  $evm.log(:error, "service_template_provision_task object not provided")
   exit(MIQ_STOP)
 end
 


### PR DESCRIPTION
changed line 9 from miq_provision to the actual task name of service_template_provision_task