### PR TITLE
Purge large tables from any zone / role

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -98,31 +98,19 @@ class MiqScheduleWorker::Jobs
   end
 
   def metric_purging_purge_realtime_timer
-    zone = MiqServer.my_server(true).zone
-    if zone.role_active?("ems_metrics_processor")
-      queue_work(:class_name => "Metric::Purging", :method_name => "purge_realtime_timer")
-    end
+    queue_work(:class_name => "Metric::Purging", :method_name => "purge_realtime_timer", :zone => nil)
   end
 
   def metric_purging_purge_rollup_timer
-    zone = MiqServer.my_server(true).zone
-    if zone.role_active?("ems_metrics_processor")
-      queue_work(:class_name => "Metric::Purging", :method_name => "purge_rollup_timer")
-    end
+    queue_work(:class_name => "Metric::Purging", :method_name => "purge_rollup_timer", :zone => nil)
   end
 
   def ems_event_purge_timer
-    zone = MiqServer.my_server(true).zone
-    if zone.role_active?("event")
-      queue_work(:class_name => "EventStream", :method_name => "purge_timer")
-    end
+    queue_work(:class_name => "EventStream", :method_name => "purge_timer", :zone => nil)
   end
 
   def policy_event_purge_timer
-    zone = MiqServer.my_server(true).zone
-    if zone.role_active?("event")
-      queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer")
-    end
+    queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer", :zone => nil)
   end
 
   def storage_refresh_metrics


### PR DESCRIPTION
Since database pruning is quick and does not transfer any data to providers, there is no need to restrict the jobs to particular zones or servers.

Also, the amount of data transferred over the wire for these tasks is now trivial. Which has reduced the amount of time these tasks take. So there really is no longer the need to control this so tightly.

----

**before:**

Only prune large tables from a specific role within a specific zone.

**after:**

Prune tables from any server within the region.

---

@Fryguy is this what you had in mind when creating this BZ with Tom? Did you want me to change the scheduler behind these tasks?


Links
------

- https://bugzilla.redhat.com/show_bug.cgi?id=1207827
