### PR TITLE
[WIP] [DEPENDS ON 11369] [EUWE] Remove old methods for loading virtual columns

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -200,7 +200,7 @@ class MiqReport < ApplicationRecord
   def load_custom_attributes
     klass = db.safe_constantize
     return unless klass < CustomAttributeMixin
-    cols.concat(conditions.custom_attribute_columns) if conditions.present?
+
     klass.load_custom_attributes_for(cols.uniq)
   end
 

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -171,8 +171,7 @@ describe MiqReport do
         x.data
       end
 
-      expected_results = ["name" => vm_2.name, virtual_column_key_1 => nil, virtual_column_key_2 => custom_column_value,
-                          virtual_column_key_3 => custom_column_value]
+      expected_results = ["name" => vm_2.name, virtual_column_key_1 => nil, virtual_column_key_2 => custom_column_value]
 
       expect(report_result).to match_array(expected_results)
     end


### PR DESCRIPTION
- this https://github.com/ManageIQ/manageiq/pull/11369 need to be backported to euwe  first


we are loading virtual custom columns from MiqExpression
when MiqExpression object is created #11369

so don't need to load it in when report is generated.

@miq-bot add_label reporting, technical-debt

@miq-bot add_label euwe/yes

@miq-bot assign @chessbyte 