### PR TITLE
Vm Tree builder pruning folders

### DIFF
--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -17,9 +17,9 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
 
     tree = root.subtree_arranged(TreeBuilder.hide_vms ? {:except_type => VmOrTemplate} : {})
 
+    prune_rbac(tree)
     prune_non_vandt_folders(tree)
     reparent_hidden_folders(tree)
-    prune_rbac(tree)
     sort_tree(tree)
 
     tree


### PR DESCRIPTION
This is a followup to #11387 and #11003

Subfolders were missing from the tree view.

before:
Trees were collapsed before pruning rbac.
Prune rbac was not finding the tree nodes in the whitelist and
improperly removing valid nodes.

after:
Prune rbac first, so nodes can be properly pruned
Tree nodes can then be collapsed

https://bugzilla.redhat.com/show_bug.cgi?id=1387792

/cc @ZitaNemeckova @h-kataria thanks for bringing this to my attention.
Please let me know if this does not address your needs
@dclarizio not sure who is the best person to review / merge this one.