### PR TITLE
Add 'vm_id' field to 'extra_fields' list in chargeback_vm

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -1,5 +1,6 @@
 class ChargebackVm < Chargeback
   set_columns_hash(
+    :vm_id                    => :integer,
     :vm_name                  => :string,
     :vm_uid                   => :string,
     :vm_guid                  => :string,
@@ -86,6 +87,7 @@ class ChargebackVm < Chargeback
     @vm_owners[perf.resource_id] ||= perf.resource.evm_owner_name
 
     extra_fields = {
+      "vm_id"         => perf.resource_id,
       "vm_name"       => perf.resource_name,
       "vm_uid"        => perf.resource.ems_ref,
       "vm_guid"       => perf.resource.try(:guid),

--- a/product/chargeback/chargeback_vm_monthly.yaml
+++ b/product/chargeback/chargeback_vm_monthly.yaml
@@ -7,6 +7,7 @@ db: ChargebackVm
 cols:
 - start_date
 - display_range
+- vm_id
 - vm_name
 - cpu_allocated_cost
 - cpu_used_metric
@@ -68,7 +69,7 @@ db_options:
   :rpt_type: ChargebackVm
   :options:
     :interval: monthly
-    :interval_size: 1
+    :interval_size: 6
     :end_interval_offset: 0
 col_formats:
 - 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -806,7 +806,8 @@ describe ChargebackVm do
 
       extra_fields = ChargebackVm.get_keys_and_extra_fields(metric_rollup, timestamp_key)
       expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => @ems.name,
-                         "provider_uid" => @ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid}
+                         "provider_uid" => @ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
+                         "vm_id" => @vm1.id}
 
       expect("#{metric_rollup.resource_id}_#{timestamp_key}").to eq(extra_fields.first)
       expect(extra_fields.second).to eq(expected_fields)
@@ -824,7 +825,8 @@ describe ChargebackVm do
 
       extra_fields = ChargebackVm.get_keys_and_extra_fields(metric_rollup_without_ems, timestamp_key)
       expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => nil,
-                         "provider_uid" => nil, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid}
+                         "provider_uid" => nil, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
+                         "vm_id" => @vm1.id}
 
       expect("#{metric_rollup.resource_id}_#{timestamp_key}").to eq(extra_fields.first)
       expect(extra_fields.second).to eq(expected_fields)


### PR DESCRIPTION
There is request from UI team to include vm id in chargeback report for services.
Related  PR: #11687

in this PR: 
1. Include ```vm_id``` in chargeback report for service generated by api
2. Show last 6 months of chargeback data for service 

@miq-bot add-label chargeback, reporting, core, enhancement

\cc @gtanzillo @lpichler @himdel 