### PR TITLE
Add repmgr tables to replication excludes

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -125,7 +125,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def self.destroy_region(conn, region, tables = nil)
-    tables ||= conn.tables.reject { |t| t =~ /^schema_migrations|^ar_internal_metadata|^repl_/ }.sort
+    tables ||= (conn.tables - MiqPglogical::ALWAYS_EXCLUDED_TABLES).sort
     tables.each do |t|
       pk = conn.primary_key(t)
       if pk

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -125,7 +125,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def self.destroy_region(conn, region, tables = nil)
-    tables ||= conn.tables.reject { |t| t =~ /^schema_migrations|^ar_internal_metadata|^rr/ }.sort
+    tables ||= conn.tables.reject { |t| t =~ /^schema_migrations|^ar_internal_metadata|^repl_/ }.sort
     tables.each do |t|
       pk = conn.primary_key(t)
       if pk

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1067,6 +1067,9 @@
     - notifications
     - notification_recipients
     - notification_types
+    - repl_events
+    - repl_monitor
+    - repl_nodes
     - rss_feeds
     - scan_items
     - schema_migrations

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -68,7 +68,7 @@ class MiqPglogical
   # Lists the tables configured to be excluded in the vmdb configuration
   # @return Array<String> the table list
   def configured_excludes
-    MiqServer.my_server.get_config.config.fetch_path(*SETTINGS_PATH, :exclude_tables) | %w(ar_internal_metadata schema_migrations)
+    MiqServer.my_server.get_config.config.fetch_path(*SETTINGS_PATH, :exclude_tables) | always_excluded_tables
   end
 
   # Creates the 'miq' replication set and refreshes the excluded tables
@@ -134,5 +134,9 @@ class MiqPglogical
   # tables that are currently excluded, but we want them included
   def newly_included_tables
     (@connection.tables - configured_excludes) - included_tables
+  end
+
+  def always_excluded_tables
+    %w(ar_internal_metadata schema_migrations repl_events repl_monitor repl_nodes)
   end
 end

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -6,6 +6,7 @@ class MiqPglogical
   REPLICATION_SET_NAME = 'miq'.freeze
   SETTINGS_PATH = [:replication].freeze
   NODE_PREFIX = "region_".freeze
+  ALWAYS_EXCLUDED_TABLES = %w(ar_internal_metadata schema_migrations repl_events repl_monitor repl_nodes).freeze
 
   def initialize
     @connection = ApplicationRecord.connection
@@ -68,7 +69,7 @@ class MiqPglogical
   # Lists the tables configured to be excluded in the vmdb configuration
   # @return Array<String> the table list
   def configured_excludes
-    MiqServer.my_server.get_config.config.fetch_path(*SETTINGS_PATH, :exclude_tables) | always_excluded_tables
+    MiqServer.my_server.get_config.config.fetch_path(*SETTINGS_PATH, :exclude_tables) | ALWAYS_EXCLUDED_TABLES
   end
 
   # Creates the 'miq' replication set and refreshes the excluded tables
@@ -134,9 +135,5 @@ class MiqPglogical
   # tables that are currently excluded, but we want them included
   def newly_included_tables
     (@connection.tables - configured_excludes) - included_tables
-  end
-
-  def always_excluded_tables
-    %w(ar_internal_metadata schema_migrations repl_events repl_monitor repl_nodes)
   end
 end

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -62,8 +62,9 @@ describe MiqPglogical do
     describe "#create_replication_set" do
       it "creates the correct initial set" do
         expected_excludes = subject.configured_excludes
+        extra_excludes = subject.configured_excludes - connection.tables
         actual_excludes = connection.tables - subject.included_tables
-        expect(actual_excludes).to match_array(expected_excludes)
+        expect(actual_excludes | extra_excludes).to match_array(expected_excludes)
       end
     end
 


### PR DESCRIPTION
We don't control the structure or contents of these tables, so we cannot replicate them.

They are in a different schema, but we need them accessible without being fully qualified because the schema name is dependent on the region

@gtanzillo please review

https://bugzilla.redhat.com/show_bug.cgi?id=1385157