### PR TITLE
For resource_pools, only bring back usable Resource Pools

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -167,19 +167,11 @@ class EmsCluster < ApplicationRecord
   end
 
   def resource_pools
-    # Look for only the resource_pools at the second depth (default depth + 1)
-    rels = descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect(&:depth).min
-    rels = rels.select { |r| r.depth == min_depth + 1 }
-    Relationship.resources(rels).sort_by { |r| r.name.downcase }
+    Relationship.resources(grandchild_rels(:of_type => 'ResourcePool'))
   end
 
   def resource_pools_with_default
-    # Look for only the resource_pools up to the second depth (default depth + 1)
-    rels = descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect(&:depth).min
-    rels = rels.select { |r| r.depth <= min_depth + 1 }
-    Relationship.resources(rels).sort_by { |r| r.name.downcase }
+    Relationship.resources(child_and_grandchild_rels(:of_type => 'ResourcePool'))
   end
 
   alias_method :add_resource_pool, :set_child

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -686,19 +686,11 @@ class Host < ApplicationRecord
   end
 
   def resource_pools
-    # Look for only the resource_pools at the second depth (default depth + 1)
-    rels = descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect(&:depth).min
-    rels = rels.select { |r| r.depth == min_depth + 1 }
-    Relationship.resources(rels).sort_by { |r| r.name.downcase }
+    Relationship.resources(grandchild_rels(:of_type => 'ResourcePool'))
   end
 
   def resource_pools_with_default
-    # Look for only the resource_pools up to the second depth (default depth + 1)
-    rels = descendant_rels(:of_type => 'ResourcePool')
-    min_depth = rels.collect(&:depth).min
-    rels = rels.select { |r| r.depth <= min_depth + 1 }
-    Relationship.resources(rels).sort_by { |r| r.name.downcase }
+    Relationship.resources(child_and_grandchild_rels(:of_type => 'ResourcePool'))
   end
 
   # All RPs under this Host and all child RPs

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -390,6 +390,22 @@ module RelationshipMixin
     Relationship.arranged_rels_to_resources(subtree_rels_arranged(*args))
   end
 
+  def grandchild_rels(*args)
+    options = args.extract_options!
+    rels = relationships.inject(Relationship.none) do |stmt, r|
+      stmt.or(Relationship.where(r.grandchild_conditions))
+    end
+    Relationship.filter_by_resource_type(rels, options)
+  end
+
+  def child_and_grandchild_rels(*args)
+    options = args.extract_options!
+    rels = relationships.inject(Relationship.none) do |stmt, r|
+      stmt.or(Relationship.where(r.child_and_grandchild_conditions))
+    end
+    Relationship.filter_by_resource_type(rels, options)
+  end
+
   # Return the depth of the node, root nodes are at depth 0
   def depth(*_args)
     rel = relationship(:raise_on_multiple => true) # TODO: Handle multiple nodes with a way to detect which node you want


### PR DESCRIPTION
Part of the `/ems_infra/:id?display=ems_folders series` ( #12002). Extracted from 
#12072 

**before:**
All resource pools are fetched from the db. Only the ones at a certain depth are kept.

**after:**
Only resource pools at the preferred depth are retrieved from the db..

|        ms |queries | query (ms) |     rows |`comments`
|       ---:|  ---:|      ---:|      ---:| ---
|  22,688.1 |  288 | 21,074.3 |    1,403 |master
|   4,562.3 |  287 |  3,004.4 |      233 |after
|                 | 0%    |                | 83% |

Once you apply other PRs, the ms and query ms will probably be comperable. The number of rows brought back and therefore the number of records instantiated is the real savings - 83%.