### PR TITLE
Font icon cleanup

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -224,6 +224,13 @@ table .narrow {
   white-space: nowrap;
 }
 
+table .narrow i { /* font icon styling in table view (equivalent to fa-lg) */
+  padding-left: 2px;
+  font-size: 1.33333333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}
+
 /* disables hover and pointer on row */
 
 table.table-hover tbody tr:nth-child(odd).no-hover:hover td {

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -425,7 +425,7 @@ class MiqAeClassController < ApplicationController
       end
       srow = root.add_element("row", "id" => "#{cls}-#{to_cid(kids.id)}", "style" => "border-bottom: 1px solid #CCCCCC;color:black; text-align: center")
       srow.add_element("cell").text = "0" # Checkbox column unchecked
-      srow.add_element("cell", "image" => "blank.png", "title" => cls.to_s, "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = REXML::CData.new("<ul class='icons list-unstyled'><li><span class='#{glyphicon}' alt='#{cls}' title='#{cls}'></span></li></ul>")
+      srow.add_element("cell", "image" => "blank.png", "title" => cls.to_s, "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = REXML::CData.new("<i class='#{glyphicon}' alt='#{cls}' title='#{cls}'></i>")
       srow.add_element("cell", "image" => "blank.png", "title" => rec_name.to_s, "style" => "border-bottom: 1px solid #CCCCCC;text-align: left;height:28px;").text = rec_name
     end
     xml.to_s

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1769,12 +1769,8 @@ module ApplicationHelper
       glyphicon2 = listicon_glyphicon_tag_for_widget(row)
     end
 
-    content_tag(:ul, :class => 'icons list-unstyled') do
-      content_tag(:li) do
-        content_tag(:span, nil, :class => glyphicon) do
-          content_tag(:span, nil, :class => glyphicon2) if glyphicon2
-        end
-      end
+    content_tag(:i, nil, :class => glyphicon) do
+      content_tag(:i, nil, :class => glyphicon2) if glyphicon2
     end
   end
 

--- a/app/views/alert/_rss_list.html.haml
+++ b/app/views/alert/_rss_list.html.haml
@@ -25,7 +25,7 @@
         - @rss_feeds.each do |feed|
           %tr{:title => _("Subscribe to this feed"), :onclick => "DoNav('#{feed.link}');"}
             %td.narrow
-              %i.pficon.fa.fa-2x.fa-rss
+              %i.fa.fa-rss
             %td
               = h(feed.title)
             %td

--- a/app/views/chargeback/_assignments_list.html.haml
+++ b/app/views/chargeback/_assignments_list.html.haml
@@ -3,13 +3,11 @@
   %tbody
     %tr{:onclick => remote_function(:url => {:action => 'tree_select', :id => 'xx-Compute'})}
       %td.narrow{:title => _("Edit Compute Rate Assignments")}
-        %ul.icons.list-unstyled
-          %li
-            %span.product.product-memory
+        %i.product.product-memory
       %td{:title => _("Edit Compute Rate Assignments")}
         = _('Compute')
     %tr{:onclick => remote_function(:url => {:action => 'tree_select', :id => "xx-Storage"})}
       %td.narrow{:title => _("Edit Storage Rate Assignments")}
-        %i.fa-2x.fa.fa-hdd-o
+        %i.fa.fa-hdd-o
       %td{:title => _("Edit Storage Rate Assignments")}
         = _('Storage')

--- a/app/views/chargeback/_rates_list.html.haml
+++ b/app/views/chargeback/_rates_list.html.haml
@@ -3,13 +3,11 @@
   %tbody
     %tr{:onclick => "miqTreeActivateNode('#{x_active_tree}', 'xx-Compute');"}
       %td.narrow{:title => _("View Compute Rates")}
-        %ul.icons.list-unstyled
-          %li
-            %span.product.product-memory
+        %i.product.product-memory
       %td{:title => _("View Compute Rates")}
         Compute
     %tr{:onclick => "miqTreeActivateNode('#{x_active_tree}', 'xx-Storage');"}
       %td.narrow{:title => _("View Storage Rates")}
-        %i.fa.fa-2x.fa-hdd-o
+        %i.fa.fa-hdd-o
       %td{:title => _("View Storage Rates")}
         Storage

--- a/app/views/chargeback/_reports_list.html.haml
+++ b/app/views/chargeback/_reports_list.html.haml
@@ -15,9 +15,7 @@
         - @parent_reports.each do |r|
           %tr{:title => _("View this Report"), :onclick => "miqTreeActivateNode('#{x_active_tree}', 'xx-#{r[1]}');"}
             %td.narrow
-              %ul.icons.list-unstyled
-                %li
-                  %span.product.product-report
+              %i.product.product-report
             %td
               = r[0]
 
@@ -40,7 +38,7 @@
               - t = _("Click to view saved report")
               %td{:title => t, :onclick => remote_function(:loading => "miqSparkle(true);",
                 :complete => "miqSparkle(false);", :url => {:action => 'tree_select', :id => row_id})}
-                %i.fa.fa-2x.fa-clock-o{:title => _("Saved Report: %{report_name}") % {:report_name => row['name']}}
+                %i.fa.fa-clock-o{:title => _("Saved Report: %{report_name}") % {:report_name => row['name']}}
               %td{:title => t, :onclick => remote_function(:loading => "miqSparkle(true);",
                 :complete => "miqSparkle(false);", :url => {:action => 'tree_select', :id => row_id})}
                 = h(format_timezone(row['last_run_on'], Time.zone, "gtl"))

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -77,7 +77,7 @@
                 = cell[:text]
             - else
               - if cell[:icon]
-                %i.fa-lg{:class => cell[:icon], :title => cell[:title]}
+                %i{:class => cell[:icon], :title => cell[:title]}
               - elsif cell[:image]
                 = image_tag(image_path(cell[:image]), :alt => cell[:title], :title => cell[:title])
               = cell[:text]

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -17,9 +17,7 @@
               %td.narrow.noclick
                 %input{:type => 'checkbox', :value => cls_cid}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span{:class => icon_class(record.class)}
+                %i{:class => icon_class(record.class)}
               %td
                 = record_name(record)
       :javascript

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -17,9 +17,7 @@
               %td.narrow.noclick
                 %input{:type => 'checkbox', :value => cls_cid}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span{:class => icon_class(record.class)}
+                %i{:class => icon_class(record.class)}
               %td
                 = record_name(record)
       :javascript

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -16,9 +16,7 @@
             %td.narrow.noclick
               %input{:type => 'checkbox', :value => cls_cid}
             %td.narrow
-              %ul.icons.list-unstyled
-                %li
-                  %span{:class => icon_class(record.class)}
+              %i{:class => icon_class(record.class)}
             %td
               = record_name(record)
     :javascript

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -23,11 +23,11 @@
               - if record.git_enabled?
                 %img{:src => image_path('100/ae_git_domain.png')}
               - elsif record.name == MiqAeDatastore::MANAGEIQ_DOMAIN
-                %img{:src => image_path('100/miq.png')}
-              - elsif record.top_level_namespace  
-                %img{:src => image_path("100/vendor-#{record.top_level_namespace.downcase}.png")}
+                %i.product.product-product
+              - elsif record.top_level_namespace
+                %img{:src => image_path("svg/vendor-#{record.top_level_namespace.downcase}.svg")}
               - else
-                %i.fa.fa-2x.fa-globe
+                %i.fa.fa-globe
             %td
               = record_name(record).html_safe
             %td

--- a/app/views/miq_policy/_condition_list.html.haml
+++ b/app/views/miq_policy/_condition_list.html.haml
@@ -15,8 +15,6 @@
             %tr{:title => _("View this Condition"),
               :onclick => "miqTreeActivateNode('condition_tree', 'xx-#{c.towhat.downcase}_co-#{to_cid(c.id)}');"}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span{:class => "product product-miq_condition"}
+                %i{:class => "product product-miq_condition"}
               %td
                 = c.description

--- a/app/views/miq_policy/_event_list.html.haml
+++ b/app/views/miq_policy/_event_list.html.haml
@@ -13,6 +13,6 @@
             %tr{:title => _("View this Event"),
               :onclick => "miqTreeActivateNode('event_tree', 'ev-#{to_cid(e.id)}');"}
               %td.narrow
-                %i.fa-lg{:class => e.decorate.try(:fonticon)}
+                %i{:class => e.decorate.try(:fonticon)}
               %td
                 = e.description

--- a/app/views/miq_policy/_policy_details.html.haml
+++ b/app/views/miq_policy/_policy_details.html.haml
@@ -103,7 +103,7 @@
                                             "data-click_url" => {:url => url_for(:action => 'policy_edit',
                                                                                  :button => action,
                                                                                  :id => @policy)}.to_json}
-                      %i.fa.fa-lg{:class => arrow_style}
+                      %i.fa{:class => arrow_style}
               %td{:align => "right", :valign => "top"}
                 %span#members_chosen_div
                   = select_tag('members_chosen[]',
@@ -130,9 +130,7 @@
                 %tr{:title => _("View this Condition"),
                   :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_co-#{to_cid(c.id)}');"}
                   %td.narrow
-                    %ul.icons.list-unstyled
-                      %li
-                        %span{:class => "product product-miq_condition"}
+                    %i{:class => "product product-miq_condition"}
                   %td
                     = c.description
                   %td
@@ -178,7 +176,7 @@
                 %tr
                   %td.narrow{:title => _("View this Policy Event"),
                     :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_ev-#{to_cid(e.id)}');"}
-                    %i.fa-lg{:class => e.decorate.try(:fonticon)}
+                    %i{:class => e.decorate.try(:fonticon)}
                   %td{:title => _("View this Policy Event"),
                     :onclick => "miqTreeActivateNode('#{x_active_tree}', '#{x_node}_ev-#{to_cid(e.id)}');"}
                     = h(e.description)

--- a/app/views/ops/_rbac_details_tab.html.haml
+++ b/app/views/ops/_rbac_details_tab.html.haml
@@ -24,32 +24,24 @@
         - if role_allows?(:feature => "rbac_user_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-u');", :title => _("View Users")}
-              %ul.icons.list-unstyled
-                %li
-                  %span.pficon.pficon-user
+              %i.pficon.pficon-user
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-u');", :title => _("View Users")}
               = _("Users (%{users_count})") % {:users_count => @users_count.to_s}
         - if role_allows?(:feature => "rbac_group_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
-              %ul.icons.list-unstyled
-                %li
-                  %span.product.product-group
+              %i.product.product-group
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-g');", :title => _("View Groups")}
               = _("Groups (%{groups_count})") % {:groups_count => @groups_count.to_s}
         - if role_allows?(:feature => "rbac_role_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
-              %ul.icons.list-unstyled
-                %li
-                  %span.product.product-role
+              %i.product.product-role
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-ur');", :title => _("View Roles")}
               = _("Roles (%{roles_count})") % {:roles_count => @roles_count.to_s}
         - if role_allows?(:feature => "rbac_tenant_view", :any => true)
           %tr
             %td.narrow{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
-              %ul.icons.list-unstyled
-                %li
-                  %span.product.product-tenant
+              %i.product.product-tenant
             %td{:onclick => "miqTreeActivateNode('rbac_tree', 'xx-tn');", :title => _("View Tenants")}
               = _("Tenants (%{tenants_count})") % {:tenants_count => @tenants_count.to_s}

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -36,7 +36,7 @@
               - params = {}
             %tr{params}
               %td
-                %span.product.product-group
+                %i.product.product-group
                 = h(g.name)
   - all_subtenants = @tenant.all_subtenants
   - unless all_subtenants.blank?
@@ -50,9 +50,7 @@
             %tr{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
               :title => _("Click to view child Tenant")}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span.product.product-tenant
+                %i.product.product-tenant
               %td= tenant.name
   - all_subprojects = @tenant.all_subprojects
   - unless all_subprojects.blank?
@@ -66,9 +64,7 @@
             %tr{:onclick => "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');",
               :title => _("Click to view child TenantProject")}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span.product.product-project
+                %i.product.product-project
               %td= tenant.name
   .row
     .col-md-12.col-lg-10

--- a/app/views/report/_db_list.html.haml
+++ b/app/views/report/_db_list.html.haml
@@ -12,9 +12,7 @@
           %tr{:title => _("Click to view '%{title}'") % {:title => @db_nodes[node][:title]},
             :onclick => "miqTreeActivateNode('#{@sb[:active_tree]}', '#{@db_nodes[node][:id]}');"}
             %td.narrow{:nowrap => 1}
-              %ul.icons.list-unstyled
-                %li
-                  %span{:class => @db_nodes[node][:glyph]}
+              %i{:class => @db_nodes[node][:glyph]}
             %td
               = h(@db_nodes[node][:text])
   - elsif @sb[:nodes] && @sb[:nodes].last == "g" && !@in_a_form
@@ -31,9 +29,7 @@
           %tr{:onclick => remote_function(:loading => "miqSparkle(true);", :complete => "miqSparkle(false);",
               :url => {:action => 'tree_select', :id => "xx-g_g-#{to_cid(g.id)}"}), :title => _("Click to view %{group} ") % {:group => g.description}, :class => "icon"}
             %td.narrow
-              %ul.icons.list-unstyled
-                %li
-                  %span.product.product-group
+              %i.product.product-group
             %td
               = h(g.description)
   - elsif @sb[:nodes].length == 3 && @sb[:nodes][1] == "g_g" && !@in_a_form
@@ -52,7 +48,7 @@
             %tr{:onclick => remote_function(:loading => "miqSparkle(true);", :complete => "miqSparkle(false);", :url => {:action => 'tree_select',
                 :id => "xx-g_g-#{@sb[:nodes][2]}_-#{to_cid(ws.id)}"}), :title => _("Click to view '%{widgetset_description} (%{widgetset_name})'") % {:widgetset_description => ws.description, :widgetset_name => ws.name}, :class => "icon"}
               %td.narrow
-                %i.fa.fa-2x.fa-dashboard{:title => ws.description}
+                %i.fa.fa-dashboard{:title => ws.description}
               %td
                 = "#{h(ws.description)} (#{h(ws.name)})"
   - elsif ((@sb[:nodes].length == 4 && @sb[:nodes][1] == "g_g") || (@sb[:nodes].length == 2 && @sb[:nodes].first == "xx")) && !@in_a_form

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -41,9 +41,7 @@
                     - glyphicon = "pficon pficon-folder-close-blue"
                   - else
                     - glyphicon = "pficon pficon-folder-close"
-                  %ul.icons.list-unstyled
-                    %li
-                      %span{:class => "#{glyphicon}"}
+                  %i{:class => "#{glyphicon}"}
                 %td
                   -# removing :::#{@sb[:count]} that was added at the end of report name to make id's unique in the tree
                   -# custom reports will be shown in assigned folders and custom folder both
@@ -58,9 +56,7 @@
                     = _('Name')
               %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('reports_tree','xx-#{nodes[1].to_i}_xx-#{nodes[1].to_i}-#{i}');"}
                 %td.narrow
-                  %ul.icons.list-unstyled
-                    %li
-                      %span.pficon{:class => "pficon-folder-close#{@sb[:rpt_menu][nodes[1].to_i][0] == @sb[:grp_title] ? '-blue' : ''}"}
+                  %i.pficon{:class => "pficon-folder-close#{@sb[:rpt_menu][nodes[1].to_i][0] == @sb[:grp_title] ? '-blue' : ''}"}
                 %td
                   -# removing :::#{@sb[:count]} that was added at the end of report name to make id's unique in the tree
                   -# custom reports will be shown in assigned folders and custom folder both
@@ -89,9 +85,7 @@
               - if @sb[:rep_details][rep]
                 %tr{:title => _('Click to view details'), :onclick => "miqTreeActivateNode('reports_tree','xx-#{nodes[1].to_i}_xx-#{nodes[2].to_i}-#{nodes[3].to_i}_rep-#{to_cid(@sb[:rep_details][rep]["id"])}');"}
                   %td.narrow
-                    %ul.icons.list-unstyled
-                      %li
-                        %span.product.product-report
+                    %i.product.product-report
                   %td
                     -# removing :::#{@sb[:count]} that was added at the end of report name to make id's unique in the tree
                     -# custom reports will be shown in assigned folders and custom folder both

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -27,9 +27,7 @@
             - @sb[:menu].invert.each do |pp|
               %tr{:title => _("View this Profile"), :onclick => "miqTreeActivateNode('#{@sb[:active_tree]}', 'g-#{to_cid(pp[1])}');"}
                 %td.narrow
-                  %ul.icons.list-unstyled
-                    %li
-                      %span.product.product-group
+                  %i.product.product-group
                 %td
                   = pp[0]
     - else

--- a/app/views/shared/buttons/_ab_list.html.haml
+++ b/app/views/shared/buttons/_ab_list.html.haml
@@ -33,9 +33,7 @@
           - if obj.kind_of?(String)
             %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('ab_tree', '-ub-#{@nodetype[1]}')"}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span{:class => "pficon pficon-folder-close"}
+                %i{:class => "pficon pficon-folder-close"}
               %td
                 = obj
               %td
@@ -53,9 +51,7 @@
               - rec_type = "Group"
             %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('#{tree_box}', '#{tree_id}_#{typ}-#{to_cid(obj[:id])}')"}
               %td.narrow
-                %ul.icons.list-unstyled
-                  %li
-                    %span{:class => "product product-custom-#{img}"}
+                %i{:class => "product product-custom-#{img}"}
               %td
                 = obj[:name].split("|").first
               - if x_active_tree == :sandt_tree
@@ -108,9 +104,7 @@
           - id = @nodetype[0].split('-')[1] == "ub" ? "#{@nodetype[0]}_cb-#{to_cid(obj[:id])}" : "#{x_node}_cb-#{to_cid(obj[:id])}"
           %tr{:title => _("Click to view details"), :onclick => "miqTreeActivateNode('#{tree_box}', '#{id}')"}
             %td.narrow
-              %ul.icons.list-unstyled
-                %li
-                  %span{:class => "product product-custom-#{obj[:button_image]}"}
+              %i{:class => "product product-custom-#{obj[:button_image]}"}
             %td
               = obj[:name]
             %td


### PR DESCRIPTION
This PR standardizes the rendering of font icons using the "i" tag. It also moves sizing of icons used in Table View (td.narrow) into the stylesheet.

https://www.pivotaltracker.com/n/projects/1613907/stories/129081417