### PR TITLE
add operator class indexes for ancestry

### DIFF
--- a/db/migrate/20160922235000_create_ancestry_indexes.rb
+++ b/db/migrate/20160922235000_create_ancestry_indexes.rb
@@ -1,0 +1,8 @@
+class CreateAncestryIndexes < ActiveRecord::Migration[5.0]
+  def change
+    add_index :relationships, 'ancestry varchar_pattern_ops', :name => "index_relationships_on_ancestry_vpo"
+    add_index :orchestration_stacks, 'ancestry varchar_pattern_ops', :name => "index_orchestration_stacks_on_ancestry_vpo"
+    add_index :services, 'ancestry varchar_pattern_ops', :name => "index_services_on_ancestry_vpo"
+    add_index :tenants, 'ancestry varchar_pattern_ops', :name => "index_tenants_on_ancestry_vpo"
+  end
+end


### PR DESCRIPTION
Adding an operator class index on `ancestry` speeds up ancestry queries.
## Query 1

491 records (with a filter on `resource_type`):

| query | master (ms) | PR (ms) | comments |
| :-- | --: | --: | :-- |
| ilike | 151.359 | 11.681 | ancestry 2.0 |
| like | 77.825 | 11.681 | ancestry 2.2 |
## Query 2

8376 records (with no `resource_type` filter):

| query | master (ms) | PR (ms) | comments |
| :-- | --: | --: | :-- |
| ilike | 337.902 | 133.775 | ancestry 2.0 |
| like | 174.936 | 133.775 | ancestry 2.2 |
---

Base Query used:

``` sql
SELECT * FROM "relationships"
WHERE ("relationships"."ancestry" = '509000000058932' OR "relationships"."ancestry" ilike '509000000058932/%'
  OR "relationships"."id" = 509000000058932)
  AND ("relationships"."resource_type" != 'VmOrTemplate')
ORDER BY coalesce("relationships"."ancestry", '');
```

variations on the query:
- change the `ilike` to `like`
- remove `("relationships"."resource_type" != 'VmOrTemplate')`
