### PR TITLE
textual_ems is defined twice with the same body.  :scissors:

### DIFF
--- a/app/helpers/cloud_object_store_object_helper/textual_summary.rb
+++ b/app/helpers/cloud_object_store_object_helper/textual_summary.rb
@@ -34,10 +34,6 @@ module CloudObjectStoreObjectHelper::TextualSummary
     @record.etag
   end
 
-  def textual_ems
-    textual_link(@record.ext_management_system)
-  end
-
   def textual_cloud_tenant
     cloud_tenant = @record.cloud_tenant if @record.respond_to?(:cloud_tenant)
     label = ui_lookup(:table => "cloud_tenant")


### PR DESCRIPTION
Seen with:
rubocop --only Lint/DuplicateMethods

The original definition is on line 17.