### PR TITLE
Pulled out simulation parameters

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -74,7 +74,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.object_request  = data.object_request;
         $scope.scheduleModel.target_class    = data.target_class;
         $scope.scheduleModel.target_id       = data.target_id;
-        $scope.scheduleModel.readonly        = data.readonly;
         $scope.scheduleModel.attrs           = data.attrs;
 
         $scope.setTimerType();
@@ -216,7 +215,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.object_request  = data.object_request;
         $scope.scheduleModel.target_class    = data.tagert_class;
         $scope.scheduleModel.target_id       = data.target_id;
-        $scope.scheduleModel.readonly        = data.readonly;
         $scope.scheduleModel.targets         = [];
         $scope.scheduleModel.filter_typ      = null;
         $scope.scheduleModel.attrs           = data.attrs;

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -14,8 +14,7 @@ module OpsController::Settings::AutomateSchedules
       :target_class    => automate_request[:target_class],
       :target_classes  => automate_request[:target_classes],
       :target_id       => automate_request[:target_id],
-      :attrs           => automate_request[:attrs],
-      :readonly        => automate_request[:readonly]
+      :attrs           => automate_request[:attrs]
     }
   end
 
@@ -53,7 +52,6 @@ module OpsController::Settings::AutomateSchedules
       automate_request[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
     end
     automate_request[:target_id]      = filter[:parameters][:target_id] || ""
-    automate_request[:readonly]       = filter[:parameters][:readonly] || true
     automate_request[:attrs]          = filter[:parameters][:attrs] || []
 
     if automate_request[:attrs].empty?

--- a/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
+++ b/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
@@ -63,17 +63,6 @@
           = _("Required")
 
   %div
-    = _("Simulation Parameters")
-    .form-group
-      %label.col-md-2.control-label{"for" => "readonly"}
-        = _("Execute Methods")
-      .col-md-8
-        %input#readonly{"type"        => "checkbox",
-                        "name"        => "readonly",
-                        "ng-model"    => "scheduleModel.readonly",
-                        "checkchange" => ""}
-
-  %div
     = _("Attribute/Value Pairs")
     .form-group{"ng-repeat" => "key_val in scheduleModel.attrs track by $index"}
       %label.col-md-2.control-label{"for" => "key_val"}

--- a/app/views/ops/_schedule_show.html.haml
+++ b/app/views/ops/_schedule_show.html.haml
@@ -77,24 +77,18 @@
             %p.form-control-static
               = h(@object_name)
 
-      %div
-        = _("Simulation Parameters")
-        .form-group
-          %label.col-md-2.control-label= _("Execute Methods")
-          .col-md-10
-            %p.form-control-static
-              = h(@selected_schedule.filter[:parameters][:readonly].to_s.titleize)
-      %div
-        = _("Attribute/Value Pairs")
-        - @selected_schedule.filter[:parameters][:attrs].each_with_index do |attr, i|
-          .form-group
-            %label.control-label.col-md-2
-              = (i + 1).to_s
-            - if attr
-              .col-md-2
-                = h(attr[0])
-              .col-md-2
-                = h(attr[1])
+      - if @selected_schedule.filter[:parameters][:attrs].present?
+        %div
+          = _("Attribute/Value Pairs")
+          - @selected_schedule.filter[:parameters][:attrs].each_with_index do |attr, i|
+            .form-group
+              %label.control-label.col-md-2
+                = (i + 1).to_s
+              - if attr
+                .col-md-2
+                  = h(attr[0])
+                .col-md-2
+                  = h(attr[1])
 
     - if @selected_schedule.sched_action[:method] != 'db_backup'
       %div


### PR DESCRIPTION
The execute method checkbox is not needed for
Schedule Automate methods, since all methods would
need to be executed, and currently are regardless
of that setting

Before

<img width="1318" alt="screen shot 2016-11-01 at 3 09 56 pm" src="https://cloud.githubusercontent.com/assets/697347/19903509/589a945a-a045-11e6-9925-b140e2cc0c84.png">

After

<img width="1341" alt="screen shot 2016-11-01 at 3 12 59 pm" src="https://cloud.githubusercontent.com/assets/697347/19903643/b9b70782-a045-11e6-85c5-99ffb9b86a0b.png">

## Links
- [PT #133269097](https://www.pivotaltracker.com/story/show/133269097)
