### PR TITLE
short circuit count_or_objects_only

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -39,7 +39,7 @@ class EmsFolder < ApplicationRecord
 
   # Folder relationship methods
   def folders
-    children(:of_type => 'EmsFolder').sort_by { |c| c.name.downcase }
+    children(:of_type => 'EmsFolder')
   end
 
   alias_method :add_folder, :set_child
@@ -59,7 +59,7 @@ class EmsFolder < ApplicationRecord
 
   # Cluster relationship methods
   def clusters
-    children(:of_type => 'EmsCluster').sort_by { |c| c.name.downcase }
+    children(:of_type => 'EmsCluster')
   end
 
   alias_method :add_cluster, :set_child

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -43,7 +43,7 @@ class ResourcePool < ApplicationRecord
 
   # Resource Pool relationship methods
   def resource_pools
-    children(:of_type => 'ResourcePool').sort_by { |c| c.name.downcase }
+    children(:of_type => 'ResourcePool')
   end
 
   alias_method :add_resource_pool, :set_child
@@ -115,7 +115,7 @@ class ResourcePool < ApplicationRecord
 
   # All RPs under this RP and all child RPs
   def all_resource_pools
-    descendants(:of_type => 'ResourcePool').sort_by { |r| r.name.downcase }
+    descendants(:of_type => 'ResourcePool')
   end
 
   # Parent relationship methods

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -295,6 +295,23 @@ class TreeBuilder
     count_only ? 0 : []
   end
 
+  # count_only_or_objects but for many sets of objects
+  # count_only will short circuit the sizes
+  # the last parameter is a required sort_by (which is typically 'name')
+  #
+  # Passing a lambda around a collection will delay loading the collection.
+  # Especially useful when the collection downloads a lot of data.
+  def count_only_or_many_objects(count_only, *collections)
+    sort_by = collections.pop
+
+    if count_only
+      collections.detect { |objects| resolve_object_lambdas(count_only, objects).size > 0 } ? 1 : 0
+    else
+      collections.map! { |objects| resolve_object_lambdas(count_only, objects) }
+      collections.flat_map { |objects| count_only_or_objects(count_only, objects, sort_by) }
+    end
+  end
+
   def count_only_or_objects(count_only, objects, sort_by = nil)
     if count_only
       objects.size
@@ -319,6 +336,16 @@ class TreeBuilder
     open_nodes = @tree_state.x_tree(@name)[:open_nodes]
     open_nodes.push(id) unless open_nodes.include?(id)
   end
+
+  def resolve_object_lambdas(count_only, objects)
+    if objects.respond_to?(:call)
+      # works with a no-param lambda OR a lambda that requests the count_only
+      (objects.arity == 1) ? objects.call(count_only) : objects.call
+    else
+      objects
+    end
+  end
+  private :resolve_object_lambdas
 
   X_TREE_NODE_CLASSES = {
     # Catalog explorer trees

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -41,46 +41,30 @@ class TreeBuilderDatacenter < TreeBuilder
 
   def x_get_tree_roots(count_only = false, _options)
     if @root.kind_of?(EmsCluster)
-      hosts = count_only_or_objects(count_only, @root.hosts, "name")
-      resource_pools = count_only_or_objects(count_only, @root.resource_pools, "name")
-      vms = count_only_or_objects(count_only, @root.vms, "name")
-      hosts + resource_pools + vms
+      count_only_or_many_objects(count_only, @root.hosts, @root.resource_pools, @root.vms, "name")
     elsif @root.kind_of?(ResourcePool)
-      resource_pools = count_only_or_objects(count_only, @root.resource_pools, "name")
-      vms = count_only_or_objects(count_only, @root.vms, "name")
-      resource_pools + vms
+      count_only_or_many_objects(count_only, @root.resource_pools, @root.vms, "name")
     end
   end
 
   def x_get_tree_datacenter_kids(parent, count_only = false, _type)
-    folders = count_only_or_objects(count_only, parent.folders, "name")
-    clusters = count_only_or_objects(count_only, parent.clusters, "name")
-    folders + clusters
+    count_only_or_many_objects(count_only, parent.folders, parent.clusters, "name")
   end
 
   def x_get_tree_folder_kids(parent, count_only, _type)
     objects = count_only ? 0 : []
 
     if parent.name == "Datacenters"
-      folders = count_only_or_objects(count_only, parent.folders_only, "name")
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
-      objects = folders + datacenters
+      count_only_or_many_objects(count_only, parent.folders_only, parent.datacenters_only, "name")
     elsif parent.name == "host" && parent.parent.kind_of?(Datacenter)
-      folders = count_only_or_objects(count_only, parent.folders_only, "name")
-      clusters = count_only_or_objects(count_only, parent.clusters, "name")
-      hosts = count_only_or_objects(count_only, parent.hosts, "name")
-      objects = folders + clusters + hosts
+      count_only_or_many_objects(count_only, parent.folders_only, parent.clusters, parent.hosts, "name")
     elsif parent.name == "datastore" && parent.parent.kind_of?(Datacenter)
       # Skip showing the datastore folder and sub-folders
     elsif parent.name == "vm" && parent.parent.kind_of?(Datacenter)
       #
     else
-      folders = count_only_or_objects(count_only, parent.folders_only, "name")
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
-      clusters = count_only_or_objects(count_only, parent.clusters, "name")
-      hosts = count_only_or_objects(count_only, parent.hosts, "name")
-      vms = count_only_or_objects(count_only, parent.vms, "name")
-      objects = folders + datacenters + clusters + hosts + vms
+      count_only_or_many_objects(count_only, parent.folders_only, parent.datacenters_only, parent.clusters,
+                                 parent.hosts, parent.vms, "name")
     end
     objects
   end
@@ -97,15 +81,10 @@ class TreeBuilderDatacenter < TreeBuilder
   end
 
   def x_get_tree_cluster_kids(parent, count_only = false)
-    resource_pools = count_only_or_objects(count_only, parent.resource_pools, "name")
-    hosts = count_only_or_objects(count_only, parent.hosts, "name")
-    vms = count_only_or_objects(count_only, parent.vms, "name")
-    resource_pools + hosts + vms
+    count_only_or_many_objects(count_only, parent.resource_pools, parent.hosts, parent.vms, "name")
   end
 
   def x_get_resource_pool_kids(parent, count_only = false)
-    resource_pools = count_only_or_objects(count_only, parent.resource_pools, "name")
-    vms = count_only_or_objects(count_only, parent.vms, "name")
-    resource_pools + vms
+    count_only_or_many_objects(count_only, parent.resource_pools, parent.vms, "name")
   end
 end

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -70,14 +70,13 @@ class TreeBuilderDatacenter < TreeBuilder
   end
 
   def x_get_tree_host_kids(parent, count_only)
-    objects = count_only ? 0 : []
     if parent.authorized_for_user?(@user_id)
-      objects += count_only_or_objects(count_only, parent.resource_pools, "name")
-      if parent.default_resource_pool
-        objects += count_only_or_objects(count_only, parent.default_resource_pool.vms, "name")
-      end
+      count_only_or_many_objects(count_only,
+                                 parent.resource_pools,
+                                 -> { parent.default_resource_pool.try!(:vms) || [] }, "name")
+    else
+      count_only ? 0 : []
     end
-    objects
   end
 
   def x_get_tree_cluster_kids(parent, count_only = false)

--- a/app/presenters/tree_builder_datacenter.rb
+++ b/app/presenters/tree_builder_datacenter.rb
@@ -42,19 +42,19 @@ class TreeBuilderDatacenter < TreeBuilder
   def x_get_tree_roots(count_only = false, _options)
     if @root.kind_of?(EmsCluster)
       hosts = count_only_or_objects(count_only, @root.hosts, "name")
-      resource_pools = count_only_or_objects(count_only, @root.resource_pools)
+      resource_pools = count_only_or_objects(count_only, @root.resource_pools, "name")
       vms = count_only_or_objects(count_only, @root.vms, "name")
       hosts + resource_pools + vms
     elsif @root.kind_of?(ResourcePool)
-      resource_pools = count_only_or_objects(count_only, @root.resource_pools)
+      resource_pools = count_only_or_objects(count_only, @root.resource_pools, "name")
       vms = count_only_or_objects(count_only, @root.vms, "name")
       resource_pools + vms
     end
   end
 
   def x_get_tree_datacenter_kids(parent, count_only = false, _type)
-    folders = count_only_or_objects(count_only, parent.folders)
-    clusters = count_only_or_objects(count_only, parent.clusters)
+    folders = count_only_or_objects(count_only, parent.folders, "name")
+    clusters = count_only_or_objects(count_only, parent.clusters, "name")
     folders + clusters
   end
 
@@ -62,12 +62,12 @@ class TreeBuilderDatacenter < TreeBuilder
     objects = count_only ? 0 : []
 
     if parent.name == "Datacenters"
-      folders = count_only_or_objects(count_only, parent.folders_only)
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only)
+      folders = count_only_or_objects(count_only, parent.folders_only, "name")
+      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
       objects = folders + datacenters
     elsif parent.name == "host" && parent.parent.kind_of?(Datacenter)
-      folders = count_only_or_objects(count_only, parent.folders_only)
-      clusters = count_only_or_objects(count_only, parent.clusters)
+      folders = count_only_or_objects(count_only, parent.folders_only, "name")
+      clusters = count_only_or_objects(count_only, parent.clusters, "name")
       hosts = count_only_or_objects(count_only, parent.hosts, "name")
       objects = folders + clusters + hosts
     elsif parent.name == "datastore" && parent.parent.kind_of?(Datacenter)
@@ -75,9 +75,9 @@ class TreeBuilderDatacenter < TreeBuilder
     elsif parent.name == "vm" && parent.parent.kind_of?(Datacenter)
       #
     else
-      folders = count_only_or_objects(count_only, parent.folders_only)
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only)
-      clusters = count_only_or_objects(count_only, parent.clusters)
+      folders = count_only_or_objects(count_only, parent.folders_only, "name")
+      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
+      clusters = count_only_or_objects(count_only, parent.clusters, "name")
       hosts = count_only_or_objects(count_only, parent.hosts, "name")
       vms = count_only_or_objects(count_only, parent.vms, "name")
       objects = folders + datacenters + clusters + hosts + vms
@@ -88,7 +88,7 @@ class TreeBuilderDatacenter < TreeBuilder
   def x_get_tree_host_kids(parent, count_only)
     objects = count_only ? 0 : []
     if parent.authorized_for_user?(@user_id)
-      objects += count_only_or_objects(count_only, parent.resource_pools)
+      objects += count_only_or_objects(count_only, parent.resource_pools, "name")
       if parent.default_resource_pool
         objects += count_only_or_objects(count_only, parent.default_resource_pool.vms, "name")
       end
@@ -97,14 +97,14 @@ class TreeBuilderDatacenter < TreeBuilder
   end
 
   def x_get_tree_cluster_kids(parent, count_only = false)
-    resource_pools = count_only_or_objects(count_only, parent.resource_pools)
+    resource_pools = count_only_or_objects(count_only, parent.resource_pools, "name")
     hosts = count_only_or_objects(count_only, parent.hosts, "name")
     vms = count_only_or_objects(count_only, parent.vms, "name")
     resource_pools + hosts + vms
   end
 
   def x_get_resource_pool_kids(parent, count_only = false)
-    resource_pools = count_only_or_objects(count_only, parent.resource_pools)
+    resource_pools = count_only_or_objects(count_only, parent.resource_pools, "name")
     vms = count_only_or_objects(count_only, parent.vms, "name")
     resource_pools + vms
   end

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -17,9 +17,8 @@ class TreeBuilderVat < TreeBuilderDatacenter
   end
 
   def x_get_tree_roots(count_only = false, _options)
-    folders = count_only_or_objects(count_only, @root.children.first.folders_only, "name")
-    datacenters = count_only_or_objects(count_only, @root.children.first.datacenters_only, "name")
-    folders + datacenters
+    root_child = @root.children.first
+    count_only_or_many_objects(count_only, root_child.folders_only, root_child.datacenters_only, "name")
   end
 
   def x_get_tree_datacenter_kids(parent, count_only = false, type)
@@ -36,31 +35,20 @@ class TreeBuilderVat < TreeBuilderDatacenter
     objects = count_only ? 0 : []
 
     if parent.name == "Datacenters"
-      folders = count_only_or_objects(count_only, parent.folders_only, "name")
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
-      objects = folders + datacenters
+      objects = count_only_or_many_objects(count_only, parent.folders_only, parent.datacenters_only, "name")
     elsif parent.name == "host" && parent.parent.kind_of?(Datacenter)
       unless @vat
-        folders = count_only_or_objects(count_only, parent.folders_only, "name")
-        clusters = count_only_or_objects(count_only, parent.clusters, "name")
-        hosts = count_only_or_objects(count_only, parent.hosts, "name")
-        objects = folders + clusters + hosts
+        objects = count_only_or_many_objects(count_only, parent.folders_only, parent.clusters, parent.hosts, "name")
       end
     elsif parent.name == "datastore" && parent.parent.kind_of?(Datacenter)
       # Skip showing the datastore folder and sub-folders
     elsif parent.name == "vm" && parent.parent.kind_of?(Datacenter)
       if @vat
-        folders = count_only_or_objects(count_only, parent.folders_only, "name")
-        vms = count_only_or_objects(count_only, parent.vms, "name")
-        objects = folders + vms
+        objects = count_only_or_many_objects(count_only, parent.folders_only, parent.vms, "name")
       end
     else
-      folders = count_only_or_objects(count_only, parent.folders_only, "name")
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
-      clusters = count_only_or_objects(count_only, parent.clusters, "name")
-      hosts = count_only_or_objects(count_only, parent.hosts, "name")
-      vms = count_only_or_objects(count_only, parent.vms, "name")
-      objects = folders + datacenters + clusters + hosts + vms
+      objects = count_only_or_many_objects(count_only, parent.folders_only, parent.datacenters_only,
+                                           parent.clusters, parent.hosts, parent.vms, "name")
     end
     objects
   end

--- a/app/presenters/tree_builder_vat.rb
+++ b/app/presenters/tree_builder_vat.rb
@@ -17,8 +17,8 @@ class TreeBuilderVat < TreeBuilderDatacenter
   end
 
   def x_get_tree_roots(count_only = false, _options)
-    folders = count_only_or_objects(count_only, @root.children.first.folders_only)
-    datacenters = count_only_or_objects(count_only, @root.children.first.datacenters_only)
+    folders = count_only_or_objects(count_only, @root.children.first.folders_only, "name")
+    datacenters = count_only_or_objects(count_only, @root.children.first.datacenters_only, "name")
     folders + datacenters
   end
 
@@ -36,13 +36,13 @@ class TreeBuilderVat < TreeBuilderDatacenter
     objects = count_only ? 0 : []
 
     if parent.name == "Datacenters"
-      folders = count_only_or_objects(count_only, parent.folders_only)
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only)
+      folders = count_only_or_objects(count_only, parent.folders_only, "name")
+      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
       objects = folders + datacenters
     elsif parent.name == "host" && parent.parent.kind_of?(Datacenter)
       unless @vat
-        folders = count_only_or_objects(count_only, parent.folders_only)
-        clusters = count_only_or_objects(count_only, parent.clusters)
+        folders = count_only_or_objects(count_only, parent.folders_only, "name")
+        clusters = count_only_or_objects(count_only, parent.clusters, "name")
         hosts = count_only_or_objects(count_only, parent.hosts, "name")
         objects = folders + clusters + hosts
       end
@@ -50,14 +50,14 @@ class TreeBuilderVat < TreeBuilderDatacenter
       # Skip showing the datastore folder and sub-folders
     elsif parent.name == "vm" && parent.parent.kind_of?(Datacenter)
       if @vat
-        folders = count_only_or_objects(count_only, parent.folders_only)
+        folders = count_only_or_objects(count_only, parent.folders_only, "name")
         vms = count_only_or_objects(count_only, parent.vms, "name")
         objects = folders + vms
       end
     else
-      folders = count_only_or_objects(count_only, parent.folders_only)
-      datacenters = count_only_or_objects(count_only, parent.datacenters_only)
-      clusters = count_only_or_objects(count_only, parent.clusters)
+      folders = count_only_or_objects(count_only, parent.folders_only, "name")
+      datacenters = count_only_or_objects(count_only, parent.datacenters_only, "name")
+      clusters = count_only_or_objects(count_only, parent.clusters, "name")
       hosts = count_only_or_objects(count_only, parent.hosts, "name")
       vms = count_only_or_objects(count_only, parent.vms, "name")
       objects = folders + datacenters + clusters + hosts + vms


### PR DESCRIPTION
Part 2/3 for the `/ems_infra/:id?display=ems_folders` series. part of #12002

Currently, for `count_only`, we add up a bunch of counts.
But in truth, we just care if any of the counts are greater than 0.

This allows those calculations to be short circuited.

details
-------

Introduced `count_only_or_many_objects` which is essentially a varargs version of `count_only_or_objects`. The body just calls `count_only_or_objects` on each of the `objects` passed in.

When running in `count_only` mode, it really just needs to know if any of the `objects` has records. So if one returns a value greater than 0, then short circuit.

This assumes that the collection itself will be lazy. Good news is most of them are lazy except for the first `objects` passed in. If this assumption breaks down, a lambda can be passed in instead. (I have not tried running with #12002 not applied, I'm assuming if we want to backport this screen's improvements, we'll need to backport that one as well)

This just reduces the number of `count(*)` that are called. So the number of objects returned is the same.  Will look into reducing the cost of some of these `count(*)` queries.

numbers
---------

|        ms |queries | query (ms) |     rows |comments
|       ---:|  ---:|      ---:|      ---:| ---
|  22,630.0 |  289 | 21,439.7 |    1,925 |master
|  21,458.7 |  229 | 20,328.4 |    1,925 |count_only
|   3,819.0 |  229 |  2,712.2 |      759 |count_only+grandkids
| 83% | 21% | 87.3% | 61%