### PR TITLE
Reintroduce ems_*/show templates

### DIFF
--- a/app/views/ems_cloud/show.html.haml
+++ b/app/views/ems_cloud/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/ems_container/show.html.haml
+++ b/app/views/ems_container/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/ems_infra/show.html.haml
+++ b/app/views/ems_infra/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/ems_middleware/show.html.haml
+++ b/app/views/ems_middleware/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/ems_network/show.html.haml
+++ b/app/views/ems_network/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"


### PR DESCRIPTION
The templates were removed in https://github.com/ManageIQ/manageiq/pull/10154 but turns out they're needed by the various `render :action => "show"` calls from `ApplicationController` - so they need to go back for now.

https://bugzilla.redhat.com/show_bug.cgi?id=1381162

Cc: @martinpovolny 