### PR TITLE
Fix erratic test in conditions spec

### DIFF
--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -124,7 +124,7 @@ describe "Conditions API" do
 
       expect(response.parsed_body["results"].count).to eq(2)
 
-      expect(Condition.pluck(:description)).to eq(%w(change change2))
+      expect(Condition.pluck(:description)).to match_array(%w(change change2))
     end
   end
 


### PR DESCRIPTION
`Condition.pluck(:description)` can't guarantee the order, so I've seen
this test failing randomly.