### PR TITLE
Extract constants for custom headers in the API

### DIFF
--- a/app/controllers/api/base_controller/authentication.rb
+++ b/app/controllers/api/base_controller/authentication.rb
@@ -7,10 +7,10 @@ module Api
       def require_api_user_or_token
         log_request_initiated
         @auth_token = @auth_user = nil
-        if request.headers['X-MIQ-Token']
-          authenticate_with_system_token(request.headers['X-MIQ-Token'])
-        elsif request.headers['X-Auth-Token']
-          authenticate_with_user_token(request.headers['X-Auth-Token'])
+        if request.headers[HttpHeaders::MIQ_TOKEN]
+          authenticate_with_system_token(request.headers[HttpHeaders::MIQ_TOKEN])
+        elsif request.headers[HttpHeaders::AUTH_TOKEN]
+          authenticate_with_user_token(request.headers[HttpHeaders::AUTH_TOKEN])
         else
           authenticate_options = {
             :require_user => true,
@@ -65,7 +65,7 @@ module Api
       end
 
       def authorize_user_group(user_obj)
-        group_name = request.headers['X-MIQ-Group']
+        group_name = request.headers[HttpHeaders::MIQ_GROUP]
         if group_name.present?
           group_obj = user_obj.miq_groups.find_by_description(group_name)
           raise AuthenticationError, "Invalid Authorization Group #{group_name} specified" if group_obj.nil?

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -14,13 +14,13 @@ module Api
         return unless api_log_info?
         if @miq_token_hash
           auth_type = "system"
-          log_request("System Auth", {:x_miq_token => request.headers['X-MIQ-Token']}.merge(@miq_token_hash))
+          log_request("System Auth", {:x_miq_token => request.headers[HttpHeaders::MIQ_TOKEN]}.merge(@miq_token_hash))
         else
           auth_type = @auth_token.blank? ? "basic" : "token"
         end
         log_request("Authentication", :type        => auth_type,
                                       :token       => @auth_token,
-                                      :x_miq_group => request.headers['X-MIQ-Group'],
+                                      :x_miq_group => request.headers[HttpHeaders::MIQ_GROUP],
                                       :user        => @auth_user)
         if @auth_user_obj
           group = @auth_user_obj.current_group

--- a/lib/api/http_headers.rb
+++ b/lib/api/http_headers.rb
@@ -1,0 +1,7 @@
+module Api
+  module HttpHeaders
+    AUTH_TOKEN = "HTTP_X_AUTH_TOKEN".freeze
+    MIQ_TOKEN = "HTTP_X_MIQ_TOKEN".freeze
+    MIQ_GROUP = "HTTP_X_MIQ_GROUP".freeze
+  end
+end

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -277,8 +277,9 @@ describe "Authentication API" do
     end
 
     it "authentication using a token with an old timestamp" do
-      run_get entrypoint_url,
-              :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)}
+      miq_token = systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)
+
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -287,8 +288,9 @@ describe "Authentication API" do
     end
 
     it "authentication using a valid token succeeds" do
-      run_get entrypoint_url,
-              :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)}
+      miq_token = systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)
+
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -57,7 +57,7 @@ describe "Authentication API" do
     it "test basic authentication with incorrect group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => "bogus_group"}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => "bogus_group"}
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -65,7 +65,7 @@ describe "Authentication API" do
     it "test basic authentication with a primary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => group1.description}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group1.description}
 
       expect(response).to have_http_status(:ok)
     end
@@ -73,7 +73,7 @@ describe "Authentication API" do
     it "test basic authentication with a secondary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => group2.description}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group2.description}
 
       expect(response).to have_http_status(:ok)
     end
@@ -91,7 +91,7 @@ describe "Authentication API" do
     it "basic authentication with a secondary group" do
       api_basic_authorize
 
-      run_get entrypoint_url, :headers => {"miq_group" => group2.description}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_GROUP => group2.description}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -134,7 +134,7 @@ describe "Authentication API" do
     end
 
     it "authentication using a bad token" do
-      run_get entrypoint_url, :headers => {"auth_token" => "badtoken"}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => "badtoken"}
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -149,7 +149,7 @@ describe "Authentication API" do
 
       auth_token = response.parsed_body["auth_token"]
 
-      run_get entrypoint_url, :headers => {"auth_token" => auth_token}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -171,7 +171,7 @@ describe "Authentication API" do
       expect(token_info[:expires_on].utc.iso8601).to eq(token_expires_on)
 
       expect_any_instance_of(TokenManager).to receive(:reset_token).with(auth_token)
-      run_get entrypoint_url, :headers => {"auth_token" => auth_token}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => auth_token}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)
@@ -214,7 +214,7 @@ describe "Authentication API" do
       auth_token = response.parsed_body["auth_token"]
 
       expect_any_instance_of(TokenManager).to receive(:invalidate_token).with(auth_token)
-      run_delete auth_url, "auth_token" => auth_token
+      run_delete auth_url, Api::HttpHeaders::AUTH_TOKEN => auth_token
     end
 
     context 'Tokens for Web Sockets' do
@@ -232,7 +232,7 @@ describe "Authentication API" do
         run_get auth_url, :requester_type => 'ws'
         ws_token = response.parsed_body["auth_token"]
 
-        run_get entrypoint_url, :headers => {'auth_token' => ws_token}
+        run_get entrypoint_url, :headers => {Api::HttpHeaders::AUTH_TOKEN => ws_token}
 
         expect(response).to have_http_status(:unauthorized)
       end
@@ -248,7 +248,7 @@ describe "Authentication API" do
 
     it "authentication using a bad token" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => "badtoken"}
+              :headers => {Api::HttpHeaders::MIQ_TOKEN => "badtoken"}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -258,7 +258,7 @@ describe "Authentication API" do
 
     it "authentication using a token with a bad server guid" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken("bad_server_guid", api_config(:user), Time.now.utc)}
+              :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken("bad_server_guid", api_config(:user), Time.now.utc)}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -268,7 +268,7 @@ describe "Authentication API" do
 
     it "authentication using a token with bad user" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken(MiqServer.first.guid, "bad_user_id", Time.now.utc)}
+              :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken(MiqServer.first.guid, "bad_user_id", Time.now.utc)}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -278,7 +278,7 @@ describe "Authentication API" do
 
     it "authentication using a token with an old timestamp" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)}
+              :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken(MiqServer.first.guid, api_config(:user), 10.minutes.ago.utc)}
 
       expect(response).to have_http_status(:unauthorized)
       expect(response.parsed_body).to include(
@@ -288,7 +288,7 @@ describe "Authentication API" do
 
     it "authentication using a valid token succeeds" do
       run_get entrypoint_url,
-              :headers => {"miq_token" => systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)}
+              :headers => {Api::HttpHeaders::MIQ_TOKEN => systoken(MiqServer.first.guid, api_config(:user), Time.now.utc)}
 
       expect(response).to have_http_status(:ok)
       expect_result_to_have_keys(ENTRYPOINT_KEYS)

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -74,7 +74,7 @@ describe "Logging" do
 
       expect_log_requests(log_request_expectations)
 
-      run_get entrypoint_url, :headers => {"miq_token" => miq_token}
+      run_get entrypoint_url, :headers => {Api::HttpHeaders::MIQ_TOKEN => miq_token}
     end
   end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -8,24 +8,12 @@ require 'json'
 module Spec
   module Support
     module ApiHelper
-      HEADER_ALIASES = {
-        "auth_token" => Api::HttpHeaders::AUTH_TOKEN,
-        "miq_token"  => Api::HttpHeaders::MIQ_TOKEN,
-        "miq_group"  => Api::HttpHeaders::MIQ_GROUP
-      }
-
       DEF_HEADERS = {
         "Content-Type" => "application/json",
         "Accept"       => "application/json"
       }
 
       def update_headers(headers)
-        HEADER_ALIASES.keys.each do |k|
-          if headers.key?(k)
-            headers[HEADER_ALIASES[k]] = headers[k]
-            headers.delete(k)
-          end
-        end
         headers.merge!("HTTP_AUTHORIZATION" => @http_authorization) if @http_authorization
         headers.merge(DEF_HEADERS)
       end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -9,9 +9,9 @@ module Spec
   module Support
     module ApiHelper
       HEADER_ALIASES = {
-        "auth_token" => "HTTP_X_AUTH_TOKEN",
-        "miq_token"  => "HTTP_X_MIQ_TOKEN",
-        "miq_group"  => "HTTP_X_MIQ_GROUP"
+        "auth_token" => Api::HttpHeaders::AUTH_TOKEN,
+        "miq_token"  => Api::HttpHeaders::MIQ_TOKEN,
+        "miq_group"  => Api::HttpHeaders::MIQ_GROUP
       }
 
       DEF_HEADERS = {


### PR DESCRIPTION
Some refactoring based on discussions in https://github.com/ManageIQ/manageiq/pull/11258

To summarize:

* Extracts some constants for the custom HTTP headers we use
* Updates test and production code to be consistent about the way we refer to those headers everywhere (we're not obliged to use the `env_name` key, as in https://github.com/rails/rails/blob/67263020ec4c40ff1cef5080056b233e9d723116/actionpack/lib/action_dispatch/http/headers.rb#L118-L127)
* Remove the header aliases in the API specs in favor of using the constants

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 

:scissors: 