### PR TITLE
Correct unique ref for saving cloud_subnet_network_ports

### DIFF
--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -272,7 +272,7 @@ module EmsRefresh::SaveInventoryNetwork
       end
     end
 
-    save_inventory_multi(network_port.cloud_subnet_network_ports, hashes, deletes, [:cloud_subnet_id])
+    save_inventory_multi(network_port.cloud_subnet_network_ports, hashes, deletes, [:cloud_subnet_id, :address])
   end
 
   def save_load_balancer_pool_members_inventory(ems, hashes, target = nil)


### PR DESCRIPTION
Correct unique ref for saving cloud_subnet_network_ports, the
ref need to also contain address, otherwise the data will be
updated badly.

Right now, multiple fixed IPs on one port and one subnet would be updated badly. One would be updated, other would be deleted&created.