### PR TITLE
Set default value of param visible to true for all field types

### DIFF
--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -895,6 +895,9 @@ module MiqAeCustomizationController::Dialogs
     # set default value - element type was added/changed
     if params[:field_typ]
 
+      # default values for all element types
+      @edit[:field_visible] = key[:visible] = true
+
       # added TagControl - initialize values
       if params[:field_typ].include?("Tag")
         @edit[:field_category]     = key[:category]     = nil


### PR DESCRIPTION
As per [bz](https://bugzilla.redhat.com/show_bug.cgi?id=1388626) below, set default visibility to `true` for all dialog fields

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1388626
* https://trello.com/c/TJKACsZb/37-https-bugzilla-redhat-com-show-bug-cgi-id-1388626

Thanks @jntullo !!