### PR TITLE
Add .class_from_request_data for inverse lookup of model from request_type

### DIFF
--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -359,4 +359,18 @@ describe MiqRequest do
       expect(request.request_state).to eq('active')
     end
   end
+
+  context ".class_from_request_data" do
+    it "with a valid request_type" do
+      expect(described_class.class_from_request_data(:request_type => "template")).to eq(MiqProvisionRequest)
+    end
+
+    it "with a invalid request_type" do
+      expect { described_class.class_from_request_data(:request_type => "abc") }.to raise_error("Invalid request_type")
+    end
+
+    it "without a request_type" do
+      expect { described_class.class_from_request_data({}) }.to raise_error("Invalid request_type")
+    end
+  end
 end


### PR DESCRIPTION
Ease reverse lookup of MiqRequest subclass from the request_type for the API.  With the correct subclass the task description and other defaulted attributes will be properly set.