### PR TITLE
Fix the dropdown name for HW attribute

### DIFF
--- a/app/views/miq_policy/_alert_builtin_exp.html.haml
+++ b/app/views/miq_policy/_alert_builtin_exp.html.haml
@@ -166,7 +166,7 @@
           :class => "selectpicker")
         :javascript
           miqInitSelectPicker();
-          miqSelectPickerEvent('select_event_log_message_filter_type', '#{url}', {beforeSend: true, complete: true})
+          miqSelectPickerEvent('select_hdw_attr', '#{url}', {beforeSend: true, complete: true})
         = select_tag('select_operator',
           options_for_select(@edit[:operators], @edit[:new][:expression][:options][:operator]),
           :class => "selectpicker")


### PR DESCRIPTION
With wrong name in ```miqSelectPickerEvent``` the user was not able to change HW attribute to RAM

https://bugzilla.redhat.com/show_bug.cgi?id=1378919