### PR TITLE
Avoid constantize in #name_for_klass

### DIFF
--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -70,9 +70,7 @@ module Api
     end
 
     def name_for_klass(resource_klass)
-      @cfg.detect do |_, spec|
-        spec[:klass] && spec[:klass].constantize == resource_klass
-      end.try(:first)
+      @cfg.detect { |_, spec| spec[:klass] == resource_klass.name }.try(:first)
     end
 
     def what_refers_to_feature(product_feature_name)


### PR DESCRIPTION
`CollectionConfig#name_for_klass` will call `#constantize` on every value
for `:klass` in the API config. This can cause an issue with autoloading
if a class included in the config calls this method as part of its
definition - a circular dependency resulting in a `LoadError`. This can
be avoided if we instead inspect the name of the class passed in and
compare that to the config, removing the need to call `#constantize` at
all.

See https://github.com/ManageIQ/manageiq/pull/11782 for the code the illustrates the scenario outlined above.

@carbonin LMK if this works for you - I decided to preserve the existing API for this for now.

@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 