### PR TITLE
Ensure orchestration postprovision is called even when provisioning fails

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned.rb
@@ -102,8 +102,7 @@ module ManageIQ
                 @handle.log("info", "Check refresh status of stack (#{service.stack_name})")
 
                 if refresh_may_have_completed?(service)
-                  @handle.root['ae_result'] = @handle.get_state_var('deploy_result')
-                  @handle.root['ae_reason'] = @handle.get_state_var('deploy_reason')
+                  @handle.root['ae_result'] = 'ok' # 'ok' here, error will be handled at the postprovision state.
                   @handle.log("info", "Refresh completed.")
                 else
                   @handle.root['ae_result']         = 'retry'

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/postprovision.rb
@@ -20,3 +20,6 @@ service.post_provision_configure
 # For example, dump all outputs from the stack
 #
 # dump_stack_outputs(stack)
+
+$evm.root['ae_result'] = $evm.get_state_var('deploy_result')
+$evm.root['ae_reason'] = $evm.get_state_var('deploy_reason')

--- a/spec/automation/unit/method_validation/orchestration_postprovision_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_postprovision_spec.rb
@@ -3,10 +3,16 @@ describe "Orchestration postprovision Method Validation" do
   let(:request)               { FactoryGirl.create(:service_template_provision_request, :requester => user) }
   let(:service_orchestration) { FactoryGirl.create(:service_orchestration) }
   let(:user)                  { FactoryGirl.create(:user_with_group) }
-  let(:ws)                    { MiqAeEngine.instantiate("/Cloud/Orchestration/Provisioning/StateMachines/Methods/PostProvision?MiqRequestTask::service_template_provision_task=#{miq_request_task.id}", user) }
+  let(:deploy_result)         { 'deploy_error' }
+  let(:ws_url)                { "/Cloud/Orchestration/Provisioning/StateMachines/Methods/PostProvision?MiqRequestTask::service_template_provision_task=#{miq_request_task.id}" }
+  let(:ws)                    { MiqAeEngine.instantiate("#{ws_url}&ae_state_data=#{URI.escape(YAML.dump('deploy_result' => deploy_result))}", user) }
 
-  it "updates the owners of the resulting vm" do
+  it "notifies the service to do post-provisioning configuration" do
     expect_any_instance_of(ServiceOrchestration).to receive(:post_provision_configure)
     ws
+  end
+
+  it "sets ae_result from provisioning state" do
+    expect(ws.root['ae_result']).to eq(deploy_result)
   end
 end

--- a/spec/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned_spec.rb
+++ b/spec/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/check_provisioned_spec.rb
@@ -114,12 +114,10 @@ describe ManageIQ::Automate::Cloud::Orchestration::Provisioning::StateMachines::
 
     it "completes check_provisioned step when refresh is done" do
       ae_service.set_state_var('provider_last_refresh', true)
-      ae_service.set_state_var('deploy_result', deploy_result)
-      ae_service.set_state_var('deploy_reason', deploy_reason)
       amazon_stack.status = "success"
       amazon_stack.save
       described_class.new(ae_service).main
-      expect(ae_service.root['ae_result']).to eq(deploy_result)
+      expect(ae_service.root['ae_result']).to eq('ok')
     end
   end
 


### PR DESCRIPTION
Do not set the `ae_result` to error when orchestration provisioning fails, so it will automatically forward to the next state which is postprovision. 

In postprovisioin state set `ae_result` according to state_var `deploy_result` which is set by the checkprovisioned state.

https://www.pivotaltracker.com/story/show/132667791
