### PR TITLE
Remove wrong/old gsub

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -513,7 +513,7 @@ class InfraNetworkingController < ApplicationController
   # set partial name and cell header for edit screens
   def set_right_cell_vars
     @sb[:action] = params[:action]
-    name = @record ? @record.name.to_s.gsub(/'/, "\\\\'") : "" # If record, get escaped name
+    name = @record.try(:name).to_s
     table = 'switch'
     partial = if ["details"].include?(@showtype)
                 "layouts/x_gtl"

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -460,7 +460,7 @@ class MiqAeCustomizationController < ApplicationController
                 else
                   ""
                 end
-        @right_cell_text = _("Editing %{model} \"%{name}\"") % {:name => @dialog.description.gsub(/'/, "\\'"), :model => "#{title} #{ui_lookup(:model => "MiqDialog")}"}
+        @right_cell_text = _("Editing %{model} \"%{name}\"") % {:name => @dialog.description, :model => "#{title} #{ui_lookup(:model => "MiqDialog")}"}
       end
 
       presenter.reset_one_trans

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -638,7 +638,7 @@ class MiqPolicyController < ApplicationController
                         end
     when 'ev'
       presenter.update(:main_div, r[:partial => 'event_details', :locals => {:read_only => true}])
-      options = {:name => @event.description.gsub(/'/, "\\\\'"), :model => ui_lookup(:table => 'miq_event_definition')}
+      options = {:name => @event.description, :model => ui_lookup(:table => 'miq_event_definition')}
       right_cell_text = @edit ? _("Editing %{model} \"%{name}\"") % options : _("%{model} \"%{name}\"") % options
     when 'a', 'ta', 'fa'
       presenter.update(:main_div, r[:partial => 'action_details', :locals => {:read_only => true}])
@@ -647,11 +647,11 @@ class MiqPolicyController < ApplicationController
                         else
                           if @edit
                             _("Editing %{model} \"%{name}\"") %
-                            {:name  => @action.description.gsub(/'/, "\\\\'"),
+                            {:name  => @action.description,
                              :model => ui_lookup(:model => 'MiqAction')}
                           else
                             _("%{model} \"%{name}\"") %
-                            {:name  => @action.description.gsub(/'/, "\\\\'"),
+                            {:name  => @action.description,
                              :model => ui_lookup(:model => 'MiqAction')}
                           end
                         end
@@ -670,7 +670,7 @@ class MiqPolicyController < ApplicationController
                         else
                           pfx = @assign ? ' assignments for ' : ''
                           msg = @edit ? _("Editing %{model} \"%{name}\"") : _("%{model} \"%{name}\"")
-                          msg % {:name => @alert.description.gsub(/'/, "\\\\'"), :model => "#{pfx} #{ui_lookup(:model => "MiqAlert")}"}
+                          msg % {:name => @alert.description, :model => "#{pfx} #{ui_lookup(:model => "MiqAlert")}"}
                         end
     end
     presenter[:right_cell_text] = right_cell_text

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -563,8 +563,8 @@ class MiqPolicyController < ApplicationController
         if @profile && @profile.id.blank?
           _("Adding a new %{record}") % {:record => ui_lookup(:model => 'MiqPolicySet')}
         else
-          @edit ? _("Editing %{model} \"%{name}\"") % {:name => @profile.description.gsub(/'/, "\\'"), :model => ui_lookup(:model => "MiqPolicySet")} :
-                  _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @profile.description.gsub(/'/, "\\'")}
+          @edit ? _("Editing %{model} \"%{name}\"") % {:name => @profile.description, :model => ui_lookup(:model => "MiqPolicySet")} :
+                  _("%{model} \"%{name}\"") % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @profile.description}
         end
     when 'xx'
       presenter.update(:main_div,
@@ -603,7 +603,7 @@ class MiqPolicyController < ApplicationController
                           end
       else
         options = {:model => "#{model_name} #{@sb[:mode] ? @sb[:mode].capitalize : ""} Policy",
-                   :name  => @policy.description.gsub(/'/, "\\'")}
+                   :name  => @policy.description}
         right_cell_text = @edit ? _("Editing %{model} \"%{name}\"") % options : _("%{model} \"%{name}\"") % options
         if @edit && @edit[:typ] == 'conditions'
           right_cell_text += _(" %{model} Assignments") % {:model => ui_lookup(:model => 'Condition')}
@@ -660,8 +660,8 @@ class MiqPolicyController < ApplicationController
       right_cell_text = if @alert_profile.id.blank?
                           _("Adding a new %{record}") % {:record => ui_lookup(:model => 'MiqAlertSet')}
                         else
-                          @edit ? _("Editing %{model} \"%{name}\"") % {:name => @alert_profile.description.gsub(/'/, "\\'"), :model => "#{ui_lookup(:model => @edit[:new][:mode])} #{ui_lookup(:model => 'MiqAlertSet')}"} :
-                                  _("%{model} \"%{name}\"") % {:name => @alert_profile.description.gsub(/'/, "\\'"), :model => ui_lookup(:model => 'MiqAlertSet')}
+                          @edit ? _("Editing %{model} \"%{name}\"") % {:name => @alert_profile.description, :model => "#{ui_lookup(:model => @edit[:new][:mode])} #{ui_lookup(:model => 'MiqAlertSet')}"} :
+                                  _("%{model} \"%{name}\"") % {:name => @alert_profile.description, :model => ui_lookup(:model => 'MiqAlertSet')}
                         end
     when 'al'
       presenter.update(:main_div, r[:partial => 'alert_details', :locals => {:read_only => true}])

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -232,7 +232,7 @@ module MiqPolicyController::Policies
     @record = @policy = policy
     @right_cell_text = _("%{model} \"%{name}\"") % {
       :model => "#{@sb[:mode]} Policy",
-      :name  => @policy.description.gsub(/'/, "\\'")
+      :name  => @policy.description
     }
     @right_cell_div = "policy_details"
     @policy_conditions = @policy.conditions

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -144,13 +144,13 @@ class PxeController < ApplicationController
                             if @ps.id.blank?
                               _("Adding a new %{model}") % {:model => ui_lookup(:model => "PxeServer")}
                             else
-                              temp = _("%{model} \"%{name}\"") % {:name  => @ps.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeServer")}
+                              temp = _("%{model} \"%{name}\"") % {:name  => @ps.name, :model => ui_lookup(:model => "PxeServer")}
                               @edit ? "Editing #{temp}" : temp
                             end
                           when 'pi'
-                            _("%{model} \"%{name}\"") % {:name  => @img.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeImage")}
+                            _("%{model} \"%{name}\"") % {:name  => @img.name, :model => ui_lookup(:model => "PxeImage")}
                           when 'wi'
-                            _("%{model} \"%{name}\"") % {:name  => @wimg.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "WindowsImage")}
+                            _("%{model} \"%{name}\"") % {:name  => @wimg.name, :model => ui_lookup(:model => "WindowsImage")}
                           end
       end
     when :pxe_image_types_tree
@@ -162,11 +162,11 @@ class PxeController < ApplicationController
                           if @pxe_image_type.id.blank?
                             _("Adding a new %{models}") % {:models => ui_lookup(:model => "PxeImageType")}
                           else
-                            temp = _("%{model} \"%{name}\"") % {:name  => @pxe_image_type.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeImageType")}
+                            temp = _("%{model} \"%{name}\"") % {:name  => @pxe_image_type.name, :model => ui_lookup(:model => "PxeImageType")}
                             @edit ? "Editing #{temp}" : temp
                           end
                         else
-                          _("%{model} \"%{name}\"") % {:name  => @pxe_image_type.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeImageType")}
+                          _("%{model} \"%{name}\"") % {:name  => @pxe_image_type.name, :model => ui_lookup(:model => "PxeImageType")}
                         end
     when :customization_templates_tree
       presenter.update(:main_div, r[:partial => "template_list"])
@@ -176,8 +176,8 @@ class PxeController < ApplicationController
           if @ct.id.blank?
             _("Adding a new %{model}") % {:model => ui_lookup(:model => "PxeCustomizationTemplate")}
           else
-            @edit ? _("Editing %{model} \"%{name}\"") % {:name  => @ct.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeCustomizationTemplate")} :
-                    _("%{model} \"%{name}\"") % {:name  => @ct.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "PxeCustomizationTemplate")}
+            @edit ? _("Editing %{model} \"%{name}\"") % {:name  => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")} :
+                    _("%{model} \"%{name}\"") % {:name  => @ct.name, :model => ui_lookup(:model => "PxeCustomizationTemplate")}
           end
         # resetting ManageIQ.oneTransition.oneTrans when tab loads
         presenter.reset_one_trans
@@ -189,7 +189,7 @@ class PxeController < ApplicationController
         case nodetype
         when 'root' then _("All %{models}") % {:models => ui_lookup(:models => "IsoDatastore")}
         when 'isd'  then _("Adding a new %{models}") % {:models => ui_lookup(:model => "IsoDatastore")}
-        when 'isi'  then _("%{model} \"%{name}\"") % {:name => @img.name.gsub(/'/, "\\'"), :model => ui_lookup(:model => "IsoImage")}
+        when 'isi'  then _("%{model} \"%{name}\"") % {:name => @img.name, :model => ui_lookup(:model => "IsoImage")}
         end
     end
 

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -245,7 +245,6 @@ class ServiceController < ApplicationController
 
   # set partial name and cell header for edit screens
   def set_right_cell_vars(action)
-    name = @record ? @record.name.to_s.gsub(/'/, "\\\\'") : "" # If record, get escaped name
     case action
     when "dialog_provision"
       partial = "shared/dialogs/dialog_provision"

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1611,7 +1611,7 @@ module VmCommon
 
   # set partial name and cell header for edit screens
   def set_right_cell_vars
-    name = @record ? @record.name.to_s.gsub(/'/, "\\\\'") : "" # If record, get escaped name
+    name = @record.try(:name).to_s
     table = request.parameters["controller"]
     case @sb[:action]
     when "attach"


### PR DESCRIPTION
Based on PR https://github.com/ManageIQ/manageiq/pull/11792 it was found that: 
 
- In PR https://github.com/ManageIQ/manageiq/pull/639 was introduced error `.gsub(/'/, "\\'")` (`"what'ever".gsub(/'/, "\\'") == "whateverever"`). 

-  `.gsub(/'/, "\\\\'")` doesn't work anymore

This PR removes both.

@Fryguy please review.

@miq-bot add_label ui, bug