### PR TITLE
enable image snapshot UI for OpenStack VMs

### DIFF
--- a/app/helpers/application_helper/button/vm_snapshot_revert.rb
+++ b/app/helpers/application_helper/button/vm_snapshot_revert.rb
@@ -1,0 +1,8 @@
+class ApplicationHelper::Button::VmSnapshotRevert < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def visible?
+    return false if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
+    super
+  end
+end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -292,7 +292,8 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
       N_('Revert to selected snapshot'),
       nil,
       :confirm => N_("This VM will revert to selected snapshot. Are you sure you want to revert to the selected snapshot?"),
-      :onwhen  => "1"),
+      :onwhen  => "1",
+      :klass   => ApplicationHelper::Button::VmSnapshotRevert),
   ])
   button_group('vmtree_tasks', [
     button(

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -72,14 +72,14 @@ class ApplicationHelper::ToolbarChooser
   def center_toolbar_filename_explorer
     if @record && @button_group &&
        !["catalogs", "chargeback", "miq_capacity_utilization", "miq_capacity_planning", "services"].include?(@layout)
-      if @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
+      if @button_group.eql? "snapshot"
+        return "x_vm_center_tb"
+      elsif @record.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
         return "openstack_vm_cloud_center_tb"
       elsif @record.kind_of?(ManageIQ::Providers::CloudManager::Vm)
         return "x_vm_cloud_center_tb"
       elsif @record.kind_of?(ManageIQ::Providers::CloudManager::Template)
         return "x_template_cloud_center_tb"
-      elsif @button_group.eql? "snapshot"
-        return "x_vm_center_tb"
       else
         return "x_#{@button_group}_center_tb"
       end

--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -18,7 +18,9 @@ module VmCloudHelper::TextualSummary
   #
 
   def textual_group_properties
-    %i(name region server description ipaddress mac_address custom_1 container preemptible tools_status load_balancer_health_check_state osinfo architecture advanced_settings resources guid virtualization_type root_device_type ems_ref)
+    %i(name region server description ipaddress mac_address custom_1 container preemptible tools_status
+       load_balancer_health_check_state osinfo architecture snapshots advanced_settings resources guid
+       virtualization_type root_device_type ems_ref)
   end
 
   def textual_group_security
@@ -91,6 +93,17 @@ module VmCloudHelper::TextualSummary
     bitness = @record.hardware.try!(:bitness)
     return nil if bitness.blank?
     {:label => _("Architecture"), :value => "#{bitness} bit"}
+  end
+
+  def textual_snapshots
+    num = @record.number_of(:snapshots)
+    h = {:label => _("Snapshots"), :image => "snapshot", :value => (num == 0 ? _("None") : num)}
+    if role_allows?(:feature => "vm_snapshot_show_list") && @record.supports_snapshots?
+      h[:title] = _("Show the snapshot info for this VM")
+      h[:explorer] = true
+      h[:link] = url_for(:action => 'show', :id => @record, :display => 'snapshot_info')
+    end
+    h
   end
 
   def textual_resources

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -201,6 +201,57 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
+  def vm_create_snapshot(vm, options = {})
+    log_prefix = "vm=[#{vm.name}]"
+
+    miq_openstack_instance = MiqOpenStackInstance.new(vm.ems_ref, openstack_handle)
+    snapshot = miq_openstack_instance.create_snapshot(options)
+    snapshot_id = snapshot["id"]
+
+    # Add new snapshot to the snapshots table.
+    vm.snapshots.create!(
+      :name        => options[:name],
+      :description => options[:desc],
+      :uid         => snapshot_id,
+      :uid_ems     => snapshot_id,
+      :ems_ref     => snapshot_id,
+      :create_time => snapshot["created"]
+    )
+
+    return snapshot_id
+  rescue => err
+    _log.error "#{log_prefix}, error: #{err}"
+    _log.debug { err.backtrace.join("\n") }
+    raise
+  end
+
+  def vm_remove_snapshot(vm, options = {})
+    snapshot_uid = options[:snMor]
+
+    log_prefix = "snapshot=[#{snapshot_uid}]"
+
+    miq_openstack_instance = MiqOpenStackInstance.new(vm.ems_ref, openstack_handle)
+    miq_openstack_instance.delete_evm_snapshot(snapshot_uid)
+
+    # Remove from the snapshots table.
+    ar_snapshot = vm.snapshots.find_by(:ems_ref  => snapshot_uid)
+    _log.debug "#{log_prefix}: ar_snapshot = #{ar_snapshot.class.name}"
+    ar_snapshot.destroy if ar_snapshot
+
+    # Remove from the vms table.
+    ar_template = miq_templates.find_by(:ems_ref  => snapshot_uid)
+    _log.debug "#{log_prefix}: ar_template = #{ar_template.class.name}"
+    ar_template.destroy if ar_template
+  rescue => err
+    _log.error "#{log_prefix}, error: #{err}"
+    _log.debug { err.backtrace.join("\n") }
+    raise
+  end
+
+  def vm_remove_all_snapshots(vm, options = {})
+    vm.snapshots.each { |snapshot| vm_remove_snapshot(vm, :snMor => snapshot.uid) }
+  end
+
   # TODO: Should this be in a VM-specific subclass or mixin?
   #       This is a general EMS question.
   def vm_create_evm_snapshot(vm, options = {})

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -100,4 +100,8 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
   def memory_mb_available?
     true
   end
+
+  def supports_snapshots?
+    true
+  end
 end

--- a/app/presenters/tree_builder_snapshots.rb
+++ b/app/presenters/tree_builder_snapshots.rb
@@ -25,7 +25,7 @@ class TreeBuilderSnapshots < TreeBuilder
   end
 
   def x_get_tree_roots(count_only = false, _options = {})
-    root_kid = @record.snapshots.present? ? [@record.snapshots.find { |x| x.parent_id.nil? }] : []
+    root_kid = @record.snapshots.present? ? @record.snapshots.find_all { |x| x.parent_id.nil? } : []
     open_node("sn-#{to_cid(root_kid.first.id)}") if root_kid.present?
     count_only_or_objects(count_only, root_kid)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2753,6 +2753,7 @@ Vmdb::Application.routes.draw do
                exp_post +
                policy_post +
                pre_prov_post +
+               snap_post +
                x_post
     },
 

--- a/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -46,6 +46,27 @@ class MiqOpenStackInstance
     @temp_image_file.unlink
   end
 
+  def create_snapshot(options = {})
+    log_prefix = "MIQ(#{self.class.name}##{__method__}) instance_id=[#{@instance_id}]"
+
+    $log.debug "#{log_prefix}: Snapshotting instance: #{instance.name}..."
+
+    snapshot = compute_service.create_image(instance.id, options[:name], :description => options[:desc])
+
+    $log.debug "#{log_prefix}: #{snapshot.status}"
+    $log.debug "#{log_prefix}: snapshot creation complete"
+
+    return snapshot.body["image"]
+  rescue => err
+    $log.error "#{log_prefix}, error: #{err}"
+    $log.debug err.backtrace.join("\n") if $log.debug?
+    raise
+  end
+
+  def delete_snapshot(image_id)
+    delete_evm_snapshot(image_id)
+  end
+
   def create_evm_snapshot(options = {})
     log_prefix = "MIQ(#{self.class.name}##{__method__}) instance_id=[#{@instance_id}]"
 


### PR DESCRIPTION
This PR enables the existing snapshot UI used for VMWare for OpenStack instances.  Test controller coverage already exists.