### PR TITLE
Remove duplicate flash_msg_div from cb rate editor

### DIFF
--- a/app/views/chargeback/_cb_rate_edit.html.haml
+++ b/app/views/chargeback/_cb_rate_edit.html.haml
@@ -1,6 +1,5 @@
 - url = url_for(:action => 'cb_rate_form_field_changed', :id => @edit[:rec_id] || "new")
 - currency = ChargebackRateDetailCurrency.currencies_for_select
-#flash_msg_div
 #form_div
   %h3
     = _('Basic Info')


### PR DESCRIPTION
Before
----------------
![before](https://cloud.githubusercontent.com/assets/6666052/19675981/d7cb7438-9a91-11e6-85f8-ef43ea1ffb7d.jpg)

After
-------------------------------
![after](https://cloud.githubusercontent.com/assets/6666052/19675987/e10bcb60-9a91-11e6-8015-6a37441f1bdf.jpg)

@miq-bot add_label bug, ui, technical debt
@miq-bot assign @martinpovolny 

:dolphin: 