### PR TITLE
Fetch a shallow branch when running in the CI environment

### DIFF
--- a/lib/tasks/test_replication.rake
+++ b/lib/tasks/test_replication.rake
@@ -58,7 +58,7 @@ class EvmTestSetupReplication
   private
 
   def released_migrations
-    unless system("git fetch http://github.com/ManageIQ/manageiq.git refs/heads/euwe:#{TEST_BRANCH}")
+    unless system(fetch_command)
       return []
     end
     files = `git ls-tree -r --name-only #{TEST_BRANCH} db/migrate/`
@@ -73,6 +73,10 @@ class EvmTestSetupReplication
     migrations.keep_if { |timestamp| timestamp =~ /\d+/ }
   ensure
     `git branch -D #{TEST_BRANCH}`
+  end
+
+  def fetch_command
+    "git fetch #{'--depth=1 ' if ENV['CI']}http://github.com/ManageIQ/manageiq.git refs/heads/euwe:#{TEST_BRANCH}"
   end
 
   def prepare_slave_database


### PR DESCRIPTION
This prevents us from messing with user's local repos, but also allows the fetch to be faster when running in CI.

Original PR to remove shallow fetch: https://github.com/ManageIQ/manageiq/pull/11769

@jrafanie @Fryguy please review