### PR TITLE
Explorer js - reloadToolbars being empty array means don't update toolbars, not remove

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -213,12 +213,14 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
       .html(data.rightCellText);
   }
 
-
-  if (_.isArray(data.reloadToolbars)) {
+  if (_.isArray(data.reloadToolbars) && data.reloadToolbars.length) {
     ManageIQ.angular.rxSubject.onNext({
       redrawToolbar: data.reloadToolbars
-    })
-  } else if (_.isObject(data.reloadToolbars)) {
+    });
+  } else if (_.isObject(data.reloadToolbars) && !_.isArray(data.reloadToolbars)) {
+    // FIXME remove this branch completely once sure
+    console.error('Found a toolbar using the obsolete path! Please report or fix');
+
     _.forEach(data.reloadToolbars, function (content, element) {
       $('#' + element).html(content);
     });


### PR DESCRIPTION
Right now, when the ExplorerPresenter genereates `data.reloadToolbars` to be an empty array, the toolbar simply disappears.

Instead, it should not be touched - adding a length check to the array.

Also, the `isObject` code path exists solely for backward compatibility purposes, adding a big warning to catch these and a FIXME to remove eventually.


Steps to reproduce: `Optimize -> Bottlenecks -> choose a provider`. Change a value in any of the selects. Without this, the toolbar will disappear.

Cc: @karelhala , @martinpovolny 