### PR TITLE
[EUWE] Remove reference to :ems_physical_infra

### DIFF
--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -83,7 +83,6 @@ describe TreeNodeBuilder do
         :configuration_manager_ansible_tower => "AnsibleTower ConfigurationManager",
         :configuration_manager_foreman       => "Foreman ConfigurationManager",
         :provisioning_manager_foreman        => "Foreman ProvisioningManager",
-        :ems_physical_infra                  => "PhysicalInfraManager",
         :ems_openshift_enterprise            => "Openshift Enterprise ContainerManager",
         :ems_hawkular                        => "Hawkular MiddlewareManager",
         :ems_azure_network                   => "Azure NetworkManager",


### PR DESCRIPTION
Removes `:ems_physical_infra` reference introduced in backporting #12060 to Euwe.

This should make the [failing specs](https://travis-ci.org/ManageIQ/manageiq/builds/169638511) pass again.