### PR TITLE
Use standard class inheritance for Rollup processing modes

### DIFF
--- a/app/models/metric/aggregation.rb
+++ b/app/models/metric/aggregation.rb
@@ -1,5 +1,11 @@
 module Metric::Aggregation
-  module Aggregate
+  class Common
+    def self.supports?(meth)
+      singleton_methods(false).include?(meth.to_sym)
+    end
+  end
+
+  class Aggregate < Common
     def self.summation(col, _obj, result, counts, value)
       return if value.nil?
       result[col] += value
@@ -44,7 +50,7 @@ module Metric::Aggregation
     end
   end
 
-  module Process
+  class Process < Common
     def self.average(col, _dummy, result, counts, aggregate_only = false)
       return if aggregate_only || result[col].nil?
       result[col] = result[col] / counts[col] unless counts[col] == 0
@@ -92,12 +98,8 @@ module Metric::Aggregation
     args = args[0..3]
 
     meth = col
-    meth = col.to_s.split("_").last unless supports?(mode, meth)
-    meth = default_operation        unless supports?(mode, meth) || default_operation.nil?
-    mode.send(meth, col, *args) if supports?(mode, meth)
-  end
-
-  def self.supports?(mode, meth)
-    mode.singleton_methods(false).include?(meth.to_sym)
+    meth = col.to_s.split("_").last unless mode.supports?(meth)
+    meth = default_operation        unless mode.supports?(meth) || default_operation.nil?
+    mode.send(meth, col, *args) if mode.supports?(meth)
   end
 end

--- a/app/models/metric/aggregation.rb
+++ b/app/models/metric/aggregation.rb
@@ -94,8 +94,4 @@ module Metric::Aggregation
       end
     end
   end
-
-  def self.process_for_column(*args)
-    Process.column(*args)
-  end
 end

--- a/app/models/metric/aggregation.rb
+++ b/app/models/metric/aggregation.rb
@@ -3,6 +3,16 @@ module Metric::Aggregation
     def self.supports?(meth)
       singleton_methods(false).include?(meth.to_sym)
     end
+
+    def self.column(col, *args) # args => obj, result, counts, value, default_operation = nil
+      default_operation = args[4]
+      args = args[0..3]
+
+      meth = col
+      meth = col.to_s.split("_").last unless supports?(meth)
+      meth = default_operation        unless supports?(meth) || default_operation.nil?
+      send(meth, col, *args) if supports?(meth)
+    end
   end
 
   class Aggregate < Common
@@ -86,20 +96,10 @@ module Metric::Aggregation
   end
 
   def self.aggregate_for_column(*args)
-    execute_for_column(Aggregate, *args)
+    Aggregate.column(*args)
   end
 
   def self.process_for_column(*args)
-    execute_for_column(Process, *args)
-  end
-
-  def self.execute_for_column(mode, col, *args) # args => obj, result, counts, value, default_operation = nil
-    default_operation = args[4]
-    args = args[0..3]
-
-    meth = col
-    meth = col.to_s.split("_").last unless mode.supports?(meth)
-    meth = default_operation        unless mode.supports?(meth) || default_operation.nil?
-    mode.send(meth, col, *args) if mode.supports?(meth)
+    Process.column(*args)
   end
 end

--- a/app/models/metric/aggregation.rb
+++ b/app/models/metric/aggregation.rb
@@ -95,10 +95,6 @@ module Metric::Aggregation
     end
   end
 
-  def self.aggregate_for_column(*args)
-    Aggregate.column(*args)
-  end
-
   def self.process_for_column(*args)
     Process.column(*args)
   end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -225,7 +225,7 @@ module Metric::Rollup
           rollup_burst(col, new_perf[:min_max], rt.timestamp, value)
         end
 
-        Metric::Aggregation.aggregate_for_column(col, nil, new_perf, new_perf_counts, value)
+        Metric::Aggregation::Aggregate.column(col, nil, new_perf, new_perf_counts, value)
       end
     end
 
@@ -268,7 +268,7 @@ module Metric::Rollup
         result[c] ||= 0
         counts[c] ||= 0
         value = perf ? perf.send(c) : 0
-        Metric::Aggregation.aggregate_for_column(c, state, result, counts, value, :average)
+        Metric::Aggregation::Aggregate.column(c, state, result, counts, value, :average)
       end
     end
 

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -137,7 +137,7 @@ module Metric::Rollup
     NON_STORAGE_ROLLUP_COLS.include?(col) && !INFREQUENTLY_CHANGING_COLS.include?(col)
   end
 
-  # these columns will pass false for aggregate_only to process_for_column
+  # these columns will pass false for aggregate_only to Aggregation::Process.column
   # this means that when processing the totals for a parent rollup, the total
   # values will be averaged across the number of children
   AVG_VALUE_COLUMNS = [
@@ -230,7 +230,7 @@ module Metric::Rollup
     end
 
     new_perf.each_key do |col|
-      Metric::Aggregation.process_for_column(col, nil, new_perf, new_perf_counts)
+      Metric::Aggregation::Process.column(col, nil, new_perf, new_perf_counts)
     end
 
     new_perf[:intervals_in_rollup] = Metric::Helper.max_count(new_perf_counts)
@@ -274,7 +274,7 @@ module Metric::Rollup
 
     agg_cols.each do |c|
       aggregate_only = !AVG_VALUE_COLUMNS.include?(c)
-      Metric::Aggregation.process_for_column(c, obj.vim_performance_state_for_ts(timestamp), result, counts, aggregate_only, :average)
+      Metric::Aggregation::Process.column(c, obj.vim_performance_state_for_ts(timestamp), result, counts, aggregate_only, :average)
     end
 
     result

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -526,7 +526,7 @@ module VimPerformanceAnalysis
         result[key][c] ||= 0
         counts[key][c] ||= 0
 
-        Metric::Aggregation.aggregate_for_column(c, nil, result[key], counts[key], p.send(c), :average)
+        Metric::Aggregation::Aggregate.column(c, nil, result[key], counts[key], p.send(c), :average)
       end
     end
 

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -543,7 +543,7 @@ module VimPerformanceAnalysis
       ts, v = k
       cols.each do |c|
         next unless v[c].kind_of?(Float)
-        Metric::Aggregation.process_for_column(c, nil, v, counts[k], true, :average)
+        Metric::Aggregation::Process.column(c, nil, v, counts[k], true, :average)
       end
 
       recs.push(perf_klass.new(v))


### PR DESCRIPTION
This is just a little clean-up ensuring the next person to see it will spend a less time comprehending it. This is basically follow-up on 0340b568b0b399c46d59d3c23a63e140a46cad3f.

@miq-bot add_label refactoring, metric
@miq-bot assign @gtanzillo 
