### PR TITLE
Add regional method relay mixin for generic central administration of models

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -246,7 +246,7 @@ class MiqRegion < ApplicationRecord
 
   def remote_ws_url
     hostname = remote_ws_address
-    hostname.nil? ? nil : "https://#{hostname}"
+    hostname && URI::HTTPS.build(:host => hostname).to_s
   end
 
   def generate_auth_key_queue(ssh_user, ssh_password, ssh_host = nil)

--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -49,7 +49,7 @@ module InterRegionApiMethodRelay
   end
 
   def self.api_client_connection_for_region(region)
-    url = MiqRegion.find_by_region(region).remote_ws_url
+    url = MiqRegion.find_by(:region => region).remote_ws_url
     if url.nil?
       _log.error("The remote region [#{region}] does not have a web service address.")
       raise "Failed to establish API connection to region #{region}"

--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -1,0 +1,80 @@
+module InterRegionApiMethodRelay
+  def self.extended(klass)
+    unless klass.const_defined?("InstanceMethodRelay")
+      instance_relay = klass.const_set("InstanceMethodRelay", Module.new)
+      klass.prepend(instance_relay)
+    end
+
+    unless klass.const_defined?("ClassMethodRelay")
+      class_relay = klass.const_set("ClassMethodRelay", Module.new)
+      klass.singleton_class.prepend(class_relay)
+    end
+  end
+
+  def api_relay_method(method, action = method)
+    relay = const_get("InstanceMethodRelay")
+    collection_name = collection_for_class
+
+    relay.class_eval do
+      define_method(method) do |*meth_args, &meth_block|
+        api_args = block_given? ? yield(*meth_args) : {}
+
+        if in_current_region?
+          super(*meth_args, &meth_block)
+        else
+          api_client = InterRegionApiMethodRelay.api_client_connection_for_region(region_number)
+          collection = api_client.public_send(collection_name)
+          obj = collection.find(id)
+          obj.public_send(action, api_args)
+        end
+      end
+    end
+  end
+
+  def api_relay_class_method(method, action = method)
+    relay = const_get("ClassMethodRelay")
+    collection_name = collection_for_class
+    raise ArgumentError, "A block is required to determine target object region and API arguments" unless block_given?
+
+    relay.class_eval do
+      define_method(method) do |*meth_args, &meth_block|
+        record_id, api_args = yield(*meth_args)
+
+        if id_in_current_region?(record_id)
+          super(*meth_args, &meth_block)
+        else
+          api_client = InterRegionApiMethodRelay.api_client_connection_for_region(id_to_region(record_id))
+          collection = api_client.public_send(collection_name)
+          collection.public_send(action, api_args || {})
+        end
+      end
+    end
+  end
+
+  def self.api_client_connection_for_region(region)
+    hostname = MiqRegion.find_by_region(region).remote_ws_address
+    if hostname.nil?
+      _log.error("The remote region [#{region}] does not have a web service address.")
+      raise "Failed to establish API connection to region #{region}"
+    end
+
+    require 'manageiq-api-client'
+
+    ManageIQ::API::Client.new(
+      :url      => "https://#{hostname}",
+      :miqtoken => MiqRegion.api_system_auth_token_for_region(region, User.current_userid),
+      :ssl      => {:verify => false}
+    )
+  end
+
+  private
+
+  def collection_for_class
+    collection_name = Api::CollectionConfig.new.name_for_klass(self)
+    unless collection_name
+      _log.error("No API endpoint found for class #{name}")
+      raise NotImplementedError, "No API endpoint found for class #{name}"
+    end
+    collection_name
+  end
+end

--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -49,8 +49,8 @@ module InterRegionApiMethodRelay
   end
 
   def self.api_client_connection_for_region(region)
-    hostname = MiqRegion.find_by_region(region).remote_ws_address
-    if hostname.nil?
+    url = MiqRegion.find_by_region(region).remote_ws_url
+    if url.nil?
       _log.error("The remote region [#{region}] does not have a web service address.")
       raise "Failed to establish API connection to region #{region}"
     end
@@ -58,7 +58,7 @@ module InterRegionApiMethodRelay
     require 'manageiq-api-client'
 
     ManageIQ::API::Client.new(
-      :url      => "https://#{hostname}",
+      :url      => url,
       :miqtoken => MiqRegion.api_system_auth_token_for_region(region, User.current_userid),
       :ssl      => {:verify => false}
     )

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -2,6 +2,9 @@ class Vm < VmOrTemplate
   default_scope { where(:template => false) }
   has_one :container_deployment, :through => :container_deployment_node
   has_one :container_deployment_node
+
+  extend InterRegionApiMethodRelay
+
   include_concern 'Operations'
 
   def self.base_model

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -4,6 +4,10 @@ class Vm < VmOrTemplate
   has_one :container_deployment_node
   include_concern 'Operations'
 
+  extend InterRegionApiMethodRelay
+  api_relay_method :start
+  api_relay_method :stop
+
   def self.base_model
     Vm
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -4,10 +4,6 @@ class Vm < VmOrTemplate
   has_one :container_deployment_node
   include_concern 'Operations'
 
-  extend InterRegionApiMethodRelay
-  api_relay_method :start
-  api_relay_method :stop
-
   def self.base_model
     Vm
   end

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -1,4 +1,13 @@
 module Vm::Operations::Guest
+  extend ActiveSupport::Concern
+
+  included do
+    api_relay_method :shutdown_guest
+    api_relay_method :standby_guest
+    api_relay_method :reboot_guest
+    api_relay_method :reset
+  end
+
   def validate_shutdown_guest
     validate_unsupported("Shutdown Guest Operation")
   end

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -3,7 +3,6 @@ module Vm::Operations::Guest
 
   included do
     api_relay_method :shutdown_guest
-    api_relay_method :standby_guest
     api_relay_method :reboot_guest
     api_relay_method :reset
   end

--- a/app/models/vm/operations/lifecycle.rb
+++ b/app/models/vm/operations/lifecycle.rb
@@ -11,6 +11,12 @@ module Vm::Operations::Lifecycle
         unsupported_reason_add(:migrate, "Migrate operation in not supported.")
       end
     end
+
+    api_relay_method :retire do |options|
+      options
+    end
+
+    api_relay_method :retire_now, :retire
   end
 
   def validate_clone

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -4,6 +4,7 @@ module Vm::Operations::Power
   included do
     api_relay_method :start
     api_relay_method :stop
+    api_relay_method :suspend
   end
 
   def validate_start

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -1,4 +1,11 @@
 module Vm::Operations::Power
+  extend ActiveSupport::Concern
+
+  included do
+    api_relay_method :start
+    api_relay_method :stop
+  end
+
   def validate_start
     validate_vm_control_not_powered_on
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -8,8 +8,6 @@ class VmOrTemplate < ApplicationRecord
   include SupportsFeatureMixin
   include VirtualTotalMixin
 
-  extend InterRegionApiMethodRelay
-
   self.table_name = 'vms'
 
   include_concern 'Operations'

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -8,6 +8,8 @@ class VmOrTemplate < ApplicationRecord
   include SupportsFeatureMixin
   include VirtualTotalMixin
 
+  extend InterRegionApiMethodRelay
+
   self.table_name = 'vms'
 
   include_concern 'Operations'

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -1,0 +1,248 @@
+describe InterRegionApiMethodRelay do
+  let(:collection_name) { :test_class_collection }
+  let(:api_config)      { double("Api::CollectionConfig") }
+
+  context "with a valid class definition" do
+    let!(:test_class) do
+      allow(Api::CollectionConfig).to receive(:new).and_return(api_config)
+      allow(api_config).to receive(:name_for_klass).and_return(collection_name)
+
+      Class.new do
+        extend InterRegionApiMethodRelay
+
+        def self.name
+          "RegionalMethodRelayTestClass"
+        end
+
+        def test_instance_method
+          "my test instance method"
+        end
+        api_relay_method :test_instance_method
+
+        def test_instance_method_action
+        end
+        api_relay_method :test_instance_method_action, :test_instance_method
+
+        def test_instance_method_arg(arg)
+          block_given? ? yield(arg) : arg
+        end
+        api_relay_method :test_instance_method_arg do |arg|
+          arg
+        end
+
+        def self.test_class_method(arg)
+          block_given? ? yield(arg.to_s) : arg.to_s
+        end
+        api_relay_class_method :test_class_method do |arg|
+          [arg[0], arg[1]]
+        end
+
+        def self.test_class_method_action(_arg)
+        end
+        api_relay_class_method :test_class_method_action, :test_class_method do |arg|
+          [arg[0], arg[1]]
+        end
+      end
+    end
+
+    describe ".extended" do
+      it "properly creates the relay classes" do
+        expect(test_class.ancestors.first).to eq(test_class::InstanceMethodRelay)
+        expect(test_class.singleton_class.ancestors.first).to eq(test_class::ClassMethodRelay)
+      end
+    end
+
+    describe "method defined by #api_relay_method" do
+      let(:test_instance) { test_class.new }
+
+      context "when the instance is in my region" do
+        before do
+          expect(test_instance).to receive(:in_current_region?).and_return(true)
+        end
+
+        it "calls the original" do
+          expect(test_instance.test_instance_method).to eq("my test instance method")
+        end
+
+        it "calls the original with arguments" do
+          expect(test_instance.test_instance_method_arg(5)).to eq(5)
+        end
+
+        it "calls the original with a block" do
+          expect { |b| test_instance.test_instance_method_arg(5, &b) }.to yield_with_args(5)
+        end
+      end
+
+      context "when the instance is not in my region" do
+        let(:api_connection) { double("ManageIQ::Api::Client connection") }
+        let(:api_collection) { double("ManageIQ::Api::Client collection") }
+        let(:api_resource)   { double("ManageIQ::Api::Client resource") }
+
+        before do
+          expect(test_instance).to receive(:in_current_region?).and_return(false)
+          expect(test_instance).to receive(:region_number).and_return(0)
+          expect(test_instance).to receive(:id).and_return(123)
+
+          expect(described_class).to receive(:api_client_connection_for_region).with(0).and_return(api_connection)
+          expect(api_connection).to receive(collection_name).and_return(api_collection)
+          expect(api_collection).to receive(:find).with(123).and_return(api_resource)
+        end
+
+        it "executes the method name as an action by default" do
+          expect(api_resource).to receive(:test_instance_method).with({})
+          test_instance.test_instance_method
+        end
+
+        it "executes the action name if given" do
+          expect(api_resource).to receive(:test_instance_method).with({})
+          test_instance.test_instance_method_action
+        end
+
+        it "passes the result of the block as post args" do
+          post_args = {:my => "post args"}
+          expect(api_resource).to receive(:test_instance_method_arg).with(post_args)
+          test_instance.test_instance_method_arg(post_args)
+        end
+      end
+    end
+
+    describe "method defined by #api_relay_class_method" do
+      let(:id)          { 5 }
+      let(:post_args)   { {:do => "these things"} }
+      let(:method_arg)  { [id, post_args] }
+
+      context "when the subject is in my region" do
+        before do
+          expect(test_class).to receive(:id_in_current_region?).with(id).and_return(true)
+        end
+
+        it "calls the original" do
+          expect(test_class.test_class_method(method_arg)).to eq(method_arg.to_s)
+        end
+
+        it "calls the original with a block" do
+          expect { |b| test_class.test_class_method(method_arg, &b) }.to yield_with_args(method_arg.to_s)
+        end
+      end
+
+      context "when the subject is not in my region" do
+        let(:api_connection) { double("ManageIQ::Api::Client connection") }
+        let(:api_collection) { double("ManageIQ::Api::Client collection") }
+
+        before do
+          expect(test_class).to receive(:id_in_current_region?).with(id).and_return(false)
+          expect(test_class).to receive(:id_to_region).with(id).and_return(0)
+          expect(described_class).to receive(:api_client_connection_for_region).with(0).and_return(api_connection)
+          expect(api_connection).to receive(collection_name).and_return(api_collection)
+        end
+
+        it "executes the method name action by default with the second yielded parameter" do
+          expect(api_collection).to receive(:test_class_method).with(post_args)
+          test_class.test_class_method(method_arg)
+        end
+
+        it "executes the action name if given" do
+          expect(api_collection).to receive(:test_class_method).with(post_args)
+          test_class.test_class_method_action(method_arg)
+        end
+      end
+    end
+
+    describe ".api_client_connection_for_region" do
+      let!(:server)           { EvmSpecHelper.local_miq_server(:has_active_webservices => true) }
+      let(:region_seq_start)  { ApplicationRecord.rails_sequence_start }
+      let(:request_user)      { "test_user" }
+      let(:api_connection)    { double("ManageIQ::API::Client connection") }
+      let(:region_auth_token) { double("MiqRegion API auth token") }
+
+      before do
+        FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)
+      end
+
+      it "opens an api connection to that address when the server has an ip address" do
+        require "manageiq-api-client"
+
+        server.ipaddress = "192.0.2.1"
+        server.save!
+
+        expect(User).to receive(:current_userid).and_return(request_user)
+        expect(MiqRegion).to receive(:api_system_auth_token_for_region)
+          .with(ApplicationRecord.my_region_number, request_user).and_return(region_auth_token)
+
+        client_connection_hash = {
+          :url      => "https://#{server.ipaddress}",
+          :miqtoken => region_auth_token,
+          :ssl      => {:verify => false}
+        }
+        expect(ManageIQ::API::Client).to receive(:new).with(client_connection_hash).and_return(api_connection)
+        described_class.api_client_connection_for_region(ApplicationRecord.my_region_number)
+      end
+
+      it "raises if the server doesn't have an ip address" do
+        expect {
+          described_class.api_client_connection_for_region(ApplicationRecord.my_region_number)
+        }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  context "with an invalid class definition" do
+    describe "#api_relay_method" do
+      it "raises a NotImplementedError if the class does not have an api collection" do
+        expect {
+          Class.new do
+            extend InterRegionApiMethodRelay
+
+            def self.name
+              "RegionalMethodRelayTestClass"
+            end
+
+            def test_instance_method
+              "my test instance method"
+            end
+            api_relay_method :test_instance_method
+          end
+        }.to raise_error(NotImplementedError)
+      end
+    end
+
+    describe "#api_relay_class_method" do
+      it "raises a NotImplementedError if the class does not have an api collection" do
+        expect {
+          Class.new do
+            extend InterRegionApiMethodRelay
+
+            def self.name
+              "RegionalMethodRelayTestClass"
+            end
+
+            def self.test_instance_method
+              "my test instance method"
+            end
+            api_relay_class_method :test_instance_method do
+            end
+          end
+        }.to raise_error(NotImplementedError)
+      end
+
+      it "raises a ArgumentError if no block is defined" do
+        allow(Api::CollectionConfig).to receive(:new).and_return(api_config)
+        allow(api_config).to receive(:name_for_klass).and_return(collection_name)
+        expect {
+          Class.new do
+            extend InterRegionApiMethodRelay
+
+            def self.name
+              "RegionalMethodRelayTestClass"
+            end
+
+            def self.test_instance_method
+              "my test instance method"
+            end
+            api_relay_class_method :test_instance_method
+          end
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow any method on a model to be easily routed to a remote region using a new DSL defined by the mixin.

When the method is called it will be first filtered through logic to determine if the subject of the method belongs to the current region. If it does, the call will continue to the model logic, but if it does not, a REST API call will be issued for the method in question.

The blocks that accompany the DSL can be used to deliver API post payload to the relay method based on the parameters of the original method (which will be passed to the block).

In the case of class methods, the block is required and must yield two values, the target resource id (in order to determine the region the call should be relayed to), and then the API post payload (or nil).

Paired with @bdunne on this work.

@Fryguy please review