### PR TITLE
Use #schedule_cron instead of #cron

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -255,26 +255,23 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
     sched = cfg.fetch_path(:database, :metrics_collection, :collection_schedule)
     _log.info("database_metrics_collection_schedule: #{sched}")
-    scheduler.cron(
+    scheduler.schedule_cron(
       sched,
       :tags => [:database_operations, :database_metrics_collection_schedule],
-      :job  => true
     ) { enqueue :vmdb_database_capture_metrics_timer }
 
     sched = cfg.fetch_path(:database, :metrics_collection, :daily_rollup_schedule)
     _log.info("database_metrics_daily_rollup_schedule: #{sched}")
-    scheduler.cron(
+    scheduler.schedule_cron(
       sched,
       :tags => [:database_operations, :database_metrics_daily_rollup_schedule],
-      :job  => true
     ) { enqueue :vmdb_database_rollup_metrics_timer }
 
     sched = cfg.fetch_path(:database, :metrics_history, :purge_schedule)
     _log.info("database_metrics_purge_schedule: #{sched}")
-    scheduler.cron(
+    scheduler.schedule_cron(
       sched,
       :tags => [:database_operations, :database_metrics_purge_schedule],
-      :job  => true
     ) { enqueue :metric_purge_all_timer }
 
     @schedules[:database_operations]
@@ -290,10 +287,9 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     sched = VMDB::Config.new("vmdb").config.fetch_path(ldap_synchronization_schedule) || ldap_synchronization_schedule_default
     _log.info("ldap_synchronization_schedule: #{sched}")
 
-    scheduler.cron(
+    scheduler.schedule_cron(
       sched,
       :tags => [:ldap_synchronization, :ldap_synchronization_schedule],
-      :job  => true
     ) { enqueue :ldap_server_sync_data_from_timer }
 
     @schedules[:ldap_synchronization]
@@ -363,14 +359,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Storage metrics collection
     sched = cfg.fetch_path(:storage, :metrics_collection, :collection_schedule)
     _log.info("storage_metrics_collection_schedule: #{sched}")
-    scheduler.cron(sched, :job => true) do
+    scheduler.schedule_cron(sched) do
       enqueue :storage_refresh_metrics
     end
 
     # Schedule - Storage metrics hourly rollup
     sched = cfg.fetch_path(:storage, :metrics_collection, :hourly_rollup_schedule)
     _log.info("storage_metrics_hourly_rollup_schedule: #{sched}")
-    scheduler.cron(sched, :job => true) do
+    scheduler.schedule_cron(sched) do
       enqueue :storage_metrics_rollup_hourly
     end
 
@@ -380,7 +376,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       tz = ActiveSupport::TimeZone::MAPPING[tp.tz]
       sched = "#{base_sched} #{tz}"
       _log.info("storage_metrics_daily_rollup_schedule: #{sched}")
-      scheduler.cron(sched, :job => true) do
+      scheduler.schedule_cron(sched) do
         enqueue [:storage_metrics_rollup_daily, tp.id]
       end
     end
@@ -388,14 +384,14 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Storage metrics purge
     sched = cfg.fetch_path(:storage, :metrics_history, :purge_schedule)
     _log.info("storage_metrics_purge_schedule: #{sched}")
-    scheduler.cron(sched, :job => true) do
+    scheduler.schedule_cron(sched) do
       enqueue :miq_storage_metric_purge_all_timer
     end
 
     # Schedule - Storage inventory collection
     sched = cfg.fetch_path(:storage, :inventory, :full_refresh_schedule)
     _log.info("storage_inventory_full_refresh_schedule: #{sched}")
-    scheduler.cron(sched, :job => true) do
+    scheduler.schedule_cron(sched) do
       enqueue :storage_refresh_inventory
     end
 

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -359,16 +359,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Storage metrics collection
     sched = cfg.fetch_path(:storage, :metrics_collection, :collection_schedule)
     _log.info("storage_metrics_collection_schedule: #{sched}")
-    scheduler.schedule_cron(sched) do
-      enqueue :storage_refresh_metrics
-    end
+    scheduler.schedule_cron(sched) { enqueue :storage_refresh_metrics }
 
     # Schedule - Storage metrics hourly rollup
     sched = cfg.fetch_path(:storage, :metrics_collection, :hourly_rollup_schedule)
     _log.info("storage_metrics_hourly_rollup_schedule: #{sched}")
-    scheduler.schedule_cron(sched) do
-      enqueue :storage_metrics_rollup_hourly
-    end
+    scheduler.schedule_cron(sched) { enqueue :storage_metrics_rollup_hourly }
 
     # Schedule - Storage metrics daily rollup
     base_sched = cfg.fetch_path(:storage, :metrics_collection, :daily_rollup_schedule)
@@ -376,24 +372,18 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       tz = ActiveSupport::TimeZone::MAPPING[tp.tz]
       sched = "#{base_sched} #{tz}"
       _log.info("storage_metrics_daily_rollup_schedule: #{sched}")
-      scheduler.schedule_cron(sched) do
-        enqueue [:storage_metrics_rollup_daily, tp.id]
-      end
+      scheduler.schedule_cron(sched) { enqueue [:storage_metrics_rollup_daily, tp.id] }
     end
 
     # Schedule - Storage metrics purge
     sched = cfg.fetch_path(:storage, :metrics_history, :purge_schedule)
     _log.info("storage_metrics_purge_schedule: #{sched}")
-    scheduler.schedule_cron(sched) do
-      enqueue :miq_storage_metric_purge_all_timer
-    end
+    scheduler.schedule_cron(sched) { enqueue :miq_storage_metric_purge_all_timer }
 
     # Schedule - Storage inventory collection
     sched = cfg.fetch_path(:storage, :inventory, :full_refresh_schedule)
     _log.info("storage_inventory_full_refresh_schedule: #{sched}")
-    scheduler.schedule_cron(sched) do
-      enqueue :storage_refresh_inventory
-    end
+    scheduler.schedule_cron(sched) { enqueue :storage_refresh_inventory }
 
     @schedules[:storage_metrics_coordinator]
   end

--- a/app/models/miq_schedule_worker/scheduler.rb
+++ b/app/models/miq_schedule_worker/scheduler.rb
@@ -21,8 +21,8 @@ class MiqScheduleWorker
     end
     alias every schedule_every
 
-    def cron(cronline, callable = nil, opts = {}, &block)
-      role_schedule << rufus_scheduler.cron(cronline, callable, opts, &block)
+    def schedule_cron(cronline, callable = nil, opts = {}, &block)
+      role_schedule << rufus_scheduler.schedule_cron(cronline, callable, opts, &block)
     end
   end
 end

--- a/spec/models/miq_schedule_worker/scheduler_spec.rb
+++ b/spec/models/miq_schedule_worker/scheduler_spec.rb
@@ -67,10 +67,10 @@ describe MiqScheduleWorker::Scheduler do
     end
   end
 
-  describe "#cron" do
+  describe "#schedule_cron" do
     it "returns the job" do
       work = lambda {}
-      scheduler.cron("0 0 * * *", :tags => [:a, :b], &work)
+      scheduler.schedule_cron("0 0 * * *", :tags => [:a, :b], &work)
       job = rufus_scheduler.jobs.first
 
       expect(job.frequency).to eq(1.day)
@@ -79,14 +79,14 @@ describe MiqScheduleWorker::Scheduler do
     end
 
     it "adds to the list of scheduled jobs" do
-      scheduler.cron("0 0 * * *", :job => true) {}
+      scheduler.schedule_cron("0 0 * * *") {}
       job = rufus_scheduler.jobs.first
 
       expect(schedules).to eq([job])
     end
 
     it "adds a job to rufus's collection of all jobs" do
-      scheduler.cron("0 0 * * *") {}
+      scheduler.schedule_cron("0 0 * * *") {}
       job = rufus_scheduler.jobs.first
 
       expect(rufus_scheduler.jobs).to eq([job])


### PR DESCRIPTION
The former variant always returns the job, so the `:job => true` option
passed to `cron` can be omitted.

Source: https://github.com/jmettraux/rufus-scheduler#schedule_x-vs-x

@miq-bot add-label core, refactoring, technical debt
@miq-bot assign @jrafanie 


