### PR TITLE
Corrected typo in toolbar builder

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -530,7 +530,7 @@ class ApplicationHelper::ToolbarBuilder
                    %w(instance_check_compliance instance_compare).include?(id)
 
     # don't hide view buttons in toolbar
-    return false if %( view_grid view_tile view_list view_dashboard view_summary view_topology
+    return false if %w(view_grid view_tile view_list view_dashboard view_summary view_topology
       refresh_log fetch_log common_drift download_text download_csv download_pdf download_view vm_download_pdf
       tree_large tree_small).include?(id) && !%w(miq_policy_rsop ops).include?(@layout)
 


### PR DESCRIPTION
Corrected `%()` to `%w()`
