### PR TITLE
Update moment-strftime to 0.2.0

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,7 @@
 //= require angular-sanitize
 //= require angular.validators
 //= require moment
-//= require moment-strftime/build/moment-strftime.min
+//= require moment-strftime/lib/moment-strftime
 //= require moment-timezone
 //= require sprintf
 //= require numeral

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "jquery.observe_field": "himdel/jquery.observe_field#~0.1.0",
     "kubernetes-topology-graph": "~0.0.23",
     "manageiq-ui-components": "~0.0.8",
-    "moment-strftime": "himdel/moment-strftime#~0.1.7",
+    "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",
     "numeral": "~1.5.3",
     "patternfly-bootstrap-treeview": "~2.1.1",


### PR DESCRIPTION
We've been using my fork of moment-strftime because 0.1.5 had a dependency conflict with patternfly.

This got fixed in benjaminoakes/moment-strftime#19 - changing back to use upstream.
