### PR TITLE
config setting for amazon provider to disable regions at runtime

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -97,6 +97,8 @@
       :read_timeout: 1.hour
   :ems_kubernetes:
     :miq_namespace: management-infra
+  :ems_amazon:
+    :disabled_regions: []
 :ems_events:
   :history:
     :keep_ems_events: 6.months


### PR DESCRIPTION
default settings for disabled regions in the amazon provider.
see the amazon pr for the actual code.

I wanted the setting in the amazon repo, but we havent migrated settings over for euwe :(

in essence this is a forward port from the darga pr.

amazon pr https://github.com/ManageIQ/manageiq-providers-amazon/pull/44
original darga pr https://github.com/ManageIQ/manageiq/pull/10902
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1346065

@miq-bot add_labels euwe/yes, providers/amazon
@miq-bot assign @blomquisg 