### PR TITLE
Makes OS Snapshot.connection_options not private

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_snapshot.rb
@@ -123,13 +123,14 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot < ::Clou
     raise MiqException::MiqVolumeSnapshotDeleteError, e.to_s, e.backtrace
   end
 
-  private
 
   def self.connection_options(cloud_tenant = nil)
     connection_options = { :service => 'Volume' }
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
     connection_options
   end
+
+  private
 
   def connection_options
     self.class.connection_options(cloud_tenant)


### PR DESCRIPTION
This makes ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot.connection_options
method public and solves issue with rubocop.

Discussed with @jrafanie and @chessbyte at https://github.com/ManageIQ/manageiq/pull/11751#discussion_r84704028 and https://github.com/ManageIQ/manageiq/pull/12162#issuecomment-256030574

If needed this can be backported to Euwe.