### PR TITLE
Convert libs from VMDB::Config over to using Settings

### DIFF
--- a/lib/memcache_helper.rb
+++ b/lib/memcache_helper.rb
@@ -14,7 +14,7 @@ module MemcacheHelper
         :urlencode => false,
       }
 
-      memcache_server = VMDB::Config.new("vmdb").config[:session][:memcache_server]
+      memcache_server = ::Settings.session.memcache_server
       memcache_server ||= "127.0.0.1:11211"
       CACHE = MemCache.new(memcache_server, memcache_options)
     EOL

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -358,7 +358,7 @@ class MiqExpression
 
   def self.proto?
     return @proto if defined?(@proto)
-    @proto = VMDB::Config.new("vmdb").config.fetch_path(:product, :proto)
+    @proto = ::Settings.product.proto
   end
 
   def self.to_human(exp)

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -435,24 +435,24 @@ class MiqLdap
   end
 
   def self.default_bind_timeout
-    value = VMDB::Config.new("vmdb").config[:authentication][:bind_timeout] || DEFAULT_BIND_TIMEOUT
+    value = ::Settings.authentication.bind_timeout || DEFAULT_BIND_TIMEOUT
     value = value.to_i_with_method if value.respond_to?(:to_i_with_method)
     value
   end
 
   def self.default_search_timeout
-    value = VMDB::Config.new("vmdb").config[:authentication][:search_timeout] || DEFAULT_SEARCH_TIMEOUT
+    value = ::Settings.authentication.search_timeout || DEFAULT_SEARCH_TIMEOUT
     value = value.to_i_with_method if value.respond_to?(:to_i_with_method)
     value
   end
 
   def self.using_ldap?
-    VMDB::Config.new("vmdb").config[:authentication][:mode].include?('ldap')
+    ::Settings.authentication.mode.include?('ldap')
   end
 
   def self.resolve_ldap_host?
     if @resolve_ldap_host.nil?
-      @resolve_ldap_host = VMDB::Config.new("vmdb").config[:authentication][:resolve_ldap_host]
+      @resolve_ldap_host = ::Settings.authentication.resolve_ldap_host
       @resolve_ldap_host = false if @resolve_ldap_host.nil?
     end
 

--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -96,11 +96,6 @@ module ReportFormatter
       save_val = nil
       counter = 0
 
-      cfg = VMDB::Config.new("vmdb").config[:reporting]       # Read in the reporting column precisions
-      default_precision = cfg[:precision][:default]           # Set the default
-      precision_by_column = cfg[:precision_by_column]         # get the column overrides
-      precisions = {}                                         # Hash to store columns we hit
-
       row_limit = mri.rpt_options && mri.rpt_options[:row_limit] ? mri.rpt_options[:row_limit] : 0
       use_table = mri.sub_table ? mri.sub_table : mri.table
       use_table.data.each_with_index do |r, d_idx|

--- a/lib/token_store.rb
+++ b/lib/token_store.rb
@@ -8,7 +8,7 @@ class TokenStore
         ActiveSupport::Cache::MemoryStore.new(cache_store_options(namespace, token_ttl))
       else
         require 'active_support/cache/dalli_store'
-        memcache_server = VMDB::Config.new("vmdb").config[:session][:memcache_server] || "127.0.0.1:11221"
+        memcache_server = ::Settings.session.memcache_server || "127.0.0.1:11221"
         ActiveSupport::Cache::DalliStore.new(memcache_server, cache_store_options(namespace, token_ttl))
       end
     end


### PR DESCRIPTION
Just some low hanging fruit in the lib directory

Trying to keep these small, but cookie cutter

- converted `[]` to `.` (let me know if they are not the same thing - e.g.: when a value is missing)
- Left `fetch_path` since that handles missing keys gracefully
- Used `::Settings` since `Settings` is potentially defined in a few places.
- `lib/report_formatter/text.rb` did not (ever) use the settings.