### PR TITLE
Added missing originating_server argument for VMRC console startup

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -48,7 +48,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
   # VMRC
   #
 
-  def remote_console_vmrc_acquire_ticket(_userid = nil)
+  def remote_console_vmrc_acquire_ticket(_userid = nil, _originating_server = nil)
     validate_remote_console_acquire_ticket("vmrc")
     ext_management_system.remote_console_vmrc_acquire_ticket
   end


### PR DESCRIPTION
Caused by #11273, @martinpovolny please review.

https://bugzilla.redhat.com/show_bug.cgi?id=1388164