### PR TITLE
use ancestry 2.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "activerecord-session_store",     "~>1.0.0"
 gem "actioncable",                    "~>5.0.0"
 gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
-gem "ancestry",                       "~>2.1.0",       :require => false
+gem "ancestry",                       "~>2.2.1",       :require => false
 gem "ansible_tower_client",           "~>0.4.0",       :require => false
 gem "aws-sdk",                        "~>2.2.19",      :require => false
 gem "color",                          "~>1.8"


### PR DESCRIPTION
We have a number of performance improvements in ancestry 2.2.1

@Fryguy not sure if you want euwe or not. but I want to see people running this on master for a little bit before we backport

numbers
---------

The number of queries and results are the same. The difference is the use of `like` instead of `ilike` which are better able to use indexes.

http://localhost:3000/ems_infra/:id?display=ems_folders

|        ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  21,981.0 |  288 | 20,274.8 |    1,403 | master
|   4,622.9 |  288 |  3,078.0 |    1,403 | #12190
| 79% | 0% | 85% | 0%

http://localhost:3000/vm_infra/explorer

|       ms |queries | query (ms) |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  5,703.8 |  128 | 2,999.9 |    5,548 |master
|  4,411.8 |  128 | 1,783.4 |    5,548 | #12190
|22.7%| 0% | 40.6% | 0%