### PR TITLE
Handle errors during git repository fetch

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -209,7 +209,8 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
           new_git_repo = git_repo
         end
         git_repo.update_attributes(:verify_ssl => verify_ssl)
-        git_repo.update_authentication(:values => {:userid => params[:git_username], :password => params[:git_password]})
+        git_repo.update_authentication(:values => {:userid   => params[:git_username],
+                                                   :password => params[:git_password]})
 
         task_options = {
           :action => "Retrieve git repository",
@@ -222,7 +223,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
           :role        => "git_owner",
           :args        => []
         }
-  
+
         task_id = MiqTask.generic_action_with_callback(task_options, queue_options)
         MiqTask.wait_for_taskid(task_id)
 

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -209,8 +209,10 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
           new_git_repo = git_repo
         end
         git_repo.update_attributes(:verify_ssl => verify_ssl)
-        git_repo.update_authentication(:values => {:userid   => params[:git_username],
-                                                   :password => params[:git_password]})
+        if params[:git_username] && params[:git_password]
+          git_repo.update_authentication(:values => {:userid   => params[:git_username],
+                                                     :password => params[:git_password]})
+        end
 
         task_options = {
           :action => "Retrieve git repository",

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -194,44 +194,52 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
   def retrieve_git_datastore
     redirect_options = {:action => :review_git_import}
     git_url = params[:git_url]
-    verify_ssl = params[:git_verify_ssl] == "true" ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE 
+    verify_ssl = params[:git_verify_ssl] == "true" ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+    new_git_repo = nil
 
     if git_url.blank?
       add_flash(_("Please provide a valid git URL"), :error)
     elsif !GitBasedDomainImportService.available?
       add_flash(_("Please enable the git owner role in order to import git repositories"), :error)
     else
-      if GitRepository.exists?(:url => git_url)
-        flash_message = _("This repository has been used previously for imports; If you use the same domain it will get deleted and recreated")
-        status = :warning
-      else
-        flash_message = _("Successfully found git repository, please choose a branch or tag")
-        status = :success
+      begin
+        git_repo = GitRepository.find_by(:url => git_url)
+        unless git_repo
+          git_repo = GitRepository.create!(:url => git_url)
+          new_git_repo = git_repo
+        end
+        git_repo.update_attributes(:verify_ssl => verify_ssl)
+        git_repo.update_authentication(:values => {:userid => params[:git_username], :password => params[:git_password]})
+
+        task_options = {
+          :action => "Retrieve git repository",
+          :userid => current_user.userid
+        }
+        queue_options = {
+          :class_name  => "GitRepository",
+          :method_name => "refresh",
+          :instance_id => git_repo.id,
+          :role        => "git_owner",
+          :args        => []
+        }
+  
+        task_id = MiqTask.generic_action_with_callback(task_options, queue_options)
+        MiqTask.wait_for_taskid(task_id)
+
+        task = MiqTask.find(task_id)
+        raise task.message unless task.status == "Ok"
+
+        branch_names = git_repo.git_branches.collect(&:name)
+        tag_names = git_repo.git_tags.collect(&:name)
+        redirect_options[:git_branches] = branch_names.to_json
+        redirect_options[:git_tags] = tag_names.to_json
+        redirect_options[:git_repo_id] = git_repo.id
+        flash_message = "Successfully found git repository, please choose a branch or tag"
+        add_flash(_(flash_message), :success)
+      rescue => err
+        new_git_repo.destroy if new_git_repo
+        add_flash(_("Error during repository fetch: #{err.message}"), :error)
       end
-
-      git_repo = GitRepository.create(:url => git_url, :verify_ssl => verify_ssl)
-      git_repo.update_authentication(:values => {:userid => params[:git_username], :password => params[:git_password]})
-      task_options = {
-        :action => "Retrieve git repository",
-        :userid => current_user.userid
-      }
-      queue_options = {
-        :class_name  => "GitRepository",
-        :method_name => "refresh",
-        :instance_id => git_repo.id,
-        :role        => "git_owner",
-        :args        => []
-      }
-
-      task_id = MiqTask.generic_action_with_callback(task_options, queue_options)
-      MiqTask.wait_for_taskid(task_id)
-
-      add_flash(flash_message, status)
-      branch_names = git_repo.git_branches.collect(&:name)
-      tag_names = git_repo.git_tags.collect(&:name)
-      redirect_options[:git_branches] = branch_names.to_json
-      redirect_options[:git_tags] = tag_names.to_json
-      redirect_options[:git_repo_id] = git_repo.id
     end
 
     redirect_options[:message] = @flash_array.first.to_json

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -330,8 +330,7 @@ Methods updated/added: 10
           allow(git_repo).to receive(:update_authentication).with(:values => {:userid => "", :password => ""})
           allow(MiqTask).to receive(:generic_action_with_callback)
             .with(task_options, queue_options).and_return(miq_task.id)
-          allow(MiqTask).to receive(:wait_for_taskid).with(miq_task.id)
-          allow(MiqTask).to receive(:find).with(miq_task.id).and_return(miq_task)
+          allow(MiqTask).to receive(:wait_for_taskid).with(miq_task.id).and_return(miq_task)
           allow(git_repo).to receive(:git_branches).and_return(git_branches)
           allow(git_repo).to receive(:git_tags).and_return(git_tags)
           allow(git_repo).to receive(:update_attributes).and_return(nil)
@@ -352,7 +351,7 @@ Methods updated/added: 10
 
         context "when the git repository exists with the given url" do
           before do
-            allow(GitRepository).to receive(:find_by).with(:url => git_url).and_return(git_repo)
+            allow(GitRepository).to receive(:find_or_create_by!).with(:url => git_url).and_return(git_repo)
           end
 
           it "queues the refresh action" do
@@ -387,7 +386,7 @@ Methods updated/added: 10
 
         context "when the git repository does not exist with the given url" do
           before do
-            allow(GitRepository).to receive(:find_by).with(:url => git_url).and_return(nil)
+            allow(GitRepository).to receive(:find_or_create_by!).with(:url => git_url).and_return(git_repo)
           end
 
           it "queues the refresh action" do
@@ -396,7 +395,7 @@ Methods updated/added: 10
           end
 
           it "waits for the refresh action" do
-            expect(MiqTask).to receive(:wait_for_taskid).with(miq_task.id)
+            expect(MiqTask).to receive(:wait_for_taskid).with(miq_task.id).and_return(miq_task)
             post :retrieve_git_datastore, :params => params
           end
 

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -328,7 +328,8 @@ Methods updated/added: 10
         before do
           allow(GitRepository).to receive(:create!).with(:url => git_url).and_return(git_repo)
           allow(git_repo).to receive(:update_authentication).with(:values => {:userid => "", :password => ""})
-          allow(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(miq_task.id)
+          allow(MiqTask).to receive(:generic_action_with_callback)
+            .with(task_options, queue_options).and_return(miq_task.id)
           allow(MiqTask).to receive(:wait_for_taskid).with(miq_task.id)
           allow(MiqTask).to receive(:find).with(miq_task.id).and_return(miq_task)
           allow(git_repo).to receive(:git_branches).and_return(git_branches)
@@ -346,8 +347,8 @@ Methods updated/added: 10
                 :level   => :error
               }.to_json
             )
-          end 
-        end 
+          end
+        end
 
         context "when the git repository exists with the given url" do
           before do
@@ -363,7 +364,7 @@ Methods updated/added: 10
             expect(MiqTask).to receive(:wait_for_taskid).with(miq_task.id)
             post :retrieve_git_datastore, :params => params
           end
-          
+
           context "task failure" do
             let(:task_message) { "Disaster happened" }
             let(:task_status) { "Failed" }


### PR DESCRIPTION
When we fetch the git repository we delegate the task to an
appliance that has the git_owner "Git Repositories Owner" role
enabled. Handle error cases when the task fails.
## Links
- https://bugzilla.redhat.com/show_bug.cgi?id=1386254
