### PR TITLE
Fix targeted refresh of a VM without its host clearing all folder relationships

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter.rb
@@ -299,7 +299,7 @@ class ManageIQ::Providers::Vmware::InfraManager
       ems_metadata = []
       parent_mor = vm_mor
 
-      # Traverse the path from the vm's parent folder to the datacenter
+      # Traverse the path from the vm's parent folder to the root folder
       #   collecting information along the way
       until parent_mor.nil?
         # Find the parent
@@ -309,7 +309,7 @@ class ManageIQ::Providers::Vmware::InfraManager
           parent_type, parent = ems_metadata_target_by_mor(parent_mor, data_source)
         end
 
-        break if parent.nil? || parent_type == :dc
+        break if parent.nil?
         ems_metadata << [parent_type, parent_mor, parent]
 
         # Find the next parent

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter_spec.rb
@@ -1,0 +1,89 @@
+describe ManageIQ::Providers::Vmware::InfraManager::RefreshParser::Filter do
+  context "filter_vc_data" do
+    let(:ems) { FactoryGirl.create(:ems_vmware) }
+
+    before(:each) do
+      @refresher = ems.refresher.new([ems])
+      @refresher.instance_variable_set(:@vc_data, vc_data)
+    end
+
+    context "with 1 host and 1 vm" do
+      let(:vm)   { FactoryGirl.create(:vm_with_ref) }
+      let(:host) { FactoryGirl.create(:host_with_ref) }
+      let(:vc_data) do
+        inv = Hash.new { |h, k| h[k] = {} }
+
+        inv[:host][host.ems_ref] = { "MOR" => host.ems_ref }
+        inv[:vm][vm.ems_ref]     = {
+          "MOR"     => vm.ems_ref,
+          "summary" => { "runtime" => { "host" => host.ems_ref } }
+        }
+
+        inv
+      end
+
+      context "targeting the ems" do
+        it "returns the full inventory" do
+          filtered_data = @refresher.filter_vc_data(ems, ems)
+          expect(filtered_data).to eq(vc_data)
+        end
+      end
+
+      context "targeting a vm" do
+        it "returns relevent data" do
+          filtered_data = @refresher.filter_vc_data(ems, vm)
+
+          expect(filtered_data[:host].count).to eq(1)
+          expect(filtered_data[:host]).to       include(host.ems_ref)
+
+          expect(filtered_data[:vm].count).to   eq(1)
+          expect(filtered_data[:vm]).to         include(vm.ems_ref)
+        end
+      end
+    end
+
+    context "with a vm and no host" do
+      let(:vm)          { FactoryGirl.create(:vm_with_ref) }
+      let(:dc)          { FactoryGirl.create(:datacenter, :ems_ref => "datacenter-1", :name => "dc1") }
+      let(:root_folder) { FactoryGirl.create(:ems_folder, :ems_ref => "group-d1",     :name => "Datacenters") }
+      let(:vm_folder)   { FactoryGirl.create(:ems_folder, :ems_ref => "group-v3",     :name => "vm") }
+
+      let(:vc_data) do
+        inv = Hash.new { |h, k| h[k] = {} }
+
+        inv[:vm][vm.ems_ref] = {
+          "MOR"     => vm.ems_ref,
+          "summary" => { "runtime" => { "host" => "host-1234" } }
+        }
+
+        inv[:dc][dc.ems_ref] = {
+          "MOR"    => dc.ems_ref,
+          "parent" => root_folder.ems_ref
+        }
+
+        inv[:folder][root_folder.ems_ref] = {
+          "MOR"         => root_folder.ems_ref,
+          "childEntity" => [dc.ems_ref]
+        }
+
+        inv[:folder][vm_folder.ems_ref] = {
+          "MOR"         => vm_folder.ems_ref,
+          "childEntity" => [vm.ems_ref],
+          "parent"      => dc.ems_ref
+        }
+
+        inv
+      end
+
+      context "targeting a vm" do
+        # Test to make sure that a targeted refresh of a VM with no host
+        # in inventory still returns the root folder
+        it "returns the root folder" do
+          filtered_data = @refresher.filter_vc_data(ems, vm)
+
+          expect(filtered_data[:folder]).to include(root_folder.ems_ref)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When filtering folder inventory during a targeted refresh, `ems_metadata_inv_by_vm_inv` walks up the hosts & clusters path and the vms & templates path.  These two paths share common ancestors, the datacenter and root folder.

A simple folder structure looks something like this:

```
     rootFolder
      /      \
     DC1     DC2
     / \
    vm host
    /    \
 folder1 cluster1
    \       \
     \     host1
      \    /
        vm1
```

It is possible to configure permissions such that the user has administrator access to everything under the vm folder, but no access to anything on the clusters/hosts side.  This leads to VMs in inventory that have we do not have hosts for.

When we do a targeted refresh of one of these VMs the walk up the hosts & clusters view fails because there is no host, the walk up the vms & templates view breaks out at the datacenter, meaning there is no root folder (the datacenter's parent) return in inventory.

This causes `link_ems_inventory` to change the root folder which deletes the rest of the relationships.

Before the patch:

```
MIQ(EmsRefresh.link_ems_inventory) EMS: [vc], id: [1] Linking EMS Inventory...
MIQ(EmsRefresh.link_ems_inventory) EMS: [vc], id: [1] prev_relats: {:folders_to_vms=>{13=>[108]}, :folders_to_folders=>{8=>[13], 15=>[8], 1=>[15]}, :ext_management_systems_to_folders=>{1=>[1]}}
MIQ(EmsRefresh.link_ems_inventory) EMS: [vc], id: [1] new_relats:  {:folders_to_vms=>{13=>[108]}, :folders_to_folders=>{8=>[13]}, :ext_management_systems_to_folders=>{1=>[8]}
```

```
  Relationship Load (1.9ms)  SELECT "relationships".* FROM "relationships" WHERE ("relationships"."ancestry" ILIKE '197/5740/%' OR "relationships"."ancestry" = '197/5740')
  Relationship Inst Including Associations (3.9ms - 550rows)
  SQL (0.3ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5741]]
  SQL (0.2ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5742]]
  SQL (0.2ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5749]]
  SQL (0.2ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5747]]
  SQL (0.2ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5748]]
  SQL (0.2ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5746]]
  SQL (0.1ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5750]]
  SQL (0.2ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5751]]
  SQL (0.1ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5744]]
  SQL (0.1ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5745]]
  SQL (0.1ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5743]]
  SQL (0.1ms)  DELETE FROM "relationships" WHERE "relationships"."id" = $1  [["id", 5752]]
```

![screenshot from 2016-10-26 16-19-34](https://cloud.githubusercontent.com/assets/12851112/19743686/3f854480-9b98-11e6-902c-7e224312a654.png)

After the patch:

```
MIQ(EmsRefresh.link_ems_inventory) EMS: [vc], id: [1] Linking EMS Inventory...
MIQ(EmsRefresh.link_ems_inventory) EMS: [vc], id: [1] prev_relats: {:folders_to_vms=>{13=>[108]}, :folders_to_folders=>{8=>[13], 15=>[8], 1=>[15]}, :ext_management_systems_to_folders=>{1=>[1]}}
MIQ(EmsRefresh.link_ems_inventory) EMS: [vc], id: [1] new_relats:  {:folders_to_folders=>{1=>[15], 8=>[13], 15=>[8]}, :folders_to_vms=>{13=>[108]}, :ext_management_systems_to_folders=>{1=>[1]}}
```

```
  Relationship Load (0.4ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."resource_type" = $1 AND "relationships"."resource_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)  [["resource_type", "EmsFolder"]]
  Relationship Inst Including Associations (0.2ms - 13rows)
  Relationship Load (0.2ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '197/6844'
  Relationship Inst Including Associations (0.0ms - 2rows)
  Relationship Load (0.5ms)  SELECT "relationships".* FROM "relationships" WHERE "relationships"."ancestry" = '197/6844/6849/6856'
```

![screenshot from 2016-10-26 16-34-12](https://cloud.githubusercontent.com/assets/12851112/19744121/12e0c2ea-9b9a-11e6-933c-e7d1275bec9b.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1387336
