### PR TITLE
Fixed associations for network_port and openstack network_port servic…

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-network_port.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-network_manager-network_port.rb
@@ -1,6 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_NetworkPort < MiqAeServiceNetworkPort
-    expose :cloud_subnets,   :association => true
     expose :network_routers, :association => true
     expose :public_networks, :association => true
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_network_port.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_network_port.rb
@@ -2,7 +2,6 @@ module MiqAeMethodService
   class MiqAeServiceNetworkPort < MiqAeServiceModelBase
     expose :ext_management_system, :association => true
     expose :cloud_tenant,          :association => true
-    expose :cloud_subnet,          :association => true
     expose :cloud_subnets,         :association => true
     expose :device,                :association => true
   end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_network_port_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_network_port_spec.rb
@@ -8,8 +8,8 @@ module MiqAeServiceCloudNetworkSpec
       expect(described_class.instance_methods).to include(:cloud_tenant)
     end
 
-    it "#cloud_subnet" do
-      expect(described_class.instance_methods).to include(:cloud_subnet)
+    it "#cloud_subnets" do
+      expect(described_class.instance_methods).to include(:cloud_subnets)
     end
 
     it "#device" do


### PR DESCRIPTION
The MiqAeServiceManageIQ_Providers_Openstack_NetworkManager_NetworkPort service model defined an association 'cloud_subnets' that was also defined in its superclass MiqAeServiceNetworkPort, so this appeared twice in its list of associations. The class MiqAeServiceNetworkPort defined an association 'cloud_subnet' that was not defined in the NetworkPort AR, so this gave a NoMethodError when accessed.

This PR removes the two erroneous lines from the service model definitions
