### PR TITLE
Fix filtering of encrypted attributes while logging parameters.

### DIFF
--- a/app/controllers/api/base_controller/logger.rb
+++ b/app/controllers/api/base_controller/logger.rb
@@ -35,7 +35,7 @@ module Api
         @parameter_filter ||= ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
         return unless api_log_info?
         log_request("Request", @req.to_hash)
-        log_request("Parameters", @parameter_filter.filter(params))
+        log_request("Parameters", @parameter_filter.filter(params.to_unsafe_h))
         log_request_body
       end
 

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -58,6 +58,22 @@ describe "Logging" do
       run_get entrypoint_url
     end
 
+    it "filters password attributes in nested parameters" do
+      api_basic_authorize collection_action_identifier(:services, :create)
+
+      log_request_expectations = EXPECTED_LOGGED_PARAMETERS.merge(
+        "Parameters" => a_hash_including(
+          "resource" => a_hash_including(
+            "options" => a_hash_including("password" => "[FILTERED]")
+          )
+        )
+      )
+
+      expect_log_requests(log_request_expectations)
+
+      run_post(services_url, gen_request(:create, "name" => "new_service_1", "options" => { "password" => "SECRET" }))
+    end
+
     it "logs additional system authentication with miq_token" do
       server_guid = MiqServer.first.guid
       userid = api_config(:user)


### PR DESCRIPTION

- Needed to use to_unsafe_h to get the unfiltered hash representation
of the parameters.  Otherwise, ActionDispatch::Http::ParameterFilter.filter
would not be able to traverse the embedded parameters.

Requires PR# https://github.com/ManageIQ/manageiq/pull/12216 to work.