### PR TITLE
Remove jasmine and phantomjs restrictions (Fixes Sierra issues)

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -80,9 +80,7 @@ unless ENV['APPLIANCE']
   group :test do
     gem "camcorder",                    :require => false
     gem "coveralls",                    :require => false
-    gem "jasmine",       "~>2.4.0",     :require => false
-    gem "jasmine-core",  "~>2.4.0",     :require => false  # force the expected version, jasmine/jasmine-gem#271
-    gem "phantomjs",     "=1.9.8.0",    :require => false
+    gem "jasmine",                      :require => false
     gem "rspec",         "~>3.5.0",     :require => false
     gem "test-unit",                    :require => false
     gem "timecop",       "~>0.7.3",     :require => false


### PR DESCRIPTION
Removes the restrictions on these dependencies to install the latest version. Aka letting jasmine handle it's own dependencies.

There is a bug in phantomjs on MacOS Sierra seen when running `rake test:javascript` (`0 tests actually run`) that is fixed in a newer version of phantomjs.

I do not believe the issue seen in https://github.com/ManageIQ/manageiq/pull/11090 is an issue anymore