### PR TITLE
Fix unique constraint failure when configuring a pglogical provider node

### DIFF
--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -41,9 +41,11 @@ class MiqPglogical
   #   node and creating the replication set
   def configure_provider
     return if provider?
-    pglogical.enable
-    create_node unless node?
-    create_replication_set
+    @connection.transaction(:requires_new => true) do
+      pglogical.enable
+      create_node unless node?
+      create_replication_set
+    end
   end
 
   # Removes the replication configuration and pglogical node from the

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -25,6 +25,12 @@ describe MiqPglogical do
       expect(pglogical.enabled?).to be true
       expect(pglogical.replication_sets).to include(described_class::REPLICATION_SET_NAME)
     end
+
+    it "does not enable the extension when an exception is raised" do
+      expect(subject).to receive(:create_replication_set).and_raise(PG::UniqueViolation)
+      expect { subject.configure_provider }.to raise_error(PG::UniqueViolation)
+      expect(pglogical.enabled?).to be false
+    end
   end
 
   context "when configured as a provider" do

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -99,6 +99,11 @@ describe MiqPglogical do
         subject.refresh_excludes
         expect(subject.included_tables).to include(table)
       end
+
+      it "continues if we attempt to add a table twice" do
+        expect(subject).to receive(:newly_included_tables).and_return([subject.included_tables.first])
+        expect { subject.refresh_excludes }.not_to raise_error
+      end
     end
   end
 

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -5,69 +5,94 @@ describe MiqPglogical do
   before do
     skip "pglogical must be installed" unless pglogical.installed?
     MiqServer.seed
-    subject.configure_provider
   end
 
   describe "#provider?" do
-    it "is true when a provider is configured" do
-      expect(subject.provider?).to be true
+    it "is false when a provider is not configured" do
+      expect(subject.provider?).to be false
     end
   end
 
   describe "#node?" do
-    it "is true when a provider is configured" do
-      expect(subject.node?).to be true
-    end
-  end
-
-  describe "#destroy_provider" do
-    it "removes the provider configuration" do
-      subject.destroy_provider
-      expect(subject.provider?).to be false
+    it "is false when a provider is not configured" do
       expect(subject.node?).to be false
-      expect(connection.extension_enabled?("pglogical")).to be false
     end
   end
 
-  describe "#create_replication_set" do
-    it "creates the correct initial set" do
-      expected_excludes = subject.configured_excludes
-      actual_excludes = connection.tables - subject.included_tables
-      expect(actual_excludes).to match_array(expected_excludes)
+  describe "#configure_provider" do
+    it "enables the extenstion and creates the replication set" do
+      subject.configure_provider
+      expect(pglogical.enabled?).to be true
+      expect(pglogical.replication_sets).to include(described_class::REPLICATION_SET_NAME)
     end
   end
 
-  describe "#refresh_excludes" do
-    it "adds a new non excluded table" do
-      connection.exec_query(<<-SQL)
-        CREATE TABLE test (id INTEGER PRIMARY KEY)
-      SQL
-      subject.refresh_excludes
-      expect(subject.included_tables).to include("test")
+  context "when configured as a provider" do
+    before do
+      subject.configure_provider
     end
 
-    it "removes a newly excluded table" do
-      table = subject.included_tables.first
-      new_excludes = subject.configured_excludes << table
-
-      c = MiqServer.my_server.get_config
-      c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
-      c.save
-
-      subject.refresh_excludes
-      expect(subject.included_tables).not_to include(table)
+    describe "#provider?" do
+      it "is true" do
+        expect(subject.provider?).to be true
+      end
     end
 
-    it "adds a newly included table" do
-      table = subject.configured_excludes.last
-      new_excludes = subject.configured_excludes - [table]
+    describe "#node?" do
+      it "is true" do
+        expect(subject.node?).to be true
+      end
+    end
 
-      c = MiqServer.my_server.get_config
-      c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
-      c.save
+    describe "#destroy_provider" do
+      it "removes the provider configuration" do
+        subject.destroy_provider
+        expect(subject.provider?).to be false
+        expect(subject.node?).to be false
+        expect(connection.extension_enabled?("pglogical")).to be false
+      end
+    end
 
-      subject.refresh_excludes
-      expect(subject.included_tables).to include(table)
+    describe "#create_replication_set" do
+      it "creates the correct initial set" do
+        expected_excludes = subject.configured_excludes
+        actual_excludes = connection.tables - subject.included_tables
+        expect(actual_excludes).to match_array(expected_excludes)
+      end
+    end
+
+    describe "#refresh_excludes" do
+      it "adds a new non excluded table" do
+        connection.exec_query(<<-SQL)
+          CREATE TABLE test (id INTEGER PRIMARY KEY)
+        SQL
+        subject.refresh_excludes
+        expect(subject.included_tables).to include("test")
+      end
+
+      it "removes a newly excluded table" do
+        table = subject.included_tables.first
+        new_excludes = subject.configured_excludes << table
+
+        c = MiqServer.my_server.get_config
+        c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
+        c.save
+
+        subject.refresh_excludes
+        expect(subject.included_tables).not_to include(table)
+      end
+
+      it "adds a newly included table" do
+        table = subject.configured_excludes.last
+        new_excludes = subject.configured_excludes - [table]
+
+        c = MiqServer.my_server.get_config
+        c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
+        c.save
+
+        subject.refresh_excludes
+        expect(subject.included_tables).to include(table)
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes two issues encountered when a unique constraint failure is raised when adding tables to the replication set:
  1. We still report the region as a replication "remote" type (`MiqRegion.replication_type`) in the UI
    - This may not be strictly true because we could have not added some tables to the replication set that need to be added
    - This is fixed by configuring the provider node in a transaction and rolling back when one of the pieces fails (enabling the extension, creating the replication set, or adding the tables)
  2. We can ignore unique constraint failures when adding tables to the replication set because that means that they have already been added successfully.
    - Ideally we would not attempt to add the tables again, so we will continue to log these as warning messages, but will allow the process to continue configuration until we can track down the root cause of the issue.

@gtanzillo please review

https://bugzilla.redhat.com/show_bug.cgi?id=1380475