### PR TITLE
Store volume types in VimPerformanceState

### DIFF
--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -22,6 +22,7 @@ class VimPerformanceState < ApplicationRecord
     :reserve_cpu,
     :reserve_mem,
     :vm_allocated_disk_storage,
+    :allocated_disk_types,
     :vm_used_disk_storage
   ].each do |m|
     define_method(m)       { state_data[m] }
@@ -67,6 +68,7 @@ class VimPerformanceState < ApplicationRecord
     capture_totals
     capture_reserve
     capture_vm_disk_storage
+    capture_disk_types
     capture_tag_names
     capture_image_tag_names
     capture_host_sockets
@@ -145,6 +147,15 @@ class VimPerformanceState < ApplicationRecord
   end
 
   private
+
+  def capture_disk_types
+    if hardware
+      self.allocated_disk_types = hardware.disks.each_with_object({}) do |disk, res|
+        type = disk.backing.try(:volume_type) || 'unclassified'
+        res[type] = (res[type] || 0) + disk.size
+      end
+    end
+  end
 
   def capture_totals
     self.total_cpu = capture_total(:cpu_speed)

--- a/spec/models/vim_performance_state_spec.rb
+++ b/spec/models/vim_performance_state_spec.rb
@@ -43,4 +43,21 @@ RSpec.describe VimPerformanceState do
       expect(actual.host_sockets).to eq(2)
     end
   end
+
+  describe '#allocated_disk_types' do
+    let(:ssd_size) { 1_234 }
+    let(:hdd1_size) { 5_678 }
+    let(:hdd2_size) { 9_101 }
+    let(:ssd_volume) { FactoryGirl.create(:cloud_volume_openstack, :volume_type => 'ssd') }
+    let(:ssd_disk) { FactoryGirl.create(:disk, :size => ssd_size, :backing => ssd_volume) }
+    let(:hdd_volume) { FactoryGirl.create(:cloud_volume_openstack) }
+    let(:hdd1_disk) { FactoryGirl.create(:disk, :size => hdd1_size, :backing => hdd_volume) }
+    let(:hdd2_disk) { FactoryGirl.create(:disk, :size => hdd2_size) }
+    let(:hardware) { FactoryGirl.create(:hardware, :disks => [ssd_disk, hdd1_disk, hdd2_disk]) }
+    let(:vm) { FactoryGirl.create(:vm_openstack, :hardware => hardware) }
+
+    subject { vm.perf_capture_state.allocated_disk_types }
+
+    it { is_expected.to match('ssd' => ssd_size, 'unclassified' => hdd1_size + hdd2_size) }
+  end
 end


### PR DESCRIPTION
Disk types may differ in costs associated to them. This data can be later used in Chargeback calculation.

At this point we capture only storage allocation and not usage, as we don't always refresh per-disk usage from providers.

This is first part for https://bugzilla.redhat.com/show_bug.cgi?id=1375506

@miq-bot enhancement, metrics
@miq-bot assign @gtanzillo 