### PR TITLE
s/Api::Settings/Api::ApiConfig/

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,9 +6,9 @@ module Api
 
     def index
       res = {
-        :name         => Settings.base.name,
-        :description  => Settings.base.description,
-        :version      => Settings.base.version,
+        :name         => ApiConfig.base.name,
+        :description  => ApiConfig.base.description,
+        :version      => ApiConfig.base.version,
         :versions     => entrypoint_versions,
         :settings     => user_settings,
         :identity     => auth_identity,
@@ -23,7 +23,7 @@ module Api
     private
 
     def entrypoint_versions
-      Settings.version.definitions.select(&:ident).collect do |version_specification|
+      ApiConfig.version.definitions.select(&:ident).collect do |version_specification|
         {
           :name => version_specification[:name],
           :href => "#{@req.api_prefix}/#{version_specification[:ident]}"

--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -65,7 +65,7 @@ module Api
         method = api_get_method_name(caller.first, __method__)
         log_prefix = "MIQ(#{self.class.name}.#{method})"
 
-        $api_log.error("#{log_prefix} #{Settings.base.name} Error")
+        $api_log.error("#{log_prefix} #{ApiConfig.base.name} Error")
         msg.split("\n").each { |l| $api_log.error("#{log_prefix} #{l}") }
       end
 

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -13,7 +13,7 @@ module Api
         # API Version Validation
         if @req.version
           vname = @req.version
-          unless Settings.version.definitions.collect { |vent| vent[:name] }.include?(vname)
+          unless ApiConfig.version.definitions.collect { |vent| vent[:name] }.include?(vname)
             raise BadRequestError, "Unsupported API Version #{vname} specified"
           end
         end
@@ -81,7 +81,7 @@ module Api
 
       def href_collection_id(path)
         path_array = path.split('/')
-        cidx = path_array[2] && path_array[2].match(Settings.version.regex) ? 3 : 2
+        cidx = path_array[2] && path_array[2].match(ApiConfig.version.regex) ? 3 : 2
 
         collection, c_id    = path_array[cidx..cidx + 1]
         subcollection, s_id = path_array[cidx + 2..cidx + 3]

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -91,7 +91,7 @@ module Api
           @version ||= if version_override?
                          @params[:version][1..-1] # Switching API Version
                        else
-                         Settings.base[:version] # Default API Version
+                         ApiConfig.base[:version] # Default API Version
                        end
         end
 
@@ -102,7 +102,7 @@ module Api
         end
 
         def version_override?
-          @params[:version] && @params[:version].match(Settings.version[:regex]) # v#.# version signature
+          @params[:version] && @params[:version].match(ApiConfig.version[:regex]) # v#.# version signature
         end
 
         def fullpath

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -16,7 +16,7 @@ module Api
     private
 
     def exposed_settings
-      Settings.collections[:settings][:categories]
+      ApiConfig.collections[:settings][:categories]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3045,7 +3045,7 @@ Vmdb::Application.routes.draw do
       }.freeze
     end
 
-    Api::Settings.collections.each do |collection_name, collection|
+    Api::ApiConfig.collections.each do |collection_name, collection|
       # OPTIONS action for each collection
       match collection_name.to_s, :controller => collection_name, :action => :options, :via => :options
 
@@ -3063,7 +3063,7 @@ Vmdb::Application.routes.draw do
         end
 
         Array(collection.subcollections).each do |subcollection_name|
-          Api::Settings.collections[subcollection_name].verbs.each do |verb|
+          Api::ApiConfig.collections[subcollection_name].verbs.each do |verb|
             match("/:c_id/#{subcollection_name}(/:s_id)", :action => API_ACTIONS[verb], :via => verb)
           end
         end

--- a/lib/api/api_config.rb
+++ b/lib/api/api_config.rb
@@ -1,7 +1,7 @@
 require "config"
 
 module Api
-  Settings = ::Config::Options.new.tap do |o|
+  ApiConfig = ::Config::Options.new.tap do |o|
     o.add_source!(Rails.root.join("config/api.yml").to_s)
     o.load!
   end

--- a/lib/api/collection_config.rb
+++ b/lib/api/collection_config.rb
@@ -1,7 +1,7 @@
 module Api
   class CollectionConfig
     def initialize
-      @cfg = Api::Settings.collections
+      @cfg = ApiConfig.collections
     end
 
     def [](collection_name)

--- a/lib/api/environment.rb
+++ b/lib/api/environment.rb
@@ -5,7 +5,7 @@ module Api
     end
 
     def self.user_token_service
-      @user_token_service ||= UserTokenService.new(Settings, :log_init => true)
+      @user_token_service ||= UserTokenService.new(ApiConfig, :log_init => true)
     end
 
     def self.fetch_encrypted_attribute_names(klass)

--- a/lib/api/initializer.rb
+++ b/lib/api/initializer.rb
@@ -13,14 +13,14 @@ module Api
     # Initializing REST API environment, called once @ startup
     #
     def init_env
-      $api_log.info("Initializing Environment for #{Settings.base[:name]}")
+      $api_log.info("Initializing Environment for #{ApiConfig.base[:name]}")
       log_config
     end
 
     def log_config
       $api_log.info("")
       $api_log.info("Static Configuration")
-      Settings.base.each { |key, val| log_kv(key, val) }
+      ApiConfig.base.each { |key, val| log_kv(key, val) }
 
       $api_log.info("")
       $api_log.info("Dynamic Configuration")
@@ -40,7 +40,7 @@ module Api
     # Let's dynamically get the :date and :datetime attributes from the Classes we care about.
     #
     def gen_time_attr_type_hash
-      Settings.collections.each do |_, cspec|
+      ApiConfig.collections.each do |_, cspec|
         next if cspec[:klass].blank?
         klass = cspec[:klass].constantize
         klass.columns_hash.collect do |name, typeobj|

--- a/lib/api/user_token_service.rb
+++ b/lib/api/user_token_service.rb
@@ -4,7 +4,7 @@ module Api
     # Additional Requester type token ttl's for authentication
     TYPE_TO_TTL_OVERRIDE = {'ui' => ::Settings.session.timeout}.freeze
 
-    def initialize(config = Settings, args = {})
+    def initialize(config = ApiConfig, args = {})
       @config = config
       @svc_options = args
     end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -10,7 +10,7 @@ describe "Rest API Collections" do
   end
 
   def test_collection_query(collection, collection_url, klass, attr = :id)
-    if Api::Settings.fetch_path(:collections, collection, :collection_actions, :get)
+    if Api::ApiConfig.fetch_path(:collections, collection, :collection_actions, :get)
       api_basic_authorize collection_action_identifier(collection, :read, :get)
     else
       api_basic_authorize
@@ -27,7 +27,7 @@ describe "Rest API Collections" do
 
     obj = id.nil? ? klass.first : klass.find(id)
     url = send("#{collection}_url", obj.id)
-    attr_list = String(Api::Settings.collections[collection].identifying_attrs).split(",")
+    attr_list = String(Api::ApiConfig.collections[collection].identifying_attrs).split(",")
     attr_list |= %w(guid) if klass.attribute_method?(:guid)
     resources = [{"id" => obj.id}, {"href" => url}]
     attr_list.each { |attr| resources << {attr => obj.public_send(attr)} }

--- a/spec/requests/api/config_spec.rb
+++ b/spec/requests/api/config_spec.rb
@@ -1,5 +1,5 @@
 describe 'API configuration (config/api.yml)' do
-  let(:api_settings) { Api::Settings }
+  let(:api_settings) { Api::ApiConfig }
 
   describe 'collections' do
     let(:collection_settings) { api_settings.collections }

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -2,7 +2,7 @@
 # REST API Request Tests - /api/settings
 #
 describe "Settings API" do
-  let(:api_settings) { Api::Settings.collections[:settings][:categories] }
+  let(:api_settings) { Api::ApiConfig.collections[:settings][:categories] }
 
   context "Settings Queries" do
     it "tests queries of all exposed settings" do

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -83,7 +83,7 @@ module Spec
         "#{api_config(:entrypoint)}/auth"
       end
 
-      (Api::Settings.collections.keys - [:auth]).each do |collection|
+      (Api::ApiConfig.collections.keys - [:auth]).each do |collection|
         define_method("#{collection}_url".to_sym) do |id = nil|
           path = "#{api_config(:entrypoint)}/#{collection}"
           id.nil? ? path : "#{path}/#{id}"
@@ -112,7 +112,7 @@ module Spec
       end
 
       def action_identifier(type, action, selection = :resource_actions, method = :post)
-        Api::Settings.collections[type][selection][method]
+        Api::ApiConfig.collections[type][selection][method]
           .detect { |spec| spec[:name] == action.to_s }[:identifier]
       end
 
@@ -122,7 +122,7 @@ module Spec
 
       def subcollection_action_identifier(type, subtype, action, method = :post)
         subtype_actions = "#{subtype}_subcollection_actions".to_sym
-        if Api::Settings.collections[type][subtype_actions]
+        if Api::ApiConfig.collections[type][subtype_actions]
           action_identifier(type, action, subtype_actions, method)
         else
           action_identifier(subtype, action, :subcollection_actions, method)


### PR DESCRIPTION
Originally we wanted to have a `Settings` object nested under the `Api`
namespace that looked and behaved just like the top-level `Settings`.

Furthermore, we enforced a nested style of class/module children so that
constants would not have to be fully qualified.

That turned out to be problematic. First, if the top-level `Settings`
was loaded before that of `Api`, the latter may never be loaded, meaning
that all those unqualified `Settings`' would point to the wrong object.

Second, we were using both `Api::Settings` and `::Settings` in the API
code, leading to confusing constructs such as:

```ruby
::Settings[Settings.base.module]
```

Since we want unqualified constants in the API code, it seemed
acceptable to introduce some redundancy in renaming `Api::Settings` to
`Api::ApiConfig`. Further, we preferred "Config" over "Settings" since
for the most part we refer to this thing as "config" everywhere
else (e.g. it's persisted in config/api.yml, methods such as
`api_config`, `CollectionConfig`, etc.)

@miq-bot add-label api, refactoring, technical debt
@miq-bot assign @abellotti 
/cc @Fryguy 