### PR TITLE
Disable upload button to prevent upload when no file selected

### DIFF
--- a/app/views/miq_policy/_export.html.haml
+++ b/app/views/miq_policy/_export.html.haml
@@ -48,8 +48,12 @@
                          "data-buttonName"  => "btn-default")
             :javascript
               $(":file").filestyle({icon: false, placeholder: "No file chosen"});
+              $("#upload_file").on("change", function() {
+                ImportSetup.setUpUploadImportButton('#upload_tags')
+              });
+
           .col-md-6
-            = submit_tag(_("Upload"), :id => "upload_tags", :class => "btn btn-default")
+            = submit_tag(_("Upload"), :id => "upload_tags", :class => "btn btn-default", :disabled => true)
 
   - if @sb[:hide] == false
     %hr


### PR DESCRIPTION
To prevent upload functionality when no file selected in Control
Import/Export screen.