### PR TITLE
Make :tag factory usable with no arguments

### DIFF
--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :tag do
+    sequence(:name) { |n| "/namespace/cat/tag_#{seq_padded_for_sorting(n)}" }
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -114,6 +114,20 @@ describe Tag do
     end
   end
 
+  describe "#==" do
+    it "equals only itself" do
+      tag1 = FactoryGirl.build(:tag)
+      tag2 = FactoryGirl.build(:tag)
+      expect(tag1).to eq tag1
+      expect(tag1).not_to eq tag2
+    end
+
+    it "equals its name" do
+      tag1 = FactoryGirl.build(:tag, :name => '/a/b/c')
+      expect(tag1).to eq '/a/b/c'
+    end
+  end
+
   describe "#destroy" do
     let(:miq_group)       { FactoryGirl.create(:miq_group, :entitlement => Entitlement.create!) }
     let(:other_miq_group) { FactoryGirl.create(:miq_group, :entitlement => Entitlement.create!) }


### PR DESCRIPTION
Previously .name defaulted to nil, which is broken in most ways,
even `==` would raise exception:
```
(byebug) tag = FactoryGirl.create(:tag)
(byebug) ctag = FactoryGirl.create(:classification_tag).tag
(byebug) ctag == tag
false
(byebug) tag == ctag
*** NoMethodError Exception: undefined method `downcase' for nil:NilClass
```

No existing tests were affected, AFAICT all uses of this factory passed an explicit name.

Added simple tests for `==` method, while I'm at it.  (Not realy related to the factory change.)