### PR TITLE
Raise an error if a region is not configured for central admin

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -597,7 +597,15 @@ module ApplicationController::MiqRequestMethods
     id = session[:edit][:req_id] || "new"
     return unless load_edit("prov_edit__#{id}", "show_list")
     @edit[:new][:schedule_time] = @edit[:new][:schedule_time].in_time_zone("Etc/UTC") if @edit[:new][:schedule_time]
-    if @edit[:wf].make_request(@edit[:req_id], @edit[:new])
+
+    begin
+      request = @edit[:wf].make_request(@edit[:req_id], @edit[:new])
+    rescue => bang
+      request = false
+      add_flash(bang.message, :error)
+    end
+
+    if request
       @breadcrumbs.pop if @breadcrumbs
       typ = @edit[:org_controller]
       case typ


### PR DESCRIPTION
Now when someone tries to do something with an object that belongs to a remote region and hasn't configured the authentication key yet for that region, they will get a clear error message.

Previously the error was `Error caught: [NoMethodError] undefined method '[]' for false:FalseClass` which is not very helpful.

https://bugzilla.redhat.com/show_bug.cgi?id=1389536

@bdunne please review