### PR TITLE
rename tab from "Import" to "Import Variables"

### DIFF
--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -59,7 +59,7 @@
           = miq_tab_header("settings_import_tags", @sb[:active_tab]) do
             = _("Import Tags")
           = miq_tab_header("settings_import", @sb[:active_tab]) do
-            = _("Import")
+            = _("Import Variables")
           = miq_tab_header("settings_rhn", @sb[:active_tab]) do
             = _("Red Hat Updates")
           = miq_tab_header("settings_replication", @sb[:active_tab]) do


### PR DESCRIPTION
For consistency, the "Import" tab should be renamed more specifically to "Import Variables" to match the format of the "Import Tags" tab.

After:
![import_variables](https://cloud.githubusercontent.com/assets/2433314/19737252/a7bb8d88-9b80-11e6-80d6-dddfc1a5e315.png)


Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1388630

@miq-bot add_label bug, euwe/yes
@miq-bot assign @h-kataria 
