### PR TITLE
Always use explorer layout in datastores screen

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -2610,7 +2610,7 @@ module ApplicationController::CiProcessing
     storages = []
 
     # Either a list or coming from a different controller (eg from host screen, go to its storages)
-    if %w(show_list storage_list storage_pod_list).include?(@lastaction) || @layout != "storage"
+    if params.key?(:miq_grid_checks)
       storages = find_checked_items
 
       if method == 'scan' && !Storage.batch_operation_supported?('smartstate_analysis', storages)

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -414,6 +414,7 @@ class StorageController < ApplicationController
     end
 
     build_accordions_and_trees
+    @lastaction = "explorer" # restore the explorer layout, which was changed by process_show_list() to "show_list"
 
     render :layout => "application"
   end


### PR DESCRIPTION
The `process_show_list()` routine would change the previously set `@lastaction` to `"show_list"`.
We need to restore the explorer layout here, otherwise the datastores screen would be incorrectly
rendered with a listnav controls on the left (rather than tree controls).

As a side effect of this fix, the advanced search clear function will work correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1381614