### PR TITLE
Use ::Settings instead of deprecated VMDB.Config.new in ApplicationHelper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -430,6 +430,8 @@ module ApplicationHelper
 
   # Replacing calls to VMDB::Config.new in the views/controllers
   def get_vmdb_config
+    Vmdb::Deprecation.deprecation_warning("ApplicationHelper#get_vmdb_config",
+                                          "Prefer using ::Settings directly.", caller)
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 
@@ -1607,13 +1609,13 @@ module ApplicationHelper
                              ontap_storage_system_show_list
                              ontap_storage_volume_show_list
                              storage_manager_show_list)
-    return false if storage_start_pages.include?(start_page) && !get_vmdb_config[:product][:storage]
+    return false if storage_start_pages.include?(start_page) && !::Settings.product.storage
     containers_start_pages = %w(ems_container_show_list
                                 container_node_show_list
                                 container_group_show_list
                                 container_service_show_list
                                 container_view)
-    return false if containers_start_pages.include?(start_page) && !get_vmdb_config[:product][:containers]
+    return false if containers_start_pages.include?(start_page) && !::Settings.product.containers
     role_allows?(:feature => start_page, :any => true)
   end
 
@@ -1838,7 +1840,7 @@ module ApplicationHelper
   end
 
   def auth_mode_name
-    case get_vmdb_config.fetch_path(:authentication, :mode).downcase
+    case ::Settings.authentication.mode.downcase
     when "ldap"
       _("LDAP")
     when "ldaps"
@@ -1853,9 +1855,8 @@ module ApplicationHelper
   end
 
   def ext_auth?(auth_option = nil)
-    auth_config = get_vmdb_config[:authentication]
-    return false unless auth_config[:mode] == "httpd"
-    auth_option ? auth_config[auth_option] : true
+    return false unless ::Settings.authentication.mode == "httpd"
+    auth_option ? ::Settings.authentication[auth_option] : true
   end
   public :ext_auth?
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -430,8 +430,6 @@ module ApplicationHelper
 
   # Replacing calls to VMDB::Config.new in the views/controllers
   def get_vmdb_config
-    Vmdb::Deprecation.deprecation_warning("ApplicationHelper#get_vmdb_config",
-                                          "Prefer using ::Settings directly.", caller)
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -1,4 +1,4 @@
-- auth_mode = get_vmdb_config[:authentication][:mode]
+- auth_mode = ::Settings.authentication.mode
 
 %span#badge
   %img{:src => "#{current_tenant.logo? ? '/upload/custom_logo.png' : image_path("login-screen-logo.png")}"}
@@ -109,7 +109,7 @@
                       :onclick              => "miqAjaxAuthSso('#{j sso_url}'); return false;")
 
     .col-md-6.col-lg-7.details
-      - if get_vmdb_config[:session][:show_login_info]
+      - if ::Settings.session.show_login_info
         %p
           = _('Region:')
           %span
@@ -123,8 +123,8 @@
           %span
             = (MiqServer.my_server.name)
         %p.message
-          - if get_vmdb_config[:server][:use_custom_login_text]
-            = (get_vmdb_config[:server][:custom_login_text].to_s)
+          - if ::Settings.server.use_custom_login_text
+            = (::Settings.server.custom_login_text.to_s)
 
 :javascript
   miqGetTZO();

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -124,7 +124,7 @@
             = (MiqServer.my_server.name)
         %p.message
           - if ::Settings.server.use_custom_login_text
-            = (::Settings.server.custom_login_text.to_s)
+            = ::Settings.server.custom_login_text.to_s
 
 :javascript
   miqGetTZO();

--- a/app/views/layouts/_i18n_js.html.haml
+++ b/app/views/layouts/_i18n_js.html.haml
@@ -1,3 +1,3 @@
-- if get_vmdb_config.fetch_path(:ui, :mark_translated_strings) && !Rails.env.test?
+- if ::Settings.ui.mark_translated_strings && !Rails.env.test?
   :javascript
     ManageIQ.i18n.mark_translated_strings = true

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1322,7 +1322,8 @@ describe ApplicationHelper do
     end
 
     it "should return true for storage start pages when product flag is set" do
-      allow(helper).to receive(:get_vmdb_config).and_return(:product => { :storage => true })
+      stub_settings(:product => { :storage => true })
+
       result = helper.start_page_allowed?("cim_storage_extent_show_list")
       expect(result).to be_truthy
     end
@@ -1333,7 +1334,8 @@ describe ApplicationHelper do
     end
 
     it "should return true for containers start pages when product flag is set" do
-      allow(helper).to receive(:get_vmdb_config).and_return(:product => { :containers => true })
+      stub_settings(:product => { :containers => true })
+
       result = helper.start_page_allowed?("ems_container_show_list")
       expect(result).to be_truthy
     end
@@ -1655,7 +1657,7 @@ Datasources\" href=\"/ems_middleware/#{ems.id}?display=middleware_datasources\">
 
     modes.zip modes_pretty.each do |mode, mode_pretty|
       it "Returns #{mode_pretty} when mode is #{mode}" do
-        stub_server_configuration(:authentication => { :mode => mode })
+        stub_settings(:authentication => { :mode => mode }, :server => {})
         expect(helper.auth_mode_name).to eq(mode_pretty)
       end
     end

--- a/spec/views/dashboard/login.html.haml_spec.rb
+++ b/spec/views/dashboard/login.html.haml_spec.rb
@@ -4,7 +4,7 @@ describe "dashboard/login.html.haml" do
   context "login_div contains browser and TZ hidden fields" do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      stub_server_configuration(:server => {}, :session => {}, :authentication => {})
+      stub_settings(:server => {}, :session => {}, :authentication => {})
     end
 
     it "when authentication is 'database'" do
@@ -37,8 +37,7 @@ describe "dashboard/login.html.haml" do
 
     it "show" do
       allow(view).to receive(:current_tenant).and_return(Tenant.seed)
-      allow(view).to receive(:get_vmdb_config).and_return(:server => {},
-        :session => {:show_login_info => true}, :authentication => {})
+      stub_settings(:server => {}, :session => {:show_login_info => true}, :authentication => {})
       render
       labels.each do |label|
         expect(response).to have_selector('p', :text => label)
@@ -47,8 +46,7 @@ describe "dashboard/login.html.haml" do
 
     it "hide" do
       allow(view).to receive(:current_tenant).and_return(Tenant.seed)
-      allow(view).to receive(:get_vmdb_config).and_return(:server => {},
-        :session => {:show_login_info => false}, :authentication => {})
+      stub_settings(:server => {}, :session => {:show_login_info => false}, :authentication => {})
       render
       labels.each do |label|
         expect(response).not_to have_selector('p', :text => label)

--- a/spec/views/ops/_rbac_group_details.html.haml_spec.rb
+++ b/spec/views/ops/_rbac_group_details.html.haml_spec.rb
@@ -21,35 +21,35 @@ describe 'ops/_rbac_group_details.html.haml' do
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode ldap' do
-      stub_server_configuration(:authentication => { :mode => 'ldap' })
+      stub_settings(:authentication => { :mode => 'ldap' }, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up LDAP Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode ldaps' do
-      stub_server_configuration(:authentication => { :mode => 'ldaps' })
+      stub_settings(:authentication => { :mode => 'ldaps' }, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up LDAPS Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode amazon' do
-      stub_server_configuration(:authentication => { :mode => 'amazon' })
+      stub_settings(:authentication => { :mode => 'amazon' }, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up Amazon Groups')
     end
 
     it 'should show "Look up groups" checkbox and label for auth mode httpd' do
-      stub_server_configuration(:authentication => { :mode => 'httpd' })
+      stub_settings(:authentication => { :mode => 'httpd' }, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).to have_selector('input#lookup')
       expect(rendered).to include('Look up External Authentication Groups')
     end
 
     it 'should not show "Look up groups" checkbox and label for auth mode database' do
-      stub_server_configuration(:authentication => { :mode => 'database' })
+      stub_settings(:authentication => { :mode => 'database' }, :server => {})
       render :partial => 'ops/rbac_group_details'
       expect(rendered).not_to have_selector('input#lookup')
       expect(rendered).not_to include('Look up External Authentication Groups')


### PR DESCRIPTION
Removed deprecated calls to VMDB::Config.new in ApplicationHelper

@miq-boat add-label core, refactoring

\cc @Fryguy 