### PR TITLE
Enable Provision VMs button via relationships

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -536,7 +536,7 @@ class ApplicationHelper::ToolbarBuilder
 
     # need to hide add buttons when on sub-list view screen of a CI.
     return true if id.ends_with?("_new", "_discover") &&
-                   @lastaction == "show" && @display != "main"
+                   @lastaction == "show" && !["main", "vms"].include?(@display)
 
     if id == "summary_reload"                             # Show reload button if
       return @explorer && # we are in explorer and

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -578,6 +578,16 @@ describe ApplicationHelper do
       end
     end
 
+    context "when with vm_miq_request_new" do
+      it "and @lastaction = show, @display = vms" do
+        @id = "vm_miq_request_new"
+        @lastaction = "show"
+        @display = "vms"
+        stub_user(:features => :all)
+        expect(subject).to be_falsey
+      end
+    end
+
     context "when with vm_console" do
       before do
         @id = "vm_console"


### PR DESCRIPTION
Make the Provision VMs button appear consistently when navigating to a list of VMs from Providers or other relationships.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1373850