### PR TITLE
Fix quota requested method to bypass prov_types starting with generic.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/QuotaMethods.class/__methods__/requested.rb
@@ -219,7 +219,7 @@ def service_options
 end
 
 def composite_service_options_value(child_service_resource, prov_option, options_array)
-  return if child_service_resource.resource.prov_type == 'generic'
+  return if child_service_resource.resource.prov_type.starts_with?('generic')
   child_service_resource.resource.service_resources.each do |grandchild_service_template_service_resource|
     service_prov_option_value(prov_option, grandchild_service_template_service_resource.resource, options_array)
   end
@@ -258,7 +258,7 @@ error("request") if @miq_request.nil?
 
 options_hash = service_options if @service
 
-if @service && @service_template.prov_type == 'generic'
+if @service && @service_template.prov_type.starts_with?("generic")
   $evm.log(:info, "Generic Service Item.  No quota check being done.")
   $evm.root['ae_result'] = 'ok'
   $evm.root['ae_next_state'] = 'finished'

--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -30,6 +30,12 @@ describe "Quota Validation" do
       expect { run_automate_method(service_attrs) }.not_to raise_exception
     end
 
+    it "generic ansible tower calculate_requested" do
+      setup_model("generic")
+      build_generic_ansible_tower_service_item
+      expect { run_automate_method(service_attrs) }.not_to raise_exception
+    end
+
     it "vmware service item calculate_requested" do
       setup_model("vmware")
       build_small_environment

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -140,6 +140,15 @@ module Spec
         @service_request = build_service_template_request("generic", @user, :dialog => {"test" => "dialog"})
       end
 
+      def build_generic_ansible_tower_service_item
+        @service_template = FactoryGirl.create(:service_template,
+                                               :name         => 'generic_ansible_tower',
+                                               :service_type => 'atomic',
+                                               :prov_type    => 'generic_ansible_tower')
+        @service_request = build_service_template_request("generic_ansible_tower", @user,
+                                                          :dialog => {"test" => "dialog"})
+      end
+
       def build_vmware_service_item
         options = {:src_vm_id => @vm_template.id, :requester => @user}.merge(vmware_requested_quota_values)
         model = {"vmware_service_item" => {:type      => 'atomic',


### PR DESCRIPTION
Quota checking for service bundles attempts to get values for each service bundle item to determine the requested values for memory, storage, number of cpus, and number of vms.
There a several types of "generic" service item prov_types that need to be excluded from checking for the requested values.  The Ansible tower prov_type is generic_ansible_tower.

https://bugzilla.redhat.com/show_bug.cgi?id=1363901