### PR TITLE
Allow collection of tags from ContainerImage again

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -224,8 +224,4 @@ module Metric::CiMixin::Capture
 
     perf_capture_queue('realtime', :priority => MiqQueue::HIGH_PRIORITY)
   end
-
-  def perf_tags
-    tag_list(:ns => '/managed').split.join("|")
-  end
 end

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -202,4 +202,8 @@ module ActsAsTaggable
       return ""
     end
   end
+
+  def perf_tags
+    tag_list(:ns => '/managed').split.join("|")
+  end
 end


### PR DESCRIPTION
We need to move `perf_tag` method from CiMixing to `ArTaggable`. That is because in case of `ContainerImage` we collect tags, however we don't collect C&U for the image -> ContainerImage does not participate in CiMixin.

This bug was introduced in #11761 and reported by @zeari. Thanks! And sorry for the inconvenience.

@miq-bot add_label bug, metrics, provider/containers
@miq-bot assign @gtanzillo 