### PR TITLE
Protect against non-rendering timeline messages

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/runner.rb
@@ -87,6 +87,13 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Runner <
       event.middleware_ref = event.context['resource_path'] # optional context for linking to resource
     end
     event.message ||= event.text
+    # at time of writing the timeline can not handle newlines or double quotes in the message. Because the
+    # timeline popup is not meant to show huge messages, like stack traces, just truncate after the first line.
+    # And replace double quotes with single quotes.
+    unless event.message.nil?
+      event.message = event.message.lines.first.strip
+      event.message.tr!('"', "'")
+    end
     event.middleware_type = event.tags[TAG_RESOURCE_TYPE] # optional tag for linking to resource
     {
       :ems_id          => ems_id,


### PR DESCRIPTION
The new timeline widget does not like newlines or double-quotes in the event fields (when you click on the item in the timeline).  Some hawkular provider events were hitting this issue.  This PR provides protection.

This is likely a timeline widget problem and I will generate issues.  But this PR aims to get the hawkular provider events working in the near term.

https://bugzilla.redhat.com/show_bug.cgi?id=1388040
