### PR TITLE
Display Advanced Search in Configuration management

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -763,7 +763,7 @@ module ApplicationController::Filter
     if ["delete", "saveit"].include?(params[:button])
       if @edit[:in_explorer]
         if "cs_filter_tree" == x_active_tree.to_s
-          build_configuration_mananger_tree(:cs_filter, x_active_tree)
+          build_configuration_manager_tree(:cs_filter, x_active_tree)
         else
           tree_type = x_active_tree.to_s.sub(/_tree/, '').to_sym
           builder = TreeBuilder.class_for_type(tree_type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -859,6 +859,7 @@ module ApplicationHelper
        ontap_storage_volume
        orchestration_stack
        persistent_volume
+       provider_foreman
        resource_pool
        retired
        security_group
@@ -1459,6 +1460,7 @@ module ApplicationHelper
       ontap_storage_volume
       orchestration_stack
       persistent_volume
+      provider_foreman
       resource_pool
       retired
       security_group


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1381631

Display Advanced Search when clicking on the button
when reaching Configuration -> Configuration Management
and selecting Configured Systems or Ansible Tower Job Templates.
