### PR TITLE
stringify parameters before passing to create_from_ws

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -41,6 +41,7 @@ class AutomationRequest < MiqRequest
     [:namespace, :class_name].each { |key| uri_parts.delete(key) if uri_parts.key?(key) }
     approval = {'auto_approve' => true}
     uri_parts.stringify_keys!
+    parameters.stringify_keys!
     create_from_ws("1.1", user, uri_parts, parameters, approval)
   end
 

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -141,6 +141,12 @@ describe AutomationRequest do
         :namespace  => "SYSTEM"
       )
     end
+
+    it "only allow parameters that are stringified" do
+      parameters_sym = {:var1 => @ae_var1.to_s, :var2 => @ae_var2.to_s, :var3 => @ae_var3.to_s}
+      expect(AutomationRequest).to receive(:create_from_ws).with(anything, anything, anything, @parameters, anything)
+      AutomationRequest.create_from_scheduled_task(admin, @uri_parts, parameters_sym)
+    end
   end
 
   context "#approve" do


### PR DESCRIPTION
>stringifying parameters before passing to `create_from_ws`
