### PR TITLE
Change user_or_group_owned specs to reuse the objects already created.

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -52,6 +52,10 @@ module ArRegion
       id.to_i / rails_sequence_factor
     end
 
+    def id_in_region(id, region_number)
+      region_number * rails_sequence_factor + id
+    end
+
     def region_to_range(region_number)
       (region_number * rails_sequence_factor)..(region_number * rails_sequence_factor + rails_sequence_factor - 1)
     end

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -15,6 +15,12 @@ describe "AR Regions extension" do
     expect(base_class.id_to_region(25)).to eq(2)
   end
 
+  it ".id_in_region" do
+    expect(base_class.id_in_region(5, 0)).to eq(5)
+    expect(base_class.id_in_region(5, 1)).to eq(15)
+    expect(base_class.id_in_region(5, 2)).to eq(25)
+  end
+
   it ".region_to_range" do
     expect(base_class.region_to_range(0)).to eq(0..9)
     expect(base_class.region_to_range(1)).to eq(10..19)

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -18,7 +18,7 @@ shared_examples_for "OwnershipMixin" do
       FactoryGirl.create(factory, :name => "user_owned2", :evm_owner => user2)
     end
 
-    describe ".owning_ldap_group" do
+    describe "#owning_ldap_group" do
       before { User.current_user = user }
 
       context "when miq_group is in the ldap group" do
@@ -38,7 +38,7 @@ shared_examples_for "OwnershipMixin" do
       end
     end
 
-    describe ".owned_by_current_ldap_group" do
+    describe "#owned_by_current_ldap_group" do
       before { User.current_user = user }
 
       it "usable as arel" do
@@ -91,7 +91,7 @@ shared_examples_for "OwnershipMixin" do
       end
     end
 
-    describe ".evm_owner_name" do
+    describe "#evm_owner_name" do
       before { User.current_user = user }
 
       context "when has a user" do
@@ -111,7 +111,7 @@ shared_examples_for "OwnershipMixin" do
       end
     end
 
-    describe ".evm_owner_userid" do
+    describe "#evm_owner_userid" do
       before { User.current_user = user }
 
       context "when has a user" do
@@ -131,7 +131,7 @@ shared_examples_for "OwnershipMixin" do
       end
     end
 
-    describe ".evm_owner_email" do
+    describe "#evm_owner_email" do
       before { User.current_user = user }
 
       context "when has a user" do
@@ -205,7 +205,7 @@ shared_examples_for "OwnershipMixin" do
       end
     end
 
-    describe ".owned_by_current_user" do
+    describe "#owned_by_current_user" do
       before { User.current_user = user }
 
       it "usable as arel" do

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -2,20 +2,23 @@ shared_examples_for "OwnershipMixin" do
   context "includes OwnershipMixin" do
     include Spec::Support::ArelHelper
 
-    let(:user) { User.where(:userid => "ownership_user").first }
+    let(:user) do
+      FactoryGirl.create(:user,
+                         :userid     => "ownership_user",
+                         :miq_groups => FactoryGirl.create_list(:miq_group, 1))
+    end
 
-    before do
-      user = FactoryGirl.create(:user,
-                                :userid     => "ownership_user",
-                                :miq_groups => FactoryGirl.create_list(:miq_group, 1))
-      user2 = FactoryGirl.create(:user)
+    let(:user2)  { FactoryGirl.create(:user) }
+    let(:group)  { user.current_group }
+    let(:group2) { FactoryGirl.create(:miq_group) }
 
-      factory = described_class.to_s.underscore.to_sym
-      FactoryGirl.create(factory, :name => "in_ldap",     :miq_group_id => user.current_group.id)
-      FactoryGirl.create(factory, :name => "not_in_ldap", :miq_group => FactoryGirl.create(:miq_group))
-      FactoryGirl.create(factory, :name => "no_group")
-      FactoryGirl.create(factory, :name => "user_owned",  :evm_owner => user)
-      FactoryGirl.create(factory, :name => "user_owned2", :evm_owner => user2)
+    let(:factory) { described_class.to_s.underscore.to_sym }
+
+    let!(:in_ldap)     { FactoryGirl.create(factory, :name => "in_ldap",     :miq_group => group) }
+    let!(:not_in_ldap) { FactoryGirl.create(factory, :name => "not_in_ldap", :miq_group => group2) }
+    let!(:no_group)    { FactoryGirl.create(factory, :name => "no_group") }
+    let!(:user_owned)  { FactoryGirl.create(factory, :name => "user_owned",  :evm_owner => user) }
+    let!(:user_owned2) { FactoryGirl.create(factory, :name => "user_owned2", :evm_owner => user2) }
     end
 
     describe "#owning_ldap_group" do


### PR DESCRIPTION
Even though I has asked him to do it, I never saw @gtanzillo's change come through in #11993 , so I had written up these specs instead.  I spoke with him, and I'm pushing up to see if it's better.

I personally think it's better because it reuses the existing setup, and is more concise.  Additionally, I have made two changes that allow for future cleanup PRs to make the OwnershipMixin specs faster and more readable

1. I have changed the giant before block to let statements to allow reuse of the objects that are created.  I leverage this in my new .user_or_group_owned tests, but in future PRs we can remove stuff like [this](https://github.com/ManageIQ/manageiq/blob/d309798bc6b04ac97a14578583ec778d9bcc842b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb#L260-L264)

2. I've also introduced a new helper method to ArRegion, which in this PR seems as if it's only useful here, but I see a bunch of DRYing up opportunities in ArRegion itself by introducing it.  Additionally, I know there are a few other places in tests where we manually create records in "other regions", and this can be reused.