### PR TITLE
Expose service power state

### DIFF
--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -68,9 +68,19 @@ module ServiceMixin
   end
 
   def delay_for_action(grp_idx, action)
-    delay_type = :start_delay if action == :start
-    delay_type = :stop_delay if action == :stop
-    max_group_delay(grp_idx, delay_type)
+    max_group_delay(grp_idx, delay_type(action))
+  end
+
+  def combined_group_delay(action)
+    group_idxs = service_resources.map(&:group_idx).uniq
+    [].tap do |results|
+      group_idxs.each { |idx| results << max_group_delay(idx, delay_type(action)) }
+    end.sum
+  end
+
+  def delay_type(action)
+    return :start_delay if action == :start
+    return :stop_delay if action == :stop
   end
 
   def each_group_resource(grp_idx = nil)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -211,7 +211,7 @@ class Service < ApplicationRecord
   end
 
   def update_progress(hash = {})
-    increment = hash.keys.include?(:increment) ?  hash.delete(:increment) : nil
+    increment = hash.keys.include?(:increment) ? hash.delete(:increment) : nil
     hash.keys.each do |attribute|
       options[attribute] = hash[attribute]
       update_attributes(:options => options)
@@ -263,6 +263,7 @@ class Service < ApplicationRecord
     nh[:deliver_on] = deliver_delay.seconds.from_now.utc if deliver_delay > 0
     nh[:zone] = my_zone if my_zone
     MiqQueue.put(nh)
+    true
   end
 
   def queue_power_calculation(delay, action)
@@ -278,7 +279,6 @@ class Service < ApplicationRecord
     }
 
     MiqQueue.put(calculate_power)
-    true
   end
 
   def my_zone

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -258,14 +258,11 @@ class Service < ApplicationRecord
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "process_group_action",
-      :role        => "ems_operations",
-      :task_id     => "#{self.class.name.underscore}_#{id}",
       :args        => [action, group_idx, direction]
     }
     nh[:deliver_on] = deliver_delay.seconds.from_now.utc if deliver_delay > 0
     nh[:zone] = my_zone if my_zone
     MiqQueue.put(nh)
-    true
   end
 
   def queue_power_calculation(delay, action)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -8,7 +8,7 @@ describe Service do
 
     it "raise_request_start_event" do
       expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_start)
-      expect(@service).to receive(:update_progress).with({:power_status=>"starting"})
+      expect(@service).to receive(:update_progress).with(:power_status=>"starting")
 
       @service.raise_request_start_event
     end
@@ -21,7 +21,7 @@ describe Service do
 
     it "raise_request_stop_event" do
       expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_stop)
-      expect(@service).to receive(:update_progress).with({:power_status=>"stopping"})
+      expect(@service).to receive(:update_progress).with(:power_status=>"stopping")
 
       @service.raise_request_stop_event
     end
@@ -94,16 +94,15 @@ describe Service do
 
     it "#update_progress" do
       expect(@service.power_state).to be_nil
-      @service.update_progress(:power_state => "on" )
+      @service.update_progress(:power_state => "on")
       expect(@service.power_state).to eq "on"
       @service.update_progress(:power_state => "off")
       expect(@service.power_state).to eq "off"
       @service.update_progress(:power_status => "stopping")
       expect(@service.power_status).to eq "stopping"
-      expect{ |b| @service.update_progress(:power_state => "timeout", &b) }.to yield_with_args(:reset => true)
-      expect{ |b| @service.update_progress(:increment => true, &b) }.to yield_with_args(:increment => 1)
+      expect { |b| @service.update_progress(:power_state => "timeout", &b) }.to yield_with_args(:reset => true)
+      expect { |b| @service.update_progress(:increment => true, &b) }.to yield_with_args(:increment => 1)
     end
-
 
     it "#timed_out?" do
       @service.options[:delayed] = 3
@@ -113,7 +112,6 @@ describe Service do
     end
 
     context "#calculate_power_state" do
-
       it "delays if power states don't match" do
         @service.calculate_power_state(:start)
         expect(@service.options[:delayed]).to eq 1
@@ -125,11 +123,9 @@ describe Service do
         expect(@service.power_state).to eq "on"
         expect(@service.power_status).to eq "start_complete"
       end
-
     end
 
     context "#power_states_match?" do
-
       it "returns the uniq value for the 'on' power state" do
         expect(@service).to receive(:map_power_states).with(:start).and_return(["on"])
         expect(@service.power_states_match?(:start)).to be_truthy
@@ -140,11 +136,9 @@ describe Service do
         expect(@service).to receive(:vm_power_states).and_return(["off"])
         expect(@service.power_states_match?(:stop)).to be_truthy
       end
-
     end
 
     context "#modify_power_state_delay" do
-
       it "sets delayed to nil on a reset request" do
         options = {:reset => true}
         @service.options[:delayed] = 3
@@ -160,7 +154,6 @@ describe Service do
         @service.modify_power_state_delay(options)
         expect(@service.options[:delayed]).to eq 1
       end
-
     end
 
     it "#direct_vms" do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -8,6 +8,7 @@ describe Service do
 
     it "raise_request_start_event" do
       expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_start)
+      expect(@service).to receive(:update_progress).with({:power_status=>"starting"})
 
       @service.raise_request_start_event
     end
@@ -20,6 +21,7 @@ describe Service do
 
     it "raise_request_stop_event" do
       expect(MiqEvent).to receive(:raise_evm_event).with(@service, :request_service_stop)
+      expect(@service).to receive(:update_progress).with({:power_status=>"stopping"})
 
       @service.raise_request_stop_event
     end
@@ -47,10 +49,34 @@ describe Service do
 
       @service.raise_final_process_event('stop')
     end
+
+    it "queues a power calculation if the next_group_index is nil" do
+      expect(@service).to receive(:next_group_index).and_return(nil)
+      expect(@service).to receive(:queue_power_calculation).once
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_started)
+
+      @service.process_group_action(:start, 0, 1)
+    end
+
+    it "does not queue a power calculation if the next_group_index is not nil" do
+      expect(@service).to receive(:next_group_index).and_return(1)
+      expect(@service).to receive(:queue_power_calculation).never
+      expect(@service).to receive(:queue_group_action).once
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_started).never
+
+      @service.process_group_action(:start, 0, 1)
+    end
+
+    it "places a calculate_power_state job on the queue" do
+      expect(MiqQueue).to receive(:put).once
+      @service.queue_power_calculation(30, :start)
+    end
   end
 
   context "VM associations" do
     before do
+      @zone1 = FactoryGirl.create(:small_environment)
+      allow(MiqServer).to receive(:my_server).and_return(@zone1.miq_servers.first)
       @vm          = FactoryGirl.create(:vm_vmware)
       @vm_1        = FactoryGirl.create(:vm_vmware)
 
@@ -60,6 +86,81 @@ describe Service do
       @service_c1 << @vm_1
       @service.save
       @service_c1.save
+    end
+
+    it "#vm_power_states" do
+      expect(@service.vm_power_states).to eq %w(on on)
+    end
+
+    it "#update_progress" do
+      expect(@service.power_state).to be_nil
+      @service.update_progress(:power_state => "on" )
+      expect(@service.power_state).to eq "on"
+      @service.update_progress(:power_state => "off")
+      expect(@service.power_state).to eq "off"
+      @service.update_progress(:power_status => "stopping")
+      expect(@service.power_status).to eq "stopping"
+      expect{ |b| @service.update_progress(:power_state => "timeout", &b) }.to yield_with_args(:reset => true)
+      expect{ |b| @service.update_progress(:increment => true, &b) }.to yield_with_args(:increment => 1)
+    end
+
+
+    it "#timed_out?" do
+      @service.options[:delayed] = 3
+      expect(@service.timed_out?).to be_truthy
+      @service.options[:delayed] = 2
+      expect(@service.timed_out?).to be_falsey
+    end
+
+    context "#calculate_power_state" do
+
+      it "delays if power states don't match" do
+        @service.calculate_power_state(:start)
+        expect(@service.options[:delayed]).to eq 1
+      end
+
+      it "returns a power_state of 'on' and a power_status of 'start_complete' if power_states_match" do
+        expect(@service).to receive(:power_states_match?).and_return(true)
+        @service.calculate_power_state(:start)
+        expect(@service.power_state).to eq "on"
+        expect(@service.power_status).to eq "start_complete"
+      end
+
+    end
+
+    context "#power_states_match?" do
+
+      it "returns the uniq value for the 'on' power state" do
+        expect(@service).to receive(:map_power_states).with(:start).and_return(["on"])
+        expect(@service.power_states_match?(:start)).to be_truthy
+      end
+
+      it "returns the uniq value for the 'off' power state" do
+        expect(@service).to receive(:map_power_states).with(:stop).and_return(["off"])
+        expect(@service).to receive(:vm_power_states).and_return(["off"])
+        expect(@service.power_states_match?(:stop)).to be_truthy
+      end
+
+    end
+
+    context "#modify_power_state_delay" do
+
+      it "sets delayed to nil on a reset request" do
+        options = {:reset => true}
+        @service.options[:delayed] = 3
+        @service.save
+        expect(@service.options[:delayed]).to eq 3
+        @service.modify_power_state_delay(options)
+        expect(@service.options[:delayed]).to be_nil
+      end
+
+      it "increments delayed by one when increment is passed in" do
+        options = {:increment => 1}
+        expect(@service.options[:delayed]).to be_nil
+        @service.modify_power_state_delay(options)
+        expect(@service.options[:delayed]).to eq 1
+      end
+
     end
 
     it "#direct_vms" do
@@ -154,6 +255,7 @@ describe Service do
 
     it "suspend" do
       @service.add_resource(Vm.first, :group_idx => 1, :stop_delay => 60)
+      expect(@service).to receive(:update_progress).with(:power_status=>"suspending")
       expect(@service).to receive(:queue_group_action).with(:suspend, 1, -1, 60)
 
       @service.suspend


### PR DESCRIPTION
This PR exposes one `power_state` for a bundled service while interpolating all the `power_states` of the associated resources (VM's.)

It also exposes a `power_status` for the service as it walks through changing the state of the child resources.

When a `:start`, `:stop`, `:suspend` action is called on the service we change the `power_status` to `:starting`, `:stopping`, `:suspending` while waiting for the resources to complete their state changes.

The `calculate_power_state` job is queued up on a service once all resource specific jobs have been completed. If power_states of all the resources do not match the action called on the service then the job will queue itself up again with a longer delay.

Example
1. Call `:start`
2. `start` is called on each resource
3. `calculate_power_state` is run
      - It checks if the states of the resources match the expected value of the called power_state - `:start` - which for 3 child resources with a `start_action` of `Power on` would = `["on", "on", "on"]`
      - If the states do not match then the job requeues itself with a delay of the `combined_group_delay` + 60 seconds
          - The system will retry up to 3 times before the `power_state` is set to `timeout`
      - If the states do match then the power_state is set to the value expected of the called action - `:start` = "on", `:stop` = "off". `power_status` is set to `stop_complete` or `start_complete`

This PR offers 2  `power_state` values:  "on", "off".

"on" - only if all VM's are started
"off" - only if all VM's are stopped


Links
----------------

* [PT #131907917](https://www.pivotaltracker.com/story/show/131907917)

Steps for Testing/QA
-------------------------------

1. Create a bundled service.
2. Order the service.
3. go to the console `rails c` and lookup up the bundled service `s = Service.find_by_guid '<guid>'`
`s.start`
4. Immediately after calling start you should see the `power_status` on `s` change to `starting` (you may need to reload the object to see the update.
5. After the service is finished you should see a value of `on` when checking `s.power_state`.
(This only works if all your VM's are set to start) and a value of `start_complete` for the `power_status`. 

-- Note without normal refreshes - power_status will never get beyond `starting`, `stopping` and the power_state will always end up at `timeout` as the system depends on a refresh to know the current state of the children resources.

