### PR TITLE
Dont commit transactions during specs

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -132,6 +132,7 @@ class MiqRegion < ApplicationRecord
         conditions = sanitize_conditions(region_to_conditions(region, pk))
       else
         id_cols = connection.columns(t).select { |c| c.name.ends_with?("_id") }
+        next if id_cols.empty?
         conditions = id_cols.collect { |c| "(#{sanitize_conditions(region_to_conditions(region, c.name))})" }.join(" OR ")
       end
 

--- a/spec/tools/column_ordering/column_ordering_spec.rb
+++ b/spec/tools/column_ordering/column_ordering_spec.rb
@@ -43,6 +43,8 @@ describe ColumnOrdering do
       allow(co).to receive(:table_dump).and_return(data_file_contents("test.sql"))
       allow(co).to receive(:expected_columns).and_return(%w(id uuid data))
 
+      expect(connection).to receive(:begin_db_transaction)
+      expect(connection).to receive(:commit_db_transaction)
       expect(co.current_columns).to eq(%w(id data uuid))
       expect(co.ordering_okay?).to be false
 
@@ -51,10 +53,6 @@ describe ColumnOrdering do
       expect(co.ordering_okay?).to be true
       data = connection.select_rows("SELECT * FROM test")
       expect(data).to eq([[1, "unique", "stuff"], [2, "unique1", "more stuff"]])
-    end
-
-    after do
-      connection.select_value("DROP TABLE test")
     end
   end
 


### PR DESCRIPTION
The specs for the column ordering tool were accidentally committing the transaction that rspec-rails uses to clean up the database after each spec run.

This was causing us to have to clean up the test table used in that spec manually and also changing the schema search path for all other specs. In certain orderings this would cause a failure with the `MiqRegion.destroy_region` method as it looks at all the tables in our search path for rows to delete.

This failure can be seen here https://travis-ci.org/ManageIQ/manageiq/jobs/167668422#L1144

This failure exposed an issue with that method where it could attempt to execute invalid SQL if a table had neither a primary key or a column matching *_id which it could use to identify the region the row belonged to.

@gtanzillo please review