### PR TITLE
fix_serialized_reports_for_rails_four migration cleanup

### DIFF
--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -4,14 +4,14 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
                   :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
                   :report_run_time, :chart, :reserved].to_set
 
-    def serialize_report_to_hash(val, migration)
+    def self.serialize_report_to_hash(val, klass, id, migration)
       if val.include?("!ruby/object:MiqReport")
         val.sub!(/MiqReport/, 'Hash')
       elsif val.starts_with?('--- !')
-        migration.say "#{self.class} Id: #{id} is not an MiqReport object, skipping conversion"
+        migration.say "#{klass} id: #{id} does not contain an MiqReport object, skipping conversion", :subitem
         return
       else
-        raise "unexpected format of report attribute encountered, '#{val.inspect}'"
+        raise "unexpected format of report attribute encountered, '#{val.inspect.truncate(10000)}'"
       end
       raw_hash = YAML.load(val)
       # MiqReport was serialized as an Array with 1 element in miq_report_results
@@ -22,9 +22,9 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
       YAML.dump(new_hash)
     end
 
-    def serialize_hash_to_report(val, from, migration)
+    def self.serialize_hash_to_report(val, from, klass, id, migration)
       if val.starts_with?('--- !')
-        migration.say "#{self.class} Id: #{id} is not a Hash, skipping conversion"
+        migration.say "#{klass} id: #{id} does not contain a Hash, skipping conversion", :subitem
       elsif val.starts_with?("---")
         new_hash = {'attributes' => {}}
         YAML.load(val).each do |k, v|
@@ -38,29 +38,17 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
           YAML.dump(new_hash).sub(/---/, "--- !ruby/object:MiqReport")
         end
       else
-        raise "unexpected format of report attribute encountered, '#{val.inspect}'"
+        raise "unexpected format of report attribute encountered, '#{val.inspect.truncate(10000)}'"
       end
     end
   end
 
   class MiqReportResult < ActiveRecord::Base
-    include Serializer
   end
 
   class BinaryBlobPart < ActiveRecord::Base
     def self.default_part_size
       @default_part_size ||= 1.megabyte
-    end
-
-    def inspect
-      # Clean up inspect so that we don't flood script/console
-      attrs = attribute_names.inject("{") { |s, n| s << "#{n.inspect}=>#{n == "data" ? "\"...\"" : read_attribute(n).inspect}, "; s }
-      attrs.chomp!(", ")
-      attrs << "}"
-      iv = instance_variables.inject(" ") { |s, v| s << "#{v}=#{v == "@attributes" ? attrs : instance_variable_get(v).inspect}, "; s }
-      iv.chomp!(", ")
-      iv.rstrip!
-      "#{to_s.chop}#{iv}>"
     end
 
     def data
@@ -82,8 +70,6 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
   class BinaryBlob < ActiveRecord::Base
     has_many :binary_blob_parts, -> { order(:id) }, :class_name => 'FixSerializedReportsForRailsFour::BinaryBlobPart'
     belongs_to :resource, :class_name => 'FixSerializedReportsForRailsFour::MiqReportResult'
-
-    include Serializer
 
     def delete_binary
       self.md5 = self.size = self.part_size = nil
@@ -127,7 +113,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
   def up
     say_with_time("Converting MiqReportResult#report to a serialized hash") do
       MiqReportResult.where('report IS NOT NULL').find_each do |rr|
-        val = rr.serialize_report_to_hash(rr.read_attribute(:report), self)
+        val = Serializer.serialize_report_to_hash(rr.report, rr.class, rr.id, self)
         rr.update_attribute(:report, val) if val
       end
     end
@@ -135,7 +121,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
     say_with_time("Converting BinaryBlob report results to a serialized hash") do
       BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').find_each do |bb|
         if bb.resource
-          val = bb.serialize_report_to_hash(bb.binary, self)
+          val = Serializer.serialize_report_to_hash(bb.binary, bb.class, bb.id, self)
           bb.binary = val if val
         end
       end
@@ -145,7 +131,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
   def down
     say_with_time("Converting MiqReportResult#report back to a serialized MiqReport") do
       MiqReportResult.where('report IS NOT NULL').find_each do |rr|
-        val = rr.serialize_hash_to_report(rr.read_attribute(:report), :miq_report_result, self)
+        val = Serializer.serialize_hash_to_report(rr.report, :miq_report_result, rr.class, rr.id, self)
         rr.update_attribute(:report, val) if val
       end
     end
@@ -153,7 +139,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
     say_with_time("Converting BinaryBlob report results back to a serialized MiqReport") do
       BinaryBlob.includes(:resource).where(:resource_type => 'MiqReportResult').find_each do |bb|
         if bb.resource
-          val = bb.serialize_hash_to_report(bb.binary, :binary_blob, self)
+          val = Serializer.serialize_hash_to_report(bb.binary, :binary_blob, bb.class, bb.id, self)
           bb.binary = val if val
         end
       end

--- a/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
+++ b/db/migrate/20150625220141_fix_serialized_reports_for_rails_four.rb
@@ -2,7 +2,7 @@ class FixSerializedReportsForRailsFour < ActiveRecord::Migration[4.2]
   module Serializer
     YAML_ATTRS = [:table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                   :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
-                  :report_run_time, :chart, :reserved]
+                  :report_run_time, :chart, :reserved].to_set
 
     def serialize_report_to_hash(val, migration)
       if val.include?("!ruby/object:MiqReport")

--- a/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
+++ b/spec/migrations/20150625220141_fix_serialized_reports_for_rails_four_spec.rb
@@ -11,11 +11,11 @@ describe FixSerializedReportsForRailsFour do
   end
 
   let(:report_result_stub)  { migration_stub(:MiqReportResult) }
-  let(:binary_blob)  { migration_stub(:BinaryBlob) }
+  let(:binary_blob_stub)  { migration_stub(:BinaryBlob) }
   let(:data_dir) { File.expand_path(File.join("data", File.basename(__FILE__, '.rb')), __dir__) }
 
   migration_context :up do
-    before(:each) do
+    before do
       @raw_report   = File.read(File.join(data_dir, 'miq_report_obj.yaml'))
       @raw_blob     = File.read(File.join(data_dir, 'binary_blob_obj.yaml'))
       @raw_blob_csv = File.read(File.join(data_dir, 'binary_blob_csv.yaml'))
@@ -38,7 +38,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "migrates existing binary blobs serialized as MiqReport objects to Hashes" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,
@@ -57,7 +57,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "skips existing binary blobs serialized as CSV" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,
@@ -100,7 +100,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "migrates existing binary blobs serialized as Hashes objects to MiqReports" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,
@@ -119,7 +119,7 @@ describe FixSerializedReportsForRailsFour do
     end
 
     it "skips existing binary blobs serialized as CSV" do
-      bb = binary_blob.create!(
+      bb = binary_blob_stub.create!(
         :resource_type => "MiqReportResult",
         :md5           => "b540c6aec8a7726c1154d71c06017150",
         :size          => 67_124,


### PR DESCRIPTION
This PR extracts the first 3 commits from #9119, which are mostly cleanup + Decouple the Serializer from ActiveRecord objects.

This will allow #9119 to just have the "meaty" part of the PR.

@gtanzillo Please review...Marking as euwe/no, but if #9119 needs backport, then this will need to go too.  @gtanzillo If you think this should be euwe/yes, please update
