### PR TITLE
Fix undefined method `hardware' for nil:NilClass

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
       if @target.respond_to?(:hardware)
         hardware = @target.hardware
       else
-        hardware = @target.container_node.hardware
+        hardware = @target.try(:container_node).try(:hardware)
       end
 
       @node_cores = hardware.try(:cpu_total_cores)

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -256,7 +256,7 @@ class VimPerformanceState < ApplicationRecord
     if resource.respond_to?(:hardware)
       resource.hardware
     elsif resource.respond_to?(:container_node)
-      resource.container_node.hardware
+      resource.container_node.try(:hardware)
     end
   end
 end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1386926

Problem caused when trying to collect CPU cores on Container/Container Group objects: when the objects are archived, they are no longer belong to a Container Node so we can't collect the CPU cores. 

cc @simon3z @zeari 