### PR TITLE
Disable Casecmp cop

### DIFF
--- a/.rubocop_base.yml
+++ b/.rubocop_base.yml
@@ -24,6 +24,8 @@ Metrics/ParameterLists:
   Severity: refactor
 Metrics/PerceivedComplexity:
   Severity: refactor
+Performance/Casecmp:
+  Enabled: false
 Rails/FindEach:
   Enabled: false
 Rails/ReadWriteAttribute:

--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -129,8 +129,6 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Performance/CaseWhenSplat:
   Enabled: true
-Performance/Casecmp:
-  Enabled: true
 Performance/Count:
   Enabled: true
 Performance/Detect:


### PR DESCRIPTION
Based on discussion in [this thread]. There might be situations where the
performance aspect of this is crucial, but in general the readability
that's traded isn't worth enabling this cop IMHO.

[this thread]: https://github.com/ManageIQ/manageiq/pull/7583#r58563265

