### PR TITLE
Force codemirror to 5.19.*

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "es6-shim": "^0.35.0",
     "phantomjs-polyfill": "^0.0.2",
     "fetch": "^1.0.0",
-    "codemirror": "^5.16.0",
+    "codemirror": "~5.19.0",
     "array-includes": "^1.0.0",
     "qs": "^0.3.10",
     "rxjs": "^4.1.0",


### PR DESCRIPTION
codemirror-5.20.0 [came out today](https://github.com/codemirror/CodeMirror/releases/tag/5.20.0), which abandons the es5 source file in favour of es6 source that has to be compiled.

We don't support that yet, forcing the version to the last one working.


Tagging as `euwe/yes` and `darga/yes`, because without this, any new build will have codemirror broken. (We had a badly fixed dependency, `^` means anything newer, not the same minor version.)

Cc @simaishi 