### PR TITLE
Toolbar button for Assigned Server Role

### DIFF
--- a/app/helpers/application_helper/button/delete_server.rb
+++ b/app/helpers/application_helper/button/delete_server.rb
@@ -1,0 +1,17 @@
+class ApplicationHelper::Button::DeleteServer < ApplicationHelper::Button::ZoneDeleteServer
+  needs :@record
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if disabled?
+  end
+
+  def disabled?
+    @error_message = unless @record.is_deleteable?
+                       N_("Server %{server_name} [%{server_id}] can only be deleted if it is stopped or has not responded for a while") %
+                         {:server_name => @record.name, :server_id => @record.id}
+                     end
+    @error_message.present?
+  end
+
+end

--- a/app/helpers/application_helper/button/zone_delete_server.rb
+++ b/app/helpers/application_helper/button/zone_delete_server.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::ZoneDeleteServer < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+     x_active_tree == :diagnostics_tree &&
+       %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab]) &&
+       @record.class == MiqServer
+  end
+end

--- a/app/helpers/application_helper/button/zone_delete_server.rb
+++ b/app/helpers/application_helper/button/zone_delete_server.rb
@@ -2,7 +2,7 @@ class ApplicationHelper::Button::ZoneDeleteServer < ApplicationHelper::Button::B
   needs :@record
 
   def visible?
-     x_active_tree == :diagnostics_tree &&
+     @view_context.x_active_tree == :diagnostics_tree &&
        %w(diagnostics_roles_servers diagnostics_servers_roles).include?(@sb[:active_tab]) &&
        @record.class == MiqServer
   end

--- a/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_region_center.rb
@@ -23,7 +23,8 @@ class ApplicationHelper::Toolbar::DiagnosticsRegionCenter < ApplicationHelper::T
           :confirm => proc do
                         _("Do you want to delete Server %{server_name} [%{server_id}]?") %
                           {:server_name => @record.name, :server_id => @record.id}
-                      end
+                      end,
+          :klass => ApplicationHelper::Button::DeleteServer
         ),
         button(
           :role_start,

--- a/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
+++ b/app/helpers/application_helper/toolbar/diagnostics_zone_center.rb
@@ -25,7 +25,8 @@ class ApplicationHelper::Toolbar::DiagnosticsZoneCenter < ApplicationHelper::Too
                           :server_name => @record.name,
                           :server_id   => @record.id
                         }
-                      end
+                      end,
+          :klass => ApplicationHelper::Button::ZoneDeleteServer
         ),
         button(
           :zone_role_start,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -423,8 +423,6 @@ class ApplicationHelper::ToolbarBuilder
         case id
         when "reload_server_tree"
           return false
-        when "delete_server"
-          return @record.class != MiqServer
         when "zone_collect_current_logs", "zone_collect_logs", "zone_log_depot_edit"
           return true
         end
@@ -668,11 +666,6 @@ class ApplicationHelper::ToolbarBuilder
 
     # Now check model/record specific rules
     case get_record_cls(@record)
-    when "AssignedServerRole"
-      case id
-      when "delete_server"
-        return true
-      end
     when "MiqAeClass", "MiqAeDomain", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
       return true unless role_allows?(:feature => "miq_ae_domain_edit")
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
@@ -896,11 +889,6 @@ class ApplicationHelper::ToolbarBuilder
         end
         unless @record.log_file_depot
           return N_("Log collection requires the Log Depot settings to be configured")
-        end
-      when "delete_server"
-        unless @record.is_deleteable?
-          return N_("Server %{server_name} [%{server_id}] can only be deleted if it is stopped or has not responded for a while") %
-            {:server_name => @record.name, :server_id => @record.id}
         end
       when "restart_workers"
         return N_("Select a worker to restart") if @sb[:selected_worker_id].nil?

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -423,7 +423,7 @@ class ApplicationHelper::ToolbarBuilder
         case id
         when "reload_server_tree"
           return false
-        when "delete_server", "zone_delete_server"
+        when "delete_server"
           return @record.class != MiqServer
         when "zone_collect_current_logs", "zone_collect_logs", "zone_log_depot_edit"
           return true

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -658,23 +658,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when with AssignedServerRole" do
-      before do
-        @record = AssignedServerRole.new
-        stub_user(:features => :all)
-      end
-
-      it "and id = delete_server" do
-        @id = "delete_server"
-        expect(subject).to be_truthy
-      end
-
-      it "and id != server_delete" do
-        @id = "server_add"
-        expect(subject).to be_falsey
-      end
-    end
-
     context "CustomButtonSet" do
       before do
         @record = CustomButtonSet.new
@@ -1065,18 +1048,6 @@ describe ApplicationHelper do
 
       before do
         @record = MiqServer.new('name' => 'Server1', 'id' => 'Server ID')
-      end
-
-      context "and id = delete_server" do
-        before do
-          @id = "delete_server"
-        end
-        it "is deleteable?" do
-          allow(@record).to receive(:is_deleteable?).and_return(false)
-          expect(subject).to include('Server ')
-          expect(subject).to include('can only be deleted if it is stopped or has not responded for a while')
-        end
-        it_behaves_like 'default case'
       end
 
       it "'collecting' log_file with started server and disables button" do


### PR DESCRIPTION
Toolbar buttons for AssignedServerRole class moved from toolbar builder to separate button class

| Toolbar buttons id | Toolbar buttons class |
| --- | --- |
| `zone_delete_server` | `ZoneDeleteServer` |
| `delete_server` | `DeleteServer < ZoneDeleteServer` |
## Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/126782031
