### PR TITLE
Add link to Host to Network Port details page

### DIFF
--- a/app/helpers/network_port_helper/textual_summary.rb
+++ b/app/helpers/network_port_helper/textual_summary.rb
@@ -11,7 +11,7 @@ module NetworkPortHelper::TextualSummary
   end
 
   def textual_group_relationships
-    %i(parent_ems_cloud ems_network cloud_tenant instance cloud_subnets floating_ips)
+    %i(parent_ems_cloud ems_network cloud_tenant instance cloud_subnets floating_ips host)
   end
 
   #
@@ -64,5 +64,12 @@ module NetworkPortHelper::TextualSummary
 
   def textual_floating_ips
     @record.floating_ips
+  end
+
+  def textual_host
+    return nil unless @record.device_type == "Host"
+    {:image => "host", :value => @record.device, :link => url_for(:controller => "host",
+                                                                  :action     => "show",
+                                                                  :id         => @record.device.id)}
   end
 end


### PR DESCRIPTION
Adding basic UI for Openstack infra get missing network ports from
smartstate PR https://github.com/ManageIQ/manageiq/pull/11743

A link leading to Host was added to Network provider details page. It is displayed
only when network port belongs to a Host.

Links
----------------
* https://github.com/ManageIQ/manageiq/pull/11743
* https://bugzilla.redhat.com/show_bug.cgi?id=1266152
