### PR TITLE
Update Service Dialog Contents

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -118,7 +118,7 @@ class Dialog < ApplicationRecord
           tabs << tab
         end
       else
-        tabs << DialogImportService.new.build_tab('dialog_tabs' => [dialog_tab]).first
+        tabs << DialogImportService.new.build_dialog_tabs('dialog_tabs' => [dialog_tab]).first
       end
     end
     self.dialog_tabs = tabs

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -104,24 +104,24 @@ class Dialog < ApplicationRecord
     DialogSerializer.new.serialize(Array[workflow.dialog])
   end
 
-  # Allows you to pass an altered content and update the dialog tabs, groups, and fields accordingly
+  # Allows you to pass dialog tabs as a hash
   # Will update any item passed with an ID,
   # Creates a new item without an ID,
   # Removes any items not passed in the content.
-  def update_content(content)
-    tabs = []
-    content['dialog_tabs'].each do |dialog_tab|
+  def update_tabs(tabs)
+    updated_tabs = []
+    tabs.each do |dialog_tab|
       if dialog_tab.key?('id')
         DialogTab.find(dialog_tab['id']).tap do |tab|
           tab.update_attributes(dialog_tab.except('dialog_groups'))
           tab.update_dialog_groups(dialog_tab['dialog_groups'])
-          tabs << tab
+          updated_tabs << tab
         end
       else
-        tabs << DialogImportService.new.build_dialog_tabs('dialog_tabs' => [dialog_tab]).first
+        updated_tabs << DialogImportService.new.build_dialog_tabs('dialog_tabs' => [dialog_tab]).first
       end
     end
-    self.dialog_tabs = tabs
+    self.dialog_tabs = updated_tabs
   end
 
   def deep_copy(new_attributes = {})

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -101,10 +101,6 @@ class DialogField < ApplicationRecord
     validate_error_message(dialog_tab, dialog_group) if visible? && required? && required_value_error?
   end
 
-  def update_dialog_fields(content)
-    exi
-  end
-
   def resource
     self
   end

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -101,6 +101,10 @@ class DialogField < ApplicationRecord
     validate_error_message(dialog_tab, dialog_group) if visible? && required? && required_value_error?
   end
 
+  def update_dialog_fields(content)
+    exi
+  end
+
   def resource
     self
   end

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -14,6 +14,19 @@ class DialogGroup < ApplicationRecord
     dialog_fields
   end
 
+  def update_dialog_fields(fields)
+    existing_items = dialog_fields.pluck(:id)
+    fields.each do |field|
+      if field.key?('id')
+        existing_items.delete(group['id'])
+        DialogField.find(field['id']).tap do |dialog_field|
+          dialog_field.update_attributes(field)
+        end
+      end
+    end
+    DialogField.where(:id => existing_items).each(&:destroy)
+  end
+
   def validate_children
     if dialog_fields.blank?
       errors.add(:base, _("Box %{box_label} must have at least one Element") % {:box_label => label})

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -15,16 +15,18 @@ class DialogGroup < ApplicationRecord
   end
 
   def update_dialog_fields(fields)
-    existing_items = dialog_fields.pluck(:id)
+    updated_fields = []
     fields.each do |field|
       if field.key?('id')
-        existing_items.delete(group['id'])
         DialogField.find(field['id']).tap do |dialog_field|
           dialog_field.update_attributes(field)
+          updated_fields << dialog_field
         end
+      else
+        updated_fields << DialogImportService.new.build_fields('dialog_fields' => [field]).first
       end
     end
-    DialogField.where(:id => existing_items).each(&:destroy)
+    self.dialog_fields = updated_fields
   end
 
   def validate_children

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -23,7 +23,7 @@ class DialogGroup < ApplicationRecord
           updated_fields << dialog_field
         end
       else
-        updated_fields << DialogImportService.new.build_fields('dialog_fields' => [field]).first
+        updated_fields << DialogImportService.new.build_dialog_fields('dialog_fields' => [field]).first
       end
     end
     self.dialog_fields = updated_fields

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -31,19 +31,19 @@ class DialogTab < ApplicationRecord
   end
 
   def update_dialog_groups(groups)
-    existing_items = dialog_groups.pluck(:id)
+    updated_groups = []
     groups.each do |group|
       if group.key?('id')
-        existing_items.delete(group['id'])
         DialogGroup.find(group['id']).tap do |dialog_group|
-          dialog_group.update_attributes(group)
-          dialog_group.update_dialog_fields(group['fields'])
+          dialog_group.update_attributes(group.except('dialog_fields'))
+          dialog_group.update_dialog_fields(group['dialog_fields'])
+          updated_groups << dialog_group
         end
       else
-        dialog_groups << DialogImportService.new.build_group(group)
+        updated_groups << DialogImportService.new.build_group('dialog_groups' => [group]).first
       end
     end
-    DialogGroup.where(:id => existing_items).each(&:destroy)
+    self.dialog_groups = updated_groups
   end
 
   def deep_copy

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -40,7 +40,7 @@ class DialogTab < ApplicationRecord
           updated_groups << dialog_group
         end
       else
-        updated_groups << DialogImportService.new.build_group('dialog_groups' => [group]).first
+        updated_groups << DialogImportService.new.build_dialog_groups('dialog_groups' => [group]).first
       end
     end
     self.dialog_groups = updated_groups

--- a/app/services/dialog_import_service.rb
+++ b/app/services/dialog_import_service.rb
@@ -32,18 +32,6 @@ class DialogImportService
     end
   end
 
-  def build_tab(dialog_tab)
-    build_dialog_tabs(dialog_tab)
-  end
-
-  def build_group(dialog_group)
-    build_dialog_groups(dialog_group)
-  end
-
-  def build_fields(dialog_fields)
-    build_dialog_fields(dialog_fields)
-  end
-
   def import_all_service_dialogs_from_yaml_file(filename)
     dialogs = YAML.load_file(filename)
 

--- a/app/services/dialog_import_service.rb
+++ b/app/services/dialog_import_service.rb
@@ -33,15 +33,15 @@ class DialogImportService
   end
 
   def build_tab(dialog_tab)
-    build_dialog_tabs('dialog_tabs' => [dialog_tab])
+    build_dialog_tabs(dialog_tab)
   end
 
   def build_group(dialog_group)
-    build_dialog_groups('dialog_groups' => [dialog_group])
+    build_dialog_groups(dialog_group)
   end
 
   def build_fields(dialog_fields)
-    build_dialog_fields('dialog_fields' => [dialog_fields])
+    build_dialog_fields(dialog_fields)
   end
 
   def import_all_service_dialogs_from_yaml_file(filename)

--- a/app/services/dialog_import_service.rb
+++ b/app/services/dialog_import_service.rb
@@ -74,6 +74,24 @@ class DialogImportService
     queue_deletion(import_file_upload.id)
   end
 
+  def build_dialog_tabs(dialog)
+    dialog["dialog_tabs"].collect do |dialog_tab|
+      DialogTab.create(dialog_tab.merge("dialog_groups" => build_dialog_groups(dialog_tab)))
+    end
+  end
+
+  def build_dialog_groups(dialog_tab)
+    dialog_tab["dialog_groups"].collect do |dialog_group|
+      DialogGroup.create(dialog_group.merge("dialog_fields" => build_dialog_fields(dialog_group)))
+    end
+  end
+
+  def build_dialog_fields(dialog_group)
+    dialog_group["dialog_fields"].collect do |dialog_field|
+      @dialog_field_importer.import_field(dialog_field)
+    end
+  end
+
   def import(dialog)
     @dialog_import_validator.determine_dialog_validity(dialog)
     new_dialog = Dialog.create(dialog.except('dialog_tabs'))
@@ -97,24 +115,6 @@ class DialogImportService
     end
   rescue DialogFieldImporter::InvalidDialogFieldTypeError
     raise
-  end
-
-  def build_dialog_tabs(dialog)
-    dialog["dialog_tabs"].collect do |dialog_tab|
-      DialogTab.create(dialog_tab.merge("dialog_groups" => build_dialog_groups(dialog_tab)))
-    end
-  end
-
-  def build_dialog_groups(dialog_tab)
-    dialog_tab["dialog_groups"].collect do |dialog_group|
-      DialogGroup.create(dialog_group.merge("dialog_fields" => build_dialog_fields(dialog_group)))
-    end
-  end
-
-  def build_dialog_fields(dialog_group)
-    dialog_group["dialog_fields"].collect do |dialog_field|
-      @dialog_field_importer.import_field(dialog_field)
-    end
   end
 
   def dialog_with_label?(label)

--- a/app/services/dialog_import_service.rb
+++ b/app/services/dialog_import_service.rb
@@ -32,6 +32,18 @@ class DialogImportService
     end
   end
 
+  def build_tab(dialog_tab)
+    build_dialog_tabs('dialog_tabs' => [dialog_tab])
+  end
+
+  def build_group(dialog_group)
+    build_dialog_groups('dialog_groups' => [dialog_group])
+  end
+
+  def build_fields(dialog_fields)
+    build_dialog_fields('dialog_fields' => [dialog_fields])
+  end
+
   def import_all_service_dialogs_from_yaml_file(filename)
     dialogs = YAML.load_file(filename)
 

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -21,4 +21,45 @@ describe DialogGroup do
       expect(dialog_group.dialog_fields).to be_empty
     end
   end
+
+  context '#update_dialog_tabs' do
+    before(:each) do
+      @dialog_group = FactoryGirl.create(:dialog_group)
+      @dialog_fields = FactoryGirl.create_list(:dialog_field, 2)
+      @dialog_group.dialog_fields << @dialog_fields
+    end
+
+    it 'deletes a dialog tab' do
+      fields = [
+        { 'id' => @dialog_fields.first.id }
+      ]
+
+      expect do
+        @dialog_group.update_dialog_fields(fields)
+      end.to change(@dialog_group.reload.dialog_fields, :count).by(-1)
+    end
+
+    it 'adds a dialog tab' do
+      fields = [
+        { 'id' => @dialog_fields.first.id },
+        { 'id' => @dialog_fields.last.id },
+        { 'name' => 'new tab', 'label' => 'new label' }
+      ]
+
+      expect do
+        @dialog_group.update_dialog_fields(fields)
+      end.to change(@dialog_group.reload.dialog_fields, :count).by(1)
+    end
+
+    it 'updates a dialog tab' do
+      fields = [
+        { 'id' => @dialog_fields.first.id, 'name' => 'updated name'},
+        { 'id' => @dialog_fields.first.id }
+      ]
+
+      expect do
+        @dialog_group.update_dialog_fields(fields)
+      end.to change(@dialog_fields.first.reload, :name)
+    end
+  end
 end

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -25,50 +25,41 @@ describe DialogGroup do
     let(:dialog_fields) { FactoryGirl.create_list(:dialog_field, 2) }
     let(:dialog_group) { FactoryGirl.create(:dialog_group, :dialog_fields => dialog_fields) }
 
-    context 'with an id' do
+    context 'a collection of dialog fields containing two objects with ids and one without an id' do
       let(:updated_fields) do
         [
           { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label' },
-          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label' }
+          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label' },
+          { 'name' => 'new field', 'label' => 'new field label' }
         ]
       end
 
-      it 'updates a dialog_field' do
+      it 'updates a the dialog fields with an id' do
         dialog_group.update_dialog_fields(updated_fields)
 
         dialog_group.reload
         expect(dialog_group.dialog_fields.first.label).to eq('updated_field_label')
         expect(dialog_group.dialog_fields.last.label).to eq('updated_field_label')
       end
+
+      it 'creates a new dialog field from the dialog fields without an id' do
+        expect do
+          dialog_group.update_dialog_fields(updated_fields)
+        end.to change(dialog_group.reload.dialog_fields, :count).by(1)
+      end
     end
 
-    context 'with a dialog_field removed' do
+    context 'with a dialog field removed from the dialog fields' do
       let(:updated_fields) do
         [
           { 'id' => dialog_fields.first.id }
         ]
       end
 
-      it 'deletes a dialog_field' do
+      it 'deletes the removed dialog field' do
         expect do
           dialog_group.update_dialog_fields(updated_fields)
         end.to change(dialog_group.reload.dialog_fields, :count).by(-1)
-      end
-    end
-
-    context 'without an id' do
-      let(:updated_fields) do
-        [
-          { 'id' => dialog_fields.first.id },
-          { 'id' => dialog_fields.last.id },
-          { 'name' => 'new field', 'label' => 'new field label' }
-        ]
-      end
-
-      it 'adds a new dialog_field' do
-        expect do
-          dialog_group.update_dialog_fields(updated_fields)
-        end.to change(dialog_group.reload.dialog_fields, :count).by(1)
       end
     end
   end

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -1,7 +1,6 @@
 describe DialogGroup do
   let(:dialog_group) { FactoryGirl.build(:dialog_group, :label => 'group') }
   context "#validate_children" do
-
     it "fails without element" do
       expect { dialog_group.save! }
         .to raise_error(ActiveRecord::RecordInvalid, /Box group must have at least one Element/)
@@ -22,44 +21,55 @@ describe DialogGroup do
     end
   end
 
-  context '#update_dialog_tabs' do
-    before(:each) do
-      @dialog_group = FactoryGirl.create(:dialog_group)
-      @dialog_fields = FactoryGirl.create_list(:dialog_field, 2)
-      @dialog_group.dialog_fields << @dialog_fields
+  describe '#update_dialog_fields' do
+    let(:dialog_fields) { FactoryGirl.create_list(:dialog_field, 2) }
+    let(:dialog_group) { FactoryGirl.create(:dialog_group, :dialog_fields => dialog_fields) }
+
+    context 'with an id' do
+      let(:updated_fields) do
+        [
+          { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label' },
+          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label' }
+        ]
+      end
+
+      it 'updates a dialog_field' do
+        dialog_group.update_dialog_fields(updated_fields)
+
+        dialog_group.reload
+        expect(dialog_group.dialog_fields.first.label).to eq('updated_field_label')
+        expect(dialog_group.dialog_fields.last.label).to eq('updated_field_label')
+      end
     end
 
-    it 'deletes a dialog tab' do
-      fields = [
-        { 'id' => @dialog_fields.first.id }
-      ]
+    context 'with a dialog_field removed' do
+      let(:updated_fields) do
+        [
+          { 'id' => dialog_fields.first.id }
+        ]
+      end
 
-      expect do
-        @dialog_group.update_dialog_fields(fields)
-      end.to change(@dialog_group.reload.dialog_fields, :count).by(-1)
+      it 'deletes a dialog_field' do
+        expect do
+          dialog_group.update_dialog_fields(updated_fields)
+        end.to change(dialog_group.reload.dialog_fields, :count).by(-1)
+      end
     end
 
-    it 'adds a dialog tab' do
-      fields = [
-        { 'id' => @dialog_fields.first.id },
-        { 'id' => @dialog_fields.last.id },
-        { 'name' => 'new tab', 'label' => 'new label' }
-      ]
+    context 'without an id' do
+      let(:updated_fields) do
+        [
+          { 'id' => dialog_fields.first.id },
+          { 'id' => dialog_fields.last.id },
+          { 'name' => 'new field', 'label' => 'new field label' }
+        ]
+      end
 
-      expect do
-        @dialog_group.update_dialog_fields(fields)
-      end.to change(@dialog_group.reload.dialog_fields, :count).by(1)
-    end
-
-    it 'updates a dialog tab' do
-      fields = [
-        { 'id' => @dialog_fields.first.id, 'name' => 'updated name'},
-        { 'id' => @dialog_fields.first.id }
-      ]
-
-      expect do
-        @dialog_group.update_dialog_fields(fields)
-      end.to change(@dialog_fields.first.reload, :name)
+      it 'adds a new dialog_field' do
+        expect do
+          dialog_group.update_dialog_fields(updated_fields)
+        end.to change(dialog_group.reload.dialog_fields, :count).by(1)
+      end
     end
   end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -286,6 +286,149 @@ describe Dialog do
     end
   end
 
+  context '#update_content' do
+    before(:each) do
+      @dialog_field = FactoryGirl.create_list(:dialog_field, 1, :label => 'field')
+      @dialog_group = FactoryGirl.create_list(:dialog_group, 1, :label => 'group', :dialog_fields => @dialog_field)
+      @dialog_tab = FactoryGirl.create_list(:dialog_tab, 1, :label => 'tab', :dialog_groups => @dialog_group)
+      @dialog = FactoryGirl.create(:dialog, :label => 'dialog', :dialog_tabs => @dialog_tab)
+
+      @dialog.dialog_tabs << FactoryGirl.create(:dialog_tab)
+      @dialog.save
+    end
+
+    # todo: make this test 'updates contents of a dialog tab'
+    it 'updates a dialog field' do
+      updated_content = {
+        'dialog_tabs' => [
+          {
+            'id' => @dialog_tab.first.id,
+            'label' => 'updated label',
+            'dialog_groups' => [
+              {
+                'id' => @dialog_group.first.id,
+                'dialog_fields' => [
+                  { 'id' => @dialog_field.first.id }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      @dialog.update_content(updated_content)
+      expect(@dialog_tab.first.reload.label).to eq('updated label')
+    end
+
+    it 'adds a new dialog tab' do
+      updated_content = {
+        'dialog_tabs' => [
+          {
+            'id' => @dialog_tab.first.id,
+            'label' => 'updated label',
+            'dialog_groups' => [
+              {
+                'id' => @dialog_group.first.id,
+                'dialog_fields' => [
+                  { 'id' => @dialog_field.first.id }
+                ]
+              }
+            ]
+          },
+          {
+            'label' => 'new tab',
+            'dialog_groups' => [
+              {
+                'label' => 'a new group',
+                'dialog_fields' => [
+                  { 'name' => 'new field', 'label' => 'field' }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      @dialog.update_content(updated_content)
+      expect(@dialog.reload.content.first['dialog_tabs'].count).to eq(2)
+    end
+
+    it 'adds a new dialog group to a tab' do
+      updated_content = {
+        'dialog_tabs' => [
+          {
+            'id' => @dialog_tab.first.id,
+            'label' => 'updated label',
+            'dialog_groups' => [
+              {
+                'id' => @dialog_group.first.id,
+                'dialog_fields' => [
+                  { 'id' => @dialog_field.first.id }
+                ]
+              },
+              {
+                'label' => 'new group',
+                'dialog_fields' => [
+                  { 'name' => 'new field', 'label' => 'field'}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      @dialog.update_content(updated_content)
+      expect(@dialog.reload.content.first['dialog_tabs'].first['dialog_groups'].count).to eq(2)
+    end
+
+    it 'adds a new dialog field to a group' do
+      updated_content = {
+        'dialog_tabs' => [
+          {
+            'id' => @dialog_tab.first.id,
+            'label' => 'updated label',
+            'dialog_groups' => [
+              {
+                'id' => @dialog_group.first.id,
+                'dialog_fields' => [
+                  { 'id' => @dialog_field.first.id },
+                  { 'name' => 'new field', 'label' => 'field' }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      @dialog.update_content(updated_content)
+      expect(@dialog.reload.content.first['dialog_tabs'].first['dialog_groups'].first['dialog_fields'].count).to eq(2)
+    end
+
+    it 'removes a dialog tab from a dialog' do
+      @dialog.dialog_tabs << FactoryGirl.create(:dialog_tab)
+      @dialog.save
+
+      updated_content = {
+        'dialog_tabs' => [
+          {
+            'id' => @dialog_tab.first.id,
+            'dialog_groups' => [
+              {
+                'id' => @dialog_group.first.id,
+                'dialog_fields' => [
+                  { 'id' => @dialog_field.first.id }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      @dialog.update_content(updated_content)
+      expect(@dialog.reload.content.first['dialog_tabs'].count).to eq(1)
+    end
+  end
+
   context "#dialog_fields" do
     before(:each) do
       @dialog        = FactoryGirl.create(:dialog, :label => 'dialog')

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -325,21 +325,19 @@ describe Dialog do
       ]
     end
 
-    context 'dialog_tab with an id' do
-      it 'updates the dialog_tab' do
+    context 'a collection of dialog tabs containing one with an id and one without an id' do
+      it 'updates the dialog_tab with an id' do
         dialog.update_tabs(updated_content)
         expect(dialog.reload.dialog_tabs.first.label).to eq('updated_label')
       end
-    end
 
-    context 'dialog_tab without an id' do
-      it 'creates the dialog_tab' do
+      it 'creates the dialog tab from the dialog tabs without an id' do
         dialog.update_tabs(updated_content)
         expect(dialog.reload.dialog_tabs.count).to eq(2)
       end
     end
 
-    context 'with a dialog_tab removed' do
+    context 'with a dialog tab removed from the dialog tabs collection' do
       let(:updated_content) do
         [
           'id'            => dialog_tab.first.id,
@@ -353,7 +351,7 @@ describe Dialog do
         dialog.dialog_tabs << FactoryGirl.create(:dialog_tab)
       end
 
-      it 'removes a dialog tab' do
+      it 'deletes the removed dialog_tab' do
         expect do
           dialog.update_tabs(updated_content)
         end.to change(dialog.reload.dialog_tabs, :count).by(-1)

--- a/spec/models/dialog_tab_spec.rb
+++ b/spec/models/dialog_tab_spec.rb
@@ -26,4 +26,64 @@ describe DialogTab do
       expect(dialog_tab.dialog_fields).to be_empty
     end
   end
+
+  context '#update_dialog_groups' do
+    before(:each) do
+      @dialog_tab = FactoryGirl.create(:dialog_tab)
+      @dialog_groups = FactoryGirl.create_list(:dialog_group, 2)
+      @dialog_groups.first.dialog_fields << FactoryGirl.create_list(:dialog_field, 1)
+      @dialog_tab.dialog_groups << @dialog_groups
+    end
+
+    it 'deletes a dialog group' do
+      groups = [
+        {
+          'id' => @dialog_groups.first.id,
+          'dialog_fields' => []
+        }
+      ]
+      expect do
+        @dialog_tab.update_dialog_groups(groups)
+      end.to change(@dialog_tab.reload.dialog_groups, :count).by(-1)
+    end
+
+    it 'adds a new dialog group' do
+      groups = [
+        {
+          'id' => @dialog_groups.first.id,
+          'dialog_fields' => []
+        },
+        {
+          'id' => @dialog_groups.last.id,
+          'dialog_fields' => []
+        },
+        {
+          'label' => 'new group',
+          'dialog_fields' => [ { 'name' => 'field', 'label' => 'field' } ]
+        }
+      ]
+
+      expect do
+        @dialog_tab.update_dialog_groups(groups)
+      end.to change(@dialog_tab.reload.dialog_groups, :count).by(1)
+    end
+
+    it 'updates a dialog group' do
+      groups = [
+        {
+          'id' => @dialog_groups.first.id,
+          'label' => 'new label',
+          'dialog_fields' => []
+        },
+        {
+          'id' => @dialog_groups.last.id,
+          'dialog_fields' => []
+        }
+      ]
+
+      expect do
+        @dialog_tab.update_dialog_groups(groups)
+      end.to change(@dialog_groups.first.reload, :label)
+    end
+  end
 end

--- a/spec/models/dialog_tab_spec.rb
+++ b/spec/models/dialog_tab_spec.rb
@@ -35,19 +35,25 @@ describe DialogTab do
       dialog_groups.each_with_index { |group, index| group.dialog_fields << dialog_fields[index] }
     end
 
-    context 'with an id' do
+    context 'a collection of dialog groups containing two objects with ids and one without an id' do
       let(:updated_groups) do
         [
           { 'id'            => dialog_groups.first.id,
             'label'         => 'updated_label',
-            'dialog_fields' => [{ 'id' => dialog_fields.first.id}]},
+            'dialog_fields' => [{ 'id' => dialog_fields.first.id}]
+          },
           { 'id'            => dialog_groups.last.id,
             'label'         => 'updated_label',
-            'dialog_fields' => [{'id' => dialog_fields.last.id}] }
+            'dialog_fields' => [{'id' => dialog_fields.last.id}]
+          },
+          {
+            'label'         => 'a new label',
+            'dialog_fields' => [{'name' => 'field name', 'label' => 'field label'}]
+          }
         ]
       end
 
-      it 'updates a dialog_group' do
+      it 'updates the dialog groups with an id' do
         dialog_tab.update_dialog_groups(updated_groups)
 
         dialog_tab.reload
@@ -55,32 +61,22 @@ describe DialogTab do
         expect(dialog_tab.dialog_groups.first.label).to eq('updated_label')
         expect(dialog_tab.dialog_groups.last.label).to eq('updated_label')
       end
-    end
 
-    context 'without an id' do
-      let(:updated_groups) do
-        [
-          { 'id' => dialog_groups.first.id, 'dialog_fields' => [{'id' => dialog_fields.first.id}] },
-          { 'id' => dialog_groups.last.id, 'dialog_fields' => [{'id' => dialog_fields.last.id}] },
-          { 'label' => 'label', 'dialog_fields' => [{ 'name' => 'field name', 'label' => 'field name' }]}
-        ]
-      end
-
-      it 'creates a new group' do
+      it 'creates a new dialog group from the dialog group without an id' do
         expect do
           dialog_tab.update_dialog_groups(updated_groups)
         end.to change(dialog_tab.reload.dialog_groups, :count).by(1)
       end
     end
 
-    context 'with a dialog_group removed' do
+    context 'with a dialog group removed from the dialog groups' do
       let(:updated_groups) do
         [
           { 'id' => dialog_groups.first.id, 'dialog_fields' => []}
         ]
       end
 
-      it 'deletes a dialog_group' do
+      it 'deletes the removed dialog group' do
         expect do
           dialog_tab.update_dialog_groups(updated_groups)
         end.to change(dialog_tab.reload.dialog_groups, :count).by(-1)

--- a/spec/services/dialog_import_service_spec.rb
+++ b/spec/services/dialog_import_service_spec.rb
@@ -351,6 +351,75 @@ describe DialogImportService do
         end
       end
     end
+
+    describe '#build_dialog_tabs' do
+      let(:dialog_tabs) do
+        {
+          'dialog_tabs' => [
+            {
+              'label'         => 'new dialog tab',
+              'dialog_groups' => [
+                {
+                  'label'         => 'group label',
+                  'dialog_fields' => [
+                    {
+                      'name'  => 'field name',
+                      'label' => 'field label'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'creates a new dialog_tab' do
+        expect do
+          DialogImportService.new.build_dialog_tabs(dialog_tabs)
+        end.to change(DialogTab, :count).by(1)
+      end
+    end
+
+    describe '#build_dialog_groups' do
+      let(:dialog_groups) do
+        {
+          'dialog_groups' => [
+            {
+              'label'         => 'new group',
+              'dialog_fields' => [
+                {
+                  'name'  => 'field name',
+                  'label' => 'field label'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'creates a new dialog_group' do
+        expect do
+          DialogImportService.new.build_dialog_groups(dialog_groups)
+        end.to change(DialogGroup, :count).by(1)
+      end
+    end
+
+    describe '#build_dialog_fields' do
+      let(:dialog_fields) do
+        {
+          'dialog_fields' => [
+            {'name' => 'field name', 'label' => 'field label'}
+          ]
+        }
+      end
+
+      it 'creates a new dialog_field' do
+        expect do
+          DialogImportService.new.build_dialog_fields(dialog_fields)
+        end.to change(DialogField, :count).by(1)
+      end
+    end
   end
 
   context '#import' do


### PR DESCRIPTION
For the REST api, needed a way to pass updated `content` of a Dialog back to a dialog and have it update the associated `dialog_groups`, `dialog_tabs`, and `dialog_fields`. This PR is 1 of 2 and adds an `update_content` method to the dialog. Utilized as much of the DialogImportService as possible.

Will update the API to use this method in an upcoming PR. 

@miq-bot add_label wip, enhancement 