### PR TITLE
Fix production by downgrading patternfly to 3.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "angular-ui-bootstrap-rails",   "~>0.13.0"
   gem "jquery-hotkeys-rails"
   gem "lodash-rails",                 "~>3.10.0"
-  gem "patternfly-sass",              "~>3.12.0"
+  gem "patternfly-sass",              "~>3.11.0"
   gem "sass-rails"
   gem "coffee-rails"
 

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "angular-animate": "~1.5.8",
     "angular-bootstrap-switch": "~0.5.1",
     "angular-mocks": "~1.5.8",
-    "angular-patternfly-sass": "~3.12.0",
+    "angular-patternfly-sass": "~3.11.0",
     "angular-sanitize": "~1.5.8",
     "angular.validators": "~4.4.2",
     "array-includes": "~1.0.0",


### PR DESCRIPTION
Since #12019, running `rails s -e production` causes this error in browser console..

```
Navigated to http://localhost:3000/
application-57d139a….js:155 Uncaught Error: [$injector:nomod] Module 'miq.wizard' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
http://errors.angularjs.org/1.5.8/$injector/nomod?p0=miq.wizard(anonymous function) @ application-57d139a….js:155(anonymous function) @ application-57d139a….js:155i @ application-57d139a….js:155wizardButtonDirective @ application-57d139a….js:1(anonymous function) @ application-57d139a….js:213
application-57d139a….js:1 Uncaught ReferenceError: moment is not definedmiqGetTZO @ application-57d139a….js:1(anonymous function) @ (index):111
(index):117 Uncaught ReferenceError: API is not defined(anonymous function) @ (index):117
```

Downgrading until it's fixed. The culprit is somewhere in angular-patternfly and breaks concatenated JS, even without uglifier.