### PR TITLE
Added missing key_pair decorators.

### DIFF
--- a/app/decorators/manageiq/providers/google/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/google/cloud_manager/auth_key_pair_decorator.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Google::CloudManager::AuthKeyPairDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{item_image}.png"
+  end
+
+  private
+
+  # Determine the icon
+  def item_image
+    'auth_key_pair'
+  end
+end

--- a/app/decorators/manageiq/providers/openstack/cloud_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/openstack/cloud_manager/auth_key_pair_decorator.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Openstack::CloudManager::AuthKeyPairDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{item_image}.png"
+  end
+
+  private
+
+  # Determine the icon
+  def item_image
+    'auth_key_pair'
+  end
+end

--- a/app/decorators/manageiq/providers/openstack/infra_manager/auth_key_pair_decorator.rb
+++ b/app/decorators/manageiq/providers/openstack/infra_manager/auth_key_pair_decorator.rb
@@ -1,0 +1,18 @@
+class ManageIQ::Providers::Openstack::InfraManager::AuthKeyPairDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    "100/#{item_image}.png"
+  end
+
+  private
+
+  # Determine the icon
+  def item_image
+    'auth_key_pair'
+  end
+end


### PR DESCRIPTION
This fixes quadicons on different types of key pair summary screens. This was partially fixed by https://github.com/ManageIQ/manageiq/pull/9062

https://bugzilla.redhat.com/show_bug.cgi?id=1352914

before:
![before](https://cloud.githubusercontent.com/assets/3450808/19317998/e8348c46-9074-11e6-9e3b-defda8902497.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/19317996/e56edac0-9074-11e6-8d5c-b5e6d9b2e149.png)

@dclarizio please review.