### PR TITLE
Remove no-op method call, that is followed useless by nil? check

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -210,7 +210,6 @@ class ChargebackController < ApplicationController
 
   def cb_rate_show
     @display = "main"
-    @record.chargeback_rate_details
     if @record.nil?
       redirect_to :action => "cb_rates_list", :flash_msg => _("Error: Record no longer exists in the database"), :flash_error => true
       return


### PR DESCRIPTION
The  `chargeback_rate_details` is an association on ChargebackRate.

There is no point to fetch the association and then verify that the given `ChargebackRate` was not nil. Unless you are into surrealism.

@miq-bot add_label technical debt, chargeback, ui
@miq-bot assign @mzazrivec 