### PR TITLE
Remove #fetch_value from API helper

### DIFF
--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -81,7 +81,7 @@ describe "Automation Requests API" do
       run_post(request1_url, gen_request(:approve, :reason => "approve reason"))
 
       expected_msg = "Automation request #{request1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => :request1_url)
+      expect_single_action_result(:success => true, :message => expected_msg, :href => request1_url)
     end
 
     it "supports denying a request" do
@@ -90,7 +90,7 @@ describe "Automation Requests API" do
       run_post(request2_url, gen_request(:deny, :reason => "deny reason"))
 
       expected_msg = "Automation request #{request2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => :request2_url)
+      expect_single_action_result(:success => true, :message => expected_msg, :href => request2_url)
     end
 
     it "supports approving multiple requests" do

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -53,7 +53,7 @@ describe "Conditions API" do
       run_get conditions_url, :expand => "resources"
 
       expect_query_result(:conditions, 3, 3)
-      expect_result_resources_to_include_data("resources", "guid" => :condition_guid_list)
+      expect_result_resources_to_include_data("resources", "guid" => condition_guid_list)
     end
   end
 
@@ -78,7 +78,7 @@ describe "Conditions API" do
       run_get policy_conditions_url, :expand => "resources"
 
       expect_query_result(:conditions, 3, 3)
-      expect_result_resources_to_include_data("resources", "guid" => :condition_guid_list)
+      expect_result_resources_to_include_data("resources", "guid" => condition_guid_list)
     end
 
     it "query policy with expanded conditions" do
@@ -89,7 +89,7 @@ describe "Conditions API" do
       run_get policy_url, :expand => "conditions"
 
       expect_single_resource_query("name" => policy.name, "description" => policy.description, "guid" => policy.guid)
-      expect_result_resources_to_include_data("conditions", "guid" => :condition_guid_list)
+      expect_result_resources_to_include_data("conditions", "guid" => condition_guid_list)
     end
   end
 end

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -49,7 +49,7 @@ describe "Events API" do
       run_get events_url, :expand => "resources"
 
       expect_query_result(:events, 3, 3)
-      expect_result_resources_to_include_data("resources", "guid" => :miq_event_guid_list)
+      expect_result_resources_to_include_data("resources", "guid" => miq_event_guid_list)
     end
   end
 
@@ -80,7 +80,7 @@ describe "Events API" do
       run_get policy_events_url, :expand => "resources"
 
       expect_query_result(:events, 3, 3)
-      expect_result_resources_to_include_data("resources", "guid" => :miq_event_guid_list)
+      expect_result_resources_to_include_data("resources", "guid" => miq_event_guid_list)
     end
 
     it "query policy with expanded events" do
@@ -91,7 +91,7 @@ describe "Events API" do
       run_get policy_url, :expand => "events"
 
       expect_single_resource_query("name" => policy.name, "description" => policy.description, "guid" => policy.guid)
-      expect_result_resources_to_include_data("events", "guid" => :miq_event_guid_list)
+      expect_result_resources_to_include_data("events", "guid" => miq_event_guid_list)
     end
   end
 end

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Instances API" do
       expect_single_action_result(
         :success => true,
         :message => /#{instance.id}.* terminating/i,
-        :href    => :instance_url
+        :href    => instance_url
       )
     end
 
@@ -104,7 +104,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "stops a valid instance" do
@@ -112,7 +112,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => :instance_url, :task => true)
+      expect_single_action_result(:success => true, :message => "stopping", :href => instance_url, :task => true)
     end
 
     it "stops multiple valid instances" do
@@ -121,7 +121,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:stop, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 
@@ -147,7 +147,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is powered on", :href => instance_url)
     end
 
     it "starts an instance" do
@@ -156,7 +156,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => :instance_url, :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => instance_url, :task => true)
     end
 
     it "starts multiple instances" do
@@ -166,7 +166,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:start, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 
@@ -193,7 +193,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "fails to pause a paused instance" do
@@ -202,7 +202,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "pauses an instance" do
@@ -210,7 +210,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => :instance_url, :task => true)
+      expect_single_action_result(:success => true, :message => "pausing", :href => instance_url, :task => true)
     end
 
     it "pauses multiple instances" do
@@ -219,7 +219,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:pause, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 
@@ -246,7 +246,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "cannot suspend a suspended instance" do
@@ -255,7 +255,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "suspends an instance" do
@@ -263,7 +263,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => :instance_url, :task => true)
+      expect_single_action_result(:success => true, :message => "suspending", :href => instance_url, :task => true)
     end
 
     it "suspends multiple instances" do
@@ -272,7 +272,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:suspend, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 
@@ -299,7 +299,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => :instance_url)
+      expect_single_action_result(:success => true, :message => 'shelving', :href => instance_url)
     end
 
     it "shelves a suspended instance" do
@@ -308,7 +308,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => :instance_url)
+      expect_single_action_result(:success => true, :message => 'shelving', :href => instance_url)
     end
 
     it "shelves a paused instance" do
@@ -317,7 +317,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => :instance_url)
+      expect_single_action_result(:success => true, :message => 'shelving', :href => instance_url)
     end
 
     it "cannot shelve a shelved instance" do
@@ -329,7 +329,7 @@ RSpec.describe "Instances API" do
       expect_single_action_result(
         :success => false,
         :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-        :href    => :instance_url
+        :href    => instance_url
       )
     end
 
@@ -340,7 +340,7 @@ RSpec.describe "Instances API" do
 
       expect_single_action_result(:success => true,
                                   :message => "shelving",
-                                  :href    => :instance_url,
+                                  :href    => instance_url,
                                   :task    => true)
     end
 
@@ -350,7 +350,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:shelve, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 
@@ -377,7 +377,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "reboots a valid instance" do
@@ -385,7 +385,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => "rebooting", :href => :instance_url, :task => true)
+      expect_single_action_result(:success => true, :message => "rebooting", :href => instance_url, :task => true)
     end
 
     it "reboots multiple valid instances" do
@@ -394,7 +394,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:reboot_guest, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 
@@ -421,7 +421,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reset))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :instance_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => instance_url)
     end
 
     it "resets a valid instance" do
@@ -429,7 +429,7 @@ RSpec.describe "Instances API" do
 
       run_post(instance_url, gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => "resetting", :href => :instance_url, :task => true)
+      expect_single_action_result(:success => true, :message => "resetting", :href => instance_url, :task => true)
     end
 
     it "resets multiple valid instances" do
@@ -438,7 +438,7 @@ RSpec.describe "Instances API" do
       run_post(instances_url, gen_request(:reset, nil, instance1_url, instance2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :instances_list)
+      expect_result_resources_to_include_hrefs("results", instances_list)
     end
   end
 end

--- a/spec/requests/api/notifications_spec.rb
+++ b/spec/requests/api/notifications_spec.rb
@@ -31,7 +31,7 @@ describe 'Notifications API' do
 
         run_post(notification_url, gen_request(:delete))
         expect(response).to have_http_status(:ok)
-        expect_single_action_result(:success => true, :href => :notification_url)
+        expect_single_action_result(:success => true, :href => notification_url)
         expect { notification_recipient.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -104,7 +104,7 @@ describe 'Notifications API' do
 
       expect(notification_recipient.seen).to be_falsey
       run_post(notification_url, gen_request(:mark_as_seen))
-      expect_single_action_result(:success => true, :href => :notification_url)
+      expect_single_action_result(:success => true, :href => notification_url)
       expect(notification_recipient.reload.seen).to be_truthy
     end
   end

--- a/spec/requests/api/policy_actions_spec.rb
+++ b/spec/requests/api/policy_actions_spec.rb
@@ -51,7 +51,7 @@ describe "Policy Actions API" do
       run_get policy_actions_url, :expand => "resources"
 
       expect_query_result(:policy_actions, 4, 4)
-      expect_result_resources_to_include_data("resources", "guid" => :miq_action_guid_list)
+      expect_result_resources_to_include_data("resources", "guid" => miq_action_guid_list)
     end
   end
 
@@ -82,7 +82,7 @@ describe "Policy Actions API" do
       run_get policy_actions_url, :expand => "resources"
 
       expect_query_result(:policy_actions, 4, 4)
-      expect_result_resources_to_include_data("resources", "guid" => :miq_action_guid_list)
+      expect_result_resources_to_include_data("resources", "guid" => miq_action_guid_list)
     end
 
     it "query policy with expanded policy actions" do
@@ -93,7 +93,7 @@ describe "Policy Actions API" do
       run_get policy_url, :expand => "policy_actions"
 
       expect_single_resource_query("name" => policy.name, "description" => policy.description, "guid" => policy.guid)
-      expect_result_resources_to_include_data("policy_actions", "guid" => :miq_action_guid_list)
+      expect_result_resources_to_include_data("policy_actions", "guid" => miq_action_guid_list)
     end
   end
 end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -126,7 +126,7 @@ describe "Providers API" do
 
       expect_query_result(:custom_attributes, 2)
 
-      expect_result_resources_to_include_hrefs("resources", :provider_ca_url_list)
+      expect_result_resources_to_include_hrefs("resources", provider_ca_url_list)
     end
 
     it "getting custom_attributes from a provider in expanded form" do

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -271,7 +271,7 @@ describe "Provision Requests API" do
       run_post(provreq1_url, gen_request(:approve))
 
       expected_msg = "Provision request #{provreq1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => :provreq1_url)
+      expect_single_action_result(:success => true, :message => expected_msg, :href => provreq1_url)
     end
 
     it "supports denying a request" do
@@ -280,7 +280,7 @@ describe "Provision Requests API" do
       run_post(provreq2_url, gen_request(:deny))
 
       expected_msg = "Provision request #{provreq2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => :provreq2_url)
+      expect_single_action_result(:success => true, :message => expected_msg, :href => provreq2_url)
     end
 
     it "supports approving multiple requests" do

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -98,7 +98,7 @@ describe "Queries API" do
       run_get vm1_accounts_url
 
       expect_query_result(:accounts, 2)
-      expect_result_resources_to_include_hrefs("resources", :vm1_accounts_url_list)
+      expect_result_resources_to_include_hrefs("resources", vm1_accounts_url_list)
     end
 
     it "includes both id and href when getting a single resource" do
@@ -119,7 +119,7 @@ describe "Queries API" do
 
       expect_query_result(:accounts, 2)
       expect_result_resources_to_include_keys("resources", %w(id href))
-      expect_result_resources_to_include_hrefs("resources", :vm1_accounts_url_list)
+      expect_result_resources_to_include_hrefs("resources", vm1_accounts_url_list)
       expect_result_resources_to_include_data("resources", "id" => [acct1.id, acct2.id])
     end
 

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -68,7 +68,7 @@ describe "Roles API" do
     expect(response.parsed_body).to have_key("name")
     expect(response.parsed_body["name"]).to eq(role.name)
     expect(response.parsed_body).to have_key("features")
-    expect(response.parsed_body["features"].size).to eq(fetch_value(role.miq_product_features.count))
+    expect(response.parsed_body["features"].size).to eq(role.miq_product_features.count)
 
     expect_result_resources_to_include_data("features", attr.to_s => klass.pluck(attr))
   end

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -103,7 +103,7 @@ describe "Service Requests API" do
       run_post(svcreq1_url, gen_request(:approve, :reason => "approve reason"))
 
       expected_msg = "Service request #{svcreq1.id} approved"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => :svcreq1_url)
+      expect_single_action_result(:success => true, :message => expected_msg, :href => svcreq1_url)
     end
 
     it "supports denying a request" do
@@ -112,7 +112,7 @@ describe "Service Requests API" do
       run_post(svcreq2_url, gen_request(:deny, :reason => "deny reason"))
 
       expected_msg = "Service request #{svcreq2.id} denied"
-      expect_single_action_result(:success => true, :message => expected_msg, :href => :svcreq2_url)
+      expect_single_action_result(:success => true, :message => expected_msg, :href => svcreq2_url)
     end
 
     it "supports approving multiple requests" do

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -10,7 +10,6 @@ describe "Tag Collections API" do
   let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
   let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
   let(:tag_paths)    { [tag1[:path], tag2[:path]] }
-  let(:tag_count)    { Tag.count }
 
   def classify_resource(resource)
     Classification.classify(resource, tag1[:category], tag1[:name])
@@ -43,8 +42,8 @@ describe "Tag Collections API" do
 
       run_get provider_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Provider without appropriate role" do
@@ -92,8 +91,8 @@ describe "Tag Collections API" do
 
       run_get host_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Host without appropriate role" do
@@ -142,8 +141,8 @@ describe "Tag Collections API" do
 
       run_get ds_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Data Store without appropriate role" do
@@ -192,8 +191,8 @@ describe "Tag Collections API" do
 
       run_get rp_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Resource Pool without appropriate role" do
@@ -249,8 +248,8 @@ describe "Tag Collections API" do
 
       run_get cluster_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Cluster without appropriate role" do
@@ -299,8 +298,8 @@ describe "Tag Collections API" do
 
       run_get service_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Service without appropriate role" do
@@ -349,8 +348,8 @@ describe "Tag Collections API" do
 
       run_get service_template_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Service Template without appropriate role" do
@@ -399,8 +398,8 @@ describe "Tag Collections API" do
 
       run_get tenant_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
-      expect_result_resources_to_include_data("resources", "name" => :tag_paths)
+      expect_query_result(:tags, 2, Tag.count)
+      expect_result_resources_to_include_data("resources", "name" => tag_paths)
     end
 
     it "does not assign a tag to a Tenant without appropriate role" do

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -10,7 +10,6 @@ describe "Tags API" do
   let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
   let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
   let(:invalid_tag_url) { tags_url(999_999) }
-  let(:tag_count)    { Tag.count }
 
   before(:each) do
     FactoryGirl.create(:classification_department_with_tags)
@@ -23,7 +22,7 @@ describe "Tags API" do
 
       run_get tags_url
 
-      expect_query_result(:tags, :tag_count)
+      expect_query_result(:tags, Tag.count)
     end
 
     context "with an appropriate role" do
@@ -263,7 +262,7 @@ describe "Tags API" do
 
       run_get tags_url, :expand => "resources"
 
-      expect_query_result(:tags, :tag_count, :tag_count)
+      expect_query_result(:tags, Tag.count, Tag.count)
       expect_result_resources_to_include_keys("resources", %w(id name))
     end
 
@@ -307,7 +306,7 @@ describe "Tags API" do
 
       run_get tags_url, :expand => "resources", :attributes => "categorization"
 
-      expect_query_result(:tags, :tag_count, :tag_count)
+      expect_query_result(:tags, Tag.count, Tag.count)
       expect_result_resources_to_include_keys("resources", %w(id name categorization))
     end
   end

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -54,7 +54,7 @@ describe "Vms API" do
       run_get vm_accounts_url
 
       expect_query_result(:accounts, 2)
-      expect_result_resources_to_include_hrefs("resources", :vm_accounts_url_list)
+      expect_result_resources_to_include_hrefs("resources", vm_accounts_url_list)
     end
 
     it "query VM accounts subcollection with a valid Account Id" do
@@ -81,8 +81,8 @@ describe "Vms API" do
 
       run_get vm_url, :expand => "accounts"
 
-      expect_single_resource_query("guid" => :vm_guid)
-      expect_result_resources_to_include_hrefs("accounts", :vm_accounts_url_list)
+      expect_single_resource_query("guid" => vm_guid)
+      expect_result_resources_to_include_hrefs("accounts", vm_accounts_url_list)
     end
   end
 
@@ -111,7 +111,7 @@ describe "Vms API" do
       run_get vm_software_url
 
       expect_query_result(:software, 2)
-      expect_result_resources_to_include_hrefs("resources", :vm_software_url_list)
+      expect_result_resources_to_include_hrefs("resources", vm_software_url_list)
     end
 
     it "query VM software subcollection with a valid Software Id" do
@@ -138,8 +138,8 @@ describe "Vms API" do
 
       run_get vms_url(vm.id), :expand => "software"
 
-      expect_single_resource_query("guid" => :vm_guid)
-      expect_result_resources_to_include_hrefs("software", :vm_software_url_list)
+      expect_single_resource_query("guid" => vm_guid)
+      expect_result_resources_to_include_hrefs("software", vm_software_url_list)
     end
   end
 
@@ -165,7 +165,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:start))
 
-      expect_single_action_result(:success => false, :message => "is powered on", :href => :vm_url)
+      expect_single_action_result(:success => false, :message => "is powered on", :href => vm_url)
     end
 
     it "starts a vm" do
@@ -174,7 +174,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => vm_url, :task => true)
     end
 
     it "starting a vm queues it properly" do
@@ -183,7 +183,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:start))
 
-      expect_single_action_result(:success => true, :message => "starting", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "starting", :href => vm_url, :task => true)
       expect(MiqQueue.where(:class_name  => vm.class.name,
                             :instance_id => vm.id,
                             :method_name => "start",
@@ -197,7 +197,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:start, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
+      expect_result_resources_to_include_hrefs("results", vms_list)
     end
   end
 
@@ -224,7 +224,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:stop))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :vm_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => vm_url)
     end
 
     it "stops a vm" do
@@ -232,7 +232,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:stop))
 
-      expect_single_action_result(:success => true, :message => "stopping", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "stopping", :href => vm_url, :task => true)
     end
 
     it "stops multiple vms" do
@@ -241,7 +241,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:stop, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
+      expect_result_resources_to_include_hrefs("results", vms_list)
     end
   end
 
@@ -268,7 +268,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :vm_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => vm_url)
     end
 
     it "suspends a suspended vm" do
@@ -277,7 +277,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :vm_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => vm_url)
     end
 
     it "suspends a vm" do
@@ -285,7 +285,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:suspend))
 
-      expect_single_action_result(:success => true, :message => "suspending", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "suspending", :href => vm_url, :task => true)
     end
 
     it "suspends multiple vms" do
@@ -294,7 +294,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:suspend, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
+      expect_result_resources_to_include_hrefs("results", vms_list)
     end
   end
 
@@ -321,7 +321,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :vm_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => vm_url)
     end
 
     it "pauses a pauseed vm" do
@@ -330,7 +330,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:pause))
 
-      expect_single_action_result(:success => false, :message => "is not powered on", :href => :vm_url)
+      expect_single_action_result(:success => false, :message => "is not powered on", :href => vm_url)
     end
 
     it "pauses a vm" do
@@ -338,7 +338,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:pause))
 
-      expect_single_action_result(:success => true, :message => "pausing", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "pausing", :href => vm_url, :task => true)
     end
 
     it "pauses multiple vms" do
@@ -347,7 +347,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:pause, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
+      expect_result_resources_to_include_hrefs("results", vms_list)
     end
   end
 
@@ -374,7 +374,7 @@ describe "Vms API" do
 
       run_post(vm_openstack_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => :vm_openstack_url)
+      expect_single_action_result(:success => true, :message => 'shelving', :href => vm_openstack_url)
     end
 
     it "shelves a suspended vm" do
@@ -383,7 +383,7 @@ describe "Vms API" do
 
       run_post(vm_openstack_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => :vm_openstack_url)
+      expect_single_action_result(:success => true, :message => 'shelving', :href => vm_openstack_url)
     end
 
     it "shelves a paused off vm" do
@@ -392,7 +392,7 @@ describe "Vms API" do
 
       run_post(vm_openstack_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => 'shelving', :href => :vm_openstack_url)
+      expect_single_action_result(:success => true, :message => 'shelving', :href => vm_openstack_url)
     end
 
     it "shelves a shelveed vm" do
@@ -403,7 +403,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved, current state has to be powered on, off, suspended or paused",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelves a vm" do
@@ -411,7 +411,7 @@ describe "Vms API" do
 
       run_post(vm_openstack_url, gen_request(:shelve))
 
-      expect_single_action_result(:success => true, :message => "shelving", :href => :vm_openstack_url, :task => true)
+      expect_single_action_result(:success => true, :message => "shelving", :href => vm_openstack_url, :task => true)
     end
 
     it "shelve for a VMWare vm is not supported" do
@@ -421,7 +421,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "Shelve Operation is not available for Vmware VM.",
-                                  :href    => :vm_url,
+                                  :href    => vm_url,
                                   :task    => false)
     end
 
@@ -431,7 +431,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:shelve, nil, vm_openstack1_url, vm_openstack2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_openstack_list)
+      expect_result_resources_to_include_hrefs("results", vms_openstack_list)
     end
   end
 
@@ -459,7 +459,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelve_offloads a powered off vm" do
@@ -470,7 +470,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelve_offloads a suspended vm" do
@@ -481,7 +481,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelve_offloads a paused off vm" do
@@ -492,7 +492,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelve_offloads a shelve_offloaded vm" do
@@ -503,7 +503,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "The VM can't be shelved offload, current state has to be shelved",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelve_offloads a shelved vm" do
@@ -514,7 +514,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => true,
                                   :message => "shelve-offloading",
-                                  :href    => :vm_openstack_url)
+                                  :href    => vm_openstack_url)
     end
 
     it "shelve_offload for a VMWare vm is not supported" do
@@ -524,7 +524,7 @@ describe "Vms API" do
 
       expect_single_action_result(:success => false,
                                   :message => "Shelve Offload Operation is not available for Vmware VM.",
-                                  :href    => :vm_url,
+                                  :href    => vm_url,
                                   :task    => false)
     end
 
@@ -537,7 +537,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:shelve_offload, nil, vm_openstack1_url, vm_openstack2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_openstack_list)
+      expect_result_resources_to_include_hrefs("results", vms_openstack_list)
     end
   end
 
@@ -571,7 +571,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:delete))
 
-      expect_single_action_result(:success => true, :message => "deleting", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "deleting", :href => vm_url, :task => true)
     end
 
     it "deletes a vm via a resource DELETE" do
@@ -621,7 +621,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:set_owner, "owner" => "bad_user"))
 
-      expect_single_action_result(:success => false, :message => /.*/, :href => :vm_url)
+      expect_single_action_result(:success => false, :message => /.*/, :href => vm_url)
     end
 
     it "set_owner to a vm" do
@@ -629,7 +629,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:set_owner, "owner" => api_config(:user)))
 
-      expect_single_action_result(:success => true, :message => "setting owner", :href => :vm_url)
+      expect_single_action_result(:success => true, :message => "setting owner", :href => vm_url)
       expect(vm.reload.evm_owner).to eq(@user)
     end
 
@@ -639,7 +639,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:set_owner, {"owner" => api_config(:user)}, vm1_url, vm2_url))
 
       expect_multiple_action_result(2)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
+      expect_result_resources_to_include_hrefs("results", vms_list)
       expect(vm1.reload.evm_owner).to eq(@user)
       expect(vm2.reload.evm_owner).to eq(@user)
     end
@@ -668,7 +668,7 @@ describe "Vms API" do
       run_get vm_ca_url
 
       expect_query_result(:custom_attributes, 2)
-      expect_result_resources_to_include_hrefs("resources", :vm_ca_url_list)
+      expect_result_resources_to_include_hrefs("resources", vm_ca_url_list)
     end
 
     it "getting custom_attributes from a vm in expanded form" do
@@ -687,7 +687,7 @@ describe "Vms API" do
 
       run_get vm_url, :expand => "custom_attributes"
 
-      expect_single_resource_query("guid" => :vm_guid)
+      expect_single_resource_query("guid" => vm_guid)
       expect_result_resources_to_include_data("custom_attributes", "name" => %w(name1 name2))
     end
 
@@ -793,7 +793,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:add_lifecycle_event, events[0]))
 
-      expect_single_action_result(:success => true, :message => /adding lifecycle event/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /adding lifecycle event/i, :href => vm_url)
       expect(vm.lifecycle_events.size).to eq(1)
       expect(vm.lifecycle_events.first.event).to eq(events[0][:event])
     end
@@ -832,7 +832,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:scan))
 
-      expect_single_action_result(:success => true, :message => "scanning", :href => :vm_url, :task => true)
+      expect_single_action_result(:success => true, :message => "scanning", :href => vm_url, :task => true)
     end
 
     it "scan multiple Vms" do
@@ -841,7 +841,7 @@ describe "Vms API" do
       run_post(vms_url, gen_request(:scan, nil, vm1_url, vm2_url))
 
       expect_multiple_action_result(2, :task => true)
-      expect_result_resources_to_include_hrefs("results", :vms_list)
+      expect_result_resources_to_include_hrefs("results", vms_list)
     end
   end
 
@@ -867,7 +867,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:add_event, :event_type => "special", :event_message => "message"))
 
-      expect_single_action_result(:success => true, :message => /adding event/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /adding event/i, :href => vm_url)
     end
 
     it "to multiple Vms" do
@@ -919,7 +919,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:retire))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => vm_url)
     end
 
     it "to multiple Vms" do
@@ -950,7 +950,7 @@ describe "Vms API" do
       date = 2.weeks.from_now
       run_post(vm_url, gen_request(:retire, :date => date.iso8601))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* retiring/i, :href => vm_url)
     end
   end
 
@@ -976,7 +976,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:reset))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* resetting/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* resetting/i, :href => vm_url)
     end
 
     it "to multiple Vms" do
@@ -1025,7 +1025,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:shutdown_guest))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* shutting down/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* shutting down/i, :href => vm_url)
     end
 
     it "to multiple Vms" do
@@ -1074,7 +1074,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:refresh))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* refreshing/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* refreshing/i, :href => vm_url)
     end
 
     it "to multiple Vms" do
@@ -1123,7 +1123,7 @@ describe "Vms API" do
 
       run_post(vm_url, gen_request(:reboot_guest))
 
-      expect_single_action_result(:success => true, :message => /#{vm.id}.* rebooting/i, :href => :vm_url)
+      expect_single_action_result(:success => true, :message => /#{vm.id}.* rebooting/i, :href => vm_url)
     end
 
     it "to multiple Vms" do
@@ -1153,7 +1153,6 @@ describe "Vms API" do
   context "Vm Tag subcollection" do
     let(:tag1)         { {:category => "department", :name => "finance", :path => "/managed/department/finance"} }
     let(:tag2)         { {:category => "cc",         :name => "001",     :path => "/managed/cc/001"} }
-    let(:tag_count)    { Tag.count }
 
     let(:vm1) { FactoryGirl.create(:vm_vmware, :host => host, :ems_id => ems.id, :raw_power_state => "poweredOn") }
     let(:vm1_url)      { vms_url(vm1.id) }
@@ -1185,7 +1184,7 @@ describe "Vms API" do
 
       run_get vm2_tags_url
 
-      expect_query_result(:tags, 2, :tag_count)
+      expect_query_result(:tags, 2, Tag.count)
     end
 
     it "query all tags of a Vm and verify tag category and names" do
@@ -1193,7 +1192,7 @@ describe "Vms API" do
 
       run_get vm2_tags_url, :expand => "resources"
 
-      expect_query_result(:tags, 2, :tag_count)
+      expect_query_result(:tags, 2, Tag.count)
       expect_result_resources_to_include_data("resources", "name" => [tag1[:path], tag2[:path]])
     end
 


### PR DESCRIPTION
This may have been needed to pass to a method a reference to a `let`
(as a symbol) while delaying its evaluation until needed. AFAICT this is
no longer the case and it is more straightforward to always pass the
value, avoiding the need to conditionally do `public_send`s with symbols
that get passed around.

@miq-bot add-label api, test, refactoring, technical debt
@miq-bot assign @abellotti 