### PR TITLE
[WIP] Fix lint/useless-access-modifier offenses

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -61,13 +61,12 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
     super(connection_options)
   end
 
-  private
-
   def self.connection_options(cloud_tenant = nil)
     connection_options = {:service => "Network"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
     connection_options
   end
+  private_class_method :connection_options
 
   private
 

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -198,8 +198,6 @@ module SupportsFeatureMixin
       SupportsFeatureMixin::QUERYABLE_FEATURES.key?(feature.to_sym)
     end
 
-    private
-
     def unsupported
       # This is a class variable and it might be modified during runtime
       # because we dont eager load all classes at boot time, so it needs to be thread safe
@@ -241,5 +239,9 @@ module SupportsFeatureMixin
         !unsupported.key?(feature)
       end
     end
+
+    private :unsupported
+    private :unsupported_reason_add
+    private :define_supports_feature_methods
   end
 end

--- a/app/models/registration_system.rb
+++ b/app/models/registration_system.rb
@@ -52,8 +52,6 @@ module RegistrationSystem
     false
   end
 
-  private
-
   def self.assemble_options(options)
     options = database_options if options.blank?
     {

--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -16,8 +16,6 @@ module Vmdb
       delegate :silence, :warn, :to => :instance
     end
 
-    private
-
     def self.default_behavior
       [proc_for_default_log].tap { |a| a << ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:stderr] unless Rails.env.production? }
     end


### PR DESCRIPTION
Realated to the issue #12034 

**Fix lint/useless-access-modifier offenses raised by Rubocop.**

in the file [`/gems/pending/util/miq-password.rb:`](https://github.com/ManageIQ/manageiq/blob/master/gems/pending/util/miq-password.rb#L177)
there were two class methods declared as `protected` and identified as offenses by Rubocop. 
I set this 2 methods public. Is ok for you?
## Steps for Testing/QA [Optional]

`rubocop --only Lint/UselessAccessModifier`
## Links

See also #11031 and #11032
