### PR TITLE
Tree Builder: Sort data in presenter not model.

### DIFF
--- a/app/helpers/ems_infra_helper/textual_summary.rb
+++ b/app/helpers/ems_infra_helper/textual_summary.rb
@@ -136,7 +136,7 @@ module EmsInfraHelper::TextualSummary
   def textual_datastores
     return nil if @record.kind_of?(ManageIQ::Providers::Openstack::InfraManager)
 
-    textual_link(@record.storages,
+    textual_link(@record.storages.sort_by { |s| s.name.downcase },
                  :as   => Storage,
                  :link => ems_infra_path(@record.id, :display => 'storages'))
   end

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -85,7 +85,7 @@ class EmsFolder < ApplicationRecord
   # Vm relationship methods
   #   all_vms and all_vm_ids included from AggregationMixin
   def vms_and_templates
-    children(:of_type => 'VmOrTemplate').sort_by { |c| c.name.downcase }
+    children(:of_type => 'VmOrTemplate')
   end
 
   def miq_templates

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -104,7 +104,7 @@ class EmsFolder < ApplicationRecord
   end
 
   def storages
-    children(:of_type => 'Storage').sort_by { |c| c.name.downcase }
+    children(:of_type => 'Storage')
   end
 
   alias add_storage set_child

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -72,7 +72,7 @@ class EmsFolder < ApplicationRecord
   # Host relationship methods
   #   all_hosts and all_host_ids included from AggregationMixin
   def hosts
-    children(:of_type => 'Host').sort_by { |c| c.name.downcase }
+    children(:of_type => 'Host')
   end
 
   alias_method :add_host, :set_child

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -77,7 +77,7 @@ module AggregationMixin
   end
 
   def all_hosts
-    descendants(:of_type => 'Host').sort_by { |v| v.name.downcase }
+    descendants(:of_type => 'Host')
   end
 
   def all_host_ids

--- a/app/models/mixins/aggregation_mixin.rb
+++ b/app/models/mixins/aggregation_mixin.rb
@@ -53,7 +53,7 @@ module AggregationMixin
   # Default implementations which can be overridden with something more optimized
 
   def all_vms_and_templates
-    descendants(:of_type => 'VmOrTemplate').sort_by { |v| v.name.downcase }
+    descendants(:of_type => 'VmOrTemplate')
   end
 
   def all_vms

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -60,7 +60,7 @@ class ResourcePool < ApplicationRecord
 
   # VM relationship methods
   def vms_and_templates
-    children(:of_type => 'VmOrTemplate').sort_by { |c| c.name.downcase }
+    children(:of_type => 'VmOrTemplate')
   end
   alias_method :direct_vms_and_templates, :vms_and_templates
 

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -41,7 +41,7 @@ class TreeBuilderDatacenter < TreeBuilder
 
   def x_get_tree_roots(count_only = false, _options)
     if @root.kind_of?(EmsCluster)
-      hosts = count_only_or_objects(count_only, @root.hosts)
+      hosts = count_only_or_objects(count_only, @root.hosts, "name")
       resource_pools = count_only_or_objects(count_only, @root.resource_pools)
       vms = count_only_or_objects(count_only, @root.vms, "name")
       hosts + resource_pools + vms
@@ -68,7 +68,7 @@ class TreeBuilderDatacenter < TreeBuilder
     elsif parent.name == "host" && parent.parent.kind_of?(Datacenter)
       folders = count_only_or_objects(count_only, parent.folders_only)
       clusters = count_only_or_objects(count_only, parent.clusters)
-      hosts = count_only_or_objects(count_only, parent.hosts)
+      hosts = count_only_or_objects(count_only, parent.hosts, "name")
       objects = folders + clusters + hosts
     elsif parent.name == "datastore" && parent.parent.kind_of?(Datacenter)
       # Skip showing the datastore folder and sub-folders
@@ -78,7 +78,7 @@ class TreeBuilderDatacenter < TreeBuilder
       folders = count_only_or_objects(count_only, parent.folders_only)
       datacenters = count_only_or_objects(count_only, parent.datacenters_only)
       clusters = count_only_or_objects(count_only, parent.clusters)
-      hosts = count_only_or_objects(count_only, parent.hosts)
+      hosts = count_only_or_objects(count_only, parent.hosts, "name")
       vms = count_only_or_objects(count_only, parent.vms, "name")
       objects = folders + datacenters + clusters + hosts + vms
     end
@@ -98,7 +98,7 @@ class TreeBuilderDatacenter < TreeBuilder
 
   def x_get_tree_cluster_kids(parent, count_only = false)
     resource_pools = count_only_or_objects(count_only, parent.resource_pools)
-    hosts = count_only_or_objects(count_only, parent.hosts)
+    hosts = count_only_or_objects(count_only, parent.hosts, "name")
     vms = count_only_or_objects(count_only, parent.vms, "name")
     resource_pools + hosts + vms
   end

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -43,11 +43,11 @@ class TreeBuilderDatacenter < TreeBuilder
     if @root.kind_of?(EmsCluster)
       hosts = count_only_or_objects(count_only, @root.hosts)
       resource_pools = count_only_or_objects(count_only, @root.resource_pools)
-      vms = count_only_or_objects(count_only, @root.vms)
+      vms = count_only_or_objects(count_only, @root.vms, "name")
       hosts + resource_pools + vms
     elsif @root.kind_of?(ResourcePool)
       resource_pools = count_only_or_objects(count_only, @root.resource_pools)
-      vms = count_only_or_objects(count_only, @root.vms)
+      vms = count_only_or_objects(count_only, @root.vms, "name")
       resource_pools + vms
     end
   end
@@ -79,7 +79,7 @@ class TreeBuilderDatacenter < TreeBuilder
       datacenters = count_only_or_objects(count_only, parent.datacenters_only)
       clusters = count_only_or_objects(count_only, parent.clusters)
       hosts = count_only_or_objects(count_only, parent.hosts)
-      vms = count_only_or_objects(count_only, parent.vms)
+      vms = count_only_or_objects(count_only, parent.vms, "name")
       objects = folders + datacenters + clusters + hosts + vms
     end
     objects
@@ -90,7 +90,7 @@ class TreeBuilderDatacenter < TreeBuilder
     if parent.authorized_for_user?(@user_id)
       objects += count_only_or_objects(count_only, parent.resource_pools)
       if parent.default_resource_pool
-        objects += count_only_or_objects(count_only, parent.default_resource_pool.vms)
+        objects += count_only_or_objects(count_only, parent.default_resource_pool.vms, "name")
       end
     end
     objects
@@ -99,13 +99,13 @@ class TreeBuilderDatacenter < TreeBuilder
   def x_get_tree_cluster_kids(parent, count_only = false)
     resource_pools = count_only_or_objects(count_only, parent.resource_pools)
     hosts = count_only_or_objects(count_only, parent.hosts)
-    vms = count_only_or_objects(count_only, parent.vms)
+    vms = count_only_or_objects(count_only, parent.vms, "name")
     resource_pools + hosts + vms
   end
 
   def x_get_resource_pool_kids(parent, count_only = false)
     resource_pools = count_only_or_objects(count_only, parent.resource_pools)
-    vms = count_only_or_objects(count_only, parent.vms)
+    vms = count_only_or_objects(count_only, parent.vms, "name")
     resource_pools + vms
   end
 end

--- a/app/presenters/tree_builder_datastores.rb
+++ b/app/presenters/tree_builder_datastores.rb
@@ -31,7 +31,7 @@ class TreeBuilderDatastores < TreeBuilder
     nodes = @root.map do |node|
       children = []
       if @data[node[:id]].hosts.present?
-        children = @data[node[:id]].hosts.map do |kid|
+        children = @data[node[:id]].hosts.sort_by { |host| host.name.try(:downcase) }.map do |kid|
           {:name => kid.name}
         end
       end

--- a/app/presenters/tree_builder_network.rb
+++ b/app/presenters/tree_builder_network.rb
@@ -48,7 +48,7 @@ class TreeBuilderNetwork < TreeBuilder
   def x_get_tree_lan_kids(parent, count_only)
     kids = count_only ? 0 : []
     if parent.respond_to?("vms_and_templates") && parent.vms_and_templates.present?
-      kids = count_only_or_objects(count_only, parent.vms_and_templates.sort_by { |l| l.name.downcase })
+      kids = count_only_or_objects(count_only, parent.vms_and_templates, "name")
     end
     @tree_vms.concat(kids) unless count_only
     kids

--- a/app/presenters/tree_builder_storage_pod.rb
+++ b/app/presenters/tree_builder_storage_pod.rb
@@ -35,6 +35,6 @@ class TreeBuilderStoragePod < TreeBuilder
     if(dsc.size > 0)
       objects = dsc.first.storages
     end
-    count_only_or_objects(count_only, objects)
+    count_only_or_objects(count_only, objects, "name")
   end
 end

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -43,7 +43,7 @@ class TreeBuilderVat < TreeBuilderDatacenter
       unless @vat
         folders = count_only_or_objects(count_only, parent.folders_only)
         clusters = count_only_or_objects(count_only, parent.clusters)
-        hosts = count_only_or_objects(count_only, parent.hosts)
+        hosts = count_only_or_objects(count_only, parent.hosts, "name")
         objects = folders + clusters + hosts
       end
     elsif parent.name == "datastore" && parent.parent.kind_of?(Datacenter)
@@ -58,7 +58,7 @@ class TreeBuilderVat < TreeBuilderDatacenter
       folders = count_only_or_objects(count_only, parent.folders_only)
       datacenters = count_only_or_objects(count_only, parent.datacenters_only)
       clusters = count_only_or_objects(count_only, parent.clusters)
-      hosts = count_only_or_objects(count_only, parent.hosts)
+      hosts = count_only_or_objects(count_only, parent.hosts, "name")
       vms = count_only_or_objects(count_only, parent.vms, "name")
       objects = folders + datacenters + clusters + hosts + vms
     end

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -51,7 +51,7 @@ class TreeBuilderVat < TreeBuilderDatacenter
     elsif parent.name == "vm" && parent.parent.kind_of?(Datacenter)
       if @vat
         folders = count_only_or_objects(count_only, parent.folders_only)
-        vms = count_only_or_objects(count_only, parent.vms)
+        vms = count_only_or_objects(count_only, parent.vms, "name")
         objects = folders + vms
       end
     else
@@ -59,7 +59,7 @@ class TreeBuilderVat < TreeBuilderDatacenter
       datacenters = count_only_or_objects(count_only, parent.datacenters_only)
       clusters = count_only_or_objects(count_only, parent.clusters)
       hosts = count_only_or_objects(count_only, parent.hosts)
-      vms = count_only_or_objects(count_only, parent.vms)
+      vms = count_only_or_objects(count_only, parent.vms, "name")
       objects = folders + datacenters + clusters + hosts + vms
     end
     objects


### PR DESCRIPTION
This is part 1 of 3 for improving performance of UI Perf: `/ems_infra/:id?display=ems_folders`.
This should speed up any tree that displays storages in a tree.

Counts are displayed for the left hand navbar and the expanders in the tree.

Currently, all hosts, then storages are downloaded to determine the count.

**This PR does not change the numbers**
It simply removes the `sort_by` that was forcing the hosts and storages to be downloaded when doing a `count(*)`.

---

After 3 of 3, the difference for a non-expanded tree:

|     ms |queries | query (ms) |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  555.9 |   40 |  62.5 |      683 |master
|  204.2 |   39 |  26.6 |      161 |after 3 of 3
| 54% | 3% | 57% | 76% |
