### PR TITLE
Remove VM GUID from static fields in chargeback report

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -125,7 +125,7 @@ class ChargebackVm < Chargeback
   end
 
   def self.report_static_cols
-    %w(vm_name vm_guid)
+    %w(vm_name)
   end
 
   def self.report_col_options

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -50,6 +50,12 @@ describe ChargebackVm do
     Timecop.return
   end
 
+  let(:report_static_fields) { %w(vm_name) }
+
+  it "uses static fields" do
+    expect(described_class.report_static_cols).to match_array(report_static_fields)
+  end
+
   it "succeeds without a userid" do
     @options.delete(:userid)
     expect { ChargebackVm.build_results_for_report_ChargebackVm(@options) }.not_to raise_error


### PR DESCRIPTION
Static fields are columns which are displayed on
(chargeback) report always (selection is not needed) but
Vm Guid doesn't belong to static fields and it can be
selected from available fields in report definition.

Accidentaly added [here](https://github.com/ManageIQ/manageiq/pull/11939/commits/acd6056234a5923b051dd715c3836471387f5bd7#diff-c9636a46ea81685e5b668e8caa43d3adL125)


@miq-bot add_label reporting, chargeback, bug
@miq-bot add euwe/yes
@miq-bot assign @gtanzillo 

