### PR TITLE
Remove window_sizes action

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -483,7 +483,6 @@ function miqResetSizeTimer() {
   var height = window.innerHeight;
   var offset = 427;
   var h = height - offset;
-  var url = "/dashboard/window_sizes";
 
   if (h < 200) {
     h = 200;
@@ -495,9 +494,6 @@ function miqResetSizeTimer() {
   } else if (miqDomElementExists('logview')) {
     $('#logview').css({height: h + 'px'});
   }
-
-  // Send the new values to the server
-  miqJqueryRequest(miqPassFields(url, { height: height }));
 }
 
 // Pass fields to server given a URL and fields in name/value pairs

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,12 +54,12 @@ class ApplicationController < ActionController::Base
   include_concern 'ReportDownloads'
 
   before_action :reset_toolbar
-  before_action :set_session_tenant, :except => [:window_sizes]
-  before_action :get_global_session_data, :except => [:resize_layout, :window_sizes, :authenticate]
-  before_action :set_user_time_zone, :except => [:window_sizes]
-  before_action :set_gettext_locale, :except => [:window_sizes]
+  before_action :set_session_tenant
+  before_action :get_global_session_data, :except => [:resize_layout, :authenticate]
+  before_action :set_user_time_zone
+  before_action :set_gettext_locale
   before_action :allow_websocket
-  after_action :set_global_session_data, :except => [:resize_layout, :window_sizes]
+  after_action :set_global_session_data, :except => [:resize_layout]
 
   def local_request?
     Rails.env.development? || Rails.env.test?
@@ -1985,9 +1985,6 @@ class ApplicationController < ActionController::Base
 
     # Get performance hash, if it is in the sandbox for the running controller
     @perf_options = @sb[:perf_options] ? copy_hash(@sb[:perf_options]) : {}
-
-    # Set window height for views to use
-    @winH = session[:winH] ? session[:winH].to_i : 805
 
     # Set @edit key default for the expression editor to use
     @expkey = session[:expkey] ? session[:expkey] : :expression

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,13 +1,12 @@
 class DashboardController < ApplicationController
   @@items_per_page = 8
 
-  before_action :check_privileges, :except => [:csp_report, :window_sizes, :authenticate, :kerberos_authenticate,
+  before_action :check_privileges, :except => [:csp_report, :authenticate, :kerberos_authenticate,
                                                :logout, :login, :login_retry, :wait_for_task,
                                                :saml_login, :initiate_saml_login]
-  before_action :get_session_data, :except => [:csp_report, :window_sizes,
-                                               :authenticate, :kerberos_authenticate, :saml_login]
+  before_action :get_session_data, :except => [:csp_report, :authenticate, :kerberos_authenticate, :saml_login]
   after_action :cleanup_action,    :except => [:csp_report]
-  after_action :set_session_data,  :except => [:csp_report, :window_sizes]
+  after_action :set_session_data,  :except => [:csp_report]
 
   def index
     redirect_to :action => 'show'
@@ -46,12 +45,6 @@ class DashboardController < ApplicationController
       sidebar = params[:sidebar].to_i
       session[:sidebar][params[:context]] = sidebar if [0, 2, 3, 4, 5].include?(sidebar)
     end
-    head :ok # No response required
-  end
-
-  # Accept window sizes from the client
-  def window_sizes
-    session[:winH] = params[:height] if params[:height]
     head :ok # No response required
   end
 
@@ -618,7 +611,7 @@ class DashboardController < ApplicationController
 
   def session_reset
     # save some fields to recover back into session hash after session is cleared
-    keys_to_restore = [:winH, :browser, :user_TZO]
+    keys_to_restore = [:browser, :user_TZO]
     data_to_restore = keys_to_restore.each_with_object({}) { |k, v| v[k] = session[k] }
 
     session.clear
@@ -750,13 +743,8 @@ class DashboardController < ApplicationController
     session[:tl_position] = format_timezone(@report.extras[:tl_position], tz, "tl")
   end
 
-  def get_layout
-    # Don't change layout when window size changes session[:layout]
-    request.parameters["action"] == "window_sizes" ? session[:layout] : "login"
-  end
-
   def get_session_data
-    @layout       = get_layout
+    @layout       = "login"
     @current_page = session[:vm_current_page] # current page number
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1072,12 +1072,6 @@ module ApplicationHelper
     link_to(link_text, link_params, tag_args)
   end
 
-  def center_div_height(toolbar = true, min = 200)
-    max = toolbar ? 627 : 757
-    height = @winH < max ? min : @winH - (max - min)
-    height
-  end
-
   def primary_nav_class(nav_id)
     test_layout = @layout
     # FIXME: exception behavior to remove

--- a/app/views/layouts/_log_viewer.html.haml
+++ b/app/views/layouts/_log_viewer.html.haml
@@ -1,6 +1,6 @@
 - legend_text ||= _("Last 1000 lines from server %{server_name} [%{server_id}] in zone %{zone_name}") % {:server_name => @server.name, :server_id => @server_options[:server_id], :zone_name => @server.my_zone}
 = render :partial => "layouts/flash_msg"
 %h3= legend_text
-- h = @winH < 627 ? 200 : @winH - 427
-= text_area("logview", "data", :value => @log, :readonly => true, :style => "height:#{h}px;", :wrap => "off")
-= javascript_tag "$('#logview_data').scrollTop($('#logview_data').prop('scrollHeight') - $('#logview_data').prop('clientHeight'));"
+
+%pre
+  = @log

--- a/app/views/ops/_log_viewer.html.haml
+++ b/app/views/ops/_log_viewer.html.haml
@@ -6,9 +6,5 @@
   :zone  => @selected_server.my_zone}                                                |
 %h3= legend_text
 
-= text_area("logview", "data",                                |
-  :value    => @log,                                          |
-  :readonly => true,                                          |
-  :style    => "height: #{center_div_height}px; width: 100%") |
-
-= javascript_tag "$('#logview_data').scrollTop($('#logview_data').prop('scrollHeight') - $('#logview_data').prop('clientHeight'));"
+%pre
+  = @log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -947,7 +947,6 @@ Vmdb::Application.routes.draw do
         widget_dd_done
         widget_toggle_minmax
         widget_zoom
-        window_sizes
       )
     },
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -293,20 +293,6 @@ describe DashboardController do
     end
   end
 
-  context "#get_layout" do
-    it "sets layout same as session[:layout] when changing window size" do
-      request.parameters["action"] = "window_sizes"
-      session[:layout] = "host"
-      layout = controller.send(:get_layout)
-      expect(layout).to eq(session[:layout])
-    end
-
-    it "defaults layout to login on Login screen" do
-      layout = controller.send(:get_layout)
-      expect(layout).to eq("login")
-    end
-  end
-
   describe '#resize_layout' do
     before(:each) do
       controller.params[:sidebar] = sidebar
@@ -371,18 +357,15 @@ describe DashboardController do
 
   context "#session_reset" do
     it "verify certain keys are restored after session is cleared" do
-      winH               = '600'
       user_TZO           = '5'
       browser_info       = {:name => 'firefox', :version => '32'}
       session[:browser]  = browser_info
       session[:user_TZO] = user_TZO
-      session[:winH]     = winH
       session[:foo]      = 'foo_bar'
 
       controller.send(:session_reset)
 
       expect(session[:browser]).to eq(browser_info)
-      expect(session[:winH]).to eq(winH)
       expect(session[:user_TZO]).to eq(user_TZO)
       expect(session[:foo]).to eq(nil)
       expect(browser_info(:version)).to eq(browser_info[:version])

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1148,23 +1148,6 @@ describe ApplicationHelper do
         end
       end
     end
-
-    context "#center_div_height" do
-      it "calculates height for center div" do
-        @winH = 800
-        max = 627
-        min = 200
-        height = @winH < max ? min : @winH - (max - min)
-        res = helper.center_div_height
-        expect(res).to eq(height)
-
-        max = 757
-        min = 400
-        height = @winH < max ? min : @winH - (max - min)
-        res = helper.center_div_height(false, 400)
-        expect(res).to eq(height)
-      end
-    end
   end
 
   describe '#pressed2model_action' do

--- a/spec/routing/dashboard_routing_spec.rb
+++ b/spec/routing/dashboard_routing_spec.rb
@@ -176,10 +176,4 @@ describe 'routes for DashboardController' do
       expect(post("/dashboard/widget_zoom")).to route_to("dashboard#widget_zoom")
     end
   end
-
-  describe "#window_sizes" do
-    it "routes with POST" do
-      expect(post("/dashboard/window_sizes")).to route_to("dashboard#window_sizes")
-    end
-  end
 end


### PR DESCRIPTION
The `window_sizes` action would be executed automatically from javascript anytime the browser
window was resized. The action was only used to set the `winH` variable correctly, which was
used to set height of text area element when rendering log file content.

We replaced the text area by a plain `<pre>`, so this whole mechanism is no longer needed.

Fixes: https://github.com/ManageIQ/manageiq/issues/3229

https://bugzilla.redhat.com/show_bug.cgi?id=1277180