### PR TITLE
Duplicate Dom ID in chargeback rate view

### DIFF
--- a/app/views/chargeback/_cb_rate_show.html.haml
+++ b/app/views/chargeback/_cb_rate_show.html.haml
@@ -35,7 +35,7 @@
           %tr
             %td.active{:colspan => "9", :style => "background-color: #f5f5f5;"} &nbsp;
         - num_tiers = detail.chargeback_tiers.to_a.blank? ? "1" : tiers.to_a.length.to_s
-        %tr.rdetail{:id => "rate_detail_row_#{detail_index}"}
+        %tr.rdetail
           %td{:rowspan => num_tiers}
             = h(rate_detail_group(detail[:group]))
           %td{:rowspan => num_tiers}
@@ -53,7 +53,7 @@
             = detail.show_rates
         - (1..num_tiers.to_i - 1).each do |tier_index|
           - tier = tiers.to_a[tier_index]
-          %tr.rdetail{:id => "rate_detail_row_#{detail_index}"}
+          %tr.rdetail
             %td
               = tier.start
             %td


### PR DESCRIPTION
Before
-------------------------------
![before](https://cloud.githubusercontent.com/assets/6666052/19685060/dd8f1770-9aba-11e6-9726-a6a3c9bac8cb.jpg)

After
-------------------------------
![after](https://cloud.githubusercontent.com/assets/6666052/19685167/6b48b454-9abb-11e6-941f-787b4f9e1c34.jpg)


@miq-bot add_label ui, technical debt
@miq-bot assign @martinpovolny 

Martin, I bet these IDs are never used/referenced by anyone. Although, I have less experience in javascript/css. Can you confirm? :microscope: I would much rather make them go. :scissors: :hocho: :fire: :toilet: :sweat_drops: 