### PR TITLE
Adding support for /api/requests approve and deny actions

### DIFF
--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -45,7 +45,7 @@ module Api
     end
 
     def approve_resource(type, id, data)
-      raise "Must specify a reason for approving a request" unless data["reason"].present?
+      raise "Must specify a reason for approving a request" if data["reason"].blank?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
         request.approve(@auth_user, data["reason"])
@@ -56,7 +56,7 @@ module Api
     end
 
     def deny_resource(type, id, data)
-      raise "Must specify a reason for denying a request" unless data["reason"].present?
+      raise "Must specify a reason for denying a request" if data["reason"].blank?
       api_action(type, id) do |klass|
         request = resource_search(id, type, klass)
         request.deny(@auth_user, data["reason"])

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -44,6 +44,28 @@ module Api
       request
     end
 
+    def approve_resource(type, id, data)
+      raise "Must specify a reason for approving a request" unless data["reason"].present?
+      api_action(type, id) do |klass|
+        request = resource_search(id, type, klass)
+        request.approve(@auth_user, data["reason"])
+        action_result(true, "Request #{id} approved")
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
+    def deny_resource(type, id, data)
+      raise "Must specify a reason for denying a request" unless data["reason"].present?
+      api_action(type, id) do |klass|
+        request = resource_search(id, type, klass)
+        request.deny(@auth_user, data["reason"])
+        action_result(true, "Request #{id} denied")
+      end
+    rescue => err
+      action_result(false, err.to_s)
+    end
+
     def find_requests(id)
       klass = collection_class(:requests)
       return klass.find(id) if @auth_user_obj.admin?

--- a/config/api.yml
+++ b/config/api.yml
@@ -958,6 +958,10 @@
           :identifier: service_reconfigure
       - :name: edit
         :identifier: miq_request_edit
+      - :name: approve
+        :identifier: miq_request_approval
+      - :name: deny
+        :identifier: miq_request_approval
     :resource_actions:
       :get:
       - :name: read
@@ -965,6 +969,10 @@
       :post:
       - :name: edit
         :identifier: miq_request_edit
+      - :name: approve
+        :identifier: miq_request_approval
+      - :name: deny
+        :identifier: miq_request_approval
   :resource_actions:
     :description: Resource Actions
     :options:


### PR DESCRIPTION

- support approve on individual request /api/requests/:id
- support approve on bulk requests /api/requests
- support deny on individual request /api/requests/:id
- support deny on bulk requests /api/requests
- added rspecs