### PR TITLE
Use VmOrTemplate instead of MiqTemplate for lookup

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -124,7 +124,6 @@ class TreeNodeBuilder
                                                 _("LUN: %{name}") % {:name => object.canonical_name}) },
     "MiqScsiTarget"              => -> { miq_scsi_target(object.iscsi_name, object.target) },
     "MiqServer"                  => -> { miq_server_node },
-    "MiqTemplate"                => -> { generic_node(object.name, "currentstate-#{object.normalized_state.downcase}.png") },
     "MiqAlert"                   => -> { generic_node(object.description, "miq_alert.png") },
     "MiqAction"                  => -> { miq_action_node },
     "MiqEventDefinition"         => -> { generic_node(object.description, "event-#{object.name}.png") },
@@ -164,6 +163,7 @@ class TreeNodeBuilder
     "Tenant"                     => -> { generic_node(object.name, "#{object.tenant? ? "tenant" : "project"}.png") },
     "VmdbTableEvm"               => -> { generic_node(object.name, "vmdbtableevm.png") },
     "VmdbIndex"                  => -> { generic_node(object.name, "vmdbindex.png") },
+    "VmOrTemplate"               => -> { generic_node(object.name, "currentstate-#{object.normalized_state.downcase}.png") },
     "Zone"                       => -> { zone_node },
     "Hash"                       => -> { hash_node },
   }.freeze


### PR DESCRIPTION
Attempts to fix #11875

See the commit message and the [issue comment](https://github.com/ManageIQ/manageiq/issues/11875#issuecomment-253348837) I wrote for further details.


Cons
----
One con with this solution is `VmOrTemplate` is a widely inherited class in `MIQ`, and it is possible that other records that don't inherit from `MiqTemplate`, but who's `.base_class` is `VmOrTemplate` will now resolve to that incorrectly when they previously resolved to something else.

There might need to be a fundamental re-thinking of this case statement business if we wish to keep this here, or a general knowledge of the [previous change](https://github.com/ManageIQ/manageiq/commit/4ca079a8) so that dev/QE is aware of this when it crops up again.

While my pride also doesn't want to suggest this, possibly reverting 4ca079a8 is another option as well...


Links
-----
* https://github.com/ManageIQ/manageiq/commit/4ca079a8
* https://github.com/ManageIQ/manageiq/issues/11875
* https://github.com/ManageIQ/manageiq/issues/11875#issuecomment-253348837