### PR TITLE
Method for hiding timeline toolbar buttons moved to separate class

### DIFF
--- a/app/helpers/application_helper/button/timeline_download.rb
+++ b/app/helpers/application_helper/button/timeline_download.rb
@@ -4,6 +4,10 @@ class ApplicationHelper::Button::TimelineDownload < ApplicationHelper::Button::B
     self[:title] = N_("Choose a Timeline from the menus on the left.") if disabled?
   end
 
+  def visible?
+    @report
+  end
+
   def disabled?
     @record.nil?
   end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -731,12 +731,6 @@ class ApplicationHelper::ToolbarBuilder
         return true if ["download_logs", "evm_logs", "audit_logs"].include?(@lastaction)
       when "refresh_logs"
         return true if ["audit_logs", "evm_logs", "workers"].include?(@lastaction)
-      when "timeline_csv"
-        return true unless @report
-      when "timeline_pdf"
-        return true unless @report
-      when "timeline_txt"
-        return true unless @report
       end
     end
     false  # No reason to hide, allow the button to show

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -891,21 +891,6 @@ describe ApplicationHelper do
           end
         end
       end
-
-      ["timeline_csv", "timeline_pdf", "timeline_txt"].each do |id|
-        context "and id = #{id}" do
-          before { @id = id }
-
-          it "and !@report" do
-            expect(subject).to be_truthy
-          end
-
-          it "and @report" do
-            @report = ''
-            expect(subject).to be_falsey
-          end
-        end
-      end
     end
 
     context "NilClass" do


### PR DESCRIPTION
The class for timeline buttons aready exists, but hiding buttons was still done by `build_toolbar_hide_button` method in `toolbar_builder.rb`.

Links
----------------
Parent issue: #6259
Related issue: #6554