### PR TITLE
Replace call to #get_vmdb_config with direct call to ::Settings in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2267,7 +2267,7 @@ class ApplicationController < ActionController::Base
     if session.class != Hash
       session_hash = session.respond_to?(:to_hash) ? session.to_hash : session.data
       get_data_size(session_hash)
-      dump_session_data(session_hash) if get_vmdb_config[:product][:dump_session]
+      dump_session_data(session_hash) if ::Settings.product.dump_session
     end
   end
 


### PR DESCRIPTION
Removed deprecated calls to VMDB::Config.new in ApplicationController

@miq-boat add-label core, refactoring

\cc @Fryguy