### PR TITLE
StorageController#show - set x_node for the right tree, when called with an id

### DIFF
--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -30,8 +30,7 @@ class StorageController < ApplicationController
   def show(record = nil)
     return if perfmenu_click?
     @display = params[:display] || "main" unless control_selected?
-    @record = @storage = find_record( Storage, record || params[:id])
-    # @storage = @record = identify_record(params[:id])
+    @record = @storage = find_record(Storage, record || params[:id])
     return if record_no_longer_exists?(@storage)
 
     if !@explorer && @display == "main"
@@ -59,7 +58,6 @@ class StorageController < ApplicationController
     end
 
     @gtl_url = "/show"
-    #   drop_breadcrumb({:name=>ui_lookup(:tables=>"storages"), :url=>"/storage/show_list?page=#{@current_page}&refresh=y"}, true)
 
     case @display
     when "all_miq_templates", "all_vms"
@@ -406,7 +404,8 @@ class StorageController < ApplicationController
       nodetype, id = params[:id].split("-")
       # treebuilder initializes x_node to root first time in locals_for_render,
       # need to set this here to force & activate node when link is clicked outside of explorer.
-      @reselect_node = self.x_node = "#{nodetype}-#{to_cid(id)}"
+      self.x_active_tree = :storage_tree
+      self.x_node = @reselect_node = "#{nodetype}-#{to_cid(id)}"
     end
 
     build_accordions_and_trees

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -205,6 +205,19 @@ describe StorageController do
         flash_messages = assigns(:flash_array)
         expect(flash_messages.first[:message]).to_not include("Datastores no longer exists")
       end
+
+      it 'can render datastore details' do
+        tree_node_id = TreeBuilder.build_node_id(storage)
+        session[:sandboxes] = {} # no prior data in @sb
+        session[:exp_parms] = {:controller => 'storage',
+                               :action     => 'show',
+                               :id         => tree_node_id}
+
+        get :explorer
+        expect(response.status).to eq(200)
+        expect(response.body).to_not be_empty
+        expect(response).to render_template('shared/summary/_textual')
+      end
     end
 
     context "#tree_select" do


### PR DESCRIPTION
Going to a specific datastore from lists that live outside of `storage_controller` - for example from `/ems_infra/123?display=storages` - works by linking to `/storage/show/456`.

However, that code path updates `x_node` before the trees are built and so before the right tree is selected. Forcing to `:storage_tree` in such a case.

Reproducing:
1. log out
2. log in
3. go to `/storage/show/10r1` (a valid datastore id)
4. if you get the datastore detail, it works :) if you get a list, it doesn't :)

https://bugzilla.redhat.com/show_bug.cgi?id=1380707
