### PR TITLE
Fixed class name and key name in add/edit of user role code

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -736,7 +736,7 @@ module OpsController::OpsRbac
     when :role  then
       rbac_role_validate?
       rbac_role_set_record_vars(
-        record = @edit[:user_id] ? User.find_by_id(@edit[:user_id]) : User.new)
+        record = @edit[:role_id] ? MiqUserRole.find_by_id(@edit[:role_id]) : MiqUserRole.new)
     end
 
     if record.valid? && !flash_errors? && record.save

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -398,4 +398,28 @@ describe OpsController do
       expect(edit[:current][:ldap_groups].find { |lg| lg.group_type == 'user' }).not_to be(nil)
     end
   end
+
+  context "rbac_role_edit" do
+    before do
+      MiqUserRole.seed
+      MiqGroup.seed
+      MiqRegion.seed
+      stub_user(:features => :all)
+    end
+
+    it "creates a new user role successfully" do
+      allow(controller).to receive(:replace_right_cell)
+      controller.instance_variable_set(:@_params, :button => "add")
+      new = {:features => ["everything"], :name => "foo"}
+      edit = {:key     => "rbac_role_edit__new",
+              :new     => new,
+              :current => new
+      }
+      session[:edit] = edit
+      controller.send(:rbac_role_edit)
+      flash_messages = assigns(:flash_array)
+      expect(flash_messages.first[:message]).to include("Role \"foo\" was saved")
+      expect(controller.send(:flash_errors?)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Fixed inssue introduced in sha: 93f3f5e1c7e4fad747d29e889129fa79b1b7c7ad in https://github.com/ManageIQ/manageiq/pull/11466

@martinpovolny @romanblanco please review. This fixes an issue introduced in https://github.com/ManageIQ/manageiq/pull/11466 that is preventing from adding User Roles in UI.