### PR TITLE
Update chat links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cloud environments.  It has the following feature sets:
 ## Learn more
 
 *  [**Read** developer guides](https://github.com/ManageiQ/guides)
-*  **Chat** with contributors on [irc.freenode.net \#manageiq](http://manageiq.org/community/irc/) or [Gitter](https://gitter.im/ManageIQ/manageiq)
+*  [**Chat** with contributors on Gitter](https://gitter.im/ManageIQ/manageiq)
 *  [**File or view bug reports and feature requests** using Issues on Github](https://github.com/ManageIQ/manageiq/issues?state=open)
 *  [**Ask** questions of ManageIQ experts](http://talk.manageiq.org/)
 *  [**Discuss** ManageIQ with developers and power users](http://talk.manageiq.org/)


### PR DESCRIPTION
The IRC link is a 404 (new site, I imagine) but more importantly we really don't use IRC at all, even if many of us are still in the room. We really use Gitter, and anyone looking for help should go there and not IRC.