### PR TITLE
Fix Orchestration stack summary screen styling

### DIFF
--- a/app/views/orchestration_stack/_stack_orchestration_template.html.haml
+++ b/app/views/orchestration_stack/_stack_orchestration_template.html.haml
@@ -1,7 +1,7 @@
 #form_div
   #basic_info_div
   = render :partial => "layouts/flash_msg"
-  %table.table.table-bordered.table-striped
+  %table.table.table-bordered.table-striped.table-summary-screen
     %thead
       %tr
         %th{:colspan => "2"}= _('Details')


### PR DESCRIPTION
Add "table-summary-screen" class to Orchestration Stack summary screen

This bug was caused by the following PR: #11288 and is a followup to https://github.com/ManageIQ/manageiq/pull/11560

https://bugzilla.redhat.com/show_bug.cgi?id=1383800