### PR TITLE
Disable html5 mode for the toolbar angular module

### DIFF
--- a/app/assets/javascripts/angular_modules/module_toolbar.js
+++ b/app/assets/javascripts/angular_modules/module_toolbar.js
@@ -4,8 +4,8 @@ miqHttpInject(
   ])
   .config(['$locationProvider', function ($locationProvider) {
     $locationProvider.html5Mode({
-      enabled: true,
-      requireBase: false
-    })
+      enabled: false,
+      requireBase: false,
+    });
   }])
 );


### PR DESCRIPTION
When the current url contains a query string parameter with plus signs (like `?flash_msg=Edit+of+Cloud+Provider+"Amazon"+was+cancelled+by+the+user`), clicking on the toolbar would first mangle the url to use `%20` instead of `+`, and then clicking again would finally work.

This is because in html5 mode, angular needs to control the URL.

However, there's no reason the toolbar should even be aware of the current URL, etc.

Thus, disabling html5 mode in that module.

Closes #11537 
Closes #11394

Cc @AparnaKarve, @karelhala 