### PR TITLE
Added JS code back to handle buttons that are not part of toolbars.

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -470,6 +470,14 @@ function miqSetButtons(count, button_div) {
       var button = $(v);
       miqButtonOnWhen(button.parent(), button.data('onwhen'), count);
     });
+  } else if (button_div.match("_buttons$")) { // Handle buttons that are not part of miq toolbars
+    if (count === 0) {
+      $("#" + button_div + " button[id$=on_1]").prop('disabled', true);
+    } else if (count == 1) {
+      $("#" + button_div + " button[id$=on_1]").prop('disabled', false);
+    } else {
+      $("#" + button_div + " button[id$=on_1]").prop('disabled', false);
+    }
   }
 }
 


### PR DESCRIPTION
Buttons on RHN Updates screen are html biuttons that are not part of center toolbars. Added code back to handle enable/disable state of such buttons. This issues was introduced by changes in https://github.com/ManageIQ/manageiq/pull/4853 commit: c731ca576b93f658c9706114b093f92b447dd9af

https://bugzilla.redhat.com/show_bug.cgi?id=1378165

@dclarizio @martinpovolny @skateman please review.

before:
![before1](https://cloud.githubusercontent.com/assets/3450808/19398414/7785c83c-921a-11e6-9a05-4fc662c5b369.png)
![before2](https://cloud.githubusercontent.com/assets/3450808/19398415/795243c0-921a-11e6-9837-b92fd455b23b.png)

after:
![after1](https://cloud.githubusercontent.com/assets/3450808/19398418/7d2d1c22-921a-11e6-9171-4ae6ec302efd.png)

![after2](https://cloud.githubusercontent.com/assets/3450808/19398424/81f6e120-921a-11e6-841a-cca10ca0ca34.png)
