### PR TITLE
Add option for container performance reports

### DIFF
--- a/app/models/container_group_performance.rb
+++ b/app/models/container_group_performance.rb
@@ -1,0 +1,5 @@
+class ContainerGroupPerformance < MetricRollup
+  default_scope { where "resource_type = 'ContainerGroup' and resource_id IS NOT NULL" }
+
+  belongs_to :container_group, :foreign_key => :resource_id, :class_name => ContainerGroup.name
+end

--- a/app/models/container_node_performance.rb
+++ b/app/models/container_node_performance.rb
@@ -1,0 +1,5 @@
+class ContainerNodePerformance < MetricRollup
+  default_scope { where "resource_type = 'ContainerNode' and resource_id IS NOT NULL" }
+
+  belongs_to :container_node, :foreign_key => :resource_id, :class_name => ContainerNode.name
+end

--- a/app/models/container_performance.rb
+++ b/app/models/container_performance.rb
@@ -1,0 +1,5 @@
+class ContainerPerformance < MetricRollup
+  default_scope { where "resource_type = 'Container' and resource_id IS NOT NULL" }
+
+  belongs_to :container_node, :foreign_key => :resource_id, :class_name => Container.name
+end

--- a/app/models/container_project_performance.rb
+++ b/app/models/container_project_performance.rb
@@ -1,0 +1,5 @@
+class ContainerProjectPerformance < MetricRollup
+  default_scope { where "resource_type = 'ContainerProject' and resource_id IS NOT NULL" }
+
+  belongs_to :container_node, :foreign_key => :resource_id, :class_name => ContainerProject.name
+end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -17,11 +17,15 @@ class MiqExpression
     ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
     ManageIQ::Providers::ConfigurationManager
     Container
+    ContainerPerformance
     ContainerGroup
+    ContainerGroupPerformance
     ContainerImage
     ContainerImageRegistry
     ContainerNode
+    ContainerNodePerformance
     ContainerProject
+    ContainerProjectPerformance
     ContainerReplicator
     ContainerRoute
     ContainerService
@@ -1292,6 +1296,8 @@ class MiqExpression
         next(c) if includes.include?(c)
         c if includes.detect { |incl| c.match(incl) }
       end.compact
+    when base_model.starts_with?("Container")
+      excludes += ["^.*derived_host_count_off$", "^.*derived_host_count_on$", "^.*derived_vm_count_off$", "^.*derived_vm_count_on$", "^.*derived_storage.*$"]
     end
 
     column_names.collect do|c|

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -700,11 +700,15 @@ en:
       CustomButton:             Button
       CustomButtonSet:          Buttons Group
       Container:                Container
+      ContainerPerformance:     Performance - Container
       ContainerGroup:           Pod
+      ContainerGroupPerformance: Performance - Pod
       ContainerImageRegistry:   Image Registry
       ContainerImage:           Container Image
       ContainerNode:            Node
+      ContainerNodePerformance: Performance - ContainerNode
       ContainerProject:         Project
+      ContainerProjectPerformance: Performance - ContainerProject
       ContainerRoute:           Route
       ContainerReplicator:      Replicator
       ContainerService:         Container Service


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1376377

Added `ContainerPerformance`, `ContainerProjectPerformance`, `ContainerGroupPerformance`, `ContainerNodePerformance`.

![screencapture-localhost-3000-report-explorer-1476371764097](https://cloud.githubusercontent.com/assets/11256940/19355303/912bbf60-9172-11e6-8a51-557e4ab15311.png)

cc @simon3z 
@miq-bot add_label providers/containers, reporting
