### PR TITLE
Add Network Topology button for the Load Balancer class

### DIFF
--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -70,6 +70,14 @@
             %text{:y => "9"} &#xF02b;
         %label
           = _("Tags")
+      %kubernetes-topology-icon{tooltipOptions, :kind => "LoadBalancer"}
+        %svg.kube-topology
+          %g.EntityLegend.Network.LoadBalancer
+            %circle{:r => "17"}
+            -# pficon-network
+            %text{:y => "8"} &#xE909;
+        %label
+          = _("Load Balancer")
 
   .alert.alert-info.alert-dismissable
     %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"}


### PR DESCRIPTION
No toolbar button exists for the Load Balancer class in the provider NetworkTopology view. This PR addresses this by adding it.
## Before

![screenshot-20161021 132733 1](https://cloud.githubusercontent.com/assets/4379675/19781807/23769c46-9c59-11e6-8dcb-ce28679de77e.png)
## After

<img width="1440" alt="screen shot 2016-10-27 at 3 23 21 pm" src="https://cloud.githubusercontent.com/assets/4379675/19781854/6113b994-9c59-11e6-823b-1b39d4885ac5.png">

<img width="1440" alt="screen shot 2016-10-27 at 3 23 28 pm" src="https://cloud.githubusercontent.com/assets/4379675/19781894/806124da-9c59-11e6-9393-688020cb1bb5.png">
## Links

https://bugzilla.redhat.com/show_bug.cgi?id=1387612
## Notes

This fix is not Azure specific despite the BZ description.
