### PR TITLE
Change size of widget charts to be generated automatically

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1671,6 +1671,7 @@ function chartData(type, data, data2) {
     }
   }
   var ret = _.defaultsDeep({}, data, config, data2);
+  ret.size = {};
   return ret;
 }
 

--- a/app/views/dashboard/_widget_chart.html.haml
+++ b/app/views/dashboard/_widget_chart.html.haml
@@ -1,8 +1,6 @@
 -#
   Parameters:
     widget -- MiqWidget instance
-- width  ||= 350
-- height ||= 250
 .card-pf-body.chart_widget
   .mc{:id => "dd_w#{widget.id}_box",
     :style => @sb[:dashboards][@sb[:active_db]][:minimized].include?(widget.id) ? 'display:none' : ''}
@@ -19,8 +17,6 @@
       - chart_data = Charting.deserialized(datum)
 
       = chart_local(chart_data,
-                    :id     => "miq_widgetchart_#{chart_index}".html_safe,
-                    :width  => width,
-                    :height => height)
+                    :id     => "miq_widgetchart_#{chart_index}".html_safe)
     - else
       = _('Invalid chart data. Try regenerating the widgets.')

--- a/app/views/dashboard/_zoomed_chart.html.haml
+++ b/app/views/dashboard/_zoomed_chart.html.haml
@@ -10,5 +10,5 @@
             :onclick => "miqSparkle(false);$('#lightbox-panel').fadeOut(300);"}
           %i.fa.fa-close.pull-right
     .card-pf-body
-      = chart_remote('dashboard', :id => 'my_chart', :width => 664, :height => 450, :bgcolor => "#f2f2f2")
+      = chart_remote('dashboard', :id => 'my_chart',:bgcolor => "#f2f2f2")
     = render :partial => 'widget_footer', :locals => {:widget => widget}


### PR DESCRIPTION
Remove widget chart size limitation from code

# Fullscreen view
Before:
![screenshot from 2016-10-25 14-57-42](https://cloud.githubusercontent.com/assets/9535558/19686866/731b15de-9ac3-11e6-84b1-aa57181e304e.png)

After:
![screenshot from 2016-10-25 14-56-13](https://cloud.githubusercontent.com/assets/9535558/19686869/77d65e8a-9ac3-11e6-8fa1-24fccdee82cf.png)

# Dashboard view
Before:
![screenshot from 2016-10-25 14-57-25](https://cloud.githubusercontent.com/assets/9535558/19686872/7ed1c68e-9ac3-11e6-878f-14620b5eee85.png)

After:
![screenshot from 2016-10-25 14-56-26](https://cloud.githubusercontent.com/assets/9535558/19686873/824a2f54-9ac3-11e6-8410-b3b8424418e3.png)

