### PR TITLE
Add ::ContainerManager to the TAG_CLASSES to display its tags in adva…

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -238,6 +238,7 @@ class MiqExpression
     'ManageIQ::Providers::CloudManager'           => 'ext_management_system',
     'EmsCluster'                                  => 'ems_cluster',
     'ManageIQ::Providers::InfraManager'           => 'ext_management_system',
+    'ManageIQ::Providers::ContainerManager'       => 'ext_management_system',
     'ExtManagementSystem'                         => 'ext_management_system',
     'Host'                                        => 'host',
     'MiqGroup'                                    => 'miq_group',


### PR DESCRIPTION
The advanced search was missing the own tags for the ```::ContainerManager``` (Container Providers), this PR's fixing the issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1372442