### PR TITLE
Authentication check retry

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -34,6 +34,8 @@ class Authentication < ApplicationRecord
     "invalid"     => 3,
   ).freeze
 
+  RETRYABLE_STATUS = %w(error unreachable).freeze
+
   # FIXME: To address problem with url resolution when displayed as a quadicon,
   # but it's not *really* the db_name. Might be more proper to override `to_partial_path`
   def self.db_name
@@ -42,6 +44,10 @@ class Authentication < ApplicationRecord
 
   def status_severity
     STATUS_SEVERITY[status.to_s.downcase]
+  end
+
+  def retryable_status?
+    RETRYABLE_STATUS.include?(status.to_s.downcase)
   end
 
   def authentication_type

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -194,16 +194,16 @@ module AuthenticationMixin
   MAX_ATTEMPTS = 6
   def authentication_check_retry_deliver_on(attempt)
     # Existing callers who pass no attempt will have no delay.
-    attempt ||= MAX_ATTEMPTS
-    return if attempt >= MAX_ATTEMPTS
-
-    Time.now.utc + exponential_delay(attempt).minutes
+    case attempt
+    when nil, 0, ->(a) { a >= MAX_ATTEMPTS }
+      nil
+    else
+      Time.now.utc + exponential_delay(attempt - 1).minutes
+    end
   end
 
   def exponential_delay(attempt)
-    return 0 if attempt <= 0
-
-    2 ** (attempt - 1)
+    2**attempt
   end
 
   def authentication_check_types_queue(*args)

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -257,7 +257,7 @@ module AuthenticationMixin
     # Let the individual classes determine what authentication(s) need to be checked
     types = authentications_to_validate if self.respond_to?(:authentications_to_validate) && types.nil?
     types = [nil] if types.blank?
-    types.to_miq_a.each do |t|
+    Array(types).each do |t|
       success = authentication_check(t, options).first
       retry_scheduled_authentication_check(t, options) unless success
     end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -192,6 +192,11 @@ module AuthenticationMixin
   end
 
   MAX_ATTEMPTS = 6
+  # The default for the schedule is every 1.hour now.
+  #   6 will gives us:
+  #   A failure now and retries in 2, 4, 8, and 16 minutes, for a total of 30 minutes.
+  #   We'll wait another 30 minutes, minus the time it takes to queue and perform the checks
+  #   before the schedule fires again.
   def authentication_check_retry_deliver_on(attempt)
     # Existing callers who pass no attempt will have no delay.
     case attempt

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -266,7 +266,8 @@ module AuthenticationMixin
   def retry_scheduled_authentication_check(auth_type, options)
     return unless options[:attempt]
     auth = authentication_best_fit(auth_type)
-    if auth.retryable_status?
+
+    if auth.try(:retryable_status?)
       options[:attempt] += 1
 
       # Force the authentication message to be queued

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -191,6 +191,15 @@ module AuthenticationMixin
     end
   end
 
+  MAX_ATTEMPTS = 6
+  def authentication_check_retry_deliver_on(attempt)
+    # Existing callers who pass no attempt will have no delay.
+    attempt ||= MAX_ATTEMPTS
+    return if attempt >= MAX_ATTEMPTS
+
+    Time.now.utc + exponential_delay(attempt).minutes
+  end
+
   def exponential_delay(attempt)
     return 0 if attempt <= 0
 

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -191,6 +191,12 @@ module AuthenticationMixin
     end
   end
 
+  def exponential_delay(attempt)
+    return 0 if attempt <= 0
+
+    2 ** (attempt - 1)
+  end
+
   def authentication_check_types_queue(*args)
     options = args.extract_options!
     types = args.first

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -227,12 +227,13 @@ module AuthenticationMixin
     options[:role] = role if role
     options[:zone] = zone if zone
 
-    MiqQueue.put_unless_exists(options) do |msg|
+    MiqQueue.put_unless_exists(options.except(:deliver_on)) do |msg|
       # TODO: Refactor the help in this and the ScheduleWorker#queue_work method into the merge method
       help = "Check for a running server"
       help << " in zone: [#{options[:zone]}]"   if options[:zone]
       help << " with role: [#{options[:role]}]" if options[:role]
       _log.warn("Previous authentication_check_types for [#{name}] [#{id}] with opts: [#{options[:args].inspect}] is still running, skipping...#{help}") unless msg.nil?
+      options
     end
   end
 

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -207,7 +207,8 @@ module AuthenticationMixin
   end
 
   def authentication_check_types_queue(*args)
-    options = args.extract_options!
+    method_options = args.extract_options!
+
     types = args.first
     role = authentication_check_role if self.respond_to?(:authentication_check_role)
     zone = my_zone if self.respond_to?(:my_zone)
@@ -219,7 +220,7 @@ module AuthenticationMixin
       :class_name  => self.class.base_class.name,
       :instance_id => id,
       :method_name => 'authentication_check_types',
-      :args        => [types.to_miq_a, options]
+      :args        => [types.to_miq_a, method_options],
     }
 
     options[:role] = role if role

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1399,7 +1399,7 @@
         :poll_method: :normal
         :queue_timeout: 120.minutes
     :schedule_worker:
-      :authentication_check_interval: 1.day
+      :authentication_check_interval: 1.hour
       :db_diagnostics_interval: 30.minutes
       :ems_events_purge_interval: 1.day
       :evm_snapshot_delete_delay_for_job_not_found: 1.hour

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -30,4 +30,19 @@ describe Authentication do
       expect(auth.reload.password).to eq(pwd_plain)
     end
   end
+
+  context "#retryable_status?" do
+    it "works" do
+      expect(described_class.new(:status => 'valid').retryable_status?).to       be_falsy
+      expect(described_class.new(:status => 'none').retryable_status?).to        be_falsy
+      expect(described_class.new(:status => 'incomplete').retryable_status?).to  be_falsy
+      expect(described_class.new(:status => 'error').retryable_status?).to       be_truthy
+      expect(described_class.new(:status => 'unreachable').retryable_status?).to be_truthy
+      expect(described_class.new(:status => 'invalid').retryable_status?).to     be_falsy
+    end
+
+    it "is case insensitive" do
+      expect(described_class.new(:status => 'Error').retryable_status?).to be_truthy
+    end
+  end
 end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -113,21 +113,22 @@ describe AuthenticationMixin do
   end
 
   it "#exponential_delay" do
-    expect(test_class_instance.exponential_delay(0)).to eq(0)
-    expect(test_class_instance.exponential_delay(1)).to eq(1)
-    expect(test_class_instance.exponential_delay(2)).to eq(2)
-    expect(test_class_instance.exponential_delay(3)).to eq(4)
-    expect(test_class_instance.exponential_delay(4)).to eq(8)
-    expect(test_class_instance.exponential_delay(5)).to eq(16)
+    expect(test_class_instance.exponential_delay(0)).to eq(1)
+    expect(test_class_instance.exponential_delay(1)).to eq(2)
+    expect(test_class_instance.exponential_delay(2)).to eq(4)
+    expect(test_class_instance.exponential_delay(3)).to eq(8)
+    expect(test_class_instance.exponential_delay(4)).to eq(16)
+    expect(test_class_instance.exponential_delay(5)).to eq(32)
   end
 
   it "#authentication_check_retry_deliver_on" do
     Timecop.freeze(Time.new(2015, 1, 2, 0, 0, 0, 0)) do
       expect(test_class_instance.authentication_check_retry_deliver_on(nil)).to be_nil
+      expect(test_class_instance.authentication_check_retry_deliver_on(0)).to   be_nil
       expect(test_class_instance.authentication_check_retry_deliver_on(6)).to   be_nil
 
-      expect(test_class_instance.authentication_check_retry_deliver_on(0)).to eq(Time.now.utc)
-      expect(test_class_instance.authentication_check_retry_deliver_on(1)).to eq(Time.now.utc + 1.minutes)
+      expect(test_class_instance.authentication_check_retry_deliver_on(1)).to eq(Time.now.utc + 1.minute)
+      expect(test_class_instance.authentication_check_retry_deliver_on(5)).to eq(Time.now.utc + 16.minutes)
     end
   end
 

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -112,6 +112,15 @@ describe AuthenticationMixin do
     end
   end
 
+  it "#exponential_delay" do
+    expect(test_class_instance.exponential_delay(0)).to eq(0)
+    expect(test_class_instance.exponential_delay(1)).to eq(1)
+    expect(test_class_instance.exponential_delay(2)).to eq(2)
+    expect(test_class_instance.exponential_delay(3)).to eq(4)
+    expect(test_class_instance.exponential_delay(4)).to eq(8)
+    expect(test_class_instance.exponential_delay(5)).to eq(16)
+  end
+
   context "with server and zone" do
     before(:each) do
       @miq_server = EvmSpecHelper.local_miq_server

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -121,6 +121,16 @@ describe AuthenticationMixin do
     expect(test_class_instance.exponential_delay(5)).to eq(16)
   end
 
+  it "#authentication_check_retry_deliver_on" do
+    Timecop.freeze(Time.new(2015, 1, 2, 0, 0, 0, 0)) do
+      expect(test_class_instance.authentication_check_retry_deliver_on(nil)).to be_nil
+      expect(test_class_instance.authentication_check_retry_deliver_on(6)).to   be_nil
+
+      expect(test_class_instance.authentication_check_retry_deliver_on(0)).to eq(Time.now.utc)
+      expect(test_class_instance.authentication_check_retry_deliver_on(1)).to eq(Time.now.utc + 1.minutes)
+    end
+  end
+
   context "with server and zone" do
     before(:each) do
       @miq_server = EvmSpecHelper.local_miq_server


### PR DESCRIPTION
This pull request:
* changes the default schedule for authentication check from 1.day to 1.hour
* implements retries for Unreachable and generic errors (errors that are not missing/invalid credentials)
  * the first retry occurs in 2 minutes, then 4, then 8, then 16 (last retry is scheduled ~30 minutes after the first failure
  * after the last failure, we'll fall back to the hourly schedule
  * there is some logic to prevent us from queueing up the same authentication check twice, although it's a bit more complicated than I like because the "in-flight" message that fails also tries to queue up a message and SHOULD even though the "in-flight" one is in the queue.