### PR TITLE
Validate user roles against domain edit before allowing copy/edit on any objects under it

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -672,6 +672,7 @@ class ApplicationHelper::ToolbarBuilder
         return true if x_active_tree == :condition_tree || !role_allows?(:feature => "condition_delete")
       end
     when "MiqAeClass", "MiqAeDomain", "MiqAeField", "MiqAeInstance", "MiqAeMethod", "MiqAeNamespace"
+      return true unless role_allows?(:feature => "miq_ae_domain_edit")
       return false if MIQ_AE_COPY_ACTIONS.include?(id) && User.current_tenant.any_editable_domains? && MiqAeDomain.any_unlocked?
       case id
       when "miq_ae_domain_lock"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2184,7 +2184,15 @@ describe ApplicationHelper do
   context "#build_toolbar_hide_button" do
     before do
       Tenant.seed
-      user = FactoryGirl.create(:user_with_group)
+      feature_list = %w(
+        miq_ae_class_edit
+        miq_ae_domain_edit
+        miq_ae_class_copy
+        miq_ae_instance_copy
+        miq_ae_method_copy
+        miq_ae_namespace_edit
+      )
+      user = FactoryGirl.create(:user, :features => feature_list)
       login_as user
       @domain = FactoryGirl.create(:miq_ae_domain)
       @namespace = FactoryGirl.create(:miq_ae_namespace, :name => "test1", :parent => @domain)
@@ -2193,6 +2201,11 @@ describe ApplicationHelper do
 
     it "Enables buttons for Unlocked domain" do
       expect(build_toolbar_hide_button('miq_ae_class_edit')).to be_falsey
+    end
+
+    it "a user with view access should not be able to edit class" do
+      login_as FactoryGirl.create(:user, :features => 'miq_ae_domain_view')
+      expect(build_toolbar_hide_button('miq_ae_class_edit')).to be_truthy
     end
 
     it "Disables buttons for Locked domain" do
@@ -2256,10 +2269,6 @@ describe ApplicationHelper do
     it "Enables miq_ae_namespace_edit for Unlocked domain" do
       @record = @namespace
       expect(build_toolbar_hide_button('miq_ae_namespace_edit')).to be_falsey
-    end
-
-    def role_allows?(_)
-      true
     end
   end
 


### PR DESCRIPTION
Previously we were not checking if the currently logged
in user has enough privileges to modify the contents of
the domain.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1365493

Steps for Testing/QA 
-------------------------------
1. Login as ADMIN to the CFME UI.
2. Configuration -> Access Control -> Roles 
3. Add a new role (e.g. read_only_automate)
4. In the Product Features only enable the View for Automate->Explorer->Automate Domains
5. Add a new group (e.g. AutomateViewer) and assign the newly created role (e.g read_only_automate)
6. Add a new user (e.g user1) and make him a part of the newly created group (e.g. AutomateViewer)
7. Login to the UI as user1 you should be able to view classes/instances/methods but won't be able to edit it

<img width="1125" alt="screen shot 2016-10-11 at 4 30 53 pm" src="https://cloud.githubusercontent.com/assets/6452699/19287570/2c6aaea4-8fd0-11e6-8b8a-fd3a7ba395d7.png">
