### PR TITLE
Simplify OwnershipMixin specs by removing before(:context)

### DIFF
--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,5 +1,5 @@
 describe Service do
-  include_examples "miq ownership"
+  include_examples "OwnershipMixin"
 
   context "service events" do
     before do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1,5 +1,5 @@
 describe ServiceTemplate do
-  include_examples "miq ownership"
+  include_examples "OwnershipMixin"
 
   describe "#custom_actions" do
     let(:service_template) do

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -1,5 +1,5 @@
 describe Vm do
-  include_examples "miq ownership"
+  include_examples "OwnershipMixin"
 
   it "#corresponding_model" do
     expect(Vm.corresponding_model).to eq(MiqTemplate)


### PR DESCRIPTION
The before(:context) forces the spec to have a manual teardown, and none of it is necessary.  Technically the tests are slower, but only marginally...The 3 specs that mixin the shared examples were 12s before and 15s after.

@chrisarcand Please review.