### PR TITLE
Ensure there are scheduled jobs in scheduler specs

### DIFF
--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -270,20 +270,16 @@ describe MiqScheduleWorker::Runner do
                 when %w(ldap_synchronization ldap_synchronization_schedule)
                   expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@ldap_synchronization_collection[:ldap_synchronization_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(1)
-                  message = MiqQueue.where(:class_name => "LdapServer", :method_name => "sync_data_from_timer").first
-                  expect(message).not_to be_nil
-
-                  MiqQueue.delete_all
+                  while_calling_job(job) do
+                    expect(MiqQueue.count).to eq(1)
+                    message = MiqQueue.where(:class_name => "LdapServer", :method_name => "sync_data_from_timer").first
+                    expect(message).not_to be_nil
+                  end
                 else
                   raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
                         "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
                         "handler=#{job.handler.inspect}"
                 end
-
-                job.unschedule
               end
             end
           end
@@ -328,44 +324,31 @@ describe MiqScheduleWorker::Runner do
               scheduled_jobs.each do |job|
                 expect(job).to be_a_kind_of(Rufus::Scheduler::CronJob)
 
-                case job.tags
-                when %w(database_operations database_metrics_collection_schedule)
-                  expect(job.original).to eq(@metrics_collection[:collection_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(1)
-                  message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
-                  expect(message).to have_attributes(:role => "database_owner", :zone => nil)
-
-                  MiqQueue.delete_all
-                when %w(database_operations database_metrics_daily_rollup_schedule)
-                  expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(1)
-                  message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
-                  expect(message).to have_attributes(:role => "database_owner", :zone => nil)
-
-                  MiqQueue.delete_all
-                when %w(database_operations database_metrics_purge_schedule)
-                  expect(job.original).to eq(@metrics_history[:purge_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(2)
-
-                  ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
-                    message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
-                    expect(message).to have_attributes(:role => "database_operations", :zone => nil)
+                while_calling_job(job) do
+                  case job.tags
+                  when %w(database_operations database_metrics_collection_schedule)
+                    expect(job.original).to eq(@metrics_collection[:collection_schedule])
+                    expect(MiqQueue.count).to eq(1)
+                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
+                    expect(message).to have_attributes(:role => "database_owner", :zone => nil)
+                  when %w(database_operations database_metrics_daily_rollup_schedule)
+                    expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
+                    expect(MiqQueue.count).to eq(1)
+                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
+                    expect(message).to have_attributes(:role => "database_owner", :zone => nil)
+                  when %w(database_operations database_metrics_purge_schedule)
+                    expect(job.original).to eq(@metrics_history[:purge_schedule])
+                    expect(MiqQueue.count).to eq(2)
+                    ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
+                      message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
+                      expect(message).to have_attributes(:role => "database_operations", :zone => nil)
+                    end
+                  else
+                    raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
+                          "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
+                          "handler=#{job.handler.inspect}"
                   end
-
-                  MiqQueue.delete_all
-                else
-                  raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                        "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                        "handler=#{job.handler.inspect}"
                 end
-
-                job.unschedule
               end
             end
           end
@@ -381,44 +364,32 @@ describe MiqScheduleWorker::Runner do
               scheduled_jobs.each do |job|
                 expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
 
-                case job.tags
-                when %w(database_operations database_metrics_collection_schedule)
-                  expect(job.original).to eq(@metrics_collection[:collection_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(1)
-                  message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
-                  expect(message).to have_attributes(:role => "database_operations", :zone => nil)
-
-                  MiqQueue.delete_all
-                when %w(database_operations database_metrics_daily_rollup_schedule)
-                  expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(1)
-                  message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
-                  expect(message).to have_attributes(:role => "database_operations", :zone => nil)
-
-                  MiqQueue.delete_all
-                when %w(database_operations database_metrics_purge_schedule)
-                  expect(job.original).to eq(@metrics_history[:purge_schedule])
-                  job.call
-                  @schedule_worker.do_work
-                  expect(MiqQueue.count).to eq(2)
-
-                  ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
-                    message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
+                while_calling_job(job) do
+                  case job.tags
+                  when %w(database_operations database_metrics_collection_schedule)
+                    expect(job.original).to eq(@metrics_collection[:collection_schedule])
+                    expect(MiqQueue.count).to eq(1)
+                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
                     expect(message).to have_attributes(:role => "database_operations", :zone => nil)
+                  when %w(database_operations database_metrics_daily_rollup_schedule)
+                    expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
+                    expect(MiqQueue.count).to eq(1)
+                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
+                    expect(message).to have_attributes(:role => "database_operations", :zone => nil)
+                  when %w(database_operations database_metrics_purge_schedule)
+                    expect(job.original).to eq(@metrics_history[:purge_schedule])
+                    expect(MiqQueue.count).to eq(2)
+
+                    ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
+                      message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
+                      expect(message).to have_attributes(:role => "database_operations", :zone => nil)
+                    end
+                  else
+                    raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
+                          "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
+                          "handler=#{job.handler.inspect}"
                   end
-
-                  MiqQueue.delete_all
-                else
-                  raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                        "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                        "handler=#{job.handler.inspect}"
                 end
-
-                job.unschedule
               end
             end
           end
@@ -502,23 +473,21 @@ describe MiqScheduleWorker::Runner do
             scheduled_jobs.each do |job|
               expect(job).to be_kind_of(Rufus::Scheduler::EveryJob)
               expect(job.original).to eq(1.day)
-              job.call
-              @schedule_worker.do_work
 
-              case job.tags
-              when %w(ems_event purge_schedule)
-                messages = MiqQueue.where(:class_name => "EventStream", :method_name => "purge_timer")
-                expect(messages.count).to eq(1)
-              when %w(policy_event purge_schedule)
-                messages = MiqQueue.where(:class_name => "PolicyEvent", :method_name => "purge_timer")
-                expect(messages.count).to eq(1)
-              else
-                raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                      "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                      "handler=#{job.handler.inspect}"
+              while_calling_job(job) do
+                case job.tags
+                when %w(ems_event purge_schedule)
+                  messages = MiqQueue.where(:class_name => "EventStream", :method_name => "purge_timer")
+                  expect(messages.count).to eq(1)
+                when %w(policy_event purge_schedule)
+                  messages = MiqQueue.where(:class_name => "PolicyEvent", :method_name => "purge_timer")
+                  expect(messages.count).to eq(1)
+                else
+                  raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
+                        "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
+                        "handler=#{job.handler.inspect}"
+                end
               end
-
-              job.unschedule
             end
           end
         end
@@ -596,6 +565,15 @@ describe MiqScheduleWorker::Runner do
 
       expect(settings[ManageIQ::Providers::Vmware::InfraManager]).to    eq(86_400) # Uses default
       expect(settings[ManageIQ::Providers::Microsoft::InfraManager]).to eq(900)    # Uses override
+    end
+
+    def while_calling_job(job)
+      job.call
+      @schedule_worker.do_work
+      yield
+    ensure
+      MiqQueue.delete_all
+      job.unschedule
     end
   end
 end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -264,6 +264,7 @@ describe MiqScheduleWorker::Runner do
 
             it "queues the right items" do
               scheduled_jobs = @schedule_worker.schedules_for_ldap_synchronization_role
+              expect(scheduled_jobs.size).to be(1)
 
               scheduled_jobs.each do |job|
                 case job.tags
@@ -320,6 +321,7 @@ describe MiqScheduleWorker::Runner do
 
             it "queues the right items" do
               scheduled_jobs = @schedule_worker.schedules_for_database_operations_role
+              expect(scheduled_jobs.size).to be(3)
 
               scheduled_jobs.each do |job|
                 expect(job).to be_a_kind_of(Rufus::Scheduler::CronJob)
@@ -360,6 +362,7 @@ describe MiqScheduleWorker::Runner do
 
             it "queues the right items" do
               scheduled_jobs = @schedule_worker.schedules_for_database_operations_role
+              expect(scheduled_jobs.size).to be(3)
 
               scheduled_jobs.each do |job|
                 expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
@@ -469,6 +472,7 @@ describe MiqScheduleWorker::Runner do
 
           it "queues the right items" do
             scheduled_jobs = @schedule_worker.schedules_for_event_role
+            expect(scheduled_jobs.size).to be(2)
 
             scheduled_jobs.each do |job|
               expect(job).to be_kind_of(Rufus::Scheduler::EveryJob)

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -335,9 +335,7 @@ describe MiqScheduleWorker::Runner do
                   @schedule_worker.do_work
                   expect(MiqQueue.count).to eq(1)
                   message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
-                  expect(message).not_to be_nil
-                  expect(message.role).to eq("database_owner")
-                  expect(message.zone).to be_nil
+                  expect(message).to have_attributes(:role => "database_owner", :zone => nil)
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_daily_rollup_schedule)
@@ -346,9 +344,7 @@ describe MiqScheduleWorker::Runner do
                   @schedule_worker.do_work
                   expect(MiqQueue.count).to eq(1)
                   message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
-                  expect(message).not_to be_nil
-                  expect(message.role).to eq("database_owner")
-                  expect(message.zone).to be_nil
+                  expect(message).to have_attributes(:role => "database_owner", :zone => nil)
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_purge_schedule)
@@ -359,9 +355,7 @@ describe MiqScheduleWorker::Runner do
 
                   ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
                     message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
-                    expect(message).not_to be_nil
-                    expect(message.role).to eq("database_operations")
-                    expect(message.zone).to be_nil
+                    expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                   end
 
                   MiqQueue.delete_all
@@ -394,9 +388,7 @@ describe MiqScheduleWorker::Runner do
                   @schedule_worker.do_work
                   expect(MiqQueue.count).to eq(1)
                   message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
-                  expect(message).not_to be_nil
-                  expect(message.role).to eq("database_operations")
-                  expect(message.zone).to be_nil
+                  expect(message).to have_attributes(:role => "database_operations", :zone => nil)
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_daily_rollup_schedule)
@@ -405,9 +397,7 @@ describe MiqScheduleWorker::Runner do
                   @schedule_worker.do_work
                   expect(MiqQueue.count).to eq(1)
                   message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
-                  expect(message).not_to be_nil
-                  expect(message.role).to eq("database_operations")
-                  expect(message.zone).to be_nil
+                  expect(message).to have_attributes(:role => "database_operations", :zone => nil)
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_purge_schedule)
@@ -418,9 +408,7 @@ describe MiqScheduleWorker::Runner do
 
                   ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
                     message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
-                    expect(message).not_to be_nil
-                    expect(message.role).to eq("database_operations")
-                    expect(message.zone).to be_nil
+                    expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                   end
 
                   MiqQueue.delete_all

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -326,9 +326,10 @@ describe MiqScheduleWorker::Runner do
               scheduled_jobs = @schedule_worker.schedules_for_database_operations_role
 
               scheduled_jobs.each do |job|
+                expect(job).to be_a_kind_of(Rufus::Scheduler::CronJob)
+
                 case job.tags
                 when %w(database_operations database_metrics_collection_schedule)
-                  expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@metrics_collection[:collection_schedule])
                   job.call
                   @schedule_worker.do_work
@@ -340,7 +341,6 @@ describe MiqScheduleWorker::Runner do
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_daily_rollup_schedule)
-                  expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
                   job.call
                   @schedule_worker.do_work
@@ -352,7 +352,6 @@ describe MiqScheduleWorker::Runner do
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_purge_schedule)
-                  expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@metrics_history[:purge_schedule])
                   job.call
                   @schedule_worker.do_work
@@ -386,9 +385,10 @@ describe MiqScheduleWorker::Runner do
               scheduled_jobs = @schedule_worker.schedules_for_database_operations_role
 
               scheduled_jobs.each do |job|
+                expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
+
                 case job.tags
                 when %w(database_operations database_metrics_collection_schedule)
-                  expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@metrics_collection[:collection_schedule])
                   job.call
                   @schedule_worker.do_work
@@ -400,7 +400,6 @@ describe MiqScheduleWorker::Runner do
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_daily_rollup_schedule)
-                  expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
                   job.call
                   @schedule_worker.do_work
@@ -412,7 +411,6 @@ describe MiqScheduleWorker::Runner do
 
                   MiqQueue.delete_all
                 when %w(database_operations database_metrics_purge_schedule)
-                  expect(job).to be_kind_of(Rufus::Scheduler::CronJob)
                   expect(job.original).to eq(@metrics_history[:purge_schedule])
                   job.call
                   @schedule_worker.do_work

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -277,9 +277,7 @@ describe MiqScheduleWorker::Runner do
                     expect(message).not_to be_nil
                   end
                 else
-                  raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                        "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                        "handler=#{job.handler.inspect}"
+                  raise_unexpected_job_error(job)
                 end
               end
             end
@@ -346,9 +344,7 @@ describe MiqScheduleWorker::Runner do
                       expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                     end
                   else
-                    raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                          "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                          "handler=#{job.handler.inspect}"
+                    raise_unexpected_job_error(job)
                   end
                 end
               end
@@ -388,9 +384,7 @@ describe MiqScheduleWorker::Runner do
                       expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                     end
                   else
-                    raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                          "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                          "handler=#{job.handler.inspect}"
+                    raise_unexpected_job_error(job)
                   end
                 end
               end
@@ -487,9 +481,7 @@ describe MiqScheduleWorker::Runner do
                   messages = MiqQueue.where(:class_name => "PolicyEvent", :method_name => "purge_timer")
                   expect(messages.count).to eq(1)
                 else
-                  raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
-                        "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
-                        "handler=#{job.handler.inspect}"
+                  raise_unexpected_job_error(job)
                 end
               end
             end
@@ -578,6 +570,12 @@ describe MiqScheduleWorker::Runner do
     ensure
       MiqQueue.delete_all
       job.unschedule
+    end
+
+    def raise_unexpected_job_error(job)
+      raise "Unexpected Job: tags=#{job.tags.inspect}, original=#{job.original.inspect}, "\
+            "last_time=#{job.last_time.inspect}, id=#{job.job_id.inspect}, next=#{job.next_time.inspect}, "\
+            "handler=#{job.handler.inspect}"
     end
   end
 end

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -329,17 +329,19 @@ describe MiqScheduleWorker::Runner do
                   when %w(database_operations database_metrics_collection_schedule)
                     expect(job.original).to eq(@metrics_collection[:collection_schedule])
                     expect(MiqQueue.count).to eq(1)
-                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
+                    message = MiqQueue.where(:class_name  => "VmdbDatabase",
+                                             :method_name => "capture_metrics_timer").first
                     expect(message).to have_attributes(:role => "database_owner", :zone => nil)
                   when %w(database_operations database_metrics_daily_rollup_schedule)
                     expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
                     expect(MiqQueue.count).to eq(1)
-                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
+                    message = MiqQueue.where(:class_name  => "VmdbDatabase",
+                                             :method_name => "rollup_metrics_timer").first
                     expect(message).to have_attributes(:role => "database_owner", :zone => nil)
                   when %w(database_operations database_metrics_purge_schedule)
                     expect(job.original).to eq(@metrics_history[:purge_schedule])
                     expect(MiqQueue.count).to eq(2)
-                    ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
+                    %w(VmdbDatabaseMetric VmdbMetric).each do |class_name|
                       message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
                       expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                     end
@@ -368,18 +370,20 @@ describe MiqScheduleWorker::Runner do
                   when %w(database_operations database_metrics_collection_schedule)
                     expect(job.original).to eq(@metrics_collection[:collection_schedule])
                     expect(MiqQueue.count).to eq(1)
-                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "capture_metrics_timer").first
+                    message = MiqQueue.where(:class_name  => "VmdbDatabase",
+                                             :method_name => "capture_metrics_timer").first
                     expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                   when %w(database_operations database_metrics_daily_rollup_schedule)
                     expect(job.original).to eq(@metrics_collection[:daily_rollup_schedule])
                     expect(MiqQueue.count).to eq(1)
-                    message = MiqQueue.where(:class_name => "VmdbDatabase", :method_name => "rollup_metrics_timer").first
+                    message = MiqQueue.where(:class_name  => "VmdbDatabase",
+                                             :method_name => "rollup_metrics_timer").first
                     expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                   when %w(database_operations database_metrics_purge_schedule)
                     expect(job.original).to eq(@metrics_history[:purge_schedule])
                     expect(MiqQueue.count).to eq(2)
 
-                    ["VmdbDatabaseMetric", "VmdbMetric"].each do |class_name|
+                    %w(VmdbDatabaseMetric VmdbMetric).each do |class_name|
                       message = MiqQueue.where(:class_name => class_name, :method_name => "purge_all_timer").first
                       expect(message).to have_attributes(:role => "database_operations", :zone => nil)
                     end


### PR DESCRIPTION
Mainly just adding some expectations here to ensure that some jobs got scheduled - I've found these specs failing silently because all the expectations happen inside an `each` block.

Couldn't resist also going in and DRYing up a bit. Personally not a fan of overly DRY tests but for me this improved readability in seeing what stayed the same on each iteration and what changed more easily.

@miq-bot add-label test, refactoring
@miq-bot assign @jrafanie 

/cc @kbrock 