### PR TITLE
Remove unwanted node selection in Edit Report Menu

### DIFF
--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -32,8 +32,3 @@
                   = pp[0]
     - else
       = render :partial => 'layouts/info_msg', :locals => {:message => _("Choose a Role to edit from the left.")}
-
--# clear selection in menu tree in right cell
-- if @sb[:trees][:roles_tree][:active_node] != "root" && params[:action] != "menu_editor"
-  :javascript
-    miqTreeActivateNodeSilently("menu_roles_tree", "b__#{_('Report Menus for')} #{session[:role_choice]}")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1384518

Cloud Intel -> Reports -> Edit Report Menus -> select any group

At first load Reports tree should have no node selected to match right side that says `Please select a node from the tree to edit.`.

Before: 
![screen shot 2016-10-19 at 3 32 33 pm](https://cloud.githubusercontent.com/assets/9210860/19520661/4a5a1f34-9611-11e6-8236-c6d1e817da19.png)
Top Level node cannot be selected.

After:
![screen shot 2016-10-19 at 3 31 47 pm](https://cloud.githubusercontent.com/assets/9210860/19520666/4fa6aec6-9611-11e6-8d2c-e59cc32f9551.png)
Top Level node can be selected.


@miq-bot add_label ui, bug