### PR TITLE
Update rbvmomi to current version

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -38,7 +38,7 @@ gem "pg",                      "~>0.18.2",          :require => false
 gem "pg-dsn_parser",           "~>0.1.0",           :require => false
 gem "psych",                   "~>2.0.12"
 gem "rake",                    "~>10.1"
-gem "rbvmomi",                 "~>1.8.0",           :require => false
+gem "rbvmomi",                 "~>1.9.4",           :require => false
 gem "rest-client",             "~>2.0.0",           :require => false
 gem "rubyzip",                 "~>1.2.0",           :require => false
 gem "rufus-lru",               "~>1.0.3",           :require => false


### PR DESCRIPTION
Now that SPBM is fixed on rbvmomi (https://github.com/vmware/rbvmomi/pull/95), we can update to rbvmomi v1.94.