### PR TITLE
Prefer params over RAW_POST_DATA

### DIFF
--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -21,15 +21,15 @@ module Spec
       end
 
       def run_post(url, body = {}, headers = {})
-        post url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
+        post url, :params => body.to_json, :headers => update_headers(headers)
       end
 
       def run_put(url, body = {}, headers = {})
-        put url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
+        put url, :params => body.to_json, :headers => update_headers(headers)
       end
 
       def run_patch(url, body = {}, headers = {})
-        patch url, :headers => update_headers(headers).merge('RAW_POST_DATA' => body.to_json)
+        patch url, :params => body.to_json, :headers => update_headers(headers)
       end
 
       def run_delete(url, headers = {})


### PR DESCRIPTION
While either will work, the former seems more idiomatic. `post api_path,
'{"some": "json"}'` will also work, but the kwargs version is newer and
more future-proof.

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 