### PR TITLE
Add object type conversion when calling / returning Generic Object methods.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -23,7 +23,19 @@ module MiqAeMethodService
 
     def method_missing(method_name, *args)
       ae_user_identity unless @ae_user
-      object_send(method_name, *args)
+      args = convert_params_to_ar_model(args)
+      results = object_send(method_name, *args)
+      wrap_results(results)
+    end
+
+    def convert_params_to_ar_model(args)
+      if args.kind_of?(Array)
+        args.collect { |arg| convert_params_to_ar_model(arg) }
+      elsif args.kind_of?(Hash)
+        args.each { |k, v| args[k] = convert_params_to_ar_model(v) }
+      else
+        args.kind_of?(MiqAeMethodService::MiqAeServiceModelBase) ? args.object_send(:itself) : args
+      end
     end
 
     def respond_to_missing?(method_name, include_private = false)


### PR DESCRIPTION
Generic Object relationships are defined and implemented for AR objects.
Generic Object methods are defined as for AR objects and implemented in automate model.

Converting the object into AR model object when calling the generic object methods from automate as these methods are defined as AR model methods.
Converting the object into service model object when returning the generic object method results back to automate.

Fix #11728.

cc @gmcculloug @bzwei @mkanoor 
