### PR TITLE
Middleware Datasource validation enhancement

### DIFF
--- a/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
+++ b/app/assets/javascripts/controllers/middleware_datasource/middleware_datasource_controller.js
@@ -37,6 +37,7 @@ function MwAddDataSourceCtrl($scope, $http, $q, miqService) {
   $scope.step2DsModel.driverClass = '';
 
   $scope.step3DsModel = {};
+  $scope.step3DsModel.validationRegex = /^jdbc:\S+$/;
   $scope.step3DsModel.connectionUrl = '';
   $scope.step3DsModel.userName = '';
   $scope.step3DsModel.password = '';

--- a/app/views/middleware_server/_add_datasource_step1.html.haml
+++ b/app/views/middleware_server/_add_datasource_step1.html.haml
@@ -39,10 +39,10 @@
 
     .modal-footer
       %button.btn.btn-default.dialog-cancel-button{:type      => "button",
-                                                   "ng-click" =>"reset()"}
+                                                   "ng-click" => "reset()"}
         = _("Cancel")
       %button.btn.btn-default{:type      => "button",
-                              "ng-click" =>"addDatasourceStep1Back()"}
+                              "ng-click" => "addDatasourceStep1Back()"}
         = _("Back")
       %button.btn.btn-primary{:type         => "button",
                               "ng-click"    => "addDatasourceStep1Next()",

--- a/app/views/middleware_server/_add_datasource_step1.html.haml
+++ b/app/views/middleware_server/_add_datasource_step1.html.haml
@@ -40,11 +40,11 @@
           = _("Maximum length is 256")
 
     .modal-footer
-      %button.btn.btn-default.dialog-cancel-button{:type          => "button",
-                                                   "ng-click"     =>"reset()"}
+      %button.btn.btn-default.dialog-cancel-button{:type      => "button",
+                                                   "ng-click" =>"reset()"}
         = _("Cancel")
-      %button.btn.btn-default{:type          => "button",
-                              "ng-click"     =>"addDatasourceStep1Back()"}
+      %button.btn.btn-default{:type      => "button",
+                              "ng-click" =>"addDatasourceStep1Back()"}
         = _("Back")
       %button.btn.btn-primary{:type         => "button",
                               "ng-click"    => "addDatasourceStep1Next()",

--- a/app/views/middleware_server/_add_datasource_step1.html.haml
+++ b/app/views/middleware_server/_add_datasource_step1.html.haml
@@ -14,8 +14,7 @@
                                           "ng-maxlength" => "100",
                                           "ng-model"     => "step1DsModel.datasourceName"}
 
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step1Form.ds_name_input.$error.required"}
           = _("Required")
         %p.ng-error-messages{"ng-show" => "step1Form.ds_name_input.$error.maxlength"}
@@ -32,8 +31,7 @@
                                             "ng-required"  => "true",
                                             "ng-model"     => "step1DsModel.jndiName"}
 
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step1Form.jndi_name_input.$error.required"}
           = _("Required")
         %p.ng-error-messages{"ng-show" => "step1Form.jndi_name_input.$error.maxlength"}

--- a/app/views/middleware_server/_add_datasource_step2.html.haml
+++ b/app/views/middleware_server/_add_datasource_step2.html.haml
@@ -58,10 +58,10 @@
 
     .modal-footer
       %button.btn.btn-default.dialog-cancel-button{:type      => "button",
-                                                   "ng-click" =>"reset()"}
+                                                   "ng-click" => "reset()"}
         = _("Cancel")
       %button.btn.btn-default{:type      => "button",
-                              "ng-click" =>"addDatasourceStep2Back()"}
+                              "ng-click" => "addDatasourceStep2Back()"}
         = _("Back")
       %button.btn.btn-primary{:type         => "button",
                               "ng-click"    => "addDatasourceStep2Next()",

--- a/app/views/middleware_server/_add_datasource_step2.html.haml
+++ b/app/views/middleware_server/_add_datasource_step2.html.haml
@@ -8,13 +8,12 @@
         = _("Name")
       .col-md-8
         %input.form-control#jdbc_ds_driver_name_input{:type          => "text",
-                                                      "name"         => "jdbc_driver_name_input",
+                                                      "name"         => "jdbc_ds_driver_name_input",
                                                       "ng-required"  => "true",
                                                       "ng-maxlength" => "100",
                                                       "placeholder"  => _("Enter JDBC Driver name"),
                                                       "ng-model"     => "step2DsModel.jdbcDriverName"}
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_name_input.$error.required"}
           = _("Required")
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_name_input.$error.maxlength"}
@@ -32,8 +31,7 @@
                                                     "placeholder"  => _("Enter JDBC Module name"),
                                                     "ng-model"     => "step2DsModel.jdbcModuleName"}
 
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_modoule_name_input.$error.required"}
           = _("Required")
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_modoule_name_input.$error.maxlength"}
@@ -51,8 +49,7 @@
                                                  "placeholder"  => _("Enter JDBC Driver Class"),
                                                  "ng-model"     => "step2DsModel.driverClass"}
 
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_input.$error.required"}
           = _("Required")
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_input.$error.maxlength"}

--- a/app/views/middleware_server/_add_datasource_step2.html.haml
+++ b/app/views/middleware_server/_add_datasource_step2.html.haml
@@ -7,7 +7,7 @@
       %label.col-md-4.control-label{:for => "jdbc_driver_name_input"}
         = _("Name")
       .col-md-8
-        %input.form-control#jdbc_driver_name_input{:type          => "text",
+        %input.form-control#jdbc_ds_driver_name_input{:type          => "text",
                                                    "name"         => "jdbc_driver_name_input",
                                                    "ng-required"  => "true",
                                                    "ng-maxlength" => "100",
@@ -15,9 +15,9 @@
                                                    "ng-model"     => "step2DsModel.jdbcDriverName"}
       .col-sm-2
       .col-sm-10
-        %p.ng-error-messages{"ng-show" => "step2Form.jdbc_driver_name_input.$error.required"}
+        %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_name_input.$error.required"}
           = _("Required")
-        %p.ng-error-messages{"ng-show" => "step2Form.jdbc_driver_name_input.$error.maxlength"}
+        %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_name_input.$error.maxlength"}
           = _("Maximum length is 100")
 
 

--- a/app/views/middleware_server/_add_datasource_step2.html.haml
+++ b/app/views/middleware_server/_add_datasource_step2.html.haml
@@ -8,11 +8,11 @@
         = _("Name")
       .col-md-8
         %input.form-control#jdbc_ds_driver_name_input{:type          => "text",
-                                                   "name"         => "jdbc_driver_name_input",
-                                                   "ng-required"  => "true",
-                                                   "ng-maxlength" => "100",
-                                                   "placeholder"  => _("Enter JDBC Driver name"),
-                                                   "ng-model"     => "step2DsModel.jdbcDriverName"}
+                                                      "name"         => "jdbc_driver_name_input",
+                                                      "ng-required"  => "true",
+                                                      "ng-maxlength" => "100",
+                                                      "placeholder"  => _("Enter JDBC Driver name"),
+                                                      "ng-model"     => "step2DsModel.jdbcDriverName"}
       .col-sm-2
       .col-sm-10
         %p.ng-error-messages{"ng-show" => "step2Form.jdbc_ds_driver_name_input.$error.required"}
@@ -45,11 +45,11 @@
         = _("Driver Class")
       .col-md-8
         %input.form-control#jdbc_ds_driver_input{:type          => "text",
-                                                    "name"         => "jdbc_ds_driver_input",
-                                                    "ng-required"  => "true",
-                                                    "ng-maxlength" => "256",
-                                                    "placeholder"  => _("Enter JDBC Driver Class"),
-                                                    "ng-model"     => "step2DsModel.driverClass"}
+                                                 "name"         => "jdbc_ds_driver_input",
+                                                 "ng-required"  => "true",
+                                                 "ng-maxlength" => "256",
+                                                 "placeholder"  => _("Enter JDBC Driver Class"),
+                                                 "ng-model"     => "step2DsModel.driverClass"}
 
       .col-sm-2
       .col-sm-10
@@ -60,11 +60,11 @@
 
 
     .modal-footer
-      %button.btn.btn-default.dialog-cancel-button{:type          => "button",
-                                                   "ng-click"     =>"reset()"}
+      %button.btn.btn-default.dialog-cancel-button{:type      => "button",
+                                                   "ng-click" =>"reset()"}
         = _("Cancel")
-      %button.btn.btn-default{:type          => "button",
-                              "ng-click"     =>"addDatasourceStep2Back()"}
+      %button.btn.btn-default{:type      => "button",
+                              "ng-click" =>"addDatasourceStep2Back()"}
         = _("Back")
       %button.btn.btn-primary{:type         => "button",
                               "ng-click"    => "addDatasourceStep2Next()",

--- a/app/views/middleware_server/_add_datasource_step3.html.haml
+++ b/app/views/middleware_server/_add_datasource_step3.html.haml
@@ -53,10 +53,10 @@
 
     .modal-footer
       %button.btn.btn-default.dialog-cancel-button{:type          => "button",
-                                                   "ng-click"     =>"reset()"}
+                                                   "ng-click"     => "reset()"}
         = _("Cancel")
       %button.btn.btn-default{:type      => "button",
-                              "ng-click" =>"finishAddDatasourceBack()"}
+                              "ng-click" => "finishAddDatasourceBack()"}
         = _("Back")
       %button.btn.btn-primary{:type         => "button",
                               "ng-click"    => "finishAddDatasource()",

--- a/app/views/middleware_server/_add_datasource_step3.html.haml
+++ b/app/views/middleware_server/_add_datasource_step3.html.haml
@@ -13,8 +13,7 @@
                                                  "ng-minlength" => "10",
                                                  "ng-model"     => "step3DsModel.connectionUrl"}
 
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step3Form.connection_url_input.$error.required"}
           = _("Required")
         %p.ng-error-messages{"ng-show" => "step3Form.connection_url_input.$error.minlength"}
@@ -30,8 +29,7 @@
                                             "placeholder"  => _("Enter Username"),
                                             "ng-model"     => "step3DsModel.userName"}
 
-      .col-sm-2
-      .col-sm-10
+      .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step3Form.user_name_input.$error.required"}
           = _("Required")
 

--- a/app/views/middleware_server/_add_datasource_step3.html.haml
+++ b/app/views/middleware_server/_add_datasource_step3.html.haml
@@ -10,14 +10,14 @@
         %input.form-control#connection_url_input{:type          => "textarea",
                                                  "name"         => "connection_url_input",
                                                  "ng-required"  => "true",
-                                                 "ng-minlength" => "10",
+                                                 "ng-pattern"   => "step3DsModel.validationRegex",
                                                  "ng-model"     => "step3DsModel.connectionUrl"}
 
       .col-sm-8.col-sm-offset-4
         %p.ng-error-messages{"ng-show" => "step3Form.connection_url_input.$error.required"}
           = _("Required")
-        %p.ng-error-messages{"ng-show" => "step3Form.connection_url_input.$error.minlength"}
-          = _("Minimum length is 10")
+        %p.ng-error-messages{"ng-show" => "step3Form.connection_url_input.$error.pattern"}
+          = _("Must start with 'jdbc:'")
 
     .form-group
       %label.col-md-4.control-label{:for => "user_name_input"}

--- a/app/views/middleware_server/_choose_datasource.html.haml
+++ b/app/views/middleware_server/_choose_datasource.html.haml
@@ -18,7 +18,7 @@
 
   .modal-footer
     %button.btn.btn-default.dialog-cancel-button{:type        => "button",
-                                                 "ng-click"   =>"reset()"}
+                                                 "ng-click"   => "reset()"}
       = _("Cancel")
     %button.btn.btn-primary{:type         => "button",
                             "ng-click"    => "addDatasourceChooseNext()",


### PR DESCRIPTION
Some minor enhancements for datasource validation including better validation around connection url strings (via regex expression instead of minlength) and better alignment with fields for all datasource validations.

![manageiq__middleware_servers](https://cloud.githubusercontent.com/assets/1312165/19204145/ef667954-8c8f-11e6-9f2f-0881bd1659c9.jpg)

@miq-bot add_label provider/hawkular, enhancement, ui, darga/no, euwe/yes

