### PR TITLE
Flash DIV fixes

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -51,7 +51,7 @@ module ApplicationController::Filter
     end
 
     if flash_errors?
-      javascript_flash
+      javascript_flash(:flash_div_id => 'adv_search_flash')
     else
       if ["commit", "not", "remove"].include?(params[:pressed])
         copy = copy_hash(@edit[@expkey][:expression])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1124,8 +1124,10 @@ module ApplicationHelper
   def javascript_flash(**args)
     add_flash(args[:text], args[:severity]) if args[:text].present?
 
-    ex = ExplorerPresenter.flash.replace('flash_msg_div',
-                                         render_to_string(:partial => "layouts/flash_msg"))
+    flash_div_id = args.key?(:flash_div_id) ? args[:flash_div_id] : 'flash_msg_div'
+    ex = ExplorerPresenter.flash.replace(flash_div_id,
+                                         render_to_string(:partial => "layouts/flash_msg",
+                                                          :locals => {:flash_div_id => flash_div_id}))
     ex.scroll_top if args[:scroll_top]
     ex.spinner_off if args[:spinner_off]
     ex.focus(args[:focus]) if args[:focus]

--- a/app/views/dashboard/auth_error.html.haml
+++ b/app/views/dashboard/auth_error.html.haml
@@ -1,4 +1,4 @@
 #main_div
   %fieldset
     %h3= _('Authorization Error')
-    = render :partial => 'layouts/flash_msg', :locals => {:click_remove => false}
+    = render :partial => 'layouts/flash_msg'

--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -8,7 +8,7 @@
       = " (#{h(@edit[@expkey][:selected][:description])})"
     - elsif @edit && @edit[:adv_search_report]
       = " (from report #{h(@edit[:adv_search_report])})"
-    = render :partial => 'layouts/flash_msg'
+    = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'adv_search_flash'}
     %br
     - if @edit && @edit[@expkey][:expression]
       = render(:partial => 'layouts/exp_editor')
@@ -50,7 +50,7 @@
                 = _("Choose a %{model} report filter") % {:model => ui_lookup(:model => @edit[@expkey][:exp_model])}
   - elsif mode == "save"
     .modal-body
-      = render :partial => "layouts/flash_msg"
+      = render :partial => 'layouts/flash_msg', :locals => {:flash_div_id => 'adv_search_flash'}
       .form-horizontal.static
         .form-group
           %label.control-label.col-md-5

--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -1,12 +1,6 @@
-- click_remove = true if click_remove.nil?
-- top_pad ||= false
-- bottom_pad ||= false
-
 %div{:id => "flash_msg_div", :style => ("display: none" unless @flash_array)}
-  - if top_pad
-    %div{:style => "padding-top: #{top_pad}px;"}
   - if @flash_array
-    %div{:id      => "flash_text_div"}
+    %div{:id => "flash_text_div"}
       - @flash_array.each do |fl|
         - case fl[:level]
         - when :error
@@ -30,5 +24,3 @@
               %span.pficon.pficon-close
             %span.pficon.pficon-ok
             %strong= h(fl[:message])
-  - if bottom_pad
-    %div{:style => "padding-top: #{bottom_pad}px;"}

--- a/app/views/layouts/_flash_msg.html.haml
+++ b/app/views/layouts/_flash_msg.html.haml
@@ -1,4 +1,6 @@
-%div{:id => "flash_msg_div", :style => ("display: none" unless @flash_array)}
+- flash_div_id ||= 'flash_msg_div'
+
+%div{:id => flash_div_id, :style => ("display: none" unless @flash_array)}
   - if @flash_array
     %div{:id => "flash_text_div"}
       - @flash_array.each do |fl|

--- a/app/views/ops/_settings_import_tab.html.haml
+++ b/app/views/ops/_settings_import_tab.html.haml
@@ -1,7 +1,7 @@
 - if @sb[:active_tab] == "settings_import"
   - url = url_for(:action => 'upload_form_field_changed', :id => @sb[:active_tab].split('_').last)
   %h3= _("Messages")
-  = render(:partial => "layouts/flash_msg", :locals => {:click_remove => false})
+  = render(:partial => "layouts/flash_msg")
   %hr/
   %h3= _("Upload Custom Variable Values")
   = form_tag({:action => "upload_csv",

--- a/app/views/ops/_settings_import_tags_tab.html.haml
+++ b/app/views/ops/_settings_import_tags_tab.html.haml
@@ -2,7 +2,7 @@
   #tab_div
     %h3
       = _("Messages")
-    = render(:partial => "layouts/flash_msg", :locals => {:click_remove => false})
+    = render(:partial => "layouts/flash_msg")
     %hr/
     %h3
       = _("Upload %{customer_name} Tag Assignments for VMs") % {:customer_name => session[:customer_name]}


### PR DESCRIPTION
Advanced search was a valid use of the special flash DIV id that was removed in https://github.com/ManageIQ/manageiq/pull/11383.

Here I:
 1. cleanup some unused parts of the `flash_msg` partial
 1. reintroduce the ability to have multiple flash DIVs now through the JSON based helper function
 1. fix advanced search to flash into it's own flash DIV

Steps for Testing/QA
-------------------------------

 1. Go to VM list.
 1. Open the advanced search.
 1. enter something invalid (keep the "choose" option selected when clicking "add")
 1. observe that now the flash message is displayed in the expression editor, not in the main page body