### PR TITLE
Reformat static list in ApplicationHelper#taskbar_in_header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -648,7 +648,7 @@ module ApplicationHelper
         report 
         rss
         server_build
-        ).include?(@layout) ||).include?(@layout) ||
+        ).include?(@layout) ||
         (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
         unless @explorer
           @show_taskbar = true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -625,10 +625,30 @@ module ApplicationHelper
     if @show_taskbar.nil?
       @show_taskbar = false
       if ! (@layout == "" && %w(auth_error change_tab show).include?(controller.action_name) ||
-        %w(about chargeback ems_infra_dashboard exception miq_ae_automate_button miq_ae_class miq_ae_export
-           miq_ae_tools miq_capacity_bottlenecks miq_capacity_planning miq_capacity_utilization
-           miq_capacity_waste miq_policy miq_policy_export miq_policy_rsop ops pxe report rss
-           server_build middleware_topology network_topology container_dashboard).include?(@layout) ||
+        %w(about
+        chargeback
+        container_dashboard
+        ems_infra_dashboard 
+        exception 
+        middleware_topology 
+        miq_ae_automate_button 
+        miq_ae_class 
+        miq_ae_export
+        miq_ae_tools 
+        miq_capacity_bottlenecks 
+        miq_capacity_planning 
+        miq_capacity_utilization
+        miq_capacity_waste 
+        miq_policy 
+        miq_policy_export 
+        miq_policy_rsop 
+        network_topology 
+        ops 
+        pxe 
+        report 
+        rss
+        server_build
+        ).include?(@layout) ||).include?(@layout) ||
         (@layout == "configuration" && @tabform != "ui_4")) && !controller.action_name.end_with?("tagging_edit")
         unless @explorer
           @show_taskbar = true


### PR DESCRIPTION
Reformat static list in ApplicationHelper#taskbar_in_header to be sorted and one to a line. For #11838. Example from 326f59093a9eac6ea723c60bed58cc1ea55f7bf6 