### PR TITLE
Enable VM reconfigure disks for supported rhevm version

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -3,6 +3,7 @@ module ApplicationController::CiProcessing
 
   included do
     private(:process_elements)
+    helper_method :supports_reconfigure_disks?
   end
 
   def ownership_form_fields
@@ -1711,6 +1712,7 @@ module ApplicationController::CiProcessing
     cores_per_socket = @reconfigureitems.first.cpu_cores_per_socket
     cores_per_socket = '' unless @reconfigureitems.all? { |vm| vm.cpu_cores_per_socket == cores_per_socket }
     memory, memory_type = reconfigure_calculations(memory)
+
     # if only one vm that supports disk reconfiguration is selected, get the disks information
     vmdisks = []
     @reconfigureitems.first.hardware.disks.each do |disk|
@@ -1731,6 +1733,10 @@ module ApplicationController::CiProcessing
      :socket_count           => socket_count.to_s,
      :cores_per_socket_count => cores_per_socket.to_s,
      :disks                  => vmdisks}
+  end
+
+  def supports_reconfigure_disks?
+    @reconfigitems && @reconfigitems.size == 1 && @reconfigitems.first.supports_reconfigure_disks?
   end
 
   def get_reconfig_limits

--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -218,7 +218,12 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     end
 
     def api4_supported_features
-      [:quick_stats, :snapshots, :migrate]
+      [
+        :migrate,
+        :quick_stats,
+        :reconfigure_disks,
+        :snapshots
+      ]
     end
 
     def api_features

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -10,6 +10,16 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
     end
   end
 
+  supports :reconfigure_disks do
+    if storage.blank?
+      unsupported_reason_add(:reconfigure_disks, _('storage is missing'))
+    elsif ext_management_system.blank?
+      unsupported_reason_add(:reconfigure_disks, _('The virtual machine is not associated with a provider'))
+    elsif !ext_management_system.supports_reconfigure_disks?
+      unsupported_reason_add(:reconfigure_disks, _('The provider does not support reconfigure disks'))
+    end
+  end
+
   POWER_STATES = {
     'up'        => 'on',
     'down'      => 'off',

--- a/app/models/manageiq/providers/vmware/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::Vmware::InfraManager::Vm < ManageIQ::Providers::Infra
     unsupported_reason_add(:clone, _('Clone operation is not supported')) if blank? || orphaned? || archived?
   end
 
+  supports :reconfigure_disks
+
   def add_miq_alarm
     raise "VM has no EMS, unable to add alarm" unless ext_management_system
     ext_management_system.vm_add_miq_alarm(self)

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -89,6 +89,7 @@ module SupportsFeatureMixin
     :quick_stats                => 'Quick Stats',
     :reboot_guest               => 'Reboot Guest Operation',
     :reconfigure                => 'Reconfiguration',
+    :reconfigure_disks          => 'Reconfigure Virtual Machines Disks',
     :refresh_network_interfaces => 'Refresh Network Interfaces for a Host',
     :refresh_new_target         => 'Refresh non-existing record',
     :regions                    => 'Regions of a Provider',

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -105,7 +105,7 @@
                                 "auto-focus"     => ""}
             %span{"style" => "color:red", "ng-show" => "angularForm.total_cpus.$invalid"}
               = _(" Total processors value larger than the maximum allowed")
-  - if @reconfigitems.length == 1 && @reconfigitems.first.vendor  && (@reconfigitems.first.vendor == 'vmware' || @reconfigitems.first.vendor == 'redhat')
+  - if supports_reconfigure_disks?
     %hr
     %div
       %h3

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -90,6 +90,38 @@ describe ApplicationController do
     end
   end
 
+  describe "#supports_reconfigure_disks?" do
+    let(:vm) { FactoryGirl.create(:vm_redhat) }
+
+    context "when a single is vm selected" do
+      let(:supports_reconfigure_disks) { true }
+      before(:each) do
+        allow(vm).to receive(:supports_reconfigure_disks?).and_return(supports_reconfigure_disks)
+        controller.instance_variable_set(:@reconfigitems, [vm])
+      end
+
+      context "when vm supports reconfiguring disks" do
+        it "enables reconfigure disks" do
+          expect(controller.send(:supports_reconfigure_disks?)).to be_truthy
+        end
+      end
+      context "when vm does not supports reconfiguring disks" do
+        let(:supports_reconfigure_disks) { false }
+        it "disables reconfigure disks" do
+          expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
+        end
+      end
+    end
+
+    context "when multiple vms selected" do
+      let(:vm1) { FactoryGirl.create(:vm_redhat) }
+      it "disables reconfigure disks" do
+        controller.instance_variable_set(:@reconfigitems, [vm, vm1])
+        expect(controller.send(:supports_reconfigure_disks?)).to be_falsey
+      end
+    end
+  end
+
   context "#discover" do
     it "checks that keys in @to remain set if there is an error after submit is pressed" do
       from_first = "1"


### PR DESCRIPTION
The VM reconfigure disks is supported only by v4 of the API
which was introduced in RHEVM 4.0. The functionality will not
be available for an earlier versions in the 'VM reconfigure' dialog.
Also the feature requires the vm to have a store type associated
with it, so it can be used as a target storage for the new disks.

http://bugzilla.redhat.com/1373916
