### PR TITLE
Add VM specific customisations to vApp orchestration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     "~>0.3.0",       :require => false
-gem "fog-vcloud-director",            "~>0.1.6",       :require => false
+gem "fog-vcloud-director",            "~>0.1.8",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "~>0.8.6",       :require => false

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_service_option_converter.rb
@@ -1,11 +1,79 @@
 module ManageIQ::Providers
   class Vmware::CloudManager::OrchestrationServiceOptionConverter < ::ServiceOrchestration::OptionConverter
+    include Vmdb::Logging
+
     def stack_create_options
-      {
+      options = {
         :deploy  => stack_parameters['deploy'] == 't',
-        :powerOn => stack_parameters['powerOn'] == 't',
-        :vdc_id  => @dialog_options['dialog_availability_zone']
+        :powerOn => stack_parameters['powerOn'] == 't'
       }
+      options[:vdc_id] = @dialog_options['dialog_availability_zone'] unless @dialog_options['dialog_availability_zone'].blank?
+
+      options.merge!(customize_vapp_template(collect_vm_params))
+    end
+
+    private
+
+    # customize_vapp_template will prepare the options in a format suitable for the fog-vcloud-director.
+    # This mainly results in creating two top level objects in a hash. The :InstantiationParams, contains
+    # a single :NetworkConfig element with the array of all references to the networks used in the
+    # deployed vApp. We are using IDs here and let fog library create concrete HREFs that are required
+    # by the vCloud director. The second object is an array of source items. Each source item references
+    # a single VM from the vApp template, customises its name and optionally sets network info.
+    def customize_vapp_template(vm_params)
+      network_config = {}
+
+      source_vms = vm_params.collect do |vm_id, vm_opts|
+        src_vm = { :vm_id => "vm-#{vm_id}" }
+        src_vm[:name] = vm_opts["instance_name"] if vm_opts.key?("instance_name")
+
+        network_id = vm_opts["vdc_network"]
+        unless network_id.nil?
+          # Create new network config if it hasn't been created before.
+          network_config[network_id] ||= {
+            :networkName => network_id,
+            :networkId   => network_id,
+            :fenceMode   => "bridged"
+          }
+
+          # Add network configuration to the source VM.
+          src_vm[:networks] = [
+            :networkName             => network_id,
+            :IsConnected             => true,
+            :IpAddressAllocationMode => "DHCP"
+          ]
+        end
+
+        src_vm
+      end
+
+      # Create options suitable for VMware vCloud provider.
+      custom_opts = {
+        :source_vms => source_vms
+      }
+      custom_opts[:InstantiationParams] = {
+        :NetworkConfig => network_config.values
+      } unless network_config.empty?
+
+      custom_opts
+    end
+
+    def collect_vm_params
+      allowed_vm_params = %w(instance_name vdc_network)
+      stack_parameters.each_with_object({}) do |(key, value), vm_params|
+        allowed_vm_params.each do |param|
+          # VM-specific parameters are named as instance_name-<VM_ID>. The
+          # following will test the param name for this kind of pattern and use
+          # the <VM_ID> to store the configuration about this VM.
+          param_match = key.match(/#{param}-([0-9a-f-]*)/)
+          next if param_match.nil?
+
+          vm_id = param_match.captures.first
+          vm_params[vm_id] ||= {}
+          # Store the parameter value.
+          vm_params[vm_id][param] = value
+        end
+      end
     end
   end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -1,9 +1,17 @@
 class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < OrchestrationTemplate
   def parameter_groups
-    [OrchestrationTemplate::OrchestrationParameterGroup.new(
+    # Define vApp's general purpose parameters.
+    groups = [OrchestrationTemplate::OrchestrationParameterGroup.new(
       :label      => "vApp Parameters",
       :parameters => vapp_parameters,
     )]
+
+    # Parse template's OVF file
+    ovf_doc = MiqXml.load(content)
+    # Collect VM-specific parameters from the OVF template if it is a valid one.
+    groups.concat(vm_param_groups(ovf_doc.root)) unless ovf_doc.root.nil?
+
+    groups
   end
 
   def vapp_parameters
@@ -27,6 +35,41 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
         ]
       )
     ]
+  end
+
+  def vm_param_groups(ovf)
+    groups = []
+    # Parse the XML template document for specific vCloud attributes.
+    ovf.each_element("//vcloud:GuestCustomizationSection") do |el|
+      vm_id = el.elements["vcloud:VirtualMachineId"].text
+      vm_name = el.elements["vcloud:ComputerName"].text
+
+      groups << OrchestrationTemplate::OrchestrationParameterGroup.new(
+        :label      => vm_name,
+        :parameters => [
+          # Name of the provisioned instance.
+          OrchestrationTemplate::OrchestrationParameter.new(
+            :name          => "instance_name-#{vm_id}",
+            :label         => "Instance name",
+            :data_type     => "string",
+            :default_value => vm_name
+          ),
+
+          # List of available VDC networks.
+          OrchestrationTemplate::OrchestrationParameter.new(
+            :name          => "vdc_network-#{vm_id}",
+            :label         => "Network",
+            :data_type     => "string",
+            :default_value => "(default)",
+            :constraints   => [
+              OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(:fqname => "/Cloud/Orchestration/Operations/Methods/Available_Vdc_Networks")
+            ]
+          )
+        ]
+      )
+    end
+
+    groups
   end
 
   def self.eligible_manager_types

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
@@ -24,4 +24,86 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
       expect(template.validate_format).not_to be_nil
     end
   end
+
+  describe "OVF content of vApp template" do
+    let(:vdc_net1) { FactoryGirl.create(:cloud_network_vmware_vdc, :name => "VDC1", :ems_ref => "vdc_net1") }
+    let(:vapp_net) { FactoryGirl.create(:cloud_network_vmware_vapp, :name => "vapp", :ems_ref => "vapp") }
+    let(:ems) do
+      FactoryGirl.create(:ems_vmware_cloud) do |ems|
+        ems.cloud_networks << vdc_net1
+        ems.cloud_networks << vapp_net
+      end
+    end
+    let(:orchestration_template) { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content, :ems_id => ems.id) }
+
+    context "orchestration template OVF file" do
+      it "is properly read" do
+        expect(orchestration_template.content.include?('ovf:Envelope')).to be_truthy
+      end
+
+      it "is parsed using MiqXml" do
+        ovf_doc = MiqXml.load(orchestration_template.content)
+
+        expect(ovf_doc).not_to be(nil)
+        expect(ovf_doc.root.name).not_to be("Envelope")
+      end
+    end
+
+    context "orchestration template" do
+      it "creates parameter groups for the given template" do
+        parameter_groups = orchestration_template.parameter_groups
+
+        expect(parameter_groups.size).to eq(3)
+
+        assert_vapp_parameter_group(parameter_groups[0])
+        assert_vm_parameter_group(parameter_groups[1], "VM1", "e9b55b85-640b-462c-9e7a-d18c47a7a5f3")
+        assert_vm_parameter_group(parameter_groups[2], "VM2", "04f85cca-3f8d-43b4-8473-7aa099f95c1b")
+      end
+    end
+  end
+
+  def assert_vapp_parameter_group(group)
+    expect(group.parameters.size).to eq(2)
+
+    expect(group.parameters[0]).to have_attributes(
+      :name          => "deploy",
+      :label         => "Deploy vApp",
+      :data_type     => "boolean",
+      :default_value => true,
+    )
+    expect(group.parameters[0].constraints.size).to be(1)
+    expect(group.parameters[0].constraints[0]).to be_instance_of(OrchestrationTemplate::OrchestrationParameterBoolean)
+    expect(group.parameters[1]).to have_attributes(
+      :name          => "powerOn",
+      :label         => "Power On vApp",
+      :data_type     => "boolean",
+      :default_value => false,
+    )
+    expect(group.parameters[1].constraints.size).to be(1)
+    expect(group.parameters[1].constraints[0]).to be_instance_of(OrchestrationTemplate::OrchestrationParameterBoolean)
+  end
+
+  def assert_vm_parameter_group(group, vm_name, vm_id)
+    expect(group.parameters.size).to eq(2)
+
+    assert_parameter(group.parameters[0],
+                     :name          => "instance_name-#{vm_id}",
+                     :label         => "Instance name",
+                     :data_type     => "string",
+                     :default_value => vm_name)
+
+    assert_parameter(group.parameters[1],
+                     :name          => "vdc_network-#{vm_id}",
+                     :label         => "Network",
+                     :data_type     => "string",
+                     :default_value => "(default)")
+
+    network_parameter = group.parameters[1]
+    expect(network_parameter.constraints.count).to eq(1)
+    expect(network_parameter.constraints[0].fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Vdc_Networks")
+  end
+
+  def assert_parameter(field, attributes)
+    expect(field).to have_attributes(attributes)
+  end
 end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/vmware_vcloud_ovf.xml
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/vmware_vcloud_ovf.xml
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://vcd-portal.vmware.local/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+    <ovf:References/>
+    <ovf:NetworkSection>
+        <ovf:Info>The list of logical networks</ovf:Info>
+        <ovf:Network ovf:name="none">
+            <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+        </ovf:Network>
+    </ovf:NetworkSection>
+    <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
+        <ovf:Info>VApp template customization section</ovf:Info>
+        <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
+    </vcloud:CustomizationSection>
+    <vcloud:NetworkConfigSection ovf:required="false">
+        <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+        <vcloud:NetworkConfig networkName="none">
+            <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
+            <vcloud:Configuration>
+                <vcloud:IpScopes>
+                    <vcloud:IpScope>
+                        <vcloud:IsInherited>false</vcloud:IsInherited>
+                        <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
+                        <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
+                        <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
+                    </vcloud:IpScope>
+                </vcloud:IpScopes>
+                <vcloud:FenceMode>isolated</vcloud:FenceMode>
+            </vcloud:Configuration>
+            <vcloud:IsDeployed>false</vcloud:IsDeployed>
+        </vcloud:NetworkConfig>
+    </vcloud:NetworkConfigSection>
+    <vcloud:LeaseSettingsSection ovf:required="false">
+        <ovf:Info>Lease settings section</ovf:Info>
+        <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
+        <vcloud:StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</vcloud:StorageLeaseExpiration>
+    </vcloud:LeaseSettingsSection>
+    <ovf:VirtualSystemCollection ovf:id="vapp_template">
+        <ovf:Info>A collection of virtual machines</ovf:Info>
+        <ovf:Name>sample_vapp_template</ovf:Name>
+        <ovf:StartupSection>
+            <ovf:Info>VApp startup section</ovf:Info>
+            <ovf:Item ovf:id="VM1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+            <ovf:Item ovf:id="VM2" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+        </ovf:StartupSection>
+        <ovf:VirtualSystem ovf:id="VM1">
+            <ovf:Info>A virtual machine</ovf:Info>
+            <ovf:Name>VM1</ovf:Name>
+            <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
+                <ovf:Info>Specifies the operating system installed</ovf:Info>
+                <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+            </ovf:OperatingSystemSection>
+            <ovf:VirtualHardwareSection ovf:transport="">
+                <ovf:Info>Virtual hardware requirements</ovf:Info>
+                <ovf:System>
+                    <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                    <vssd:InstanceID>0</vssd:InstanceID>
+                    <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                    <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                </ovf:System>
+                <ovf:Item>
+                    <rasd:Address>00:50:56:01:00:4d</rasd:Address>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                    <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                    <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                    <rasd:InstanceID>1</rasd:InstanceID>
+                    <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                    <rasd:ResourceType>10</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+                    <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>SCSI Controller</rasd:Description>
+                    <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>2</rasd:InstanceID>
+                    <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                    <rasd:ResourceType>6</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="16"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:Description>Hard disk</rasd:Description>
+                    <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                    <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                    <rasd:InstanceID>2000</rasd:InstanceID>
+                    <rasd:Parent>2</rasd:Parent>
+                    <rasd:ResourceType>17</rasd:ResourceType>
+                    <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                    <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                    <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>IDE Controller</rasd:Description>
+                    <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>3</rasd:InstanceID>
+                    <rasd:ResourceType>5</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>Floppy Drive</rasd:Description>
+                    <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>8000</rasd:InstanceID>
+                    <rasd:ResourceType>14</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                    <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                    <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                    <rasd:InstanceID>4</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>3</rasd:ResourceType>
+                    <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                    <rasd:Description>Memory Size</rasd:Description>
+                    <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                    <rasd:InstanceID>5</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>4</rasd:ResourceType>
+                    <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>CD/DVD Drive</rasd:Description>
+                    <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>3000</rasd:InstanceID>
+                    <rasd:Parent>3</rasd:Parent>
+                    <rasd:ResourceType>15</rasd:ResourceType>
+                </ovf:Item>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
+            </ovf:VirtualHardwareSection>
+            <vcloud:GuestCustomizationSection ovf:required="false">
+                <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                <vcloud:Enabled>false</vcloud:Enabled>
+                <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                <vcloud:VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</vcloud:VirtualMachineId>
+                <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
+                <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                <vcloud:ComputerName>VM1</vcloud:ComputerName>
+            </vcloud:GuestCustomizationSection>
+            <vcloud:NetworkConnectionSection ovf:required="false">
+                <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                <vcloud:NetworkConnection needsCustomization="true" network="none">
+                    <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                    <vcloud:IsConnected>false</vcloud:IsConnected>
+                    <vcloud:MACAddress>00:50:56:01:00:4d</vcloud:MACAddress>
+                    <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                </vcloud:NetworkConnection>
+            </vcloud:NetworkConnectionSection>
+        </ovf:VirtualSystem>
+        <ovf:VirtualSystem ovf:id="VM2">
+            <ovf:Info>A virtual machine</ovf:Info>
+            <ovf:Name>VM2</ovf:Name>
+            <ovf:OperatingSystemSection ovf:id="112" vmw:osType="centos64Guest">
+                <ovf:Info>Specifies the operating system installed</ovf:Info>
+                <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+            </ovf:OperatingSystemSection>
+            <ovf:VirtualHardwareSection ovf:transport="">
+                <ovf:Info>Virtual hardware requirements</ovf:Info>
+                <ovf:System>
+                    <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                    <vssd:InstanceID>0</vssd:InstanceID>
+                    <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                    <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                </ovf:System>
+                <ovf:Item>
+                    <rasd:Address>00:50:56:01:00:4c</rasd:Address>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                    <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                    <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                    <rasd:InstanceID>1</rasd:InstanceID>
+                    <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                    <rasd:ResourceType>10</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="192"/>
+                    <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>SCSI Controller</rasd:Description>
+                    <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>2</rasd:InstanceID>
+                    <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+                    <rasd:ResourceType>6</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:Description>Hard disk</rasd:Description>
+                    <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                    <rasd:HostResource vcloud:capacity="40960" vcloud:busSubType="lsilogicsas" vcloud:busType="6"/>
+                    <rasd:InstanceID>2000</rasd:InstanceID>
+                    <rasd:Parent>2</rasd:Parent>
+                    <rasd:ResourceType>17</rasd:ResourceType>
+                    <rasd:VirtualQuantity>42949672960</rasd:VirtualQuantity>
+                    <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                    <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>SATA Controller</rasd:Description>
+                    <rasd:ElementName>SATA Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>3</rasd:InstanceID>
+                    <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
+                    <rasd:ResourceType>20</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="33"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>CD/DVD Drive</rasd:Description>
+                    <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>16000</rasd:InstanceID>
+                    <rasd:Parent>3</rasd:Parent>
+                    <rasd:ResourceType>15</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>Floppy Drive</rasd:Description>
+                    <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>8000</rasd:InstanceID>
+                    <rasd:ResourceType>14</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                    <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                    <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                    <rasd:InstanceID>4</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>3</rasd:ResourceType>
+                    <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                    <rasd:Description>Memory Size</rasd:Description>
+                    <rasd:ElementName>4096 MB of memory</rasd:ElementName>
+                    <rasd:InstanceID>5</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>4</rasd:ResourceType>
+                    <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204a04c-cb69-b862-2a14-5d573643bf78"/>
+            </ovf:VirtualHardwareSection>
+            <vcloud:GuestCustomizationSection ovf:required="false">
+                <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                <vcloud:Enabled>true</vcloud:Enabled>
+                <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                <vcloud:VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</vcloud:VirtualMachineId>
+                <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                <vcloud:AdminPasswordEnabled>false</vcloud:AdminPasswordEnabled>
+                <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                <vcloud:ComputerName>VM2</vcloud:ComputerName>
+            </vcloud:GuestCustomizationSection>
+            <vcloud:NetworkConnectionSection ovf:required="false">
+                <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                <vcloud:NetworkConnection needsCustomization="true" network="none">
+                    <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                    <vcloud:IsConnected>false</vcloud:IsConnected>
+                    <vcloud:MACAddress>00:50:56:01:00:4c</vcloud:MACAddress>
+                    <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                </vcloud:NetworkConnection>
+            </vcloud:NetworkConnectionSection>
+        </ovf:VirtualSystem>
+    </ovf:VirtualSystemCollection>
+</ovf:Envelope>

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -40,7 +40,7 @@ describe OrchestrationTemplateDialogService do
 
       tabs = dialog.dialog_tabs
       assert_tab_attributes(tabs[0])
-      expect(tabs[0].dialog_groups.size).to eq(2)
+      expect(tabs[0].dialog_groups.size).to eq(4)
       assert_vmware_cloud_stack_group(tabs[0].dialog_groups[0])
       assert_vmware_cloud_parameters_group(tabs[0].dialog_groups[1])
     end


### PR DESCRIPTION
Previously users were only allowed to modify the name of the provisioned vApp and parameters that control the power state of the vApp.

With this change we are adding support for changing the name of the instance as well as the ability to select a different VDC network to which instances may be connected.

Currently we are focusing on the UI part of the changes. I am also adding the spec file for these kinds of tests (it's not complete yet as more different cases are needed). The spec file was previously not used because I was mainly following other orchestration templates.

@miq-bot add_label providers/vmware/cloud, enhancement, ui, wip

<img width="1113" alt="screen shot 2016-10-28 at 15 46 07" src="https://cloud.githubusercontent.com/assets/1437960/19810840/4cf2df68-9d2f-11e6-824b-f86d7c7172a3.png">
