### PR TITLE
UX: Simplify Chargeback rates editor

### DIFF
--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -48,7 +48,7 @@
           %td{:align => "right"}
             = tier.fixed_rate ? tier.fixed_rate : 0.0
           %td{:align => "right"}
-            = tier.variable_rate ? tier.variable_rate : 0.0
+            = detail[:group] == 'fixed' && tier.variable_rate.zero? ? '-' : tier.variable_rate
           %td{:align => "right", :rowspan => num_tiers}
             = detail.show_rates
         - (1..num_tiers.to_i - 1).each do |tier_index|
@@ -61,7 +61,7 @@
             %td{:align => "right"}
               = tier.fixed_rate
             %td{:align => "right"}
-              = tier.variable_rate
+              = (detail[:group] == 'fixed' && tier.variable_rate.zero?) ? '-' : tier.variable_rate
         %tr
           %td{:colspan => "9"}
 

--- a/app/views/chargeback/_cb_tier_edit_values.html.haml
+++ b/app/views/chargeback/_cb_tier_edit_values.html.haml
@@ -1,4 +1,5 @@
 - tier = @edit[:new][:tiers][detail_index][row_within_rate]
+- detail = @edit[:new][:details][detail_index]
 %td
   - tier_val = (tier[:start].to_s.eql? 'Infinity') ? '' : tier[:start]
   = text_field_tag("start_#{detail_index}_#{row_within_rate}", tier_val,
@@ -11,5 +12,9 @@
   = text_field_tag("fixed_rate_#{detail_index}_#{row_within_rate}", tier[:fixed_rate],
     :maxlength => MAX_NAME_LEN, 'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
 %td{:align => 'right'}
-  = text_field_tag("variable_rate_#{detail_index}_#{row_within_rate}", tier[:variable_rate],
-    :maxlength => MAX_NAME_LEN, 'data-miq_observe' => {:interval => '.5', :url => url}.to_json)
+  - if detail['group'] == 'fixed' && (tier[:variable_rate].blank? || tier[:variable_rate].zero?)
+    /simplify editor, by disabling variable rate edit for fixed rates (allow edit only when this value already exists)
+    = '-'
+  - else
+    = text_field_tag("variable_rate_#{detail_index}_#{row_within_rate}", tier[:variable_rate],
+      :maxlength => MAX_NAME_LEN, 'data-miq_observe' => {:interval => '.5', :url => url}.to_json)


### PR DESCRIPTION
Description
-------------------------------
Do not allow edit of variable rate for a tier in fixed rate_detail.
    
This Simplifies rates editor. The rates editor is a complex form (:heavy_exclamation_mark:) and user can hardly comprehend what it does. :no_mouth: By removing useless field we give at least some clue to the user. :tipping_hand_woman: :bulb:
    
Why this is valid change?
 * For variable rate the computation goes like

    ```
    cost = fixed_rate + variable_rate * metric
    ```
 * For fixed rate the computation goes like

    ```
    metric = 1
    cost = fixed_rate + variable_rate * metric
    ```

Before
-------------------------------
![before](https://cloud.githubusercontent.com/assets/6666052/19678252/3fc63aae-9a9d-11e6-900d-ce9b1a1a3d87.jpg)

After
-------------------------------
![after](https://cloud.githubusercontent.com/assets/6666052/19678254/42909a9a-9a9d-11e6-8a50-e3b0322021ca.jpg)

@miq-bot add_label chargeback, ui, enhancement, wip
@miq-bot assign @mzazrivec 
/cc @lpichler 
:tropical_fish: 
