### PR TITLE
Ensure spinner gets turned off when there is an error during git import

### DIFF
--- a/app/assets/javascripts/import.js
+++ b/app/assets/javascripts/import.js
@@ -17,9 +17,7 @@ var ImportSetup = {
       if (messageData.level === 'error') {
         showErrorMessage(messageData.message);
         $('#git-url-import').prop('disabled', null);
-      }
-
-      if (event.data.git_branches || event.data.git_tags) {
+      } else if (event.data.git_branches || event.data.git_tags) {
         Automate.renderGitImport(
           event.data.git_branches,
           event.data.git_tags,
@@ -27,6 +25,8 @@ var ImportSetup = {
           event.data.message
         );
       }
+
+      miqSparkleOff();
     });
   },
 


### PR DESCRIPTION
When there was an error, the spinner wasn't being turned off, so the error message would show up, but you couldn't do anything because it would be stuck with the spinner on the screen.

This was discovered by @mkanoor while trying to fix https://bugzilla.redhat.com/show_bug.cgi?id=1386254.

@mkanoor Please review, and/or tag others to review. Thanks!