### PR TITLE
Provide an API to set headers ahead of request

### DIFF
--- a/spec/requests/api/headers_spec.rb
+++ b/spec/requests/api/headers_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Headers" do
     it "returns JSON when set to application/json" do
       api_basic_authorize
 
-      get entrypoint_url, :headers => {"Accept" => "application/json", "HTTP_AUTHORIZATION" => @http_authorization}
+      get entrypoint_url, :headers => headers.merge("Accept" => "application/json")
 
       expect(response.parsed_body).to include("name" => "API", "description" => "REST API")
       expect(response).to have_http_status(:ok)
@@ -12,7 +12,7 @@ RSpec.describe "Headers" do
     it "returns JSON when not provided" do
       api_basic_authorize
 
-      get entrypoint_url, :headers => {"HTTP_AUTHORIZATION" => @http_authorization}
+      get entrypoint_url, :headers => headers
 
       expect(response.parsed_body).to include("name" => "API", "description" => "REST API")
       expect(response).to have_http_status(:ok)
@@ -21,7 +21,7 @@ RSpec.describe "Headers" do
     it "responds with an error for unsupported mime-types" do
       api_basic_authorize
 
-      get entrypoint_url, :headers => {"Accept" => "application/xml", "HTTP_AUTHORIZATION" => @http_authorization}
+      get entrypoint_url, :headers => headers.merge("Accept" => "application/xml")
 
       expected = {
         "error" => a_hash_including(
@@ -39,7 +39,7 @@ RSpec.describe "Headers" do
     it "accepts JSON by default" do
       api_basic_authorize(collection_action_identifier(:groups, :create))
 
-      post groups_url, :params => '{"description": "foo"}', :headers => {"HTTP_AUTHORIZATION" => @http_authorization}
+      post groups_url, :params => '{"description": "foo"}', :headers => headers
 
       expect(response).to have_http_status(:ok)
     end
@@ -49,7 +49,7 @@ RSpec.describe "Headers" do
 
       post(groups_url,
            :params  => '{"description": "foo"}',
-           :headers => {"Content-Type" => "application/json", "HTTP_AUTHORIZATION" => @http_authorization})
+           :headers => headers.merge("Content-Type" => "application/json"))
 
       expect(response).to have_http_status(:ok)
     end
@@ -59,7 +59,7 @@ RSpec.describe "Headers" do
 
       post(groups_url,
            :params  => '{"description": "foo"}',
-           :headers => {"Content-Type" => "application/xml", "HTTP_AUTHORIZATION" => @http_authorization})
+           :headers => headers.merge("Content-Type" => "application/xml"))
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -5,34 +5,33 @@
 module Spec
   module Support
     module ApiHelper
-      def update_headers(headers)
-        headers.merge!("HTTP_AUTHORIZATION" => @http_authorization) if @http_authorization
-        headers
+      def headers
+        @headers ||= {}
       end
 
       def run_get(url, options = {})
         headers = options.delete(:headers) || {}
-        get url, :params => options, :headers => update_headers(headers)
+        get url, :params => options, :headers => self.headers.merge!(headers)
       end
 
       def run_post(url, body = {}, headers = {})
-        post url, :params => body.to_json, :headers => update_headers(headers)
+        post url, :params => body.to_json, :headers => self.headers.merge!(headers)
       end
 
       def run_put(url, body = {}, headers = {})
-        put url, :params => body.to_json, :headers => update_headers(headers)
+        put url, :params => body.to_json, :headers => self.headers.merge!(headers)
       end
 
       def run_patch(url, body = {}, headers = {})
-        patch url, :params => body.to_json, :headers => update_headers(headers)
+        patch url, :params => body.to_json, :headers => self.headers.merge!(headers)
       end
 
       def run_delete(url, headers = {})
-        delete url, :headers => update_headers(headers)
+        delete url, :headers => self.headers.merge!(headers)
       end
 
       def run_options(url, headers = {})
-        options url, update_headers(headers)
+        options url, self.headers.merge!(headers)
       end
 
       def resources_include_suffix?(resources, key, suffix)
@@ -91,7 +90,7 @@ module Spec
       end
 
       def basic_authorize(user, password)
-        @http_authorization = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
+        headers["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
       end
 
       def update_user_role(role, *identifiers)


### PR DESCRIPTION
The current implementation made setting the "HTTP_AUTHORIZATION" header
declaratively quite awkward - it involved setting an instance variable
and merging in the header at request time (i.e. with `run_get`, etc.),
depending on whether that variable was set.

The alternative proposed in this revision is to provide a memoized
`headers` variable which contains the default headers used in every API
request, allowing for the authorization header to be set where it is
created in the declarative `basic_authorize`.

Pulled out of https://github.com/ManageIQ/manageiq/pull/11258

@miq-bot add-label test, api, refactor
@miq-bot assign @abellotti 
