### PR TITLE
Rbac: Use ordering passed in on the scope

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -206,11 +206,11 @@ module Rbac
 
       # for belongs_to filters, scope_targets uses scope to make queries. want to remove limits for those.
       # if you note, the limits are put back into scope a few lines down from here
-      scope = scope.except(:offset, :limit)
+      scope = scope.except(:offset, :limit, :order)
       scope = scope_targets(klass, scope, user_filters, user, miq_group)
               .where(conditions).where(sub_filter).where(where_clause).where(exp_sql).where(ids_clause)
               .includes(include_for_find).includes(exp_includes)
-              .order(options[:order])
+              .order(order)
 
       scope = include_references(scope, klass, include_for_find, exp_includes)
       scope = scope.limit(limit).offset(offset) if attrs[:apply_limit_in_sql]
@@ -233,7 +233,7 @@ module Rbac
       end
 
       # Preserve sort order of incoming target_ids
-      if !target_ids.nil? && !options[:order]
+      if !target_ids.nil? && !order
         targets = targets.sort_by { |a| target_ids.index(a.id) }
       end
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1085,6 +1085,13 @@ describe Rbac::Filterer do
       result = described_class.filtered(Vm.limit(2).order(:location), :filter => filter)
       expect(result.size).to eq(2)
     end
+
+    it "supports order on scopes" do
+      FactoryGirl.create(:vm_vmware, :location => "a")
+      FactoryGirl.create(:vm_vmware, :location => "b")
+      FactoryGirl.create(:vm_vmware, :location => "a")
+      expect(described_class.filtered(Vm.all.order(:location)).map(&:location)).to eq(%w(a a b))
+    end
   end
 
   describe ".filtered_object" do


### PR DESCRIPTION
fixes #11943

In rbac, `order` is either from the scope or the `options`.
It was being pulled off of the correct spot, but only the options version was applied back.

All in all, Since the `order` was taken from the scope, it was already applied, so applying `order(nil)` did nothing and everything worked just fine. (could not get specs to fail)
But we were taking a hit in the `scope_targets` queries, and it was a little sloppy.

Now we are pulling those values off for `scope_targets` and applying on the final query.

Thanks @jrafanie and rubocop for finding this one.
I'm mixed on euwe - this will not show up as a bug in the appliance, but I'm assuming other issues may arise near that and it may cause code conflicts.