### PR TITLE
Upgraded PatternFly to v3.12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "angular-ui-bootstrap-rails",   "~>0.13.0"
   gem "jquery-hotkeys-rails"
   gem "lodash-rails",                 "~>3.10.0"
-  gem "patternfly-sass",              "~>3.11.0"
+  gem "patternfly-sass",              "~>3.12.0"
   gem "sass-rails"
   gem "coffee-rails"
 

--- a/app/views/layouts/listnav/_timeline.html.haml
+++ b/app/views/layouts/listnav/_timeline.html.haml
@@ -4,7 +4,7 @@
       = miq_accordion_panel(h(rg),
         @panels["timelines_#{rg_idx}"].nil? || @panels["timelines_#{rg_idx}"] == false, "timelines_#{rg_idx}") do
         - tree_id = "timeline_treebox#{rg_idx}"
-        %div{:id => tree_id}
+        .treeview-pf-hover.treeview-pf-select{:id => tree_id}
         = render(:partial => "layouts/tree",
           :locals         => {:tree_id => tree_id,
             :tree_name                 => "#{tree_id}_#{rg_idx}",

--- a/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
+++ b/app/views/miq_ae_customization/_dialog_edit_tree.html.haml
@@ -8,7 +8,7 @@
       .panel-body
         -# Div to hold the actual tree
         #dialog_edit_tree_div{:style => "width: 100%; height: 100%"}
-          #dialog_edit_treebox{:style => "width: 100%; height: 100%; color: #000; overflow: hidden;"}
+          #dialog_edit_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; height: 100%; color: #000; overflow: hidden;"}
           = render(:partial => "layouts/tree",
             :locals         => {:tree_id  => "dialog_edit_treebox",
               :tree_name                  => "dialog_edit_tree",

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -67,7 +67,7 @@
     .form-horizontal
       .form-group
         .col-md-8
-          #action_tags_treebox
+          #action_tags_treebox.treeview-pf-hover.treeview-pf-select
           = render(:partial => "layouts/tree",
             :locals         => {:tree_id   => "action_tags_treebox",
               :tree_name                   => "action_tags_tree",

--- a/app/views/miq_policy/_alert_profile_assign.html.haml
+++ b/app/views/miq_policy/_alert_profile_assign.html.haml
@@ -35,7 +35,7 @@
     %h3
       = _('Selections')
     - if @assign[:obj_tree]
-      #obj_treebox{:style => "width: 100%; color: #000;"}
+      #obj_treebox.treeview-pf-hover.treeview-pf-select{:style => "width: 100%; color: #000;"}
       = render(:partial => "layouts/tree",
         :locals         => {:tree_id    => "obj_treebox",
           :tree_name                    => "obj_tree",

--- a/app/views/miq_request/_prov_field.html.haml
+++ b/app/views/miq_request/_prov_field.html.haml
@@ -198,7 +198,7 @@
       - elsif [:ldap_ous].include?(field)
         -# tree control for tags fields
         .col-md-8
-          %div{:id => "ldap_ous_treebox", :style => "color:#000; overflow: hidden;"}
+          #ldap_ous_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000; overflow: hidden;"}
           - if @edit && @edit[:req_id]
             - click = @edit[:req_id]
           - elsif @miq_request
@@ -307,7 +307,7 @@
       - elsif [:tag_ids, :vm_tags].include?(field)
         -# tree control for tags fields
         .col-md-8
-          %div{:id => "all_tags_treebox", :style => "color:#000; overflow: hidden;"}
+          #all_tags_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000; overflow: hidden;"}
           - if @edit && @edit[:req_id]
             - check = @edit[:req_id]
           - elsif @miq_request

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -186,7 +186,7 @@
         = _("This user is limited to the selected items and their children.")
         %br/
         %br/
-        #hac_treebox{:style => "color:#000"}
+        #hac_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
         = render(:partial => "layouts/tree",
                  :locals  => {:tree_id           => "hac_treebox",
                               :tree_name         => "hac_tree",
@@ -200,7 +200,7 @@
         = _("This user is limited to the selected folders and their children.")
         %br/
         %br/
-        #vat_treebox{:style => "color:#000"}
+        #vat_treebox.treeview-pf-hover.treeview-pf-select{:style => "color:#000"}
         = render(:partial => "layouts/tree",
                  :locals  => {:tree_id           => "vat_treebox",
                               :tree_name         => "vat_tree",

--- a/app/views/ops/_rbac_role_details.html.haml
+++ b/app/views/ops/_rbac_role_details.html.haml
@@ -60,7 +60,7 @@
       - else
         = _("Product Features (Read Only)")
       %h3
-      #features_treebox{:style => "width:100%;height:100%;color:#000"}
+      #features_treebox.treeview-pf-hover.treeview-pf-select{:style => "width:100%;height:100%;color:#000"}
       = render(:partial => "layouts/tree",
                :locals  => {:tree_id        => "features_treebox",
                             :tree_name      => "features_tree",

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -5,7 +5,7 @@
       .col-sm-5
         %h3
           = _("Reports")
-        #menu_roles_treebox{:style => "overflow-y: hidden !important;"}
+        #menu_roles_treebox.treeview-pf-hover.treeview-pf-select{:style => "overflow-y: hidden !important;"}
       = render(:partial => "layouts/tree",
         :locals         => {:tree_id => 'menu_roles_treebox',
           :tree_name                 => 'menu_roles_tree',

--- a/app/views/shared/_tree.html.haml
+++ b/app/views/shared/_tree.html.haml
@@ -1,3 +1,3 @@
 %div{:id => "#{name}_div"}
-  %div{:id => "#{name}box", :style => "overflow: hidden"}
+  .treeview-pf-hover.treeview-pf-select{:id => "#{name}box", :style => "overflow: hidden"}
     = render :partial  => "layouts/tree", :locals => tree.locals_for_render

--- a/app/views/vm_common/_vmtree.html.haml
+++ b/app/views/vm_common/_vmtree.html.haml
@@ -4,7 +4,7 @@
   = _("(Check All)")
   %p
 
-  #genealogy_treebox{:style => "width:100%"}
+  #genealogy_treebox.treeview-pf-hover.treeview-pf-select{:style => "width:100%"}
   = render(:partial => "layouts/tree",
     :locals         => {:tree_id => "genealogy_treebox",
       :tree_name                 => @tree_name,

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "angular-animate": "~1.5.8",
     "angular-bootstrap-switch": "~0.5.1",
     "angular-mocks": "~1.5.8",
-    "angular-patternfly-sass": "~3.11.0",
+    "angular-patternfly-sass": "~3.12.0",
     "angular-sanitize": "~1.5.8",
     "angular.validators": "~4.4.2",
     "array-includes": "~1.0.0",


### PR DESCRIPTION
In this version the selected and hover node styling is [disabled by default](https://github.com/patternfly/patternfly/pull/462) so I added them back in 38ed360. Also this update brings the new patternfly-bootstrap-treeview that was already in our codebase after #11270.