### PR TITLE
Fix the handling of 'Display in Catalog' checkbox

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1339,6 +1339,7 @@ class CatalogController < ApplicationController
     @edit[:new]     = {}
     @edit[:current] = {}
     set_form_vars
+    default_entry_point("generic", "composite")
     @edit[:new][:service_type] = "composite"
     @edit[:new][:rsc_groups] = []
     @edit[:new][:selected_resources] = []

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -379,7 +379,7 @@ class CatalogController < ApplicationController
   def st_form_field_changed
     return unless load_edit("st_edit__#{params[:id]}", "replace_cell__explorer")
     @group_idx = false
-    default_entry_point("generic") if params[:display]
+    default_entry_point("generic", "composite") if params[:display]
     st_get_form_vars
     changed = (@edit[:new] != @edit[:current])
     build_ae_tree(:automate, :automate_tree) # Build Catalog Items tree

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -58,7 +58,7 @@
           = _('Subtype')
         .col-md-4
           %p.form-control-static
-            - if @record.id
+            - if @record.try(:id)
               = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@edit[:new][:generic_subtype]])
             - else
               - available_subtypes = ServiceTemplate::GENERIC_ITEM_SUBTYPES.invert.to_a.sort_by { |a| a.first.downcase }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -646,4 +646,17 @@ describe CatalogController do
       expect(@st.service_template_catalog).to match(@catalog)
     end
   end
+
+  context "#st_set_form_vars" do
+    before do
+      bundle = FactoryGirl.create(:service_template)
+      controller.instance_variable_set(:@record, bundle)
+    end
+
+    it "sets default entry points for Catalog Bundle" do
+      controller.send(:st_set_form_vars)
+      expect(assigns(:edit)[:new][:fqname]).to include("CatalogBundleInitialization")
+      expect(assigns(:edit)[:new][:retire_fqname]).to include("Default")
+    end
+  end
 end


### PR DESCRIPTION
For Catalog Bundle, we called default_entry_point method with wrong number of arguments, caused by change in https://github.com/ManageIQ/manageiq/pull/11103

2nd commit is optional, as I noticed exception also on 'generic' Catalog Item (not Bundle), when user try check the 'Display in Catalog' checkbox.

https://bugzilla.redhat.com/show_bug.cgi?id=1384759