### PR TITLE
Allow li_link helper not to pass a condition.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -915,7 +915,8 @@ module ApplicationHelper
   # met.
   #
   # args
-  #     :cond         --- bool    - the condition to be met
+  #     :if           --- bool    - the condition to be met
+  #                                 if no condition is passed, it's considered true
   #     :table/tables --- string  - name of entity
   #                               - determines singular/plural case
   #     :link_text    --- string  - to override calculated link text
@@ -929,6 +930,8 @@ module ApplicationHelper
   #
   def li_link(args)
     args[:if] = (args[:count] != 0) if args[:count]
+    args[:if] = true unless args.key?(:if)
+
     link_text, title = build_link_text(args)
 
     if args[:if]

--- a/app/views/layouts/listnav/_ems_network.html.haml
+++ b/app/views/layouts/listnav/_ems_network.html.haml
@@ -5,8 +5,7 @@
 
     = miq_accordion_panel(_("Properties"), false, "ems_prop") do
       %ul.nav.nav-pills.nav-stacked
-        = li_link(:if => true,
-          :text       =>_('Summary'),
+        = li_link(:text =>_('Summary'),
           :record_id  => @record.id,
           :display    => 'main',
           :title      => _("Show Summary"))


### PR DESCRIPTION
I saw `:if => true` being passed to `link_li` in a PR.

So updating the helper to avoid that and fixing that in an existing partial.

Steps for Testing/QA
-------------------------------

Go to network providers. Click on a network provider.