### PR TITLE
Validate user defined names in Generic Object Definition.

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -26,12 +26,12 @@ class GenericObject < ApplicationRecord
         raise ActiveModel::UnknownAttributeError.new(self, k)
       end
     end
-    options.each { |k, v| property_setter(k, v) }
+    options.each { |k, v| _property_setter(k, v) }
   end
 
   def property_attributes
     properties.select { |k, _| property_attribute_defined?(k) }.each_with_object({}) do |(k, _), h|
-      h[k] = property_getter(k)
+      h[k] = _property_getter(k)
     end
   end
 
@@ -99,10 +99,10 @@ class GenericObject < ApplicationRecord
   def method_missing(method_name, *args)
     m = method_name.to_s.chomp("=")
 
-    return call_automate(m, *args) if property_method_defined?(m)
+    return _call_automate(m, *args) if property_method_defined?(m)
 
     if property_attribute_defined?(m) || property_association_defined?(m)
-      return method_name.to_s.end_with?('=') ? property_setter(m, args.first) : property_getter(m)
+      return method_name.to_s.end_with?('=') ? _property_setter(m, args.first) : _property_getter(m)
     end
 
     super
@@ -113,11 +113,11 @@ class GenericObject < ApplicationRecord
     super
   end
 
-  def property_getter(name)
+  def _property_getter(name)
     generic_object_definition.property_getter(name, properties[name])
   end
 
-  def property_setter(name, value)
+  def _property_setter(name, value)
     name = name.to_s
     val =
       if property_attribute_defined?(name)
@@ -134,7 +134,7 @@ class GenericObject < ApplicationRecord
   # the method parameters are passed into automate as a hash:
   # {:param_1 => 12, :param_1_type => "Vm", :param_2 => 14, :param_2_type => "Fixnum"}
   # the return value from automate is in $evm.root['method_result']
-  def call_automate(method_name, *args)
+  def _call_automate(method_name, *args)
     raise "A user is required to send [#{method_name}] to automate." unless @user
 
     attrs = { :method_name => method_name }

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -274,4 +274,78 @@ describe GenericObjectDefinition do
       expect(subject.first).to eq(@g1)
     end
   end
+
+  shared_examples 'AR attribute allowing letters' do |hash|
+    it 'allows letters' do
+      expect(described_class.new(:name => 'test', :properties => hash)).to be_valid
+    end
+  end
+
+  shared_examples 'AR attribute allowing numbers' do |hash|
+    it 'allows numbers' do
+      expect(described_class.new(:name => 'test', :properties => hash)).to be_valid
+    end
+  end
+
+  shared_examples 'AR attribute allowing _' do |hash|
+    it 'allows _' do
+      expect(described_class.new(:name => 'test', :properties => hash)).to be_valid
+    end
+  end
+
+  shared_examples 'AR attribute starting with letters only' do |hash|
+    it 'starts with letter only' do
+      testdef = described_class.new(:name => 'test', :properties => hash)
+      expect { testdef.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  shared_examples 'AR attribute allowing letters, numbers and _ only' do |hash|
+    it 'allows not other characters' do
+      testdef = described_class.new(:name => 'test', :properties => hash)
+      expect { testdef.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  context 'property attribute name' do
+    it_behaves_like 'AR attribute allowing letters', :attributes => {'address' => :string}
+    it_behaves_like 'AR attribute allowing numbers', :attributes => {'address2' => :string}
+    it_behaves_like 'AR attribute allowing _', :attributes => {'my_address' => :string}
+    it_behaves_like 'AR attribute starting with letters only', :attributes => {'1st_vm' => "string"}
+    it_behaves_like 'AR attribute starting with letters only', :attributes => {'_vm' => "string"}
+    it_behaves_like 'AR attribute allowing letters, numbers and _ only', :attributes => {'my-vm' => "string"}
+    it_behaves_like 'AR attribute allowing letters, numbers and _ only', :attributes => {'my_vm!' => "string"}
+  end
+
+  context 'property association name' do
+    it_behaves_like 'AR attribute allowing letters', :associations => {'vms' => :Vm}
+    it_behaves_like 'AR attribute allowing numbers', :associations => {'vms2' => :Vm}
+    it_behaves_like 'AR attribute allowing _', :associations => {'my_vms' => "Vm"}
+    it_behaves_like 'AR attribute starting with letters only', :associations => {'1st_vm' => "Vm"}
+    it_behaves_like 'AR attribute starting with letters only', :associations => {'_vm' => "Vm"}
+    it_behaves_like 'AR attribute allowing letters, numbers and _ only', :associations => {'active-vms' => "Vm"}
+    it_behaves_like 'AR attribute allowing letters, numbers and _ only', :associations => {'active_vms!' => "Vm"}
+  end
+
+  context 'property method name' do
+    it_behaves_like 'AR attribute allowing letters', :methods => ['vms']
+    it_behaves_like 'AR attribute allowing numbers', :methods => ['vms2']
+    it_behaves_like 'AR attribute allowing _', :methods => ['active_vms']
+    it_behaves_like 'AR attribute starting with letters only', :methods => ['1st_vm']
+    it_behaves_like 'AR attribute starting with letters only', :methods => ['_vm']
+    it_behaves_like 'AR attribute allowing letters, numbers and _ only', :methods => ['active-vms']
+    it_behaves_like 'AR attribute allowing letters, numbers and _ only', :methods => ['active@vms']
+
+    subject { described_class.new(:name => 'test', :properties => {:methods => @attrs}) }
+
+    it 'allows ending with ?' do
+      @attrs = ['active_vm?']
+      expect(subject).to be_valid
+    end
+
+    it 'allows ending with !' do
+      @attrs = ['rename_vm!']
+      expect(subject).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Validate property attribute / association / method names of GenericObjectDefinition.
An error message is thrown out when the validation fails.

Prefixed GenericObject private methods with "_" to avoid name conflict.
## Links

https://www.pivotaltracker.com/story/show/128430239

cc @bzwei @gmcculloug 
