### PR TITLE
Dockerfile systemd cleanup on base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,13 +69,13 @@ VOLUME [ "/var/opt/rh/rh-postgresql95/lib/pgsql/data" ]
 
 ## Systemd cleanup base image
 RUN (cd /lib/systemd/system/sysinit.target.wants && for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -vf $i; done) && \
-rm -vf /lib/systemd/system/multi-user.target.wants/* && \
-rm -vf /etc/systemd/system/*.wants/* && \
-rm -vf /lib/systemd/system/local-fs.target.wants/* && \
-rm -vf /lib/systemd/system/sockets.target.wants/*udev* && \
-rm -vf /lib/systemd/system/sockets.target.wants/*initctl* && \
-rm -vf /lib/systemd/system/basic.target.wants/* && \
-rm -vf /lib/systemd/system/anaconda.target.wants/*
+    rm -vf /lib/systemd/system/multi-user.target.wants/* && \
+    rm -vf /etc/systemd/system/*.wants/* && \
+    rm -vf /lib/systemd/system/local-fs.target.wants/* && \
+    rm -vf /lib/systemd/system/sockets.target.wants/*udev* && \
+    rm -vf /lib/systemd/system/sockets.target.wants/*initctl* && \
+    rm -vf /lib/systemd/system/basic.target.wants/* && \
+    rm -vf /lib/systemd/system/anaconda.target.wants/*
 
 # Download chruby and chruby-install, install, setup environment, clean all
 RUN curl -sL https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz | tar xz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,16 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 # Add persistent data volume for postgres
 VOLUME [ "/var/opt/rh/rh-postgresql95/lib/pgsql/data" ]
 
+## Systemd cleanup base image
+RUN (cd /lib/systemd/system/sysinit.target.wants && for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -vf $i; done) && \
+rm -vf /lib/systemd/system/multi-user.target.wants/* && \
+rm -vf /etc/systemd/system/*.wants/* && \
+rm -vf /lib/systemd/system/local-fs.target.wants/* && \
+rm -vf /lib/systemd/system/sockets.target.wants/*udev* && \
+rm -vf /lib/systemd/system/sockets.target.wants/*initctl* && \
+rm -vf /lib/systemd/system/basic.target.wants/* && \
+rm -vf /lib/systemd/system/anaconda.target.wants/*
+
 # Download chruby and chruby-install, install, setup environment, clean all
 RUN curl -sL https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz | tar xz && \
     cd chruby-0.3.9 && \


### PR DESCRIPTION
@carbonin @simaishi @bazulay @Fryguy Please review, systemd will re-create essential units being aware it is running inside a container, a safer choice. The supplied base centos image (VM based) contains many units that could be conflictive or harmful to the docker host, specially in privileged mode.

- Remove and clean base centos image unit files that can cause conflicts with docker host
- Followed best practices from systemd on official Centos images :

https://github.com/docker-library/docs/tree/master/centos#dockerfile-for-systemd-base-image

Tested on OCP 3.3 and Fedora24