### PR TITLE
Fix for Error:no implicit conversion of String into Integer on service dialog import

### DIFF
--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -17,6 +17,8 @@ class DialogImportValidator
       raise ParsedNonDialogYamlError unless dialog["dialog_tabs"]
       check_dialog_tabs_for_validity(dialog["dialog_tabs"])
     end
+  rescue TypeError
+    raise ParsedNonDialogYamlError
   end
 
   def check_dialog_tabs_for_validity(dialog_tabs)

--- a/spec/models/dialog_import_validator_spec.rb
+++ b/spec/models/dialog_import_validator_spec.rb
@@ -67,6 +67,12 @@ describe DialogImportValidator do
         end
       end
 
+      context "when the 'dialog' is an array instead of a hash" do
+        let(:uploaded_content) { [[1, 2, 3]].to_yaml }
+
+        it_behaves_like "DialogImportValidator#determine_validity parsing non dialog yaml content"
+      end
+
       context "when the 'dialog' does not have dialog tabs'" do
         let(:uploaded_content) { [{"this is not" => "dialog yaml"}].to_yaml }
 


### PR DESCRIPTION
When attempting to upload a valid yaml file that contains an array of hashes (instead of a hash of hashes), the validator was attempting to index the array with a hash key and was blowing up.

This is now handled gracefully and we tell them that their yaml file does not conform to 'dialog' standards.

https://bugzilla.redhat.com/show_bug.cgi?id=1383331

@miq-bot assign @gmcculloug 