### PR TITLE
Ensure that only one filter dropdown gets rendered per action type

### DIFF
--- a/app/assets/javascripts/directives/selectpickerForSelectTag.js
+++ b/app/assets/javascripts/directives/selectpickerForSelectTag.js
@@ -17,6 +17,10 @@ ManageIQ.angular.app.directive('selectpickerForSelectTag', function() {
       scope.$watch('loaded.bs.select', function() {
         $('.bootstrap-select button').removeAttr('title');
       });
+
+      scope.$on('$destroy', function () {
+        elem.selectpicker('destroy');
+      });
     }
   }
 });

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -50,7 +50,6 @@
           = select_tag('provider_region',
                        options_for_select([["<#{_('Choose')}>", nil]] + regions, disabled: ["<#{_('Choose')}>", nil]),
                        "ng-model"                    => "emsCommonModel.provider_region",
-                       "ng-if"                       => "emsCommonModel.emstype == '#{name}'",
                        "ng-switch-when"              => name,
                        "required"                    => "",
                        "checkchange"                 => "",


### PR DESCRIPTION
When the `Action` dropdown values are changed one after the other, say, from `VM Analysis` to `Template Analysis` to `Host Analysis` , the `Filter` dropdown from the earlier `Action` dropdown value still lingers around.

See the below screenshot : 
<img width="887" alt="screen shot 2016-10-12 at 4 06 41 pm" src="https://cloud.githubusercontent.com/assets/1538216/19330880/f096adf8-9095-11e6-91bb-b51158b7714a.png">

This PR addresses the above bug.

IIRC, this used to work before so I'm going to attribute this behavior to the latest version of angular?(maybe)



