### PR TITLE
CloudVolume.available query shall honour polymorphic relation

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -20,8 +20,7 @@ class CloudVolume < ApplicationRecord
   acts_as_miq_taggable
 
   def self.available
-    joins("LEFT OUTER JOIN disks ON disks.backing_id = cloud_volumes.id AND disks.backing_type = 'CloudVolume'")
-      .where("disks.backing_id" => nil)
+    left_outer_joins(:attachments).where("disks.backing_id" => nil)
   end
 
   def self.class_by_ems(ext_management_system)

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -20,7 +20,7 @@ class CloudVolume < ApplicationRecord
   acts_as_miq_taggable
 
   def self.available
-    joins("LEFT OUTER JOIN disks ON disks.backing_id = cloud_volumes.id")
+    joins("LEFT OUTER JOIN disks ON disks.backing_id = cloud_volumes.id AND disks.backing_type = 'CloudVolume'")
       .where("disks.backing_id" => nil)
   end
 


### PR DESCRIPTION
Previously, we didn't bind backing_type in left outer join. The `Disk.backing` is polymorphic relation to CloudVolumes. If someone attaches a `Disk.backing` that is not CloudVolume it would mess up this outer join. Fortunately, Rails 5 brings `left_outer_joins` that solves this for us and binds backing_id AND backing_type for this polymorphic relation.

@miq-bot add_label bug, core
@miq-bot assign @gtanzillo 