### PR TITLE
Middleware provider: Filtering out all the host controllers (except t…

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -123,11 +123,14 @@ module ManageIQ::Providers
       with_provider_connection do |connection|
         path = ::Hawkular::Inventory::CanonicalPath.new(:feed_id          => hawk_escape_id(feed),
                                                         :resource_type_id => hawk_escape_id('Domain Host'))
-        connection.inventory.list_resources_for_type(path.to_s, :fetch_properties => true)
+        host_controllers = connection.inventory.list_resources_for_type(path.to_s, :fetch_properties => true)
+
+        # filter only the domain controllers
+        host_controllers.select { |host_controller| host_controller.properties['Is Domain Controller'] == 'true' }
       end
     end
 
-    def server_groups(feed, _domain)
+    def server_groups(feed)
       with_provider_connection do |connection|
         path = ::Hawkular::Inventory::CanonicalPath.new(:feed_id          => hawk_escape_id(feed),
                                                         :resource_type_id => hawk_escape_id('Domain Server Group'))

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/middleware_manager/refresher.yml
@@ -5220,4 +5220,100 @@ http_interactions:
         }
     http_version: 
   recorded_at: Mon, 26 Sep 2016 13:57:55 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server/rl;defines/type=r
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 21 Oct 2016 17:01:18 GMT
+      X-Total-Count:
+      - '3'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2338'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server/rl;defines/type=r>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-one",
+          "name" : "Domain WildFly Server [server-one]",
+          "identityHash" : "db1945a8f54a1d9c7769bf44729c94a84fec1",
+          "contentHash" : "705759e8a9d7833b8293d6acfc2e6e4d75ca2f",
+          "syncHash" : "17c6a82927c6c1f5c54791913e2105ff3799ea5",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
+            "name" : "Domain WildFly Server",
+            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
+            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
+            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
+            "id" : "Domain WildFly Server"
+          },
+          "id" : "Local~/host=master/server=server-one"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-three",
+          "name" : "Domain WildFly Server [server-three]",
+          "identityHash" : "9af84d40e44f91a7576e212aa5e832cf62fb874",
+          "contentHash" : "f91dd171df9499743c8d937a4858a2b57a3f2",
+          "syncHash" : "b6a175a8080b5b76d5f6dcff8cb4fb2e4d7b0ca",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
+            "name" : "Domain WildFly Server",
+            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
+            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
+            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
+            "id" : "Domain WildFly Server"
+          },
+          "id" : "Local~/host=master/server=server-three"
+        }, {
+          "path" : "/t;hawkular/f;master.Unnamed%20Domain/r;Local~~/r;Local~%2Fhost%3Dmaster/r;Local~%2Fhost%3Dmaster%2Fserver%3Dserver-two",
+          "name" : "Domain WildFly Server [server-two]",
+          "identityHash" : "1ae2848bad79c3ec8316d54150520d6862c9d31",
+          "contentHash" : "33f194ba088df5d7e5dcdc72c1bee57617cbef",
+          "syncHash" : "df633ccaca8f15d9262f3bb2b21b7dbcb2a0e5",
+          "type" : {
+            "path" : "/t;hawkular/f;master.Unnamed%20Domain/rt;Domain%20WildFly%20Server",
+            "name" : "Domain WildFly Server",
+            "identityHash" : "3498788d788a114fec3a155ea78f2f373764c0",
+            "contentHash" : "796591cd152f75923c60c28fffa02e721fd1a1f1",
+            "syncHash" : "bf5ad8a330c649cdbf3f2757287ac6c2cf20b115",
+            "id" : "Domain WildFly Server"
+          },
+          "id" : "Local~/host=master/server=server-two"
+        } ]
+    http_version: 
+  recorded_at: Fri, 21 Oct 2016 17:01:18 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
there are 2 changes in the code:
- The first one (`middleware_manager.rb`) changes the way how the domains are fetched from the provider. We basically count, how many domain controllers are in the hawkular-inventory. Not every host controller is also a domain controller so this needs to be assured, this information is in the resource configuration.
- The second change is about how the domain servers are fetched. Before we asked about all the children resources of the host/domain controller. This was we obtained the information about which host has which server, but domain is an abstract concept (not dealing with where is each server running) so now we just asked the feed about all the resources of type `Domain WildFly Server`. This is faster then filtering all the child resources in memory based on the type, but it assumes that there is only 1 domain per feed which is always true, afaik. 

@pilhuhn could you please correct me if I am wrong with my assumption?

for QA: see [reproduction steps](https://github.com/ManageIQ/manageiq/issues/12074) in the issue description.

@miq-bot add_label providers/hawkular, bug, euwe/yes
