### PR TITLE
Not all eap domain server fields populated

### DIFF
--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -16,7 +16,11 @@ module MiddlewareServerHelper::TextualSummary
   # Items
   #
   def textual_hostname
-    @record.hostname
+    if not_yet_started?(@record) && @record.hostname.nil?
+      _('not yet available')
+    else
+      @record.hostname
+    end
   end
 
   def textual_feed
@@ -24,8 +28,13 @@ module MiddlewareServerHelper::TextualSummary
   end
 
   def textual_bind_addr
+    address = if not_yet_started?(@record) && @record.properties['Bound Address'].nil?
+                _('not yet available')
+              else
+                @record.properties['Bound Address']
+              end
     {:label => _('Bind Address'),
-     :value => @record.properties['Bound Address']}
+     :value => address}
   end
 
   def textual_server_state
@@ -34,7 +43,11 @@ module MiddlewareServerHelper::TextualSummary
   end
 
   def textual_product
-    @record.product
+    if not_yet_started?(@record) && @record.product.nil?
+      _('not yet available')
+    else
+      @record.product
+    end
   end
 
   def textual_version
@@ -55,5 +68,10 @@ module MiddlewareServerHelper::TextualSummary
            :id         => @record.lives_on.id
           )
      }
+  end
+
+  def not_yet_started?(server)
+    # domain server case when it hasn't been started yet (it has auto-start flag set to false)
+    !server.middleware_server_group.nil? && server.properties['Server State'] == 'STOPPED'
   end
 end

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -28,6 +28,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
     assert_specific_datasource('Local~/subsystem=datasources/data-source=ExampleDS')
     assert_specific_datasource('Local~/host=master/server=server-one/subsystem=datasources/data-source=ExampleDS')
     assert_specific_server_group(domain)
+    assert_specific_domain_server
     assert_specific_domain
   end
 
@@ -67,5 +68,16 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
       :profile  => 'full',
     )
     expect(server_group.properties).not_to be_nil
+  end
+
+  def assert_specific_domain_server
+    server = @ems_hawkular.middleware_servers.find_by_name('server-three')
+    expect(server).to have_attributes(
+      :name     => 'server-three',
+      :nativeid => 'Local~/host=master/server=server-three',
+      :product  => 'not yet available',
+      :hostname => 'not yet available',
+    )
+    expect(server.properties).not_to be_nil
   end
 end


### PR DESCRIPTION
This is fix for this [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1376929). I was hoping it'd be enough to add it only to the `middleware_server_helper/textual_summary.rb`, but these are not called for the table view in the gtl. I haven't found any easy way to intercept the data being fetched by the gtl layer in the `application_controller.rb`. If there is anything better, I am open and willing to improve it. Perhaps adding the methods `hostname` and `product` to `middleware_server.rb` model that would return the 'not yet available' if the conditions are met, is that a good practice in rails (?)

https://bugzilla.redhat.com/show_bug.cgi?id=1376929

@miq-bot add_label providers/hawkular, bug, euwe/yes
