### PR TITLE
Automate - Enhanced messaging for Ansible provisioning.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/update_serviceprovision_status.rb
@@ -13,7 +13,12 @@ end
 # Get status from input field status
 status = $evm.inputs['status']
 
-# Update Status for on_entry,on_exit
-if $evm.root['ae_result'] == 'ok' || $evm.root['ae_result'] == 'error'
-  prov.message = status
-end
+# Update Status Message
+updated_message  = "Server [#{$evm.root['miq_server'].name}] "
+updated_message += "Service [#{prov.destination.name}] "
+updated_message += "Step [#{$evm.root['ae_state']}] "
+updated_message += "Status [#{status}] "
+updated_message += "Message [#{prov.message}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+prov.miq_request.user_message = updated_message
+prov.message = status


### PR DESCRIPTION
Modified update_serviceprovision_status method in /Service/Provisioning/StateMachines/ServiceProvision_Template.class/

for Ansible service provisioning messages.

Previous Enhanced Messaging PR:

https://github.com/ManageIQ/manageiq/pull/9333
