### PR TITLE
Scope tenant to the current region

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -785,7 +785,7 @@ module OpsController::OpsRbac
                     when "role"
                       get_view(MiqUserRole)
                     when "tenant"
-                      get_view(Tenant)
+                      get_view(Tenant, :named_scope => :in_my_region)
                     end
 
     @current_page = @pages[:current] unless @pages.nil? # save the current page number

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -286,7 +286,7 @@ class Tenant < ApplicationRecord
   #     [["tenant/tenant2/project4", 4]]
   #   ]
   def self.tenant_and_project_names
-    tenants_and_projects = Tenant.select(:id, :ancestry, :divisible, :use_config_for_attributes, :name)
+    tenants_and_projects = Tenant.in_my_region.select(:id, :ancestry, :divisible, :use_config_for_attributes, :name)
                            .to_a.sort_by { |t| [t.ancestry || "", t.name] }
     tenants_by_id = tenants_and_projects.index_by(&:id)
 


### PR DESCRIPTION
Fixes bug in settings/access control where tenants from remote regions
are displayed in the tenant list view and in the tenant selection when adding/editing a group

https://www.pivotaltracker.com/story/show/131768923