### PR TITLE
Handle authentication_check on hosts with no credentials

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -246,11 +246,11 @@ module AuthenticationMixin
   def authentication_check(*args)
     options         = args.last.kind_of?(Hash) ? args.last : {}
     save            = options.fetch(:save, true)
-    type            = args.first
-    auth            = authentication_best_fit(type)
-    status, details = authentication_check_no_validation(type || auth.authtype, options)
+    auth            = authentication_best_fit(args.first)
+    type            = args.first || auth.try(:authtype)
+    status, details = authentication_check_no_validation(type, options)
 
-    if save
+    if auth && save
       status == :valid ? auth.validation_successful : auth.validation_failed(status, details)
     end
 

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -158,8 +158,9 @@ describe AuthenticationMixin do
 
     context "with a host and ems" do
       before(:each) do
-        @host = FactoryGirl.create(:host_vmware_esx_with_authentication)
-        @ems  = FactoryGirl.create(:ems_vmware_with_authentication)
+        @host         = FactoryGirl.create(:host_vmware_esx_with_authentication)
+        @host_no_auth = FactoryGirl.create(:host_vmware_esx)
+        @ems          = FactoryGirl.create(:ems_vmware_with_authentication)
         MiqQueue.destroy_all
         @auth = @ems.authentication_type(:default)
         @orig_ems_user, @orig_ems_pwd = @ems.auth_user_pwd(:default)
@@ -366,8 +367,7 @@ describe AuthenticationMixin do
         end
 
         it "missing credentials" do
-          allow(@host).to receive(:missing_credentials?).and_return(true)
-          expect(@host.authentication_check).to eq([false, "Missing credentials"])
+          expect(@host_no_auth.authentication_check).to eq([false, "Missing credentials"])
         end
 
         it "verify_credentials fails" do


### PR DESCRIPTION
The schedule worker runs an `authentication_check` on all hosts once a day, if these hosts do not have any saved credentials the `authentication_check` method throws an exception because it does not check for `auth.nil?` before running `auth.authtype` or `auth.validation_failed`.

```
MIQ(MiqQueue#deliver) Message id: [1000012731760], Error: [undefined method `authtype' for nil:NilClass]
[----] E, [2016-09-30T14:28:20.159937 #121870:130f998] ERROR -- : [NoMethodError]: undefined method `authtype' for nil:NilClass  Method:[rescue in deliver]
[----] E, [2016-09-30T14:28:20.160112 #121870:130f998] ERROR -- : /var/www/miq/vmdb/app/models/mixins/authentication_mixin.rb:258:in `authentication_check'
/var/www/miq/vmdb/app/models/mixins/authentication_mixin.rb:236:in `block in authentication_check_types'
/var/www/miq/vmdb/app/models/mixins/authentication_mixin.rb:236:in `each'
/var/www/miq/vmdb/app/models/mixins/authentication_mixin.rb:236:in `authentication_check_types'
```

The spec test wasn't catching this because the mocked host had credentials, it just stubbed `missing_credentials?` to return `true`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1382684