### PR TITLE
Make C&U Metrics Database a mandatory field for Validation

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -218,6 +218,7 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       $scope.emsCommonModel.ssh_keypair_password != '' && $scope.angularForm.ssh_keypair_password.$valid)) {
       return true;
     } else if(($scope.currentTab == "metrics" && $scope.emsCommonModel.emstype == "rhevm") &&
+      $scope.emsCommonModel.metrics_database_name &&
       ($scope.emsCommonModel.metrics_hostname != '' && $scope.angularForm.metrics_hostname.$valid) &&
       ($scope.emsCommonModel.metrics_userid != '' && $scope.angularForm.metrics_userid.$valid &&
       $scope.emsCommonModel.metrics_password != '' && $scope.angularForm.metrics_password.$valid &&


### PR DESCRIPTION
In the absence of the `Database` field in the `RHEVM` `C&U` tab, the Validate button is displayed as an active, clickable button which is incorrect.
The `Database` field should be set to mandatory for validation.

Before:
![image](https://cloud.githubusercontent.com/assets/1538216/19749619/3d65e39c-9b9f-11e6-9eb8-d531aa3488ef.png)

After:
![image](https://cloud.githubusercontent.com/assets/1538216/19749599/0d3ace94-9b9f-11e6-9f45-20a4fb5ad915.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1388361