### PR TITLE
Fix Add a new chargeback rate

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -165,7 +165,7 @@ class ChargebackController < ApplicationController
       @_params[:id] ||= find_checked_items[0]
       session[:changed] = params[:pressed] == 'chargeback_rates_copy'
 
-      @rate = params[:id] == 'new' ? ChargebackRate.new : ChargebackRate.find(params[:id])
+      @rate = new_rate_edit? ? ChargebackRate.new : ChargebackRate.find(params[:id])
       @record = @rate
 
       if params[:pressed] == 'chargeback_rates_edit' && @rate.default?
@@ -518,7 +518,7 @@ class ChargebackController < ApplicationController
 
     tiers = []
     rate_details = @rate.chargeback_rate_details
-    rate_details = ChargebackRateDetail.default_rate_details_for(@edit[:new][:rate_type]) if params[:id] == 'new'
+    rate_details = ChargebackRateDetail.default_rate_details_for(@edit[:new][:rate_type]) if new_rate_edit?
 
     # Select the currency of the first chargeback_rate_detail. All the chargeback_rate_details have the same currency
     @edit[:new][:currency] = rate_details[0].detail_currency.id
@@ -707,6 +707,10 @@ class ChargebackController < ApplicationController
     @edit[:current] = copy_hash(@edit[:new])
     session[:edit] = @edit
     @in_a_form = true
+  end
+
+  def new_rate_edit?
+    params[:id] == 'new' || params[:pressed] == 'chargeback_rates_new'
   end
 
   def get_categories_all

--- a/spec/controllers/chargeback_controller_spec.rb
+++ b/spec/controllers/chargeback_controller_spec.rb
@@ -378,7 +378,7 @@ describe ChargebackController do
 
       count_of_chargeback_rates = ChargebackRate.count
 
-      post :x_button, :params => {:id => "new", :pressed => "chargeback_rates_new"}
+      post :x_button, :params => {:pressed => "chargeback_rates_new"}
       post :cb_rate_form_field_changed, :params => {:id => "new", :description => "chargeback rate 1"}
       post :cb_rate_edit, :params => {:button => "add"}
 
@@ -396,7 +396,7 @@ describe ChargebackController do
 
       ChargebackRate.seed
 
-      post :x_button, :params => {:id => "new", :pressed => "chargeback_rates_new"}
+      post :x_button, :params => {:pressed => "chargeback_rates_new"}
       post :cb_rate_form_field_changed, :params => {:id => "new", :description => "chargeback rate 1"}
 
       post :cb_tier_add, :params => {:button => "add", :detail_index => index_to_rate_type}
@@ -429,7 +429,7 @@ describe ChargebackController do
 
       ChargebackRate.seed
 
-      post :x_button, :params => {:id => "new", :pressed => "chargeback_rates_new"}
+      post :x_button, :params => {:pressed => "chargeback_rates_new"}
       post :cb_rate_form_field_changed, :params => {:id => "new", :description => "chargeback rate 1"}
 
       post :cb_tier_add, :params => {:button => "add", :detail_index => index_to_rate_type}


### PR DESCRIPTION
When `chargeback_rates_new` is pressed `id=nil` is sent. The `id="new"` is sent only on `chargeback_rates_edit`.

Unfortunately, there were specs that assumed the `id="new"` is being sent together with `chargeback_rates_new`, so these spec lured me and the reviewer into thinking, the #12018 was fine, while it wasn't. :scream: 

@miq-bot add_label bug, euwe/no, chargeback, ui
@miq-bot assign @martinpovolny 

