### PR TITLE
Remove redundant vm_pause from VMware InfraManager

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -181,10 +181,6 @@ module ManageIQ::Providers
       invoke_vim_ws(:suspend, vm, options[:user_event])
     end
 
-    def vm_pause(vm, options = {})
-      invoke_vim_ws(:pause, vm, options[:user_event])
-    end
-
     def vm_shutdown_guest(vm, options = {})
       invoke_vim_ws(:shutdownGuest, vm, options[:user_event])
     end

--- a/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -114,8 +114,7 @@ class MiqVimVm
     $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).suspend: returned from suspendVM_Task" if $vim_log
     return taskMor unless wait
     waitForTask(taskMor)
-  end # def pause
-  alias_method :pause, :suspend
+  end # def suspend
 
   def reset(wait = true)
     $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).reset: calling resetVM_Task" if $vim_log

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm_spec.rb
@@ -21,11 +21,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm do
       include_examples "Vm operation is available when powered on"
     end
 
-    context("with :pause") do
-      let(:state) { :pause }
-      include_examples "Vm operation is available when powered on"
-    end
-
     context("with :shutdown_guest") do
       let(:state) { :shutdown_guest }
       include_examples "Vm operation is available when powered on"


### PR DESCRIPTION
It was found in discussion of https://github.com/ManageIQ/manageiq/pull/12056 that the `vm_pause` method in VMware is just an alias for `vm_suspend` and it was completely unused (https://github.com/ManageIQ/manageiq/pull/12056#issuecomment-255122359).

This removes the unused method and the alias in the broker.

cc @bronaghs @durandom 
