### PR TITLE
API relay for MiqRequest#approve and #deny

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -268,6 +268,8 @@ class MiqRequest < ApplicationRecord
   def approve(userid, reason)
     first_approval.approve(userid, reason) unless self.approved?
   end
+  api_relay_method(:approve) { |_userid, reason| {:reason => reason} }
+  api_relay_method(:deny)    { |_userid, reason| {:reason => reason} }
 
   def stamped_by
     first_approval.stamper.try(:userid)

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_miq_request_spec.rb
@@ -23,7 +23,8 @@ module MiqAeServiceMiqRequestSpec
       reason   = "Why Not?"
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].approve('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
-      expect_any_instance_of(MiqRequest).to receive(:approve).with(approver, reason).once
+      expect(MiqRequest).to receive(:find).with(@miq_request.id.to_s).and_return(@miq_request)
+      expect(@miq_request).to receive(:approve).with(approver, reason).once
       expect(invoke_ae.root(@ae_result_key)).to  be_truthy
     end
 
@@ -32,7 +33,8 @@ module MiqAeServiceMiqRequestSpec
       reason   = "Why Not?"
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].deny('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
-      expect_any_instance_of(MiqRequest).to receive(:deny).with(approver, reason).once
+      expect(MiqRequest).to receive(:find).with(@miq_request.id.to_s).and_return(@miq_request)
+      expect(@miq_request).to receive(:deny).with(approver, reason).once
       expect(invoke_ae.root(@ae_result_key)).to  be_truthy
     end
 

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_service_template_provision_request_spec.rb
@@ -21,7 +21,9 @@ module MiqAeServiceServiceTemplateProvisionRequestSpec
       reason   = "Why Not?"
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_request'].approve('#{approver}', '#{reason}')"
       @ae_method.update_attributes(:data => method)
-      expect_any_instance_of(MiqRequest).to receive(:approve).with(approver, reason).once
+      expect(MiqRequest).to receive(:find).with(@service_template_provision_request.id.to_s)
+        .and_return(@service_template_provision_request)
+      expect(@service_template_provision_request).to receive(:approve).with(approver, reason).once
       expect(invoke_ae.root(@ae_result_key)).to be_truthy
     end
 


### PR DESCRIPTION
Based on #12109 

Required to route MiqRequest approvals to the correct region
