### PR TITLE
Refactor of VMs subcollection 

### DIFF
--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -10,15 +10,8 @@ module Api
         return vms if vm_attrs.blank? && vm_decorators.blank?
 
         vms.collect do |vm|
-          decorated = vm.decorator_class? ? vm.decorate : nil
-
-          attributes_hash = vm_attrs.each_with_object({}) do |attr, hash|
-            hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)
-          end.compact
-
-          decorators_hash = vm_decorators.each_with_object({}) do |name, hash|
-            hash[name] = vm.decorate.public_send(name.to_sym) if decorated.respond_to?(name.to_sym)
-          end.compact unless decorated.nil?
+          attributes_hash = create_vm_attributes_hash(vm_attrs, vm)
+          decorators_hash = create_vm_decorators_hash(vm_decorators, vm)
 
           conflictless_hash = attributes_hash.merge(decorators_hash || {}) do |key, _, _|
             raise BadRequestError, "Requested both an attribute and a decorator of the same name: #{key}"
@@ -26,6 +19,20 @@ module Api
 
           vm.as_json.merge(conflictless_hash)
         end
+      end
+
+      private
+
+      def create_vm_attributes_hash(vm_attrs, vm)
+        vm_attrs.each_with_object({}) do |attr, hash|
+          hash[attr] = vm.public_send(attr.to_sym) if vm.respond_to?(attr.to_sym)
+        end.compact
+      end
+
+      def create_vm_decorators_hash(vm_decorators, vm)
+        vm_decorators.each_with_object({}) do |name, hash|
+          hash[name] = vm.decorate.public_send(name.to_sym) if vm.decorate.respond_to?(name.to_sym)
+        end.compact
       end
     end
   end


### PR DESCRIPTION
Create two private methods to fix branch condition size too high/cyclomatic and perceived complexity rubocop issues in the VMs subcollection API

@miq-bot add_label api, cleanup/rubocop, euwe/no
@miq-bot assign @abellotti 
