### PR TITLE
Handle possibility of nil for virtual dvd drives for SCVMM

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -401,7 +401,7 @@ module ManageIQ::Providers::Microsoft
 
     def process_vm_guest_devices(vm)
       dvds = vm[:Properties][:Props][:VirtualDVDDrives]
-      return [] if dvds.empty?
+      return [] if dvds.blank?
 
       dvdprops   = dvds[0][:Props]
       connection = dvdprops[:Connection]


### PR DESCRIPTION
This fixes an issue that @jerryk55 encountered where he got:

    undefined method empty?' for nil:NilClass

This changes the method call so that it works even if the object is nil.