### PR TITLE
Clarify database initialization question

### DIFF
--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -46,7 +46,7 @@ module ApplianceConsole
 
     def ask_questions
       choose_disk
-      self.run_as_evm_server = ask_yn?("Do you also want to use this server as an application server")
+      self.run_as_evm_server = ask_yn?("Is this a standard install? (Enter N if it will be a database ONLY) Y/N")
       # TODO: Assume we want to create a region for a new internal database disk
       # until we allow for the internal selection against an already initialized disk.
       create_new_region_questions(false) if run_as_evm_server

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -46,7 +46,7 @@ module ApplianceConsole
 
     def ask_questions
       choose_disk
-      self.run_as_evm_server = ask_yn?("Is this a standard install? (Enter N if it will be a database ONLY) Y/N")
+      self.run_as_evm_server = ask_yn?("Is this a standard install? (Enter N if it will be a database ONLY)")
       # TODO: Assume we want to create a region for a new internal database disk
       # until we allow for the internal selection against an already initialized disk.
       create_new_region_questions(false) if run_as_evm_server


### PR DESCRIPTION
The new application_console step for database initialization is confusing and and it is no way to enable normal functionality if "N" is selected without deleting and redeploying the appliance.

This pull request clarifies the question to what it is asking.

https://bugzilla.redhat.com/show_bug.cgi?id=1389080