### PR TITLE
No reset button for Job Template Service Dialog

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -1026,6 +1026,7 @@ class ProviderForemanController < ApplicationController
 
   def locals_for_service_dialog
     {:action_url => 'service_dialog',
+     :no_reset    => true,
      :record_id  => @sb[:rec_id] || @edit[:object_ids] && @edit[:object_ids][0]
     }
   end
@@ -1035,6 +1036,7 @@ class ProviderForemanController < ApplicationController
                                   :locals  => locals_for_service_dialog])
     locals = {:record_id  => @edit[:rec_id],
               :action_url => "configscript_service_dialog_submit",
+              :no_reset    => true,
               :serialize  => true}
     presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons',
                                           :locals  => locals])

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -661,6 +661,13 @@ describe ProviderForemanController do
       expect(response.status).to eq(200)
     end
 
+    it "displays the new dialog form with no reset button" do
+      post :x_button, :params => {:pressed => 'configscript_service_dialog', :id => @cs.id}
+      expect(response.status).to eq(200)
+      expect(response.body).to include('Save Changes')
+      expect(response.body).not_to include('Reset')
+    end
+
     it "Service Dialog is created from an Ansible Tower Job Template" do
       controller.instance_variable_set(:@_params, :button => "save", :id => @cs.id)
       allow(controller).to receive(:replace_right_cell)


### PR DESCRIPTION
The Tower Job Template Service Dialog should not have a Reset button - as the form is always creating a new dialog, not editing an existing one

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1382618

Steps for  #Testing
-------------------------------
Steps to Reproduce:
1. Add Tower provider, perform refresh and navigate to Ansible Tower Job templates
2. Click on any template and 'Create Service dialog from the template

Before

![screenshot from 2016-10-11 17-48-23](https://cloud.githubusercontent.com/assets/12769982/19289906/f5997fb2-8fda-11e6-970c-98c60d967d5f.png)

After:
![screenshot from 2016-10-11 17-45-20](https://cloud.githubusercontent.com/assets/12769982/19289919/0318c40e-8fdb-11e6-89b1-7c3003136b59.png)
