### PR TITLE
Disable domains priority edit button for single domain

### DIFF
--- a/app/helpers/application_helper/button/miq_ae_domain_priority_edit.rb
+++ b/app/helpers/application_helper/button/miq_ae_domain_priority_edit.rb
@@ -1,0 +1,10 @@
+class ApplicationHelper::Button::MiqAeDomainPriorityEdit < ApplicationHelper::Button::Basic
+  def disabled?
+    (User.current_tenant.visible_domains.length < 2)
+  end
+
+  def calculate_properties
+    super
+    self[:title] = N_("You need two or more domains to edit domain priorities") if disabled?
+  end
+end

--- a/app/helpers/application_helper/toolbar/miq_ae_domains_center.rb
+++ b/app/helpers/application_helper/toolbar/miq_ae_domains_center.rb
@@ -32,8 +32,9 @@ class ApplicationHelper::Toolbar::MiqAeDomainsCenter < ApplicationHelper::Toolba
         button(
           :miq_ae_domain_priority_edit,
           'pficon pficon-edit fa-lg',
-          N_('Edit Priority Order  of Domains'),
-          N_('Edit Priority Order of Domains')),
+          t = N_('Edit Priority Order of Domains'),
+          t,
+          :klass => ApplicationHelper::Button::MiqAeDomainPriorityEdit),
       ]
     ),
   ])


### PR DESCRIPTION
Disable domains priority edit button in automate explorer screen
instead of displaying empty screen when domains count is less than
or equal to 1.