### PR TITLE
Removed superfluous hand pointed on brand logo

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -7,7 +7,7 @@
       %span.icon-bar
       %span.icon-bar
       %span.icon-bar
-    %a.navbar-brand{:href => '#'}
+    %a.navbar-brand{:href => '#', :style => "cursor: default"}
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic


### PR DESCRIPTION
Since the link to the user home screen has been removed from the brand logo (for now), the hand pointed is no longer needed.

https://bugzilla.redhat.com/show_bug.cgi?id=1383166