### PR TITLE
Making tables in action edit screen nicer

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -201,6 +201,10 @@ table.table tbody td img {
   vertical-align: top;
 }
 
+.table-borderless tbody tr td, .table-borderless tbody tr th, .table-borderless thead tr th {
+  border: none;
+}
+
 /* Report widget table customizations */
 
 .panel-body {

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -303,7 +303,7 @@
         %label.control-label.col-md-2
           = _("Categories")
         .col-md-8
-          %table
+          %table.table.table-borderless
             - @edit[:cats].each_slice(3) do |cats|
               %tr
                 - cats.each do |cat|
@@ -319,7 +319,7 @@
         %label.control-label.col-md-2
           = _("Categories")
         .col-md-8
-          %table
+          %table.table.table-borderless
             - @edit[:cats].each_slice(3) do |cats|
               %tr
                 - cats.each do |cat|


### PR DESCRIPTION
Firefox before:
![ff_before](https://cloud.githubusercontent.com/assets/1011257/19381200/dba12b42-91fa-11e6-81d3-28351e56c6e0.png)
Firefox after:
![ff_after](https://cloud.githubusercontent.com/assets/1011257/19381203/e1bc4f7a-91fa-11e6-84af-8ceb0ef3ed35.png)
Chrome before:
![chrome_before](https://cloud.githubusercontent.com/assets/1011257/19381213/e8df0d88-91fa-11e6-900a-963c92334157.png)
Chrome after:
![chrome_after](https://cloud.githubusercontent.com/assets/1011257/19381220/ee497b46-91fa-11e6-9634-72a4b1a9550b.png)



