### PR TITLE
Allow cloud_subnets to be saved as a top level collection

### DIFF
--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -53,7 +53,7 @@ module EmsRefresh::SaveInventoryNetwork
     # Save and link other subsections
     save_child_inventory(ems, hashes, child_keys, target)
 
-    link_cloud_subnets_to_network_routers(hashes[:cloud_subnets]) if hashes.key?(:cloud_subnets)
+    link_cloud_subnets_to_network_routers(hashes[:cloud_networks].collect { |x| x[:cloud_subnets] }.flatten) if hashes.key?(:network_routers)
 
     ems.save!
     hashes[:id] = ems.id
@@ -404,6 +404,8 @@ module EmsRefresh::SaveInventoryNetwork
   end
 
   def link_cloud_subnets_to_network_routers(hashes)
+    return if hashes.blank?
+
     hashes.each do |hash|
       network_router = hash.fetch_path(:network_router, :_object)
       hash[:_object].update_attributes(:network_router => network_router)

--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -37,6 +37,7 @@ module EmsRefresh::SaveInventoryNetwork
 
     child_keys = [
       :cloud_networks,
+      :cloud_subnets,
       :network_groups,
       :security_groups,
       :network_routers,
@@ -109,18 +110,18 @@ module EmsRefresh::SaveInventoryNetwork
     store_ids_for_new_records(ems.network_groups, hashes, :ems_ref)
   end
 
-  def save_cloud_subnets_inventory(network, hashes)
+  def save_cloud_subnets_inventory(network, hashes, _target = nil)
     hashes.each do |h|
-      %i(availability_zone parent_cloud_subnet).each do |relation|
+      %i(availability_zone parent_cloud_subnet cloud_network).each do |relation|
         h[relation] = h.fetch_path(relation, :_object) if h.fetch_path(relation, :_object)
       end
 
-      h[:ems_id] = network.ems_id
+      h[:ems_id] = network.ems_id if network.respond_to?(:ems_id)
     end
 
     save_inventory_multi(network.cloud_subnets, hashes, :use_association, [:ems_ref], nil, [:network_router])
 
-    network.save!
+    network.save! unless network.kind_of?(ManageIQ::Providers::NetworkManager)
     store_ids_for_new_records(network.cloud_subnets, hashes, :ems_ref)
   end
 

--- a/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/network_manager/refresh_parser.rb
@@ -79,7 +79,7 @@ class ManageIQ::Providers::Azure::NetworkManager::RefreshParser
 
   def get_cloud_subnets(cloud_network)
     subnets = cloud_network.properties.subnets
-    process_collection(subnets, :cloud_subnets) { |subnet| parse_cloud_subnet(subnet) }
+    process_collection(subnets, :cloud_subnets, false) { |subnet| parse_cloud_subnet(subnet) }
   end
 
   def get_security_groups

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -1,14 +1,14 @@
 module ManageIQ::Providers::Azure::RefreshHelperMethods
   extend ActiveSupport::Concern
 
-  def process_collection(collection, key)
-    @data[key] ||= []
+  def process_collection(collection, key, store_in_data = true)
+    @data[key] ||= [] if store_in_data
 
     return if collection.nil?
 
     collection.each do |item|
       uid, new_result = yield(item)
-      @data[key] << new_result
+      @data[key] << new_result if store_in_data
       @data_index.store_path(key, uid, new_result)
     end
   end

--- a/app/models/manageiq/providers/google/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/google/network_manager/refresh_parser.rb
@@ -240,7 +240,7 @@ module ManageIQ::Providers
       end
 
       def get_cloud_subnets(subnets)
-        process_collection(subnets, :cloud_subnets) { |s| parse_cloud_subnet(s) }
+        process_collection(subnets, :cloud_subnets, false) { |s| parse_cloud_subnet(s) }
       end
 
       def get_security_groups

--- a/app/models/manageiq/providers/google/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/google/refresh_helper_methods.rb
@@ -1,8 +1,8 @@
 module ManageIQ::Providers::Google::RefreshHelperMethods
   extend ActiveSupport::Concern
 
-  def process_collection(collection, key)
-    @data[key]       ||= []
+  def process_collection(collection, key, store_in_data = true)
+    @data[key]       ||= [] if store_in_data
     @data_index[key] ||= {}
 
     collection.each do |item|
@@ -14,15 +14,15 @@ module ManageIQ::Providers::Google::RefreshHelperMethods
       if result.first.kind_of?(Array)
         result.each { |x| process_item(key, x.first, x.second) }
       else
-        process_item(key, result.first, result.second)
+        process_item(key, result.first, result.second, store_in_data)
       end
     end
   end
 
-  def process_item(key, uid, result)
+  def process_item(key, uid, result, store_in_data = true)
     return if uid.nil?
 
-    @data[key] << result
+    @data[key] << result if store_in_data
     @data_index.store_path(key, uid, result)
   end
 

--- a/app/models/manageiq/providers/nuage/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/nuage/network_manager/refresh_parser.rb
@@ -57,7 +57,6 @@ module ManageIQ::Providers
     end
 
     def get_subnets
-      @data[:cloud_subnets] = []
       @data[:network_groups].each do |net|
         # filtering out subnets based on the enterprise they are mapped to
         net[:cloud_subnets] = @vsd_client.get_subnets.collect { |s| parse_subnet(s) }.select { |filter| filter[:extra_attributes]['enterprise_name'] == net[:name] }
@@ -65,7 +64,6 @@ module ManageIQ::Providers
         # Lets store also subnets into indexed data, so we can reference them elsewhere
         net[:cloud_subnets].each do |x|
           @data_index.store_path(:cloud_subnets, x[:ems_ref], x)
-          @data[:cloud_subnets] << x
         end
       end
     end

--- a/app/models/manageiq/providers/openstack/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/refresh_parser.rb
@@ -104,7 +104,6 @@ module ManageIQ::Providers
 
     def get_subnets
       return unless @network_service.name == :neutron
-      @data[:cloud_subnets] = []
 
       networks.each do |n|
         new_net = @data_index.fetch_path(:cloud_networks, n.id)
@@ -113,7 +112,6 @@ module ManageIQ::Providers
         # Lets store also subnets into indexed data, so we can reference them elsewhere
         new_net[:cloud_subnets].each do |x|
           @data_index.store_path(:cloud_subnets, x[:ems_ref], x)
-          @data[:cloud_subnets] << x
         end
       end
     end

--- a/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/network_manager/refresh_parser.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers
       @inv[:networks] += get_vapp_networks
 
       process_collection(@inv[:networks], :cloud_networks) { |n| parse_network(n) }
-      process_collection(@inv[:networks], :cloud_subnets) { |n| parse_network_subnet(n) }
+      process_collection(@inv[:networks], :cloud_subnets, false) { |n| parse_network_subnet(n) }
     end
 
     def get_network_ports

--- a/app/models/manageiq/providers/vmware/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/vmware/refresh_helper_methods.rb
@@ -1,14 +1,14 @@
 module ManageIQ::Providers::Vmware::RefreshHelperMethods
   extend ActiveSupport::Concern
 
-  def process_collection(collection, key)
-    @data[key] ||= []
+  def process_collection(collection, key, store_in_data = true)
+    @data[key] ||= [] if store_in_data
 
     collection.each do |item|
       uid, new_result = yield(item)
       next if uid.nil?
 
-      @data[key] << new_result
+      @data[key] << new_result if store_in_data
       @data_index.store_path(key, uid, new_result)
     end
   end


### PR DESCRIPTION
Allow cloud_subnets to be saved as a top level collection. It will allow us to get rid of the n+1 API requests