### PR TITLE
Fix erratic ChargebackContainerProject test

### DIFF
--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -389,7 +389,8 @@ describe ChargebackContainerProject do
       FactoryGirl.create(:chargeback_rate_detail_fixed_compute_cost,
                          :chargeback_rate_id => @cbr.id,
                          :per_time           => "hourly",
-                         :chargeback_tiers   => [cbt])
+                         :chargeback_tiers   => [cbt],
+                         :source             => "compute_1")
     end
 
     it "fixed_compute" do


### PR DESCRIPTION
This test is implicitly dependent on an auto-incrementing field in the
chargeback rate detail factory. If another test creates a chargeback
rate detail using the factory before this test is run, it will
fail. This fixes the issue by making the depended-on field explicit when
building the object.

@miq-bot add-label test, core, bug
@miq-bot assign @gtanzillo 

/cc @lpichler 