### PR TITLE
Fix openstack network object create to immediately create a manageiq …

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -17,7 +17,13 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
       network = service.networks.new(raw_options)
       network.save
     end
-    {:ems_ref => network.id, :name => options[:name]}
+
+    create(
+      :name                  => network.name,
+      :ems_ref               => network.id,
+      :cloud_tenant          => cloud_tenant,
+      :ext_management_system => ext_management_system
+    )
   rescue => e
     _log.error "network=[#{options[:name]}], error: #{e}"
     raise MiqException::MiqNetworkCreateError, e.to_s, e.backtrace

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -7,7 +7,13 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
       subnet = service.subnets.new(options)
       subnet.save
     end
-    {:ems_ref => subnet.id, :name => options[:name]}
+
+    create(
+      :name                  => subnet.name,
+      :ems_ref               => subnet.id,
+      :cloud_tenant          => cloud_tenant,
+      :ext_management_system => ext_management_system
+    )
   rescue => e
     _log.error "subnet=[#{options[:name]}], error: #{e}"
     raise MiqException::MiqCloudSubnetCreateError, e.to_s, e.backtrace

--- a/app/models/manageiq/providers/openstack/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/network_router.rb
@@ -13,9 +13,15 @@ class ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter < ::NetworkR
     router = nil
 
     ext_management_system.with_provider_connection(connection_options(cloud_tenant)) do |service|
-      router = service.create_router(name, options).body
+      router = service.create_router(name, options).body['router']
     end
-    {:ems_ref => router['id'], :name => options[:name]}
+
+    create(
+      :name                  => router['name'],
+      :ems_ref               => router['id'],
+      :cloud_tenant          => cloud_tenant,
+      :ext_management_system => ext_management_system
+    )
   rescue => e
     _log.error "router=[#{options[:name]}], error: #{e}"
     raise MiqException::MiqNetworkRouterCreateError, e.to_s, e.backtrace


### PR DESCRIPTION
Other cloud object create methods create the matching ManageIQ object as soon as the create API request returns successfully, allowing the user to immediately interact with the object without waiting for a refresh.  This PR brings the network object create methods in-line with this practice.

https://bugzilla.redhat.com/show_bug.cgi?id=1390333