### PR TITLE
Use parents from resource when there are not exist in MetricRollup

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -131,7 +131,7 @@ class Chargeback < ActsAsArModel
         prefix = Chargeback.report_cb_model(self.class.name).underscore
         ChargebackRate.get_assigned_for_target(perf.resource,
                                                :tag_list => perf.tag_list_reconstruct.map! { |t| prefix + t },
-                                               :parents  => get_rate_parents(perf).compact)
+                                               :parents  => get_rate_parents(perf))
       end
   end
 

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -83,6 +83,6 @@ class ChargebackContainerProject < Chargeback
 
   def get_rate_parents(perf)
     # Get rate from assigned containers providers only
-    [perf.parent_ems]
+    [perf.parent_ems].compact
   end
 end # class Chargeback

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -150,6 +150,7 @@ class ChargebackVm < Chargeback
 
   def get_rate_parents(perf)
     @enterprise ||= MiqEnterprise.my_enterprise
-    [perf.parent_host, perf.parent_ems_cluster, perf.parent_storage, perf.parent_ems, @enterprise, perf.resource.try(:tenant)]
+    parents = perf.resource_parents + [@enterprise]
+    parents.compact
   end
 end # class Chargeback

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -1,10 +1,8 @@
 module Metric::ChargebackHelper
   def hash_features_affecting_rate
     tags = tag_names.split('|').reject { |n| n.starts_with?('folder_path_') }.sort.join('|')
-    keys = [tags, parent_host_id, parent_ems_cluster_id, parent_storage_id, parent_ems_id]
+    keys = [tags] + resource_parents.map(&:id)
     keys += [resource.container_image, timestamp] if resource_type == Container.name
-    tenant_resource = resource.try(:tenant)
-    keys.push(tenant_resource.id) unless tenant_resource.nil?
     keys.join('_')
   end
 
@@ -16,5 +14,9 @@ module Metric::ChargebackHelper
       tag_list += state.image_tag_names.split("|").inject([]) { |arr, t| arr << "/tag/managed/#{t}" } if state.present?
     end
     tag_list
+  end
+
+  def resource_parents
+    [parent_host, parent_ems_cluster, parent_storage, parent_ems, resource.try(:tenant)].compact
   end
 end

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -17,6 +17,11 @@ module Metric::ChargebackHelper
   end
 
   def resource_parents
-    [parent_host, parent_ems_cluster, parent_storage, parent_ems, resource.try(:tenant)].compact
+    [parent_host || resource.try(:host),
+     parent_ems_cluster || resource.try(:ems_cluster),
+     parent_storage || resource.try(:storage),
+     parent_ems || resource.try(:ext_management_system),
+     resource.try(:tenant)
+    ].compact
   end
 end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -50,6 +50,79 @@ describe ChargebackVm do
     Timecop.return
   end
 
+  describe "#get_rate_parents" do
+    let(:vm) do
+      FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => @admin, :ems_ref => "ems_ref",
+                         :ems_cluster => @ems_cluster, :storage => @storage, :host => @host1,
+                         :ext_management_system => @ems
+                        )
+    end
+
+    let(:metric_rollup_without_parents) do
+      FactoryGirl.create(:metric_rollup_vm_hr,
+                         :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
+                         :derived_vm_numvcpus               => @cpu_count,
+                         :derived_memory_available          => @memory_available,
+                         :derived_memory_used               => @memory_used,
+                         :disk_usage_rate_average           => @disk_usage_rate,
+                         :net_usage_rate_average            => @net_usage_rate,
+                         :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
+                         :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                         :tag_names                         => "environment/prod",
+                         :resource                          => vm
+                        )
+    end
+
+    let(:metric_rollup_with_parents) do
+      FactoryGirl.create(:metric_rollup_vm_hr,
+                         :cpu_usagemhz_rate_average         => @cpu_usagemhz_rate,
+                         :derived_vm_numvcpus               => @cpu_count,
+                         :derived_memory_available          => @memory_available,
+                         :derived_memory_used               => @memory_used,
+                         :disk_usage_rate_average           => @disk_usage_rate,
+                         :net_usage_rate_average            => @net_usage_rate,
+                         :derived_vm_used_disk_storage      => @vm_used_disk_storage.gigabytes,
+                         :derived_vm_allocated_disk_storage => @vm_allocated_disk_storage.gigabytes,
+                         :tag_names                         => "environment/prod",
+                         :resource                          => vm,
+                         :parent_host_id                    => @host1.id,
+                         :parent_ems_cluster_id             => @ems_cluster.id,
+                         :parent_ems_id                     => @ems.id,
+                         :parent_storage_id                 => @storage.id,
+                        )
+    end
+
+    it "uses resource's host, cluster, storage and ems" do
+      parents = described_class.new.send(:get_rate_parents, metric_rollup_without_parents)
+
+      expected_array = [
+        vm.host,
+        vm.ems_cluster,
+        vm.storage,
+        vm.ext_management_system,
+        vm.tenant,
+        MiqEnterprise.my_enterprise
+      ].compact
+
+      expect(parents).to match_array(expected_array)
+    end
+
+    it "uses host, cluster, storage ems from MetricRollup record" do
+      parents = described_class.new.send(:get_rate_parents, metric_rollup_with_parents)
+
+      expected_array = [
+        metric_rollup_with_parents.parent_host,
+        metric_rollup_with_parents.parent_ems_cluster,
+        metric_rollup_with_parents.parent_storage,
+        metric_rollup_with_parents.parent_ems,
+        vm.tenant,
+        MiqEnterprise.my_enterprise
+      ].compact
+
+      expect(parents).to match_array(expected_array)
+    end
+  end
+
   let(:report_static_fields) { %w(vm_name) }
 
   it "uses static fields" do


### PR DESCRIPTION
Select parents from resource when there are nils in MetricRollups records

In this PR https://github.com/ManageIQ/manageiq/pull/11648 we
introduced selecting rates according to first MetricRollup
record of group. We can do it because group of these records
belong to one resource.

Selection is based on
MetricRollup#parent_host or parent_ems_cluster or
parent_storage or parent_ems but sometimes this fields in
MetricRollup are nil and it produces empty cells on the
report - it is because proper rate was not selected.

Fix provides that we are selecting parents from
the resource direcly when there are not exists in
MetricRollup.

Screenshot of issue: MetricRollup#parent_storage was nil in May records.
before
![screen shot 2016-10-25 at 15 22 36](https://cloud.githubusercontent.com/assets/14937244/19687729/e5c5acb8-9ac6-11e6-8c56-9ba3654509da.png)

after
![screen shot 2016-10-25 at 15 19 41](https://cloud.githubusercontent.com/assets/14937244/19687703/d3f4da22-9ac6-11e6-828c-f7bc9c4d91cd.png)

@miq-bot add_label chargeback, bug, reporting
@miq-bot assign @gtanzillo 
