### PR TITLE
'Downcase' the Azure flavor name

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -195,7 +195,7 @@ module ManageIQ::Providers
       end
 
       def parse_series(s)
-        name = uid = s.name
+        name = uid = s.name.downcase
         new_result = {
           :type           => "ManageIQ::Providers::Azure::CloudManager::Flavor",
           :ems_ref        => uid,
@@ -225,7 +225,7 @@ module ManageIQ::Providers
                            instance.resource_group.downcase,
                            instance.type.downcase,
                            instance.name)
-        series_name = instance.properties.hardware_profile.vm_size
+        series_name = instance.properties.hardware_profile.vm_size.downcase
         series      = @data_index.fetch_path(:flavors, series_name)
 
         # TODO(lsmola) NetworkManager, storing IP addresses under hardware/network will go away, once all providers are

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -295,9 +295,13 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   end
 
   def assert_specific_flavor
-    @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "Basic_A0").first
+    @flavor_not_found = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "Basic_A0").first
+    expect(@flavor_not_found).to eq(nil)
+
+    @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "basic_a0").first
+
     expect(@flavor).to have_attributes(
-      :name                     => "Basic_A0",
+      :name                     => "basic_a0",
       :description              => nil,
       :enabled                  => true,
       :cpus                     => 1,


### PR DESCRIPTION
When we parse an Azure instance we use the instance size property to look up the associated flavor object, refer to the exact code [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb#L229):

The Azure API can be inconsistent with the case of the VM size name; for example Standard_F4S instead of Standard_F4s.  Given that the flavor lookup is case sensitive, it will fail in this example.
This PR consistently stores and looks up the flavors using a lowercase version of the flavor name.

fixes https://github.com/ManageIQ/manageiq/issues/11828