### PR TITLE
Notifications: Allow bind of custom messages from automate

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -35,22 +35,22 @@
   :level: :warning
   :audience: tenant
 - :name: automate_user_success
-  :message: Automate user success
+  :message: '%{message}'
   :expires_in: 24.hours
   :level: :success
   :audience: user
 - :name: automate_user_error
-  :message: Automate user error
+  :message: '%{message}'
   :expires_in: 24.hours
   :level: :error
   :audience: user
 - :name: automate_user_info
-  :message: Automate user info
+  :message: '%{message}'
   :expires_in: 24.hours
   :level: :info
   :audience: user
 - :name: automate_user_warning
-  :message: Automate user warning
+  :message: '%{message}'
   :expires_in: 24.hours
   :level: :warning
   :audience: user

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -160,6 +160,7 @@ module MiqAeServiceSpec
       let(:miq_ae_service) { MiqAeService.new(workspace) }
       let(:user) { FactoryGirl.create(:user_with_group) }
       let(:vm) { FactoryGirl.create(:vm) }
+      let(:msg_text) { 'mary had a little lamb' }
 
       context "#create_notification!" do
         it "invalid type" do
@@ -178,7 +179,7 @@ module MiqAeServiceSpec
         it "default type of automate_user_info" do
           allow(workspace).to receive(:persist_state_hash).and_return({})
           allow(workspace).to receive(:ae_user).and_return(user)
-          result = miq_ae_service.create_notification!(:message => 'mary had a little lamb')
+          result = miq_ae_service.create_notification!(:message => msg_text)
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
@@ -207,8 +208,11 @@ module MiqAeServiceSpec
         it "default type of automate_user_info" do
           allow(workspace).to receive(:persist_state_hash).and_return({})
           allow(workspace).to receive(:ae_user).and_return(user)
-          result = miq_ae_service.create_notification(:message => 'mary had a little lamb')
+          result = miq_ae_service.create_notification(:message => msg_text)
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
+          ui_representation = result.object_send(:to_h)
+          expect(ui_representation).to include(:text     => '%{message}',
+                                               :bindings => a_hash_including(:message=>{:text=> msg_text}))
         end
 
         it "type of automate_user_info" do


### PR DESCRIPTION
TLDR
---------
Notification types for automate should allow for custom text bind.

@tinaafitz found that notifications from automate do not correctly display in the ui. Thanks! And sorry for the inconvenience. :chocolate_bar: 

Details
---------
To understand nature of the problem, let's quickly dive into why the notification text is composed as late as possible. :memo: 

Naïve implementation of notifications would store a message in a database and later it would be shown as it is. There are three problems to this implementation
 * We want to have links (`a:href`) from notification to subject/cause/... That means we need to insert the links to the text at some point.
 * We need to support two distinct user interfaces, each has a different URL schema and routes. That means we cannot insert links in the backend. As we don't know through which UI user receives it.
 * We need to support multiple languages. That means, *after* we compose final custom message, we cannot run it through gettext, as the custom information is already bound. That means we need to run it through gettext *before* the custom parts are bound.
 * The service-ui uses browser settings to get user language. That means backend cannot tell what language the user prefers given day.
 * In future, users may want to filter based on notification type, want to see past notification per given entity (vm, service), etc. That all means, we need to have notifications somewhat typed. The more we know (metadata) about a given notification, the more we can achieve in terms of user experience.

On top of that, the automate subsystem has extra requirement, to have an ability to bind custom textual information to the msg. That means we need to allow for custom text to cater this need. However, I advise, we don't allow this to anyone, but only to the automate engine. Otherwise we risk, that majority of notifications will be just hairy hashes, without any metadata, hindering our future ability to improve UX. :no_good_woman: 

@miq-bot add_label bug, ui, automate, euwe/yes
@miq-bot assign @gtanzillo 
/cc @skateman @gmcculloug 
