### PR TITLE
Shorten view name to avoid obfuscating truncation

### DIFF
--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -11,10 +11,12 @@ module Menu
 
       def configuration_menu_section
         Menu::Section.new(:conf, N_("Configuration"), 'fa fa-cog  fa-2x', [
-          Menu::Item.new('provider_foreman', N_('Configuration Management'), 'provider_foreman_explorer',
-                         {:feature => 'provider_foreman_explorer', :any => true}, '/provider_foreman/explorer'),
-          Menu::Item.new('configuration_job', N_('Jobs'), 'configuration_job', {:feature => 'configuration_job_show_list'}, '/configuration_job'),
-        ])
+                            Menu::Item.new('provider_foreman', N_('Management'), 'provider_foreman_explorer',
+                                           {:feature => 'provider_foreman_explorer',
+                                            :any     => true}, '/provider_foreman/explorer'),
+                            Menu::Item.new('configuration_job', N_('Jobs'), 'configuration_job',
+                                           {:feature => 'configuration_job_show_list'}, '/configuration_job'),
+                          ])
       end
 
       def cloud_inteligence_menu_section


### PR DESCRIPTION
Renames "Configuration Management" to "Management", verified acceptable change with originator

## Before
<img width="958" alt="screen shot 2016-10-26 at 1 44 10 pm" src="https://cloud.githubusercontent.com/assets/6640236/19737735/a398ffae-9b82-11e6-8c2d-55c179d9d9ad.png">

## After
<img width="957" alt="screen shot 2016-10-26 at 1 22 07 pm" src="https://cloud.githubusercontent.com/assets/6640236/19737734/a3946b74-9b82-11e6-9ce2-5c592ff2f13d.png">


Links
----------------

- https://bugzilla.redhat.com/show_bug.cgi?id=1388975
- https://trello.com/c/yUm1EzXI/50-configuration-management-link-is-truncated-https-bugzilla-redhat-com-show-bug-cgi-id-1388975