### PR TITLE
Pdf/Txt/Csv download toolbar buttons - add features so that these don't get skipped

### DIFF
--- a/app/helpers/application_helper/toolbar/compare_view.rb
+++ b/app/helpers/application_helper/toolbar/compare_view.rb
@@ -21,7 +21,7 @@ class ApplicationHelper::Toolbar::CompareView < ApplicationHelper::Toolbar::Basi
       nil,
       :items => [
         button(
-          :compare_download_txt,
+          :compare_download_text,
           'fa fa-file-text-o fa-lg',
           N_('Download comparison report in text format'),
           N_('Download as Text'),
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::CompareView < ApplicationHelper::Toolbar::Basi
           N_('Download as CSV'),
           :url => "/compare_to_csv"),
         button(
-          :download_pdf,
+          :compare_download_pdf,
           'fa fa-file-pdf-o fa-lg',
           N_('Download comparison report in PDF format'),
           N_('Download as PDF'),

--- a/app/helpers/application_helper/toolbar/drift_view.rb
+++ b/app/helpers/application_helper/toolbar/drift_view.rb
@@ -33,7 +33,7 @@ class ApplicationHelper::Toolbar::DriftView < ApplicationHelper::Toolbar::Basic
           N_('Download as CSV'),
           :url => "/drift_to_csv"),
         button(
-          :drift_pdf,
+          :drift_download_pdf,
           'fa fa-file-pdf-o fa-lg',
           N_('Download comparison report in PDF format'),
           N_('Download as PDF'),

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1553,6 +1553,22 @@
   :description: Everything under Timelines
   :feature_type: node
   :identifier: timeline
+  :children:
+  - :name: Download CSV Format
+    :description: Download Timeline Data in CSV Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: timeline_csv
+  - :name: Download PDF Format
+    :description: Download Timeline Data in PDF Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: timeline_pdf
+  - :name: Download Text Format
+    :description: Download Timeline Data in Text Format
+    :feature_type: admin
+    :hidden: true
+    :identifier: timeline_txt
 
 # RSS
 - :name: RSS

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5003,6 +5003,22 @@
         :description: Display Instances Drift
         :feature_type: view
         :identifier: instance_drift
+        :children:
+        - :name: Download as CSV
+          :description: Download comparison report in CSV Format
+          :feature_type: admin
+          :hidden: true
+          :identifier: drift_download_csv
+        - :name: Download as PDF
+          :description: Download comparison report in PDF Format
+          :feature_type: admin
+          :hidden: true
+          :identifier: drift_download_pdf
+        - :name: Download as Text
+          :description: Download comparison report in Text Format
+          :feature_type: admin
+          :hidden: true
+          :identifier: drift_download_txt
       - :name: Utilization
         :description: Show Capacity & Utilization data of Instances
         :feature_type: view


### PR DESCRIPTION
Since #10942, all the toolbar buttons need an RBAC feature with the same name, or an explicit skip, otherwise they never get shown. Related to https://github.com/ManageIQ/manageiq/issues/11872 (but doesn't close, it's more than just the download buttons).

Drift:
Added the features under "Display Instances Drift", and updated pdf button id for consistency.

Compare:
Updated button ids to match the existing features.

Timelines:
Added features under "Timelines"