### PR TITLE
Get a rid of extra #index actions on explorer screens

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -11,11 +11,6 @@ class ChargebackController < ApplicationController
     'chargeback_rates_new'    => :cb_rate_edit
   }.freeze
 
-  # FIXME: -- is INDEX needed ?
-  def index
-    redirect_to :action => 'explorer'
-  end
-
   def x_button
     generic_x_button(CB_X_BUTTON_ALLOWED_ACTIONS)
   end

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -17,10 +17,6 @@ class InfraNetworkingController < ApplicationController
     redirect_to :action => 'explorer', :flash_msg => @flash_array ? @flash_array[0][:message] : nil
   end
 
-  def index
-    redirect_to :action => 'explorer'
-  end
-
   def show(id = nil)
     @explorer = true
     @display = params[:display] || "main" unless control_selected?

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -15,10 +15,6 @@ class MiqPolicyController < ApplicationController
 
   UI_FOLDERS = [Host, Vm, ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage].freeze
 
-  def index
-    redirect_to :action => 'explorer'
-  end
-
   def export
     @breadcrumbs = []
     @layout = "miq_policy_export"

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -10,10 +10,6 @@ class PxeController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  def index
-    redirect_to :action => 'explorer'
-  end
-
   PXE_X_BUTTON_ALLOWED_ACTIONS = {
     'pxe_image_edit'                => :pxe_image_edit,
     'pxe_image_type_new'            => :pxe_image_type_new,

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -7,10 +7,6 @@ class StorageController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  def index
-    redirect_to :action => 'explorer'
-  end
-
   def show_list
     redirect_to :action => 'explorer', :flash_msg => @flash_array ? @flash_array[0][:message] : nil
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -70,7 +70,7 @@ module Menu
                                                '/vm_infra/explorer'),
                                 Menu::Item.new('resource_pool',    N_('Resource Pools'),   'resource_pool',    {:feature => 'resource_pool_show_list'}, '/resource_pool'),
                                 Menu::Item.new('storage',          deferred_ui_lookup(:tables => 'storages'),
-                                               'storage',       {:feature => 'storage_show_list'},       '/storage'),
+                                               'storage',       {:feature => 'storage_show_list'},       '/storage/explorer'),
                                 Menu::Item.new('pxe',              N_('PXE'),              'pxe',              {:feature => 'pxe', :any => true},           '/pxe/explorer'),
                                 Menu::Item.new('infra_networking', N_('Networking'),       'infra_networking', {:feature => 'infra_networking', :any => true}, '/infra_networking/explorer'),
                                 Menu::Item.new('miq_request_host', N_('Requests'),         nil,                {:feature => 'miq_request_show_list'},       '/miq_request?typ=host'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,7 +269,6 @@ Vmdb::Application.routes.draw do
     :chargeback               => {
       :get  => %w(
         explorer
-        index
         render_csv
         render_pdf
         render_txt
@@ -1713,7 +1712,6 @@ Vmdb::Application.routes.draw do
         download_data
         explorer
         hosts
-        index
         show
         show_list
         tagging
@@ -1902,7 +1900,6 @@ Vmdb::Application.routes.draw do
         fetch_yaml
         get_json
         import
-        index
         log
         rsop
       ),
@@ -2558,7 +2555,6 @@ Vmdb::Application.routes.draw do
         download_data
         explorer
         files
-        index
         perf_chart_chooser
         protect
         show


### PR DESCRIPTION
Most of the explorer screens do not respond to `#index` action. However, there are some that do. Let's carefully investigate.

It turns out that in most cases the `index` action is not referenced by anyone. In case of `/storage`, the menu refers to `index` action, that is however extra useless redirect.

@miq-bot add_label ui, refactoring