### PR TITLE
Fix the issue that alerts don't send SNMP v1 traps.

### DIFF
--- a/app/models/miq_snmp.rb
+++ b/app/models/miq_snmp.rb
@@ -28,10 +28,10 @@ class MiqSnmp
     raise MiqException::Error, _("MiqSnmp.trap_v1: Ensure that enterprise OID is provided") if enterprise.nil?
 
     # The IP address of the SNMP agent as a String or IpAddress.
-    agent_address = inputs[:agent_address] || inputs['agent_address'] || self.agent_address
-    if agent_address.nil?
+    address = inputs[:agent_address] || inputs['agent_address'] || agent_address
+    if address.nil?
       raise MiqException::Error,
-            _("MiqSnmp.trap_v1: Ensure that server.host is configured properly in your vmdb.yml file")
+            _("MiqSnmp.trap_v1: Ensure that server.host is configured properly in your settings.yml file")
     end
 
     # An integer respresenting the number of hundredths of a second that this system has been up.

--- a/spec/models/miq_snmp_spec.rb
+++ b/spec/models/miq_snmp_spec.rb
@@ -9,4 +9,15 @@ describe MiqSnmp do
                       :object_list => [{:oid => "1.2.3", :var_type => "Integer", :value => "1"}])
     end
   end
+
+  describe '.trap_v1' do
+    it 'calls agent_address' do
+      expect(MiqSnmp).to receive(:agent_address).at_least(1).and_return("192.168.1.8")
+
+      MiqSnmp.trap_v1(:host          => ["localhost"],
+                      :sysuptime     => 1,
+                      :specific_trap => "56",
+                      :object_list   => [{:oid=>"1.2.3", :var_type=>"Integer", :value=>"1"}])
+    end
+  end
 end


### PR DESCRIPTION
Followup of #11988.
Private methods can only be called without an explicit receiver.

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1381287