### PR TITLE
[DARGA] Omit the version part from the OS name

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/refresh_parser.rb
@@ -344,14 +344,7 @@ module ManageIQ::Providers::Redhat::InfraManager::RefreshParser
 
   def self.extract_host_os_name(host_inv)
     host_os = host_inv[:os]
-    name = host_os && host_os[:type]
-    if name
-      os_full_version = extract_host_os_full_version(host_os)
-      name = "#{name} - #{os_full_version}" if os_full_version
-    else
-      name = host_inv[:type]
-    end
-    name
+    host_os && host_os[:type] || host_inv[:type]
   end
 
   def self.vm_inv_to_hashes(inv, _storage_inv, storage_uids, cluster_uids, host_uids, lan_uids)

--- a/spec/models/manageiq/providers/redhat/infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/refresh_parser_spec.rb
@@ -79,4 +79,33 @@ describe ManageIQ::Providers::Redhat::InfraManager::RefreshParser do
       ])
     end
   end
+
+  context "#extract_host_os_name" do
+    it "should extract the host OS name from os element" do
+      host_inv = {
+        :type => "some_os_type",
+        :os   => {
+          :type => "expected_os_type"
+        }
+      }
+      result = ManageIQ::Providers::Redhat::InfraManager::RefreshParser.extract_host_os_name(host_inv)
+      expect(result).to eq("expected_os_type")
+    end
+
+    it "should extract the host OS name from type element" do
+      host_inv = {
+        :type => "some_os_type",
+      }
+      result = ManageIQ::Providers::Redhat::InfraManager::RefreshParser.extract_host_os_name(host_inv)
+      expect(result).to eq("some_os_type")
+    end
+
+    it "should call #extract_host_os_name as part of host OS parsing" do
+      host_inv = {
+        :type => "some_os_type",
+      }
+      expect(ManageIQ::Providers::Redhat::InfraManager::RefreshParser).to receive(:extract_host_os_name)
+      ManageIQ::Providers::Redhat::InfraManager::RefreshParser.host_inv_to_os_hash(host_inv, "")
+    end
+  end
 end


### PR DESCRIPTION
The convention of other providers and the expected format
of the OS field name is to contain the name only, without the
version.

The version is being concatenated to the OS name on the UI
side, therefore the code which did it on the provider side is
removed.

http://bugzilla.redhat.com/1376543

PR on master:
https://github.com/ManageIQ/manageiq/pull/11384
