### PR TITLE
Enable eslint-3 on codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,9 +46,8 @@ engines:
       - ruby
       - javascript
   eslint:
-    # Still failing :sad_panda:
-    enabled: false
-    channel: "eslint-2"
+    enabled: true
+    channel: "eslint-3"
   fixme:
     # let's enable later
     enabled: false


### PR DESCRIPTION
Try eslint-3

Note: eslint-config-airbnb is not yet supported directly in the eslint-3 code climate engine, so #12059 in-lined the config for now.

https://docs.codeclimate.com/docs/eslint#eslint-versions

[skip ci]