### PR TITLE
Rewrite of auto-tagging, fixing multiple bugs

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -16,13 +16,8 @@ class ContainerLabelTagMapping < ApplicationRecord
 
   # Returns {[name, type, value] => [tag_id, ...]}}} hash.  Pass it to map_* methods.
   def self.cache
-    hash = {}
-    find_each do |m|
-      key = [m.label_name, m.labeled_resource_type, m.label_value].freeze
-      hash[key] ||= []
-      hash[key] << m.tag_id
-    end
-    hash
+    find_each.group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
+             .transform_values { |mappings| mappings.collect(&:tag_id) }
   end
 
   # We expect labels to be {:name, :value} hashes

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -14,10 +14,12 @@ class ContainerLabelTagMapping < ApplicationRecord
 
   belongs_to :tag
 
-  # Returns {[name, type, value] => [tag_id, ...]}}} hash.  Pass it to map_* methods.
+  # Pass the data this returns to map_* methods.
   def self.cache
-    find_each.group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
-             .transform_values { |mappings| mappings.collect(&:tag_id) }
+    # {[name, type, value] => [tag_id, ...]}
+    in_my_region.find_each
+                .group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
+                .transform_values { |mappings| mappings.collect(&:tag_id) }
   end
 
   # We expect labels to be {:name, :value} hashes

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -44,14 +44,12 @@ class ContainerLabelTagMapping < ApplicationRecord
     if !specific_value.empty?
       specific_value.map { |tag_id| {:tag_id => tag_id} }
     else
-      # Note: if the way we compute `entry_name` changes,
-      # consider what will happen to previously created tags.
-      any_value.map do |tag_id|
-        if value.empty?
-          {:category_tag_id   => tag_id,
-           :entry_name        => ':empty:', # ':' character won't occur in kubernetes values.
-           :entry_description => '<empty value>'}
-        else
+      if value.empty?
+        [] # Don't map empty value to any tag.
+      else
+        # Note: if the way we compute `entry_name` changes,
+        # consider what will happen to previously created tags.
+        any_value.map do |tag_id|
           {:category_tag_id   => tag_id,
            :entry_name        => Classification.sanitize_name(value),
            :entry_description => value}

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -420,10 +420,17 @@ module EmsRefresh::SaveInventoryContainer
                      :name          => label_hash[:name],
                      :value         => label_hash[:value])
     end
-    current_tags = labels.collect_concat { |label| ContainerLabelTagMapping.tags_for_label(label) }
-    mappable_tags = ContainerLabelTagMapping.mappable_tags
 
-    entity.tags = entity.tags - mappable_tags + current_tags
+    begin
+      current_tags = labels.collect_concat { |label| ContainerLabelTagMapping.tags_for_label(label) }
+      mappable_tags = ContainerLabelTagMapping.mappable_tags
+      entity.tags = entity.tags - mappable_tags + current_tags
+    rescue => err
+      raise if EmsRefresh.debug_failures
+      _log.error("Auto-tagging failed on #{entity.class} [#{entity.name}] with error [#{err}].")
+      _log.error("Labels: [#{labels}]")
+      _log.log_backtrace(err)
+    end
   end
 
   def save_selector_parts_inventory(entity, hashes, target = nil)

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -422,9 +422,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     begin
-      current_tags = labels.collect_concat { |label| ContainerLabelTagMapping.tags_for_label(label) }
-      mappable_tags = ContainerLabelTagMapping.mappable_tags
-      entity.tags = entity.tags - mappable_tags + current_tags
+      ContainerLabelTagMapping.retag_entity(entity, labels)
     rescue => err
       raise if EmsRefresh.debug_failures
       _log.error("Auto-tagging failed on #{entity.class} [#{entity.name}] with error [#{err}].")

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -28,7 +28,7 @@ module EmsRefresh::SaveInventoryContainer
               end
 
     save_inventory_multi(ems.container_projects, hashes, deletes, [:ems_ref],
-                         [:labels_and_tags], [], true)
+                         [:labels, :tags], [], true)
     store_ids_for_new_records(ems.container_projects, hashes, :ems_ref)
   end
 
@@ -146,7 +146,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_routes, hashes, deletes, [:ems_ref],
-                         [:labels_and_tags], [:container_service, :project, :namespace])
+                         [:labels, :tags], [:container_service, :project, :namespace])
     store_ids_for_new_records(ems.container_routes, hashes, :ems_ref)
   end
 
@@ -162,7 +162,7 @@ module EmsRefresh::SaveInventoryContainer
               end
 
     save_inventory_multi(ems.container_nodes, hashes, deletes, [:ems_ref],
-                         [:labels_and_tags, :computer_system, :container_conditions], [:namespace])
+                         [:labels, :tags, :computer_system, :container_conditions], [:namespace])
     store_ids_for_new_records(ems.container_nodes, hashes, :ems_ref)
   end
 
@@ -186,7 +186,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_replicators, hashes, deletes, [:ems_ref],
-                         [:labels_and_tags, :selector_parts], [:project, :namespace])
+                         [:labels, :tags, :selector_parts], [:project, :namespace])
     store_ids_for_new_records(ems.container_replicators, hashes, :ems_ref)
   end
 
@@ -208,7 +208,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_services, hashes, deletes, [:ems_ref],
-                         [:labels_and_tags, :selector_parts, :container_service_port_configs],
+                         [:labels, :tags, :selector_parts, :container_service_port_configs],
                          [:container_groups, :project, :container_image_registry, :namespace])
 
     store_ids_for_new_records(ems.container_services, hashes, :ems_ref)
@@ -234,7 +234,7 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_groups, hashes, deletes, [:ems_ref],
-                         [:container_definitions, :containers, :labels_and_tags,
+                         [:container_definitions, :containers, :labels, :tags,
                           :node_selector_parts, :container_conditions, :container_volumes],
                          [:container_node, :container_replicator, :project, :namespace, :build_pod_name],
                          true)
@@ -409,26 +409,14 @@ module EmsRefresh::SaveInventoryContainer
     store_ids_for_new_records(entity.labels, hashes, [:section, :name])
   end
 
-  def save_labels_and_tags_inventory(entity, hashes, target = nil)
-    save_labels_inventory(entity, hashes, target)
-    save_tags_generated_from_labels(entity, hashes, target)
-  end
+  def save_tags_inventory(entity, hashes, _target = nil)
+    return if hashes.nil?
 
-  def save_tags_generated_from_labels(entity, hashes, _target = nil)
-    labels = hashes.collect do |label_hash|
-      OpenStruct.new(:resource_type => entity.class.base_class.name,
-                     :name          => label_hash[:name],
-                     :value         => label_hash[:value])
-    end
-
-    begin
-      ContainerLabelTagMapping.retag_entity(entity, labels)
-    rescue => err
-      raise if EmsRefresh.debug_failures
-      _log.error("Auto-tagging failed on #{entity.class} [#{entity.name}] with error [#{err}].")
-      _log.error("Labels: [#{labels}]")
-      _log.log_backtrace(err)
-    end
+    ContainerLabelTagMapping.retag_entity(entity, hashes) # Keeps user-assigned tags.
+  rescue => err
+    raise if EmsRefresh.debug_failures
+    _log.error("Auto-tagging failed on #{entity.class} [#{entity.name}] with error [#{err}].")
+    _log.log_backtrace(err)
   end
 
   def save_selector_parts_inventory(entity, hashes, target = nil)
@@ -469,7 +457,7 @@ module EmsRefresh::SaveInventoryContainer
     hashes.each do |h|
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
-    save_inventory_multi(ems.container_builds, hashes, deletes, [:ems_ref], [:labels_and_tags],
+    save_inventory_multi(ems.container_builds, hashes, deletes, [:ems_ref], [:labels, :tags],
                          [:project, :resources])
     store_ids_for_new_records(ems.container_builds, hashes, :ems_ref)
   end

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -10,6 +10,7 @@ module ManageIQ::Providers::Kubernetes
     def initialize
       @data = {}
       @data_index = {}
+      @label_tag_mapping = ContainerLabelTagMapping.cache
     end
 
     def ems_inv_to_hashes(inventory)
@@ -138,6 +139,10 @@ module ManageIQ::Providers::Kubernetes
       new_result
     end
 
+    def map_labels(model_name, labels)
+      ContainerLabelTagMapping.map_labels(@label_tag_mapping, model_name, labels)
+    end
+
     def find_host_by_provider_id(provider_id)
       scheme, instance_uri = provider_id.split("://", 2)
       prov, name_field = scheme_to_provider_mapping[scheme]
@@ -187,12 +192,14 @@ module ManageIQ::Providers::Kubernetes
     def parse_node(node)
       new_result = parse_base_item(node)
 
+      labels = parse_labels(node)
       new_result.merge!(
-        :type            => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
-        :identity_infra  => node.spec.providerID,
-        :labels_and_tags => parse_labels(node),
-        :lives_on_id     => nil,
-        :lives_on_type   => nil
+        :type           => 'ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode',
+        :identity_infra => node.spec.providerID,
+        :labels         => labels,
+        :tags           => map_labels('ContainerNode', labels),
+        :lives_on_id    => nil,
+        :lives_on_type  => nil
       )
 
       node_info = node.status.try(:nodeInfo)
@@ -250,13 +257,14 @@ module ManageIQ::Providers::Kubernetes
         container_groups << cg unless cg.nil?
       end
 
+      labels = parse_labels(service)
       new_result.merge!(
         # TODO: We might want to change portal_ip to clusterIP
         :portal_ip        => service.spec.clusterIP,
         :session_affinity => service.spec.sessionAffinity,
         :service_type     => service.spec.type,
-
-        :labels_and_tags  => parse_labels(service),
+        :labels           => labels,
+        :tags             => map_labels('ContainerService', labels),
         :selector_parts   => parse_selector_parts(service),
         :container_groups => container_groups
       )
@@ -333,7 +341,8 @@ module ManageIQ::Providers::Kubernetes
 
       new_result[:container_conditions] = parse_conditions(pod)
 
-      new_result[:labels_and_tags] = parse_labels(pod)
+      new_result[:labels] = parse_labels(pod)
+      new_result[:tags] = map_labels('ContainerGroup', new_result[:labels])
       new_result[:node_selector_parts] = parse_node_selector_parts(pod)
       new_result[:container_volumes] = parse_volumes(pod)
       new_result
@@ -360,7 +369,8 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_namespace(namespace)
       new_result = parse_base_item(namespace).except(:namespace)
-      new_result[:labels_and_tags] = parse_labels(namespace)
+      new_result[:labels] = parse_labels(namespace)
+      new_result[:tags] = map_labels('ContainerProject', new_result[:labels])
       new_result
     end
 
@@ -511,11 +521,13 @@ module ManageIQ::Providers::Kubernetes
     def parse_replication_controllers(container_replicator)
       new_result = parse_base_item(container_replicator)
 
+      labels = parse_labels(container_replicator)
       # TODO: parse template
       new_result.merge!(
         :replicas         => container_replicator.spec.replicas,
         :current_replicas => container_replicator.status.replicas,
-        :labels_and_tags  => parse_labels(container_replicator),
+        :labels           => labels,
+        :tags             => map_labels('ContainerReplicator', labels),
         :selector_parts   => parse_selector_parts(container_replicator)
       )
 

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -61,11 +61,13 @@ module ManageIQ::Providers
       def parse_route(route)
         new_result = parse_base_item(route)
 
+        labels = parse_labels(route)
         new_result.merge!(
           # TODO: persist tls
-          :host_name       => route.spec.try(:host),
-          :labels_and_tags => parse_labels(route),
-          :path            => route.path
+          :host_name => route.spec.try(:host),
+          :labels    => labels,
+          :tags      => map_labels('ContainerRoute', labels),
+          :path      => route.path
         )
 
         new_result[:project] = @data_index.fetch_path(:container_projects, :by_name,
@@ -89,8 +91,10 @@ module ManageIQ::Providers
       def parse_build(build)
         new_result = parse_base_item(build)
         new_result.merge! parse_build_source(build.spec.source)
+        labels = parse_labels(build)
         new_result.merge!(
-          :labels_and_tags             => parse_labels(build),
+          :labels                      => labels,
+          :tags                        => map_labels('ContainerBuild', labels),
           :service_account             => build.spec.serviceAccount,
           :completion_deadline_seconds => build.spec.try(:completionDeadlineSeconds),
           :output_name                 => build.spec.try(:output).try(:to).try(:name)

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -178,11 +178,9 @@ describe ContainerLabelTagMapping do
   end
 
   context "given a label with empty value" do
-    it "any-value mapping generates a tag" do
+    it "any-value mapping is ignored" do
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
-      tags = map_to_tags('ContainerNode', 'name' => '')
-      expect(tags.size).to eq(1)
-      expect(tags[0].classification.description).to eq('<empty value>')
+      expect(map_to_tags('ContainerNode', 'name' => '')).to be_empty
     end
 
     it "honors specific mapping for the empty value" do

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -8,15 +8,17 @@ describe ContainerLabelTagMapping do
     FactoryGirl.create(:kubernetes_label, :resource => node, :name => name, :value => value)
   end
 
-  let(:tag1) { FactoryGirl.create(:tag, :name => '/ns1/category1/tag1') }
-  let(:tag2) { FactoryGirl.create(:tag, :name => '/ns2/category2/tag2') }
-  let(:cat_tag_without_classification) { FactoryGirl.create(:tag, :name => '/ns3/category3') }
-
-  let(:cat_classification) { FactoryGirl.create(:classification) }
+  let(:cat_classification) { FactoryGirl.create(:classification, :read_only => true) }
   let(:cat_tag) { cat_classification.tag }
-  let(:tag_under_cat) { cat_classification.add_entry(:name => 'value_1', :description => 'value-1').tag }
+  let(:tag1) { cat_classification.add_entry(:name => 'value_1', :description => 'value-1').tag }
+  let(:tag2) { cat_classification.add_entry(:name => 'something_else', :description => 'Another tag').tag }
+  let(:tag3) { cat_classification.add_entry(:name => 'yet_another', :description => 'Yet another tag').tag }
   let(:empty_tag_under_cat) do
     cat_classification.add_entry(:name => 'my_empty', :description => 'Custom description for empty value').tag
+  end
+  let(:tag_in_another_cat) do
+    cat = FactoryGirl.create(:classification, :read_only => true)
+    cat.add_entry(:name => 'unrelated', :description => 'Unrelated tag').tag
   end
 
   # Each test here may populate the table differently.
@@ -31,8 +33,9 @@ describe ContainerLabelTagMapping do
 
   context "with empty mapping" do
     it "does nothing" do
-      expect(ContainerLabelTagMapping.tags_for_entity(node)).to be_empty
-      expect(ContainerLabelTagMapping.mappable_tags).to be_empty
+      expect {
+        expect(ContainerLabelTagMapping.tags_for_entity(node)).to be_empty
+      }.not_to change { Tag.count }
     end
   end
 
@@ -59,18 +62,20 @@ describe ContainerLabelTagMapping do
     before do
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag1)
-      FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag_under_cat)
-      # Force a tag to exist that we don't map to (for testing .mappable_tags).
-      tag2
+      FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag2)
+      # Force a tag to exist that we don't map to (for testing .controls_tag?).
+      tag_in_another_cat
     end
 
     it "prefers specific-value" do
       label(node, 'name', 'value-1')
-      expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(tag1, tag_under_cat)
+      expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(tag1, tag2)
     end
 
     it "creates tag for new value" do
-      expect(ContainerLabelTagMapping.mappable_tags).to contain_exactly(tag1, tag_under_cat)
+      expect(ContainerLabelTagMapping.controls_tag?(tag1)).to be true
+      expect(ContainerLabelTagMapping.controls_tag?(tag2)).to be true
+      expect(ContainerLabelTagMapping.controls_tag?(tag_in_another_cat)).to be false
 
       label(node, 'name', 'value-2')
       tags = ContainerLabelTagMapping.tags_for_entity(node)
@@ -78,13 +83,17 @@ describe ContainerLabelTagMapping do
       expect(tags[0].name).to eq(cat_tag.name + '/value_2')
       expect(tags[0].classification.description).to eq('value-2')
 
-      expect(ContainerLabelTagMapping.mappable_tags).to contain_exactly(tag1, tag_under_cat, tags[0])
+      expect(ContainerLabelTagMapping.controls_tag?(tag1)).to be true
+      expect(ContainerLabelTagMapping.controls_tag?(tag2)).to be true
+      expect(ContainerLabelTagMapping.controls_tag?(tags[0])).to be true
 
       # But nothing changes when called again, the previously created tag is re-used.
 
       expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(tags[0])
 
-      expect(ContainerLabelTagMapping.mappable_tags).to contain_exactly(tag1, tag_under_cat, tags[0])
+      expect(ContainerLabelTagMapping.controls_tag?(tag1)).to be true
+      expect(ContainerLabelTagMapping.controls_tag?(tag2)).to be true
+      expect(ContainerLabelTagMapping.controls_tag?(tags[0])).to be true
     end
 
     it "handles names that differ only by case" do
@@ -103,24 +112,30 @@ describe ContainerLabelTagMapping do
       # /managed/kubernetes:name vs /managed/kubernetes:naME.
     end
 
-    pending "handles values that differ only by case / punctuation" do
+    it "handles values that differ only by case / punctuation" do
       label(node, 'name', 'value-case.punct')
       label(node2, 'name', 'VaLuE-CASE.punct')
       label(node3, 'name', 'value-case/punct')
       tags = ContainerLabelTagMapping.tags_for_entity(node)
       tags2 = ContainerLabelTagMapping.tags_for_entity(node2)
       tags3 = ContainerLabelTagMapping.tags_for_entity(node3)
-      # TODO: do we want them to get same tag or 2 tags?
-      # What do we want the description to be?
+      # TODO: They get mapped to the same tag, is this desired?
+      # TODO: What do we want the description to be?
+      expect(tags2).to eq(tags)
+      expect(tags3).to eq(tags)
     end
 
-    pending "handles values that differ only past 50th character" do
+    it "handles values that differ only past 50th character" do
       label(node, 'name', 'x' * 50)
       label(node2, 'name', 'x' * 50 + 'y')
       label(node3, 'name', 'x' * 50 + 'z')
       tags = ContainerLabelTagMapping.tags_for_entity(node)
       tags2 = ContainerLabelTagMapping.tags_for_entity(node2)
       tags3 = ContainerLabelTagMapping.tags_for_entity(node3)
+      # TODO: They get mapped to the same tag, is this desired?
+      # TODO: What do we want the description to be?
+      expect(tags2).to eq(tags)
+      expect(tags3).to eq(tags)
     end
   end
 
@@ -142,20 +157,6 @@ describe ContainerLabelTagMapping do
       # same with both any-value and specific-value mappings
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
       expect(ContainerLabelTagMapping.tags_for_entity(node)).to contain_exactly(empty_tag_under_cat)
-    end
-  end
-
-  context "with any-value mapping whose tag has no classification" do
-    before do
-      FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag_without_classification)
-    end
-
-    it "creates specific-value tag and the 2 needed classifications" do
-      label(node, 'name', 'value-3')
-      tags = ContainerLabelTagMapping.tags_for_entity(node)
-      expect(tags.size).to eq(1)
-      expect(tags[0].category.description).to eq("Kubernetes label 'name'")
-      expect(tags[0].classification.description).to eq('value-3')
     end
   end
 

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -24,14 +24,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                                  :name             => "proj2",
                                  :ems_created_on   => "2016-03-28T15:04:13Z",
                                  :resource_version => "150569",
-                                 :labels_and_tags  => [
+                                 :labels           => [
                                    {
                                      :section => "labels",
                                      :name    => "department",
                                      :value   => "Warp-drive",
                                      :source  => "kubernetes"
                                    }
-                                 ])
+                                 ],
+                                 :tags             => [])
     end
   end
 
@@ -740,7 +741,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         :identity_system            => 'uuid',
         :kubernetes_kubelet_version => nil,
         :kubernetes_proxy_version   => nil,
-        :labels_and_tags            => [],
+        :labels                     => [],
+        :tags                       => [],
         :lives_on_id                => nil,
         :lives_on_type              => nil,
         :max_container_groups       => nil,
@@ -792,7 +794,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         :identity_system            => 'uuid',
         :kubernetes_kubelet_version => nil,
         :kubernetes_proxy_version   => nil,
-        :labels_and_tags            => [],
+        :labels                     => [],
+        :tags                       => [],
         :lives_on_id                => nil,
         :lives_on_type              => nil,
         :max_container_groups       => nil,
@@ -836,7 +839,8 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
           :ems_created_on       => '2016-01-01T11:10:21Z',
           :container_conditions => [],
           :identity_infra       => 'aws:///zone/aws-id',
-          :labels_and_tags      => [],
+          :labels               => [],
+          :tags                 => [],
           :lives_on_id          => nil,
           :lives_on_type        => nil,
           :max_container_groups => nil,

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -26,10 +26,6 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :container_label_tag_mapping,
       :label_name => 'name', :tag => @name_category.tag
     )
-    ContainerLabelTagMapping.drop_cache # ensure just created mappings are loaded
-  end
-  after :each do
-    ContainerLabelTagMapping.drop_cache # don't affect other tests
   end
 
   it "will perform a full refresh on k8s" do

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresher_spec.rb
@@ -19,6 +19,19 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     expect(described_class.ems_type).to eq(:kubernetes)
   end
 
+  # Smoke test the use of ContainerLabelTagMapping during refresh.
+  before :each do
+    @name_category = FactoryGirl.create(:classification, :name => 'name', :description => 'Name')
+    @label_tag_mapping = FactoryGirl.create(
+      :container_label_tag_mapping,
+      :label_name => 'name', :tag => @name_category.tag
+    )
+    ContainerLabelTagMapping.drop_cache # ensure just created mappings are loaded
+  end
+  after :each do
+    ContainerLabelTagMapping.drop_cache # don't affect other tests
+  end
+
   it "will perform a full refresh on k8s" do
     2.times do # Run twice to verify that a second run with existing data does not change anything
       VCR.use_cassette(described_class.name.underscore) do # , :record => :new_episodes) do
@@ -138,7 +151,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :dns_policy     => "ClusterFirst",
       :phase          => "Running",
     )
-    expect(@containergroup.labels.count).to eq(1)
+    expect(@containergroup.labels).to contain_exactly(
+      label_with_name_value("name", "heapster")
+    )
+    expect(@containergroup.tags).to contain_exactly(
+      tag_in_category_with_description(@name_category, "heapster")
+    )
 
     # Check the relation to container node
     expect(@containergroup.container_node).not_to be_nil
@@ -159,6 +177,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
     # Check relations to replicator, labels and provider
     expect(@containergroup.container_replicator).to eq(
       ContainerReplicator.find_by(:name => "monitoring-heapster-controller")
+    )
+    expect(@containergroup.container_replicator.labels).to contain_exactly(
+      label_with_name_value("name", "heapster")
     )
     expect(@containergroup.ext_management_system).to eq(@ems)
 
@@ -189,7 +210,9 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :status => "True"
     )
 
-    expect(@containernode.labels.count).to eq(1)
+    expect(@containernode.labels).to contain_exactly(
+      label_with_name_value("kubernetes.io/hostname", "10.35.0.169")
+    )
 
     expect(@containernode.computer_system.operating_system).to have_attributes(
       :distribution   => "Fedora 20 (Heisenbug)",
@@ -226,7 +249,10 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :session_affinity => "None",
       :portal_ip        => "10.0.0.1",
     )
-    expect(@containersrv.labels.count).to eq(2)
+    expect(@containersrv.labels).to contain_exactly(
+      label_with_name_value("provider", "kubernetes"),
+      label_with_name_value("component", "apiserver")
+    )
     expect(@containersrv.selector_parts.count).to eq(0)
 
     @confs = @containersrv.container_service_port_configs
@@ -262,7 +288,12 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :replicas         => 1,
       :current_replicas => 1
     )
-    expect(@replicator.labels.count).to eq(1)
+    expect(@replicator.labels).to contain_exactly(
+      label_with_name_value("name", "influxGrafana")
+    )
+    expect(@replicator.tags).to contain_exactly(
+      tag_in_category_with_description(@name_category, "influxGrafana")
+    )
     expect(@replicator.selector_parts.count).to eq(1)
 
     @group = ContainerGroup.where(:name => "monitoring-influx-grafana-controller-22icy").first
@@ -344,5 +375,16 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::Refresher do
       :condition => "Healthy",
       :status    => "True"
     )
+  end
+
+  def label_with_name_value(name, value)
+    an_object_having_attributes(
+      :section => 'labels', :source => 'kubernetes',
+      :name => name, :value => value
+    )
+  end
+
+  def tag_in_category_with_description(category, description)
+    satisfy { |tag| tag.category == category && tag.classification.description == description }
   end
 end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -48,7 +48,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                  :output_name                 => 'spec_output_to_name',
 
                                  :completion_deadline_seconds => '11',
-                                 :labels_and_tags             => []
+                                 :labels                      => [],
+                                 :tags                        => []
                                 )
     end
   end


### PR DESCRIPTION
A major rewrite of auto-tagging from kubernetes labels.
Sorry for big PR, but old code was broken in too many ways.

## Functionality changes:

- Find existing tag if already created.  This should fix refresh crashes:

  https://bugzilla.redhat.com/show_bug.cgi?id=1382347
  (cases were several values with different case/punctuation are mapped to the same tag)
  https://bugzilla.redhat.com/show_bug.cgi?id=1382361
  (when concurrent refresh already created the same classification but it is not in our cache)

  - Added regression tests for all these failure modes.
    Added some auto-tagging testing to the full refresh integration tests.

  - This will map `name=value` and `name=VALUE` labels to same tag,
    which does not reflect Kubernetes label case-sensitive semantics, but is OK in practice.
    Alternative would be creating tags with ugly `name` containing e.g. SHA1 of the label value.

- Catch & log exceptions so if any auto-tagging bugs remain, they won't break refresh.

- Do not insert mappings while mapping.
  Previously given any-value mapping for `name`, when encountering new `name=value` label,
  we'd insert both new Tag + Classification and a new specific-value mapping for (`name`, `value`).

  This reduces cache issues, plus will be less confusing in UI #11591.

  - We still insert Tag + Classification.  Attempted making this race-condition-free.  Locking the parent Classification row (only when created new entry for a new label value).  Not sure it's bulletproof.

- Caching is now bounded to one refresh.
  Will allow UI (#11591) editing the table to take effect on next refresh.

- Reverted [previous decision](https://github.com/ManageIQ/manageiq/issues/9713#issuecomment-233929144) on empty-value handling — we decided to not create special "\<Empty>" tags for them.

## Refactoring

Rewrote how mapping table is cached (no more permanent global cache), and how it's called from refresh.

ContainerLabelTagMapping interface is now a bit weird:
1. obtain cache
2. given cache, map labels to hashes - called in refresh_parser
3. given hashes, create and [un]assign tags - called in save_tags_inventory

The labels it takes are now in {:name, :value} format rather than CustomAttribute instances.

Parsing now returns independent :labels and :tags, got rid of :labels_and_tags.

@miq-bot add-label providers/containers, bug, darga/yes, euwe/yes

Thanks @moolitayer for design help & pair programming.