### PR TITLE
Disable 'Upload' button when no file is chosen.

### DIFF
--- a/app/assets/javascripts/import.js
+++ b/app/assets/javascripts/import.js
@@ -12,8 +12,7 @@ var ImportSetup = {
   setUpUploadImportButton: function(button_id) {
     if ($("#upload_file").val()){
       $(button_id).prop('disabled', false);
-    }
-    else {
+    } else {
       $(button_id).prop('disabled', true);
     }
   },

--- a/app/assets/javascripts/import.js
+++ b/app/assets/javascripts/import.js
@@ -9,6 +9,15 @@ var ImportSetup = {
     });
   },
 
+  setUpUploadImportButton: function(button_id) {
+    if ($("#upload_file").val()){
+      $(button_id).prop('disabled', false);
+    }
+    else {
+      $(button_id).prop('disabled', true);
+    }
+  },
+
   listenForGitPostMessages: function() {
     window.addEventListener('message', function(event) {
       var unencodedMessage = event.data.message.replace(/&quot;/g, '"');

--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -154,7 +154,7 @@
       ImportSetup.setUpUploadImportButton('#upload-datastore-import')
     });
 
-    $('#upload-datastore-import').click(function() {
+    $('#upload-datastore-import').on("click", function() {
       miqSparkleOn();
     });
 

--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -22,7 +22,7 @@
           :javascript
             $(":file").filestyle({icon: false, placeholder: "No file chosen"});
         .col-md-6
-          = submit_tag(_("Upload"), :id => "upload-datastore-import", :class => "upload btn btn-default")
+          = submit_tag(_("Upload"), :id => "upload-datastore-import", :class => "upload btn btn-default", :disabled => true)
 
   %hr
   %h3
@@ -149,6 +149,10 @@
 :javascript
   $(function() {
     miqInitSelectPicker();
+
+    $("#upload_file").on("change", function() {
+      ImportSetup.setUpUploadImportButton('#upload-datastore-import')
+    });
 
     $('#upload-datastore-import').click(function() {
       miqSparkleOn();

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -27,16 +27,10 @@
       .col-md-6
         = submit_tag(_("Upload"), :class => "btn btn-default", :id => "upload_atags", :disabled => true)
         :javascript
-          $("#upload_file").on("change",
-            function(){
-              if ($(this).val()){
-                $('#upload_atags').prop('disabled', false);
-              }
-              else {
-                $('#upload_atags').prop('disabled', true);
-              }
-            }
-          );
+          $("#upload_file").on("change", function() {
+            ImportSetup.setUpUploadImportButton('#upload_atags')
+          });
+
 %hr
 %h3
   = _('Export')

--- a/app/views/report/_export_widgets.html.haml
+++ b/app/views/report/_export_widgets.html.haml
@@ -47,16 +47,9 @@
       .col-md-6
         = submit_tag(_("Upload"), :class => "btn btn-default", :id => "upload_widget", :disabled => true)
         :javascript
-          $("#upload_file").on("change",
-             function(){
-               if ($(this).val()){
-                 $('#upload_widget').prop('disabled', false);
-               }
-               else {
-                 $('#upload_widget').prop('disabled', true);
-               }
-             }
-           );
+          $("#upload_file").on("change", function() {
+            ImportSetup.setUpUploadImportButton('#upload_widget')
+          });
   %hr
 
   %h3

--- a/spec/javascripts/import_spec.js
+++ b/spec/javascripts/import_spec.js
@@ -183,6 +183,33 @@ describe('import.js', function() {
         });
       });
     });
+
+    describe('SettingUpImportButton', function() {
+      beforeEach(function() {
+        var html = '';
+        html += '<div class="col-md-6">'
+        html += ' <input id="upload_button" />';
+        html += '</div>';
+        html += '<div>';
+        html += ' <input id="upload_file" />';
+        html += '</div>';
+
+        setFixtures(html);
+      });
+
+      it('make upload button to not be disabled', function(){
+        $('#upload_button').prop('disabled', true);
+        $('#upload_file').prop('value', 'test_value');
+        ImportSetup.setUpUploadImportButton('#upload_button');
+        expect($('#upload_button').prop('disabled')).toEqual(false);
+      });
+
+      it('make upload button to be disabled', function(){
+        $('#upload_button').prop('disabled', false);
+        ImportSetup.setUpUploadImportButton('#upload_button');
+        expect($('#upload_button').prop('disabled')).toEqual(true);
+      });
+    });
   });
 
   describe('#clearMessages', function() {


### PR DESCRIPTION
Fixing the bug bellow by disabling the 'Upload' button in automate import/export page when no file is chosen. 

Screenshots
-----------------
### before:
![before](https://cloud.githubusercontent.com/assets/19405716/19435371/955d56e8-946a-11e6-9011-7280e3dfd9c0.png)

### after:
![after](https://cloud.githubusercontent.com/assets/19405716/19435377/9b2d00be-946a-11e6-8bc3-c365e64e3a47.png)


Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1383174