### PR TITLE
Expose the current_user.userid at the navbar__user-name

### DIFF
--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -2,7 +2,7 @@
   %li.dropdown
     %a{:href => "#", :class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu2", "data-toggle" => "dropdown", "aria-haspopup" => "true"}
       %span.fa.pficon-user
-      %p.navbar__user-name
+      %p.navbar__user-name{"data-userid" => current_user.userid, :id => "username_display"}
         = "#{current_user.name} | #{appliance_name}"
       %span.caret
     %ul.dropdown-menu


### PR DESCRIPTION
This pull request is designed to make QE's life easier by exposing the userid as a parameter of the paragraph that shows the user's name. Because for login, QE's codebase only requires the login and a password, it will make a great simplification for us to check it.

You can try this PR out in browser by passing a command like this one in the dev console:

```javascript
$$('#username_display')[0].getAttribute('data-userid')
```