### PR TITLE
Disable export when no report is selected in custom reports

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -353,7 +353,7 @@ function miqValidateButtons(h_or_s, prefix) {
 // Convert Button image to hyperlink
 function toggleConvertButtonToLink(button, url, toggle) {
   if (toggle) {
-    button.removeClass('dimmed');
+    button.removeClass('disabled');
     if (!button.parent().is('a[href]')) {
       button
         .wrap($('<a/>')
@@ -361,7 +361,7 @@ function toggleConvertButtonToLink(button, url, toggle) {
           .attr('title', button.attr('alt')));
     }
   } else {
-    button.addClass('dimmed');
+    button.addClass('disabled');
     if (button.parent().is('a[href]')) {
       button.unwrap();
     }

--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -264,6 +264,14 @@ ManageIQ.explorer.processReplaceRightCell = function(data) {
 
   miqInitMainContent();
   miqInitAccordions();
+  //Disable export button when no report is selected in Custom Reports 
+  if ($('#custom_reports')!=undefined && $('#custom_reports').val()=='true') {
+    if($('#choices_chosen').val()==null) {
+      $('#export_button').addClass('disabled');
+    } else {
+      $('#export_button').removeClass('disabled');
+    }
+  }
 
   if (data.hideModal) { $('#quicksearchbox').modal('hide'); }
   if (data.initAccords) { miqInitAccordions(); }

--- a/app/views/report/_export_custom_reports.html.haml
+++ b/app/views/report/_export_custom_reports.html.haml
@@ -37,6 +37,7 @@
       = _('Available Custom Reports:')
     .col-md-8
       %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}
+        %input{:type => "hidden", :id => "custom_reports", :name => "custom_reports", :value => "true"}
         = select_tag('choices_chosen',
           options_for_select(@export_reports.sort),
           :size              => 15,


### PR DESCRIPTION
Export button is displayed as disabled when no report is selected
and enabled when reports are selected in custom reports tab.
