### PR TITLE
Rest API Git refresh and import

### DIFF
--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -30,6 +30,29 @@ class GitBasedDomainImportService
     MiqTask.generic_action_with_callback(task_options, queue_options)
   end
 
+  def queue_refresh_and_import(git_url, ref, ref_type, tenant_id)
+    import_options = {
+      "git_url"   => git_url,
+      "ref"       => ref,
+      "ref_type"  => ref_type,
+      "tenant_id" => tenant_id
+    }
+
+    task_options = {
+      :action => "Refresh and import git repository",
+      :userid => User.current_user.userid
+    }
+
+    queue_options = {
+      :class_name  => "MiqAeDomain",
+      :method_name => "import_git_url",
+      :role        => "git_owner",
+      :args        => [import_options]
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
   def import(git_repo_id, branch_or_tag, tenant_id)
     task_id = queue_import(git_repo_id, branch_or_tag, tenant_id)
     task = MiqTask.wait_for_taskid(task_id)

--- a/lib/miq_automation_engine/models/miq_ae_git_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_git_import.rb
@@ -43,6 +43,7 @@ class MiqAeGitImport
 
   def create_repo
     @git_repo = GitRepository.find_or_create_by(:url => @options['git_url'])
+    @git_repo.update_attributes(:verify_ssl => @options['verify_ssl'] || OpenSSL::SSL::VERIFY_PEER)
     if @options['userid'] && @options['password']
       @git_repo.update_authentication(:default => @options.slice(*AUTH_KEYS))
     end

--- a/lib/miq_automation_engine/models/miq_ae_git_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_git_import.rb
@@ -1,5 +1,9 @@
 class MiqAeGitImport
   AUTH_KEYS = %w(userid password).freeze
+  BRANCH = 'branch'.freeze
+  TAG    = 'tag'.freeze
+  DEFAULT_BRANCH = 'origin/master'.freeze
+
   def initialize(options)
     @options = options
     @preview = options['preview']
@@ -46,14 +50,14 @@ class MiqAeGitImport
   end
 
   def default_import_options
-    @options['ref'] ||= MiqAeDomain::DEFAULT_BRANCH
-    @options['ref_type'] ||= MiqAeDomain::BRANCH
+    @options['ref'] ||= DEFAULT_BRANCH
+    @options['ref_type'] ||= BRANCH
     @options['ref_type'] = @options['ref_type'].downcase
 
     case @options['ref_type']
-    when MiqAeDomain::BRANCH
+    when BRANCH
       @options['branch'] = @options['ref']
-    when MiqAeDomain::TAG
+    when TAG
       @options['tag'] = @options['ref']
     else
       raise ArgumentError, "Invalid reference type #{@options['ref_type']} should be branch or tag"
@@ -63,11 +67,11 @@ class MiqAeGitImport
   def validate_refs
     match = nil
     case @options['ref_type']
-    when MiqAeDomain::BRANCH
+    when BRANCH
       other_name = "origin/#{@options['ref']}"
       match = @git_repo.git_branches.detect { |branch| branch.name.casecmp(@options['ref']) == 0 }
       match ||= @git_repo.git_branches.detect { |branch| branch.name.casecmp(other_name) == 0 }
-    when MiqAeDomain::TAG
+    when TAG
       match = @git_repo.git_tags.detect { |tag| tag.name.casecmp(@options['ref']) == 0 }
     end
     unless match

--- a/lib/miq_automation_engine/models/miq_ae_git_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_git_import.rb
@@ -1,0 +1,78 @@
+class MiqAeGitImport
+  AUTH_KEYS = %w(userid password).freeze
+  def initialize(options)
+    @options = options
+    @preview = options['preview']
+  end
+
+  def import
+    pre_import
+    @options['git_dir'] = @git_repo.directory_name
+    MiqAeDomain.find_by(:name => @options['domain']).try(:destroy) if @options['domain'] && !@preview
+    result = MiqAeYamlImportGitfs.new(@options['domain'] || '*', @options).import
+    domain = Array.wrap(result).first
+    post_import(domain) unless @preview
+    domain
+  end
+
+  private
+
+  def pre_import
+    repo_from_id if @options['git_repository_id']
+    create_repo unless @git_repo
+    default_import_options
+    validate_refs
+  end
+
+  def post_import(domain)
+    if domain
+      domain.update_git_info(@git_repo, @options['ref'], @options['ref_type'])
+    else
+      raise MiqAeException::DomainNotFound, "Import of domain failed"
+    end
+  end
+
+  def repo_from_id
+    @git_repo = GitRepository.find(@options['git_repository_id'])
+    raise "Git repository with id #{@options['git_repository_id']} not found" unless @git_repo
+  end
+
+  def create_repo
+    @git_repo = GitRepository.find_or_create_by(:url => @options['git_url'])
+    if @options['userid'] && @options['password']
+      @git_repo.update_authentication(:default => @options.slice(*AUTH_KEYS))
+    end
+    @git_repo.refresh
+  end
+
+  def default_import_options
+    @options['ref'] ||= MiqAeDomain::DEFAULT_BRANCH
+    @options['ref_type'] ||= MiqAeDomain::BRANCH
+    @options['ref_type'] = @options['ref_type'].downcase
+
+    case @options['ref_type']
+    when MiqAeDomain::BRANCH
+      @options['branch'] = @options['ref']
+    when MiqAeDomain::TAG
+      @options['tag'] = @options['ref']
+    else
+      raise ArgumentError, "Invalid reference type #{@options['ref_type']} should be branch or tag"
+    end
+  end
+
+  def validate_refs
+    match = nil
+    case @options['ref_type']
+    when MiqAeDomain::BRANCH
+      other_name = "origin/#{@options['ref']}"
+      match = @git_repo.git_branches.detect { |branch| branch.name.casecmp(@options['ref']) == 0 }
+      match ||= @git_repo.git_branches.detect { |branch| branch.name.casecmp(other_name) == 0 }
+    when MiqAeDomain::TAG
+      match = @git_repo.git_tags.detect { |tag| tag.name.casecmp(@options['ref']) == 0 }
+    end
+    unless match
+      raise ArgumentError, "#{@options['ref_type'].titleize} #{@options['ref']} doesn't exist in repository"
+    end
+    @options['ref'] = match.name
+  end
+end

--- a/lib/miq_automation_engine/models/miq_ae_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_import.rb
@@ -8,6 +8,8 @@ class MiqAeImport
       MiqAeYamlImportConsolidated.new(domain, options)
     elsif options['git_dir'].present?
       MiqAeYamlImportGitfs.new(domain, options)
+    elsif options['git_url'].present? || options['git_repository_id'].present?
+      MiqAeGitImport.new(options)
     end
   end
 end

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -152,7 +152,8 @@ namespace :evm do
           import_options['yaml_file']   = ENV['YAML_FILE']
         elsif ENV['GIT_URL'].present?
           puts "Importing automate domain from url #{ENV['GIT_URL']}"
-          import_options['url'] = ENV['GIT_URL']
+          ENV['DOMAIN'] = nil
+          import_options['git_url'] = ENV['GIT_URL']
           import_options['overwrite'] = true
           import_options['userid'] = ENV['USERID']
           import_options['password'] = ENV['PASSWORD']
@@ -165,11 +166,7 @@ namespace :evm do
             import_options[name.downcase] = ENV[name]
           end
         end
-        if ENV['GIT_URL'].present?
-          MiqAeDomain.import_git_url(import_options)
-        else
-          MiqAeImport.new(ENV['DOMAIN'], import_options).import
-        end
+        MiqAeImport.new(ENV['DOMAIN'], import_options).import
       rescue => err
         STDERR.puts err.backtrace
         STDERR.puts err.message

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -159,6 +159,7 @@ namespace :evm do
           import_options['password'] = ENV['PASSWORD']
           import_options['ref'] = ENV['REF'] || MiqAeGitImport::DEFAULT_BRANCH
           import_options['ref_type'] = ENV['REF_TYPE'] || MiqAeGitImport::BRANCH
+          import_options['verify_ssl'] = ENV['verify_ssl'] || OpenSSL::SSL::VERIFY_PEER
         end
         %w(SYSTEM ENABLED).each do |name|
           if ENV[name].present?

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -157,8 +157,8 @@ namespace :evm do
           import_options['overwrite'] = true
           import_options['userid'] = ENV['USERID']
           import_options['password'] = ENV['PASSWORD']
-          import_options['ref'] = ENV['REF'] || MiqAeDomain::DEFAULT_BRANCH
-          import_options['ref_type'] = ENV['REF_TYPE'] || MiqAeDomain::BRANCH
+          import_options['ref'] = ENV['REF'] || MiqAeGitImport::DEFAULT_BRANCH
+          import_options['ref_type'] = ENV['REF_TYPE'] || MiqAeGitImport::BRANCH
         end
         %w(SYSTEM ENABLED).each do |name|
           if ENV[name].present?

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -126,9 +126,9 @@ namespace :evm do
     desc 'Import automate model information from an export folder or zip file. '
     task :import => :environment do
       begin
-        raise "Must specify domain for import:" if ENV['DOMAIN'].blank?
-        if ENV['YAML_FILE'].blank? && ENV['IMPORT_DIR'].blank? && ENV['ZIP_FILE'].blank?
-          raise 'Must specify either a directory with exported automate model or a zip file'
+        raise "Must specify domain for import:" if ENV['DOMAIN'].blank? && ENV['GIT_URL'].blank?
+        if ENV['YAML_FILE'].blank? && ENV['IMPORT_DIR'].blank? && ENV['ZIP_FILE'].blank? && ENV['GIT_URL'].blank?
+          raise 'Must specify either a directory with exported automate model or a zip file or a http based git url'
         end
         preview        = ENV['PREVIEW'] ||= 'true'
         raise 'Preview must be true or false' unless %w{true false}.include?(preview)
@@ -150,6 +150,14 @@ namespace :evm do
         elsif ENV['YAML_FILE'].present?
           puts "Importing automate domain: #{ENV['DOMAIN']} from file #{ENV['YAML_FILE']}"
           import_options['yaml_file']   = ENV['YAML_FILE']
+        elsif ENV['GIT_URL'].present?
+          puts "Importing automate domain from url #{ENV['GIT_URL']}"
+          import_options['url'] = ENV['GIT_URL']
+          import_options['overwrite'] = true
+          import_options['userid'] = ENV['USERID']
+          import_options['password'] = ENV['PASSWORD']
+          import_options['ref'] = ENV['REF'] || MiqAeDomain::DEFAULT_BRANCH
+          import_options['ref_type'] = ENV['REF_TYPE'] || MiqAeDomain::BRANCH
         end
         %w(SYSTEM ENABLED).each do |name|
           if ENV[name].present?
@@ -157,7 +165,11 @@ namespace :evm do
             import_options[name.downcase] = ENV[name]
           end
         end
-        MiqAeImport.new(ENV['DOMAIN'], import_options).import
+        if ENV['GIT_URL'].present?
+          MiqAeDomain.import_git_url(import_options)
+        else
+          MiqAeImport.new(ENV['DOMAIN'], import_options).import
+        end
       rescue => err
         STDERR.puts err.backtrace
         STDERR.puts err.message

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -305,7 +305,7 @@ describe MiqAeDomain do
     let(:new_info) { {'commit_time' => commit_time_new, 'commit_message' => "BB-8", 'commit_sha' => "def"} }
     let(:commit_hash) do
       {'commit_message' => commit_message, 'commit_time' => commit_time,
-       'commit_sha' => commit_sha, 'ref' => branch_name, 'ref_type' => MiqAeDomain::BRANCH}
+       'commit_sha' => commit_sha, 'ref' => branch_name, 'ref_type' => MiqAeGitImport::BRANCH}
     end
     let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }
     let(:tag) { FactoryGirl.create(:git_tag, :name => tag_name) }
@@ -322,79 +322,9 @@ describe MiqAeDomain do
     it "git info" do
       expect(repo).to receive(:branch_info).with(branch_name).and_return(info)
 
-      dom1.update_git_info(repo, branch_name, MiqAeDomain::BRANCH)
+      dom1.update_git_info(repo, branch_name, MiqAeGitImport::BRANCH)
       dom1.reload
       expect(dom1.attributes).to have_attributes(commit_hash)
-    end
-
-    it "import a domain" do
-      domain_name = dom1.name
-      expect(MiqAeImport).to receive(:new).with(any_args).and_return(git_import)
-      expect_any_instance_of(GitRepository).to receive(:branch_info).with(branch_name).and_return(info)
-      allow(git_import).to receive(:import) { MiqAeDomain.create(:name => domain_name) }
-      options = {'domain' => domain_name, 'git_repository_id' => repo.id,
-                 'tenant_id' => @user.current_tenant.id, 'ref' => branch_name,
-                 'ref_type' => 'BrancH'}
-      dom1 = MiqAeDomain.import_git_repo(options)
-      expect(dom1.attributes).to have_attributes(commit_hash)
-    end
-
-    it "import a domain given a git url and a branch" do
-      options = {'url' => url, 'tenant_id' => @user.current_tenant.id,
-                 'ref' => branch_name, 'ref_type' => 'BrancH',
-                 'userid' => "fred", "password" => "secret" }
-      expect_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      expect_any_instance_of(GitRepository).to receive(:git_branches).with(no_args).and_return([branch])
-      expect(MiqAeDomain).to receive(:import_git_repo).with(any_args).and_return(dom1)
-
-      MiqAeDomain.import_git_url(options)
-    end
-
-    it "import a domain given a git url and a tag" do
-      options = {'url' => url, 'tenant_id' => @user.current_tenant.id,
-                 'ref' => tag_name, 'ref_type' => 'TaG',
-                 'userid' => "fred", "password" => "secret" }
-      expect_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      expect_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
-      expect(MiqAeDomain).to receive(:import_git_repo).with(any_args).and_return(dom1)
-
-      MiqAeDomain.import_git_url(options)
-    end
-
-    it "import a domain given a git url and a non existent tag" do
-      options = {'url' => url, 'tenant_id' => @user.current_tenant.id,
-                 'ref' => "nada", 'ref_type' => 'TaG',
-                 'userid' => "fred", "password" => "secret" }
-      expect_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      expect_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
-      expect { MiqAeDomain.import_git_url(options) }.to raise_error(ArgumentError)
-    end
-
-    it "import domain embedded in git repository" do
-      domain_name = "ASTERIX"
-      expect(MiqAeImport).to receive(:new).with(any_args).and_return(git_import)
-      expect_any_instance_of(GitRepository).to receive(:branch_info).with(branch_name).and_return(info)
-      allow(git_import).to receive(:import) { [MiqAeDomain.create(:name => domain_name)] }
-      options = {'git_repository_id' => repo.id,
-                 'tenant_id' => @user.current_tenant.id, 'ref' => branch_name,
-                 'ref_type' => "BRANCH" }
-      dom1 = MiqAeDomain.import_git_repo(options)
-
-      expect(dom1.attributes).to have_attributes(commit_hash)
-    end
-
-    it "import a domain fails" do
-      expect(MiqAeImport).to receive(:new).with(any_args).and_return(git_import)
-      allow(git_import).to receive(:import) { nil }
-      expect do
-        options = {'git_repository_id' => repo.id,
-                   'tenant_id' => @user.current_tenant.id, 'ref' => branch_name}
-        MiqAeDomain.import_git_repo(options)
-      end.to raise_error(MiqAeException::DomainNotFound)
-    end
-
-    it "import without git_repository_id" do
-      expect { MiqAeDomain.import_git_repo({}) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "git repo changed for non git domain" do
@@ -404,14 +334,14 @@ describe MiqAeDomain do
     it "git repo branch changed" do
       expect_any_instance_of(GitRepository).to receive(:branch_info).with(branch_name).twice.and_return(new_info)
       dom1.update_attributes(:ref => branch_name, :git_repository => repo,
-                             :ref_type => MiqAeDomain::BRANCH, :commit_sha => commit_sha)
+                             :ref_type => MiqAeGitImport::BRANCH, :commit_sha => commit_sha)
       expect(dom1.git_repo_changed?).to be_truthy
       expect(dom1.latest_ref_info).to have_attributes(new_info)
     end
 
     it "git repo tag changed" do
       expect(repo).to receive(:tag_info).with(tag_name).twice.and_return(new_info)
-      dom1.update_attributes(:ref => tag_name, :ref_type => MiqAeDomain::TAG,
+      dom1.update_attributes(:ref => tag_name, :ref_type => MiqAeGitImport::TAG,
                              :git_repository => repo, :commit_sha => commit_sha)
       expect(dom1.git_repo_changed?).to be_truthy
       expect(dom1.latest_ref_info).to have_attributes(new_info)

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -291,9 +291,15 @@ describe MiqAeDomain do
     let(:commit_sha) { "abcd" }
     let(:branch_name) { "b1" }
     let(:tag_name) { "t1" }
-    let(:dom1) { FactoryGirl.create(:miq_ae_git_domain, :tenant => @user.current_tenant) }
+    let(:domain_name) { "BB8" }
+    let(:url) { "http://www.example.com/x/y" }
+    let(:dom1) do
+      FactoryGirl.create(:miq_ae_git_domain,
+                         :tenant => @user.current_tenant,
+                         :name   => domain_name)
+    end
     let(:dom2) { FactoryGirl.create(:miq_ae_domain) }
-    let(:repo) { FactoryGirl.create(:git_repository, :url => "http://www.example.com/x/y") }
+    let(:repo) { FactoryGirl.create(:git_repository, :url => url) }
     let(:git_import) { instance_double('MiqAeYamlImportGitfs') }
     let(:info) { {'commit_time' => commit_time, 'commit_message' => commit_message, 'commit_sha' => commit_sha} }
     let(:new_info) { {'commit_time' => commit_time_new, 'commit_message' => "BB-8", 'commit_sha' => "def"} }
@@ -301,6 +307,8 @@ describe MiqAeDomain do
       {'commit_message' => commit_message, 'commit_time' => commit_time,
        'commit_sha' => commit_sha, 'ref' => branch_name, 'ref_type' => MiqAeDomain::BRANCH}
     end
+    let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }
+    let(:tag) { FactoryGirl.create(:git_tag, :name => tag_name) }
 
     it "check if a git domain is locked" do
       expect(dom1.editable?(@user)).to be_falsey
@@ -329,6 +337,37 @@ describe MiqAeDomain do
                  'ref_type' => 'BrancH'}
       dom1 = MiqAeDomain.import_git_repo(options)
       expect(dom1.attributes).to have_attributes(commit_hash)
+    end
+
+    it "import a domain given a git url and a branch" do
+      options = {'url' => url, 'tenant_id' => @user.current_tenant.id,
+                 'ref' => branch_name, 'ref_type' => 'BrancH',
+                 'userid' => "fred", "password" => "secret" }
+      expect_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      expect_any_instance_of(GitRepository).to receive(:git_branches).with(no_args).and_return([branch])
+      expect(MiqAeDomain).to receive(:import_git_repo).with(any_args).and_return(dom1)
+
+      MiqAeDomain.import_git_url(options)
+    end
+
+    it "import a domain given a git url and a tag" do
+      options = {'url' => url, 'tenant_id' => @user.current_tenant.id,
+                 'ref' => tag_name, 'ref_type' => 'TaG',
+                 'userid' => "fred", "password" => "secret" }
+      expect_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      expect_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
+      expect(MiqAeDomain).to receive(:import_git_repo).with(any_args).and_return(dom1)
+
+      MiqAeDomain.import_git_url(options)
+    end
+
+    it "import a domain given a git url and a non existent tag" do
+      options = {'url' => url, 'tenant_id' => @user.current_tenant.id,
+                 'ref' => "nada", 'ref_type' => 'TaG',
+                 'userid' => "fred", "password" => "secret" }
+      expect_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      expect_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
+      expect { MiqAeDomain.import_git_url(options) }.to raise_error(ArgumentError)
     end
 
     it "import domain embedded in git repository" do

--- a/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
@@ -17,11 +17,11 @@ describe MiqAeGitImport do
     end
     let(:repo) { FactoryGirl.create(:git_repository, :url => url) }
     let(:branch_hash) do
-      {'ref' => branch_name, 'ref_type' => MiqAeDomain::BRANCH}
+      {'ref' => branch_name, 'ref_type' => MiqAeGitImport::BRANCH}
     end
 
     let(:tag_hash) do
-      {'ref' => tag_name, 'ref_type' => MiqAeDomain::TAG}
+      {'ref' => tag_name, 'ref_type' => MiqAeGitImport::TAG}
     end
 
     let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }
@@ -70,7 +70,7 @@ describe MiqAeGitImport do
             'git_repository_id' => repo.id,
             'tenant_id'         => @user.current_tenant.id,
             'ref'               => tag_name,
-            'ref_type'          => MiqAeDomain::TAG
+            'ref_type'          => MiqAeGitImport::TAG
           }
         end
 

--- a/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
@@ -1,10 +1,11 @@
 describe MiqAeGitImport do
-  before do
-    EvmSpecHelper.local_guid_miq_server_zone
-    @user = FactoryGirl.create(:user_with_group)
-  end
+  context "#import" do
+    before do
+      EvmSpecHelper.local_guid_miq_server_zone
+      @user = FactoryGirl.create(:user_with_group)
+    end
 
-  context "git import" do
+    let(:miq_ae_git_import) { described_class.new(options) }
     let(:branch_name) { "b1" }
     let(:tag_name) { "t1" }
     let(:domain_name) { "BB8" }
@@ -26,88 +27,118 @@ describe MiqAeGitImport do
     let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }
     let(:tag) { FactoryGirl.create(:git_tag, :name => tag_name) }
 
-    it "import a domain given a git repository and a branch" do
-      domain_name = domain.name
-      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      allow_any_instance_of(GitRepository).to receive(:git_branches).with(no_args).and_return([branch])
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(domain)
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
-      options = {'domain'            => domain_name,
-                 'git_repository_id' => repo.id,
-                 'tenant_id'         => @user.current_tenant.id,
-                 'ref'               => branch_name}
-      dom = MiqAeGitImport.new(options).import
-      expect(dom.attributes).to have_attributes(branch_hash)
+    context "when the ref type and ref are valid" do
+      let(:miq_ae_yaml_import_gitfs) { double("MiqAeYamlImportGitfs") }
+
+      before do
+        allow(GitRepository).to receive(:find).with(repo.id).and_return(repo)
+        allow(repo).to receive(:refresh).and_return(nil)
+
+        allow(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, options).and_return(miq_ae_yaml_import_gitfs)
+      end
+
+      context "when there are branches returned" do
+        let(:options) do
+          {
+            'domain'            => domain_name,
+            'git_repository_id' => repo.id,
+            'tenant_id'         => @user.current_tenant.id,
+            'ref'               => branch_name
+          }
+        end
+
+        before do
+          allow(repo).to receive(:git_branches).and_return([branch])
+        end
+
+        it "imports correctly" do
+          allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
+          dom = miq_ae_git_import.import
+          expect(dom.attributes).to have_attributes(branch_hash)
+        end
+
+        it "import fails with domain not found" do
+          allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(nil)
+          expect { miq_ae_git_import.import }.to raise_error(MiqAeException::DomainNotFound)
+        end
+      end
+
+      context "when there are tags returned" do
+        let(:options) do
+          {
+            'domain'            => domain_name,
+            'git_repository_id' => repo.id,
+            'tenant_id'         => @user.current_tenant.id,
+            'ref'               => tag_name,
+            'ref_type'          => MiqAeDomain::TAG
+          }
+        end
+
+        before do
+          allow(repo).to receive(:git_tags).and_return([tag])
+        end
+
+        it "imports correctly" do
+          allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
+          dom = miq_ae_git_import.import
+          expect(dom.attributes).to have_attributes(tag_hash)
+        end
+      end
+
+      context "when a git_url and branch are given" do
+        let(:options) do
+          {
+            'git_url'  => url,
+            'ref'      => branch_name,
+            'userid'   => 'fred',
+            'password' => 'secret',
+            'preview'  => false,
+            'domain'   => domain_name
+          }
+        end
+
+        before do
+          allow(GitRepository).to receive(:find_or_create_by).with(:url => url).and_return(repo)
+          allow(repo).to receive(:git_branches).and_return([branch])
+        end
+
+        it "imports correctly" do
+          allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
+          dom = miq_ae_git_import.import
+          expect(dom.attributes).to have_attributes(branch_hash)
+        end
+      end
     end
 
-    it "import a domain given a git repository and a tag" do
-      domain_name = domain.name
-      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      allow_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(domain)
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
-      options = {'domain'            => domain_name,
-                 'git_repository_id' => repo.id,
-                 'tenant_id'         => @user.current_tenant.id,
-                 'ref'               => tag_name,
-                 'ref_type'          => 'tag'}
+    context "when the ref type and ref are not valid" do
+      let(:options) { {'git_repository_id' => repo.id, 'ref_type' => ref_type, 'ref' => ref} }
 
-      dom = MiqAeGitImport.new(options).import
-      expect(dom.attributes).to have_attributes(tag_hash)
-    end
+      shared_examples_for "#import that has invalid ref or ref type" do
+        it "throws an argument error" do
+          expect { miq_ae_git_import.import }.to raise_error(ArgumentError)
+        end
+      end
 
-    it "import fails given a git repository and a tag" do
-      domain_name = domain.name
-      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      allow_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(nil)
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
-      options = {'domain'            => domain_name,
-                 'git_repository_id' => repo.id,
-                 'tenant_id'         => @user.current_tenant.id,
-                 'ref'               => tag_name,
-                 'ref_type'          => 'tag'}
+      context "when the branch does not exist" do
+        let(:ref) { 'branch does not exist' }
+        let(:ref_type) { nil }
 
-      expect { MiqAeGitImport.new(options).import }.to raise_error(MiqAeException::DomainNotFound)
-    end
+        it_behaves_like "#import that has invalid ref or ref type"
+      end
 
-    it "import a domain given a git url and a branch" do
-      options = {'git_url'   => url,
-                 'tenant_id' => @user.current_tenant.id,
-                 'ref'       => branch_name,
-                 'userid'    => 'fred',
-                 'password'  => 'secret',
-                 'preview'   => false }
-      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
-      allow_any_instance_of(GitRepository).to receive(:git_branches).with(no_args).and_return([branch])
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(domain)
-      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
+      context "when the ref type is tag but the tag does not exist" do
+        let(:ref) { 'tag does not exist' }
+        let(:ref_type) { 'tag' }
 
-      dom = MiqAeGitImport.new(options).import
-      expect(dom.attributes).to have_attributes(branch_hash)
-    end
+        it_behaves_like "#import that has invalid ref or ref type"
+      end
 
-    it "non existent branch throws an exception" do
-      options = {'git_repository_id' => repo.id,
-                 'ref'               => 'Does not exist'}
+      context "when the ref type is invalid" do
+        let(:ref_type) { "Invalid" }
+        let(:ref) { "branch" }
 
-      expect { MiqAeGitImport.new(options).import }.to raise_error(ArgumentError)
-    end
-
-    it "non existent tag throws an exception" do
-      options = {'git_repository_id' => repo.id,
-                 'ref'               => 'Does not exist',
-                 'ref_type'          => 'tag'}
-
-      expect { MiqAeGitImport.new(options).import }.to raise_error(ArgumentError)
-    end
-
-    it "invalid ref_type throws an exception" do
-      options = {'git_repository_id' => repo.id,
-                 'ref_type'          => 'Invalid',
-                 'ref'               => 'branch'}
-
-      expect { MiqAeGitImport.new(options).import }.to raise_error(ArgumentError)
+        it_behaves_like "#import that has invalid ref or ref type"
+      end
     end
   end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
@@ -1,0 +1,113 @@
+describe MiqAeGitImport do
+  before do
+    EvmSpecHelper.local_guid_miq_server_zone
+    @user = FactoryGirl.create(:user_with_group)
+  end
+
+  context "git import" do
+    let(:branch_name) { "b1" }
+    let(:tag_name) { "t1" }
+    let(:domain_name) { "BB8" }
+    let(:url) { "http://www.example.com/x/y" }
+    let(:domain) do
+      FactoryGirl.create(:miq_ae_git_domain,
+                         :tenant => @user.current_tenant,
+                         :name   => domain_name)
+    end
+    let(:repo) { FactoryGirl.create(:git_repository, :url => url) }
+    let(:branch_hash) do
+      {'ref' => branch_name, 'ref_type' => MiqAeDomain::BRANCH}
+    end
+
+    let(:tag_hash) do
+      {'ref' => tag_name, 'ref_type' => MiqAeDomain::TAG}
+    end
+
+    let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }
+    let(:tag) { FactoryGirl.create(:git_tag, :name => tag_name) }
+
+    it "import a domain given a git repository and a branch" do
+      domain_name = domain.name
+      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      allow_any_instance_of(GitRepository).to receive(:git_branches).with(no_args).and_return([branch])
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(domain)
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
+      options = {'domain'            => domain_name,
+                 'git_repository_id' => repo.id,
+                 'tenant_id'         => @user.current_tenant.id,
+                 'ref'               => branch_name}
+      dom = MiqAeGitImport.new(options).import
+      expect(dom.attributes).to have_attributes(branch_hash)
+    end
+
+    it "import a domain given a git repository and a tag" do
+      domain_name = domain.name
+      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      allow_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(domain)
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
+      options = {'domain'            => domain_name,
+                 'git_repository_id' => repo.id,
+                 'tenant_id'         => @user.current_tenant.id,
+                 'ref'               => tag_name,
+                 'ref_type'          => 'tag'}
+
+      dom = MiqAeGitImport.new(options).import
+      expect(dom.attributes).to have_attributes(tag_hash)
+    end
+
+    it "import fails given a git repository and a tag" do
+      domain_name = domain.name
+      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      allow_any_instance_of(GitRepository).to receive(:git_tags).with(no_args).and_return([tag])
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(nil)
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
+      options = {'domain'            => domain_name,
+                 'git_repository_id' => repo.id,
+                 'tenant_id'         => @user.current_tenant.id,
+                 'ref'               => tag_name,
+                 'ref_type'          => 'tag'}
+
+      expect { MiqAeGitImport.new(options).import }.to raise_error(MiqAeException::DomainNotFound)
+    end
+
+    it "import a domain given a git url and a branch" do
+      options = {'git_url'   => url,
+                 'tenant_id' => @user.current_tenant.id,
+                 'ref'       => branch_name,
+                 'userid'    => 'fred',
+                 'password'  => 'secret',
+                 'preview'   => false }
+      allow_any_instance_of(GitRepository).to receive(:refresh).with(no_args).and_return(nil)
+      allow_any_instance_of(GitRepository).to receive(:git_branches).with(no_args).and_return([branch])
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:import).with(any_args).and_return(domain)
+      allow_any_instance_of(MiqAeYamlImportGitfs).to receive(:load_repo).with(any_args).and_return(nil)
+
+      dom = MiqAeGitImport.new(options).import
+      expect(dom.attributes).to have_attributes(branch_hash)
+    end
+
+    it "non existent branch throws an exception" do
+      options = {'git_repository_id' => repo.id,
+                 'ref'               => 'Does not exist'}
+
+      expect { MiqAeGitImport.new(options).import }.to raise_error(ArgumentError)
+    end
+
+    it "non existent tag throws an exception" do
+      options = {'git_repository_id' => repo.id,
+                 'ref'               => 'Does not exist',
+                 'ref_type'          => 'tag'}
+
+      expect { MiqAeGitImport.new(options).import }.to raise_error(ArgumentError)
+    end
+
+    it "invalid ref_type throws an exception" do
+      options = {'git_repository_id' => repo.id,
+                 'ref_type'          => 'Invalid',
+                 'ref'               => 'branch'}
+
+      expect { MiqAeGitImport.new(options).import }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This function allows the Rest API to
- Refresh the contents/branches of the remote repository
- Import a new branch/tag into the Automate domain


Links 
----------------

* https://www.pivotaltracker.com/n/projects/1613499/stories/128530211
* Depends on PR #10298 

Steps for Testing/QA 
-------------------------------

1. Import a domain from a Git Repository using the UI (Automate -> Import/Export)
2. Update the Remote Git Repository with a new branch
3. Use the REST API to refresh the domain and pass in the new branch

This should result in the existing domain getting updated to have the contents of the new branch.