### PR TITLE
Toolbar builder refactoring  miq event definition

### DIFF
--- a/app/helpers/application_helper/button/miq_action_modify.rb
+++ b/app/helpers/application_helper/button/miq_action_modify.rb
@@ -16,4 +16,8 @@ class ApplicationHelper::Button::MiqActionModify < ApplicationHelper::Button::Ba
                      end
     end
   end
+
+  def visible?
+    x_active_tree != :event_tree && role_allows?(:feature => 'event_edit')
+  end
 end

--- a/app/helpers/application_helper/button/miq_action_modify.rb
+++ b/app/helpers/application_helper/button/miq_action_modify.rb
@@ -18,6 +18,6 @@ class ApplicationHelper::Button::MiqActionModify < ApplicationHelper::Button::Ba
   end
 
   def visible?
-    x_active_tree != :event_tree && role_allows?(:feature => 'event_edit')
+    @view_context.x_active_tree != :event_tree && role_allows?(:feature => 'event_edit')
   end
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -679,11 +679,6 @@ class ApplicationHelper::ToolbarBuilder
       else
         return true unless editable_domain?(@record)
       end
-    when "MiqEventDefinition"
-      case id
-      when "event_edit"
-        return true if x_active_tree == :event_tree || !role_allows?(:feature => "event_edit")
-      end
     when "MiqServer", "MiqRegion"
       case id
       when "role_start", "role_suspend", "promote_server", "demote_server"

--- a/spec/factories/miq_policy.rb
+++ b/spec/factories/miq_policy.rb
@@ -4,4 +4,8 @@ FactoryGirl.define do
     sequence(:description) { |num| "Test Policy_#{seq_padded_for_sorting(num)}" }
     towhat                 "Vm"
   end
+
+  factory :miq_policy_read_only, :parent => :miq_policy do
+    read_only true
+  end
 end

--- a/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
@@ -9,7 +9,7 @@ describe ApplicationHelper::Button::MiqActionModify do
       it 'hides toolbar in policy event tree' do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        button.instance_variable_set(:@sb, {:active_tree => :event_tree})
+        button.instance_variable_set(:@sb, :active_tree => :event_tree)
         allow(view_context).to receive(:x_active_tree).and_return(:event_tree)
         allow(button).to receive(:role_allows?).and_return(true)
         expect(button.visible?).to be_falsey
@@ -18,7 +18,7 @@ describe ApplicationHelper::Button::MiqActionModify do
       it 'shows toolbar in policy tree' do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
-        button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
+        button.instance_variable_set(:@sb, :active_tree => :policy_tree)
         allow(view_context).to receive(:x_active_tree).and_return(:policy_tree)
         allow(button).to receive(:role_allows?).and_return(true)
         expect(button.visible?).to be_truthy
@@ -33,7 +33,7 @@ describe ApplicationHelper::Button::MiqActionModify do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         allow(view_context).to receive(:x_node).and_return("p-#{policy.id}")
-        button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
+        button.instance_variable_set(:@sb, :active_tree => :policy_tree)
         expect(button.disabled?).to be_truthy
       end
 
@@ -42,7 +42,7 @@ describe ApplicationHelper::Button::MiqActionModify do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         allow(view_context).to receive(:x_node).and_return("p-#{policy.id}")
-        button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
+        button.instance_variable_set(:@sb, :active_tree => :policy_tree)
         expect(button.disabled?).to be_falsey
       end
     end
@@ -55,7 +55,7 @@ describe ApplicationHelper::Button::MiqActionModify do
         'This Event belongs to a read only Policy and cannot be modified',
         nil
       ]
-      %w(a ev u).each_with_index do |type,i|
+      %w(a ev u).each_with_index do |type, i|
         it "sets message for #{type} when #{type} is active" do
           view_context = setup_view_context_with_sandbox({})
           button = described_class.new(view_context, {}, {'record' => @record}, {})

--- a/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
@@ -1,0 +1,69 @@
+describe ApplicationHelper::Button::MiqActionModify do
+  before(:each) do
+    @record = FactoryGirl.create(:miq_event_definition)
+    @layout = 'miq_policy'
+  end
+
+  describe '#visible?' do
+    context 'when id == event_edit' do
+      it 'hides toolbar in policy event tree' do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tree => :event_tree})
+        allow(button).to receive(:x_active_tree).and_return(:event_tree)
+        allow(button).to receive(:role_allows?).and_return(true)
+        expect(button.visible?).to be_falsey
+      end
+
+      it 'shows toolbar in policy tree' do
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
+        allow(button).to receive(:x_active_tree).and_return(:policy_tree)
+        allow(button).to receive(:role_allows?).and_return(true)
+        expect(button.visible?).to be_truthy
+      end
+    end
+  end
+
+  describe '#disabled?' do
+    context 'when id == event_edit' do
+      it 'gets disabled if policy is read-only' do
+        policy = FactoryGirl.create(:miq_policy_read_only)
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(view_context).to receive(:x_node).and_return("p-#{policy.id}")
+        button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
+        expect(button.disabled?).to be_truthy
+      end
+
+      it 'is enabled if policy is not read-only' do
+        policy = FactoryGirl.create(:miq_policy)
+        view_context = setup_view_context_with_sandbox({})
+        button = described_class.new(view_context, {}, {'record' => @record}, {})
+        allow(view_context).to receive(:x_node).and_return("p-#{policy.id}")
+        button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
+        expect(button.disabled?).to be_falsey
+      end
+    end
+  end
+
+  describe '#calculate_properties' do
+    context 'when id == event_edit' do
+      messages = [
+        'This Action belongs to a read only Policy and cannot be modified',
+        'This Event belongs to a read only Policy and cannot be modified',
+        nil
+      ]
+      %w(a ev u).each_with_index do |type,i|
+        it "sets message for #{type} when #{type} is active" do
+          view_context = setup_view_context_with_sandbox({})
+          button = described_class.new(view_context, {}, {'record' => @record}, {})
+          allow(button).to receive(:disabled?).and_return(true)
+          allow(view_context).to receive(:x_node).and_return("#{type}-1")
+          expect(button.calculate_properties).to eq(messages[i])
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
+++ b/spec/helpers/application_helper/buttons/miq_action_modify_spec.rb
@@ -10,7 +10,7 @@ describe ApplicationHelper::Button::MiqActionModify do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tree => :event_tree})
-        allow(button).to receive(:x_active_tree).and_return(:event_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:event_tree)
         allow(button).to receive(:role_allows?).and_return(true)
         expect(button.visible?).to be_falsey
       end
@@ -19,7 +19,7 @@ describe ApplicationHelper::Button::MiqActionModify do
         view_context = setup_view_context_with_sandbox({})
         button = described_class.new(view_context, {}, {'record' => @record}, {})
         button.instance_variable_set(:@sb, {:active_tree => :policy_tree})
-        allow(button).to receive(:x_active_tree).and_return(:policy_tree)
+        allow(view_context).to receive(:x_active_tree).and_return(:policy_tree)
         allow(button).to receive(:role_allows?).and_return(true)
         expect(button.visible?).to be_truthy
       end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1091,26 +1091,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when id == event_edit" do
-      before(:each) do
-        @record = FactoryGirl.create(:miq_event_definition)
-        @layout = "miq_policy"
-        stub_user(:features => :all)
-      end
-
-      it "hides toolbar in policy event tree" do
-        @sb = {:active_tree => :event_tree}
-        result = build_toolbar_hide_button('event_edit')
-        expect(result).to be(true)
-      end
-
-      it "shows toolbar in policy tree" do
-        @sb = {:active_tree => :policy_tree}
-        result = build_toolbar_hide_button('event_edit')
-        expect(result).to be(false)
-      end
-    end
-
     context "when record class = ExtManagementSystem" do
       before do
         @record = FactoryGirl.create(:ems_amazon)


### PR DESCRIPTION
@romanblanco, review please.
Things done:
- removed event_edit button from #build_toolbar_hide_button,
- added #visible? to MiqActionModify button class,
- wrote missing spec for the mentioned class,
- removed old specs,
- created a new factory for mocking purposes to test #disabled?.

| Toolbar buttons id  | Toolbar buttons class edited |
| ------------- | ------------- |
| event_edit  | MiqActionModify |

Links
====
Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/126784041