### PR TITLE
Support for case insensitive tag and branch name when importing from Git

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_git_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_git_import.rb
@@ -26,6 +26,7 @@ class MiqAeGitImport
     create_repo unless @git_repo
     default_import_options
     validate_refs
+    branch_or_tag
   end
 
   def post_import(domain)
@@ -54,7 +55,9 @@ class MiqAeGitImport
     @options['ref'] ||= DEFAULT_BRANCH
     @options['ref_type'] ||= BRANCH
     @options['ref_type'] = @options['ref_type'].downcase
+  end
 
+  def branch_or_tag
     case @options['ref_type']
     when BRANCH
       @options['branch'] = @options['ref']

--- a/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
@@ -1,21 +1,17 @@
 describe MiqAeGitImport do
-  context "#import" do
-    before do
-      EvmSpecHelper.local_guid_miq_server_zone
-      @user = FactoryGirl.create(:user_with_group)
-    end
-
+  shared_context "variables" do
     let(:miq_ae_git_import) { described_class.new(options) }
-    let(:branch_name) { "b1" }
-    let(:tag_name) { "t1" }
+    let(:branch_name) { "SomeBranch1" }
+    let(:tag_name) { "SomeTag1" }
     let(:domain_name) { "BB8" }
     let(:url) { "http://www.example.com/x/y" }
     let(:domain) do
       FactoryGirl.create(:miq_ae_git_domain,
-                         :tenant => @user.current_tenant,
+                         :tenant => user.current_tenant,
                          :name   => domain_name)
     end
     let(:repo) { FactoryGirl.create(:git_repository, :url => url) }
+    let(:user) { FactoryGirl.create(:user_with_group) }
     let(:branch_hash) do
       {'ref' => branch_name, 'ref_type' => MiqAeGitImport::BRANCH}
     end
@@ -26,38 +22,79 @@ describe MiqAeGitImport do
 
     let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }
     let(:tag) { FactoryGirl.create(:git_tag, :name => tag_name) }
+    let(:basic_options) do
+      {
+        'domain'    => domain_name,
+        'tenant_id' => user.current_tenant.id
+      }
+    end
+    let(:miq_ae_yaml_import_gitfs) { double("MiqAeYamlImportGitfs") }
+    let(:new_repo_options) do
+      {
+        'userid'   => 'fred',
+        'password' => 'secret',
+        'preview'  => false
+      }
+    end
+  end
+
+  context "#import" do
+    include_context "variables"
+    before do
+      EvmSpecHelper.local_guid_miq_server_zone
+    end
 
     context "when the ref type and ref are valid" do
-      let(:miq_ae_yaml_import_gitfs) { double("MiqAeYamlImportGitfs") }
-
       before do
         allow(GitRepository).to receive(:find).with(repo.id).and_return(repo)
         allow(repo).to receive(:refresh).and_return(nil)
-
-        allow(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, options).and_return(miq_ae_yaml_import_gitfs)
       end
 
       context "when there are branches returned" do
         let(:options) do
-          {
-            'domain'            => domain_name,
-            'git_repository_id' => repo.id,
-            'tenant_id'         => @user.current_tenant.id,
-            'ref'               => branch_name
-          }
+          basic_options.merge('ref' => branch_name, 'git_repository_id' => repo.id)
+        end
+
+        let(:import_options) do
+          options.merge("ref_type" => MiqAeGitImport::BRANCH,
+                        "branch"   => branch_name,
+                        "git_dir"  => repo.directory_name)
         end
 
         before do
           allow(repo).to receive(:git_branches).and_return([branch])
         end
 
-        it "imports correctly" do
-          allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
-          dom = miq_ae_git_import.import
-          expect(dom.attributes).to have_attributes(branch_hash)
+        shared_examples_for "#import that has a valid branch" do
+          it "runs successfully" do
+            expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
+              and_return(miq_ae_yaml_import_gitfs)
+            allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
+            dom = miq_ae_git_import.import
+            expect(dom.attributes).to have_attributes(branch_hash)
+          end
+        end
+
+        context "when the branch name is exact match" do
+          it_behaves_like "#import that has a valid branch"
+        end
+
+        context "when the branch name is all lowercase" do
+          let(:options) do
+            basic_options.merge('ref' => branch_name.downcase, 'git_repository_id' => repo.id)
+          end
+          let(:import_options) do
+            options.merge("ref_type" => MiqAeGitImport::BRANCH,
+                          "ref"      => branch_name,
+                          "branch"   => branch_name,
+                          "git_dir"  => repo.directory_name)
+          end
+          it_behaves_like "#import that has a valid branch"
         end
 
         it "import fails with domain not found" do
+          expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
+            and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(nil)
           expect { miq_ae_git_import.import }.to raise_error(MiqAeException::DomainNotFound)
         end
@@ -65,36 +102,56 @@ describe MiqAeGitImport do
 
       context "when there are tags returned" do
         let(:options) do
-          {
-            'domain'            => domain_name,
-            'git_repository_id' => repo.id,
-            'tenant_id'         => @user.current_tenant.id,
-            'ref'               => tag_name,
-            'ref_type'          => MiqAeGitImport::TAG
-          }
+          basic_options.reverse_merge('ref'               => tag_name,
+                                      'git_repository_id' => repo.id,
+                                      'ref_type'          => MiqAeGitImport::TAG)
+        end
+
+        let(:import_options) do
+          options.merge("tag" => tag_name, "git_dir" => repo.directory_name)
         end
 
         before do
           allow(repo).to receive(:git_tags).and_return([tag])
         end
 
-        it "imports correctly" do
-          allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
-          dom = miq_ae_git_import.import
-          expect(dom.attributes).to have_attributes(tag_hash)
+        shared_examples_for "#import that has a valid tag" do
+          it "imports correctly" do
+            expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
+              and_return(miq_ae_yaml_import_gitfs)
+            allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
+            dom = miq_ae_git_import.import
+            expect(dom.attributes).to have_attributes(tag_hash)
+          end
+        end
+
+        context "when the tag name is exact match" do
+          it_behaves_like "#import that has a valid tag"
+        end
+
+        context "when the tag name is all lowercase" do
+          let(:options) do
+            basic_options.merge('ref'               => tag_name.downcase,
+                                'git_repository_id' => repo.id,
+                                'ref_type'          => MiqAeGitImport::TAG)
+          end
+
+          let(:import_options) do
+            options.merge("tag" => tag_name, "ref" => tag_name, "git_dir" => repo.directory_name)
+          end
+          it_behaves_like "#import that has a valid tag"
         end
       end
 
       context "when a git_url and branch are given" do
         let(:options) do
-          {
-            'git_url'  => url,
-            'ref'      => branch_name,
-            'userid'   => 'fred',
-            'password' => 'secret',
-            'preview'  => false,
-            'domain'   => domain_name
-          }
+          {'ref' => branch_name, 'git_url' => url}.merge(basic_options).merge(new_repo_options)
+        end
+
+        let(:import_options) do
+          options.merge("branch"   => branch_name,
+                        "ref_type" => MiqAeGitImport::BRANCH,
+                        "git_dir"  => repo.directory_name)
         end
 
         before do
@@ -103,6 +160,8 @@ describe MiqAeGitImport do
         end
 
         it "imports correctly" do
+          expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
+            and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
           dom = miq_ae_git_import.import
           expect(dom.attributes).to have_attributes(branch_hash)

--- a/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_git_import_spec.rb
@@ -67,8 +67,8 @@ describe MiqAeGitImport do
 
         shared_examples_for "#import that has a valid branch" do
           it "runs successfully" do
-            expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
-              and_return(miq_ae_yaml_import_gitfs)
+            expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
+              .and_return(miq_ae_yaml_import_gitfs)
             allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
             dom = miq_ae_git_import.import
             expect(dom.attributes).to have_attributes(branch_hash)
@@ -93,8 +93,8 @@ describe MiqAeGitImport do
         end
 
         it "import fails with domain not found" do
-          expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
-            and_return(miq_ae_yaml_import_gitfs)
+          expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
+            .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(nil)
           expect { miq_ae_git_import.import }.to raise_error(MiqAeException::DomainNotFound)
         end
@@ -117,8 +117,8 @@ describe MiqAeGitImport do
 
         shared_examples_for "#import that has a valid tag" do
           it "imports correctly" do
-            expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
-              and_return(miq_ae_yaml_import_gitfs)
+            expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
+              .and_return(miq_ae_yaml_import_gitfs)
             allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
             dom = miq_ae_git_import.import
             expect(dom.attributes).to have_attributes(tag_hash)
@@ -160,8 +160,8 @@ describe MiqAeGitImport do
         end
 
         it "imports correctly" do
-          expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options).
-            and_return(miq_ae_yaml_import_gitfs)
+          expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
+            .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
           dom = miq_ae_git_import.import
           expect(dom.attributes).to have_attributes(branch_hash)


### PR DESCRIPTION
When importing from the Git Repository a user can type in the branch or tag in a case insensitive form. This comes in handy for rake scripts and REST API.

Links:
- https://bugzilla.redhat.com/show_bug.cgi?id=1388942
