### PR TITLE
Fixed parsing in miq_policy_controller for the conditions view

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -634,11 +634,11 @@ class MiqPolicyController < ApplicationController
                         else
                           if @right_cell_text == @edit
                             _("Editing %{model} Condition \"%{name}\"") %
-                            {:name  => @condition.description.gsub(/'/) {"\'"},
+                            {:name  => @condition.description,
                              :model => ui_lookup(:model => @edit[:new][:towhat])}
                           else
                             _("%{model} Condition \"%{name}\"") %
-                            {:name  => @condition.description.gsub(/'/) {"\'"},
+                            {:name  => @condition.description,
                              :model => ui_lookup(:model => @condition.towhat)}
                           end
                         end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -634,11 +634,11 @@ class MiqPolicyController < ApplicationController
                         else
                           if @right_cell_text == @edit
                             _("Editing %{model} Condition \"%{name}\"") %
-                            {:name  => @condition.description.gsub(/'/, "\\'"),
+                            {:name  => @condition.description.gsub(/'/) {"\'"},
                              :model => ui_lookup(:model => @edit[:new][:towhat])}
                           else
                             _("%{model} Condition \"%{name}\"") %
-                            {:name  => @condition.description.gsub(/'/, "\\'"),
+                            {:name  => @condition.description.gsub(/'/) {"\'"},
                              :model => ui_lookup(:model => @condition.towhat)}
                           end
                         end


### PR DESCRIPTION
bz: 
- https://bugzilla.redhat.com/show_bug.cgi?id=1380683

issues: 
- https://github.com/ManageIQ/manageiq/issues/10272
- https://github.com/ManageIQ/manageiq/issues/10539

before: 
![screenshot from 2016-10-10 14-02-36](https://cloud.githubusercontent.com/assets/8366181/19237522/fa2e1522-8f05-11e6-9cce-b9b370641d15.png)
after:
![screenshot from 2016-10-10 16-04-14](https://cloud.githubusercontent.com/assets/8366181/19237525/000d9774-8f06-11e6-8580-f2b1ad135a17.png)

This bug was caused because of special character interpretation used on the replacement parameter passed to gsub - this only happens when gsub is used in the form of gsub(exp, replacement), for this reason and also for aesthetic reasons I believe we should use the gsub(exp) {replacement} form instead.

@cben @zeari 
@simon3z    

