### PR TITLE
Don't consider tables that are always excluded during the schema check

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -152,8 +152,8 @@ class EvmDatabase
     end
 
     def check_schema_tables(connection)
-      current_tables  = current_schema(connection).keys
-      expected_tables = expected_schema.keys
+      current_tables  = current_schema(connection).keys - MiqPglogical::ALWAYS_EXCLUDED_TABLES
+      expected_tables = expected_schema.keys - MiqPglogical::ALWAYS_EXCLUDED_TABLES
 
       return if current_tables == expected_tables
 


### PR DESCRIPTION
This was causing pglogical to complain about the repmgr tables when a remote region was using HA and we tried to compare the schemas for compatibility.

https://bugzilla.redhat.com/show_bug.cgi?id=1385176

Builds on https://github.com/ManageIQ/manageiq/pull/11959

@gtanzillo please review
