### PR TITLE
Fix typo in auth_key_pair_cloud route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,7 @@ Vmdb::Application.routes.draw do
         show
         show_list
         tagging_edit
-        tag_edit_form_field_changed,
+        tag_edit_form_field_changed
         ems_form_choices
       ) + compare_get,
       :post => %w(


### PR DESCRIPTION
We're in a %w(...) so the comma is not needed.

This was added in 3580a50186c5939e0ebac882c1f546235bfb580a.

**Before**:

    $ bin/rake routes |grep "auth_key_pair_cloud\/tag_edit_form_field_changed"
    GET     /auth_key_pair_cloud/tag_edit_form_field_changed,(/:id)(.:format)          auth_key_pair_cloud#tag_edit_form_field_changed,
    POST    /auth_key_pair_cloud/tag_edit_form_field_changed(/:id)(.:format)           auth_key_pair_cloud#tag_edit_form_field_changed

**After**:

    $ bin/rake routes |grep "auth_key_pair_cloud\/tag_edit_form_field_changed"
    GET     /auth_key_pair_cloud/tag_edit_form_field_changed(/:id)(.:format)           auth_key_pair_cloud#tag_edit_form_field_changed
    POST    /auth_key_pair_cloud/tag_edit_form_field_changed(/:id)(.:format)           auth_key_pair_cloud#tag_edit_form_field_changed


Seen with the code climate browser extension:

![image](https://cloud.githubusercontent.com/assets/19339/19487573/730cc692-9531-11e6-950c-3111880bda79.png)


@AparnaKarve Please review.  I think this needs euwe since #9466 is in euwe