### PR TITLE
Fix error in Drift pdf/txt report

### DIFF
--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -384,7 +384,7 @@ module ApplicationController::Compare
               next if r[0] == @compare.records[0]["id"] # Skip the base VM
               cols.push(r[1][section[:name]][:_match_].to_s + "%")  # Grab the % value for this attr for this VM
             else
-              if @compare.results[r][section[:name]][:_match_]  # Does it match?
+              if r[1][section[:name]][:_match_]  # Does it match?
                 cols.push("")                     # Yes, push a blank string
               else
                 cols.push("*")                    # No, mark it with an *

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -417,7 +417,7 @@ module ApplicationController::Compare
                     {:name => ui_lookup(:model => @sb[:compare_db])}
     else
       rpt.db = "<drift>"            # Set special db setting for report formatter
-      rpt.title = _("${name} '%{vm_name}' Drift Report") % {:name    => ui_lookup(:model => @sb[:compare_db]),
+      rpt.title = _("%{name} '%{vm_name}' Drift Report") % {:name    => ui_lookup(:model => @sb[:compare_db]),
                                                             :vm_name => @sb[:miq_vm_name]}
     end
 


### PR DESCRIPTION
There was an error when downloading pdf/txt in Drift Report. Introduced by #6576 => `darga/yes, euwe/yes`

There was a typo in file title introduced by #7193  => `darga/yes, euwe/yes`

https://bugzilla.redhat.com/show_bug.cgi?id=1382939

@miq-bot add_label ui, bug, darga/yes, euwe/yes

Testing:
Compute -> Infrastructure -> Virtual Machines -> any VM with Drift History with at least two -> Drift History -> choose two Timestamps -> Drift button -> Download as txt/ Download as pdf 