### PR TITLE
Show 'Memory (MB)' chart for azure instance

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm.rb
@@ -32,6 +32,10 @@ class ManageIQ::Providers::Azure::CloudManager::Vm < ManageIQ::Providers::CloudM
     false
   end
 
+  def memory_mb_available?
+    true
+  end
+
   def self.calculate_power_state(raw_power_state)
     case raw_power_state.downcase
     when /running/, /starting/

--- a/spec/services/charts_layout_service_spec.rb
+++ b/spec/services/charts_layout_service_spec.rb
@@ -45,5 +45,13 @@ describe ChartsLayoutService do
       expect(chart.count { |x| x[:title] == "CPU (%)" }).to equal 0
       expect(chart.count { |x| x[:title] == "CPU (Mhz)" }).to equal 1
     end
+
+    it "includes Memory (MB) chart for azure instance" do
+      ems_azure = FactoryGirl.create(:ems_azure)
+      host = FactoryGirl.create(:host, :ext_management_system => ems_azure)
+      vm_azure =  FactoryGirl.create(:vm_azure, :ext_management_system => ems_azure, :host => host)
+      chart = ChartsLayoutService.layout(vm_azure,  UiConstants::CHARTS_LAYOUTS_FOLDER, 'daily_perf_charts', 'VmOrTemplate')
+      expect(chart.count { |x| x[:title] == "Memory (MB)" }).to equal 1
+    end
   end
 end


### PR DESCRIPTION
Show 'Memory (MB)' chart for report accessed by 'Compute'->'Clouds'->'Instances'->'Utilization'

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1377881

@miq-bot add-label core, bug

\cc @gtanzillo 