### PR TITLE
Enable custom attributes for chargeback reports 

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1487,7 +1487,7 @@ module ReportController::Reports::Editor
       f_len = fields.length
       for f_idx in 1..f_len # Go thru fields in reverse
         f_key = fields[f_len - f_idx].last
-        next if f_key.ends_with?(*CHARGEBACK_ALLOWED_FIELD_SUFFIXES) || f_key.include?('managed')
+        next if f_key.ends_with?(*CHARGEBACK_ALLOWED_FIELD_SUFFIXES) || f_key.include?('managed') || f_key.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
         headers.delete(f_key)
         col_formats.delete(f_key)
         fields.delete_at(f_len - f_idx)

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -23,7 +23,8 @@ class ChargebackContainerImage < Chargeback
     :memory_used_metric    => :float,
     :net_io_used_cost      => :float,
     :net_io_used_metric    => :float,
-    :total_cost            => :float
+    :total_cost            => :float,
+    :entity                => :binary
   )
 
   def self.build_results_for_report_ChargebackContainerImage(options)

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -22,7 +22,8 @@ class ChargebackContainerProject < Chargeback
     :memory_used_metric    => :float,
     :net_io_used_cost      => :float,
     :net_io_used_metric    => :float,
-    :total_cost            => :float
+    :total_cost            => :float,
+    :entity                => :binary
   )
 
   def self.build_results_for_report_ChargebackContainerProject(options)
@@ -97,10 +98,6 @@ class ChargebackContainerProject < Chargeback
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}
     }
-  end
-
-  def tags
-    ContainerProject.includes(:tags).find_by_ems_ref(project_uid).try(:tags).to_a
   end
 
   def get_rate_parents(perf)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -44,7 +44,8 @@ class ChargebackVm < Chargeback
     :storage_used_metric      => :float,
     :storage_cost             => :float,
     :storage_metric           => :float,
-    :total_cost               => :float
+    :total_cost               => :float,
+    :entity                   => :binary
   )
 
   def self.build_results_for_report_ChargebackVm(options)
@@ -161,10 +162,6 @@ class ChargebackVm < Chargeback
       "storage_used_metric"      => {:grouping => [:total]},
       "total_cost"               => {:grouping => [:total]}
     }
-  end
-
-  def tags
-    Vm.includes(:tags).find_by_ems_ref(vm_uid).try(:tags).to_a
   end
 
   def get_rate_parents(perf)

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -204,7 +204,7 @@ class MiqReport < ApplicationRecord
 
   def load_custom_attributes
     klass = db.safe_constantize
-    return unless klass < CustomAttributeMixin
+    return unless klass < CustomAttributeMixin || Chargeback.db_is_chargeback?(db)
 
     klass.load_custom_attributes_for(cols.uniq)
   end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1200,7 +1200,7 @@ class MiqExpression
       cb_model = Chargeback.report_cb_model(model)
       @reporting_available_fields[model.to_s] ||=
         MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) } +
-        MiqExpression.tag_details(cb_model, model, {})
+        MiqExpression.tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
     else
       @reporting_available_fields[model.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true)
     end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1382720
When the report generator asks for the newly defined `CustomAttribute` method, direct it to the entity class instead of the chargeback class. Each chargeback line will contain the entity(Vm/Project) required for this.

```Ruby
[root@mtayer-centos7-3 ~]# oc describe project demo2
Name:			demo2
Created:		4 days ago
Labels:			zone=east   <---------
```
`zone` becomes an available column:
![screencapture-localhost-3000-report-explorer-1476366649951](https://cloud.githubusercontent.com/assets/11256940/19351630/38f8defc-9165-11e6-9089-ab5d3068c37f.png)

yields report(blank where `zone` not defined):
![screencapture-localhost-3000-report-explorer-1476366855676](https://cloud.githubusercontent.com/assets/11256940/19351762/b0a272ce-9165-11e6-8610-8d1ca5ca0997.png)


@lpichler @gtanzillo Please review
cc @simon3z 