### PR TITLE
Remove `miqOnLoad()` from login page and replace afterOnLoad defs

### DIFF
--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -137,10 +137,16 @@
   - if auto_login != false
     - if ext_auth?(:saml_enabled)
       :javascript
-        ManageIQ.afterOnload = "$('#saml_login').click()";
+        $(function () {
+          $('#saml_login').click();
+        });
     - else
       :javascript
-        ManageIQ.afterOnload = "$('#sso_login').click()";
+        $(function () {
+          $('#sso_login').click();
+        });
 - elsif @user_name  # If user name is pre-populated by the server, press the Login button automatically
   :javascript
-    ManageIQ.afterOnload = "$('#login').click()";
+    $(function () {
+      $('#login').click();
+    });

--- a/app/views/layouts/login.html.haml
+++ b/app/views/layouts/login.html.haml
@@ -14,7 +14,7 @@
     = csrf_meta_tag
     = render :partial => 'layouts/i18n_js'
 
-  %body{:onload => "miqOnLoad();", :class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
+  %body{:class => ::Settings.server.custom_login_logo ? 'whitelabel' : ''}
     - if MiqServer.my_server(true).logon_status == :starting
       :javascript
         self.setTimeout("miqAjax('/dashboard/login_retry')",10000);


### PR DESCRIPTION
We were using only the `ManageIQ.afterOnLoad` part of `miqOnLoad()`, where a simple `eval()` is called. But because `eval == evil`, it is more "safe" to call the button clicks from `document.ready`.