### PR TITLE
Fix Directory Name Length for Superblock Type 5

### DIFF
--- a/gems/pending/fs/xfs/short_form_directory_entry.rb
+++ b/gems/pending/fs/xfs/short_form_directory_entry.rb
@@ -65,9 +65,9 @@ module XFS
       @directory_entry = SHORT_FORM_DIRECTORY_ENTRY.decode(data[0..siz])
       @name_length     = @directory_entry['name_length']
       unless @name_length == 0
+        @name        = data[siz, @name_length]
         @name_length += 1 if sb.version_has_crc?
-        @name   = data[siz, @name_length]
-        start   = siz + @name_length
+        start        = siz + @name_length
         if short_inode
           ino_size = SIZEOF_SHORT_FORM_SHORT_INO
           inode    = SHORT_FORM_SHORT_INO.decode(data[start..(start + ino_size)])

--- a/gems/pending/fs/xfs/short_form_directory_entry.rb
+++ b/gems/pending/fs/xfs/short_form_directory_entry.rb
@@ -65,9 +65,9 @@ module XFS
       @directory_entry = SHORT_FORM_DIRECTORY_ENTRY.decode(data[0..siz])
       @name_length     = @directory_entry['name_length']
       unless @name_length == 0
-        @name        = data[siz, @name_length]
+        @name = data[siz, @name_length]
         @name_length += 1 if sb.version_has_crc?
-        start        = siz + @name_length
+        start = siz + @name_length
         if short_inode
           ino_size = SIZEOF_SHORT_FORM_SHORT_INO
           inode    = SHORT_FORM_SHORT_INO.decode(data[start..(start + ino_size)])


### PR DESCRIPTION
When an XFS filesystem with Superblock Version 5 is encountered,
the spec indicates that the filename in a directory entry is to
be incremented by one to find the next field in the entry.  This
increment was occurring before capturing the true length of the name
resulting in an extra character in the name, which is obviously incorrect.

When this is the root filesystem on the VM SSA will fail to find the required
directories under root and therefore fail.

It appears a Superblock of this type had not been encountered previously.
Superblock Version 5 indicates that the filesystem is CRC-enabled.


Steps for Testing/QA [Optional]
-------------------------------

Install a VM with a CRC-enabled XFS root filesystem.  Run SSA on it and it should succeed.

@roliveri please review and merge.  Thanks!

