### PR TITLE
Remove old methods for loading virtual columns

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -205,7 +205,7 @@ class MiqReport < ApplicationRecord
   def load_custom_attributes
     klass = db.safe_constantize
     return unless klass < CustomAttributeMixin
-    cols.concat(conditions.custom_attribute_columns) if conditions.present?
+
     klass.load_custom_attributes_for(cols.uniq)
   end
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1581,25 +1581,6 @@ class MiqExpression
     end
   end
 
-  def custom_attribute_columns(expression = nil)
-    return custom_attribute_columns(exp).uniq if expression.nil?
-
-    case expression
-    when Array
-      expression.flat_map { |x| custom_attribute_columns(x) }
-    when Hash
-      expression_values = expression.values
-
-      if expression.keys.first == "field"
-        field = Field.parse(expression_values.first)
-        field.custom_attribute_column? ? [field.column] : []
-      else
-        expression.keys.first.casecmp('find').try(:zero?) ? [] : custom_attribute_columns(expression_values)
-      end
-    else
-      []
-    end
-  end
 
   private
 

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -171,8 +171,7 @@ describe MiqReport do
         x.data
       end
 
-      expected_results = ["name" => vm_2.name, virtual_column_key_1 => nil, virtual_column_key_2 => custom_column_value,
-                          virtual_column_key_3 => custom_column_value]
+      expected_results = ["name" => vm_2.name, virtual_column_key_1 => nil, virtual_column_key_2 => custom_column_value]
 
       expect(report_result).to match_array(expected_results)
     end


### PR DESCRIPTION
we are loading virtual custom columns from MiqExpression
when MiqExpression object is created #11369

so don't need to load it in when report is generated.

@miq-bot add_label reporting, technical-debt