### PR TITLE
[WIP] Refactor 'validate pause'  to use the SupportsFeatureMixin

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/vm/operations/power.rb
@@ -6,15 +6,13 @@ module ManageIQ::Providers::Azure::CloudManager::Vm::Operations::Power
       unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
       unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
     end
+
+    supports_not(:pause)
   end
 
   def raw_suspend
     provider_service.stop(name, resource_group)
     update_attributes!(:raw_power_state => "VM stopping")
-  end
-
-  def validate_pause
-    validate_unsupported(_("Pause Operation"))
   end
 
   def raw_start

--- a/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/vm/operations/power.rb
@@ -1,19 +1,17 @@
 module ManageIQ::Providers::Google::CloudManager::Vm::Operations::Power
   extend ActiveSupport::Concern
+
   included do
     supports_not :suspend
+    supports_not :pause
   end
 
-  def validate_pause
-    validate_unsupported(_("Pause Operation"))
+  def validate_suspend
+    validate_unsupported(_("Suspend Operation"))
   end
 
   def raw_suspend
     validate_unsupported(_("Suspend Operation"))
-  end
-
-  def raw_pause
-    validate_unsupported(_("Pause Operation"))
   end
 
   def raw_shelve

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
   include_concern 'ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared'
 
   supports_not :migrate, :reason => _("Migrate operation is not supported.")
+  supports_not :pause
 
   POWER_STATES = {
     "Running"  => "on",

--- a/app/models/manageiq/providers/redhat/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm.rb
@@ -5,6 +5,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm < ManageIQ::Providers::Infra
   include_concern 'ManageIQ::Providers::Redhat::InfraManager::VmOrTemplateShared'
 
   supports_not :migrate, :reason => _("Migrate operation is not supported.")
+  supports_not :pause
 
   POWER_STATES = {
     'up'        => 'on',

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/power.rb
@@ -1,7 +1,4 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Power
-  def validate_pause
-    validate_unsupported("Pause Operation")
-  end
 
   def raw_start
     start_with_cloud_init = custom_attributes.find_by(:name => "miq_provision_boot_with_cloud_init")

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations.rb
@@ -1,3 +1,5 @@
 module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations
+  extend ActiveSupport::Concern
+
   include_concern 'Power'
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/vm/operations/power.rb
@@ -1,6 +1,8 @@
 module ManageIQ::Providers::Vmware::CloudManager::Vm::Operations::Power
-  def validate_pause
-    validate_unsupported("Pause operation")
+  extend ActiveSupport::Concern
+
+  included do
+    supports_not(:pause)
   end
 
   def raw_start

--- a/app/models/miq_template/operations.rb
+++ b/app/models/miq_template/operations.rb
@@ -17,10 +17,6 @@ module MiqTemplate::Operations
     validate_invalid_for_template(_("Stop Operation"))
   end
 
-  def validate_pause
-    validate_invalid_for_template(_("Pause Operation"))
-  end
-
   def validate_standby_guest
     validate_invalid_for_template(_("Standby Guest Operation"))
   end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -81,6 +81,7 @@ module SupportsFeatureMixin
     :launch_cockpit             => 'Launch Cockpit UI',
     :live_migrate               => 'Live Migration',
     :migrate                    => 'Migration',
+    :pause                      => 'Pausing',
     :provisioning               => 'Provisioning',
     :reboot_guest               => 'Reboot Guest Operation',
     :reconfigure                => 'Reconfiguration',

--- a/app/models/vm/operations/power.rb
+++ b/app/models/vm/operations/power.rb
@@ -7,10 +7,27 @@ module Vm::Operations::Power
     api_relay_method :suspend
 
     supports :suspend do
-      msg = unsupported_reason(:control) unless supports_control?
-      msg ||= _('The VM is not powered on') unless vm_powered_on?
+      msg = supports_control_powered_on
       unsupported_reason_add(:suspend, msg) if msg
     end
+
+    supports :pause do
+      msg = supports_control_powered_on
+      unsupported_reason_add(:pause, msg) if msg
+    end
+  end
+
+  def supports_control_powered_on
+    msg = supports_control_message
+    msg || powered_on_message
+  end
+
+  def supports_control_message
+    unsupported_reason(:control) unless supports_control?
+  end
+
+  def powered_on_message
+    _('The VM is not powered on') unless vm_powered_on?
   end
 
   def vm_powered_on?
@@ -22,10 +39,6 @@ module Vm::Operations::Power
   end
 
   def validate_stop
-    validate_vm_control_powered_on
-  end
-
-  def validate_pause
     validate_vm_control_powered_on
   end
 


### PR DESCRIPTION
This PR refactors the `validate_pause methods` throughout the provider codebase to use the new SupportsFeatureMixin.

A comparable PR for the validate_suspend can be found [here](https://github.com/ManageIQ/manageiq/pull/11752) 
## Steps to test
- Add a provider to ManageIQ
- On the rails console execute the following, I am using VMware Cloud as an example:
  vm = ManageIQ::Providers::Vmware::CloudManager::Vm.find_by_name("name")
  vm.supports?(:pause)
- Check if this value (true or false) is correct
- If false, execute:
  vm.unsupported_reason(:pause)
- Make sure the reason is valid.

The UI would usually be a good place to test this but I have noticed inconsistencies with the UI power operations and have asked a member of the UI team to investigate
## Links 
- [GH issue](https://github.com/ManageIQ/manageiq/issues/11736) 
- [validate_suspend PR](https://github.com/ManageIQ/manageiq/pull/11752) 
