### PR TITLE
Fix provider input field lengths to be consistent

### DIFF
--- a/app/views/ems_container/_form.html.haml
+++ b/app/views/ems_container/_form.html.haml
@@ -6,7 +6,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
-      .col-md-8
+      .col-md-4
         %input.form-control{"type"           => "text",
                             "id"             => "ems_name",
                             "name"           => "name",
@@ -44,7 +44,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_zone"}
         = _("Zone")
-      .col-md-8
+      .col-md-4
         - if @server_zones.length <= 1
           %input.form-control{"type"      => "text",
                               "id"        => "ems_zone",

--- a/app/views/ems_container/_form_fields.html.haml
+++ b/app/views/ems_container/_form_fields.html.haml
@@ -2,7 +2,7 @@
   .form-group
     %label.control-label.col-md-2
       = _('Hostname or IP address')
-    .col-md-8
+    .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
         :maxlength         => MAX_HOSTNAME_LEN,
@@ -12,7 +12,7 @@
   .form-group
     %label.control-label.col-md-2
       = _('Port')
-    .col-md-8
+    .col-md-2
       = text_field_tag("port",
         @edit[:new][:port],
         :maxlength         => 5,

--- a/app/views/ems_infra/_form.html.haml
+++ b/app/views/ems_infra/_form.html.haml
@@ -6,7 +6,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
-      .col-md-8
+      .col-md-4
         %input.form-control{"type"           => "text",
                             "id"             => "ems_name",
                             "name"           => "name",
@@ -53,7 +53,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_zone"}
         = _("Zone")
-      .col-md-8
+      .col-md-4
         - if @server_zones.length <= 1
           %input.form-control{"type"        => "text",
                               "id"          => "ems_zone",

--- a/app/views/ems_infra/_form_fields.html.haml
+++ b/app/views/ems_infra/_form_fields.html.haml
@@ -2,7 +2,7 @@
   .form-group
     %label.control-label.col-md-2
       = _('Hostname or IP address')
-    .col-md-8
+    .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
         :maxlength => MAX_HOSTNAME_LEN,
@@ -25,7 +25,7 @@
       .form-group
         %label.control-label.col-md-2
           = _('Realm')
-        .col-md-8
+        .col-md-6
           = text_field_tag("realm",
                            @edit[:new][:realm],
                            :maxlength => MAX_NAME_LEN,

--- a/app/views/ems_middleware/_form_fields.html.haml
+++ b/app/views/ems_middleware/_form_fields.html.haml
@@ -2,7 +2,7 @@
   .form-group
     %label.control-label.col-md-2
       = _('Hostname or IP address')
-    .col-md-8
+    .col-md-4
       = text_field_tag("hostname",
         @edit[:new][:hostname],
         :maxlength         => MAX_HOSTNAME_LEN,
@@ -12,7 +12,7 @@
   .form-group
     %label.control-label.col-md-2
       = _('Port')
-    .col-md-8
+    .col-md-2
       = text_field_tag("port",
         @edit[:new][:port],
         :maxlength         => 5,

--- a/app/views/host/_form.html.haml
+++ b/app/views/host/_form.html.haml
@@ -30,7 +30,7 @@
           .form-group{"ng-class" => "{'has-error': angularForm.hostname.$invalid}"}
             %label.col-md-2.control-label{"for" => "hostname"}
               = _("Hostname (or IPv4 or IPv6 address)")
-            .col-md-8
+            .col-md-4
               %input.form-control{"type"        => "text",
                                   "id"          => "hostname",
                                   "name"        => "hostname",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -60,7 +60,7 @@
     "ng-if" => "emsCommonModel.emstype == 'rhevm'"} |
     %label.col-md-2.control-label{"for" => "#{prefix}_database_name"}
       = _('Database Name')
-    .col-md-8
+    .col-md-4
       %input.form-control{"type"          => "text",
                           "id"            => "#{prefix}_database_name",
                           "name"          => "#{prefix}_database_name",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -105,7 +105,7 @@
             "ng-if" => "emsCommonModel.emstype == 'scvmm' && emsCommonModel.default_security_protocol == 'kerberos'"}
   %label.col-md-2.control-label{"for" => "realm"}
     = _('Realm')
-  .col-md-8
+  .col-md-4
     %input.form-control{"type"          => "text",
                         "id"            => "realm",
                         "name"          => "realm",

--- a/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
+++ b/app/views/layouts/angular-bootstrap/_endpoints_angular.html.haml
@@ -7,7 +7,7 @@
   .form-group{"ng-class" => "{'has-error': angularForm.#{prefix}_hostname.$invalid}"}
     %label.col-md-2.control-label{"for" => "#{prefix}_hostname"}
       = _('Hostname (or IPv4 or IPv6 address)')
-    .col-md-8
+    .col-md-4
       %input.form-control{"type"                    => "text",
                           "id"                      => "#{prefix}_hostname",
                           "name"                    => "#{prefix}_hostname",
@@ -34,7 +34,7 @@
                          "emsCommonModel.ems_controller == 'ems_container'"} |
     %label.col-md-2.control-label{"for" => "#{prefix}_api_port"}
       = _('API Port')
-    .col-md-8
+    .col-md-2
       %input.form-control{"type"                        => "text",
                           "id"                          => "#{prefix}_api_port",
                           "name"                        => "#{prefix}_api_port",

--- a/app/views/shared/views/ems_common/_form.html.haml
+++ b/app/views/shared/views/ems_common/_form.html.haml
@@ -62,7 +62,7 @@
     .form-group
       %label.control-label.col-md-2
         = _('Zone')
-      .col-md-8
+      .col-md-2
         - if @edit[:server_zones].length <= 1
           = text_field_tag("server_zone", @edit[:new][:zone],
                             :maxlength         => 15,

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -6,7 +6,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.name.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_name"}
         = _('Name')
-      .col-md-8
+      .col-md-4
         %input.form-control{"type"           => "text",
                             "id"             => "ems_name",
                             "name"           => "name",
@@ -162,7 +162,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.zone.$invalid}"}
       %label.col-md-2.control-label{"for" => "ems_zone"}
         = _("Zone")
-      .col-md-8
+      .col-md-4
         - if @server_zones.length <= 1
           %input.form-control{"type"        => "text",
                               "id"          => "ems_zone",

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -130,7 +130,7 @@
                 "ng-if"    => "emsCommonModel.emstype == 'openstack' || emsCommonModel.emstype == 'openstack_infra'"}
       %label.col-md-2.control-label{"for" => "ems_region_input"}
         = _('Region')
-      .col-md-8
+      .col-md-4
         %input.form-control{"type"                    => "text",
                             "id"                      => "ems_region_input",
                             "name"                    => "provider_region",

--- a/app/views/shared/views/ems_common/angular/_form.html.haml
+++ b/app/views/shared/views/ems_common/angular/_form.html.haml
@@ -60,7 +60,7 @@
     .form-group{"ng-class" => "{'has-error': angularForm.project.$invalid}", "ng-if" => "emsCommonModel.emstype == 'gce'"}
       %label.col-md-2.control-label{"for" => "ems_project"}
         = _('Project')
-      .col-md-8
+      .col-md-4
         %input.form-control{"type"        => "text",
                             "id"          => "ems_project",
                             "name"        => "project",


### PR DESCRIPTION
The input fields when adding a new provider are inconsistent and fields like "API PORT" stretch across the screen.

This PR standardizes the length to be half width for all items that can easily be accommodated by that field length.  It also adjusts fields that should be short (e.g. Port number)  to a reasonable length based off what is appropriate.

This works makes the experience more consistent concise. 

https://bugzilla.redhat.com/show_bug.cgi?id=1389513
