### PR TITLE
Add more file types to skip in code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,14 @@
 ---
 exclude_paths:
 - ".git/"
-- "**.yml"
+- "**.gif"
+- "**.html"
+- "**.json"
+- "**.png"
 - "**.svg"
+- "**.xml"
+- "**.yaml"
+- "**.yml"
 - "app/assets/javascripts/dhtmlx*/"
 - "config/dictionary_strings.rb"
 - "config/model_attributes.rb"


### PR DESCRIPTION
Even if they're not analyzed by the different engines, they should not even show up in codeclimate.

![image](https://cloud.githubusercontent.com/assets/19339/19356748/d86fa6ba-913c-11e6-88b6-8a6164cf63c7.png)


![image](https://cloud.githubusercontent.com/assets/19339/19356788/f7677412-913c-11e6-9c26-c8fe6b498904.png)
