### PR TITLE
[DARGA] Add missing compliance factory

### DIFF
--- a/spec/factories/compliance.rb
+++ b/spec/factories/compliance.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :compliance do
+    sequence(:id)          { |n| 10_000_000 + n }
+    sequence(:resource_id) { |n| 10_000_010 + n }
+    resource_type          'Host'
+    compliant              true
+    timestamp              DateTime.current
+    updated_on             DateTime.current
+    event_type             'string'
+    compliance_details     []
+  end
+end


### PR DESCRIPTION
compliance factory is needed to run spec tests added in https://github.com/ManageIQ/manageiq/pull/11564

@mkanoor please review.

This PR addresses issue introduced with cherry-pick of ttps://github.com/ManageIQ/manageiq/pull/11564 to Darga due to missing compliance factory.