### PR TITLE
Expose user roles to automate engine

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_user_role.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_user_role.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqUserRole < MiqAeServiceModelBase
+    expose :name
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_user_role_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_user_role_spec.rb
@@ -1,0 +1,12 @@
+module MiqAeServiceMiqUserRoleSpec
+  describe MiqAeMethodService::MiqAeServiceMiqUserRole do
+    before(:each) do
+      @role = FactoryGirl.create(:miq_user_role, :name => "Role1")
+    end
+
+    it "check name" do 
+      expect(@role.name).to eq("Role1")
+    end
+
+  end
+end


### PR DESCRIPTION
This PR allows user roles to be accessed from Automate methods. This allows groups to be created from an Automate method using a REST call, which is a common use case for multi-tenant workflows, and dynamically creating tenants.
## Steps for Testing/QA

Attempt to find a user role from Automate:

``` ruby
role = $evm.vmdb(:miq_user_role).find_by_name("<user-role>")
$evm.log(:info, "Inspecting the user role: #{role.inspect}")
```
