### PR TITLE
Display Default label for filter in My Filters

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -769,6 +769,8 @@ module ApplicationController::Filter
           builder = TreeBuilder.class_for_type(tree_type)
           tree = builder.new(x_active_tree, tree_type, @sb)
         end
+      elsif %w(ems_cloud ems_infra).include?(@layout)
+        build_listnav_search_list(@view.db)
       else
         build_listnav_search_list(@edit[@expkey][:exp_model])
       end


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1383682

Display Default label for filter set in My Filters as default right
after adding another filter, not just after refresh,
in Filters bar in Compute -> Infrastructure -> Providers.
The same bug is in Filters bar in Compute -> Clouds -> Providers.

Before adding a new filter:
![default_label1](https://cloud.githubusercontent.com/assets/13417815/19686965/e150b176-9ac3-11e6-8c52-97018fbb939b.png)

After adding a new filter (originally):
![default_label3](https://cloud.githubusercontent.com/assets/13417815/19687192/ce058b0e-9ac4-11e6-927b-8020b6b67ffb.png)

After adding a new filter (new, fixed):
![default_label2](https://cloud.githubusercontent.com/assets/13417815/19687011/0a556148-9ac4-11e6-99a1-517501da7c48.png)
