### PR TITLE
Remove the GB label from GCE boot_disk_size description in provisioning dialog

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_google_dialogs_template.yaml
@@ -270,7 +270,7 @@
       :description: Properties
       :fields:
         :boot_disk_size:
-          :description: Boot Disk Size (GB)
+          :description: Boot Disk Size
           :values:
             10.GB: 10 GB
             50.GB: 50 GB


### PR DESCRIPTION
Remove the GB label from the Boot Disk Size field description since the possible options include both GB and TB.

![screenshot from 2016-10-17 09-55-05](https://cloud.githubusercontent.com/assets/12851112/19440540/41d2f7ea-9450-11e6-81e6-526f8ac7094a.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1383309