### PR TITLE
Clean up Entry Points Dialog

### DIFF
--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -119,8 +119,6 @@
     .form-group
       %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
         = _('Provisioning Entry Point')
-        %br
-        = _('State Machine (NS/Cls/Inst)')
       .col-md-8{:title => @edit[:new][:fqname]}
         .input-group
           = text_field_tag("fqname",
@@ -143,8 +141,6 @@
     .form-group
       %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
         = _('Reconfigure Entry Point')
-        %br
-        = _('State Machine (NS/Cls/Inst)')
       .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
         .input-group
           = text_field_tag("reconfigure_fqname",
@@ -169,8 +165,6 @@
     .form-group
       %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
         = _('Retirement Entry Point')
-        %br
-        = _('State Machine (NS/Cls/Inst)')
       .col-md-8{:title => @edit[:new][:retire_fqname]}
         .input-group
           = text_field_tag("retire_fqname",

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -72,8 +72,6 @@
           .form-group
             %label.col-md-2.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
               #{entry_points_op[0]} #{_('Entry Point')}
-              %br
-              = _('State Machine (NS/Cls/Inst)')
             .col-md-8
               = h(@sb[entry_points_op[1]])
       %hr


### PR DESCRIPTION
The service catalog Item entry point dialog text is over-complicated as the text "State Machine (NS/Cls/Inst)" is implied and just adds extra clutter while messing up the formatting. 

https://bugzilla.redhat.com/show_bug.cgi?id=1389437
