### PR TITLE
Create a request per region for vm reconfigure

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -909,7 +909,7 @@ module ApplicationController::CiProcessing
         javascript_redirect previous_breadcrumb_url
       end
     when "submit"
-      options = {:request_type => :vm_reconfigure}
+      options = {:request_type => :vm_reconfigure, :src_ids => params[:objectIds]}
       if params[:cb_memory] == 'true'
         options[:vm_memory] = params[:memory_type] == "MB" ? params[:memory] : (params[:memory].to_i.zero? ? params[:memory] : params[:memory].to_i * 1024)
       end
@@ -955,10 +955,7 @@ module ApplicationController::CiProcessing
         @request_id = params[:id]
       end
 
-      ApplicationRecord.group_ids_by_region(params[:objectIds]).each do |region, ids|
-        task_args = options.merge(:src_ids => ids)
-        VmReconfigureRequest.make_request(@request_id, task_args, current_user)
-      end
+      VmReconfigureRequest.make_request(@request_id, options, current_user)
       flash = _("VM Reconfigure Request was saved")
 
       if role_allows?(:feature => "miq_request_show_list", :any => true)

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -909,7 +909,7 @@ module ApplicationController::CiProcessing
         javascript_redirect previous_breadcrumb_url
       end
     when "submit"
-      options = {:request_type => :vm_reconfigure, :src_ids => params[:objectIds]}
+      options = {:src_ids => params[:objectIds]}
       if params[:cb_memory] == 'true'
         options[:vm_memory] = params[:memory_type] == "MB" ? params[:memory] : (params[:memory].to_i.zero? ? params[:memory] : params[:memory].to_i * 1024)
       end

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -82,12 +82,9 @@ class VmReconfigureRequest < MiqRequest
   def self.make_request(request, values, requester, auto_approve = false)
     values[:request_type] = :vm_reconfigure
 
-    requests = ApplicationRecord.group_ids_by_region(values[:src_ids]).collect do |_region, ids|
+    ApplicationRecord.group_ids_by_region(values[:src_ids]).collect do |_region, ids|
       super(request, values.merge(:src_ids => ids), requester, auto_approve)
     end
-
-    return requests.first if requests.count == 1
-    requests
   end
 
   def my_zone

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -79,6 +79,15 @@ class VmReconfigureRequest < MiqRequest
     errors
   end
 
+  def self.make_request(request, values, requester, auto_approve = false)
+    requests = ApplicationRecord.group_ids_by_region(values[:src_ids]).collect do |_region, ids|
+      super(request, values.merge(:src_ids => ids), requester, auto_approve)
+    end
+
+    return requests.first if requests.count == 1
+    requests
+  end
+
   def my_zone
     vm = Vm.find_by(:id => options[:src_ids])
     vm.nil? ? super : vm.my_zone

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -80,6 +80,8 @@ class VmReconfigureRequest < MiqRequest
   end
 
   def self.make_request(request, values, requester, auto_approve = false)
+    values[:request_type] = :vm_reconfigure
+
     requests = ApplicationRecord.group_ids_by_region(values[:src_ids]).collect do |_region, ids|
       super(request, values.merge(:src_ids => ids), requester, auto_approve)
     end

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -44,7 +44,7 @@ describe VmReconfigureRequest do
       # the dialogs populate this
       values = {:src_ids => [vm_vmware.id]}
 
-      request = described_class.make_request(nil, values, admin)
+      request = described_class.make_request(nil, values, admin).first
 
       expect(request).to                be_valid
       expect(request).to                be_a_kind_of(described_class)

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -73,11 +73,11 @@ describe VmReconfigureRequest do
       request_remote = double(:remote_region_request)
 
       expect(MiqRequest).to receive(:make_request) do |_req, vals, _requester, _auto_approve|
-        expect(vals).to eq(:src_ids => [vm_vmware.id])
+        expect(vals).to eq(:src_ids => [vm_vmware.id], :request_type => :vm_reconfigure)
       end.and_return(request_local)
 
       expect(MiqRequest).to receive(:make_request) do |_req, vals, _requester, _auto_approve|
-        expect(vals).to eq(:src_ids => [other_region_id])
+        expect(vals).to eq(:src_ids => [other_region_id], :request_type => :vm_reconfigure)
       end.and_return(request_remote)
 
       expect(described_class.make_request(nil, values, admin)).to match_array([request_local, request_remote])


### PR DESCRIPTION
This allows the make_request call to be routed to the correct region for the vms listed.

Paired with @bdunne on this.

@lgalis @h-kataria please review

/cc @gtanzillo @gmcculloug 