### PR TITLE
Remove duplicate function to handle tags editor

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -158,29 +158,6 @@ module ApplicationController::Explorer
     x_tree_history.unshift(options).slice!(11..-1)
   end
 
-  def x_edit_tags_reset(db)
-    @tagging = session[:tag_db] = db
-    @object_ids = find_checked_items
-    if params[:button] == "reset"
-      id = params[:id] if params[:id]
-      return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}", "replace_cell__explorer")
-      @object_ids = @edit[:object_ids]
-      session[:tag_db] = @tagging = @edit[:tagging]
-    else
-      @object_ids[0] = params[:id] if @object_ids.blank? && params[:id]
-      session[:tag_db] = @tagging = params[:tagging] if params[:tagging]
-    end
-
-    @gtl_type = "list"  # No quad icons for user/group list views
-    x_tags_set_form_vars
-    @in_a_form = true
-    session[:changed] = false
-    add_flash(_("All changes have been reset"), :warning)  if params[:button] == "reset"
-    @right_cell_text = _("Editing %{model} Tags for \"%{name}\"") % {:name  => ui_lookup(:models => @tagging),
-                                                                     :model => current_tenant.name}
-    replace_right_cell(@sb[:action])
-  end
-
   # Set form vars for tag editor
   def x_tags_set_form_vars
     @edit = {}

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -165,7 +165,6 @@ module ApplicationController::Explorer
     @edit[:key] = "#{session[:tag_db]}_edit_tags__#{@object_ids[0]}"
     @edit[:object_ids] = @object_ids
     @edit[:tagging] = @tagging
-    session[:assigned_filters] = assigned_filters
     tag_edit_build_screen
     build_targets_hash(@tagitems)
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2034,4 +2034,27 @@ class CatalogController < ApplicationController
     return unless @edit[:new][:display] && (@edit[:new][:dialog_id].nil? || @edit[:new][:dialog_id].to_i == 0)
     add_flash(_("Dialog has to be set if Display in Catalog is chosen"), :error)
   end
+
+  def x_edit_tags_reset(db)
+    @tagging = session[:tag_db] = db
+    @object_ids = find_checked_items
+    if params[:button] == 'reset'
+      id = params[:id] if params[:id]
+      return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}", 'replace_cell__explorer')
+      @object_ids = @edit[:object_ids]
+      session[:tag_db] = @tagging = @edit[:tagging]
+    else
+      @object_ids[0] = params[:id] if @object_ids.blank? && params[:id]
+      session[:tag_db] = @tagging = params[:tagging] if params[:tagging]
+    end
+
+    @gtl_type = 'list' # No quad icons for user/group list views
+    x_tags_set_form_vars
+    @in_a_form = true
+    session[:changed] = false
+    add_flash(_('All changes have been reset'), :warning) if params[:button] == "reset"
+    @right_cell_text = _("Editing %{model} Tags for \"%{name}\"") % {:name  => ui_lookup(:models => @tagging),
+                                                                     :model => current_tenant.name}
+    replace_right_cell(@sb[:action])
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2049,6 +2049,7 @@ class CatalogController < ApplicationController
     end
 
     @gtl_type = 'list' # No quad icons for user/group list views
+    session[:assigned_filters] = assigned_filters
     x_tags_set_form_vars
     @in_a_form = true
     session[:changed] = false

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -601,27 +601,13 @@ module OpsController::OpsRbac
     end
 
     @gtl_type = "list"  # No quad icons for user/group list views
-    rbac_tags_set_form_vars
+    x_tags_set_form_vars
     @in_a_form = true
     session[:changed] = false
     add_flash(_("All changes have been reset"), :warning)  if params[:button] == "reset"
     @sb[:pre_edit_node] = x_node  unless params[:button]  # Save active tree node before edit
     @right_cell_text = _("Editing %{model} for \"%{name}\"") % {:name => ui_lookup(:models => @tagging), :model => "#{current_tenant.name} Tags"}
     replace_right_cell("root")
-  end
-
-  # Set form vars for tag editor
-  def rbac_tags_set_form_vars
-    @edit = {}
-    @edit[:new] = {}
-    @edit[:key] = "#{session[:tag_db]}_edit_tags__#{@object_ids[0]}"
-    @edit[:object_ids] = @object_ids
-    @edit[:tagging] = @tagging
-
-    tag_edit_build_screen
-    build_targets_hash(@tagitems)
-
-    @edit[:current] = copy_hash(@edit[:new])
   end
 
   def rbac_edit_tags_cancel


### PR DESCRIPTION
This pr
 * moves `x_edit_tags_reset` to the Catalog controller, as it is the only controller that uses it
 * drops `rbac_tags_set_form_vars` as its the same as `x_tags_set_form_vars`

@miq-bot add_label ui, refactoring
@miq-bot assign @martinpovolny 