### PR TITLE
Fix updating description in cloud tenant mapping

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -77,7 +77,8 @@ module ManageIQ::Providers
       _log.info("Syncing CloudTenant with Tenants...")
 
       CloudTenant.with_ext_management_system(id).walk_tree do |cloud_tenant, _|
-        tenant_params = {:name => cloud_tenant.name, :description => cloud_tenant.name}
+        cloud_tenant_description = cloud_tenant.description.blank? ? cloud_tenant.name : cloud_tenant.description
+        tenant_params = {:name => cloud_tenant.name, :description => cloud_tenant_description}
 
         if cloud_tenant.source_tenant
           _log.info("CloudTenant #{cloud_tenant.name} has tenant #{cloud_tenant.source_tenant.name}")

--- a/spec/factories/cloud_tenants.rb
+++ b/spec/factories/cloud_tenants.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :cloud_tenant do
-    sequence(:name)    { |n| "cloud_tenant_#{seq_padded_for_sorting(n)}" }
-    sequence(:ems_ref) { |n| "ems_ref_#{seq_padded_for_sorting(n)}" }
+    sequence(:name)         { |n| "cloud_tenant_#{seq_padded_for_sorting(n)}" }
+    sequence(:description)  { |n| "cloud_tenant_description_#{seq_padded_for_sorting(n)}" }
+    sequence(:ems_ref)      { |n| "ems_ref_#{seq_padded_for_sorting(n)}" }
   end
 
   factory :cloud_tenant_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::CloudTenant", :parent => :cloud_tenant do

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -135,12 +135,20 @@ describe EmsCloud do
           [tenant_ct_1.name, tenant_ct_2.name, tenant_ct_3.name, tenant_ct_4.name]
         end
 
+        let(:tenant_descriptions) do
+          [tenant_ct_1.description, tenant_ct_2.description, tenant_ct_3.description, tenant_ct_4.description]
+        end
+
         let(:tenant_parent_names) do
           [tenant_ct_1.parent.name, tenant_ct_2.parent.name, tenant_ct_3.parent.name, tenant_ct_4.parent.name]
         end
 
         def expect_tenant_names
           expect(tenant_names).to eq([ct_1.name, ct_2.name, ct_3.name, ct_4.name])
+        end
+
+        def expect_tenant_descriptions
+          expect(tenant_descriptions).to eq([ct_1.description, ct_2.description, ct_3.description, ct_4.description])
         end
 
         def expect_tenant_parent_names
@@ -154,6 +162,8 @@ describe EmsCloud do
 
         def expect_created_tenant_tree
           expect_tenant_names
+
+          expect_tenant_descriptions
 
           expect_tenant_parent_names
 
@@ -192,7 +202,7 @@ describe EmsCloud do
           expect_created_tenant_tree
 
           ct_4.name = "New name"
-          ct_4.description = "New name"
+          ct_4.description = "New description"
           ct_4.vms_and_templates << vm_5
           ct_4.save
 
@@ -200,8 +210,20 @@ describe EmsCloud do
           tenant_ct_4.reload
 
           expect(tenant_ct_4.name).to eq(ct_4.name)
+          expect(tenant_ct_4.description).to eq(ct_4.description)
           expect(tenant_ct_4.parent.name).to eq(ct_2.name)
+          expect(tenant_ct_4.parent.description).to eq(ct_2.description)
           expect(tenant_ct_4.vm_or_templates).to match_array([vm_3, vm_4, vm_5])
+        end
+
+        it "sets description to CloudTenant#name when CloudTenant#description is empty" do
+          ct_4.description = ""
+          ct_4.save
+
+          ems_cloud.sync_cloud_tenants_with_tenants
+
+          expect(tenant_ct_4.name).to eq(ct_4.name)
+          expect(tenant_ct_4.description).to eq(ct_4.name)
         end
 
         it "moves out tenant when CloudTenant does not exist under provider's tenant" do


### PR DESCRIPTION
 Sync also Tenant#description with CloudTenant#description

when CloudTenant#description is empty then use related CloudTenant#name
because Tenant#description is mandatory

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1381842

