### PR TITLE
For scvmm, set the default security protocol to ssl

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -317,6 +317,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       }
     } else if ($scope.emsCommonModel.emstype === 'scvmm' && $scope.emsCommonModel.default_security_protocol === 'kerberos') {
       $scope.note = $scope.realmNote;
+    } else if ($scope.emsCommonModel.emstype === 'scvmm') {
+      $scope.emsCommonModel.default_security_protocol = 'ssl';
     } else if ($scope.emsCommonModel.emstype === 'rhevm') {
       $scope.emsCommonModel.metrics_api_port = "5432";
       $scope.emsCommonModel.default_api_port = $scope.getDefaultApiPort($scope.emsCommonModel.emstype);


### PR DESCRIPTION
The Validate button for `scvmm` provider goes active even though the `Security Protocol` is not populated.
The changes in this PR ensure that the `Security Protocol` for `scvmm` is prepopulated with `ssl` -- this will ensure that Validation takes into account the security protocol value and does proper validation.

Before : 
Validate button is active even though no `Security Protocol` is selected. 
Also, Flash message appears to be a Rails error more than the actual Validation error


<img width="1269" alt="screen shot 2016-10-14 at 4 54 03 pm" src="https://cloud.githubusercontent.com/assets/1538216/19405654/f2a3bb00-922e-11e6-8465-0951e94042fc.png">

After: 
`Security Protocol` is prepopulated. Flash message shows the actual Validation error

<img width="1271" alt="screen shot 2016-10-14 at 4 53 18 pm" src="https://cloud.githubusercontent.com/assets/1538216/19405687/60cf08e6-922f-11e6-8b0f-41866ee0ad52.png">



https://bugzilla.redhat.com/show_bug.cgi?id=1383222