### PR TITLE
Don't expand OPS rbac tree by default

### DIFF
--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -5,7 +5,7 @@ class TreeBuilderOpsRbac < TreeBuilder
 
   def tree_init_options(_tree_name)
     {
-      :open_all => true,
+      :open_all => false,
       :leaf     => "Access Control",
       :expand   => false
     }

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -16,6 +16,11 @@ describe TreeBuilderOpsRbac do
       assert_tree_nodes(["Groups"])
     end
 
+    it "has :open_all set to false" do
+      tree  = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
+      expect(tree.send(:tree_init_options, :open_all)[:open_all]).to be_falsey
+    end
+
     it "with user with rbac_role_view role" do
       login_as FactoryGirl.create(:user, :features => 'rbac_role_view')
       assert_tree_nodes(["Roles"])

--- a/spec/presenters/tree_builder_ops_rbac_spec.rb
+++ b/spec/presenters/tree_builder_ops_rbac_spec.rb
@@ -17,7 +17,7 @@ describe TreeBuilderOpsRbac do
     end
 
     it "has :open_all set to false" do
-      tree  = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
+      tree = TreeBuilderOpsRbac.new("rbac_tree", "rbac", {})
       expect(tree.send(:tree_init_options, :open_all)[:open_all]).to be_falsey
     end
 


### PR DESCRIPTION
Cut down the amount of scrolling necessary when managing Access Control.

https://bugzilla.redhat.com/show_bug.cgi?id=1381647.

Before:
![before](https://cloud.githubusercontent.com/assets/1630348/20228430/12ea9162-a81f-11e6-8220-d921ced9cf95.png)

After:
![after](https://cloud.githubusercontent.com/assets/1630348/20228434/175ed992-a81f-11e6-8cb8-2ba29a4c20d3.png)
