### PR TITLE
Add private_class_method to fix lint warnings

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -476,6 +476,7 @@ class Classification < ApplicationRecord
       ent ? ent.update_attributes(entry) : cat.add_entry(entry)
     end
   end
+  private_class_method :add_entries_from_hash
 
   def validate_uniqueness_on_tag_name
     tag = find_tag
@@ -494,6 +495,8 @@ class Classification < ApplicationRecord
     end
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.name2tag(name, parent_id = 0, ns = DEFAULT_NAMESPACE)
     if parent_id == 0
       File.join(ns, name)

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -262,6 +262,7 @@ class EmsEvent < EventStream
     new_event.handle_event if new_event
     new_event
   end
+  private_class_method :create_event
 
   def self.create_completed_event(event, orig_task = nil)
     if orig_task.nil?
@@ -318,6 +319,7 @@ class EmsEvent < EventStream
       create_event(new_event)
     end
   end
+  private_class_method :create_completed_event
 
   def get_refresh_target(target_type)
     m = "#{target_type}_refresh_target"

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -103,6 +103,8 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
     connection_options
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.cinder_connection_options(cloud_tenant = nil)
     connection_options = {:service => "Volume"}
     connection_options.merge!(:tenant_name => cloud_tenant.name) if cloud_tenant

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -272,10 +272,14 @@ module ManageIQ::Providers
       return uid, quota
     end
 
+    # FIXME: The intention was to make this method private but tests or code called
+    # from the tests are expecting it to be public.
     def self.key_pair_type
       'ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair'
     end
 
+    # FIXME: The intention was to make this method private but tests or code called
+    # from the tests are expecting it to be public.
     def self.miq_template_type
       "ManageIQ::Providers::Openstack::CloudManager::Template"
     end

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -379,6 +379,8 @@ module ManageIQ
         obj.body
       end
 
+      # FIXME: The intention was to make this method private but tests or code called
+      # from the tests are expecting it to be public.
       def self.miq_template_type
         "ManageIQ::Providers::Openstack::InfraManager::Template"
       end

--- a/app/models/miq_compare.rb
+++ b/app/models/miq_compare.rb
@@ -164,6 +164,7 @@ class MiqCompare
       end
     end
   end
+  private_class_method :build_sections
 
   # Add an include section to the final collected all_sections hash provided
   def self.build_section(all_sections, name, key = nil, group = nil)
@@ -172,6 +173,7 @@ class MiqCompare
     all_sections[name][:key] = key.empty? ? key : key.to_sym unless key.nil?
     all_sections[name][:group] = group unless group.blank?
   end
+  private_class_method :build_section
 
   def section_header_text(model)
     case model

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -490,6 +490,7 @@ class MiqQueue < ApplicationRecord
       :zone       => Zone.determine_queue_zone(options)
     )
   end
+  private_class_method :default_get_options
 
   # when searching miq_queue, we often want to see if a key is nil, or a particular value
   # given a set of keys, modify the params to have those values
@@ -505,6 +506,7 @@ class MiqQueue < ApplicationRecord
     end
     options
   end
+  private_class_method :optional_values
 
   def destroy_potentially_stale_record
     destroy

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -165,6 +165,8 @@ class OrchestrationTemplate < ApplicationRecord
     super
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.calc_md5(text)
     Digest::MD5.hexdigest(text) if text
   end
@@ -173,6 +175,8 @@ class OrchestrationTemplate < ApplicationRecord
     self.class.calc_md5(text)
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.with_universal_newline(text)
     # ensure universal new lines and content ending with a new line
     text.encode(:universal_newline => true).chomp.concat("\n")

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -76,6 +76,8 @@ class RssFeed < ApplicationRecord
 
   private
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.eval_item_attr(script, rec)
     _ = rec # used by eval
     if script.starts_with?("<script>", "<SCRIPT>")
@@ -112,6 +114,8 @@ class RssFeed < ApplicationRecord
     end
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.sync_from_yml_file(name)
     file = RssFeed.yml_file_name(name)
     yml = YAML.load(File.read(file)).symbolize_keys
@@ -138,10 +142,14 @@ class RssFeed < ApplicationRecord
     rec.tag_add(yml[:roles], :ns => "/managed", :cat => "roles") unless yml[:roles].nil?
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.yml_file_name(name)
     File.join(YML_DIR, name + ".yml")
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.sync_from_yml_dir
     # Add missing feeds to model
     Dir.glob(File.join(YML_DIR, "*.yml")).each do |f|
@@ -156,6 +164,8 @@ class RssFeed < ApplicationRecord
     _log.log_backtrace(err)
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.seed
     sync_from_yml_dir
   end

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -162,14 +162,20 @@ class TimeProfile < ApplicationRecord
   end
 
   # TODO: use AR "or" here
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.for_user(user_id)
     where("profile_type = ? or (profile_type = ? and profile_key = ?)", "global", "user", user_id)
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.ordered_by_desc
     order("lower(description) ASC")
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.profiles_for_user(user_id, region_id)
     in_region(region_id)
       .for_user(user_id)
@@ -177,10 +183,14 @@ class TimeProfile < ApplicationRecord
       .ordered_by_desc
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.profile_for_user_tz(user_id, user_tz)
     TimeProfile.rollup_daily_metrics.detect { |tp| tp.match_user_tz?(user_id, user_tz) }
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   # @param tz [nil|TimeProfile|TimeZone] (default timezone "UTC")
   # @return [TimeProfile] time profile that uses this time zone
   def self.default_time_profile(tz = DEFAULT_TZ)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1882,4 +1882,5 @@ class VmOrTemplate < ApplicationRecord
   def self.arel_coalesce(values)
     Arel::Nodes::NamedFunction.new('COALESCE', values)
   end
+  private_class_method :arel_coalesce
 end

--- a/gems/pending/VolumeManager/LVM/scanner.rb
+++ b/gems/pending/VolumeManager/LVM/scanner.rb
@@ -86,14 +86,13 @@ module Lvm2Scanner
     pvh
   end # def self.labelScan
 
-  private
-
   def self.readLabel(d, s)
     d.seek(s * SECTOR_SIZE, IO::SEEK_SET)
     lh = readStruct(d, LABEL_HEADER)
     return lh if lh.lvm_id == LVM_ID
     nil
   end # def self.readLabel
+  private_class_method :readLabel
 
   def self.readPvHeader(d, lh)
     pvho = (lh.sector_xl * SECTOR_SIZE) + lh.offset_xl
@@ -122,6 +121,7 @@ module Lvm2Scanner
 
     pvh
   end # def self.readPvHeader
+  private_class_method :readPvHeader
 
   def self.readMdah(d, dlh)
     d.seek(dlh.offset, IO::SEEK_SET)
@@ -141,6 +141,7 @@ module Lvm2Scanner
 
     mdah
   end # def self.readMdah
+  private_class_method :readMdah
 
   def self.readRaw(d, rlh)
     osp = d.seekPos
@@ -149,8 +150,10 @@ module Lvm2Scanner
     d.seek(osp, IO::SEEK_SET)
     da
   end # def self.readRaw
+  private_class_method :readRaw
 
   def self.readStruct(d, struct)
     OpenStruct.new(struct.decode(d.read(struct.size)))
   end # def self.readStruct
+  private_class_method :readStruct
 end # module Lvm2Scanner

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -239,6 +239,7 @@ FRIENDLY
       new_settings["production"]["password"] = yield(pass) if pass
       new_settings
     end
+    private_class_method :encrypt_decrypt_password
 
     def self.load_current
       require 'yaml'
@@ -248,6 +249,7 @@ FRIENDLY
       end
       YAML.load_file(DB_YML)
     end
+    private_class_method :load_current
 
     def do_save(settings)
       require 'yaml'

--- a/gems/pending/db/MiqBdb/MiqBdbHash.rb
+++ b/gems/pending/db/MiqBdb/MiqBdbHash.rb
@@ -130,6 +130,8 @@ module MiqBerkeleyDB
       bucket + @header['spares'][MiqBdbHashDatabase.log2(bucket + 1)]
     end
 
+    # FIXME: The intention was to make this method private but tests or code called
+    # from the tests are expecting it to be public.
     def self.log2(num)
       limit = 1
       i = 0

--- a/gems/pending/disk/modules/MSCommon.rb
+++ b/gems/pending/disk/modules/MSCommon.rb
@@ -235,6 +235,7 @@ module MSCommon
     end
     header
   end
+  private_class_method :getHeader
 
   def self.verifyFooterCopy(footer)
     hdrLoc = getHiLo(footer, "data_offset")
@@ -242,12 +243,14 @@ module MSCommon
     footer_copy = FOOTER.decode(@file.read(FOOTER_LENGTH))
     puts "Footer copy does not match header." if footer_copy != @footer
   end
+  private_class_method :verifyFooterCopy
 
   def self.blockPos(pos)
     rawSectorNumber, byteOffset = pos.divmod(@blockSize)
     blockNumber, secInBlock = rawSectorNumber.divmod(@secPerBlock)
     return blockNumber, secInBlock, byteOffset
   end
+  private_class_method :blockPos
 
   def self.process_bae
     @file.seek(@batBase, IO::SEEK_SET)
@@ -256,20 +259,24 @@ module MSCommon
       @bae << @file.read(BAE_SIZE).unpack('N')[0]
     end
   end
+  private_class_method :process_bae
 
   def self.getBAE(blockNumber)
     @bae[blockNumber]
   end
+  private_class_method :getBAE
 
   def self.putBAE(blockNum, bae)
     seekBAE(blockNum)
     @file.write([bae].pack('N'), BAE_SIZE)
   end
+  private_class_method :putBAE
 
   def self.seekBAE(blockNum)
     batOffset = blockNum * BAE_SIZE + @batBase
     @file.seek(batOffset, IO::SEEK_SET)
   end
+  private_class_method :seekBAE
 
   def self.getAllocStatus(blockNum, sectorNum)
     sectorMask = seekAllocStatus(blockNum, sectorNum)
@@ -277,6 +284,7 @@ module MSCommon
     sectorBitmap = @file.read(1).unpack('C')[0]
     sectorBitmap & sectorMask == sectorMask
   end
+  private_class_method :getAllocStatus
 
   def self.setAllocStatus(blockNum, sectorNum)
     sectorMask = seekAllocStatus(blockNum, sectorNum)
@@ -285,6 +293,7 @@ module MSCommon
     @file.seek(-1, IO::SEEK_CUR)
     @file.write([sectorBitmap].pack('C'), 1)
   end
+  private_class_method :setAllocStatus
 
   def self.seekAllocStatus(blockNum, sectorNum)
     sectorByte, bitOffset = sectorNum.divmod(8)
@@ -293,10 +302,12 @@ module MSCommon
     @file.seek(bae * @blockSize + sectorByte, IO::SEEK_SET)
     0x80 >> bitOffset
   end
+  private_class_method :seekAllocStatus
 
   def self.getAbsSectorLoc(blockNum, sectorNum)
     getBAE(blockNum) * @blockSize + sectorNum * @blockSize + @blockSectorBitmapByteCount
   end
+  private_class_method :getAbsSectorLoc
 
   def self.allocSector(blockNum, sectorNum, pos, parent)
     allocBlock(blockNum) if getBAE(blockNum) == BLOCK_NOT_ALLOCATED
@@ -310,6 +321,7 @@ module MSCommon
     @file.seek(getAbsSectorLoc(blockNum, sectorNum), IO::SEEK_SET)
     @file.write(buf, buf.size)
   end
+  private_class_method :allocSector
 
   def self.allocBlock(blockNum)
     # Alloc block.
@@ -325,6 +337,7 @@ module MSCommon
     @file.seek(pos, IO::SEEK_SET)
     @file.write(@footerBuf, @footerBuf.size)
   end
+  private_class_method :allocBlock
 
   def self.findFreeSector
     # Find a free disk sector with which to start a new block.
@@ -339,6 +352,7 @@ module MSCommon
     raise "Disk full." if @freeSector > d_size_common / @blockSize
     @freeSector
   end
+  private_class_method :findFreeSector
 
   def self.checksum(buf, skip_offset)
     csum = 0
@@ -349,4 +363,5 @@ module MSCommon
     # GRRRRR - convert to actual 32-bits.
     [~csum].pack('L').unpack('L')[0]
   end
+  private_class_method :checksum
 end # module

--- a/gems/pending/metadata/VmConfig/VmConfig.rb
+++ b/gems/pending/metadata/VmConfig/VmConfig.rb
@@ -859,6 +859,7 @@ class VmConfig
     return nil if value.blank?
     value
   end
+  private_class_method :eval_config
 
   def normalize_file_paths(config_file = @configFile)
     @cfgHash.each_pair do |k, v|

--- a/gems/pending/util/miq-password.rb
+++ b/gems/pending/util/miq-password.rb
@@ -174,8 +174,6 @@ EOS
     end
   end
 
-  protected
-
   def self.ez_load(filename, recent = true)
     return filename if filename.respond_to?(:decrypt64)
 
@@ -191,10 +189,12 @@ EOS
       CryptString.new(nil, params[:algorithm], params[:key], params[:iv])
     end
   end
+  private_class_method :ez_load
 
   def self.extract_erb_encrypted_value(value)
     return $1 if value =~ /\A<%= (?:MiqPassword|DB_PASSWORD)\.decrypt\(['"]([^'"]+)['"]\) %>\Z/
   end
+  private_class_method :extract_erb_encrypted_value
 end
 
 # Backward compatibility for the class that used to be used by Rails.

--- a/gems/pending/util/miq_apache/miq_apache.rb
+++ b/gems/pending/util/miq_apache/miq_apache.rb
@@ -140,6 +140,8 @@ module MiqApache
 
     private
 
+    # FIXME: The intention was to make this method private but tests or code called
+    # from the tests are expecting it to be public.
     def self.run_apache_cmd(command)
       Dir.mkdir(File.dirname(APACHE_CONTROL_LOG)) unless File.exist?(File.dirname(APACHE_CONTROL_LOG))
       begin

--- a/gems/pending/util/miq_logger_processor.rb
+++ b/gems/pending/util/miq_logger_processor.rb
@@ -136,8 +136,8 @@ class MiqLoggerLine < String
     parts.each { |p| yield p }
   end
 
-  private
-
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.split_raw_line(line)
     line = line.to_s
     return if line.empty?

--- a/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -461,6 +461,7 @@ class MiqGenericMountSession
       raise "platform not supported"
     end
   end
+  private_class_method :raw_disconnect
 
   private
 

--- a/lib/charting/jqplot_charting.rb
+++ b/lib/charting/jqplot_charting.rb
@@ -93,6 +93,8 @@ class JqplotCharting < Charting
     Jqplot.apply_theme(chart, report_theme)
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.available?
     true
   end

--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -511,7 +511,10 @@ module MiqAeEngine
       return false  if value.to_s.downcase == 'false' || value == '0'
       value
     end
+    private_class_method :convert_boolean_value
 
+    # FIXME: The intention was to make this method private but tests or code called
+    # from the tests are expecting it to be public.
     def self.convert_value_based_on_datatype(value, datatype)
       return value if value.blank?
 

--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -185,12 +185,14 @@ class MiqAeClass < ApplicationRecord
     end
     class_array
   end
+  private_class_method :get_sorted_homonym_class_across_domains
 
   def self.remove_domain_from_fqns(fqname)
     parts = fqname.split('/')
     parts.shift
     parts.join('/')
   end
+  private_class_method :remove_domain_from_fqns
 
   def self.get_unique_instances_from_classes(klass_array)
     name_set = Set.new
@@ -204,6 +206,7 @@ class MiqAeClass < ApplicationRecord
       end.compact.flatten
     end.compact.flatten
   end
+  private_class_method :get_unique_instances_from_classes
 
   def self.get_same_instance_from_classes(klass_array, instance)
     klass_array.collect do |klass|
@@ -212,4 +215,5 @@ class MiqAeClass < ApplicationRecord
       cls.ae_instances.select { |a| File.fnmatch(instance, a.name, File::FNM_CASEFOLD) }
     end.compact.flatten
   end
+  private_class_method :get_same_instance_from_classes
 end

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -171,10 +171,14 @@ class MiqAeDomain < MiqAeNamespace
     MiqAeDomain.enabled.count > 0
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.any_unlocked?
     MiqAeDomain.where(:source => USER_SOURCE).count > 0
   end
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.all_unlocked
     MiqAeDomain.where(:source => USER_SOURCE).order('priority DESC')
   end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1603,6 +1603,7 @@ class MiqExpression
       op2 ? "#{val_with_cast} #{op2} #{quote(val2, col_type)}" : nil,
     ].compact.join(" && ")
   end
+  private_class_method :ruby_for_date_compare
 
   def to_arel(exp, tz)
     operator = exp.keys.first
@@ -1706,7 +1707,10 @@ class MiqExpression
 
     model
   end
+  private_class_method :determine_model
 
+  # FIXME: The intention was to make this method private but tests or code called
+  # from the tests are expecting it to be public.
   def self.determine_relat_path(ref)
     last_path = ref.name.to_s
     class_from_association_name = model_class(last_path)

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -36,8 +36,6 @@ module Vmdb
       apply_config_value(config, $azure_log, :level_azure, :level_azure_in_evm)
     end
 
-    private
-
     def self.create_loggers
       # Intentionally setting false to enable logging so we can
       # diagnose an Automate method failure
@@ -68,6 +66,7 @@ module Vmdb
 
       configure_external_loggers
     end
+    private_class_method :create_loggers
 
     def self.configure_external_loggers
       require 'awesome_spawn'
@@ -81,6 +80,7 @@ module Vmdb
       apply_config_value_logged(config, logger, :level, key)
       apply_config_value_logged(config, logger, :mirror_level, mirror_key) if mirror_key
     end
+    private_class_method :apply_config_value
 
     def self.apply_config_value_logged(config, logger, level_method, key)
       old_level      = logger.send(level_method)
@@ -91,5 +91,6 @@ module Vmdb
         logger.send("#{level_method}=", new_level)
       end
     end
+    private_class_method :apply_config_value_logged
   end
 end


### PR DESCRIPTION
Fixes #12035 

Adds `private_class_method` to class methods that are private.

I think I've caught all of the relevant warnings, but I'll take another look tomorrow night!
