### PR TITLE
Openshift & Kubernetes vendor icon fix

### DIFF
--- a/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/kubernetes/container_manager_decorator.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Kubernetes::ContainerManagerDecorator < Draper::Decorator
   delegate_all
 
-  def fonticon
-    "pficon-kubernetes".freeze
+  def listicon_image
+    "svg/vendor-kubernetes.svg"
   end
 end

--- a/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift/container_manager_decorator.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Openshift::ContainerManagerDecorator < Draper::Decorator
   delegate_all
 
-  def fonticon
-    "pficon pficon-openshift fa-lg".freeze
+  def listicon_image
+    "svg/vendor-openshift.svg"
   end
 end

--- a/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
+++ b/app/decorators/manageiq/providers/openshift_enterprise/container_manager_decorator.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::OpenshiftEnterprise::ContainerManagerDecorator < Draper::Decorator
   delegate_all
 
-  def fonticon
-    "pficon pficon-openshift fa-lg".freeze
+  def listicon_image
+    "svg/vendor-openshift_enterprise.svg"
   end
 end


### PR DESCRIPTION
Openshift & Kubernetes PF fonticons were replaced with SVGs. This PR updates the relevant decorators.

Issue: #11935