### PR TITLE
Drop currency attribute from show_rates

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -124,7 +124,7 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   # New method created in order to show the rates in a easier to understand way
-  def show_rates(code_currency)
+  def show_rates
     hr = ChargebackRateDetail::PER_TIME_MAP[per_time.to_sym]
     rate_display = "#{detail_currency.code} / #{hr}"
     rate_display_unit = "#{rate_display} / #{per_unit_display}"

--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -27,7 +27,6 @@
         %th= _("Variable")
     %tbody
       /Currency code is the same for all the chargeback_rate_details
-      - code_currency = @record.chargeback_rate_details.first.detail_currency.code
       - @record.chargeback_rate_details.to_a.sort_by { |rd| [rd[:group].downcase, rd[:description].downcase] }.each_with_index do |detail, detail_index|
       - tiers = detail.chargeback_tiers.order(:start)
         - @cur_group = detail[:group] if @cur_group.nil?
@@ -51,7 +50,7 @@
           %td{:align => "right"}
             = tier.variable_rate ? tier.variable_rate : 0.0
           %td{:align => "right", :rowspan => num_tiers}
-            = detail.show_rates(code_currency)
+            = detail.show_rates
         - (1..num_tiers.to_i - 1).each do |tier_index|
           - tier = tiers.to_a[tier_index]
           %tr.rdetail{:id => "rate_detail_row_#{detail_index}"}

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -199,13 +199,13 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
                             :chargeback_rate_detail_measure_id  => cbm.id,
                             :chargeback_rate_detail_currency_id => cbc.id
                            )
-    expect(cbd.show_rates(cbc.code)).to eq("EUR / Day")
+    expect(cbd.show_rates).to eq("EUR / Day")
 
     cbd = FactoryGirl.build(:chargeback_rate_detail_memory_allocated,
                             :chargeback_rate_detail_measure_id  => cbm.id,
                             :chargeback_rate_detail_currency_id => cbc.id
                            )
-    expect(cbd.show_rates(cbc.code)).to eq("EUR / Day / MB")
+    expect(cbd.show_rates).to eq("EUR / Day / MB")
   end
 
   context "tier set correctness" do


### PR DESCRIPTION
It is no longer used.

@miq-bot add_label refactoring, chargeback
@miq-bot assign @gtanzillo 