### PR TITLE
Split "show" partials - step 1

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -69,7 +69,7 @@ module ApplicationController::Compare
         @refresh_partial = "layouts/compare"
       else
         @showtype = "compare"
-        render :action => "show"
+        render :template => 'compare'
       end
     end
   end

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -571,7 +571,7 @@ module ApplicationController::Compare
       if @explorer
         @refresh_partial = "layouts/compare"
       else
-        render :action => "show", :id => @drift_obj.id
+        render :template => "compare"
       end
     end
   end

--- a/app/views/auth_key_pair_cloud/show.html.haml
+++ b/app/views/auth_key_pair_cloud/show.html.haml
@@ -4,6 +4,7 @@
   - if @showtype == "item"
     = render :partial => "layouts/item"
   - elsif @showtype == "compare"
+    = raise 'compare partial called through "show"'
     = render :partial => "layouts/compare"
   - elsif @showtype == 'main'
     = render :partial => 'main'

--- a/app/views/availability_zone/show.html.haml
+++ b/app/views/availability_zone/show.html.haml
@@ -9,6 +9,7 @@
     - if %w(instances cloud_volumes).include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@availability_zone.id}"}
     - elsif @showtype == "compare" || @showtype == "drift_history" || @showtype == "drift" || @showtype == "item"
+      = raise 'compare partial called through "show"' if @showtype == 'compare'
       = render :partial => "layouts/#{@showtype}"
     - elsif @showtype == "timeline"
       = render :partial => "layouts/tl_show"

--- a/app/views/availability_zone/show.html.haml
+++ b/app/views/availability_zone/show.html.haml
@@ -9,7 +9,7 @@
     - if %w(instances cloud_volumes).include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@availability_zone.id}"}
     - elsif @showtype == "compare" || @showtype == "drift_history" || @showtype == "drift" || @showtype == "item"
-      = raise 'compare partial called through "show"' if @showtype == 'compare'
+      = raise 'compare or drift partial called through "show"' if %w(compare drift).include?(@showtype)
       = render :partial => "layouts/#{@showtype}"
     - elsif @showtype == "timeline"
       = render :partial => "layouts/tl_show"

--- a/app/views/cloud_tenant/show.html.haml
+++ b/app/views/cloud_tenant/show.html.haml
@@ -16,6 +16,7 @@
     - elsif @showtype == "drift_history"
       = render :partial => "layouts/drift_history"
     - elsif @showtype == "drift"
+      = raise 'drift partial called through "show"'
       = render :partial => "layouts/compare"
     - elsif @showtype == "item"
       = render :partial => "layouts/item"

--- a/app/views/cloud_tenant/show.html.haml
+++ b/app/views/cloud_tenant/show.html.haml
@@ -11,6 +11,7 @@
     - if arr.include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}
     - elsif @showtype == "compare"
+      = raise 'compare partial called through "show"'
       = render :partial => "layouts/compare"
     - elsif @showtype == "drift_history"
       = render :partial => "layouts/drift_history"

--- a/app/views/flavor/show.html.haml
+++ b/app/views/flavor/show.html.haml
@@ -10,6 +10,7 @@
     - elsif @showtype == "drift_history"
       = render :partial => "layouts/drift_history"
     - elsif @showtype == "drift"
+      = raise 'drift partial called through "show"'
       = render :partial => "layouts/compare"
     - elsif @showtype == "item"
       = render :partial => "layouts/item"

--- a/app/views/flavor/show.html.haml
+++ b/app/views/flavor/show.html.haml
@@ -5,6 +5,7 @@
     - if ["instances"].include?(@display) && @showtype != "compare"
       = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@flavor.id}"}
     - elsif @showtype == "compare"
+      = raise 'compare partial called through "show"'
       = render :partial => "layouts/compare"
     - elsif @showtype == "drift_history"
       = render :partial => "layouts/drift_history"

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -6,6 +6,7 @@
     - when "details"
       = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
     - when "compare", "drift"
+      = raise 'compare partial called through "show"' if @showtype == 'compare'
       = render(:partial => "layouts/compare")
     - when "drift_history", "item"
       = render(:partial => "layouts/#{@showtype}")

--- a/app/views/host/show.html.haml
+++ b/app/views/host/show.html.haml
@@ -6,7 +6,7 @@
     - when "details"
       = render(:partial => "layouts/gtl", :locals => {:action_url => @lastaction})
     - when "compare", "drift"
-      = raise 'compare partial called through "show"' if @showtype == 'compare'
+      = raise 'compare or drift partial called through "show"'
       = render(:partial => "layouts/compare")
     - when "drift_history", "item"
       = render(:partial => "layouts/#{@showtype}")

--- a/app/views/ontap_logical_disk/show.html.haml
+++ b/app/views/ontap_logical_disk/show.html.haml
@@ -12,6 +12,7 @@
   - elsif @showtype == "download_pdf"
     = render(:partial => "layouts/show_pdf")
   - elsif @showtype == "compare"
+    = raise 'compare partial called through "show"'
     = render(:partial => "layouts/compare")
   - else
     = render(:partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"})

--- a/app/views/ontap_storage_system/show.html.haml
+++ b/app/views/ontap_storage_system/show.html.haml
@@ -10,6 +10,7 @@
   - elsif @showtype == "download_pdf"
     = render :partial => "layouts/show_pdf"
   - elsif @showtype == "compare"
+    = raise 'compare partial called through "show"'
     = render :partial => "layouts/compare"
   - else
     = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}

--- a/app/views/ontap_storage_volume/show.html.haml
+++ b/app/views/ontap_storage_volume/show.html.haml
@@ -7,6 +7,7 @@
 - elsif @showtype == "download_pdf"
   = render :partial => "layouts/show_pdf"
 - elsif @showtype == "compare"
+  = raise 'compare partial called through "show"'
   = render :partial => "layouts/compare"
 - else
   = render :partial => "layouts/gtl", :locals => {:action_url => "show/#{@record.id}"}

--- a/app/views/resource_pool/show.html.haml
+++ b/app/views/resource_pool/show.html.haml
@@ -8,6 +8,7 @@
     - when "download_pdf"
       = render :partial => "layouts/show_pdf"
     - when "compare"
+      = raise 'compare partial called through "show"'
       = render :partial => "layouts/#{@showtype}"
     - else
       = render :partial => @showtype

--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -13,6 +13,7 @@
   - elsif @showtype ==  "item"
     = render(:partial => "layouts/item")
   - elsif @showtype == "compare"
+    = raise 'compare partial called through "show"'
     = render :partial => "layouts/compare"
   - elsif @showtype == "timeline"
     = render :partial => "layouts/tl_show"

--- a/app/views/storage/show.html.haml
+++ b/app/views/storage/show.html.haml
@@ -8,6 +8,7 @@
     - when "details"
       = render(:partial => "layouts/x_gtl", :locals => {:action_url => @lastaction})
     - when "compare", "item"
+      = raise 'compare partial called through "show"' if @showtype == 'compare'
       = render(:partial => "layouts/#{@showtype}")
     - when "performance"
       = render(:partial => "layouts/performance")


### PR DESCRIPTION
The goal is to split the "show" partial and avoid sequence of partial calls:

`@show_type = "something"` --> `render :action => "show"` --> rendering specific "show" ---> rendering shared "show" ---> crazy if statements --> rendering specialized view (such as "compare")

As discussed with @himdel : the approach is to take an action a time (per commit) rather than doing it all at once to avoid bugz.
