### PR TITLE
Set hostname on both IPv6 and IPv4 loopback addrs

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -23,7 +23,7 @@ gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.3",           :require => false
 gem "iniparse",                                     :require => false
 gem "kubeclient",              "=2.1.0",            :require => false
-gem "linux_admin",             "~>0.18.0",          :require => false
+gem "linux_admin",             "~>0.19.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -240,7 +240,7 @@ Static Network Configuration
           system_hosts.parsed_file.each { |line| line[:hosts].to_a.delete(host) } unless host =~ /^localhost.*/
 
           system_hosts.hostname = new_host
-          system_hosts.set_canonical_hostname("127.0.0.1", new_host)
+          system_hosts.set_loopback_hostname(new_host)
           system_hosts.save
           LinuxAdmin::Service.new("network").restart
           press_any_key

--- a/gems/pending/appliance_console/cli.rb
+++ b/gems/pending/appliance_console/cli.rb
@@ -131,10 +131,9 @@ module ApplianceConsole
       Trollop.educate unless set_host? || key? || database? || tmp_disk? ||
                              uninstall_ipa? || install_ipa? || certs? || extauth_opts?
       if set_host?
-        ip = LinuxAdmin::NetworkInterface.new("eth0").address
         system_hosts = LinuxAdmin::Hosts.new
         system_hosts.hostname = options[:host]
-        system_hosts.update_entry(ip, options[:host])
+        system_hosts.set_loopback_hostname(options[:host])
         system_hosts.save
         LinuxAdmin::Service.new("network").restart
       end

--- a/gems/pending/spec/appliance_console/cli_spec.rb
+++ b/gems/pending/spec/appliance_console/cli_spec.rb
@@ -4,9 +4,6 @@ describe ApplianceConsole::Cli do
   subject { described_class.new }
 
   it "should set hostname if defined" do
-    interface = double
-    expect(LinuxAdmin::NetworkInterface).to receive(:new).and_return(interface)
-    expect(interface).to receive(:address).and_return("192.168.1.10")
     expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with('host1')
     expect_any_instance_of(LinuxAdmin::Hosts).to receive(:save).and_return(true)
     expect_any_instance_of(LinuxAdmin::Service.new("test").class).to receive(:restart).and_return(true)
@@ -151,9 +148,6 @@ describe ApplianceConsole::Cli do
     end
 
     it "should not post_activate install ipa (aside: testing passing in host" do
-      interface = double
-      expect(LinuxAdmin::NetworkInterface).to receive(:new).and_return(interface)
-      expect(interface).to receive(:address).and_return("192.168.1.10")
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with("client.domain.com")
       expect_any_instance_of(LinuxAdmin::Hosts).to receive(:save).and_return(true)
       expect_any_instance_of(LinuxAdmin::Service.new("test").class).to receive(:restart).and_return(true)


### PR DESCRIPTION
This PR will ensure a `hostname` is set on both the IPv6 and IPv4 loopback addresses.              

This PR is marked WIP because it is dependent on a change to the linux_admin gem  
being tracked here:
https://github.com/ManageIQ/linux_admin/pull/170                                                   

This PR will address BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1360928
