### PR TITLE
Don't expand actions in action results, expand for bulk queries

### DIFF
--- a/app/controllers/api/base_controller/generic.rb
+++ b/app/controllers/api/base_controller/generic.rb
@@ -72,7 +72,8 @@ module Api
         opts = {
           :name             => type.to_s,
           :is_subcollection => false,
-          :expand_resources => true
+          :expand_resources => true,
+          :expand_actions   => true
         }
         resource_to_jbuilder(type, type, resource, opts).attributes!
       end

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -6,7 +6,7 @@ module Api
       #
       def render_collection_type(type, id, is_subcollection = false)
         klass = collection_class(type)
-        opts  = {:name => type.to_s, :is_subcollection => is_subcollection}
+        opts  = {:name => type.to_s, :is_subcollection => is_subcollection, :expand_actions => true}
         if id
           render_resource type, resource_search(id, type, klass), opts
         else
@@ -83,7 +83,7 @@ module Api
           expand_subcollections(json, type, resource)
         end
 
-        expand_actions(resource, json, type, opts)
+        expand_actions(resource, json, type, opts) if opts[:expand_actions]
         expand_resource_custom_actions(resource, json, type)
         json
       end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -489,6 +489,28 @@ describe "Rest API Collections" do
       test_collection_bulk_query(:vms, vms_url, Vm)
     end
 
+    it "doing a bulk query renders actions for which the user is authorized" do
+      vm = FactoryGirl.create(:vm_vmware)
+      api_basic_authorize(collection_action_identifier(:vms, :query), action_identifier(:vms, :start))
+
+      run_post(vms_url, gen_request(:query, [{"id" => vm.id, "href" => vms_url(vm.id)}]))
+
+      expected = {
+        "results" => [
+          a_hash_including(
+            "actions" => [
+              a_hash_including(
+                "name"   => "start",
+                "method" => "post",
+                "href"   => a_string_matching(vms_url(vm.id))
+              )
+            ]
+          )
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "bulk query Vms with invalid guid fails" do
       FactoryGirl.create(:vm_vmware)
       api_basic_authorize collection_action_identifier(:vms, :query)

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -251,6 +251,7 @@ module Spec
         expected["href"] = a_string_matching(options[:href]) if options[:href]
         expected.merge!(expected_task_response) if options[:task]
         expect(response.parsed_body).to include(expected)
+        expect(response.parsed_body).not_to include("actions")
       end
 
       def expect_multiple_action_result(count, options = {})


### PR DESCRIPTION
I did a bad refactoring back in
https://github.com/ManageIQ/manageiq/pull/11512. In that PR, I reasoned
that in `#get_aspecs` (see
[here](https://github.com/ManageIQ/manageiq/blob/c08abf4b3ded3c082e65301634aa86d4f555a26d/app/controllers/api_controller/renderer.rb#L110-L129)),
the controller would never respond to `typed_actions` (unless one such
method was created in the future), so this path could be removed. What I
failed to see was some implicit knowledge about how actions are
rendered:

1. `typed_actions` comes from the `:resource_actions` option, which is
set in `#render_collection_type`.
2. The *presence* of that argument decided whether `#get_aspecs` should
return anything.
3. Action results don't originate from `#render_collection_type`, since
they are a type of `POST` (`#render_collection_type` is called from
`#show`).
4. Hence, action results shouldn't expand actions.

The solution tries to make that knowledge more explicit by adding an
`:expand_actions` option, defaulting to false and set to `true` for
GETs, which should restore the original behavior.

@miq-bot add-label bug, api, euwe/yes
@miq-bot assign @abellotti 