### PR TITLE
[DARGA] EmsNetworkHelper::TextualSummary - add space between dash and number

### DIFF
--- a/app/helpers/ems_network_helper/textual_summary.rb
+++ b/app/helpers/ems_network_helper/textual_summary.rb
@@ -106,7 +106,7 @@ module EmsNetworkHelper::TextualSummary
     last_refresh_status = @ems.last_refresh_status.titleize
     if @ems.last_refresh_date
       last_refresh_date = time_ago_in_words(@ems.last_refresh_date.in_time_zone(Time.zone)).titleize
-      last_refresh_status << _(" -%{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
+      last_refresh_status << _(" - %{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}
     end
     {
       :label => _("Last Refresh"),


### PR DESCRIPTION
This is a darga-only version of 7cf2bbc (#10165).

You can verify in Network, in textual summary screen.

The master PR only changes one file because it has been unified since. Here, we just fix the one that's different...

(state after this PR:)

```
app/helpers/ems_network_helper/textual_summary.rb
109:      last_refresh_status << _(" - %{last_refresh_date} Ago") % {:last_refresh_date => last_refresh_date}

app/helpers/ems_infra_helper/textual_summary.rb
191:      last_refresh_status << " - #{last_refresh_date} Ago"

app/helpers/ems_middleware_helper/textual_summary.rb
28:      last_refresh_status << " - #{last_refresh_date} Ago"

app/helpers/ems_container_helper/textual_summary.rb
103:      last_refresh_status << " - #{last_refresh_date} Ago"

app/helpers/ems_cloud_helper/textual_summary.rb
157:      last_refresh_status << " - #{last_refresh_date} Ago"
```

(Note that this does mean that that particular string will no longer be translated in darga (unless the catalogs get updated), but since none of the other textual summaries are translated in darga..)