### PR TITLE
Add missing gettext call into storage item view

### DIFF
--- a/app/views/layouts/_item.html.haml
+++ b/app/views/layouts/_item.html.haml
@@ -53,7 +53,7 @@
     - @view.col_order[j..-1].each_with_index do |item, i|
       .form-group
         %label.control-label.col-md-2
-          = @view.headers[@view.col_order.index(item)]
+          = _(@view.headers[@view.col_order.index(item)])
         .col-md-8
           - item_data = @item.send(item)
           - if %w(data name).include?(@view.headers[i].downcase)


### PR DESCRIPTION
Compute -> Infra -> Datastores -> [A Datastore] -> Files -> [A file]

Before:
![datastores-before](https://cloud.githubusercontent.com/assets/6648365/19271768/5abdb198-8fc6-11e6-94f0-a0ec1bed20bf.jpg)

After:
![datastores-after](https://cloud.githubusercontent.com/assets/6648365/19271775/5f217c7e-8fc6-11e6-9a6c-f046143396ec.jpg)

