### PR TITLE
Ansible jobs - make it possible to get to the detail of a job

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager/job.rb
@@ -77,4 +77,8 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager::Job < ::Orchestra
     _log.error "Reading AnsibleTower Job #{name} with id(#{id}) stdout failed with error: #{err}"
     raise MiqException::MiqOrchestrationStatusError, err.to_s, err.backtrace
   end
+
+  def self.db_name
+    'ConfigurationJob'
+  end
 end

--- a/app/views/layouts/listnav/_configuration_job.html.haml
+++ b/app/views/layouts/listnav/_configuration_job.html.haml
@@ -17,7 +17,7 @@
             = link_to("#{ui_lookup(:model => @record.ext_management_system.class.to_s)}: #{@record.ext_management_system.name}",
               {:controller => "provider_foreman", :action => 'explorer', :id => "at-#{to_cid(@record.ext_management_system.id)}"},
               :title => _("Show parent %s for this Job") % ui_lookup(:model => @record.ext_management_system.class.to_s))
-        - if role_allows?(:feature => "service_view") && @record.ext_management_system
+        - if role_allows?(:feature => "service_view") && @record.service
           %li
             = link_to("#{ui_lookup(:table => "service")}: #{@record.service.name}",
               {:controller => "service", :action => 'show', :id => to_cid(@record.service.id)},

--- a/spec/controllers/configuration_job_controller_spec.rb
+++ b/spec/controllers/configuration_job_controller_spec.rb
@@ -23,6 +23,18 @@ describe ConfigurationJobController do
         expect(response.status).to eq(200)
         expect(response).to render_template(:partial => "layouts/listnav/_configuration_job")
       end
+
+      it "links to ConfigurationJobController" do  # instead of OrchestrationStackController
+        extend QuadiconHelper
+        extend ApplicationHelper
+        allow(self).to receive(:url_for) do |opt|
+          opt
+        end
+
+        url_for_options = url_for_db(quadicon_model_name(record), "show", record)
+
+        expect(url_for_options[:controller]).to eq("configuration_job")
+      end
     end
   end
 


### PR DESCRIPTION
This is actually 2 bugs..

* opening the detail via the grid or tile views would not work, because ConfigurationJob inherits from OrchestrationStack, making that the base class, so the urls would go to `/orchestration_stack/show/*` instead of `/configuration_job/show/*` - overriden `ConfigurationJob.db_name` to return `"ConfigurationJob"`

* opening the detail via list view worked only when the job had an associated service - copypasta condition from the previous paragraph, fixed to test for `service` instead of `ext_management_system`

https://bugzilla.redhat.com/show_bug.cgi?id=1378211

@lgalis can you take a look please?