### PR TITLE
Add support to overwrite an existing MW deployment

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -63,7 +63,10 @@ class MiddlewareServerController < ApplicationController
     selected_server = identify_selected_entities
     deployment_name = params["runtimeName"]
 
-    existing_deployment = MiddlewareDeployment.find_by(:name => deployment_name, :server_id => selected_server)
+    existing_deployment = false
+    if params["forceDeploy"] == 'false'
+      existing_deployment = MiddlewareDeployment.find_by(:name => deployment_name, :server_id => selected_server)
+    end
 
     if existing_deployment
       render :json => {

--- a/app/views/middleware_server/_deploy.html.haml
+++ b/app/views/middleware_server/_deploy.html.haml
@@ -34,8 +34,8 @@
             .col-md-8
               %input#enable_deployment_cb{:type             => "checkbox",
                                           "bs-switch"       => "",
-                                          "switch-on-text"  => "Yes",
-                                          "switch-off-text" => "No",
+                                          "switch-on-text"  => _("Yes"),
+                                          "switch-off-text" => _("No"),
                                           "switch-active"   => "{{!!deployAddModel.filePath}}",
                                           "ng-model"        => "deployAddModel.enableDeployment",
                                           "ng-disabled"     => "!deployAddModel.filePath"}
@@ -53,8 +53,8 @@
             .col-md-8
               %input#force_deployment_cb{:type             => "checkbox",
                                          "bs-switch"       => "",
-                                         "switch-on-text"  => "Yes",
-                                         "switch-off-text" => "No",
+                                         "switch-on-text"  => _("Yes"),
+                                         "switch-off-text" => _("No"),
                                          "switch-active"   => "{{!!deployAddModel.filePath}}",
                                          "ng-model"        => "deployAddModel.forceDeploy",
                                          "ng-disabled"     => "!deployAddModel.filePath"}

--- a/app/views/middleware_server/_deploy.html.haml
+++ b/app/views/middleware_server/_deploy.html.haml
@@ -47,6 +47,17 @@
                                                      "placeholder" => _("No file chosen"),
                                                      "ng-model"    => "deployAddModel.runtimeName",
                                                      "ng-disabled" => "!deployAddModel.filePath"}
+          .form-group
+            %label.col-md-4.control-label{:for => "force_deployment_cb"}
+              = _("Overwrite (if exists)")
+            .col-md-8
+              %input#force_deployment_cb{:type             => "checkbox",
+                                         "bs-switch"       => "",
+                                         "switch-on-text"  => "Yes",
+                                         "switch-off-text" => "No",
+                                         "switch-active"   => "{{!!deployAddModel.filePath}}",
+                                         "ng-model"        => "deployAddModel.forceDeploy",
+                                         "ng-disabled"     => "!deployAddModel.filePath"}
         .modal-footer
           %button.btn.btn-default{:type          => "button",
                                   :alt           => (t = _("Cancel")),


### PR DESCRIPTION
Allow to overwrite an existing Middleware Deployment in case it already exists.

![image](https://cloud.githubusercontent.com/assets/1737954/19642269/743de3d4-99dc-11e6-95b8-892143d584e1.png)

![image](https://cloud.githubusercontent.com/assets/1737954/19642394/f29fbfc2-99dc-11e6-8fbe-296870958c8b.png)

![image](https://cloud.githubusercontent.com/assets/1737954/19642339/c10b4152-99dc-11e6-95c4-af302cc3177e.png)
