### PR TITLE
Remove vm triggers targeted refresh

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/EmsEvent/RHEVM.class/user_remove_vm_finished.yaml
@@ -13,4 +13,4 @@ object:
   - rel5:
       value: "/System/event_handlers/event_action_policy?target=src_vm&policy_event=vm_unregister&param="
   - rel6:
-      value: "/System/event_handlers/event_action_refresh?target=src_ems_cluster"
+      value: "/System/event_handlers/event_action_refresh?target=src_vm"


### PR DESCRIPTION
This PR changes how we process a refresh for a vm being removed from full to targeting.