### PR TITLE
Remove some requires from Api helper

### DIFF
--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -2,7 +2,6 @@
 # For testing REST API via Rspec requests
 #
 
-require 'bcrypt'
 require 'json'
 
 module Spec

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -2,8 +2,6 @@
 # For testing REST API via Rspec requests
 #
 
-require 'json'
-
 module Spec
   module Support
     module ApiHelper


### PR DESCRIPTION
I don't believe we reference `BCrypt` anywhere in the api/request specs, and now that we're using `response.parsed_body` we're not parsing JSON (ourselves) anywhere either.

@miq-bot add-label test, technical debt
@miq-bot assign @abellotti 