### PR TITLE
[WIP] correct check for feature :terminate on vm_or_template

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -77,12 +77,6 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_destroy(vm, _options = {})
-    vm.vm_destroy
-  rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
-  end
-
   def vm_reboot_guest(vm, _options = {})
     vm.reboot_guest
   rescue => err

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -185,12 +185,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
-  def vm_destroy(vm, _options = {})
-    vm.vm_destroy
-  rescue => err
-    _log.error "vm=[#{vm.name}], error: #{err}"
-  end
-
   def vm_reboot_guest(vm, _options = {})
     vm.reboot_guest
   rescue => err

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -105,9 +105,14 @@ module VmOrTemplate::Operations
     end
 
     supports :terminate do
-      msg = unsupported_reason(:control) unless supports_control?
-      msg ||= _("Provider doesn't support vm_destroy") unless ext_management_system.respond_to?(:vm_destroy)
-      unsupported_reason_add(:terminate, msg) if msg
+      unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
+      if method(:raw_destroy).owner == VmOrTemplate::Operations
+        # the method in the base class forwards the operation to the manager
+        # hence we check if the operation is available on the manager
+        if ext_management_system && !ext_management_system.respond_to?(:vm_destroy)
+          unsupported_reason_add(:terminate, _("Provider doesn't support vm_destroy"))
+        end
+      end
     end
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -21,6 +21,12 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       include_examples "Vm operation is available when powered on"
     end
 
+    context("with :terminate") do
+      it "is supported" do
+        expect(vm.supports_terminate?).to be true
+      end
+    end
+
     context("with :pause") do
       let(:state) { :pause }
       include_examples "Vm operation is not available"

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -21,6 +21,12 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
       include_examples "Vm operation is available when powered on"
     end
 
+    context("with :terminate") do
+      it "is supported" do
+        expect(vm.supports_terminate?).to be true
+      end
+    end
+
     context("with :shutdown_guest") do
       let(:state) { :shutdown_guest }
       include_examples "Vm operation is available when powered on"


### PR DESCRIPTION
the operation flow of the :terminate operation is to call :vm_destroy on the instance. This method is guarded by automate policy and by default calls :raw_destroy on the instance, which forwards the operation to the manager via Manager#vm_destroy

if the vm subclass chooses to override :raw_destroy, the manager is no longer involved and hence we dont need to check for the existance of such a method

this wrong checking only lead to one false result in the ovirt provider
@oourfali can you please check if destroying a vm is currently missing from the ovirt ui?

for the other providers it was checking correctly, but only because a unused Manager#vm_destroy method got copied over.
@Ladas @agrare @djberg96 could you please ACK the removal of `Manager#vm_destroy` in your respective CloudManager?

cc @jameswnl 
original PR https://github.com/ManageIQ/manageiq/pull/11018

@miq-bot add_labels pluggable providers, providers/rhevm,  providers/openstack/cloud, providers/google, providers/microsoft/cloud, bug
