### PR TITLE
Wrong partial in Botllenecks page after checking Show Hosts Events

### DIFF
--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -623,9 +623,9 @@ class MiqCapacityController < ApplicationController
     r = proc { |opts| render_to_string(opts) }
 
     presenter[:osf_node] = x_node
-    if params.key?("tl_report_hosts")
+    if  params.keys.any? { |param| param.include?('tl_report') }
       presenter.replace(:bottlenecks_report_div, r[:partial => 'bottlenecks_report'])
-    elsif params.key?("tl_summ_hosts")
+    elsif params.keys.any? { |param| param.include?('tl_summ') }
       presenter.replace(:bottlenecks_summary_div, r[:partial => 'bottlenecks_summary'])
     else
       presenter.update(:main_div, r[:partial => 'bottlenecks_tabs'])

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -623,7 +623,13 @@ class MiqCapacityController < ApplicationController
     r = proc { |opts| render_to_string(opts) }
 
     presenter[:osf_node] = x_node
-    presenter.update(:main_div, r[:partial => 'bottlenecks_tabs'])
+    if params.key?("tl_report_hosts")
+      presenter.replace(:bottlenecks_report_div, r[:partial => 'bottlenecks_report'])
+    elsif params.key?("tl_summ_hosts")
+      presenter.replace(:bottlenecks_summary_div, r[:partial => 'bottlenecks_summary'])
+    else
+      presenter.update(:main_div, r[:partial => 'bottlenecks_tabs'])
+    end
     presenter[:build_calendar] = true
     presenter[:right_cell_text] = @right_cell_text
 

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -623,7 +623,7 @@ class MiqCapacityController < ApplicationController
     r = proc { |opts| render_to_string(opts) }
 
     presenter[:osf_node] = x_node
-    if  params.keys.any? { |param| param.include?('tl_report') }
+    if params.keys.any? { |param| param.include?('tl_report') }
       presenter.replace(:bottlenecks_report_div, r[:partial => 'bottlenecks_report'])
     elsif params.keys.any? { |param| param.include?('tl_summ') }
       presenter.replace(:bottlenecks_summary_div, r[:partial => 'bottlenecks_summary'])


### PR DESCRIPTION
Optimize -> Bottlenecks -> choose a provider

After checking/unchecking Show Hosts Events in Report it shows Summary page instead. It should stay on Report page.

After checking/unchecking Show Hosts Events in Report:
Before:
![screen shot 2016-10-10 at 1 33 15 pm](https://cloud.githubusercontent.com/assets/9210860/19234826/5dbdb6fa-8eee-11e6-8761-904ceeea1287.png)
After:
![screen shot 2016-10-10 at 1 33 01 pm](https://cloud.githubusercontent.com/assets/9210860/19234829/62401c36-8eee-11e6-87ff-bde71bb3c819.png)

Links:
https://bugzilla.redhat.com/show_bug.cgi?id=1358154

@miq-bot add_label bug, ui
