### PR TITLE
Update the repmgr service name to match the SCL naming convention

### DIFF
--- a/gems/pending/appliance_console/database_replication_standby.rb
+++ b/gems/pending/appliance_console/database_replication_standby.rb
@@ -11,7 +11,7 @@ module ApplianceConsole
 
     REGISTER_CMD    = 'repmgr standby register'.freeze
     PGPASS_FILE     = '/var/lib/pgsql/.pgpass'.freeze
-    REPMGRD_SERVICE = 'rh-repmgr95'.freeze
+    REPMGRD_SERVICE = 'rh-postgresql95-repmgr'.freeze
     REPMGRD_LOG     = '/var/log/repmgr/repmgrd.log'.freeze
 
     attr_accessor :standby_host, :run_repmgrd_configuration


### PR DESCRIPTION
Requires https://github.com/ManageIQ/manageiq-appliance-build/pull/175

https://bugzilla.redhat.com/show_bug.cgi?id=1383795