### PR TITLE
Don't stringify get params in API specs

### DIFF
--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -17,7 +17,7 @@ module Spec
 
       def run_get(url, options = {})
         headers = options.delete(:headers) || {}
-        get url, :params => options.stringify_keys, :headers => update_headers(headers)
+        get url, :params => options, :headers => update_headers(headers)
       end
 
       def run_post(url, body = {}, headers = {})


### PR DESCRIPTION
Symbols are OK. While miniscule, I was able to shave off almost a second
total when running affected tests:

| with  | without |
| ----- | ------- |
| 36.69 | 34.26   |
| 34.95 | 34.47   |
| 35.07 | 36.07   |
| 35.72 | 34.18   |
| 35.27 | 34.27   |

| avg   | avg     |
| ----- | ------- |
| 35.54 | 34.65   |

@miq-bot add-label api, test, refactoring
@miq-bot assign @abellotti 