### PR TITLE
Route the import call to the correct server with the git owner role

### DIFF
--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -35,6 +35,7 @@ class GitBasedDomainImportService
     task = MiqTask.wait_for_taskid(task_id)
 
     domain = task.task_results
+    raise MiqException::Error, "Domain object not available from task results" unless domain.kind_of?(MiqAeDomain)
     domain.update_attribute(:enabled, true)
   end
 

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -1,5 +1,5 @@
 class GitBasedDomainImportService
-  def import(git_repo_id, branch_or_tag, tenant_id)
+  def queue_import(git_repo_id, branch_or_tag, tenant_id)
     git_repo = GitRepository.find_by(:id => git_repo_id)
 
     ref_type = if git_repo.git_branches.any? { |git_branch| git_branch.name == branch_or_tag }
@@ -8,13 +8,33 @@ class GitBasedDomainImportService
                  "tag"
                end
 
-    options = {
+    import_options = {
       "git_repository_id" => git_repo.id,
       "ref"               => branch_or_tag,
       "ref_type"          => ref_type,
       "tenant_id"         => tenant_id
     }
-    domain = MiqAeDomain.import_git_repo(options)
+
+    task_options = {
+      :action => "Import git repository",
+      :userid => User.current_user.userid
+    }
+
+    queue_options = {
+        :class_name  => "MiqAeDomain",
+        :method_name => "import_git_repo",
+        :role        => "git_owner",
+        :args        => [import_options]
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  def import(git_repo_id, branch_or_tag, tenant_id)
+    task_id = queue_import(git_repo_id, branch_or_tag, tenant_id)
+    task = MiqTask.wait_for_taskid(task_id)
+
+    domain = task.task_results
     domain.update_attribute(:enabled, true)
   end
 

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -21,10 +21,10 @@ class GitBasedDomainImportService
     }
 
     queue_options = {
-        :class_name  => "MiqAeDomain",
-        :method_name => "import_git_repo",
-        :role        => "git_owner",
-        :args        => [import_options]
+      :class_name  => "MiqAeDomain",
+      :method_name => "import_git_repo",
+      :role        => "git_owner",
+      :args        => [import_options]
     }
 
     MiqTask.generic_action_with_callback(task_options, queue_options)

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -1,66 +1,87 @@
 describe GitBasedDomainImportService do
-  describe "#import" do
-    let(:git_repo) { double("GitRepository", :git_branches => git_branches, :id => 123) }
-    let(:domain) { double("MiqAeDomain") }
+  let(:git_repo) { double("GitRepository", :git_branches => git_branches, :id => 123) }
+  let(:domain) { double("MiqAeDomain") }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:task) { FactoryGirl.create(:miq_task) }
+  let(:ref_name) { 'the_branch_name' }
+  let(:ref_type) { 'branch' }
+  let(:task_options) { {:action => "Import git repository", :userid => user.userid} }
+  let(:queue_options) do
+    {
+      :class_name  => "MiqAeDomain",
+      :method_name => "import_git_repo",
+      :role        => "git_owner",
+      :args        => [import_options]
+    }
+  end
+  let(:import_options) do
+    {
+      "git_repository_id" => git_repo.id,
+      "ref"               => ref_name,
+      "ref_type"          => ref_type,
+      "tenant_id"         => 321
+    }
+  end
 
+  describe "#import" do
     before do
-      allow(GitRepository).to receive(:find_by).with(:id => 123).and_return(git_repo)
+      allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
       allow(domain).to receive(:update_attribute).with(:enabled, true)
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(task).to receive(:task_results).and_return(domain)
+      User.current_user = user
     end
 
     context "when git branches that match the given name exist" do
-      let(:git_branches) { [double("GitBranch", :name => "the_branch_name")] }
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
 
-      before do
-        allow(MiqAeDomain).to receive(:import_git_repo).with(
-          "git_repository_id" => 123,
-          "ref"               => "the_branch_name",
-          "ref_type"          => "branch",
-          "tenant_id"         => 321
-        ).and_return(domain)
-      end
-
-      it "calls 'import_git_repo' with the correct options" do
-        expect(MiqAeDomain).to receive(:import_git_repo).with(
-          "git_repository_id" => 123,
-          "ref"               => "the_branch_name",
-          "ref_type"          => "branch",
-          "tenant_id"         => 321
-        )
-        subject.import(123, "the_branch_name", 321)
-      end
-
-      it "updates the enabled attribute on the domain to true" do
+      it "calls 'import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
         expect(domain).to receive(:update_attribute).with(:enabled, true)
-        subject.import(123, "the_branch_name", 321)
+
+        subject.import(git_repo.id, ref_name, 321)
       end
     end
 
     context "when git branches that match the given name do not exist" do
       let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
 
-      before do
-        allow(MiqAeDomain).to receive(:import_git_repo).with(
-          "git_repository_id" => 123,
-          "ref"               => "the_branch_name",
-          "ref_type"          => "tag",
-          "tenant_id"         => 321
-        ).and_return(domain)
-      end
-
-      it "calls 'import_git_repo' with the correct options" do
-        expect(MiqAeDomain).to receive(:import_git_repo).with(
-          "git_repository_id" => 123,
-          "ref"               => "the_branch_name",
-          "ref_type"          => "tag",
-          "tenant_id"         => 321
-        )
-        subject.import(123, "the_branch_name", 321)
-      end
-
-      it "updates the enabled attribute on the domain to true" do
+      it "calls 'import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
         expect(domain).to receive(:update_attribute).with(:enabled, true)
-        subject.import(123, "the_branch_name", 321)
+
+        subject.import(git_repo.id, ref_name, 321)
+      end
+    end
+  end
+
+  describe "#queue_import" do
+    before do
+      allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
+      User.current_user = user
+    end
+
+    context "when git branches that match the given name exist" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
+      end
+    end
+
+    context "when git branches that match the given name do not exist" do
+      let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+        expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
       end
     end
   end


### PR DESCRIPTION
GIT imports can only be run on servers that have the "git owner"
role enabled. This is required because the repository is only
available on those servers that have the git owner role enabled.

For REST API added queue_import so that we don't block the caller.

https://www.pivotaltracker.com/n/projects/1613499/stories/132665279

Testing Instructions:

1. Have 2 appliances Appliance A and Appliance B
2. Appliance A has the Git Repository Owner role enabled
3. Appliance B has the Git Repository Owner role **disabled**
4. From Appliance B import the GIT Repository
5. What should happen is that the Request should get routed to Appliance A and the domain should get created which you can view from Appliance B
