### PR TITLE
Replace images with PF Action Menu on Analysis Profile Screens

### DIFF
--- a/app/views/ops/_ap_form_file.html.haml
+++ b/app/views/ops/_ap_form_file.html.haml
@@ -5,54 +5,46 @@
 %table.table.table-striped.table-bordered.table-hover
   %thead
     %tr
-      %th.narrow
       %th= _("Name")
       %th= _("Collect Contents?")
+      %th.action-cell= _("Actions")
   %tbody
     - if !params[:add] && params[:add] != "new"
       %tr#new_tr{:title => _("Click to add a new entry"), :onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item => "file", :id => scan_id})}
+        %td= _("<New Entry>")
         %td
-          %button.btn.btn-default
-            %i.fa.fa-plus.fa-lg
-        %td= _("<New Entry>")
-        %td= _("<New Entry>")
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
     - else
       %tr#new_tr
-        %td
-          %button.btn.btn-default{:title => _("Add this entry"),
-            "data-submit"         => 'ap_form_div',
-            "data-miq_sparkle_on" => true,
-            :remote               => true,
-            "data-method"         => :post,
-            'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
-            %i.fa.fa-plus.fa-lg
-
         %td
           = text_field("entry", "fname", :maxlength => MAX_NAME_LEN, :style => "width: 100%;")
           = hidden_field("item", "type1", :value => "file")
         %td
           = check_box_tag("entry_content", 1, false, :id => "entry_content")
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
+            "data-submit"         => 'ap_form_div',
+            "data-miq_sparkle_on" => true,
+            :remote               => true,
+            "data-method"         => :post,
+            'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
+            = _("Save")
     - Array(session[:file_names]).sort_by { |r| r["target"] }.each do |entry|
       - if session[:edit_filename] != entry["target"]
         %tr{:class => cycle('row0', 'row1'), :id => "#{entry['target']}_tr"}
-          %td{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :file_name => entry["target"], :id => scan_id}), :title => _("Click to delete this entry")}
-            %button.btn.btn-default
-              %i.fa.fa-minus.fa-lg
           %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :file_name => entry["target"], :edit_entry => 'edit_file', :field => "fname", :id => scan_id}), :title => _("Click to update this entry")}
             = h(entry["target"])
           %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :file_name => entry["target"], :edit_entry => 'edit_file', :field => "fname", :id => scan_id}), :title => _("Click to update this entry")}
             = h(entry["content"] ? entry["content"] : false)
+
+          %td.action-cell{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :file_name => entry["target"], :id => scan_id}), :title => _("Click to delete this entry")}
+            %button.btn.btn-default.btn-block.btn-sm
+              = _("Delete")
       - else
         - if params[:add] != "new"
           %tr{:class => cycle('row0', 'row1'), :id => "edit_tr"}
-            %td
-              %button.btn.btn-default{:title => _("Update this entry"),
-                "data-submit"         => 'ap_form_div',
-                "data-miq_sparkle_on" => true,
-                :remote               => true,
-                "data-method"         => :post,
-                'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
-                %i.fa.fa-save.fa-lg
             %td
               = text_field("entry", "fname", :maxlength => MAX_NAME_LEN, "value" => session[:edit_filename], :style => "width: 100%;")
               = hidden_field("item", "type1", :value => "file")
@@ -60,3 +52,12 @@
               - checked = !!entry["content"]
               = check_box_tag("entry_content", 1, checked, :id => "entry_content")
               = hidden_field("item", "type1", :value => "file")
+            %td.action-cell
+              %button.btn.btn-default.btn-block.btn-sm{:title => _("Update this entry"),
+                "data-submit"         => 'ap_form_div',
+                "data-miq_sparkle_on" => true,
+                :remote               => true,
+                "data-method"         => :post,
+                'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
+                = _("Save")
+

--- a/app/views/ops/_ap_form_nteventlog.html.haml
+++ b/app/views/ops/_ap_form_nteventlog.html.haml
@@ -1,32 +1,29 @@
+- scan_id = "#{@scan.id || 'new'}"
+- url = url_for(:action => 'ap_edit',
+                :id     => scan_id)
 %h3= _("Event Log Entry")
 %table.table.table-striped.table-bordered.table-hover
   %thead
     %tr
-      %th.narrow
       %th= _("Name")
       %th= _("Filter Message")
       %th= _("Level")
       %th= _("Source")
       %th= _(" # of Days")
+      %th.action-cell= _("Actions")
   %tbody
     - if (!params[:add] && session[:nteventlog_data].empty?) || params[:edit_entry]
       %tr#new_tr{:onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "nteventlog", :id => "#{@scan.id || "new"}"}), :title => _("Click to add a new entry")}
-        %td= image_tag(image_path('toolbars/import.png'), :class => "rollover small")
         %td= _("<New Entry>")
-        %td= _("<Click on this row to create a new entry>")
-        %td= _("<Click on this row to create a new entry>")
-        %td= _("<Click on this row to create a new entry>")
-        %td= _("<Click on this row to create a new entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %th.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
     - else
       %tr#new_tr
-        %td
-          = image_submit_tag(image_path('toolbars/import.png'),
-            :class     => "rollover small",
-            :name      => "accept",
-            :alt       => _("Add this entry"),
-            :title     => _("Add this entry"),
-            :item_type => "nteventlog",
-            :id        => "#{@scan.id || "new"}")
         %td
           = text_field("entry", "name",
             :maxlength => MAX_NAME_LEN,
@@ -52,19 +49,23 @@
             :maxlength => MAX_NAME_LEN,
             "value"    => session[:nteventlog_data][:numdays],
             :style     => "width: 100%;")
+        %td.action-cell
+          - url = url_for(:action    => 'ap_edit',
+                          :id        => scan_id,
+                          :accept    => 'accept',
+                          :item_type => 'nteventlog')
+          %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
+                                  "data-submit"         => 'ap_form_div',
+                                  "data-miq_sparkle_on" => true,
+                                  :remote               => true,
+                                  "data-method"         => :post,
+                                  'data-click_url'      => {:url => url}.to_json}
+            = _("Save")
         = hidden_field("item", "type3", :value => "nteventlog")
     - if !session[:nteventlog_entries].nil? && !session[:nteventlog_entries].empty?
       - session[:nteventlog_entries].sort_by { |r| r[:name] }.each_with_index do |nteventlog, i|
         - if session[:nteventlog_data][:name] == nteventlog[:name] && session[:nteventlog_data][:selected].to_i == i
           %tr{:id => "edit_tr"}
-            %td
-              = image_submit_tag(image_path('toolbars/import.png'),
-                :class      => "rollover small",
-                :name       => "accept",
-                :edit_entry => 'edit_registry',
-                :alt        => _("Update this entry"),
-                :title      => _("Update this entry"),
-                :id         => "#{@scan.id || "new"}")
             %td
               = text_field("entry", "name",
               :maxlength => MAX_NAME_LEN,
@@ -90,12 +91,24 @@
                 :maxlength => MAX_NAME_LEN,
                 "value"    => session[:nteventlog_data][:num_days],
                 :style     => "width: 100%;")
+
+            %td.action-cell
+              - url = url_for(:action     => 'ap_edit',
+                              :id         => scan_id,
+                              :accept     => 'accept',
+                              :edit_entry => 'edit_entry_nteventlog',
+                              :entry_id   => i)
+              %button.btn.btn-default.btn-block.btn-sm{:title => _("Update this entry"),
+                "data-submit"         => 'ap_form_div',
+                "data-miq_sparkle_on" => true,
+                :remote               => true,
+                "data-method"         => :post,
+                'data-click_url'      => {:url => url}.to_json}
+                = _("Save")
             = hidden_field("item", "type3", :value => "nteventlog")
             = hidden_field("item", "id", :value => i)
         - else
           %tr{:id => "#{i}_tr"}
-            %td{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :id => "#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
-              = image_tag(image_path('toolbars/delete.png'), :class => "rollover small")
             %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :entry_id => i, :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
               = h(nteventlog[:name])
             %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
@@ -109,3 +122,7 @@
               = h(nteventlog[:filter][:source])
             %td{:onclick => remote_function(:url => {:action => 'ap_ce_select', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :edit_entry => 'edit_nteventlog', :field => "name", :id => "#{@scan.id || "new"}"}), :title => _("Click to update this entry")}
               = h(nteventlog[:filter][:num_days].to_i)
+            %td.action-cell{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :item2 => "nteventlog", :nteventlog_name => nteventlog[:name], :entry_id => i, :id => "#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
+              %button.btn.btn-default.btn-block.btn-sm
+                = _("Delete")
+

--- a/app/views/ops/_ap_form_registry.html.haml
+++ b/app/views/ops/_ap_form_registry.html.haml
@@ -5,29 +5,22 @@
 %table.table.table-striped.table-bordered.table-hover
   %thead
     %tr
-      %th.narrow
       %th= _("Registry Hive")
       %th= _("Registry Key")
       %th= _("Registry Value")
+      %th.action-cell= _("Actions")
   %tbody
     - if (!params[:add] && session[:reg_data].empty?) || params[:edit_entry]
       %tr#new_tr{:title => _("Click to add a new entry"),
         :onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "registry", :id => "#{@scan.id || "new"}"})}
-        %td
-          = image_tag(image_path('toolbars/new.png'), :class => "rollover small")
         %td= _("<New Entry>")
-        %td= _("<Click on this row to create a new entry>")
-        %td= _("<Click on this row to create a new entry>")
+        %td= _("<New Entry>")
+        %td= _("<New Entry>")
+        %td.action-cell
+          %button.btn.btn-default.btn-block.btn-sm
+            = _("Add")
     - else
       %tr#new_tr
-        %td
-          %button.btn.btn-default{:title => _("Add this entry"),
-            "data-submit"         => 'ap_form_div',
-            "data-miq_sparkle_on" => true,
-            :remote               => true,
-            "data-method"         => :post,
-            'data-click_url'      => {:url => "#{url}?accept=accept"}.to_json}
-            %i.pficon.pficon-import.fa-lg
         %td
           = _("HKLM")
         %td
@@ -40,15 +33,24 @@
             :maxlength => MAX_NAME_LEN,
             "value"    => session[:reg_data][:value],
             :style     => "width: 100%;")
+
+        %td.action-cell
+          - url = url_for(:action => 'ap_edit',
+                          :id     => scan_id,
+                          :accept => 'accept',
+                          :item_type => 'registry')
+          %button.btn.btn-default.btn-block.btn-sm{:title => _("Add this entry"),
+                                  "data-submit"         => 'ap_form_div',
+                                  "data-miq_sparkle_on" => true,
+                                  :remote               => true,
+                                  "data-method"         => :post,
+                                  'data-click_url'      => {:url => url}.to_json}
+            = _("Save")
         = hidden_field("item", "type2", :value => "registry")
     - if !session[:reg_entries].nil? && !session[:reg_entries].empty?
       - session[:reg_entries].sort_by { |r| r["key"] }.each_with_index do |reg, i|
         - if session[:reg_data][:key] == reg["key"] && session[:reg_data][:value] == reg["value"]
           %tr#edit_tr
-            %td
-              = image_submit_tag(image_path('toolbars/import.png'),
-                :class => "rollover small",
-                :name => "accept", :entry_id => i, :edit_entry => 'edit_registry', :alt => _("Update this entry"), :title => _("Update this entry"), :id => "#{@scan.id || "new"}")
             %td
               = _("HKLM")
             %td
@@ -61,13 +63,24 @@
                 :maxlength => MAX_NAME_LEN,
                 "value"    => session[:reg_data][:value],
                 :style     => "width: 100%;")
+            %td.action-cell
+              - url = url_for(:action => 'ap_edit',
+                          :id         => scan_id,
+                          :accept     => 'accept',
+                          :edit_entry => 'edit_entry',
+                          :entry_id   => i)
+              %button.btn.btn-default.btn-block.btn-sm{:title                 => _("Update this entry"),
+                                                        "data-submit"         => 'ap_form_div',
+                                                        "data-miq_sparkle_on" => true,
+                                                        :remote               => true,
+                                                        "data-method"         => :post,
+                                                        'data-click_url'      => {:url => url}.to_json}
+                = _("Save")
             = hidden_field("item", "type2", :value => "registry")
             = hidden_field("entry", "id", :value => i)
         - else
           %tr{:id => "#{i}_tr"}
-            %td{:onclick => remote_function(:url => {:action => 'ap_ce_delete', :entry_id => i, :item1 => "registry", :reg_key => reg["key"], :reg_value => reg["value"], :id => "#{@scan.id || "new"}"}), :title => _("Click to delete this entry")}
-          %tr{:id => "#{i}_tr"}
-            - url = {:action     => 'ap_ce_delete',
+            - url = {:action     => 'ap_ce_select',
                      :entry_id   => i,
                      :item2      => "registry",
                      :reg_key    => reg["key"],
@@ -76,13 +89,14 @@
                      :field      => "kname",
                      :id         => "#{@scan.id || "new"}"}
             - remote_link = remote_function(:url => url).to_str
-            %td{:onclick => remote_link, :title => _("Click to delete this entry")}
-              = image_tag(image_path('toolbars/delete.png'))
-            - url[:action] = "ap_ce_select"
-            - remote_link = remote_function(:url => url).to_str
             %td{:onclick => remote_link, :title => _("Click to update this entry")}
               = _("HKLM")
             %td{:onclick => remote_link, :title => _("Click to update this entry")}
               = h(reg["key"])
             %td{:onclick => remote_link, :title => _("Click to update this entry")}
               = h(reg["value"])
+            - url[:action] = "ap_ce_delete"
+            - remote_link = remote_function(:url => url).to_str
+            %td.action-cell{:onclick => remote_link, :title => _("Click to delete this entry")}
+              %button.btn.btn-default.btn-block.btn-sm
+                = _("Delete")


### PR DESCRIPTION
* Convert Analysis Profile to use Action Menu instead of images
* Fix bug on Event and Registry Edit screens where update didn't work
* Remove extra alternating row on Registry Edit screen (see screenshot)

https://bugzilla.redhat.com/show_bug.cgi?id=1389065
https://www.pivotaltracker.com/n/projects/1613907/stories/130527125
Issue: #12004

Old
![screen shot 2016-10-26 at 9 29 43 am](https://cloud.githubusercontent.com/assets/1287144/19727773/cb605f42-9b5e-11e6-8635-ad0e9f44592c.png)

New
![screen shot 2016-10-26 at 9 26 03 am](https://cloud.githubusercontent.com/assets/1287144/19727642/44f7f424-9b5e-11e6-9495-0d4327afbea6.png)

Old
![screen shot 2016-10-26 at 9 29 33 am](https://cloud.githubusercontent.com/assets/1287144/19727775/cb6a2efa-9b5e-11e6-85b9-5a4d0f2ab71d.png)

New
![screen shot 2016-10-26 at 9 25 54 am](https://cloud.githubusercontent.com/assets/1287144/19727643/44fad586-9b5e-11e6-9c1e-aa0a48d629a3.png)

Old
![screen shot 2016-10-26 at 9 29 27 am](https://cloud.githubusercontent.com/assets/1287144/19727774/cb605862-9b5e-11e6-9f7f-eda1b13e7786.png)

New
![screen shot 2016-10-26 at 9 25 45 am](https://cloud.githubusercontent.com/assets/1287144/19727644/44fd39f2-9b5e-11e6-861b-08becadf5755.png)