### PR TITLE
Add the ability to use a different disk for storing log files

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -67,6 +67,7 @@ require 'appliance_console/internal_database_configuration'
 require 'appliance_console/external_database_configuration'
 require 'appliance_console/external_httpd_authentication'
 require 'appliance_console/external_auth_options'
+require 'appliance_console/logfile_configuration'
 require 'appliance_console/temp_storage_configuration'
 require 'appliance_console/key_configuration'
 require 'appliance_console/scap'
@@ -535,6 +536,19 @@ Static Network Configuration
           press_any_key
         else
           say("Database maintenance configuration unchanged")
+          press_any_key
+          raise MiqSignalError
+        end
+
+      when I18n.t("advanced_settings.log_config")
+        say("#{selection}\n\n")
+        log_config = ApplianceConsole::LogfileConfiguration.new
+        if log_config.ask_questions && log_config.activate
+          say("Log file configuration updated.")
+          say("The appliance may take a few minutes to fully restart.")
+          press_any_key
+        else
+          say("Log file configuration unchanged")
           press_any_key
           raise MiqSignalError
         end

--- a/gems/pending/appliance_console/locales/appliance/en.yml
+++ b/gems/pending/appliance_console/locales/appliance/en.yml
@@ -14,6 +14,7 @@ en:
     - db_config
     - db_replication
     - db_maintenance
+    - log_config
     - failover_monitor
     - httpdauth
     - extauth_opts
@@ -34,6 +35,7 @@ en:
     db_config: Configure Database
     db_replication: Configure Database Replication
     db_maintenance: Configure Database Maintenance
+    log_config: Logfile Configuration
     failover_monitor: Configure Application Database Failover Monitor
     httpdauth: Configure External Authentication (httpd)
     extauth_opts: Update External Authentication Options

--- a/gems/pending/appliance_console/logfile_configuration.rb
+++ b/gems/pending/appliance_console/logfile_configuration.rb
@@ -1,0 +1,65 @@
+require 'linux_admin'
+require 'pathname'
+require 'fileutils'
+require 'appliance_console/logical_volume_management'
+require 'appliance_console/prompts'
+
+module ApplianceConsole
+  class LogfileConfiguration
+    LOGFILE_DIRECTORY = Pathname.new("/var/www/miq/vmdb/log").freeze
+    LOGFILE_NAME = "miq_logs".freeze
+
+    attr_accessor :disk
+
+    include ApplianceConsole::Logging
+
+    def activate
+      stop_evm
+      initialize_logfile_disk
+      start_evm
+    end
+
+    def ask_questions
+      clear_screen
+      return false unless use_new_disk
+      choose_disk
+      confirm_selection
+    end
+
+    private
+
+    def confirm_selection
+      agree("Continue with disk: #{disk.path}: #{disk.size.to_i / 1.megabyte} MB (Y/N):")
+    end
+
+    def use_new_disk
+      agree("Configure a new logfile disk volume? (Y/N):")
+    end
+
+    def choose_disk
+      self.disk = ask_for_disk("logfile disk")
+    end
+
+    def initialize_logfile_disk
+      say 'Initializing logfile disk'
+      LogicalVolumeManagement.new(:disk => disk, :mount_point => LOGFILE_DIRECTORY, :name => LOGFILE_NAME).setup
+
+      FileUtils.mkdir_p("#{LOGFILE_DIRECTORY}/apache")
+      AwesomeSpawn.run!('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
+      AwesomeSpawn.run!("/sbin/restorecon -R -v #{LOGFILE_DIRECTORY.to_path}") if File.executable?("/sbin/restorecon")
+      true
+    end
+
+    def start_evm
+      say 'Starting EVM'
+      LinuxAdmin::Service.new("evmserverd").enable.start
+      LinuxAdmin::Service.new("httpd").enable.start
+    end
+
+    def stop_evm
+      say 'Stopping EVM'
+      LinuxAdmin::Service.new("evmserverd").stop
+      LinuxAdmin::Service.new("httpd").stop
+    end
+  end
+end

--- a/gems/pending/appliance_console/logical_volume_management.rb
+++ b/gems/pending/appliance_console/logical_volume_management.rb
@@ -1,0 +1,93 @@
+require 'linux_admin'
+require 'fileutils'
+require 'appliance_console/logging'
+
+module ApplianceConsole
+  class LogicalVolumeManagement
+    include ApplianceConsole::Logging
+
+    # Required instantiation parameters
+    attr_accessor :disk, :mount_point, :name
+
+    # Derived or optionally provided instantiation parameters
+    attr_accessor :volume_group_name, :filesystem_type, :logical_volume_path
+
+    # Logical Disk creation objects
+    attr_reader :logical_volume, :partition, :physical_volume, :volume_group
+
+    def initialize(options = {})
+      # Required instantiation parameters
+      self.disk        = options[:disk]        || raise(ArgumentError, "disk object required")
+      self.mount_point = options[:mount_point] || raise(ArgumentError, "mount point required")
+      self.name        = options[:name]        || raise(ArgumentError, "unique name required")
+
+      # Derived or optionally provided instantiation parameters
+      self.volume_group_name   ||= "vg_#{name}"
+      self.filesystem_type     ||= "xfs"
+      self.logical_volume_path ||= "/dev/#{volume_group_name}/lv_#{name}"
+    end
+
+    # Helper method
+    def setup
+      create_partition_to_fill_disk
+      create_physical_volume
+      create_volume_group
+      create_logical_volume_to_fill_volume_group
+      format_logical_volume
+      mount_disk
+      update_fstab
+    end
+
+    private
+
+    def create_partition_to_fill_disk
+      disk.create_partition_table
+      AwesomeSpawn.run!("parted -s #{disk.path} mkpart primary 0% 100%")
+
+      self.disk = LinuxAdmin::Disk.local.find { |d| d.path == disk.path }
+      @partition = disk.partitions.first
+    end
+
+    def create_physical_volume
+      @physical_volume = LinuxAdmin::PhysicalVolume.create(partition)
+    end
+
+    def create_volume_group
+      @volume_group = LinuxAdmin::VolumeGroup.create(volume_group_name, physical_volume)
+    end
+
+    def create_logical_volume_to_fill_volume_group
+      @logical_volume = LinuxAdmin::LogicalVolume.create(logical_volume_path, volume_group, 100)
+    end
+
+    def format_logical_volume
+      AwesomeSpawn.run!("mkfs.#{filesystem_type} #{logical_volume.path}")
+    end
+
+    def mount_disk
+      if mount_point.symlink?
+        FileUtils.rm_rf(mount_point)
+        FileUtils.mkdir_p(mount_point)
+      end
+      AwesomeSpawn.run!("mount", :params => {"-t" => filesystem_type,
+                                             nil  => [logical_volume.path, mount_point]})
+    end
+
+    def update_fstab
+      fstab = LinuxAdmin::FSTab.instance
+      return if fstab.entries.find { |e| e.mount_point == mount_point }
+
+      entry = LinuxAdmin::FSTabEntry.new(
+        :device        => logical_volume.path,
+        :mount_point   => mount_point,
+        :fs_type       => filesystem_type,
+        :mount_options => "rw,noatime",
+        :dumpable      => 0,
+        :fsck_order    => 0
+      )
+
+      fstab.entries << entry
+      fstab.write! # Test this more, whitespace is removed
+    end
+  end
+end

--- a/gems/pending/spec/appliance_console/logfile_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/logfile_configuration_spec.rb
@@ -1,0 +1,51 @@
+require "appliance_console/logfile_configuration"
+
+describe ApplianceConsole::LogfileConfiguration do
+  before do
+    @spec_name = File.basename(__FILE__).split(".rb").first.freeze
+    allow(LinuxAdmin::Service).to receive(:new).and_return(double(@spec_name, :running? => false))
+    allow(subject).to receive(:clear_screen)
+    allow(subject).to receive(:say)
+  end
+
+  describe "#ask_questions" do
+    it "returns true when user confirms a new disk" do
+      expect(subject).to receive(:agree).and_return(true).twice
+      expect(subject).to receive(:ask_for_disk).and_return(double(:@spec_name, :size => "22", :path => "fake disk"))
+      expect(subject.ask_questions).to be true
+    end
+
+    it "returns false when user does not confirm a new disk" do
+      expect(subject).to receive(:agree).and_return(false)
+      expect(subject).to_not receive(:ask_for_disk)
+      expect(subject.ask_questions).to be false
+    end
+
+    it "returns false when user does not confirm the selection" do
+      expect(subject).to receive(:agree).with("Configure a new logfile disk volume? (Y/N):").and_return(true)
+      expect(subject).to receive(:agree).with(/Continue with disk:/).and_return(false)
+      expect(subject).to receive(:ask_for_disk).and_return(double(:@spec_name, :size => "22", :path => "fake disk"))
+
+      expect(subject.ask_questions).to be false
+    end
+  end
+
+  describe "#activate" do
+    it "stops and starts evm and configures the logfile disk" do
+      expect(ApplianceConsole::LogicalVolumeManagement).to receive(:new).and_return(double(@spec_name, :setup => true))
+
+      expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
+      expect(AwesomeSpawn).to receive(:run!)
+        .with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
+      expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
+
+      expect(FileUtils).to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
+      expect(LinuxAdmin::Service).to receive(:new)
+        .and_return(double(@spec_name, :stop => nil)).twice
+      expect(LinuxAdmin::Service).to receive(:new)
+        .and_return(double(@spec_name, :enable => double(@spec_name, :start => true))).twice
+
+      expect(subject.activate).to be true
+    end
+  end
+end

--- a/gems/pending/spec/appliance_console/logical_volume_management_spec.rb
+++ b/gems/pending/spec/appliance_console/logical_volume_management_spec.rb
@@ -1,0 +1,115 @@
+require 'appliance_console/logical_volume_management'
+require 'pathname'
+require 'tmpdir'
+
+describe ApplianceConsole::LogicalVolumeManagement do
+  before do
+    @spec_name = File.basename(__FILE__).split(".rb").first
+    @disk_double = double(@spec_name, :path => "/dev/vtest")
+    @config = described_class.new(:disk => @disk_double, :mount_point => "/mount_point", :name => "test")
+  end
+
+  describe ".new" do
+    it "ensures required disk option is provided" do
+      expect { described_class.new(:mount_point => "/mount_point", :name => "test") }.to raise_error(ArgumentError)
+    end
+
+    it "ensures required mount_point option is provided" do
+      expect { described_class.new(:disk => @disk_double, :name => "test") }.to raise_error(ArgumentError)
+    end
+
+    it "ensures required name option is provided" do
+      expect do
+        described_class.new(:disk => @disk_double, :mount_point => "/mount_point")
+      end.to raise_error(ArgumentError)
+    end
+
+    it "sets derived and default instance variables automatically" do
+      expect(@config.volume_group_name).to eq("vg_test")
+      expect(@config.filesystem_type).to eq("xfs")
+      expect(@config.logical_volume_path).to eq("/dev/vg_test/lv_test")
+    end
+  end
+
+  describe "#setup" do
+    before do
+      expect(@disk_double).to receive(:create_partition_table)
+      expect(@disk_double).to receive(:partitions).and_return([:fake_partition])
+      @config.disk = @disk_double
+
+      @fstab = double(@spec_name)
+      allow(@fstab).to receive_messages(:entries => [])
+      allow(LinuxAdmin::FSTab).to receive_messages(:instance => @fstab)
+
+      expect(AwesomeSpawn).to receive(:run!).with("parted -s /dev/vtest mkpart primary 0% 100%")
+      expect(AwesomeSpawn).to receive(:run!).with("mkfs.#{@config.filesystem_type} /dev/vg_test/lv_test")
+      expect(LinuxAdmin::Disk).to receive(:local).and_return([@disk_double])
+      expect(LinuxAdmin::PhysicalVolume).to receive(:create).and_return(:fake_physical_volume)
+      expect(LinuxAdmin::VolumeGroup).to receive(:create).and_return(:fake_volume_group)
+      expect(FileUtils).to_not receive(:rm_rf).with(@config.mount_point)
+
+      @fake_logical_volume = double(@spec_name, :path => "/dev/vg_test/lv_test")
+      expect(LinuxAdmin::LogicalVolume).to receive(:create).and_return(@fake_logical_volume)
+    end
+
+    after do
+      FileUtils.rm_f(@tmp_mount_point)
+      FileUtils.rm_f(@config.mount_point)
+    end
+
+    it "sets up the logical disk when mount point is not a symbolic link" do
+      @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
+      expect(@fstab).to receive(:write!)
+      expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
+      expect(AwesomeSpawn).to receive(:run!)
+        .with("mount",
+              :params => {"-t" => @config.filesystem_type, nil => ["/dev/vg_test/lv_test", @config.mount_point]})
+
+      @config.setup
+      expect(@config.partition).to eq(:fake_partition)
+      expect(@config.physical_volume).to eq(:fake_physical_volume)
+      expect(@config.volume_group).to eq(:fake_volume_group)
+      expect(@config.logical_volume).to eq(@fake_logical_volume)
+      expect(@fstab.entries.count).to eq(1)
+    end
+
+    it "recreates the new mount point and sets up the logical disk when mount point is a symbolic link" do
+      @tmp_mount_point = Pathname.new(Dir.mktmpdir)
+      @config.mount_point = Pathname.new("#{Dir.tmpdir}/#{@spec_name}")
+      FileUtils.ln_s(@tmp_mount_point, @config.mount_point)
+      expect(@fstab).to receive(:write!)
+
+      expect(FileUtils).to receive(:rm_rf).with(@config.mount_point)
+      expect(FileUtils).to receive(:mkdir_p).with(@config.mount_point)
+      expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
+      expect(AwesomeSpawn).to receive(:run!)
+        .with("mount",
+              :params => {"-t" => @config.filesystem_type, nil => ["/dev/vg_test/lv_test", @config.mount_point]})
+      @config.setup
+      expect(@config.partition).to eq(:fake_partition)
+      expect(@config.physical_volume).to eq(:fake_physical_volume)
+      expect(@config.volume_group).to eq(:fake_volume_group)
+      expect(@config.logical_volume).to eq(@fake_logical_volume)
+      expect(@fstab.entries.count).to eq(1)
+    end
+
+    it "skips update if mount point is in fstab when mount point is in already fstab" do
+      @tmp_mount_point = @config.mount_point = Pathname.new(Dir.mktmpdir)
+      expect(FileUtils).to_not receive(:mkdir_p).with(@config.mount_point)
+      expect(AwesomeSpawn).to receive(:run!)
+        .with("mount",
+              :params => {"-t" => @config.filesystem_type, nil => ["/dev/vg_test/lv_test", @config.mount_point]})
+      allow(@fstab).to receive_messages(:entries => [double(@spec_name, :mount_point => @config.mount_point)])
+      expect(@fstab).to receive(:write!).never
+      allow(LinuxAdmin::FSTab).to receive_messages(:instance => @fstab)
+
+      @config.setup
+
+      expect(@config.partition).to eq(:fake_partition)
+      expect(@config.physical_volume).to eq(:fake_physical_volume)
+      expect(@config.volume_group).to eq(:fake_volume_group)
+      expect(@config.logical_volume).to eq(@fake_logical_volume)
+      expect(@fstab.entries.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This Pull Requests adds functionality to the appliance_console enabling the configuration of an additional, likely larger, disk for storing EVM `.log` files. This change will eventually allow customers to save more older logfile rotations.

No attempt is made to repurpose the storage that had been targeted for `.log` file storage This approach was approved by John Hardy.

# Two new classes are introduced: 

- `LogfileConfiguration`
- `LogicalDiskVolume`

_**class `LogfileConfiguration`**_ manages the configuration of a new logfile disk.

In the near future additional functionality will be added. For example to allow the user to specify how many logrotations can be saved beyond the current default of 2 weeks, for 14 daily rotations.

_**class `LogicalDiskVolume`**_ is simply a minor refactoring of code moved from the existing class, `InternalDatabaseConfiguration`.

This will allow the code to be shared with class `LogfileConfiguration`

# Two new spec files are introduced

- `gems/pending/spec/appliance_console/logical_disk_volume_spec.rb`
- `gems/pending/spec/appliance_console/logfile_configuration_spec.rb`

These will  exercise the two new classes  `LogfileConfiguration` and `LogicalDiskVolume`

The spec file `gems/pending/spec/appliance_console/logical_disk_volume_spec.rb` comprise test refactored from the existing `gems/pending/spec/appliance_console/internal_database_configuration_spec.rb` and more extensive tests.

Links
------

* https://www.pivotaltracker.com/n/projects/1608513/stories/126710021
