### PR TITLE
VmMiqRequestNew and InstanceMiqRequestNew enabled without added providers

### DIFF
--- a/app/helpers/application_helper/button/instance_miq_request_new.rb
+++ b/app/helpers/application_helper/button/instance_miq_request_new.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Button::InstanceMiqRequestNew < ApplicationHelper::Button::Basic
+  def disabled?
+    !provisioning_supported?
+  end
+
+  def calculate_properties
+    super
+
+    if disabled?
+      self[:title] = N_('No Cloud Provider that supports instance provisioning added')
+    end
+  end
+
+  private
+
+  def provisioning_supported?
+    EmsCloud.all.any? { |provider| provider.supports_provisioning? }
+  end
+end

--- a/app/helpers/application_helper/button/vm_miq_request_new.rb
+++ b/app/helpers/application_helper/button/vm_miq_request_new.rb
@@ -1,0 +1,19 @@
+class ApplicationHelper::Button::VmMiqRequestNew < ApplicationHelper::Button::Basic
+  def disabled?
+    !provisioning_supported?
+  end
+
+  def calculate_properties
+    super
+
+    if disabled?
+      self[:title] = N_('No Infrastructure Provider that supports VM provisioning added')
+    end
+  end
+
+  private
+
+  def provisioning_supported?
+    EmsInfra.all.any? { |provider| provider.supports_provisioning? }
+  end
+end

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -131,7 +131,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-add-circle-o fa-lg',
           N_('Request to Provision Instances'),
           N_('Provision Instances'),
-          :url_parms => "main_div"),
+          :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::InstanceMiqRequestNew),
         button(
           :instance_retire,
           'fa fa-clock-o fa-lg',

--- a/app/helpers/application_helper/toolbar/vm_infras_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_infras_center.rb
@@ -147,7 +147,8 @@ class ApplicationHelper::Toolbar::VmInfrasCenter < ApplicationHelper::Toolbar::B
           'pficon pficon-add-circle-o fa-lg',
           N_('Request to Provision VMs'),
           N_('Provision VMs'),
-          :url_parms => "main_div"),
+          :url_parms => "main_div",
+          :klass     => ApplicationHelper::Button::VmMiqRequestNew),
         button(
           :vm_clone,
           'product product-clone fa-lg',


### PR DESCRIPTION
**Problem**: VM and Instance provisioning was enabled even though there were no providers added.
**Solution**: Disable button if there is no provider added that supports provisioning.

| Toolbar button id | Toolbar button class added |
| --- | --- |
| vm_miq_request_new | VmMiqRequestNew |
| instance_miq_request_new | InstanceMiqRequestNew |
# Links

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1383205
