### PR TITLE
Adding Datawarehouse management

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -225,8 +225,8 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.metrics_password != '' && $scope.angularForm.metrics_password.$valid &&
       $scope.emsCommonModel.metrics_verify != '' && $scope.angularForm.metrics_verify.$valid)) {
       return true;
-    } else if(($scope.currentTab == "default" &&
-      ($scope.emsCommonModel.ems_controller == "ems_container" || $scope.emsCommonModel.ems_controller == "ems_middleware")) &&
+    } else if($scope.currentTab == "default" &&
+        ["ems_container", "ems_middleware", "ems_datawarehouse" ].indexOf($scope.emsCommonModel.ems_controller) >= 0 &&
       ($scope.emsCommonModel.emstype) &&
       ($scope.emsCommonModel.default_hostname != '' && $scope.emsCommonModel.default_api_port) &&
       ($scope.emsCommonModel.default_password != '' && $scope.angularForm.default_password.$valid) &&

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1692,6 +1692,8 @@ class ApplicationController < ActionController::Base
         javascript_redirect edit_ems_container_path(params[:id])
       elsif params[:pressed] == "ems_middleware_edit" && params[:id]
         javascript_redirect edit_ems_middleware_path(params[:id])
+      elsif params[:pressed] == "ems_datawarehouse_edit" && params[:id]
+        javascript_redirect edit_ems_datawarehouse_path(params[:id])
       elsif params[:pressed] == "ems_network_edit" && params[:id]
         javascript_redirect edit_ems_network_path(params[:id])
       elsif %w(arbitration_profile_edit arbitration_profile_new).include?(params[:pressed]) && params[:id]

--- a/app/controllers/ems_datawarehouse_controller.rb
+++ b/app/controllers/ems_datawarehouse_controller.rb
@@ -1,0 +1,47 @@
+class EmsDatawarehouseController < ApplicationController
+  include EmsCommon
+  include Mixins::EmsCommonAngular
+
+  before_action :check_privileges
+  before_action :get_session_data
+  after_action :cleanup_action
+  after_action :set_session_data
+
+  def self.model
+    ManageIQ::Providers::DatawarehouseManager
+  end
+
+  def self.table_name
+    @table_name ||= "ems_datawarehouse"
+  end
+
+  def index
+    redirect_to :action => 'show_list'
+  end
+
+  def show_link(ems, options = {})
+    ems_datawarehouse_path(ems.id, options)
+  end
+
+  def ems_path(*args)
+    ems_datawarehouse_path(*args)
+  end
+
+  def listicon_image(item, _view)
+    item.decorate.try(:listicon_image)
+  end
+
+  def new_ems_path
+    new_ems_datawarehouse_path
+  end
+
+  def restful?
+    true
+  end
+
+  def ems_datawarehouse_form_fields
+    ems_form_fields
+  end
+
+  menu_section :dwh
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -231,6 +231,9 @@ module ApplicationHelper
       if controller == "ems_middleware" && action == "show"
         return ems_middlewares_path
       end
+      if controller == "ems_datawarehouse" && action == "show"
+        return ems_datawarehouses_path
+      end
       if controller == "ems_network" && action == "show"
         return ems_networks_path
       end
@@ -1310,6 +1313,7 @@ module ApplicationHelper
           ems_cloud
           ems_cluster
           ems_container
+          ems_datawarehouse
           ems_infra
           ems_middleware
           ems_network
@@ -1375,6 +1379,7 @@ module ApplicationHelper
              ems_cloud
              ems_cluster
              ems_container
+             ems_datawarehouse
              ems_infra
              ems_middleware
              ems_network

--- a/app/helpers/application_helper/toolbar/ems_datawarehouse_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_datawarehouse_center.rb
@@ -1,0 +1,80 @@
+class ApplicationHelper::Toolbar::EmsDatawarehouseCenter < ApplicationHelper::Toolbar::Basic
+  button_group('ems_datawarehouse_vmdb', [
+    select(
+      :ems_datawarehouse_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :ems_datawarehouse_refresh,
+          'fa fa-refresh fa-lg',
+          N_('Refresh items and relationships related to this Datawarehouse Provider'),
+          N_('Refresh items and relationships'),
+          :confirm => N_("Refresh items and relationships related to this Datawarehouse Provider?")),
+        separator,
+        button(
+          :ems_datawarehouse_edit,
+          'pficon pficon-edit fa-lg',
+          t = N_('Edit this Datawarehouse Provider'),
+          t),
+        button(
+          :ems_datawarehouse_delete,
+          'pficon pficon-delete fa-lg',
+          t = N_('Remove this Datawarehouse Provider'),
+          t,
+          :url_parms => "&refresh=y",
+          :confirm   => N_("Warning: This Datawarehouse Provider and ALL" \
+                           " of its components will be permanently removed!")),
+      ]
+    ),
+  ])
+  button_group('ems_datawarehouse_monitoring', [
+    select(
+      :ems_datawarehouser_monitoring_choice,
+      'product product-monitoring fa-lg',
+      t = N_('Monitoring'),
+      t,
+      :items => [
+        button(
+          :ems_datawarehouse_timeline,
+          'product product-timeline fa-lg',
+          N_('Show Timelines for this Datawarehouse Provider'),
+          N_('Timelines'),
+          :url_parms => "?display=timeline"),
+      ]
+    ),
+  ])
+  button_group('ems_datawarehouse_policy', [
+    select(
+      :ems_datawarehouse_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :items => [
+        button(
+          :ems_datawarehouse_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for this Datawarehouse Provider'),
+          N_('Edit Tags')),
+      ]
+    ),
+  ])
+  button_group('ems_datawarehouse_authentication', [
+    select(
+      :ems_datawarehouse_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :items => [
+        button(
+          :ems_datawarehouse_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_("Re-check Authentication Status for this #{ui_lookup(:table=>'ems_datawarehouse')}"),
+          N_('Re-check Authentication Status'),
+          :klass => ApplicationHelper::Button::GenericFeatureButton,
+          :options => {:feature => :authentication_status}),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar/ems_datawarehouses_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_datawarehouses_center.rb
@@ -1,0 +1,86 @@
+class ApplicationHelper::Toolbar::EmsDatawarehousesCenter < ApplicationHelper::Toolbar::Basic
+  button_group('ems_datawarehouse_vmdb', [
+    select(
+      :ems_datawarehouse_vmdb_choice,
+      'fa fa-cog fa-lg',
+      t = N_('Configuration'),
+      t,
+      :items => [
+        button(
+          :ems_datawarehouse_refresh,
+          'icon fa fa-refresh fa-lg',
+          N_('Refresh Items and Relationships for these Datawarehouse Providers'),
+          N_('Refresh Items and Relationships'),
+          :confirm   => N_("Refresh Items and Relationships related to these Datawarehouse Providers?"),
+          :enabled   => false,
+          :url_parms => "main_div",
+          :onwhen    => "1+"),
+        separator,
+        button(
+          :ems_datawarehouse_new,
+          'pficon pficon-add-circle-o fa-lg',
+          t = N_('Add a New Datawarehouse Provider'),
+          t,
+          :url => "/new"),
+        button(
+          :ems_datawarehouse_edit,
+          'pficon pficon-edit fa-lg',
+          N_('Select a single Datawarehouse Providers to edit'),
+          N_('Edit Selected Datawarehouse Providers'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1"),
+        button(
+          :ems_datawarehouse_delete,
+          'pficon pficon-delete fa-lg',
+          N_('Remove selected Datawarehouse Providers'),
+          N_('Remove Datawarehouse Providers'),
+          :url_parms => "main_div",
+          :confirm   => N_("Warning: The selected Datawarehouse Providers and ALL " \
+                           "of their components will be permanently removed!"),
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+  button_group('ems_datawarehouse_policy', [
+    select(
+      :ems_datawarehouse_policy_choice,
+      'fa fa-shield fa-lg',
+      t = N_('Policy'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_datawarehouse_tag,
+          'pficon pficon-edit fa-lg',
+          N_('Edit Tags for these Datawarehouse Providers'),
+          N_('Edit Tags'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+  button_group('ems_datawarehouse_authentication', [
+    select(
+      :ems_datawarehouse_authentication_choice,
+      'fa fa-lock fa-lg',
+      t = N_('Authentication'),
+      t,
+      :enabled => false,
+      :onwhen  => "1+",
+      :items   => [
+        button(
+          :ems_datawarehouse_recheck_auth_status,
+          'fa fa-search fa-lg',
+          N_('Re-check Authentication Status for the selected Datawarehouse Providers'),
+          N_('Re-check Authentication Status'),
+          :url_parms => "main_div",
+          :enabled   => false,
+          :onwhen    => "1+"),
+      ]
+    ),
+  ])
+end

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -474,7 +474,7 @@ class ApplicationHelper::ToolbarChooser
       unless @in_a_form
         if %w(auth_key_pair_cloud availability_zone host_aggregate cloud_object_store_object cloud_object_store_container cloud_tenant
               cloud_volume cloud_volume_backup cloud_volume_snapshot configuration_job container_group container_node container_service
-              ems_cloud ems_cluster ems_container ems_middleware container_project container_route container_replicator container_image
+              ems_cloud ems_cluster ems_container ems_datawarehouse ems_middleware container_project container_route container_replicator container_image
               ems_network security_group floating_ip cloud_subnet network_router network_topology network_port cloud_network load_balancer
               container_image_registry ems_infra flavor host container_build infra_networking infra_topology ems_storage
               ontap_file_share ontap_logical_disk container_topology middleware_topology cloud_topology middleware_server

--- a/app/helpers/datawarehouse_summary_helper.rb
+++ b/app/helpers/datawarehouse_summary_helper.rb
@@ -1,0 +1,15 @@
+module DatawarehouseSummaryHelper
+  include TextualMixins::TextualName
+
+  def textual_ems
+    textual_link(@record.ext_management_system)
+  end
+
+  def textual_nativeid
+    @record.nativeid
+  end
+
+  def textual_group_smart_management
+    %i(tags)
+  end
+end

--- a/app/helpers/ems_datawarehouse_helper.rb
+++ b/app/helpers/ems_datawarehouse_helper.rb
@@ -1,0 +1,4 @@
+module EmsDatawarehouseHelper
+  include DatawarehouseSummaryHelper
+  include_concern 'TextualSummary'
+end

--- a/app/helpers/ems_datawarehouse_helper/textual_summary.rb
+++ b/app/helpers/ems_datawarehouse_helper/textual_summary.rb
@@ -1,0 +1,43 @@
+module EmsDatawarehouseHelper::TextualSummary
+  include TextualMixins::TextualRefreshStatus
+  #
+  # Groups
+  #
+
+  def textual_group_properties
+    %i(name type hostname port)
+  end
+
+  def textual_group_relationships
+    # Order of items should be from parent to child
+    []
+  end
+
+  def textual_group_status
+    %i(refresh_status)
+  end
+
+  def textual_group_smart_management
+    %i(tags)
+  end
+
+  #
+  # Items
+  #
+
+  def textual_name
+    @ems.name
+  end
+
+  def textual_type
+    @ems.emstype_description
+  end
+
+  def textual_hostname
+    @ems.hostname
+  end
+
+  def textual_port
+    @ems.supports_port? ? @ems.port : nil
+  end
+end

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -5,6 +5,7 @@ module EmsRefresh
   extend EmsRefresh::SaveInventoryInfra
   extend EmsRefresh::SaveInventoryContainer
   extend EmsRefresh::SaveInventoryMiddleware
+  extend EmsRefresh::SaveInventoryDatawarehouse
   extend EmsRefresh::SaveInventoryNetwork
   extend EmsRefresh::SaveInventorySwift
   extend EmsRefresh::SaveInventoryHelper

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -14,6 +14,7 @@ module EmsRefresh::SaveInventory
     when ManageIQ::Providers::StorageManager::CinderManager then save_ems_cinder_inventory(ems, hashes, target)
     when ManageIQ::Providers::StorageManager::SwiftManager  then save_ems_swift_inventory(ems, hashes, target)
     when ManageIQ::Providers::MiddlewareManager             then save_ems_middleware_inventory(ems, hashes, target)
+    when ManageIQ::Providers::DatawarehouseManager          then save_ems_datawarehouse_inventory(ems, hashes, target)
     end
   end
 

--- a/app/models/ems_refresh/save_inventory_datawarehouse.rb
+++ b/app/models/ems_refresh/save_inventory_datawarehouse.rb
@@ -1,0 +1,13 @@
+module EmsRefresh::SaveInventoryDatawarehouse
+  def save_ems_datawarehouse_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+
+    child_keys = []
+    # Save and link other subsections
+    child_keys.each do |k|
+      send("save_#{k}_inventory", ems, hashes[k], target)
+    end
+
+    ems.save!
+  end
+end

--- a/app/models/manageiq/providers/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/datawarehouse_manager.rb
@@ -1,0 +1,13 @@
+module ManageIQ::Providers
+  class DatawarehouseManager < BaseManager
+    class << model_name
+      def route_key
+        "ems_datawarehouse"
+      end
+
+      def singular_route_key
+        "ems_datawarehouse"
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -1,0 +1,75 @@
+module ManageIQ::Providers
+  class Hawkular::DatawarehouseManager < ManageIQ::Providers::DatawarehouseManager
+    require 'hawkular/hawkular_client'
+
+    require_nested :RefreshParser
+    require_nested :RefreshWorker
+    require_nested :Refresher
+
+    include AuthenticationMixin
+
+    DEFAULT_PORT = 80
+    default_value_for :port, DEFAULT_PORT
+
+    def verify_credentials(_auth_type = nil, options = {})
+      connect(options).fetch_version_and_status
+    rescue URI::InvalidComponentError
+      raise MiqException::MiqHostError, "Host '#{hostname}' is invalid"
+    rescue ::Hawkular::BaseClient::HawkularConnectionException
+      raise MiqException::MiqUnreachableError, "Unable to connect to #{hostname}:#{port}"
+    rescue ::Hawkular::BaseClient::HawkularException => he
+      raise MiqException::MiqInvalidCredentialsError, 'Invalid credentials' if he.status_code == 401
+      raise MiqException::MiqHostError, 'Hawkular not found on host' if he.status_code == 404
+      raise MiqException::MiqCommunicationsError, he.message
+    rescue => err
+      $log.error(err)
+      raise MiqException::Error, 'Unable to verify credentials'
+    end
+
+    def self.verify_ssl_mode
+      # TODO: support real authentication using certificates
+      OpenSSL::SSL::VERIFY_NONE
+    end
+
+    # Hawkular Client
+    def self.raw_connect(hostname, port, token, alerts = false)
+      client = alerts ? ::Hawkular::Alerts::AlertsClient : ::Hawkular::Metrics::Client
+      client.new(
+        URI::HTTPS.build(:host => hostname, :port => port.to_i).to_s,
+        { :token => token },
+        { :tenant => '_system', :verify_ssl => verify_ssl_mode }
+      )
+    end
+
+    def connect(options = {})
+      @client ||= self.class.raw_connect(hostname,
+                                         port,
+                                         authentication_token('default'),
+                                         options[:alerts])
+    end
+
+    def supports_port?
+      true
+    end
+
+    def supported_auth_types
+      %w(default bearer)
+    end
+
+    def supports_authentication?(authtype)
+      supported_auth_types.include?(authtype.to_s)
+    end
+
+    def default_authentication_type
+      :bearer
+    end
+
+    def self.ems_type
+      @ems_type ||= "hawkular_datawarehouse".freeze
+    end
+
+    def self.description
+      @description ||= "Hawkular Datawarehouse".freeze
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -26,6 +26,10 @@ module ManageIQ::Providers
       raise MiqException::Error, 'Unable to verify credentials'
     end
 
+    def validate_authentication_status
+      {:available => true, :message => nil}
+    end
+
     def self.verify_ssl_mode
       # TODO: support real authentication using certificates
       OpenSSL::SSL::VERIFY_NONE
@@ -53,7 +57,7 @@ module ManageIQ::Providers
     end
 
     def supported_auth_types
-      %w(default bearer)
+      %w(default auth_key)
     end
 
     def supports_authentication?(authtype)
@@ -61,7 +65,7 @@ module ManageIQ::Providers
     end
 
     def default_authentication_type
-      :bearer
+      :default
     end
 
     def self.ems_type

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresh_parser.rb
@@ -1,0 +1,16 @@
+module ManageIQ::Providers
+  class Hawkular::DatawarehouseManager::RefreshParser
+    def self.ems_inv_to_hashes(ems, options = nil)
+      new(ems, options).ems_inv_to_hashes
+    end
+
+    def initialize(_ems, _options = nil)
+      @data = {}
+      @data_index = {}
+    end
+
+    def ems_inv_to_hashes
+      @data
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresh_worker.rb
@@ -1,0 +1,9 @@
+module ManageIQ::Providers
+  class Hawkular::DatawarehouseManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
+    require_nested :Runner
+
+    def self.ems_class
+      ManageIQ::Providers::Hawkular::DatawarehouseManager
+    end
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresh_worker/runner.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Hawkular::DatawarehouseManager::RefreshWorker::Runner <
+  ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresher.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/refresher.rb
@@ -1,0 +1,9 @@
+module ManageIQ::Providers
+  class Hawkular::DatawarehouseManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+    include ::EmsRefresh::Refreshers::EmsRefresherMixin
+
+    def parse_legacy_inventory(ems)
+      ::ManageIQ::Providers::Hawkular::DatawarehouseManager::RefreshParser.ems_inv_to_hashes(ems)
+    end
+  end
+end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -190,6 +190,10 @@ class MiqRegion < ApplicationRecord
     ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::MiddlewareManager }
   end
 
+  def ems_datawarehouses
+    ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::DatawarehouseManager }
+  end
+
   def ems_configproviders
     ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::ConfigurationManager }
   end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -25,6 +25,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker
     ManageIQ::Providers::Foreman::ProvisioningManager::RefreshWorker
     ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshWorker
+    ManageIQ::Providers::Hawkular::DatawarehouseManager::RefreshWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker
     ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker
     ManageIQ::Providers::OpenshiftEnterprise::ContainerManager::RefreshWorker
@@ -100,6 +101,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker
     ManageIQ::Providers::Foreman::ProvisioningManager::RefreshWorker
     ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshWorker
+    ManageIQ::Providers::Hawkular::DatawarehouseManager::RefreshWorker
     ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker
     ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker
     ManageIQ::Providers::OpenshiftEnterprise::ContainerManager::RefreshWorker

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -157,6 +157,10 @@ class Zone < ApplicationRecord
     ems_middlewares.flat_map(&:middleware_servers)
   end
 
+  def ems_datawarehouses
+    ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::DatawarehouseManager }
+  end
+
   def ems_configproviders
     ext_management_systems.select { |e| e.kind_of? ManageIQ::Providers::ConfigurationManager }
   end

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -111,6 +111,17 @@ module Menu
         ])
       end
 
+      def datawarehouse_menu_section
+        if ::Settings.product.datawarehouse_manager
+          Menu::Section.new(:dwh, N_("Datawarehouse"), 'fa product-datawarehouse fa-2x', [
+            Menu::Item.new('ems_datawarehouse', N_('Providers'), 'ems_datawarehouse',
+                           {:feature => 'ems_datawarehouse_show_list'}, '/ems_datawarehouse')
+            ])
+        else
+          empty_menu_section
+        end
+      end
+
       def middleware_menu_section
         Menu::Section.new(:mdl, N_("Middleware"), 'fa product-middleware fa-2x', [
           Menu::Item.new('ems_middleware',        N_('Providers'),   'ems_middleware',        {:feature => 'ems_middleware_show_list'},          '/ems_middleware'),
@@ -205,7 +216,7 @@ module Menu
 
       def default_menu
         [cloud_inteligence_menu_section, services_menu_section, compute_menu_section, configuration_menu_section,
-         network_menu_section, middleware_menu_section, storage_menu_section,
+         network_menu_section, middleware_menu_section, datawarehouse_menu_section, storage_menu_section,
          control_menu_section, automate_menu_section, optimize_menu_section, settings_menu_section].compact
       end
     end

--- a/app/views/ems_datawarehouse/_form.html.haml
+++ b/app/views/ems_datawarehouse/_form.html.haml
@@ -1,0 +1,69 @@
+- @angular_form = true
+
+.form-horizontal{:id => "start_form_div", :style => "display:none"}
+  = render :partial => "layouts/flash_msg"
+  %div
+    .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_name"}
+        = _('Name')
+      .col-md-8
+        %input.form-control{"type"           => "text",
+                            "id"             => "ems_name",
+                            "name"           => "name",
+                            "ng-model"       => "emsCommonModel.name",
+                            "maxlength"      => MAX_NAME_LEN.to_s,
+                            "required"       => "",
+                            "checkchange"    => "",
+                            "auto-focus"     => "",
+                            "start-form-div" => "start_form_div"}
+        %span.help-block{"ng-show" => "angularForm.name.$error.required"}
+          = _("Required")
+
+    .form-group{"ng-class" => "{'has-error': angularForm.emstype.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_type"}
+        = _('Type')
+      .col-md-8
+        = select_tag('emstype',
+                     options_for_select([["<#{_('Choose')}>", nil]] + @ems_types, :disabled => ["<#{_('Choose')}>", nil]),
+                     "ng-if"                       => "newRecord",
+                     "ng-model"                    => "emsCommonModel.emstype",
+                     "ng-change"                   => "providerTypeChanged()",
+                     "required"                    => "",
+                     "checkchange"                 => "",
+                     "selectpicker-for-select-tag" => "")
+        %div{"ng-if" => "!newRecord"}
+          %label.form-control{"type"        => "text",
+                              "id"          => "ems_type",
+                              "name"        => "emstype",
+                              "ng-if"       => "!newRecord",
+                              "readonly"    => true,
+                              "style"       => "color: black; font-weight: normal;"}
+            = @emstype_display
+
+    .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
+      %label.col-md-2.control-label{"for" => "ems_zone"}
+        = _("Zone")
+      .col-md-8
+        - if @server_zones.length <= 1
+          %input.form-control{"type"        => "text",
+                              "id"          => "ems_zone",
+                              "name"        => "zone",
+                              "ng-model"    => "emsCommonModel.zone",
+                              "maxlength"   => 15,
+                              "required"    => "",
+                              "checkchange" => "",
+                              "readonly"    => true,
+                              "style"       => "color: black;"}
+        - else
+          = select_tag('zone',
+                       options_for_select(@server_zones.sort_by { |name, _name| name }),
+                       "ng-model"                    => "emsCommonModel.zone",
+                       "checkchange"                 => "",
+                       "required"                    => "",
+                       "selectpicker-for-select-tag" => "")
+
+
+  %hr
+    = render :partial => "/layouts/angular/multi_auth_credentials", :locals  => {:record => @ems, :ng_model => "emsCommonModel"}
+
+    = render :partial => "layouts/angular/x_edit_buttons_angular", :locals => {:record => @ems, :restful => true}

--- a/app/views/ems_datawarehouse/_form_fields.html.haml
+++ b/app/views/ems_datawarehouse/_form_fields.html.haml
@@ -1,0 +1,20 @@
+- unless @edit[:new][:emstype].blank?
+  .form-group
+    %label.control-label.col-md-2
+      = _('Hostname or IP address')
+    .col-md-8
+      = text_field_tag("hostname",
+        @edit[:new][:hostname],
+        :maxlength         => MAX_HOSTNAME_LEN,
+        "class"            => "form-control",
+        "data-miq_observe" => {:interval => '.5', :url => url}.to_json,
+        :title             => _('Hostname or IPv4/IPv6 address'))
+  .form-group
+    %label.control-label.col-md-2
+      = _('Port')
+    .col-md-8
+      = text_field_tag("port",
+        @edit[:new][:port],
+        :maxlength         => 5,
+        "class"            => "form-control",
+        "data-miq_observe" => {:interval => '.5', :url => url}.to_json)

--- a/app/views/ems_datawarehouse/_main.html.haml
+++ b/app/views/ems_datawarehouse/_main.html.haml
@@ -5,5 +5,7 @@
                                                                :items => textual_group_properties}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Status"), :items => textual_group_status}
   .col-sm-12.col-md-12.col-lg-6
+    = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"),
+                                                               :items => textual_group_relationships}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"),
                                                                   :items => textual_group_smart_management}

--- a/app/views/ems_datawarehouse/discover.html.haml
+++ b/app/views/ems_datawarehouse/discover.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "layouts/discover"

--- a/app/views/ems_datawarehouse/edit.html.haml
+++ b/app/views/ems_datawarehouse/edit.html.haml
@@ -1,0 +1,17 @@
+= form_for(@ems,
+           :url    => ems_datawarehouse_path(@ems),
+           :method => :patch,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "update-url"      => ems_datawarehouse_path(@ems).to_s,
+                       "form-fields-url" => "/#{controller_name}/ems_datawarehouse_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "save"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+  = render :partial => "form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());

--- a/app/views/ems_datawarehouse/new.html.haml
+++ b/app/views/ems_datawarehouse/new.html.haml
@@ -1,0 +1,19 @@
+- url = @ems.persisted? ? ems_datawarehouses_path(@ems) : ems_datawarehouses_path
+= form_for(@ems,
+           :url    => url,
+           :method => :post,
+           :html   => {"ng-controller"   => "emsCommonFormController",
+                       "name"            => "angularForm",
+                       "ng-show"         => "afterGet",
+                       "create-url"      => url.to_s,
+                       "form-fields-url" => "/#{controller_name}/ems_datawarehouse_form_fields/",
+                       "novalidate"      => true}) do |f|
+  %input{:type => 'hidden', :id => "form_id", :value => "##{f.options[:html][:id]}"}
+  %input{:type => 'hidden', :id => "button_name", :name => "button", :value => "add"}
+  %input{:type => 'hidden', :id => "cred_type", :name => "cred_type", :value => "default"}
+
+  = render :partial => "form"
+
+:javascript
+  ManageIQ.angular.app.value('emsCommonFormId', '#{@ems.id || "new"}');
+  miq_bootstrap($('#form_id').val());

--- a/app/views/ems_datawarehouse/show.html.haml
+++ b/app/views/ems_datawarehouse/show.html.haml
@@ -1,0 +1,2 @@
+-# needed by render :action => "show" in application controller
+= render :partial => "shared/views/ems_common/show"

--- a/app/views/ems_datawarehouse/show_list.html.haml
+++ b/app/views/ems_datawarehouse/show_list.html.haml
@@ -1,0 +1,2 @@
+#main_div
+  = render :partial => 'layouts/gtl'

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -1,4 +1,4 @@
-- return unless %w(ems_cloud ems_infra ems_container ems_middleware ems_network).include?(controller_name)
+- return unless %w(ems_cloud ems_infra ems_container ems_middleware ems_network ems_datawarehouse).include?(controller_name)
 - prefix ||= "default"
 - ng_reqd_hostname ||= true
 - ng_reqd_api_port ||= true
@@ -32,6 +32,7 @@
                          "emsCommonModel.emstype == 'rhevm' || " +           |
                          "emsCommonModel.emstype == 'vmware_cloud' || " +    |
                          "emsCommonModel.emstype == 'hawkular' || " +        |
+                         "emsCommonModel.emstype == 'hawkular_datawarehouse' || " +        |
                          "emsCommonModel.ems_controller == 'ems_container'"} |
     %label.col-md-2.control-label{"for" => "#{prefix}_api_port"}
       = _('API Port')

--- a/app/views/layouts/angular/_multi_auth_credentials.html.haml
+++ b/app/views/layouts/angular/_multi_auth_credentials.html.haml
@@ -35,6 +35,7 @@
       .form-group
         .col-md-12{"ng-if" => "#{ng_model}.ems_controller == 'ems_container' || " +  |
                               "#{ng_model}.ems_controller == 'ems_middleware' || " + |
+                              "#{ng_model}.ems_controller == 'ems_datawarehouse' || " + |
                               "#{ng_model}.ems_controller == 'ems_network'"}         |
           = render :partial => "layouts/angular-bootstrap/endpoints_angular",
                                    :locals  => {:ng_show                => true,
@@ -81,7 +82,7 @@
                                                 :id                     => record.id,
                                                 :prefix                 => "default",
                                                 :ng_reqd_api_port       => "false"}
-          %div{"ng-if" => controller_name != "ems_container"}
+          %div{"ng-if" => controller_name != "ems_container" && controller_name != "ems_datawarehouse"}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                    :locals  => {:ng_show           => "true",
                                                 :ng_model          => "#{ng_model}",
@@ -92,6 +93,22 @@
                                                 :id                => record.id,
                                                 :prefix            => "default",
                                                 :basic_info_needed => true}
+          %div{"ng-if" => controller_name == "ems_datawarehouse"}
+            = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
+                                   :locals  => {:ng_show                => "true",
+                                                :ng_model               => ng_model.to_s,
+                                                :validate_url           => validate_url,
+                                                :id                     => record.id,
+                                                :prefix                 => "default",
+                                                :ng_show_userid         => "false",
+                                                :ng_reqd_password       => true,
+                                                :ng_reqd_verify         => true,
+                                                :password_label         => _("Token"),
+                                                :verify_label           => _("Confirm Token"),
+                                                :passwd_mismatch        => _("Tokens do not match"),
+                                                :change_stored_password => _("Change stored token"),
+                                                :cancel_password_change => _("Cancel stored token"),
+                                                :basic_info_needed      => true}
           %div{"ng-if" => controller_name == "ems_container"}
             = render :partial => "layouts/angular-bootstrap/auth_credentials_angular_bootstrap",
                                    :locals  => {:ng_show                => "true",
@@ -313,6 +330,7 @@
                 "#{ng_model}.emstype == 'gce' || "      + |
                 "#{ng_model}.emstype == 'scvmm' || "    + |
                 "#{ng_model}.emstype == 'vmwarews' || " + |
+                "#{ng_model}.emstype == 'hawkular_datawarehouse' || " + |
                 "#{ng_model}.emstype == 'hawkular'"}      |
   :javascript
     miq_tabs_show_hide("#amqp_tab", false);

--- a/app/views/layouts/listnav/_ems_datawarehouse.html.haml
+++ b/app/views/layouts/listnav/_ems_datawarehouse.html.haml
@@ -1,0 +1,15 @@
+- if @record.try(:name)
+  #accordion.panel-group
+    = miq_accordion_panel(truncate(@record.name, :length => truncate_length), true, "icon") do
+      = render_quadicon(@record, :mode => :icon, :size => 72, :typ => :listnav)
+
+    = miq_accordion_panel(_("Properties"), false, "ems_datawarehouse_prop") do
+      %ul.nav.nav-pills.nav-stacked
+        = li_link(:text => _('Summary'),
+           :record => @record,
+           :display => 'main',
+           :title => _("Show Summary"))
+    = miq_accordion_panel(_("Relationships"), false, "ems_datawarehouse_rel") do
+      %ul.nav.nav-pills.nav-stacked
+        - %w().each do |ent|
+          = multiple_relationship_link(@record, ent)

--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -7,6 +7,7 @@
 - :conf
 - :inf
 - :mdl
+- :dwh
 - :net
 - :opt
 - :set
@@ -24,6 +25,7 @@
 - ems-type:gce
 - ems-type:gce_network
 - ems-type:hawkular
+- ems-type:hawkular_datawarehouse
 - ems-type:kubernetes
 - ems-type:nuage_network
 - ems-type:openshift

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1406,6 +1406,37 @@ Vmdb::Application.routes.draw do
         save_post
     },
 
+    :ems_datawarehouse => {
+      :get  => %w(
+        download_data
+        ems_datawarehouse_form_fields
+        show_list
+        tagging_edit
+        tag_edit_form_field_changed
+      ) +
+      compare_get,
+      :post => %w(
+        button
+        create
+        dynamic_checkbox_refresh
+        form_field_changed
+        listnav_search_selected
+        quick_search
+        sections_field_changed
+        show
+        show_list
+        tl_chooser
+        update
+        wait_for_task
+        tagging_edit
+        tag_edit_form_field_changed
+      ) +
+      adv_search_post +
+      compare_post +
+      exp_post +
+      save_post
+    },
+
     :ems_network              => {
       :get  => %w(
         dialog_load
@@ -3075,7 +3106,9 @@ Vmdb::Application.routes.draw do
 
   controller_routes.each do |controller_name, controller_actions|
     # Default route with no action to controller's index action
-    unless [:ems_cloud, :ems_infra, :ems_container, :ems_middleware, :ems_network].include?(controller_name)
+    unless [
+      :ems_cloud, :ems_infra, :ems_container, :ems_middleware, :ems_datawarehouse, :ems_network
+    ].include?(controller_name)
       match controller_name.to_s, :controller => controller_name, :action => :index, :via => :get
     end
 
@@ -3109,6 +3142,7 @@ Vmdb::Application.routes.draw do
   resources :ems_infra, :as => :ems_infras
   resources :ems_container, :as => :ems_containers
   resources :ems_middleware, :as => :ems_middlewares
+  resources :ems_datawarehouse, :as => :ems_datawarehouses
   resources :ems_network, :as => :ems_networks
 
   match "/auth/:provider/callback" => "sessions#create", :via => :get

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1013,6 +1013,7 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
+  :datawarehouse_manager: false
 :recommendations:
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4041,6 +4041,64 @@
       :feature_type: control
       :identifier: middleware_messaging_tag
 
+# EmsDatawarehouse
+- :name: Providers
+  :description: Everything under Datawarehouse Providers
+  :feature_type: node
+  :identifier: ems_datawarehouse
+  :children:
+  - :name: View
+    :description: View Datawarehouse Providers
+    :feature_type: view
+    :identifier: ems_datawarehouse_view
+    :children:
+    - :name: List
+      :description: Display Lists of Datawarehouse Providers
+      :feature_type: view
+      :identifier: ems_datawarehouse_show_list
+    - :name: Show
+      :description: Display Individual Datawarehouse Providers
+      :feature_type: view
+      :identifier: ems_datawarehouse _show
+    - :name: Timeline
+      :description: Display Timelines for Datawarehouse Providers
+      :feature_type: view
+      :identifier: ems_datawarehouse_timeline
+  - :name: Operate
+    :description: Perform Operations on Datawarehouse Providers
+    :feature_type: control
+    :identifier: ems_datawarehouse_control
+    :children:
+    - :name: Refresh
+      :description: Refresh Datawarehouse Providers
+      :feature_type: control
+      :identifier: ems_datawarehouse_refresh
+    - :name: Re-check Authentication Status
+      :description: Re-check Authentication Status of Datawarehouse Providers
+      :feature_type: control
+      :identifier: ems_datawarehouse_recheck_auth_status
+    - :name: Edit Tags
+      :description: Edit Tags of Datawarehouse Providers
+      :feature_type: control
+      :identifier: ems_datawarehouse_tag
+  - :name: Modify
+    :description: Modify Datawarehouse Providers
+    :feature_type: admin
+    :identifier: ems_datawarehouse_admin
+    :children:
+    - :name: Remove
+      :description: Remove Datawarehouse Providers
+      :feature_type: admin
+      :identifier: ems_datawarehouse_delete
+    - :name: Edit
+      :description: Edit a Datawarehouse Provider
+      :feature_type: admin
+      :identifier: ems_datawarehouse_edit
+    - :name: Add
+      :description: Add a Datawarehouse Provider
+      :feature_type: admin
+      :identifier: ems_datawarehouse_new
+
 # EmsNetwork
 - :name: Network Providers
   :description: Everything under Network Providers

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-datawarehouse_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-datawarehouse_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_DatawarehouseManager < MiqAeServiceModelBase
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-hawkular-datawarehouse_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-hawkular-datawarehouse_manager.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Hawkular_DatawarehouseManager < MiqAeServiceModelBase
+  end
+end

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -948,6 +948,7 @@ en:
       ems_infras:                  Infrastructure Providers
       ems_container:               Containers Provider
       ems_containers:              Containers Providers
+      ems_datawarehouse:           Datawarehouse Provider
       ems_middleware:              Middleware Provider
       ems_middlewares:             Middleware Providers
       evm_server:                  EVM Server

--- a/product/views/ManageIQ_Providers_DatawarehouseManager.yaml
+++ b/product/views/ManageIQ_Providers_DatawarehouseManager.yaml
@@ -1,0 +1,90 @@
+#
+# This is an MIQ Report configuration file
+#   Single value parameters are specified as:
+#     single_value_parm: value
+#   Multiple value parameters are specified as:
+#     multi_value_parm:
+#       - value 1
+#       - value 2
+#
+
+# Report title
+title: Datawarehouse Providers
+
+# Menu name
+name: EmsDatawarehouse
+
+# Main DB table report is based on
+db: ManageIQ::Providers::DatawarehouseManager
+
+# Columns to fetch from the main table
+cols:
+- name
+- hostname
+- ipaddress
+- emstype_description
+- port
+
+# Included tables (joined, has_one, has_many) and columns
+include:
+  zone:
+    columns:
+    - name
+
+# Included tables and columns for query performance
+include_for_find:
+  :zone: {}
+  :tags: {}
+
+# Order of columns (from all tables)
+col_order:
+- name
+- hostname
+- ipaddress
+- port
+- emstype_description
+
+col_formats:
+-
+-
+-
+- :string_truncate_50
+-
+
+# Column titles, in order
+headers:
+- Name
+- Hostname
+- IP Address
+- Port
+- Type
+
+# Condition(s) string for the SQL query
+conditions:
+
+# Order string for the SQL query
+order: Ascending
+
+# Columns to sort the report on, in order
+sortby:
+- name
+
+# Group rows (y=yes,n=no,c=count)
+group: n
+
+# Graph type
+#   Bar
+#   Column
+#   ColumnThreed
+#   ParallelThreedColumn
+#   Pie
+#   PieThreed
+#   StackedBar
+#   StackedColumn
+#   StackedThreedColumn
+
+graph:
+
+# Dimensions of graph (1 or 2)
+#   Note: specifying 2 for a single dimension graph may not return expected results
+dims:

--- a/spec/controllers/ems_datawarehouse_controller_spec.rb
+++ b/spec/controllers/ems_datawarehouse_controller_spec.rb
@@ -1,0 +1,102 @@
+describe EmsDatawarehouseController do
+  let!(:server) { EvmSpecHelper.local_miq_server(:zone => zone) }
+  let(:zone) { FactoryGirl.build(:zone) }
+  before(:each) do
+    stub_user(:features => :all)
+  end
+
+  it "#new" do
+    controller.instance_variable_set(:@breadcrumbs, [])
+    get :new
+
+    expect(response.status).to eq(200)
+    expect(allow(controller).to receive(:edit)).to_not be_nil
+  end
+
+  describe "#show" do
+    before do
+      session[:settings] = {:views => {}, :quadicons => {}}
+      EvmSpecHelper.create_guid_miq_server_zone
+      login_as FactoryGirl.create(:user)
+      @dwh = FactoryGirl.create(:ems_hawkular_datawarehouse)
+    end
+
+    subject { get :show, :id => @dwh.id }
+
+    context "render" do
+      render_views
+      it { is_expected.to render_template('shared/views/ems_common/show') }
+
+      it do
+        is_expected.to have_http_status 200
+        is_expected.to render_template(:partial => "layouts/listnav/_ems_datawarehouse")
+      end
+    end
+  end
+
+  describe "Datawarehouse - create, update" do
+    before do
+      allow(controller).to receive(:check_privileges).and_return(true)
+      allow(controller).to receive(:assert_privileges).and_return(true)
+      login_as FactoryGirl.create(:user, :features => "ems_datawarehouse_new")
+    end
+
+    render_views
+
+    it 'creates on post' do
+      expect do
+        post :create, :params => {
+          "button"           => "add",
+          "cred_type"        => "default",
+          "name"             => "lotsofdata",
+          "emstype"          => "hawkular_datawarehouse",
+          "zone"             => zone.name,
+          "default_hostname" => "lotsofdata.com",
+          "default_api_port" => "443",
+          "default_userid"   => "",
+          "default_password" => "VERY_SECRET",
+          "default_verify"   => "VERY_SECRET",
+        }
+      end.to change { ManageIQ::Providers::Hawkular::DatawarehouseManager.count }.by(1)
+    end
+
+    it 'creates and updates an authentication record on post' do
+      expect do
+        post :create, :params => {
+          "button"           => "add",
+          "cred_type"        => "default",
+          "name"             => "lotsofdata",
+          "emstype"          => "hawkular_datawarehouse",
+          "zone"             => zone.name,
+          "default_hostname" => "lotsofdata.com",
+          "default_userid"   => "",
+          "default_password" => "VERY_SECRET",
+          "default_verify"   => "VERY_SECRET"
+        }
+      end.to change { Authentication.count }.by(1)
+
+      expect(response.status).to eq(200)
+      dwh = ManageIQ::Providers::Hawkular::DatawarehouseManager.where(:name => "lotsofdata").first
+      expect(dwh.authentications.size).to eq(1)
+
+      expect do
+        post :update, :params => {
+          "id"               => dwh.id,
+          "button"           => "save",
+          "cred_type"        => "default",
+          "name"             => "not_so_much_data",
+          "emstype"          => "hawkular_datawarehouse",
+          "default_hostname" => "host_hawkular_updated",
+          "default_userid"   => "",
+          "default_password" => "MUCH_WOW",
+          "default_verify"   => "MUCH_WOW"
+        }
+      end.not_to change { Authentication.count }
+
+      expect(response.status).to eq(200)
+      dwh.reload
+      expect(dwh.name).to eq("not_so_much_data")
+      expect(dwh.authentications.first).to have_attributes(:auth_key => "MUCH_WOW")
+    end
+  end
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -28,6 +28,12 @@ FactoryGirl.define do
           :parent  => :ext_management_system do
   end
 
+  factory :ems_datawarehouse,
+          :aliases => ["manageiq/providers/datawarehouse_manager"],
+          :class   => "ManageIQ::Providers::DatawarehouseManager",
+          :parent  => :ext_management_system do
+  end
+
   factory :ems_network,
           :aliases => ["manageiq/providers/network_manager"],
           :class   => "ManageIQ::Providers::NetworkManager",
@@ -330,5 +336,13 @@ FactoryGirl.define do
           :aliases => ["manageiq/providers/hawkular/middleware_manager"],
           :class   => "ManageIQ::Providers::Hawkular::MiddlewareManager",
           :parent  => :ems_middleware do
+  end
+
+  # Leaf classes for datawarehouse_manager
+
+  factory :ems_hawkular_datawarehouse,
+          :aliases => ["manageiq/providers/hawkular/datawarehouse_manager"],
+          :class   => "ManageIQ::Providers::Hawkular::DatawarehouseManager",
+          :parent  => :ems_datawarehouse do
   end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -28,6 +28,7 @@ describe ExtManagementSystem do
       "gce"                         => "Google Compute Engine",
       "gce_network"                 => "Google Network",
       "hawkular"                    => "Hawkular",
+      "hawkular_datawarehouse"      => "Hawkular Datawarehouse",
       "kubernetes"                  => "Kubernetes",
       "openshift"                   => "OpenShift Origin",
       "openshift_enterprise"        => "OpenShift Container Platform",

--- a/spec/routing/ems_datawarehouse_routing_spec.rb
+++ b/spec/routing/ems_datawarehouse_routing_spec.rb
@@ -1,0 +1,50 @@
+require "routing/shared_examples"
+
+describe EmsContainerController do
+  let(:controller_name) { "ems_datawarehouse" }
+  %w(
+    button
+    form_field_changed
+    listnav_search_selected
+    save_default_search
+    show
+    show_list
+    update
+  ).each do |task|
+    describe "##{task}" do
+      it 'routes with POST' do
+        expect(post("/#{controller_name}/#{task}")).to route_to("#{controller_name}##{task}")
+      end
+    end
+  end
+
+  describe "#index" do
+    it "routes with GET" do
+      expect(get("/#{controller_name}")).to route_to("#{controller_name}#index")
+    end
+  end
+
+  describe "#create" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}")).to route_to("#{controller_name}#create")
+    end
+  end
+
+  describe "#edit" do
+    it "routes with GET" do
+      expect(get("/#{controller_name}/123/edit")).to route_to("#{controller_name}#edit", :id => "123")
+    end
+  end
+
+  describe "#show" do
+    it "routes with GET" do
+      expect(get("/#{controller_name}/123")).to route_to("#{controller_name}#show", :id => "123")
+    end
+  end
+
+  describe "#update" do
+    it "routes with POST" do
+      expect(post("/#{controller_name}/update/123")).to route_to("#{controller_name}#update", :id => "123")
+    end
+  end
+end


### PR DESCRIPTION
Adding Datawarehouse management.
Commits:
- Datawarehouse manager with an empty refresh
- Ems Datawarehouse add/delete/display

Based on bits from the current hawkular manager.

Intent: A new provider in the system. The end goal is using it to attach events, metrics and inventory to other providers in the system. One Datawarehouse manager can serve many target providers. Currently there is one hawkular implementation. elastic search is planned next.

To view the new provider screens in the UI, set in settings.yml (or settings.local.yml)
```
:product:
  :datawarehouse_manager: true
```

###### add
![dwh_add](https://cloud.githubusercontent.com/assets/3010449/20596974/cd77f158-b249-11e6-8efd-e3a894c6404a.png)

###### list
![dwh_list](https://cloud.githubusercontent.com/assets/3010449/20597022/10e42268-b24a-11e6-8dcf-5ddf1efc9bca.png)


###### view
![3](https://cloud.githubusercontent.com/assets/3010449/20597028/149e2a8e-b24a-11e6-81da-915dbd0052ea.png)
