### PR TITLE
Settings for CB calculation&report  are worth to be represented by separate class

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -87,7 +87,7 @@ class Chargeback < ActsAsArModel
   end
 
   def self.key_and_fields(metric_rollup_record)
-    ts_key = get_group_key_ts(metric_rollup_record)
+    ts_key = @options.start_of_report_step(metric_rollup_record.timestamp)
 
     key, extra_fields = if @options[:groupby_tag].present?
                           get_tag_keys_and_fields(metric_rollup_record, ts_key)
@@ -176,22 +176,6 @@ class Chargeback < ActsAsArModel
     end
 
     col_hash
-  end
-
-  def self.get_group_key_ts(perf)
-    ts = perf.timestamp.in_time_zone(@options.tz)
-    case @options.interval
-    when "daily"
-      ts = ts.beginning_of_day
-    when "weekly"
-      ts = ts.beginning_of_week
-    when "monthly"
-      ts = ts.beginning_of_month
-    else
-      raise _("interval '%{interval}' is not supported") % {:interval => interval}
-    end
-
-    ts
   end
 
   def self.get_time_range(perf)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -95,7 +95,7 @@ class Chargeback < ActsAsArModel
   end
 
   def self.date_fields(metric_rollup_record)
-    start_ts, end_ts, display_range = get_time_range(metric_rollup_record)
+    start_ts, end_ts, display_range = @options.report_step_range(metric_rollup_record.timestamp)
 
     {
       'start_date'       => start_ts,
@@ -172,24 +172,6 @@ class Chargeback < ActsAsArModel
     end
 
     col_hash
-  end
-
-  def self.get_time_range(perf)
-    ts = perf.timestamp.in_time_zone(@options.tz)
-    case @options.interval
-    when "daily"
-      [ts.beginning_of_day, ts.end_of_day, ts.strftime("%m/%d/%Y")]
-    when "weekly"
-      s_ts = ts.beginning_of_week
-      e_ts = ts.end_of_week
-      [s_ts, e_ts, "Week of #{s_ts.strftime("%m/%d/%Y")}"]
-    when "monthly"
-      s_ts = ts.beginning_of_month
-      e_ts = ts.end_of_month
-      [s_ts, e_ts, s_ts.strftime("%b %Y")]
-    else
-      raise _("interval '%{interval}' is not supported") % {:interval => interval}
-    end
   end
 
   def self.report_cb_model(model)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -8,6 +8,7 @@ class Chargeback < ActsAsArModel
 
   def self.build_results_for_report_chargeback(options)
     _log.info("Calculating chargeback costs...")
+    @options = options
 
     tz = Metric::Helper.get_time_zone(options[:ext_options])
     # TODO: Support time profiles via options[:ext_options][:time_profile]

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -33,7 +33,7 @@ class Chargeback < ActsAsArModel
     rate_cols.map! { |x| VIRTUAL_COL_USES.include?(x) ? VIRTUAL_COL_USES[x] : x }.flatten!
     base_rollup = base_rollup.select(*rate_cols)
 
-    timerange = get_report_time_range(options, options.interval)
+    timerange = options.report_time_range
     data = {}
 
     interval_duration = interval_to_duration(options.interval)
@@ -221,32 +221,6 @@ class Chargeback < ActsAsArModel
     else
       raise _("interval '%{interval}' is not supported") % {:interval => interval}
     end
-  end
-
-  # @option options :interval_size [Fixednum] Used with :end_interval_offset to generate time range
-  # @option options :end_interval_offset
-  def self.get_report_time_range(options, interval)
-    raise _("Option 'interval_size' is required") if options[:interval_size].nil?
-
-    end_interval_offset = options[:end_interval_offset] || 0
-    start_interval_offset = (end_interval_offset + options[:interval_size] - 1)
-
-    ts = Time.now.in_time_zone(options.tz)
-    case interval
-    when "daily"
-      start_time = (ts - start_interval_offset.days).beginning_of_day.utc
-      end_time   = (ts - end_interval_offset.days).end_of_day.utc
-    when "weekly"
-      start_time = (ts - start_interval_offset.weeks).beginning_of_week.utc
-      end_time   = (ts - end_interval_offset.weeks).end_of_week.utc
-    when "monthly"
-      start_time = (ts - start_interval_offset.months).beginning_of_month.utc
-      end_time   = (ts - end_interval_offset.months).end_of_month.utc
-    else
-      raise _("interval '%{interval}' is not supported") % {:interval => interval}
-    end
-
-    start_time..end_time
   end
 
   def self.report_cb_model(model)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -14,10 +14,6 @@ class Chargeback < ActsAsArModel
 
     options[:ext_options] ||= {}
 
-    if @options[:groupby_tag]
-      @tag_hash = Classification.hash_all_by_type_and_name[@options[:groupby_tag]][:entry]
-    end
-
     base_rollup = MetricRollup.includes(
       :resource           => [:hardware, :tenant, :tags, :vim_performance_states, :custom_attributes],
       :parent_host        => :tags,
@@ -114,7 +110,7 @@ class Chargeback < ActsAsArModel
   def self.get_tag_keys_and_fields(perf, ts_key)
     tag = perf.tag_names.split("|").select { |x| x.starts_with?(@options[:groupby_tag]) }.first # 'department/*'
     tag = tag.split('/').second unless tag.blank? # 'department/finance' -> 'finance'
-    classification = @tag_hash[tag]
+    classification = @options.tag_hash[tag]
     classification_id = classification.present? ? classification.id : 'none'
     key = "#{classification_id}_#{ts_key}"
     extra_fields = { "tag_name" => classification.present? ? classification.description : _('<Empty>') }

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -36,7 +36,7 @@ class Chargeback < ActsAsArModel
     timerange = options.report_time_range
     data = {}
 
-    interval_duration = interval_to_duration(options.interval)
+    interval_duration = options.duration_of_report_step
 
     timerange.step_value(interval_duration).each_cons(2) do |query_start_time, query_end_time|
       records = base_rollup.where(:timestamp => query_start_time...query_end_time, :capture_interval_name => "hourly")
@@ -84,17 +84,6 @@ class Chargeback < ActsAsArModel
     return HOURS_IN_WEEK if interval == "weekly"
 
     (query_end_time - query_start_time) / 1.hour
-  end
-
-  def self.interval_to_duration(interval)
-    case interval
-    when "daily"
-      1.day
-    when "weekly"
-      1.week
-    when "monthly"
-      1.month
-    end
   end
 
   def self.key_and_fields(metric_rollup_record, interval)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -227,12 +227,9 @@ class Chargeback < ActsAsArModel
     end
   end
 
-  # @option options :start_time [DateTime] used with :end_time to create time range
-  # @option options :end_time [DateTime]
   # @option options :interval_size [Fixednum] Used with :end_interval_offset to generate time range
   # @option options :end_interval_offset
   def self.get_report_time_range(options, interval, tz)
-    return options[:start_time]..options[:end_time] if options[:start_time]
     raise _("Option 'interval_size' is required") if options[:interval_size].nil?
 
     end_interval_offset = options[:end_interval_offset] || 0

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -8,7 +8,7 @@ class Chargeback < ActsAsArModel
 
   def self.build_results_for_report_chargeback(options)
     _log.info("Calculating chargeback costs...")
-    @options = options
+    @options = options = ReportOptions.new_from_h(options)
 
     tz = Metric::Helper.get_time_zone(options[:ext_options])
     # TODO: Support time profiles via options[:ext_options][:time_profile]

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -12,8 +12,6 @@ class Chargeback < ActsAsArModel
 
     cb = new
 
-    options[:ext_options] ||= {}
-
     base_rollup = MetricRollup.includes(
       :resource           => [:hardware, :tenant, :tags, :vim_performance_states, :custom_attributes],
       :parent_host        => :tags,

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -1,0 +1,22 @@
+class Chargeback
+  # ReportOptions are usualy stored in MiqReport.db_options[:options]
+  ReportOptions = Struct.new(
+    :interval,             # daily | weekly | monthly
+    :interval_size,
+    :end_interval_offset,
+    :owner,                # userid
+    :tenant_id,
+    :tag,                  # like /managed/environment/prod (Mutually exclusive with :user)
+    :provide_id,
+    :entity_id,            # 1/2/3.../all rails id of entity
+    :service_id,
+    :groupby,
+    :groupby_tag,
+    :userid,
+    :ext_options,
+  ) do
+    def self.new_from_h(hash)
+      new(*hash.values_at(*members))
+    end
+  end
+end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -23,6 +23,7 @@ class Chargeback
       super
       self.interval ||= 'daily'
       self.end_interval_offset ||= 0
+      self.ext_options ||= {}
     end
 
     def tz

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -74,5 +74,11 @@ class Chargeback
       when 'monthly' then 1.month
       end
     end
+
+    def tag_hash
+      if groupby_tag
+        @tag_hash ||= Classification.hash_all_by_type_and_name[groupby_tag][:entry]
+      end
+    end
   end
 end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -22,11 +22,35 @@ class Chargeback
     def initialize(*)
       super
       self.interval ||= 'daily'
+      self.end_interval_offset ||= 0
     end
 
     def tz
       # TODO: Support time profiles via options[:ext_options][:time_profile]
       @tz ||= Metric::Helper.get_time_zone(ext_options)
+    end
+
+    def report_time_range
+      raise _("Option 'interval_size' is required") if interval_size.nil?
+
+      start_interval_offset = (end_interval_offset + interval_size - 1)
+
+      ts = Time.now.in_time_zone(tz)
+      case interval
+      when 'daily'
+        start_time = (ts - start_interval_offset.days).beginning_of_day.utc
+        end_time   = (ts - end_interval_offset.days).end_of_day.utc
+      when 'weekly'
+        start_time = (ts - start_interval_offset.weeks).beginning_of_week.utc
+        end_time   = (ts - end_interval_offset.weeks).end_of_week.utc
+      when 'monthly'
+        start_time = (ts - start_interval_offset.months).beginning_of_month.utc
+        end_time   = (ts - end_interval_offset.months).end_of_month.utc
+      else
+        raise _("interval '%{interval}' is not supported") % {:interval => interval}
+      end
+
+      start_time..end_time
     end
   end
 end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -52,5 +52,13 @@ class Chargeback
 
       start_time..end_time
     end
+
+    def duration_of_report_step
+      case interval
+      when 'daily'   then 1.day
+      when 'weekly'  then 1.week
+      when 'monthly' then 1.month
+      end
+    end
   end
 end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -19,6 +19,11 @@ class Chargeback
       new(*hash.values_at(*members))
     end
 
+    def initialize(*)
+      super
+      self.interval ||= 'daily'
+    end
+
     def tz
       # TODO: Support time profiles via options[:ext_options][:time_profile]
       @tz ||= Metric::Helper.get_time_zone(ext_options)

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -67,6 +67,24 @@ class Chargeback
       end
     end
 
+    def report_step_range(timestamp)
+      ts = timestamp.in_time_zone(tz)
+      case interval
+      when 'daily'
+        [ts.beginning_of_day, ts.end_of_day, ts.strftime('%m/%d/%Y')]
+      when 'weekly'
+        s_ts = ts.beginning_of_week
+        e_ts = ts.end_of_week
+        [s_ts, e_ts, "Week of #{s_ts.strftime('%m/%d/%Y')}"]
+      when 'monthly'
+        s_ts = ts.beginning_of_month
+        e_ts = ts.end_of_month
+        [s_ts, e_ts, s_ts.strftime('%b %Y')]
+      else
+        raise _("interval '%{interval}' is not supported") % {:interval => interval}
+      end
+    end
+
     def duration_of_report_step
       case interval
       when 'daily'   then 1.day

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -18,5 +18,10 @@ class Chargeback
     def self.new_from_h(hash)
       new(*hash.values_at(*members))
     end
+
+    def tz
+      # TODO: Support time profiles via options[:ext_options][:time_profile]
+      @tz ||= Metric::Helper.get_time_zone(ext_options)
+    end
   end
 end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -53,6 +53,20 @@ class Chargeback
       start_time..end_time
     end
 
+    def start_of_report_step(timestamp)
+      ts = timestamp.in_time_zone(tz)
+      case interval
+      when 'daily'
+        ts.beginning_of_day
+      when 'weekly'
+        ts.beginning_of_week
+      when 'monthly'
+        ts.beginning_of_month
+      else
+        raise _("interval '%{interval}' is not supported") % {:interval => interval}
+      end
+    end
+
     def duration_of_report_step
       case interval
       when 'daily'   then 1.day

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -28,14 +28,7 @@ class ChargebackContainerImage < Chargeback
   )
 
   def self.build_results_for_report_ChargebackContainerImage(options)
-    # Options:
-    #   :rpt_type => chargeback
-    #   :interval => daily | weekly | monthly
-    #   :end_interval_offset
-    #   :interval_size
-    #   :owner => <userid>
-    #   :tag => /managed/environment/prod (Mutually exclusive with :user)
-    #   :entity_id => 1/2/3.../all rails id of entity
+    # Options: a hash transformable to Chargeback::ReportOptions
 
     # Find Project by id or get all projects
     provider_id = options[:provider_id]

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -41,7 +41,6 @@ class ChargebackContainerImage < Chargeback
     #   :entity_id => 1/2/3.../all rails id of entity
 
     # Find Project by id or get all projects
-    @options = options
     provider_id = options[:provider_id]
     id = options[:entity_id]
     raise "must provide option :entity_id and provider_id" if id.nil? && provider_id.nil?

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -35,7 +35,6 @@ class ChargebackContainerImage < Chargeback
     #   :interval_size
     #   :owner => <userid>
     #   :tag => /managed/environment/prod (Mutually exclusive with :user)
-    #   :chargeback_type => detail | summary
     #   :entity_id => 1/2/3.../all rails id of entity
 
     # Find Project by id or get all projects

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -31,8 +31,6 @@ class ChargebackContainerImage < Chargeback
     # Options:
     #   :rpt_type => chargeback
     #   :interval => daily | weekly | monthly
-    #   :start_time
-    #   :end_time
     #   :end_interval_offset
     #   :interval_size
     #   :owner => <userid>

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -40,7 +40,6 @@ class ChargebackContainerProject < Chargeback
     #   :entity_id => 1/2/3.../all rails id of entity
 
     # Find ContainerProjects according to any of these:
-    @options = options
     provider_id = options[:provider_id]
     project_id = options[:entity_id]
     filter_tag = options[:tag]

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -30,8 +30,6 @@ class ChargebackContainerProject < Chargeback
     # Options:
     #   :rpt_type => chargeback
     #   :interval => daily | weekly | monthly
-    #   :start_time
-    #   :end_time
     #   :end_interval_offset
     #   :interval_size
     #   :owner => <userid>

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -27,14 +27,7 @@ class ChargebackContainerProject < Chargeback
   )
 
   def self.build_results_for_report_ChargebackContainerProject(options)
-    # Options:
-    #   :rpt_type => chargeback
-    #   :interval => daily | weekly | monthly
-    #   :end_interval_offset
-    #   :interval_size
-    #   :owner => <userid>
-    #   :tag => /managed/environment/prod (Mutually exclusive with :user)
-    #   :entity_id => 1/2/3.../all rails id of entity
+    # Options: a hash transformable to Chargeback::ReportOptions
 
     # Find ContainerProjects according to any of these:
     provider_id = options[:provider_id]

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -34,7 +34,6 @@ class ChargebackContainerProject < Chargeback
     #   :interval_size
     #   :owner => <userid>
     #   :tag => /managed/environment/prod (Mutually exclusive with :user)
-    #   :chargeback_type => detail | summary
     #   :entity_id => 1/2/3.../all rails id of entity
 
     # Find ContainerProjects according to any of these:

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -53,8 +53,6 @@ class ChargebackVm < Chargeback
     # Options:
     #   :rpt_type => chargeback
     #   :interval => daily | weekly | monthly
-    #   :start_time
-    #   :end_time
     #   :end_interval_offset
     #   :interval_size
     #   :owner => <userid>

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -93,7 +93,6 @@ class ChargebackVm < Chargeback
     end
     return [[]] if vms.empty?
 
-    @options = options
     @vm_owners = vms.inject({}) { |h, v| h[v.id] = v.evm_owner_name; h }
 
     build_results_for_report_chargeback(options)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -57,7 +57,6 @@ class ChargebackVm < Chargeback
     #   :interval_size
     #   :owner => <userid>
     #   :tag => /managed/environment/prod (Mutually exclusive with :user)
-    #   :chargeback_type => detail | summary
 
     @report_user = User.find_by(:userid => options[:userid])
 

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -50,13 +50,7 @@ class ChargebackVm < Chargeback
   )
 
   def self.build_results_for_report_ChargebackVm(options)
-    # Options:
-    #   :rpt_type => chargeback
-    #   :interval => daily | weekly | monthly
-    #   :end_interval_offset
-    #   :interval_size
-    #   :owner => <userid>
-    #   :tag => /managed/environment/prod (Mutually exclusive with :user)
+    # Options: a hash transformable to Chargeback::ReportOptions
 
     @report_user = User.find_by(:userid => options[:userid])
 


### PR DESCRIPTION
There are three possible callers of `build_results_for_report_chargeback` each of them sets `@options` to the same value that is later passed in as an argument.

Having the options and `@options` in a single method brings some ambiguity. Let's have a single place to set it. 

In future, I want to get a rid of this class variable. But it will take few moments before we get there. We are on track.

@miq-bot add_label chargeback, refactoring
@miq-bot assign @gtanzillo 