### PR TITLE
Add delete functionality for generic object UI

### DIFF
--- a/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
+++ b/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
@@ -6,23 +6,31 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
     $scope.showSingleItem = false;
 
     genericObjectSubscriptionService.subscribeToShowAddForm(showAddForm);
+    genericObjectSubscriptionService.subscribeToShowEditForm(showEditForm);
     genericObjectSubscriptionService.subscribeToTreeClicks(showSelectedItem);
     genericObjectSubscriptionService.subscribeToRootTreeclicks(showAllItems);
   };
 
   var showAddForm = function(_response) {
     $scope.clearForm();
-    $scope.showAddForm = true;
+    $scope.newRecord = true;
+    $scope.showForm = true;
     sendDataWithRx({eventType: 'deselectTreeNodes'});
+  };
+
+  var showEditForm = function(_response) {
+    $scope.backupGenericObjectDefinitionModel = angular.copy($scope.genericObjectDefinitionModel);
+    $scope.newRecord = false;
+    $scope.showForm = true;
   };
 
   var showAllItems = function(response) {
     $scope.genericObjectList = response;
     $scope.showSingleItem = false;
-    $scope.showAddForm = false;
+    $scope.showForm = false;
   };
 
-  var addedGenericObject = function(_data) {
+  var addedOrUpdatedGenericObject = function(_data) {
     var successCallback = function(response) {
       sendDataWithRx({eventType: 'treeUpdated', response: JSON.parse(response.data.tree_data)});
     };
@@ -32,13 +40,14 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
 
   var hideAndClearForm = function() {
     $scope.clearForm();
-    $scope.showAddForm = false;
+    $scope.showForm = false;
   };
 
   var showSelectedItem = function(response) {
+    $scope.genericObjectDefinitionModel.id = response.id;
     $scope.genericObjectDefinitionModel.name = response.name;
     $scope.genericObjectDefinitionModel.description = response.description;
-    $scope.showAddForm = false;
+    $scope.showForm = false;
     $scope.showSingleItem = true;
     miqService.sparkleOff();
   };
@@ -52,17 +61,30 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
 
   $scope.listObjectClicked = function(name) {
     sendDataWithRx({eventType: 'singleItemSelected', response: name});
+    sendDataWithRx({eventType: 'sendCountSelectedAndUpdateToolbar', countSelected: 1});
   };
 
   $scope.addClicked = function() {
     var data = $scope.genericObjectDefinitionModel;
 
-    $http.post('create', data).then(addedGenericObject);
+    $http.post('create', data).then(addedOrUpdatedGenericObject);
+  };
+
+  $scope.saveClicked = function() {
+    var data = $scope.genericObjectDefinitionModel;
+
+    $http.post('save', data).then(addedOrUpdatedGenericObject);
   };
 
   $scope.cancelClicked = function() {
     hideAndClearForm();
     sendDataWithRx({eventType: 'cancelClicked'});
+    sendDataWithRx({eventType: 'sendCountSelectedAndUpdateToolbar', countSelected: 0});
+    $scope.angularForm.$setPristine(true);
+  };
+
+  $scope.resetClicked = function() {
+    $scope.genericObjectDefinitionModel = angular.copy($scope.backupGenericObjectDefinitionModel);
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
+++ b/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
@@ -7,6 +7,7 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
 
     genericObjectSubscriptionService.subscribeToShowAddForm(showAddForm);
     genericObjectSubscriptionService.subscribeToShowEditForm(showEditForm);
+    genericObjectSubscriptionService.subscribeToDeleteGenericObject(deleteGenericObject);
     genericObjectSubscriptionService.subscribeToTreeClicks(showSelectedItem);
     genericObjectSubscriptionService.subscribeToRootTreeclicks(showAllItems);
   };
@@ -23,6 +24,12 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
     $scope.newRecord = false;
     $scope.showForm = true;
     sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 0});
+  };
+
+  var deleteGenericObject = function(_response) {
+    var data = {id: $scope.genericObjectDefinitionModel.id};
+
+    $http.post('delete', data).then(addedOrUpdatedGenericObject);
   };
 
   var showAllItems = function(response) {

--- a/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
+++ b/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
@@ -61,7 +61,7 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
 
   $scope.listObjectClicked = function(name) {
     sendDataWithRx({eventType: 'singleItemSelected', response: name});
-    sendDataWithRx({eventType: 'sendCountSelectedAndUpdateToolbar', countSelected: 1});
+    sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 1});
   };
 
   $scope.addClicked = function() {
@@ -79,7 +79,7 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
   $scope.cancelClicked = function() {
     hideAndClearForm();
     sendDataWithRx({eventType: 'cancelClicked'});
-    sendDataWithRx({eventType: 'sendCountSelectedAndUpdateToolbar', countSelected: 0});
+    sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 0});
     $scope.angularForm.$setPristine(true);
   };
 

--- a/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
+++ b/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
@@ -22,12 +22,14 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
     $scope.backupGenericObjectDefinitionModel = angular.copy($scope.genericObjectDefinitionModel);
     $scope.newRecord = false;
     $scope.showForm = true;
+    sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 0});
   };
 
   var showAllItems = function(response) {
     $scope.genericObjectList = response;
     $scope.showSingleItem = false;
     $scope.showForm = false;
+    sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 0});
   };
 
   var addedOrUpdatedGenericObject = function(_data) {
@@ -49,6 +51,7 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
     $scope.genericObjectDefinitionModel.description = response.description;
     $scope.showForm = false;
     $scope.showSingleItem = true;
+    sendDataWithRx({eventType: 'updateToolbarCount', countSelected: 1});
     miqService.sparkleOff();
   };
 

--- a/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
+++ b/app/assets/javascripts/controllers/generic_object/generic_object_definition_controller.js
@@ -57,6 +57,7 @@ ManageIQ.angular.app.controller('genericObjectDefinitionFormController', ['$http
 
   $scope.clearForm = function() {
     $scope.genericObjectDefinitionModel = {
+      id: '',
       name: '',
       description: ''
     };

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -14,23 +14,9 @@
   */
   function subscribeToSubject() {
     ManageIQ.angular.rxSubject.subscribe(function(event) {
-      if (event.eventType === 'sendCountSelectedAndUpdateToolbar') {
-        this.MiQToolbarSettingsService.countSelected = event.countSelected;
-        var items = this.MiQToolbarSettingsService.items;
-        var _this = this;
-        _.chain(items)
-          .flatten()
-          .each(function(item) {
-            _this.MiQToolbarSettingsService.enableToolbarItemByCountSelected(item);
-          })
-          .map('items')
-          .flatten()
-          .each(function(item) {
-            _this.MiQToolbarSettingsService.enableToolbarItemByCountSelected(item);
-          })
-          .value();
-      }
-      if (event.rowSelect) {
+      if (event.eventType === 'updateToolbarCount') {
+        this.MiQToolbarSettingsService.setCount(event.countSelected);
+      } else if (event.rowSelect) {
         this.onRowSelect(event.rowSelect);
       } else if (event.redrawToolbar) {
          this.onUpdateToolbar(event.redrawToolbar);

--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -14,6 +14,22 @@
   */
   function subscribeToSubject() {
     ManageIQ.angular.rxSubject.subscribe(function(event) {
+      if (event.eventType === 'sendCountSelectedAndUpdateToolbar') {
+        this.MiQToolbarSettingsService.countSelected = event.countSelected;
+        var items = this.MiQToolbarSettingsService.items;
+        var _this = this;
+        _.chain(items)
+          .flatten()
+          .each(function(item) {
+            _this.MiQToolbarSettingsService.enableToolbarItemByCountSelected(item);
+          })
+          .map('items')
+          .flatten()
+          .each(function(item) {
+            _this.MiQToolbarSettingsService.enableToolbarItemByCountSelected(item);
+          })
+          .value();
+      }
       if (event.rowSelect) {
         this.onRowSelect(event.rowSelect);
       } else if (event.redrawToolbar) {

--- a/app/assets/javascripts/services/generic_object_subscription_service.js
+++ b/app/assets/javascripts/services/generic_object_subscription_service.js
@@ -3,6 +3,10 @@ ManageIQ.angular.app.service('genericObjectSubscriptionService', ['subscriptionS
     subscriptionService.subscribeToEventType('showAddForm', callback);
   };
 
+  this.subscribeToShowEditForm = function(callback) {
+    subscriptionService.subscribeToEventType('showEditForm', callback);
+  };
+
   this.subscribeToTreeClicks = function(callback) {
     subscriptionService.subscribeToEventType('treeClicked', callback);
   };

--- a/app/assets/javascripts/services/generic_object_subscription_service.js
+++ b/app/assets/javascripts/services/generic_object_subscription_service.js
@@ -7,6 +7,10 @@ ManageIQ.angular.app.service('genericObjectSubscriptionService', ['subscriptionS
     subscriptionService.subscribeToEventType('showEditForm', callback);
   };
 
+  this.subscribeToDeleteGenericObject = function(callback) {
+    subscriptionService.subscribeToEventType('deleteGenericObject', callback);
+  };
+
   this.subscribeToTreeClicks = function(callback) {
     subscriptionService.subscribeToEventType('treeClicked', callback);
   };

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -3,12 +3,19 @@ class GenericObjectController < ApplicationController
 
   def create
     generic_object_definition = GenericObjectDefinition.new
-    generic_object_definition.name = params[:name]
-    generic_object_definition.description = params[:description]
 
+    update_model_fields(generic_object_definition)
     generic_object_definition.save!
 
     render :json => {:message => _("Generic Object Definition created successfully")}
+  end
+
+  def save
+    generic_object_definition = GenericObjectDefinition.find(params[:id])
+
+    update_model_fields(generic_object_definition)
+
+    render :json => {:message => _("Generic Object Definition saved successfully")}
   end
 
   def explorer
@@ -32,7 +39,11 @@ class GenericObjectController < ApplicationController
   def object_data
     generic_object_definition = GenericObjectDefinition.find(params[:id])
 
-    render :json => {:name => generic_object_definition.name, :description => generic_object_definition.description}
+    render :json => {
+      :id          => generic_object_definition.id,
+      :name        => generic_object_definition.name,
+      :description => generic_object_definition.description
+    }
   end
 
   def tree_data
@@ -42,6 +53,11 @@ class GenericObjectController < ApplicationController
   end
 
   private
+
+  def update_model_fields(generic_object_definition)
+    generic_object_definition.update_attribute(:name, params[:name])
+    generic_object_definition.update_attribute(:description, params[:description])
+  end
 
   def features
     [ApplicationController::Feature.new_with_hash(:role        => "generic_object_explorer",

--- a/app/controllers/generic_object_controller.rb
+++ b/app/controllers/generic_object_controller.rb
@@ -18,6 +18,14 @@ class GenericObjectController < ApplicationController
     render :json => {:message => _("Generic Object Definition saved successfully")}
   end
 
+  def delete
+    generic_object_definition = GenericObjectDefinition.find(params[:id])
+
+    generic_object_definition.delete
+
+    render :json => {:message => _("Generic Object Definition deleted")}
+  end
+
   def explorer
     @layout = "generic_object"
 

--- a/app/helpers/application_helper/toolbar/generic_object_definition.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition.rb
@@ -15,6 +15,18 @@ class ApplicationHelper::Toolbar::GenericObjectDefinition < ApplicationHelper::T
             'function'      => 'sendDataWithRx',
             'function-data' => '{"eventType": "showAddForm"}'
           }
+        ),
+        button(
+          :generic_object_definition_edit,
+          'pficon pficon-edit fa-lg',
+          title = N_('Edit this Generic Object Definition'),
+          title,
+          :onwhen  => "1",
+          :enabled => false,
+          :data    => {
+            'function'      => 'sendDataWithRx',
+            'function-data' => '{"eventType": "showEditForm"}'
+          }
         )
       ]
     )

--- a/app/helpers/application_helper/toolbar/generic_object_definition.rb
+++ b/app/helpers/application_helper/toolbar/generic_object_definition.rb
@@ -27,6 +27,18 @@ class ApplicationHelper::Toolbar::GenericObjectDefinition < ApplicationHelper::T
             'function'      => 'sendDataWithRx',
             'function-data' => '{"eventType": "showEditForm"}'
           }
+        ),
+        button(
+          :generic_object_definition_delete,
+          'pficon pficon-delete fa-lg',
+          title = N_('Delete this Generic Object Definition'),
+          title,
+          :onwhen  => "1",
+          :enabled => false,
+          :data    => {
+            'function'      => 'sendDataWithRx',
+            'function-data' => '{"eventType": "deleteGenericObject"}'
+          }
         )
       ]
     )

--- a/app/views/generic_object/explorer.html.haml
+++ b/app/views/generic_object/explorer.html.haml
@@ -1,5 +1,5 @@
 #generic-object-div{"ng-controller" => "genericObjectDefinitionFormController"}
-  #main_div.generic-object-main-div{"ng-hide" => "showAddForm"}
+  #main_div.generic-object-main-div{"ng-hide" => "showForm"}
     .all-items{"ng-hide" => "showSingleItem"}
       %h4
         = _("Generic Objects")
@@ -33,12 +33,16 @@
           %p.generic-object-definition-description
             {{ genericObjectDefinitionModel.description }}
 
-  .form-horizontal{"ng-show" => "showAddForm"}
-    %form#generic-object-form{"name"          => "angularForm"}
+  .form-horizontal{"ng-show" => "showForm"}
+    %form#generic-object-form{"name" => "angularForm"}
+      %input{"type" => "hidden", "ng-model" => "genericObjectDefinitionModel.id"}
+
       .form-group
         .col-md-10
-          %h4
+          %h4{"ng-show" => "newRecord"}
             = _("Create a new Generic Object Definition")
+          %h4{"ng-hide" => "newRecord"}
+            = _("Edit Generic Object Definition")
 
       .form-group
         %label.col-md-2.control-label{"for" => "generic-object-definition-name"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1784,6 +1784,7 @@ Vmdb::Application.routes.draw do
       ),
       :post => %w(
         create
+        save
       )
     },
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1784,6 +1784,7 @@ Vmdb::Application.routes.draw do
       ),
       :post => %w(
         create
+        delete
         save
       )
     },

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2306,6 +2306,10 @@
       :description: Generic Object Definition Create
       :feature_type: node
       :identifier: generic_object_definition_create
+    - :name: Generic Object Definition Edit
+      :description: Generic Object Definition Edit
+      :feature_type: node
+      :identifier: generic_object_definition_edit
 
 # Automate Import/Export
 - :name: Import/Export

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2310,6 +2310,10 @@
       :description: Generic Object Definition Edit
       :feature_type: node
       :identifier: generic_object_definition_edit
+    - :name: Generic Object Definition Delete
+      :description: Generic Object Definition Delete
+      :feature_type: node
+      :identifier: generic_object_definition_delete
 
 # Automate Import/Export
 - :name: Import/Export

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -46,6 +46,25 @@ describe GenericObjectController do
     end
   end
 
+  describe "#delete" do
+    let(:params) { {:id => generic_object_definition.id} }
+    let(:generic_object_definition) { GenericObjectDefinition.create!(:name => "name", :description => "description") }
+
+    before do
+      post :delete, params
+    end
+
+    it "deletes the generic object" do
+      expect(GenericObjectDefinition.count).to eq(0)
+    end
+
+    it "renders a json message" do
+      expect(response.body).to eq({
+        :message => "Generic Object Definition deleted"
+      }.to_json)
+    end
+  end
+
   describe "#explorer" do
     let(:tree_builder_generic_object) { double("TreeBuilderGenericObject") }
 

--- a/spec/controllers/generic_object_controller_spec.rb
+++ b/spec/controllers/generic_object_controller_spec.rb
@@ -22,6 +22,30 @@ describe GenericObjectController do
     end
   end
 
+  describe "#save" do
+    let(:params) { {:id => generic_object_definition.id, :name => "new name", :description => "new description"} }
+    let(:generic_object_definition) { GenericObjectDefinition.create!(:name => "name", :description => "description") }
+
+    before do
+      post :save, params
+      generic_object_definition.reload
+    end
+
+    it "adjusts the name" do
+      expect(generic_object_definition.name).to eq("new name")
+    end
+
+    it "adjusts the description" do
+      expect(generic_object_definition.description).to eq("new description")
+    end
+
+    it "renders a json message on success" do
+      expect(response.body).to eq({
+        :message => "Generic Object Definition saved successfully"
+      }.to_json)
+    end
+  end
+
   describe "#explorer" do
     let(:tree_builder_generic_object) { double("TreeBuilderGenericObject") }
 
@@ -85,6 +109,7 @@ describe GenericObjectController do
     it "returns the name and description of the selected item in a json format" do
       get :object_data, params
       expect(response.body).to eq({
+        :id          => @generic_object_definition.id,
         :name        => "name",
         :description => "description"
       }.to_json)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1930,7 +1930,8 @@ describe ApplicationHelper do
       end
 
       it "includes the correct button items" do
-        expect(_toolbar_builder.build_toolbar(toolbar_to_build).first[:items].first).to include(
+        items = _toolbar_builder.build_toolbar(toolbar_to_build).first[:items]
+        expect(items[0]).to include(
           :id    => "generic_object_definition_choice__generic_object_definition_create",
           :type  => :button,
           :icon  => "pficon pficon-add-circle-o fa-lg",
@@ -1939,6 +1940,19 @@ describe ApplicationHelper do
           :data  => {
             'function'      => 'sendDataWithRx',
             'function-data' => '{"eventType": "showAddForm"}'
+          }
+        )
+        expect(items[1]).to include(
+          :id      => "generic_object_definition_choice__generic_object_definition_edit",
+          :type    => :button,
+          :icon    => "pficon pficon-edit fa-lg",
+          :title   => "Edit this Generic Object Definition",
+          :text    => "Edit this Generic Object Definition",
+          :onwhen  => "1",
+          :enabled => false,
+          :data    => {
+            'function'      => 'sendDataWithRx',
+            'function-data' => '{"eventType": "showEditForm"}'
           }
         )
       end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1955,6 +1955,19 @@ describe ApplicationHelper do
             'function-data' => '{"eventType": "showEditForm"}'
           }
         )
+        expect(items[2]).to include(
+          :id      => "generic_object_definition_choice__generic_object_definition_delete",
+          :type    => :button,
+          :icon    => "pficon pficon-delete fa-lg",
+          :title   => "Delete this Generic Object Definition",
+          :text    => "Delete this Generic Object Definition",
+          :onwhen  => "1",
+          :enabled => false,
+          :data    => {
+            'function'      => 'sendDataWithRx',
+            'function-data' => '{"eventType": "deleteGenericObject"}'
+          }
+        )
       end
     end
   end

--- a/spec/javascripts/controllers/generic_object/generic_object_definition_controller_spec.js
+++ b/spec/javascripts/controllers/generic_object/generic_object_definition_controller_spec.js
@@ -36,8 +36,8 @@ describe('genericObjectDefinitionFormController', function() {
     );
 
     $httpBackend.whenGET('tree_data').respond({tree_data: JSON.stringify(treeData)});
-    $httpBackend.whenPOST('create', {name: 'name', description: 'description'}).respond({message: "success"});
-    $httpBackend.whenPOST('save', {name: 'new name', description: 'description'}).respond({message: "success"});
+    $httpBackend.whenPOST('create', {id: '', name: 'name', description: 'description'}).respond({message: "success"});
+    $httpBackend.whenPOST('save', {id: 123, name: 'new name', description: 'description'}).respond({message: "success"});
 
     $controller = _$controller_('genericObjectDefinitionFormController', {
       $scope: $scope,
@@ -54,7 +54,7 @@ describe('genericObjectDefinitionFormController', function() {
   describe('initialization', function() {
     it('sets up the generic object definition model', function() {
       expect($scope.genericObjectDefinitionModel).toEqual(
-        {name: '', description: ''}
+        {id: '', name: '', description: ''}
       );
     });
 
@@ -198,12 +198,14 @@ describe('genericObjectDefinitionFormController', function() {
   describe('#clearForm', function() {
     it('clears the genericObjectDefinitionModel', function() {
       $scope.genericObjectDefinitionModel = {
+        id: 'potato',
         name: 'potato',
         description: 'potato'
       };
 
       $scope.clearForm();
       expect($scope.genericObjectDefinitionModel).toEqual({
+        id: '',
         name: '',
         description: ''
       });
@@ -225,6 +227,7 @@ describe('genericObjectDefinitionFormController', function() {
   describe('#addClicked', function() {
     beforeEach(function() {
       $scope.genericObjectDefinitionModel = {
+        id: '',
         name: 'name',
         description: 'description'
       };
@@ -246,13 +249,14 @@ describe('genericObjectDefinitionFormController', function() {
   describe('#saveClicked', function() {
     beforeEach(function() {
       $scope.genericObjectDefinitionModel = {
+        id: 123,
         name: 'new name',
         description: 'description'
       };
     });
 
     it('makes a save http request', function() {
-      $httpBackend.expectPOST('save', {name: 'new name', description: 'description'}).respond(200, '');
+      $httpBackend.expectPOST('save', {id: 123, name: 'new name', description: 'description'}).respond(200, '');
       $scope.saveClicked();
       $httpBackend.flush();
     });

--- a/spec/javascripts/controllers/generic_object/generic_object_definition_controller_spec.js
+++ b/spec/javascripts/controllers/generic_object/generic_object_definition_controller_spec.js
@@ -203,6 +203,11 @@ describe('genericObjectDefinitionFormController', function() {
       $scope.listObjectClicked('name');
       expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'singleItemSelected', response: 'name'});
     });
+
+    it('sends more data', function() {
+      $scope.listObjectClicked('name');
+      expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'updateToolbarCount', countSelected: 1});
+    });
   });
 
   describe('#addClicked', function() {
@@ -235,7 +240,7 @@ describe('genericObjectDefinitionFormController', function() {
     });
 
     it('makes a save http request', function() {
-      $httpBackend.expectPOST('save', {id: 123, name: 'new name', description: 'description'}).respond(200, '');
+      $httpBackend.expectPOST('save', {name: 'new name', description: 'description'}).respond(200, '');
       $scope.saveClicked();
       $httpBackend.flush();
     });
@@ -273,6 +278,10 @@ describe('genericObjectDefinitionFormController', function() {
 
     it('sends data', function() {
       expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'cancelClicked'});
+    });
+
+    it('sends more data', function() {
+      expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'updateToolbarCount', countSelected: 0});
     });
 
     it('sets the form to pristine', function() {

--- a/spec/javascripts/controllers/generic_object/generic_object_definition_controller_spec.js
+++ b/spec/javascripts/controllers/generic_object/generic_object_definition_controller_spec.js
@@ -128,6 +128,10 @@ describe('genericObjectDefinitionFormController', function() {
       it('sets the showForm to true', function() {
         expect($scope.showForm).toEqual(true);
       });
+
+      it('sends an updateToolbarCount event', function() {
+        expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'updateToolbarCount', countSelected: 0});
+      });
     });
 
     describe('initialization treeClickCallback', function() {
@@ -157,6 +161,10 @@ describe('genericObjectDefinitionFormController', function() {
         expect($scope.showSingleItem).toEqual(true);
       });
 
+      it('sends an updateToolbarCount event', function() {
+        expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'updateToolbarCount', countSelected: 1});
+      });
+
       it('turns the sparkle off', function() {
         expect(miqService.sparkleOff).toHaveBeenCalled();
       });
@@ -179,6 +187,10 @@ describe('genericObjectDefinitionFormController', function() {
 
       it('sets showForm to false', function() {
         expect($scope.showForm).toEqual(false);
+      });
+
+      it('sends an updateToolbarCount event', function() {
+        expect(window.sendDataWithRx).toHaveBeenCalledWith({eventType: 'updateToolbarCount', countSelected: 0});
       });
     });
   });

--- a/spec/javascripts/services/generic_object_subscription_service_spec.js
+++ b/spec/javascripts/services/generic_object_subscription_service_spec.js
@@ -32,6 +32,16 @@ describe('genericObjectSubscriptionService', function() {
     });
   });
 
+  describe('#subscribeToDeleteGenericObject', function() {
+    beforeEach(function() {
+      testService.subscribeToDeleteGenericObject(callback);
+    });
+
+    it('subscribes', function() {
+      expect(subscriptionService.subscribeToEventType).toHaveBeenCalledWith('deleteGenericObject', callback);
+    });
+  });
+
   describe('#subscribeToTreeClicks', function() {
     beforeEach(function() {
       testService.subscribeToTreeClicks(callback);

--- a/spec/javascripts/services/generic_object_subscription_service_spec.js
+++ b/spec/javascripts/services/generic_object_subscription_service_spec.js
@@ -22,6 +22,16 @@ describe('genericObjectSubscriptionService', function() {
     });
   });
 
+  describe('#subscribeToShowEditForm', function() {
+    beforeEach(function() {
+      testService.subscribeToShowEditForm(callback);
+    });
+
+    it('subscribes', function() {
+      expect(subscriptionService.subscribeToEventType).toHaveBeenCalledWith('showEditForm', callback);
+    });
+  });
+
   describe('#subscribeToTreeClicks', function() {
     beforeEach(function() {
       testService.subscribeToTreeClicks(callback);


### PR DESCRIPTION
This was built on top of #11815, so once that is merged, the first four commits here will disappear.

This enables the user to delete a selected generic object definitions via the configuration drop-down.

Before deletion:
![screen shot 2016-10-21 at 9 03 14 am](https://cloud.githubusercontent.com/assets/164557/19605133/47d8535e-976d-11e6-93b2-8d7961510e45.png)

After deletion:
![screen shot 2016-10-21 at 9 01 15 am](https://cloud.githubusercontent.com/assets/164557/19605086/1b7c5792-976d-11e6-905f-42d171443540.png)

https://www.pivotaltracker.com/story/show/129980083

@miq-bot assign @gmcculloug 
