### PR TITLE
Uses parent deployment status for subdeployments.

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -374,8 +374,8 @@ module ManageIQ::Providers
       )
     end
 
-    def build_metric_id(type, resource, metric_id)
-      "#{type}I~R~[#{resource[:middleware_server][:feed]}/#{resource[:nativeid]}]~#{type}T~#{metric_id}"
+    def build_availability_metric_id(feed_id, resource_id, metric_id)
+      "AI~R~[#{feed_id}/#{resource_id}]~AT~#{metric_id}"
     end
 
     def self.update_alert(*args)

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -91,10 +91,10 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
   describe 'parse_availability' do
     it 'handles simple data' do
       resources_by_metric_id = {
-        'resource_id_1' => {},
-        'resource_id_2' => {},
-        'resource_id_3' => {},
-        'resource_id_4' => {},
+        'resource_id_1' => [{}],
+        'resource_id_2' => [{}, {}],
+        'resource_id_3' => [{}],
+        'resource_id_4' => [{}]
       }
       availabilities = [
         {
@@ -116,18 +116,23 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
       ]
 
       parsed_resources_with_availability = {
-        'resource_id_1' => {
+        'resource_id_1' => [{
           :status => 'Enabled'
-        },
-        'resource_id_2' => {
+        }],
+        'resource_id_2' => [
+          {
           :status => 'Disabled'
-        },
-        'resource_id_3' => {
+          },
+          {
+            :status => 'Disabled'
+          }
+        ],
+        'resource_id_3' => [{
           :status => 'Unknown'
-        },
-        'resource_id_4' => {
+        }],
+        'resource_id_4' => [{
           :status => 'Unknown'
-        }
+        }]
       }
       expect(parser.send(:parse_availability,
                          availabilities,
@@ -135,10 +140,10 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
     end
     it 'handles missing metrics' do
       resources_by_metric_id = {
-        'resource_id_1' => {},
-        'resource_id_2' => {},
-        'resource_id_3' => {},
-        'resource_id_4' => {},
+        'resource_id_1' => [{}],
+        'resource_id_2' => [{}],
+        'resource_id_3' => [{}],
+        'resource_id_4' => [{}],
       }
       availabilities = [
         {
@@ -148,18 +153,18 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
       ]
 
       parsed_resources_with_availability = {
-        'resource_id_1' => {
+        'resource_id_1' => [{
           :status => 'Enabled'
-        },
-        'resource_id_2' => {
+        }],
+        'resource_id_2' => [{
           :status => 'Unknown'
-        },
-        'resource_id_3' => {
+        }],
+        'resource_id_3' => [{
           :status => 'Unknown'
-        },
-        'resource_id_4' => {
+        }],
+        'resource_id_4' => [{
           :status => 'Unknown'
-        }
+        }]
       }
       expect(parser.send(:parse_availability,
                          availabilities,


### PR DESCRIPTION

![screenshot from 2016-10-18 17-26-04](https://cloud.githubusercontent.com/assets/3845764/19498692/0baa2f40-9558-11e6-8c2f-85567ee4fd47.png)


Subdeployment status was showing as 'Unknown'.
This is because the subdeployments don't have any status attribute, thus no availability metric for them.

To fix this, the subdeployments now show the availability of its parent.

https://bugzilla.redhat.com/show_bug.cgi?id=1384118