### PR TITLE
Speed-up lookup for min/max storage_used metric

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -52,10 +52,8 @@ module Metric::Common
   def min_max_v_derived_storage_used(mode)
     cond = ["resource_type = ? and resource_id = ? and capture_interval_name = 'hourly' and timestamp >= ? and timestamp < ?",
             resource_type, resource_id, timestamp.to_date.to_s, (timestamp + 1.day).to_date.to_s]
-    meth = mode == :min ? :first : :last
     recs = MetricRollup.where(cond).where.not(:derived_storage_total => nil, :derived_storage_free => nil)
-    rec = recs.sort { |a, b| a.v_derived_storage_used <=> b.v_derived_storage_used }.send(meth)
-    rec.nil? ? nil : rec.v_derived_storage_used
+    recs.collect(&:v_derived_storage_used).sort.send(mode == :min ? :first : :last)
   end
 
   def min_v_derived_storage_used

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -53,8 +53,8 @@ module Metric::Common
     cond = ["resource_type = ? and resource_id = ? and capture_interval_name = 'hourly' and timestamp >= ? and timestamp < ?",
             resource_type, resource_id, timestamp.to_date.to_s, (timestamp + 1.day).to_date.to_s]
     meth = mode == :min ? :first : :last
-    recs = MetricRollup.where(cond)
-    rec = recs.sort { |a, b| (a.v_derived_storage_used && b.v_derived_storage_used) ? (a.v_derived_storage_used <=> b.v_derived_storage_used) : (a.v_derived_storage_used ? 1 : -1) }.send(meth)
+    recs = MetricRollup.where(cond).where.not(:derived_storage_total => nil, :derived_storage_free => nil)
+    rec = recs.sort { |a, b| a.v_derived_storage_used <=> b.v_derived_storage_used }.send(meth)
     rec.nil? ? nil : rec.v_derived_storage_used
   end
 

--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -50,9 +50,11 @@ module Metric::Common
   end
 
   def min_max_v_derived_storage_used(mode)
-    cond = ["resource_type = ? and resource_id = ? and capture_interval_name = 'hourly' and timestamp >= ? and timestamp < ?",
-            resource_type, resource_id, timestamp.to_date.to_s, (timestamp + 1.day).to_date.to_s]
-    recs = MetricRollup.where(cond).where.not(:derived_storage_total => nil, :derived_storage_free => nil)
+    recs = MetricRollup.where(:resource_type => resource_type, :resource_id => resource_id)
+                       .where(:capture_interval_name => 'hourly')
+                       .where('timestamp >= ? and timestamp < ?', # This picks only the first midnight
+                              timestamp.to_date, (timestamp + 1.day).to_date)
+                       .where.not(:derived_storage_total => nil, :derived_storage_free => nil)
     recs.collect(&:v_derived_storage_used).sort.send(mode == :min ? :first : :last)
   end
 


### PR DESCRIPTION
This improves overall performance of perf capture/rollup.

Previously, this would fetch dozen of rows and run sort on them. We can limit the rows selected and have the sort block easier to comprehend. Then we can drop custom sort block.

The method is run for instance for each MetricRollup to generate future bottleneck events (part of perf_capture). Even though I didn't benchmark it, I believe the savings are worth it. This method may be run multiple times per each entity per each perf_capture.

@miq-bot add_label performance, metrics
@miq-bot assign @kbrock 

