### PR TITLE
Don't run the pending blueprints specs

### DIFF
--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -199,8 +199,7 @@ RSpec.describe "Blueprints API" do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "can publish multiple blueprints" do
-      pending("update to Blueprint#publish")
+    xit "can publish multiple blueprints" do
       blueprint1, blueprint2 = FactoryGirl.create_list(:blueprint, 2)
 
       api_basic_authorize collection_action_identifier(:blueprints, :publish)
@@ -247,8 +246,7 @@ RSpec.describe "Blueprints API" do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "publishes a single blueprint" do
-      pending("update to Blueprint#publish")
+    xit "publishes a single blueprint" do
       blueprint = FactoryGirl.create(:blueprint)
       api_basic_authorize action_identifier(:blueprints, :publish)
 


### PR DESCRIPTION
Marking tests `pending` can be useful if iterating rapidly, but leaving
this in master can lead to some confusion over what is failing because
the output from the reporter looks almost identical to something that
failed. Marking these tests using `xit` instead will still leave them
pending but won't run the code contained in them:

```
bundle exec rspec --format progress /home/tim/src/manageiq/spec/requests/api/blueprints_spec.rb

Randomized with seed 39352
..*.........*........

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Blueprints API POST /api/blueprints can publish multiple blueprints
     # Temporarily skipped with xit
     # ./spec/requests/api/blueprints_spec.rb:202

  2) Blueprints API POST /api/blueprints/:id publishes a single blueprint
     # Temporarily skipped with xit
     # ./spec/requests/api/blueprints_spec.rb:249

Finished in 5.12 seconds (files took 7.5 seconds to load)
21 examples, 0 failures, 2 pending
```

@miq-bot add-label api, test
@miq-bot assign @abellotti 