### PR TITLE
Clear remembered widget charts between requests.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -206,6 +206,10 @@ class DashboardController < ApplicationController
       end
       @widgets_menu[:allow_reset] = can_reset
     end
+
+    # Make widget presenter forget chart data from previous HTTP request handled
+    # by this process.
+    WidgetPresenter.reset_data
   end
 
   # Destroy and recreate a user's dashboard from the default

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -102,4 +102,8 @@ class WidgetPresenter
   def self.chart_data
     @chart_data ||= []
   end
+
+  def self.reset_data
+    @chart_data = []
+  end
 end


### PR DESCRIPTION
We failed to clear the remembered chart_data for `WidgetPresenter` between requests.

This is a memory leak :-(

Steps for Testing/QA [Optional]
-------------------------------

apply this diff:
```
diff --git a/app/views/dashboard/show.html.haml b/app/views/dashboard/show.html.haml
index a075813..c0640d8 100644
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -16,6 +16,7 @@
         - widget = MiqWidget.find_by_id(w)
         - if widget && widget.enabled && @available_widgets.include?(widget.id)
           = WidgetPresenter.new(self, controller, widget).render_partial
+- Rails.logger.error("WidgetPresenter: #{WidgetPresenter.chart_data.length}")
 - if WidgetPresenter.chart_data.present?
   :javascript
     ManageIQ.charts.chartData = #{{"widgetchart" => WidgetPresenter.chart_data}.to_json.html_safe};
```

and observe:
```
tail -f log/development.log | grep WidgetPresenter:
[----] E, [2016-10-13T11:32:51.070610 #28188:5518178] ERROR -- : WidgetPresenter: 7
[----] E, [2016-10-13T11:32:56.974609 #28188:551845c] ERROR -- : WidgetPresenter: 14

```

Before the change each ruby process will have it's set of chart data and that set will grow. After the fix, the number of items will remain the same.

Found this when reviewing https://github.com/ManageIQ/manageiq/pull/11265. We need to backport these two together.