### PR TITLE
Fix  storage profile connection on 5.5 vCenters

### DIFF
--- a/gems/pending/VMwareWebService/VimService.rb
+++ b/gems/pending/VMwareWebService/VimService.rb
@@ -12,6 +12,7 @@ class VimService < Handsoap::Service
     setNameSpace('urn:vim25')
 
     @serviceInstanceMor = VimString.new("ServiceInstance", "ServiceInstance")
+    @session_cookie     = nil
 
     @sic = retrieveServiceContent
 
@@ -21,7 +22,6 @@ class VimService < Handsoap::Service
     @v2              = @apiVersion =~ /2\..*/
     @v4              = @apiVersion =~ /4\..*/
     @isVirtualCenter = @about.apiType == "VirtualCenter"
-    @session_cookie  = nil
   end
 
   def acquireCloneTicket(sm)
@@ -446,7 +446,7 @@ class VimService < Handsoap::Service
       message.add "n1:userName", username
       message.add "n1:password", password
     end
-    @session_cookie = response.cookie
+    @session_cookie ||= response.cookie
     (parse_response(response, 'LoginResponse')['returnval'])
   end
 
@@ -931,6 +931,7 @@ class VimService < Handsoap::Service
         i.set_attr "type", @serviceInstanceMor.vimType
       end
     end
+    @session_cookie ||= response.cookie
     (parse_response(response, 'RetrieveServiceContentResponse')['returnval'])
   end
 

--- a/gems/pending/VMwareWebService/VimService.rb
+++ b/gems/pending/VMwareWebService/VimService.rb
@@ -9,16 +9,11 @@ class VimService < Handsoap::Service
   def initialize(ep)
     super
 
-    setNameSpace('urn:vim2')
+    setNameSpace('urn:vim25')
 
     @serviceInstanceMor = VimString.new("ServiceInstance", "ServiceInstance")
 
-    begin
-      @sic = retrieveServiceContent
-    rescue Handsoap::Fault
-      setNameSpace('urn:vim25')
-      @sic = retrieveServiceContent
-    end
+    @sic = retrieveServiceContent
 
     @about           = @sic.about
     @apiVersion      = @about.apiVersion
@@ -27,8 +22,6 @@ class VimService < Handsoap::Service
     @v4              = @apiVersion =~ /4\..*/
     @isVirtualCenter = @about.apiType == "VirtualCenter"
     @session_cookie  = nil
-
-    setNameSpace('urn:vim25') unless @v20
   end
 
   def acquireCloneTicket(sm)

--- a/spec/vcr_cassettes/manageiq/providers/vmware/infra_manager/vm/remote_console.yml
+++ b/spec/vcr_cassettes/manageiq/providers/vmware/infra_manager/vm/remote_console.yml
@@ -7,47 +7,6 @@ http_interactions:
       encoding: UTF-8
       string: ! "<?xml version='1.0' ?>\n<env:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
         xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <env:Header />\n
-        \ <env:Body>\n    <n1:RetrieveServiceContent xmlns:n1=\"urn:vim2\">\n      <n1:_this
-        type=\"ServiceInstance\">ServiceInstance</n1:_this>\n    </n1:RetrieveServiceContent>\n
-        \ </env:Body>\n</env:Envelope>"
-    headers:
-      Content-Type:
-      - text/xml;charset=UTF-8
-      Soapaction:
-      - RetrieveServiceContent
-  response:
-    status:
-      code: 500
-      message: Internal Server Error
-    headers:
-      Date:
-      - Fri, 12 Oct 2012 17:49:14 GMT
-      Set-Cookie:
-      - vmware_soap_session="1C5C02A8-25B3-4588-AF84-E316B26CA532"; Path=/;
-      Cache-Control:
-      - no-cache
-      Connection:
-      - Keep-Alive
-      Content-Type:
-      - text/xml; charset=utf-8
-      Content-Length:
-      - '476'
-    body:
-      encoding: US-ASCII
-      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\"\n
-        xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"\n xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n
-        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soapenv:Body>\n<soapenv:Fault>\n
-        \ <faultcode>ClientFaultCode</faultcode>\n  <faultstring>Unsupported version
-        URI RetrieveServiceContent</faultstring>\n</soapenv:Fault>\n</soapenv:Body>\n</soapenv:Envelope>"
-    http_version: 
-  recorded_at: Fri, 12 Oct 2012 17:49:14 GMT
-- request:
-    method: post
-    uri: https://192.168.252.14/sdk
-    body:
-      encoding: UTF-8
-      string: ! "<?xml version='1.0' ?>\n<env:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
-        xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <env:Header />\n
         \ <env:Body>\n    <n1:RetrieveServiceContent xmlns:n1=\"urn:vim25\">\n      <n1:_this
         type=\"ServiceInstance\">ServiceInstance</n1:_this>\n    </n1:RetrieveServiceContent>\n
         \ </env:Body>\n</env:Envelope>"


### PR DESCRIPTION
The vSphere SPBM endpoint doesn't have its own authentication, instead it relies on being passed a session cookie from an authenticated VIM endpoint session.

On 6.0 vCenters this session cookie is returned in `LoginResponse` but on 5.5 vCenters it is returned only in the first `RetrieveServiceContentResponse`.

It is important to note that it is only returned in the first call, because we call `RetrieveServiceContent` with `urn:vim2` first then when that raises an exception we try again with `urn:vim25`.  This causes us to be unable to retrieve the cookie because the only response that contains it is lost when we raise the exception.

Since `urn:vim2` only applies to vCenter Server 2.0 (circa 2007) it would seem safe to remove this check.

https://bugzilla.redhat.com/show_bug.cgi?id=1386706