### PR TITLE
Fix Instance provisioning fails on missing AZ

### DIFF
--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser/cross_linkers/openstack.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser/cross_linkers/openstack.rb
@@ -45,7 +45,7 @@ module ManageIQ::Providers::StorageManager::CinderManager::RefreshParser::CrossL
     end
 
     def link_volume_to_availability_zone(volume_hash, api_obj)
-      az_ref = api_obj.availability_zone ? "volume-#{api_obj.availability_zone}" : "null_az"
+      az_ref = api_obj.availability_zone ? api_obj.availability_zone : "null_az"
       availability_zone = @parent_ems.availability_zones.detect { |az| az.ems_ref == az_ref }
       unless availability_zone
         _log.info "EMS: #{@parent_ems.name}, availability zone not found: #{az_ref}"
@@ -69,7 +69,7 @@ module ManageIQ::Providers::StorageManager::CinderManager::RefreshParser::CrossL
     end
 
     def link_backup_to_availability_zone(backup_hash, api_obj)
-      az_ref = api_obj['availability_zone'] ? "volume-#{api_obj['availability_zone']}" : "null_az"
+      az_ref = api_obj['availability_zone'] ? api_obj['availability_zone'] : "null_az"
       availability_zone = @parent_ems.availability_zones.detect { |az| az.ems_ref == az_ref }
       unless availability_zone
         _log.info "EMS: #{@parent_ems.name}, availability zone not found: #{az_ref}"

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -229,7 +229,7 @@ module Openstack
     end
 
     def availability_zones_count
-      3 # This is affected by conf files only, so needs to be hardcoded value
+      2 # This is affected by conf files only, so needs to be hardcoded value
     end
 
     def assert_table_counts
@@ -362,7 +362,7 @@ module Openstack
       # standard openstack AZs have their ems_ref set to their name ("nova" in the test case)...
       # the "null" openstack AZ has a unique ems_ref and name
       expect(@nova_az).to have_attributes(
-        :ems_ref => "compute-#{@nova_az.name}"
+        :ems_ref => @nova_az.name
       )
     end
 


### PR DESCRIPTION
Availability Zones got updated its ems_ref field in refresh to be different to one in
OpenStack which caused error when selecting some AZ in an Instance provision form.

This fix returns refresh to previous behaviour which does not change AZ ems_ref and
keeps AZ from volume and compute service as a one object if it matches by id/name.
## Links
- https://bugzilla.redhat.com/show_bug.cgi?id=1381624

## Steps for Testing/QA
- setup openstack cloud provider
- go to instance provision, select some availability zone from selectbox in provision form and run instance provision
- provision process should not fail on non existing AZ
