### PR TITLE
Remove unused and borked hardware_disk_storages

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -13,8 +13,6 @@ class Hardware < ApplicationRecord
   has_many    :floppies, -> { where("device_type = 'floppy'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
   has_many    :cdroms, -> { where("device_type LIKE '%cdrom%'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
 
-  has_many    :hard_disk_storages, -> { distinct }, :through => :hard_disks, :source => :storage
-
   has_many    :partitions, :dependent => :destroy
   has_many    :volumes, :dependent => :destroy
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1616,10 +1616,6 @@ class VmOrTemplate < ApplicationRecord
     hardware.nil? ? [] : hardware.mac_addresses
   end
 
-  def hard_disk_storages
-    hardware.nil? ? [] : hardware.hard_disk_storages
-  end
-
   def processes
     operating_system.nil? ? [] : operating_system.processes
   end


### PR DESCRIPTION
Unused since 7e92388f5b4bb6d07ebd9b39ce9130335d0d53ef.
Broken since bc865e6d3ac430dbf4e9c620861f5cee1ecae8b7.

When used
```
ActiveRecord::StatementInvalid: PG::InvalidColumnReference: ERROR: for
SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ...ppy' AND device_type NOT LIKE '%cdrom%') ORDER BY "disks"."l...
                                                             ^
SELECT DISTINCT "storages".* FROM "storages" INNER JOIN "disks"
  ON "storages"."id" = "disks"."storage_id"
  WHERE "disks"."hardware_id" = $1 AND (device_type != 'floppy'
  AND device_type NOT LIKE '%cdrom%') ORDER BY "disks"."location" ASC
```

@miq-bot add_label technical debt, core