### PR TITLE
[WIP] Enable markdown and csslint in codeclimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -32,7 +32,7 @@ engines:
     # requires Gemfile.lock
     enabled: false
   csslint:
-    enabled: false
+    enabled: true
   duplication:
     enabled: true
     config:
@@ -47,8 +47,7 @@ engines:
     # let's enable later
     enabled: false
   markdownlint:
-    # let's enable later
-    enabled: false
+    enabled: true
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'


### PR DESCRIPTION
I'm adding the markdown and csslint engines:
- to see if our results are legit problems or if configuration is needed
- to see how long the code climate build take with them

Results found here (note, I had some local gitignored files in the coverage directory that were analyzed when I ran it locally):
https://gist.github.com/jrafanie/a59b887a8179bfe535905d3ca0979bec

[skip ci]
