### PR TITLE
Tree Builder: Storages - don't download objects

### DIFF
--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -16,25 +16,25 @@ class TreeBuilderStoragePod < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    objects = []
     items = EmsFolder.where(:type => 'StorageCluster')
-    items.each do |item|
-      objects.push(:id            => item[:id],
-                   :tree          => "dsc_tree",
-                   :text          => item[:name],
-                   :image         => "folder",
-                   :tip           => item[:description],
-                   :load_children => true)
+    if count_only
+      items.size
+    else
+      items.map do |item|
+        {
+          :id            => item[:id],
+          :tree          => "dsc_tree",
+          :text          => item[:name],
+          :image         => "folder",
+          :tip           => item[:description],
+          :load_children => true
+        }
+      end
     end
-    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_custom_kids(object, count_only, type)
-    objects = []
-    dsc = EmsFolder.where(:id => object[:id])
-    if(dsc.size > 0)
-      objects = dsc.first.storages
-    end
-    count_only_or_objects(count_only, objects, "name")
+    objects = EmsFolder.find_by(:id => object[:id]).try!(:storages)
+    count_only_or_objects(count_only, objects || [], "name")
   end
 end


### PR DESCRIPTION
Was going through Storage code and found an extra `count(*)` and download unnecessary data.

This will make it perform better, but I didn't mark "performance" because I didn't want to put together the numbers.

--K
