### PR TITLE
Inline eslint-config-airbnb-es5 for Code Climate compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,18 +5,18 @@
     "browser": true,
     "jquery": true
   },
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 5,
     "sourceType": "script",
     "ecmaFeatures": {
       "globalReturn": false,
-      "impliedStrict": false,
-      "jsx": false
+      "impliedStrict": false
     }
   },
 
   "plugins": [],
-  "extends": ["airbnb-es5"],
+  "extends": [],
 
   "globals": {
     "API": false, // local: miq_api.js
@@ -34,6 +34,140 @@
   },
 
   "rules": {
+    // {{{ this section comes from eslint-config-airbnb-es5 1.0.9
+    "strict": 0,
+    "no-shadow": 2,
+    "no-shadow-restricted-names": 2,
+    "no-unused-vars": [2, {
+      "vars": "local",
+      "args": "after-used"
+      }],
+    "comma-dangle": [2, "never"],
+    "no-cond-assign": [2, "always"],
+    "no-console": 1,
+    "no-debugger": 1,
+    "no-alert": 1,
+    "no-constant-condition": 1,
+    "no-dupe-keys": 2,
+    "no-duplicate-case": 2,
+    "no-empty": 2,
+    "no-empty-character-class": 2,
+    "no-ex-assign": 2,
+    "no-extra-semi": 2,
+    "no-func-assign": 2,
+    "no-inner-declarations": 2,
+    "no-invalid-regexp": 2,
+    "no-irregular-whitespace": 2,
+    "no-negated-in-lhs": 2,
+    "no-new-require": 2,
+    "no-obj-calls": 2,
+    "no-path-concat": 2,
+    "no-regex-spaces": 2,
+    "no-sparse-arrays": 2,
+    "no-unreachable": 2,
+    "use-isnan": 2,
+    "valid-jsdoc": 2,
+    "valid-typeof": 2,
+    "consistent-return": 2,
+    "curly": [2, "multi-line"],
+    "default-case": 2,
+    "dot-notation": [2, {
+      "allowKeywords": true
+      }],
+    "eqeqeq": 2,
+    "guard-for-in": 2,
+    "no-caller": 2,
+    "no-div-regex": 2,
+    "no-else-return": 2,
+    "no-labels": 2,
+    "no-eq-null": 2,
+    "no-eval": 2,
+    "no-extend-native": 2,
+    "no-extra-bind": 2,
+    "no-fallthrough": 2,
+    "no-floating-decimal": 2,
+    "no-implied-eval": 2,
+    "no-lone-blocks": 2,
+    "no-loop-func": 2,
+    "no-multi-str": 2,
+    "no-native-reassign": 2,
+    "no-new": 2,
+    "no-new-func": 2,
+    "no-new-wrappers": 2,
+    "no-octal": 2,
+    "no-octal-escape": 2,
+    "no-param-reassign": 2,
+    "no-process-exit": 2,
+    "no-proto": 2,
+    "no-redeclare": 2,
+    "no-return-assign": 2,
+    "no-script-url": 2,
+    "no-self-compare": 2,
+    "no-sequences": 2,
+    "no-throw-literal": 2,
+    "no-undef": 2,
+    "no-undef-init": 2,
+    "no-undefined": 1,
+    "no-with": 2,
+    "handle-callback-err": 1,
+    "radix": 2,
+    "wrap-iife": [2, "any"],
+    "yoda": 2,
+    "indent": [2, 2],
+    "brace-style": [2,
+    "1tbs", {
+      "allowSingleLine": true
+      }],
+    "quotes": [
+    2, "single", "avoid-escape"
+    ],
+    "camelcase": [2, {
+      "properties": "never"
+      }],
+    "comma-spacing": [2, {
+      "before": false,
+      "after": true
+      }],
+    "comma-style": [2, "last"],
+    "eol-last": 2,
+    "func-names": 1,
+    "key-spacing": [2, {
+        "beforeColon": false,
+        "afterColon": true
+        }],
+    "new-cap": [2, {
+      "newIsCap": true
+      }],
+    "new-parens": 2,
+    "no-array-constructor": 2,
+    "no-lonely-if": 1,
+    "no-mixed-spaces-and-tabs": 1,
+    "no-multiple-empty-lines": [2, {
+      "max": 2
+      }],
+    "no-nested-ternary": 2,
+    "no-new-object": 2,
+    "no-spaced-func": 2,
+    "no-trailing-spaces": 2,
+    "no-extra-parens": [2, "functions"],
+    "one-var": [2, "never"],
+    "padded-blocks": [2, "never"],
+    "semi": [2, "always"],
+    "semi-spacing": [2, {
+      "before": false,
+      "after": true
+      }],
+    "keyword-spacing": 2,
+    "space-before-blocks": 2,
+    "space-before-function-paren": [2, "never"],
+    "space-infix-ops": 2,
+    "space-unary-ops": 2,
+    "spaced-comment": [2, "always",  {
+      "exceptions": ["-", "+"],
+      "markers": ["=", "!"]          // space here to support sprockets directives
+      }],
+    // }}} (except for removing the JSX rules)
+
     "indent": [ "error", 2, {
       "SwitchCase": 1,
       "VariableDeclarator": 1

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,15 +38,8 @@
     "strict": 0,
     "no-shadow": 2,
     "no-shadow-restricted-names": 2,
-    "no-unused-vars": [2, {
-      "vars": "local",
-      "args": "after-used"
-      }],
-    "comma-dangle": [2, "never"],
     "no-cond-assign": [2, "always"],
     "no-console": 1,
-    "no-debugger": 1,
-    "no-alert": 1,
     "no-constant-condition": 1,
     "no-dupe-keys": 2,
     "no-duplicate-case": 2,
@@ -68,23 +61,16 @@
     "use-isnan": 2,
     "valid-jsdoc": 2,
     "valid-typeof": 2,
-    "consistent-return": 2,
-    "curly": [2, "multi-line"],
-    "default-case": 2,
     "dot-notation": [2, {
       "allowKeywords": true
       }],
-    "eqeqeq": 2,
     "guard-for-in": 2,
     "no-caller": 2,
     "no-div-regex": 2,
-    "no-else-return": 2,
     "no-labels": 2,
-    "no-eq-null": 2,
     "no-eval": 2,
     "no-extend-native": 2,
     "no-extra-bind": 2,
-    "no-fallthrough": 2,
     "no-floating-decimal": 2,
     "no-implied-eval": 2,
     "no-lone-blocks": 2,
@@ -96,7 +82,6 @@
     "no-new-wrappers": 2,
     "no-octal": 2,
     "no-octal-escape": 2,
-    "no-param-reassign": 2,
     "no-process-exit": 2,
     "no-proto": 2,
     "no-redeclare": 2,
@@ -105,7 +90,6 @@
     "no-self-compare": 2,
     "no-sequences": 2,
     "no-throw-literal": 2,
-    "no-undef": 2,
     "no-undef-init": 2,
     "no-undefined": 1,
     "no-with": 2,
@@ -113,14 +97,10 @@
     "radix": 2,
     "wrap-iife": [2, "any"],
     "yoda": 2,
-    "indent": [2, 2],
     "brace-style": [2,
     "1tbs", {
       "allowSingleLine": true
       }],
-    "quotes": [
-    2, "single", "avoid-escape"
-    ],
     "camelcase": [2, {
       "properties": "never"
       }],
@@ -130,7 +110,6 @@
       }],
     "comma-style": [2, "last"],
     "eol-last": 2,
-    "func-names": 1,
     "key-spacing": [2, {
         "beforeColon": false,
         "afterColon": true
@@ -141,7 +120,6 @@
     "new-parens": 2,
     "no-array-constructor": 2,
     "no-lonely-if": 1,
-    "no-mixed-spaces-and-tabs": 1,
     "no-multiple-empty-lines": [2, {
       "max": 2
       }],
@@ -161,12 +139,11 @@
     "space-before-blocks": 2,
     "space-before-function-paren": [2, "never"],
     "space-infix-ops": 2,
-    "space-unary-ops": 2,
     "spaced-comment": [2, "always",  {
       "exceptions": ["-", "+"],
       "markers": ["=", "!"]          // space here to support sprockets directives
       }],
-    // }}} (except for removing the JSX rules)
+    // }}} (except for removing the JSX rules, and anything we override)
 
     "indent": [ "error", 2, {
       "SwitchCase": 1,
@@ -177,11 +154,6 @@
     "vars-on-top": 0,
     "no-var": 0,
     "linebreak-style": [ "error", "unix" ],
-    "semi-spacing": ["error", {
-      "before": false,
-      "after": true
-    }],
-    "semi": [ "error", "always" ],
     "comma-dangle": [ "warn", "always-multiline" ],
     "space-unary-ops": [ "error", {
       "words": true,
@@ -197,7 +169,6 @@
       "caughtErrors": "all",
       "caughtErrorsIgnorePattern": "^_"
     }],
-    "no-console": 1,
     "no-alert": 2,
     "no-debugger": 2,
     "no-else-return": 1,
@@ -211,9 +182,11 @@
     }],
     "func-names": 0,
     "no-mixed-spaces-and-tabs": 2,
-    "camelcase": 1,
+    "camelcase": [ "warn", {
+      "properties": "never"
+    }],
+
     "curly": [ "warn", "all" ],
-    "space-before-function-paren": [ "error", "never" ],
     "no-eq-null": 0,
     "no-param-reassign": 1,
     "no-fallthrough": [ "error", {
@@ -222,7 +195,6 @@
     "no-use-before-define": [ "error", {
       "functions": false,
       "classes": true
-    }],
-    "padded-blocks": [ "error", "never" ]
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "babel-eslint": "^6.0.4",
     "eslint": "^2.10.2",
-    "eslint-config-airbnb-es5": "^1.0.9",
     "eslint-config-angular": "^0.5.0",
     "eslint-plugin-angular": "^1.0.1",
     "eslint-plugin-import": "^1.9.2",


### PR DESCRIPTION
Code Climate whitelists eslint modules for security, and `eslint-config-airbnb-es5` is not in the whitelist.

Since the module is just a config file enabling default rules, inlining that config in our `.eslintrc.json` should make CC work for us.

The new addition is simply a merge of the two rule sets, except I've removed all JSX-related rules (which we had disabled anyway).

Ping @jrafanie :)