### PR TITLE
Don't pointlessly install PhantomJS on Travis

### DIFF
--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -2,13 +2,14 @@
 # You can remove it if you don't need it.
 # This file is loaded *after* jasmine.yml is interpreted.
 #
-# Example: using a different boot file.
-# Jasmine.configure do |config|
-#    config.boot_dir = '/absolute/path/to/boot_dir'
-#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
-# end
-#
-# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
-# Jasmine.configure do |config|
-#    config.prevent_phantom_js_auto_install = true
-# end
+Jasmine.configure do |config|
+  # The gemified version of Jasmine uses the gemified version of PhantomJS
+  # which auto-installs it if it can't find your installation in ~/.phantomjs
+  # Travis already has a version of PhantomJS installed in a different
+  # location, so the gem will auto-install even if it's pointless.  Also,
+  # gemified PhantomJS hardcodes install URLs from BitBucket which times out
+  # and causes failed builds.
+  #
+  # TLDR: Don't install auto-install PhantomJS on CI. In Travis we trust.
+  config.prevent_phantom_js_auto_install = true if ENV['CI']
+end


### PR DESCRIPTION
* The gemified version of Jasmine uses the gemified version of PhantomJS which auto-installs it if it can't find your installation in `~/.phantomjs`. Travis already has a version of PhantomJS installed in a different location, so the gem will auto-install even if it's pointless.  
* Also, the gemified PhantomJS hardcodes install URLs from BitBucket which times out
and causes failed builds:

```
Phantomjs does not appear to be installed in
/home/travis/.phantomjs/2.1.1/x86_64-linux/bin/phantomjs, installing!
% Total    % Received % Xferd  Average Speed   Time    Time     Time
Current
Dload  Upload   Total   Spent    Left
Speed
0     0    0     0    0     0
0      0 --:--:-- --:--:-- --:--:--
0
0     0    0   333    0     0
2955      0 --:--:-- --:--:--
--:--:--  2955
bunzip2: phantomjs-2.1.1-linux-x86_64.tar.bz2 is not a bzip2 file.
tar: phantomjs-2.1.1-linux-x86_64.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now rake aborted!
TypeError: no implicit conversion of nil into String
/home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:72:in 'block in install!'
```

TLDR: Don't install auto-install PhantomJS on CI. In Travis we trust.

### Links

* https://github.com/travis-ci/travis-ci/issues/3225
* https://github.com/ariya/phantomjs/issues/13953