### PR TITLE
Disable tenant edit from cloud tenant mapping

### DIFF
--- a/app/helpers/application_helper/button/tenant_edit.rb
+++ b/app/helpers/application_helper/button/tenant_edit.rb
@@ -1,0 +1,7 @@
+class ApplicationHelper::Button::TenantEdit < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    @record.source
+  end
+end

--- a/app/helpers/application_helper/toolbar/tenant_center.rb
+++ b/app/helpers/application_helper/toolbar/tenant_center.rb
@@ -22,7 +22,8 @@ class ApplicationHelper::Toolbar::TenantCenter < ApplicationHelper::Toolbar::Bas
           :rbac_tenant_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this item'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::TenantEdit),
         button(
           :rbac_tenant_manage_quotas,
           'pficon pficon-edit fa-lg',

--- a/spec/factories/tenant.rb
+++ b/spec/factories/tenant.rb
@@ -4,4 +4,8 @@ FactoryGirl.define do
     sequence(:subdomain) { |n| "tenant#{n}" }
     parent { Tenant.seed }
   end
+
+  factory :tenant_with_cloud_tenant, :parent => :tenant do
+    source { FactoryGirl.create(:cloud_tenant) }
+  end
 end

--- a/spec/helpers/application_helper/buttons/tenant_edit_spec.rb
+++ b/spec/helpers/application_helper/buttons/tenant_edit_spec.rb
@@ -1,0 +1,22 @@
+describe ApplicationHelper::Button::TenantEdit do
+  describe '#disabled?' do
+    let(:tenant_with_cloud_tenant)    { FactoryGirl.create(:tenant_with_cloud_tenant) }
+    let(:tenant_without_cloud_tenant) { FactoryGirl.create(:tenant) }
+
+    before do
+      @view_context = setup_view_context_with_sandbox({})
+    end
+
+    def tenant_edit_button(tenant)
+      described_class.new(@view_context, {}, {'record' => tenant}, {})
+    end
+
+    it "disables the button when tenant is created by cloud tenant mapping" do
+      expect(tenant_edit_button(tenant_with_cloud_tenant).disabled?).to be_truthy
+    end
+
+    it "does not disable the button when tenant is created by cloud tenant mapping" do
+      expect(tenant_edit_button(tenant_without_cloud_tenant).disabled?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1382687

Add class for TenantEdit button and disable when Tenant#source exist

when Tenant#source exist it means that tenant has been created
be cloud  tenant mapping process

@miq-bot add_label ui
@miq-bot assign @martinpovolny 
thanks @isimluk 

![screen shot 2016-10-14 at 10 15 17](https://cloud.githubusercontent.com/assets/14937244/19380349/335ee5b2-91f7-11e6-8571-f90c5f8b314a.png)

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1382687

