### PR TITLE
Use x_node to determine if the currently selected node is an Unassigned Profiles Group node

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -360,7 +360,7 @@ class ProviderForemanController < ApplicationController
   end
 
   def tree_select_unprovisioned_configured_system
-    if unassigned_configuration_profile?(params[:id])
+    if unassigned_configuration_profile?(x_node)
       params[:id] = "cs-#{params[:id]}"
       tree_select
     else

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -743,6 +743,16 @@ describe ProviderForemanController do
     end
   end
 
+  context "when a configured system belonging to an unassigned configuration profile is selected in the list" do
+    it "calls tree_select to select the unassigned configuration profile node in the tree" do
+      allow(controller).to receive(:check_privileges)
+      allow(controller).to receive(:build_listnav_search_list)
+      allow(controller).to receive(:x_node).and_return("-1000000000013-unassigned")
+      post :x_show, :params => {:id => "1r1", :format => :js}
+      expect(response.status).to eq(200)
+    end
+  end
+
   def user_with_feature(features)
     features = EvmSpecHelper.specific_product_features(*features)
     FactoryGirl.create(:user, :features => features)


### PR DESCRIPTION
The only way to determine if a tree node is of the type `Unassigned Profiles Group` is to check the current `x_node`. 

The PR fixes the issue introduced in https://github.com/ManageIQ/manageiq/pull/8134

https://bugzilla.redhat.com/show_bug.cgi?id=1388431