### PR TITLE
Fully qualify the Settings constant in the api collection config

### DIFF
--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -1,7 +1,7 @@
 module Api
   class CollectionConfig
     def initialize
-      @cfg = Settings.collections
+      @cfg = Api::Settings.collections
     end
 
     def [](collection_name)


### PR DESCRIPTION
During some initialization tasks this was resolving to the manageiq config settings object which was causing `@cfg` to be nil and raise during calls to `name_for_klass` which are executed at parse time.

@abellotti @imtayadeway please review

/cc @simaishi 