### PR TITLE
Metrics: Re-use and constantize metrics cols used for capture

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -134,7 +134,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
       next if counter.nil?
 
       # Filter the metrics for only the cols we will use
-      next unless Metric::Capture.capture_cols.include?(counter[:counter_key].to_sym)
+      next unless Metric::Capture::CAPTURE_COLS.include?(counter[:counter_key].to_sym)
 
       vim_key      = metric["counterId"].to_s
       instance     = metric["instance"].to_s

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -7,10 +7,8 @@ module Metric::Capture
 
   REALTIME_PRIORITY = HOURLY_PRIORITY = DAILY_PRIORITY = MiqQueue::NORMAL_PRIORITY
   HISTORICAL_PRIORITY = MiqQueue::LOW_PRIORITY
-
-  def self.capture_cols
-    Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float && c[0, 7] != "derived" }.compact
-  end
+  CAPTURE_COLS = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float && c[0, 7] != 'derived' }
+                       .compact.freeze
 
   def self.historical_days
     (Settings.performance.history.initial_capture_days || 7).to_i

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -214,7 +214,7 @@ module Metric::Rollup
     new_perf_counts = {}
 
     rt_perfs.each do |rt|
-      Metric::Capture.capture_cols.each do |col|
+      Metric::Capture::CAPTURE_COLS.each do |col|
         new_perf[col] ||= 0
         new_perf_counts[col] ||= 0
 

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -1,8 +1,8 @@
 module Metric::Rollup
-  ROLLUP_COLS  = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float || c[0, 7] == "derived" }.compact +
+  ROLLUP_COLS  = Metric::Capture::CAPTURE_COLS +
                  [:stat_container_group_create_rate,
                   :stat_container_group_delete_rate,
-                  :stat_container_image_registration_rate]
+                  :stat_container_image_registration_rate].freeze
   STORAGE_COLS = Metric.columns_hash.collect { |c, _h| c.to_sym if c.starts_with?("derived_storage_") }.compact
 
   NON_STORAGE_ROLLUP_COLS = (ROLLUP_COLS - STORAGE_COLS)


### PR DESCRIPTION
Fairly minor. Previously in `metric`, we had two places that calculated `CAPTURE_COLS`. Now we have only one place.

@miq-bot add_label refactoring, metrics
