### PR TITLE
i18n support in pdf reports

### DIFF
--- a/app/controllers/application_controller/report_downloads.rb
+++ b/app/controllers/application_controller/report_downloads.rb
@@ -96,6 +96,9 @@ module ApplicationController::ReportDownloads
     options = session[:paged_view_search_options].merge(:page => nil, :per_page => nil) # Get all pages
     @view.table, _attrs = @view.paged_view_search(options) # Get the records
 
+    @view.title = _(@view.title)
+    @view.headers.map! { |header| _(header) }
+
     @filename = filename_timestamp(@view.title)
     case params[:download_type]
     when "pdf"

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -163,8 +163,8 @@ class MiqReportResult < ApplicationRecord
     hdr << "@page{margin: 40pt 30pt 40pt 30pt}"
     hdr << "@page{@top{content: '#{title}';color:blue}}"
     hdr << "@page{@bottom-left{content: url('#{ActionController::Base.helpers.image_path('layout/reportbanner_small1.png')}')}}"
-    hdr << "@page{@bottom-center{font-size: 75%;content: 'Report date: #{run_date}'}}"
-    hdr << "@page{@bottom-right{font-size: 75%;content: 'Page ' counter(page) ' of ' counter(pages)}}"
+    hdr << "@page{@bottom-center{font-size: 75%;content: '" + _("Report date: %{report_date}") % {:report_date => run_date} + "'}}"
+    hdr << "@page{@bottom-right{font-size: 75%;content: '" + _("Page %{page_number} of %{total_pages}") % {:page_number => " ' counter(page) '", :total_pages => " ' counter(pages)}}"}
     hdr << "</style></head>"
   end
 


### PR DESCRIPTION
1. Install prince for pdf support
2. Install Japanese and Chinese fonts (on Fedora cjkuni-ukai-fonts, cjkuni-uming-fonts, vlgothic-fonts, vlgothic-p-fonts)
3. Set your locale to either Chinese or to Japanese
4. Navigate to Infra -> VMs
5. Click on download pdf report

https://bugzilla.redhat.com/show_bug.cgi?id=1387227