### PR TITLE
Find Azure orchestration stack failure from its operations

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/deployment.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/deployment.rb
@@ -1,0 +1,25 @@
+module ManageIQ::Providers::Azure::CloudManager::Deployment
+  extend ActiveSupport::Concern
+
+  def deployment_failed?(deployment)
+    deployment.properties.provisioning_state.casecmp('failed') == 0
+  end
+
+  # Azure deployment does not contain failure reason. The actual reasons exist in the operations.
+  # This method finds the FIRST error message from the operations. It can be used as the failure reason for the stack.
+  # Note: There may be multiple failure reasons.
+  def deployment_failure_reason(deployment_operations)
+    deployment_operations.each do |operation|
+      message = operation_status_message(operation)
+      return message unless message.blank?
+    end
+    nil
+  end
+
+  def operation_status_message(operation)
+    status_message = operation.properties.try(:status_message)
+    return nil unless status_message
+
+    status_message.try(:error).try(:message) || status_message.to_s
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/orchestration_stack_spec.rb
@@ -3,9 +3,6 @@ require 'azure-armrest'
 describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_azure_with_authentication) }
   let(:template) { FactoryGirl.create(:orchestration_template_azure_with_content) }
-  let(:orchestration_stack) do
-    FactoryGirl.create(:orchestration_stack_azure, :ext_management_system => ems, :name => 'test')
-  end
   let(:orchestration_service) { double }
   let(:the_raw_stack) do
     Azure::Armrest::TemplateDeployment.new(
@@ -13,6 +10,8 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
       'properties' => {'provisioningState' => 'Succeeded'}
     )
   end
+  subject { FactoryGirl.create(:orchestration_stack_azure, :ext_management_system => ems, :name => 'test') }
+
 
   before do
     allow(ManageIQ::Providers::Azure::CloudManager).to receive(:raw_connect).and_return(double)
@@ -26,7 +25,7 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
       allow(rg).to receive(:create)
     end
 
-    context ".create_stack" do
+    describe ".create_stack" do
       it 'creates a stack' do
         expect(orchestration_service).to receive(:create).and_return(the_raw_stack)
 
@@ -45,55 +44,117 @@ describe ManageIQ::Providers::Azure::CloudManager::OrchestrationStack do
       end
     end
 
-    context "#update_stack" do
+    describe "#update_stack" do
       it 'updates the stack' do
         expect(orchestration_service).to receive(:create)
-        orchestration_stack.update_stack(template, {})
+        subject.update_stack(template, {})
       end
 
       it 'catches errors from provider' do
         expect(orchestration_service).to receive(:create).and_raise('bad request')
-        expect { orchestration_stack.update_stack(template, {}) }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+        expect { subject.update_stack(template, {}) }.to raise_error(MiqException::MiqOrchestrationUpdateError)
       end
     end
 
-    context "#delete_stack" do
+    describe "#delete_stack" do
       it 'updates the stack' do
         expect(orchestration_service).to receive(:delete)
-        orchestration_stack.delete_stack
+        subject.delete_stack
       end
 
       it 'catches errors from provider' do
         expect(orchestration_service).to receive(:delete).and_raise('bad request')
-        expect { orchestration_stack.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
+        expect { subject.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
       end
     end
   end
 
   describe 'stack status' do
-    context '#raw_status and #raw_exists' do
-      it 'gets the stack status and reason' do
-        allow(orchestration_service).to receive(:get).and_return(the_raw_stack)
+    describe '#raw_status and #raw_exists' do
+      context 'stack is created successfully' do
+        before { allow(orchestration_service).to receive(:get).and_return(the_raw_stack) }
 
-        rstatus = orchestration_stack.raw_status
-        expect(rstatus).to have_attributes(:status => 'Succeeded', :reason => nil)
+        it 'gets the stack status in success' do
+          expect(subject.raw_status).to have_attributes(:status => 'Succeeded', :reason => nil)
+          expect(subject.raw_exists?).to be_truthy
+        end
+      end
 
-        expect(orchestration_stack.raw_exists?).to be_truthy
+      context 'stack creation failed' do
+        before do
+          bad_raw_stack = Azure::Armrest::TemplateDeployment.new('properties' => {'provisioningState' => 'Failed'})
+          operations = [Azure::Armrest::TemplateDeploymentOperation.new('properties' => { 'statusMessage' => 'reason'})]
+          allow(orchestration_service).to receive(:get).and_return(bad_raw_stack)
+          allow(orchestration_service).to receive(:list_deployment_operations).and_return(operations)
+        end
+
+        it 'gets the stack status in failure and finds its cause' do
+          expect(subject.raw_status).to have_attributes(:status => 'Failed', :reason => 'reason')
+          expect(subject.raw_exists?).to be_truthy
+        end
       end
 
       it 'parses error message to determine stack not exist' do
         allow(orchestration_service).to receive(:get).and_raise("Deployment xxx could not be found")
-        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+        expect { subject.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
 
-        expect(orchestration_stack.raw_exists?).to be_falsey
+        expect(subject.raw_exists?).to be_falsey
       end
 
       it 'catches errors from provider' do
         allow(orchestration_service).to receive(:get).and_raise("bad request")
-        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+        expect { subject.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
 
-        expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+        expect { subject.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
       end
+    end
+  end
+
+  describe '.deployment_failed?' do
+    let(:deployment) do
+      Azure::Armrest::TemplateDeployment.new(
+        'id'         => 'one_id',
+        'properties' => {'provisioningState' => testing_status}
+      )
+    end
+
+    context 'with succeeded deployment' do
+      let(:testing_status) { 'Succeeded' }
+
+      it { expect(subject.deployment_failed?(deployment)).to be_falsey }
+    end
+
+    context 'with failed deployment' do
+      let(:testing_status) { 'Failed' }
+
+      it { expect(subject.deployment_failed?(deployment)).to be_truthy }
+    end
+  end
+
+  describe '.deployment_failure_reason' do
+    let(:operations) do
+      [Azure::Armrest::TemplateDeploymentOperation.new(
+        'id'         => 'one',
+        'properties' => { 'statusMessage' => testing_message }
+      )]
+    end
+
+    context 'without failure operation' do
+      let(:testing_message) { nil }
+
+      it { expect(subject.deployment_failure_reason(operations)).to be_nil }
+    end
+
+    context 'operation has explicit error message' do
+      let(:testing_message) { {'error' => {'message' => 'some reason'}} }
+
+      it { expect(subject.deployment_failure_reason(operations)).to eq('some reason') }
+    end
+
+    context 'operation has general (error) message' do
+      let(:testing_message) { 'some reason' }
+
+      it { expect(subject.deployment_failure_reason(operations)).to eq('some reason') }
     end
   end
 end


### PR DESCRIPTION
Azure template deployment, aka orchestration stack, does not have an attribute for status message. For failed deployments, user needs to go through its operations, aka resources, to find out the causes.

Because of this reason, manageiq automate service currently simply shows provision failure without detailed error message. In the log the user is reminded to look into stack resources for reasons. QE often opened manageiq bugs when an Azure orchestration provisioning failed, but the actual failure happened on the provider side.

With this enhancement we scan through the operations and delegate the error message to the stack. So that the user will see clearly how the stack creation is failing.

The enhancement work is placed in a module. The code is meant to reused by the refresh logic. A follow-up PR will be created to use this module in fresh.
