### PR TITLE
Use standard health states in GCP

### DIFF
--- a/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/google/cloud_manager/refresher_spec.rb
@@ -232,7 +232,7 @@ describe ManageIQ::Providers::Google::CloudManager::Refresher do
       :healthy_threshold   => 2,
       :unhealthy_threshold => 3)
     expect(lb.load_balancer_health_checks.first.load_balancer_health_check_members.first).to have_attributes(
-      :status => "UNHEALTHY"
+      :status => "OutOfService"
     )
     expect(lb.load_balancer_health_checks.first.load_balancer_health_check_members.first.load_balancer_pool_member.vm.name)\
       .to eql("subnet-test")

--- a/spec/models/manageiq/providers/google/network_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/google/network_manager/refresh_parser_spec.rb
@@ -176,7 +176,7 @@ describe ManageIQ::Providers::Google::NetworkManager::RefreshParser do
             :load_balancer_health_check_members => [
               {
                 :load_balancer_pool_member => subject[:load_balancer_pools][0][:load_balancer_pool_member_pools][0][:load_balancer_pool_member],
-                :status                    => "HEALTHY",
+                :status                    => "InService",
                 :status_reason             => ""
               }
             ]


### PR DESCRIPTION
Uses "OutOfService" and "InService" strings instead of the ones returned by GCP.