### PR TITLE
Disable snapshots on oVirt for APIs below v4

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -1,4 +1,18 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
+  extend ActiveSupport::Concern
+
+  included do
+    supports :snapshots do
+      if supports_control?
+        unless ext_management_system.supports_snapshots?
+          unsupported_reason_add(:snapshots, ext_management_system.unsupported_reason(:snapshots))
+        end
+      else
+        unsupported_reason_add(:snapshots, unsupported_reason(:control))
+      end
+    end
+  end
+
   def raw_create_snapshot(_name, desc, memory)
     with_snapshots_service(uid_ems) do |snapshots_service|
       snapshots_service.add(:description => desc, :persist_memorystate => memory)
@@ -19,10 +33,6 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     with_snapshots_service(uid_ems) do |snapshots_service|
       snapshots_service.snapshot_service(snapshot.uid_ems).restore
     end
-  end
-
-  def supports_snapshots?
-    true
   end
 
   def snapshot_name_optional?

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1610,7 +1610,7 @@ describe ApplicationHelper do
             it "when no available message but active" do
               allow(@record).to receive(:is_available?).with(:create_snapshot).and_return(false)
               @active = true
-              expect(subject).to eq("The VM is not connected to an active Cloud/Infrastructure Providers")
+              expect(subject).to eq("Create Snapshot operation not supported for Redhat VM")
             end
           end
           it_behaves_like 'default true_case'
@@ -1623,11 +1623,10 @@ describe ApplicationHelper do
           end
           context "when without snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(0) }
-            it_behaves_like 'record with error message', 'remove_snapshot'
           end
           context "when with snapshots" do
             before { allow(@record).to receive_message_chain(:snapshots, :size).and_return(2) }
-            it_behaves_like 'default case'
+            it_behaves_like 'record with error message', 'remove_snapshot'
           end
         end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/operations/snapshot_spec.rb
@@ -28,4 +28,23 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot do
       vm.raw_create_snapshot(nil, "snap_desc", true)
     end
   end
+
+  describe 'supported above api v4' do
+    let(:ems) { FactoryGirl.create(:ems_redhat_with_authentication) }
+    let(:vm)  { FactoryGirl.create(:vm_redhat, :ext_management_system => ems) }
+    let(:supported_api_versions) { [] }
+    before(:each) do
+      allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
+    end
+    subject { vm.supports_snapshots? }
+    context 'when engine supports v4 api' do
+      let(:supported_api_versions) { [4] }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when engine does not support v4 api' do
+      let(:supported_api_versions) { [3] }
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
oVirt provider will have supports_snapshot? true only for those
instances that have API version 4.

https://bugzilla.redhat.com/show_bug.cgi?id=1375551
