### PR TITLE
Allow for setting up self signed certificate in Automate Import Screen

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -198,6 +198,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
   def retrieve_git_datastore
     redirect_options = {:action => :review_git_import}
     git_url = params[:git_url]
+    verify_ssl = params[:git_verify_ssl]  == "true" ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE 
 
     if git_url.blank?
       add_flash(_("Please provide a valid git URL"), :error)
@@ -215,7 +216,7 @@ FLASH
         status = :success
       end
 
-      git_repo = GitRepository.create(:url => git_url)
+      git_repo = GitRepository.create(:url => git_url, :verify_ssl => verify_ssl)
       git_repo.update_authentication(:values => {:userid => params[:git_username], :password => params[:git_password]})
       task_options = {
         :action => "Retrieve git repository",

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -198,7 +198,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
   def retrieve_git_datastore
     redirect_options = {:action => :review_git_import}
     git_url = params[:git_url]
-    verify_ssl = params[:git_verify_ssl]  == "true" ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE 
+    verify_ssl = params[:git_verify_ssl] == "true" ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE 
 
     if git_url.blank?
       add_flash(_("Please provide a valid git URL"), :error)

--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -47,6 +47,11 @@
         .col-md-8
           = password_field_tag(:git_password, nil)
       .form-group
+        %label.col-md-2.control-label
+          = _("Verify Peer Certificate")
+        .col-md-8
+          = check_box_tag(:git_verify_ssl, true, true)
+      .form-group
         .col-sm-2
         .col-md-8
           = submit_tag(_("Submit"),

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -259,11 +259,12 @@ Methods updated/added: 10
     include_context "valid session"
 
     let(:params) do
-      {:git_url => git_url, :git_username => nil, :git_password => nil}
+      {:git_url => git_url, :git_username => nil, :git_password => nil, :git_verify_ssl => git_verify_ssl}
     end
 
     context "when the git url is blank" do
       let(:git_url) { "" }
+      let(:git_verify_ssl) { "true" }
 
       it "redirects with a flash error" do
         post :retrieve_git_datastore, :params => params
@@ -279,6 +280,7 @@ Methods updated/added: 10
 
     context "when the git url is not blank" do
       let(:git_url) { "git_url" }
+      let(:git_verify_ssl) { "true" }
       let(:my_region) { double("MiqRegion") }
 
       before do
@@ -302,6 +304,7 @@ Methods updated/added: 10
       end
 
       context "when the MiqRegion has an active git_owner role" do
+        let(:verify_ssl) { OpenSSL::SSL::VERIFY_PEER }
         let(:git_owner_active) { true }
         let(:git_repo) { double("GitRepository", :id => 321) }
         let(:git_branches) { [double("GitBranch", :name => "git_branch1")] }
@@ -318,7 +321,6 @@ Methods updated/added: 10
         end
 
         before do
-          allow(GitRepository).to receive(:create).with(:url => git_url).and_return(git_repo)
           allow(git_repo).to receive(:update_authentication).with(:values => {:userid => "", :password => ""})
           allow(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(1234)
           allow(MiqTask).to receive(:wait_for_taskid).with(1234)
@@ -328,6 +330,7 @@ Methods updated/added: 10
 
         context "when the git repository exists with the given url" do
           before do
+            allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
             allow(GitRepository).to receive(:exists?).with(:url => git_url).and_return(true)
           end
 
@@ -356,8 +359,22 @@ Methods updated/added: 10
           end
         end
 
+        context "when the repository is using self signed certificates" do
+          let (:verify_ssl) { OpenSSL::SSL::VERIFY_NONE }
+          let (:git_verify_ssl) { "false" }
+          before do
+            allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
+            allow(GitRepository).to receive(:exists?).with(:url => git_url).and_return(false)
+          end
+          it "queues the refresh action" do
+            expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+            post :retrieve_git_datastore, :params => params
+          end
+        end
+
         context "when the git repository does not exist with the given url" do
           before do
+            allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
             allow(GitRepository).to receive(:exists?).with(:url => git_url).and_return(false)
           end
 

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -321,6 +321,7 @@ Methods updated/added: 10
         end
 
         before do
+          allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
           allow(git_repo).to receive(:update_authentication).with(:values => {:userid => "", :password => ""})
           allow(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(1234)
           allow(MiqTask).to receive(:wait_for_taskid).with(1234)
@@ -330,7 +331,6 @@ Methods updated/added: 10
 
         context "when the git repository exists with the given url" do
           before do
-            allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
             allow(GitRepository).to receive(:exists?).with(:url => git_url).and_return(true)
           end
 
@@ -362,8 +362,8 @@ Methods updated/added: 10
         context "when the repository is using self signed certificates" do
           let (:verify_ssl) { OpenSSL::SSL::VERIFY_NONE }
           let (:git_verify_ssl) { "false" }
+
           before do
-            allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
             allow(GitRepository).to receive(:exists?).with(:url => git_url).and_return(false)
           end
           it "queues the refresh action" do
@@ -374,7 +374,6 @@ Methods updated/added: 10
 
         context "when the git repository does not exist with the given url" do
           before do
-            allow(GitRepository).to receive(:create).with(:url => git_url, :verify_ssl => verify_ssl).and_return(git_repo)
             allow(GitRepository).to receive(:exists?).with(:url => git_url).and_return(false)
           end
 


### PR DESCRIPTION
When creating a new repository allow for the user
to disable certificate validation. This allows for
supporting git repositories using self signed certificates.
By default we verify the certificates, if the user wants to use self signed certificates they would have to uncheck the box.
Links 
----------------
* https://www.pivotaltracker.com/n/projects/1613499/stories/130780645

<img width="575" alt="screen shot 2016-10-14 at 5 13 41 pm" src="https://cloud.githubusercontent.com/assets/6452699/19402854/9b489f8a-9231-11e6-84fb-6ce82e20c7ba.png">
