### PR TITLE
[DARGA] Removed references to miq_ae_system_domain

### DIFF
--- a/spec/factories/compliance.rb
+++ b/spec/factories/compliance.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :compliance do
+    sequence(:id)          { |n| 10_000_000 + n }
+    sequence(:resource_id) { |n| 10_000_010 + n }
+    resource_type          'Host'
+    compliant              true
+    timestamp              DateTime.current
+    updated_on             DateTime.current
+    event_type             'string'
+    compliance_details     []
+  end
+end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -457,10 +457,10 @@ describe Tenant do
       end
 
       it "#reset_domain_priority_by_ordered_ids by subtenant" do
-        FactoryGirl.create(:miq_ae_system_domain, :name => 'ManageIQ', :priority => 0,
-                           :tenant_id => root_tenant.id)
-        FactoryGirl.create(:miq_ae_system_domain, :name => 'Redhat', :priority => 1,
-                           :tenant_id => root_tenant.id)
+        FactoryGirl.create(:miq_ae_domain, :name => 'ManageIQ', :priority => 0,
+                           :tenant_id => root_tenant.id, :system => true)
+        FactoryGirl.create(:miq_ae_domain, :name => 'Redhat', :priority => 1,
+                           :tenant_id => root_tenant.id, :system => true)
         FactoryGirl.create(:miq_ae_domain, :name => 'T1_A', :tenant_id => t1.id)
         FactoryGirl.create(:miq_ae_domain, :name => 'T1_B', :tenant_id => t1.id)
         dom5 = FactoryGirl.create(:miq_ae_domain, :name => 'T1_1_A', :tenant_id => t1_1.id)


### PR DESCRIPTION
The system domain factory exists only in Ewue release and not
in Darga, removed references to it.
Includes the factory for compliance.