### PR TITLE
Prune all EventStream events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -350,48 +350,4 @@ class EmsEvent < EventStream
   def ems_refresh_target
     ext_management_system
   end
-
-  #
-  # Purging methods
-  #
-
-  def self.keep_ems_events
-    VMDB::Config.new("vmdb").config.fetch_path(:ems_events, :history, :keep_ems_events)
-  end
-
-  def self.purge_date
-    keep = keep_ems_events.to_i_with_method.seconds
-    keep = 6.months if keep == 0
-    keep.ago.utc
-  end
-
-  def self.purge_window_size
-    VMDB::Config.new("vmdb").config.fetch_path(:ems_events, :history, :purge_window_size) || 1000
-  end
-
-  def self.purge_timer
-    purge_queue(purge_date)
-  end
-
-  def self.purge_queue(ts)
-    MiqQueue.put(
-      :class_name  => name,
-      :method_name => "purge",
-      :role        => "event",
-      :queue_name  => "ems",
-      :args        => [ts],
-    )
-  end
-
-  def self.purge(older_than, window = nil, limit = nil)
-    _log.info("Purging #{limit || "all"} events older than [#{older_than}]...")
-
-    window ||= purge_window_size
-
-    total = where(arel_table[:timestamp].lteq(older_than)).delete_in_batches(window, limit) do |count, _total|
-      _log.info("Purging #{count} events.")
-    end
-
-    _log.info("Purging #{limit || "all"} events older than [#{older_than}]...Complete - Deleted #{total} records")
-  end
 end

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -32,4 +32,48 @@ class EventStream < ApplicationRecord
   rescue => err
     _log.log_backtrace(err)
   end
+
+  #
+  # Purging methods
+  #
+
+  def self.keep_ems_events
+    VMDB::Config.new("vmdb").config.fetch_path(:ems_events, :history, :keep_ems_events)
+  end
+
+  def self.purge_date
+    keep = keep_ems_events.to_i_with_method.seconds
+    keep = 6.months if keep == 0
+    keep.ago.utc
+  end
+
+  def self.purge_window_size
+    VMDB::Config.new("vmdb").config.fetch_path(:ems_events, :history, :purge_window_size) || 1000
+  end
+
+  def self.purge_timer
+    purge_queue(purge_date)
+  end
+
+  def self.purge_queue(ts)
+    MiqQueue.put(
+      :class_name  => name,
+      :method_name => "purge",
+      :role        => "event",
+      :queue_name  => "ems",
+      :args        => [ts],
+    )
+  end
+
+  def self.purge(older_than, window = nil, limit = nil)
+    _log.info("Purging #{limit || "all"} events older than [#{older_than}]...")
+
+    window ||= purge_window_size
+
+    total = where(arel_table[:timestamp].lteq(older_than)).delete_in_batches(window, limit) do |count, _total|
+      _log.info("Purging #{count} events.")
+    end
+
+    _log.info("Purging #{limit || "all"} events older than [#{older_than}]...Complete - Deleted #{total} records")
+  end
 end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -114,7 +114,7 @@ class MiqScheduleWorker::Jobs
   def ems_event_purge_timer
     zone = MiqServer.my_server(true).zone
     if zone.role_active?("event")
-      queue_work(:class_name => "EmsEvent", :method_name => "purge_timer")
+      queue_work(:class_name => "EventStream", :method_name => "purge_timer")
     end
   end
 

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -521,7 +521,7 @@ describe MiqScheduleWorker::Runner do
 
               case job.tags
               when %w(ems_event purge_schedule)
-                messages = MiqQueue.where(:class_name => "EmsEvent", :method_name => "purge_timer")
+                messages = MiqQueue.where(:class_name => "EventStream", :method_name => "purge_timer")
                 expect(messages.count).to eq(1)
               when %w(policy_event purge_schedule)
                 messages = MiqQueue.where(:class_name => "PolicyEvent", :method_name => "purge_timer")


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1348625 (1 of 6)

I am going through our components to make sure they are pruning tables correctly.

**Before:**

It is currently pruning system events that have `type="EventStream"` class.

This is how the original code was written, but when a new top level class was introduced, it probably was overlooked.

**After:**

Now, it prunes all `EventStream` events.