### PR TITLE
[EUWE] Remove ems_physical_infra FG reference

### DIFF
--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -83,7 +83,6 @@ describe TreeNodeBuilder do
         :configuration_manager_ansible_tower => "AnsibleTower ConfigurationManager",
         :configuration_manager_foreman       => "Foreman ConfigurationManager",
         :provisioning_manager_foreman        => "Foreman ProvisioningManager",
-        :ems_physical_infra                  => "PhysicalInfraManager",
         :ems_openshift_enterprise            => "Openshift Enterprise ContainerManager",
         :ems_hawkular                        => "Hawkular MiddlewareManager",
         :ems_azure_network                   => "Azure NetworkManager",


### PR DESCRIPTION
This feature was added in #11744 to master and is not included in the Euwe release. The factory doesn't exist and thus breaks the build.

Added in a7f69bf