### PR TITLE
Extract common fields for any chargeback type

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -1,4 +1,15 @@
 class Chargeback < ActsAsArModel
+  set_columns_hash( # Fields common to any chargeback type
+    :start_date           => :datetime,
+    :end_date             => :datetime,
+    :interval_name        => :string,
+    :display_range        => :string,
+    :chargeback_rates     => :string,
+    :entity               => :binary,
+    :tag_name             => :string,
+    :fixed_compute_metric => :integer,
+  )
+
   HOURS_IN_DAY = 24
   HOURS_IN_WEEK = 168
 

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -1,20 +1,13 @@
 class ChargebackContainerImage < Chargeback
   set_columns_hash(
-    :start_date            => :datetime,
-    :end_date              => :datetime,
-    :interval_name         => :string,
-    :display_range         => :string,
-    :chargeback_rates      => :string,
     :project_name          => :string,
     :image_name            => :string,
-    :tag_name              => :string,
     :project_uid           => :string,
     :provider_name         => :string,
     :provider_uid          => :string,
     :archived              => :string,
     :cpu_cores_used_cost   => :float,
     :cpu_cores_used_metric => :float,
-    :fixed_compute_metric  => :integer,
     :fixed_compute_1_cost  => :float,
     :fixed_compute_2_cost  => :float,
     :fixed_2_cost          => :float,
@@ -24,7 +17,6 @@ class ChargebackContainerImage < Chargeback
     :net_io_used_cost      => :float,
     :net_io_used_metric    => :float,
     :total_cost            => :float,
-    :entity                => :binary
   )
 
   def self.build_results_for_report_ChargebackContainerImage(options)

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -1,19 +1,12 @@
 class ChargebackContainerProject < Chargeback
   set_columns_hash(
-    :start_date            => :datetime,
-    :end_date              => :datetime,
-    :interval_name         => :string,
-    :display_range         => :string,
-    :chargeback_rates      => :string,
     :project_name          => :string,
-    :tag_name              => :string,
     :project_uid           => :string,
     :provider_name         => :string,
     :provider_uid          => :string,
     :archived              => :string,
     :cpu_cores_used_cost   => :float,
     :cpu_cores_used_metric => :float,
-    :fixed_compute_metric  => :integer,
     :fixed_compute_1_cost  => :float,
     :fixed_compute_2_cost  => :float,
     :fixed_2_cost          => :float,
@@ -23,7 +16,6 @@ class ChargebackContainerProject < Chargeback
     :net_io_used_cost      => :float,
     :net_io_used_metric    => :float,
     :total_cost            => :float,
-    :entity                => :binary
   )
 
   def self.build_results_for_report_ChargebackContainerProject(options)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -1,12 +1,6 @@
 class ChargebackVm < Chargeback
   set_columns_hash(
-    :start_date               => :datetime,
-    :end_date                 => :datetime,
-    :interval_name            => :string,
-    :display_range            => :string,
-    :chargeback_rates         => :string,
     :vm_name                  => :string,
-    :tag_name                 => :string,
     :vm_uid                   => :string,
     :vm_guid                  => :string,
     :owner_name               => :string,
@@ -22,7 +16,6 @@ class ChargebackVm < Chargeback
     :disk_io_used_metric      => :float,
     :disk_io_cost             => :float,
     :disk_io_metric           => :float,
-    :fixed_compute_metric     => :integer,
     :fixed_compute_1_cost     => :float,
     :fixed_compute_2_cost     => :float,
     :fixed_storage_1_cost     => :float,
@@ -46,7 +39,6 @@ class ChargebackVm < Chargeback
     :storage_cost             => :float,
     :storage_metric           => :float,
     :total_cost               => :float,
-    :entity                   => :binary
   )
 
   def self.build_results_for_report_ChargebackVm(options)


### PR DESCRIPTION
There are three chargeback types: for VMs, for container images, and for container projects. 

The parent class `Chargeback` assumes that certain fields are always present (defined by all of its `descendants`). Let's define these columns top-level as they are kinda requirement as of now.

This idea was brought up in [discussion](https://github.com/ManageIQ/manageiq/pull/11925#discussion_r84647628) with @gtanzillo 

@miq-bot add_label refactoring, chargeback
@miq-bot assign @gtanzillo 