### PR TITLE
Include .rake files in codeclimate analysis.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -57,6 +57,7 @@ ratings:
   - Gemfile.lock
   - "**.erb"
   - "**.haml"
+  - "**.rake"
   - "**.rb"
   - "**.rhtml"
   - "**.slim"


### PR DESCRIPTION
We should be reviewing .rake files and we're not.  Saw this when looking at #11799

[skip ci]

cc @carbonin