### PR TITLE
We don't build on 32 bit anymore

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -61,10 +61,6 @@ end
 # Linux-only section
 if RbConfig::CONFIG["host_os"].include?("linux")
   gem "linux_block_device", ">=0.1.0", :require => false
-
-  if RbConfig::CONFIG["host_cpu"] == "x86"  # 32 bit Linux.
-    gem "large_file_linux", "~>0.1.0", :require => false
-  end
 end
 
 # Windows only. Do not put in Gemfile.lock on other platforms.

--- a/gems/pending/disk/modules/MiqLargeFile.rb
+++ b/gems/pending/disk/modules/MiqLargeFile.rb
@@ -2,9 +2,7 @@ require 'sys-uname'
 require 'util/miq-system'
 
 if Sys::Platform::IMPL == :linux
-  if MiqSystem.arch == :x86
-    require 'large_file_linux'
-  elsif MiqSystem.arch == :x86_64
+  if MiqSystem.arch == :x86_64
     require 'linux_block_device'
     require 'disk/modules/RawBlockIO'
   end
@@ -19,7 +17,6 @@ module MiqLargeFile
       return(MiqLargeFileWin32.new(file_name, flags))
     when :unix
       if Sys::Platform::IMPL == :linux
-        return(LargeFileLinux.new(file_name, flags)) if MiqSystem.arch == :x86
         return(RawBlockIO.new(file_name, flags)) if MiqLargeFileStat.new(file_name).blockdev?
       end
       return(MiqLargeFileOther.new(file_name, flags))


### PR DESCRIPTION
Preparation for #11882

Removing conditionals from the Gemfile.  Since we don't build for 32 bit anymore, we shouldn't need this.