### PR TITLE
Fix for timeline scss missing from build

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,6 +23,7 @@
  *= require container_providers_dashboard
  *= require wizard
  *= require template
+ *= require timeline
  *= require topology
  *= require container_topology
  *= require middleware_topology


### PR DESCRIPTION
This adds the timeline scss file so CloudForms displays it correct now (it worked correctly in the development build but not when switched to CF.

bz:
- https://bugzilla.redhat.com/show_bug.cgi?id=1382648

Before:
![before](https://cloud.githubusercontent.com/assets/7306953/19246790/18c58bba-8ef6-11e6-93f2-b6f72a12a955.png)

After:
![after png](https://cloud.githubusercontent.com/assets/7306953/19246793/1f3d8c18-8ef6-11e6-9d7e-b5da4ea0ffec.png)



@dclarizio @h-kataria 