### PR TITLE
Remove double Default option in Display Settings

### DIFF
--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -66,7 +66,7 @@ class C3Charting < Charting
 
   # list of themes - in options_for_select format
   def chart_themes_for_select
-    %w(Default default)
+    [%w(Default default)]
   end
 
   def serialized(data)


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1383308

Remove displaying double Default option under Display Settings section
when changing Chart Theme in My Settings -> Visual.

Before:
![display_settings_before](https://cloud.githubusercontent.com/assets/13417815/19518406/5780c9d8-9607-11e6-83e2-4409c5a8b939.png)

After:
![display_settings_after](https://cloud.githubusercontent.com/assets/13417815/19518410/5adddb7a-9607-11e6-9b9c-b5acaab6f023.png)
