### PR TITLE
Security Groups provisioning UI

### DIFF
--- a/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
+++ b/app/assets/javascripts/controllers/security_group/security_group_form_controller.js
@@ -1,0 +1,51 @@
+ManageIQ.angular.app.controller('securityGroupFormController', ['$http', '$scope', 'securityGroupFormId', 'miqService', function($http, $scope, securityGroupFormId, miqService) {
+  $scope.securityGroupModel = { name: '' };
+  $scope.formId = securityGroupFormId;
+  $scope.afterGet = false;
+  $scope.modelCopy = angular.copy( $scope.securityGroupModel );
+  $scope.model = "securityGroupModel";
+
+  ManageIQ.angular.scope = $scope;
+
+  if (securityGroupFormId == 'new') {
+    $scope.securityGroupModel.name = "";
+    $scope.securityGroupModel.description = "";
+    $scope.newRecord = true;
+  } else {
+    miqService.sparkleOn();
+
+    $http.get('/security_group/security_group_form_fields/' + securityGroupFormId).success(function(data) {
+      $scope.afterGet = true;
+      $scope.securityGroupModel.name = data.name;
+      $scope.securityGroupModel.description = data.description;
+      $scope.securityGroupModel.cloud_tenant_name = data.cloud_tenant_name;
+      $scope.modelCopy = angular.copy( $scope.securityGroupModel );
+      miqService.sparkleOff();
+    });
+  }
+
+  $scope.addClicked = function() {
+    var url = 'create/new' + '?button=add';
+    miqService.miqAjaxButton(url, $scope.securityGroupModel, { complete: false });
+  };
+
+  $scope.cancelClicked = function() {
+    if (securityGroupFormId == 'new') {
+      var url = '/security_group/create/new' + '?button=cancel';
+    } else {
+      var url = '/security_group/update/' + securityGroupFormId + '?button=cancel';
+    }
+    miqService.miqAjaxButton(url);
+  };
+
+  $scope.saveClicked = function() {
+    var url = '/security_group/update/' + securityGroupFormId + '?button=save';
+    miqService.miqAjaxButton(url, $scope.securityGroupModel, { complete: false });
+  };
+
+  $scope.resetClicked = function() {
+    $scope.securityGroupModel = angular.copy( $scope.modelCopy );
+    $scope.angularForm.$setPristine(true);
+    miqService.miqFlash("warn", "All changes have been reset");
+  };
+}]);

--- a/app/controllers/security_group_controller.rb
+++ b/app/controllers/security_group_controller.rb
@@ -14,4 +14,269 @@ class SecurityGroupController < ApplicationController
   end
 
   menu_section :net
+
+  def button
+    @edit = session[:edit] # Restore @edit for adv search box
+    params[:display] = @display if %w(vms instances images).include?(@display)
+    params[:page] = @current_page unless @current_page.nil? # Save current page for list refresh
+
+    @refresh_div = "main_div"
+
+    case params[:pressed]
+    when "security_group_tag"
+      return tag("SecurityGroup")
+    when 'security_group_delete'
+      delete_security_groups
+    when "security_group_edit"
+      checked_security_group_id = get_checked_security_group_id(params)
+      javascript_redirect :action => "edit", :id => checked_security_group_id
+    else
+      if params[:pressed] == "security_group_new"
+        javascript_redirect :action => "new"
+      elsif !flash_errors? && @refresh_div == "main_div" && @lastaction == "show_list"
+        replace_gtl_main_div
+      else
+        render_flash
+      end
+    end
+  end
+
+  def cancel_action(message)
+    session[:edit] = nil
+    @breadcrumbs.pop if @breadcrumbs
+    javascript_redirect :action    => @lastaction,
+                        :id        => @security_group.id,
+                        :display   => session[:security_group_display],
+                        :flash_msg => message
+  end
+
+  def security_group_form_fields
+    assert_privileges("security_group_edit")
+    security_group = find_by_id_filtered(SecurityGroup, params[:id])
+    render :json => {
+      :name              => security_group.name,
+      :description       => security_group.description,
+      :cloud_tenant_name => security_group.cloud_tenant.try(:name),
+    }
+  end
+
+  def create
+    assert_privileges("security_group_new")
+    case params[:button]
+    when "cancel"
+      javascript_redirect :action    => 'show_list',
+                          :flash_msg => _("Add of new Security Group was cancelled by the user") % {
+                            :model => ui_lookup(:table => 'security_group') }
+
+    when "add"
+      @security_group = SecurityGroup.new
+      options = form_params
+      ems = ExtManagementSystem.find(options[:ems_id])
+      if SecurityGroup.class_by_ems(ems).supports_create?
+        options.delete(:ems_id)
+        task_id = ems.create_security_group_queue(session[:userid], options)
+
+        add_flash(_("Security Group creation: Task start failed: ID [%{id}]") %
+                  {:id => task_id.inspect}, :error) unless task_id.kind_of?(Fixnum)
+
+        if @flash_array
+          javascript_flash(:spinner_off => true)
+        else
+          initiate_wait_for_task(:task_id => task_id, :action => "create_finished")
+        end
+      else
+        @in_a_form = true
+        add_flash(_(SecurityGroup.unsupported_reason(:create)), :error)
+        drop_breadcrumb(:name => _("Add New Security Group "), :url  => "/security_group/new")
+        javascript_flash
+      end
+    end
+  end
+
+  def create_finished
+    task_id = session[:async][:params][:task_id]
+    security_group_name = session[:async][:params][:name]
+    task = MiqTask.find(task_id)
+    if MiqTask.status_ok?(task.status)
+      add_flash(_("Security Group \"%{name}\" created") % { :name  => security_group_name })
+    else
+      add_flash(_("Unable to create Security Group \"%{name}\": %{details}") % {
+        :name    => security_group_name,
+        :details => task.message
+      }, :error)
+    end
+
+    @breadcrumbs.pop if @breadcrumbs
+    session[:edit] = nil
+    session[:flash_msgs] = @flash_array.dup if @flash_array
+
+    javascript_redirect :action => "show_list"
+  end
+
+  def delete_security_groups
+    assert_privileges("security_group_delete")
+
+    security_groups = if @lastaction == "show_list" || (@lastaction == "show" && @layout != "security_group")
+                        find_checked_items
+                      else
+                        [params[:id]]
+                      end
+
+    if security_groups.empty?
+      add_flash(_("No %{models} were selected for deletion.") % {
+        :models => ui_lookup(:tables => "security_group")
+      }, :error)
+    end
+
+    security_groups_to_delete = []
+    security_groups.each do |s|
+      security_group = SecurityGroup.find(s)
+      if security_group.nil?
+        add_flash(_("Security Group no longer exists."), :error)
+      elsif security_group.supports_delete?
+        security_groups_to_delete.push(security_group)
+      else
+        add_flash(_("Couldn't initiate deletion of Security Group \"%{name}\": %{details}") % {
+          :name    => security_group.name,
+          :details => security_group.unsupported_reason(:delete)
+        }, :error)
+      end
+    end
+    process_security_groups(security_groups_to_delete, "destroy") unless security_groups_to_delete.empty?
+
+    # refresh the list if applicable
+    if @lastaction == "show_list"
+      show_list
+      @refresh_partial = "layouts/gtl"
+    elsif @lastaction == "show" && @layout == "security_group"
+      @single_delete = true unless flash_errors?
+      if @flash_array.nil?
+        add_flash(_("The selected Security Group was deleted"))
+      else # or (if we deleted what we were showing) we redirect to the listing
+        javascript_redirect :action => 'show_list', :flash_msg => @flash_array[0][:message]
+      end
+    end
+  end
+
+  def edit
+    assert_privileges("security_group_edit")
+    @security_group = find_by_id_filtered(SecurityGroup, params[:id])
+    @in_a_form = true
+    drop_breadcrumb(
+      :name => _("Edit Security Group \"%{name}\"") % { :name  => @security_group.name},
+      :url  => "/security_group/edit/#{@security_group.id}")
+  end
+
+  def get_checked_security_group_id(params)
+    if params[:id]
+      checked_security_group_id = params[:id]
+    else
+      checked_security_groups = find_checked_items
+      checked_security_group_id = checked_security_groups[0] if checked_security_groups.length == 1
+    end
+    checked_security_group_id
+  end
+
+  def new
+    assert_privileges("security_group_new")
+    @security_group = SecurityGroup.new
+    @in_a_form = true
+
+    @ems_choices = {}
+    ExtManagementSystem.where(:type => "ManageIQ::Providers::Openstack::NetworkManager").find_each do |ems|
+      @ems_choices[ems.name] = ems.id
+    end
+
+    @cloud_tenant_choices = {}
+    CloudTenant.all.each { |tenant| @cloud_tenant_choices[tenant.name] = tenant.id }
+
+    drop_breadcrumb(:name => _("Add New Security Group"), :url => "/security_group/new")
+  end
+
+  def update
+    assert_privileges("security_group_edit")
+    @security_group = find_by_id_filtered(SecurityGroup, params[:id])
+    options = form_params
+    case params[:button]
+    when "cancel"
+      cancel_action(_("Edit of Security Group \"%{name}\" was cancelled by the user") % {
+        :name => @security_group.name
+      })
+
+    when "save"
+      if @security_group.supports_update?
+        task_id = @security_group.update_security_group_queue(session[:userid], options)
+        add_flash(_("Security Group update failed: Task start failed: ID [%{id}]") %
+                  {:id => task_id.inspect}, :error) unless task_id.kind_of?(Fixnum)
+        if @flash_array
+          javascript_flash(:spinner_off => true)
+        else
+          initiate_wait_for_task(:task_id => task_id, :action => "update_finished")
+        end
+      else
+        add_flash(_("Couldn't initiate update of Security Group \"%{name}\": %{details}") % {
+          :name    => @security_group.name,
+          :details => @security_group.unsupported_reason(:delete)
+        }, :error)
+      end
+    end
+  end
+
+  def update_finished
+    task_id = session[:async][:params][:task_id]
+    security_group_id = session[:async][:params][:id]
+    security_group_name = session[:async][:params][:name]
+    task = MiqTask.find(task_id)
+    if MiqTask.status_ok?(task.status)
+      add_flash(_("Security Group \"%{name}\" updated") % {
+        :model => ui_lookup(:table => 'security_group'),
+        :name  => security_group_name
+      })
+    else
+      add_flash(_("Unable to update Security Group \"%{name}\": %{details}") % {
+        :model   => ui_lookup(:table => 'security_group'),
+        :name    => security_group_name,
+        :details => task.message
+      }, :error)
+    end
+
+    @breadcrumbs.pop if @breadcrumbs
+    session[:edit] = nil
+    session[:flash_msgs] = @flash_array.dup if @flash_array
+
+    javascript_redirect :action => "show", :id => security_group_id
+  end
+
+  private
+
+  def form_params
+    options = {}
+    options[:name] = params[:name] if params[:name]
+    options[:description] = params[:description] if params[:description]
+    options[:ems_id] = params[:ems_id] if params[:ems_id]
+    options[:cloud_tenant] = find_by_id_filtered(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]
+    options
+  end
+
+  # dispatches operations to multiple security_groups
+  def process_security_groups(security_groups, operation)
+    return if security_groups.empty?
+
+    if operation == "destroy"
+      security_groups.each do |security_group|
+        audit = {
+          :event        => "security_group_record_delete_initiated",
+          :message      => "[#{security_group.name}] Record delete initiated",
+          :target_id    => security_group.id,
+          :target_class => "SecurityGroup",
+          :userid       => session[:userid]
+        }
+        AuditEvent.success(audit)
+        security_group.delete_security_group_queue(session[:userid])
+      end
+      add_flash(n_("Delete initiated for %{number} Security Group.",
+                   "Delete initiated for %{number} Security Groups.",
+                   security_groups.length) % {:number => security_groups.length})
+    end
+  end
 end

--- a/app/helpers/application_helper/toolbar/security_group_center.rb
+++ b/app/helpers/application_helper/toolbar/security_group_center.rb
@@ -1,4 +1,31 @@
 class ApplicationHelper::Toolbar::SecurityGroupCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'security_group_vmdb',
+    [
+      select(
+        :security_group_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :security_group_edit,
+            'pficon pficon-edit fa-lg',
+            t = N_('Edit this Security Group'),
+            t,
+            :url_parms => 'main_div'),
+          button(
+            :security_group_delete,
+            'pficon pficon-delete fa-lg',
+            t = N_('Delete this Security Group'),
+            t,
+            :url_parms => 'main_div',
+            :confirm   => N_('Warning: This Security Group and ALL of its components will be removed!')
+          )
+        ]
+      )
+    ]
+  )
   button_group('security_group_policy', [
     select(
       :security_group_policy_choice,

--- a/app/helpers/application_helper/toolbar/security_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/security_groups_center.rb
@@ -1,4 +1,42 @@
 class ApplicationHelper::Toolbar::SecurityGroupsCenter < ApplicationHelper::Toolbar::Basic
+  button_group(
+    'security_group_vmdb',
+    [
+      select(
+        :security_group_vmdb_choice,
+        'fa fa-cog fa-lg',
+        t = N_('Configuration'),
+        t,
+        :items => [
+          button(
+            :security_group_new,
+            'pficon pficon-add-circle-o fa-lg',
+            t = N_('Add a new Security Group'),
+            t),
+          separator,
+          # TODO: Uncomment until cross controllers show_list issue fully in place
+          # https://github.com/ManageIQ/manageiq/pull/12551
+          # button(
+          #  :security_group_edit,
+          #  'pficon pficon-edit fa-lg',
+          #  t = N_('Edit selected Security Group'),
+          #  t,
+          #  :url_parms => 'main_div',
+          #  :enabled   => false,
+          #  :onwhen    => '1'),
+          # button(
+          #  :security_group_delete,
+          #  'pficon pficon-delete fa-lg',
+          #  t = N_('Delete selected Security Groups'),
+          #  t,
+          #  :url_parms => 'main_div',
+          #  :confirm   => N_('Warning: The selected Security Groups and ALL of their components will be removed!'),
+          #  :enabled   => false,
+          #  :onwhen    => '1+')
+        ]
+      )
+    ]
+  )
   button_group('security_group_policy', [
     select(
       :security_group_policy_choice,

--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -18,7 +18,6 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
 
   supports :create
   supports :create_floating_ip
-  supports :create_security_group
   supports :create_network_router
 
   has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
@@ -168,7 +167,7 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
     }
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'create_floating_ip',
+      :method_name => 'create_security_group',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',

--- a/app/models/manageiq/providers/openstack/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/security_group.rb
@@ -1,11 +1,23 @@
 class ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup < ::SecurityGroup
-  include ProviderObjectMixin
-  include AsyncDeleteMixin
   include SupportsFeatureMixin
 
-  supports :create_security_group
-  supports :delete_security_group
-  supports :update_security_group
+  supports :create
+
+  supports :delete do
+    if ext_management_system.nil?
+      unsupported_reason_add(:delete_security_group, _("The Security Group is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+  end
+
+  supports :update do
+    if ext_management_system.nil?
+      unsupported_reason_add(:update_security_group, _("The Security Group is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+  end
 
   def self.raw_create_security_group(ext_management_system, options)
     cloud_tenant = options.delete(:cloud_tenant)

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -21,4 +21,9 @@ class SecurityGroup < ApplicationRecord
   def self.non_cloud_network
     where(:cloud_network_id => nil)
   end
+
+  def self.class_by_ems(ext_management_system)
+    # TODO: use a factory on ExtManagementSystem side to return correct class for each provider
+    ext_management_system && ext_management_system.class::SecurityGroup
+  end
 end

--- a/app/views/security_group/_common_new_edit.html.haml
+++ b/app/views/security_group/_common_new_edit.html.haml
@@ -1,0 +1,23 @@
+%h3
+  = _('Security Group Information')
+.form-horizontal
+  .form-group
+    %label.col-md-2.control-label
+      = _('Security Group Name')
+    .col-md-8
+      %input.form-control{:type          => "text",
+                          :name          => "name",
+                          'ng-model'     => "securityGroupModel.name",
+                          'ng-maxlength' => 128,
+                          :miqrequired   => true,
+                          :checkchange   => true}
+  .form-group
+    %label.col-md-2.control-label
+      = _('Security Group Description')
+    .col-md-8
+      %input.form-control{:type          => "text",
+                          :name          => "description",
+                          'ng-model'     => "securityGroupModel.description",
+                          'ng-maxlength' => 128,
+                          :miqrequired   => false,
+                          :checkchange   => true}

--- a/app/views/security_group/edit.html.haml
+++ b/app/views/security_group/edit.html.haml
@@ -1,0 +1,28 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "securityGroupFormController"}
+  = render :partial => "layouts/flash_msg"
+  = render :partial => "common_new_edit"
+
+  %h3
+    = _('Placement')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Cloud Tenant')
+      .col-md-8
+        %input.form-control{:type          => "text",
+                            :name          => "cloud_tenant_name",
+                            'ng-model'     => "securityGroupModel.cloud_tenant_name",
+                            'ng-maxlength' => 128,
+                            :miqrequired   => true,
+                            :checkchange   => true,
+                            "readonly"     => true}
+
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          = render :partial => "layouts/angular/x_edit_buttons_angular"
+
+:javascript
+  ManageIQ.angular.app.value('securityGroupFormId', '#{@security_group.id}');
+  miq_bootstrap('#form_div');

--- a/app/views/security_group/new.html.haml
+++ b/app/views/security_group/new.html.haml
@@ -1,0 +1,41 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "securityGroupFormController"}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Network Management Provider')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Network Manager')
+      .col-md-8
+        = select_tag("ems_id",
+                      options_for_select([["<#{_('Choose')}>", nil]] + @ems_choices.sort),
+                      "ng-model"                    => "securityGroupModel.ems_id",
+                      "required"                    => "",
+                      :miqrequired                  => true,
+                      :checkchange                  => true,
+                      "selectpicker-for-select-tag" => "")
+  = render :partial => "common_new_edit"
+  %h3
+    = _('Placement')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Cloud Tenant')
+      .col-md-8
+        = select_tag("cloud_tenant_id",
+          options_for_select([["<#{_('Choose')}>", nil]] + @cloud_tenant_choices.sort),
+                      "ng-model"                    => "securityGroupModel.cloud_tenant_id",
+                      "required"                    => "",
+                      :miqrequired                  => true,
+                      :checkchange                  => true,
+                      "selectpicker-for-select-tag" => "")
+
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          = render :partial => "layouts/angular/x_edit_buttons_angular"
+
+:javascript
+  ManageIQ.angular.app.value('securityGroupFormId', '#{@security_group.id || "new"}');
+  miq_bootstrap('#form_div');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1480,8 +1480,11 @@ Vmdb::Application.routes.draw do
 
     :security_group           => {
       :get  => %w(
+        edit
         download_data
         index
+        new
+        security_group_form_fields
         show
         show_list
         tagging_edit
@@ -1489,12 +1492,17 @@ Vmdb::Application.routes.draw do
         compare_get,
       :post => %w(
         button
+        create
+        form_field_changed
         quick_search
         listnav_search_selected
+        sections_field_changed
         show
         show_list
         tag_edit_form_field_changed
         tagging_edit
+        update
+        wait_for_task
       ) +
         adv_search_post +
         compare_post +

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4209,6 +4209,23 @@
       :description: Edit Tags of Security Group
       :feature_type: control
       :identifier: security_group_tag
+  - :name: Modify
+    :description: Modify Security Groups
+    :feature_type: admin
+    :identifier: security_group_admin
+    :children:
+    - :name: Add
+      :description: Add a Security Group
+      :feature_type: admin
+      :identifier: security_group_new
+    - :name: Edit
+      :description: Edit a Security Group
+      :feature_type: admin
+      :identifier: security_group_edit
+    - :name: Remove
+      :description: Remove Security Groups
+      :feature_type: admin
+      :identifier: security_group_delete
 
 # Floating IP
 - :name: Floating IPs

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -2,4 +2,201 @@ require Rails.root.join('spec/shared/controllers/shared_examples_for_security_gr
 
 describe SecurityGroupController do
   include_examples :shared_examples_for_security_group_controller, %w(openstack azure google)
+
+  context "#button" do
+    before(:each) do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      ApplicationController.handle_exceptions = true
+    end
+
+    it "when Edit Tag is pressed" do
+      skip "Not ready yet"
+      expect(controller).to receive(:tag)
+      post :button, :params => { :pressed => "edit_tag", :format => :js }
+      expect(controller.send(:flash_errors?)).not_to be_truthy
+    end
+  end
+
+  context "#tags_edit" do
+    let!(:user) { stub_user(:features => :all) }
+    before(:each) do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @ct = FactoryGirl.create(:security_group, :name => "security-group-01")
+      allow(@ct).to receive(:tagged_with).with(:cat => user.userid).and_return("my tags")
+      classification = FactoryGirl.create(:classification, :name => "department", :description => "Department")
+      @tag1 = FactoryGirl.create(:classification_tag,
+                                 :name   => "tag1",
+                                 :parent => classification)
+      @tag2 = FactoryGirl.create(:classification_tag,
+                                 :name   => "tag2",
+                                 :parent => classification)
+      allow(Classification).to receive(:find_assigned_entries).with(@ct).and_return([@tag1, @tag2])
+      session[:tag_db] = "SecurityGroup"
+      edit = {
+        :key        => "SecurityGroup_edit_tags__#{@ct.id}",
+        :tagging    => "SecurityGroup",
+        :object_ids => [@ct.id],
+        :current    => {:assignments => []},
+        :new        => {:assignments => [@tag1.id, @tag2.id]}
+      }
+      session[:edit] = edit
+    end
+
+    after(:each) do
+      expect(response.status).to eq(200)
+    end
+
+    it "builds tagging screen" do
+      post :button, :params => { :pressed => "security_group_tag", :format => :js, :id => @ct.id }
+      expect(assigns(:flash_array)).to be_nil
+    end
+
+    it "cancels tags edit" do
+      session[:breadcrumbs] = [{:url => "security_group/show/#{@ct.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "cancel", :format => :js, :id => @ct.id }
+      expect(assigns(:flash_array).first[:message]).to include("was cancelled by the user")
+      expect(assigns(:edit)).to be_nil
+    end
+
+    it "save tags" do
+      session[:breadcrumbs] = [{:url => "security_group/show/#{@ct.id}"}, 'placeholder']
+      post :tagging_edit, :params => { :button => "save", :format => :js, :id => @ct.id }
+      expect(assigns(:flash_array).first[:message]).to include("Tag edits were successfully saved")
+      expect(assigns(:edit)).to be_nil
+    end
+  end
+
+  describe "#show" do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      @security_group = FactoryGirl.create(:security_group)
+      login_as FactoryGirl.create(:user)
+    end
+
+    subject do
+      get :show, :params => {:id => @security_group.id}
+    end
+
+    context "render listnav partial" do
+      render_views
+      it do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_security_group")
+      end
+    end
+  end
+
+  describe "#create" do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      @ems = FactoryGirl.create(:ems_openstack).network_manager
+      @security_group = FactoryGirl.create(:security_group_openstack)
+    end
+
+    context "#create" do
+      let(:task_options) do
+        {
+          :action => "creating Security Group for user %{user}" % {:user => controller.current_user.userid},
+          :userid => controller.current_user.userid
+        }
+      end
+      let(:queue_options) do
+        {
+          :class_name  => @ems.class.name,
+          :method_name => 'create_security_group',
+          :instance_id => @ems.id,
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => 'ems_operations',
+          :zone        => @ems.my_zone,
+          :args        => [{:name => "test"}]
+        }
+      end
+
+      it "builds create screen" do
+        post :button, :params => { :pressed => "security_group_new", :format => :js }
+        expect(assigns(:flash_array)).to be_nil
+      end
+
+      it "queues the create action" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        post :create, :params => { :button => "add", :format => :js, :name => 'test',
+                                   :tenant_id => 'id', :ems_id => @ems.id }
+      end
+    end
+  end
+
+  describe "#edit" do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      @ems = FactoryGirl.create(:ems_openstack).network_manager
+      @security_group = FactoryGirl.create(:security_group_openstack, :ext_management_system => @ems)
+    end
+
+    context "#edit" do
+      let(:task_options) do
+        {
+          :action => "updating Security Group for user %{user}" % {:user => controller.current_user.userid},
+          :userid => controller.current_user.userid
+        }
+      end
+      let(:queue_options) do
+        {
+          :class_name  => @security_group.class.name,
+          :method_name => 'raw_update_security_group',
+          :instance_id => @security_group.id,
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => 'ems_operations',
+          :zone        => @ems.my_zone,
+          :args        => [{:name => "foo2"}]
+        }
+      end
+
+      it "builds edit screen" do
+        post :button, :params => { :pressed => "security_group_edit", :format => :js, :id => @security_group.id }
+        expect(assigns(:flash_array)).to be_nil
+      end
+
+      it "queues the update action" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        post :update, :params => { :button => "save", :format => :js, :id => @security_group.id, :name => "foo2" }
+      end
+    end
+  end
+
+  describe "#delete" do
+    before do
+      stub_user(:features => :all)
+      EvmSpecHelper.create_guid_miq_server_zone
+      @ems = FactoryGirl.create(:ems_openstack).network_manager
+      @security_group = FactoryGirl.create(:security_group_openstack, :ext_management_system => @ems)
+    end
+
+    context "#delete" do
+      let(:task_options) do
+        {
+          :action => "deleting Security Group for user %{user}" % {:user => controller.current_user.userid},
+          :userid => controller.current_user.userid
+        }
+      end
+      let(:queue_options) do
+        {
+          :class_name  => @security_group.class.name,
+          :method_name => 'raw_delete_security_group',
+          :instance_id => @security_group.id,
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => 'ems_operations',
+          :zone        => @ems.my_zone,
+          :args        => []
+        }
+      end
+
+      it "queues the delete action" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options)
+        post :button, :params => { :id => @security_group.id, :pressed => "security_group_delete", :format => :js }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds controller actions with task queueing
Validation using supports feature mixin.
Adds new and edit views with javascript

https://bugzilla.redhat.com/show_bug.cgi?id=1394278

Access through left navigation: Networks -> Security Groups - toolbar Configuration
![12101](https://cloud.githubusercontent.com/assets/289743/20625800/5b64165e-b30d-11e6-99f3-760e905f276f.png)
