### PR TITLE
Validate CPU and Memory Hot-Plug settings in reconfigure

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/reconfigure.rb
@@ -66,8 +66,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure
         vm_memory = options[:vm_memory].to_i
 
         raise MiqException::MiqVmError, "Memory Hot-Add not enabled"                                if vm_memory > ram_size && !memory_hot_add_enabled
+        raise MiqException::MiqVmError, "Cannot add more than #{memory_hot_add_limit}MB to this VM" if vm_memory > ram_size && vm_memory > memory_hot_add_limit
         raise MiqException::MiqVmError, "Cannot remove memory from a running VM"                    if vm_memory < ram_size
-        raise MiqException::MiqVmError, "Cannot add more than #{memory_hot_add_limit}MB to this VM" if vm_memory > memory_hot_add_limit
       end
     end
   end

--- a/spec/factories/hardware.rb
+++ b/spec/factories/hardware.rb
@@ -18,6 +18,12 @@ FactoryGirl.define do
       cpu_total_cores      2
     end
 
+    trait(:cpu4x2) do
+      cpu_sockets          4
+      cpu_cores_per_socket 2
+      cpu_total_cores      8
+    end
+
     trait(:ram1GB) { memory_mb 1024 }
   end
 end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       :name            => 'test_vm',
       :raw_power_state => 'poweredOff',
       :storage         => FactoryGirl.create(:storage, :name => 'storage'),
-      :hardware        => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB, :virtual_hw_version => "07")
+      :hardware        => FactoryGirl.create(:hardware, :cpu4x2, :ram1GB, :virtual_hw_version => "07")
     )
   end
 
@@ -91,6 +91,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
 
       context "with CPU Hot-Add disabled" do
         it "raises an exception when adding CPUs" do
+          options[:number_of_cpus] = '16'
           expect { subject }.to raise_error(MiqException::MiqVmError, "CPU Hot-Add not enabled")
         end
       end
@@ -114,14 +115,15 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         end
 
         it "sets numCPUs correctly" do
-          expect(subject["numCPUs"]).to eq(8)
+          options[:number_of_cpus] = '16'
+
+          expect(subject["numCPUs"]).to eq(16)
         end
       end
 
       context "with Memory Hot-Add disabled" do
         it "raises an exception when adding RAM" do
-          options[:vm_memory]      = '2048'
-          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+          options[:vm_memory] = '2048'
 
           expect { subject }.to raise_error(MiqException::MiqVmError, "Memory Hot-Add not enabled")
         end
@@ -134,22 +136,19 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
         end
 
         it "raises an exception when removing memory" do
-          options[:vm_memory]      = '512'
-          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+          options[:vm_memory] = '512'
 
           expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot remove memory from a running VM")
         end
 
         it "raises an exception if adding more than the memory limit" do
-          options[:vm_memory]      = '4096'
-          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+          options[:vm_memory] = '4096'
 
           expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot add more than 2048MB to this VM")
         end
 
         it "sets memoryMB correctly" do
           options[:vm_memory] = '1536'
-          options[:number_of_cpus] = vm.cpu_total_cores.to_s
 
           expect(subject["memoryMB"]).to eq(1536)
         end

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -2,9 +2,10 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
   let(:vm) do
     FactoryGirl.create(
       :vm_vmware,
-      :name     => 'test_vm',
-      :storage  => FactoryGirl.create(:storage, :name => 'storage'),
-      :hardware => FactoryGirl.create(:hardware, :virtual_hw_version => "07")
+      :name            => 'test_vm',
+      :raw_power_state => 'poweredOff',
+      :storage         => FactoryGirl.create(:storage, :name => 'storage'),
+      :hardware        => FactoryGirl.create(:hardware, :virtual_hw_version => "07")
     )
   end
 

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/reconfigure_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       :name            => 'test_vm',
       :raw_power_state => 'poweredOff',
       :storage         => FactoryGirl.create(:storage, :name => 'storage'),
-      :hardware        => FactoryGirl.create(:hardware, :virtual_hw_version => "07")
+      :hardware        => FactoryGirl.create(:hardware, :cpu2x2, :ram1GB, :virtual_hw_version => "07")
     )
   end
 
@@ -81,6 +81,78 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::Reconfigure do
       it "vm_vmware virtual_hw_version != 07" do
         vm.hardware.update_attributes(:virtual_hw_version => "08")
         expect(subject["numCoresPerSocket"]).to eq(2)
+      end
+    end
+
+    context "Running VM" do
+      before do
+        vm.update_attributes(:raw_power_state => 'poweredOn')
+      end
+
+      context "with CPU Hot-Add disabled" do
+        it "raises an exception when adding CPUs" do
+          expect { subject }.to raise_error(MiqException::MiqVmError, "CPU Hot-Add not enabled")
+        end
+      end
+
+      context "with CPU Hot-Add enabled" do
+        before do
+          vm.update_attributes(:cpu_hot_add_enabled    => true,
+                               :cpu_hot_remove_enabled => false)
+        end
+
+        it "raises an exception when removing CPUs" do
+          options[:number_of_cpus] = '2'
+
+          expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot remove CPUs from a running VM")
+        end
+
+        it "raises an exception when changing numCoresPerSocket" do
+          options[:cores_per_socket] = 4
+
+          expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot change CPU cores per socket on a running VM")
+        end
+
+        it "sets numCPUs correctly" do
+          expect(subject["numCPUs"]).to eq(8)
+        end
+      end
+
+      context "with Memory Hot-Add disabled" do
+        it "raises an exception when adding RAM" do
+          options[:vm_memory]      = '2048'
+          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+
+          expect { subject }.to raise_error(MiqException::MiqVmError, "Memory Hot-Add not enabled")
+        end
+      end
+
+      context "with Memory Hot-Add enabled" do
+        before do
+          vm.update_attributes(:memory_hot_add_enabled => true,
+                               :memory_hot_add_limit   => 2048)
+        end
+
+        it "raises an exception when removing memory" do
+          options[:vm_memory]      = '512'
+          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+
+          expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot remove memory from a running VM")
+        end
+
+        it "raises an exception if adding more than the memory limit" do
+          options[:vm_memory]      = '4096'
+          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+
+          expect { subject }.to raise_error(MiqException::MiqVmError, "Cannot add more than 2048MB to this VM")
+        end
+
+        it "sets memoryMB correctly" do
+          options[:vm_memory] = '1536'
+          options[:number_of_cpus] = vm.cpu_total_cores.to_s
+
+          expect(subject["memoryMB"]).to eq(1536)
+        end
       end
     end
   end


### PR DESCRIPTION
This validates a number of cases related to reconfigure on powered-on VMs that would lead to sometimes cryptic VMware error messages.

The cases covered are:
1. Adding CPUs to a running VM that doesn't have CPU hot-add enabled
   ![screenshot from 2016-10-28 11-27-26](https://cloud.githubusercontent.com/assets/12851112/19811949/9f0980c8-9d01-11e6-9566-c22f9ef2e9cf.png)
2. Removing CPUs from a running VM
   ![screenshot from 2016-10-28 11-29-30](https://cloud.githubusercontent.com/assets/12851112/19812027/e4032828-9d01-11e6-9edb-b9152469454b.png)
3. Changing the number of cores per sockets on a running VM
   ![screenshot from 2016-10-28 11-31-56](https://cloud.githubusercontent.com/assets/12851112/19812091/348e0560-9d02-11e6-9943-dee6de838436.png)
4. Adding memory to a running VM that doesn't have memory hot-add enabled
   ![screenshot from 2016-10-28 11-33-27](https://cloud.githubusercontent.com/assets/12851112/19812146/68dce188-9d02-11e6-8363-6fd8d99fe107.png)
5. Removing memory from a running VM
   ![screenshot from 2016-10-28 11-34-41](https://cloud.githubusercontent.com/assets/12851112/19812196/956c139a-9d02-11e6-9ed0-5524eb27df6d.png)
6. Adding more than the memory hot-add limit to a running VM
   ![screenshot from 2016-10-28 11-36-40](https://cloud.githubusercontent.com/assets/12851112/19812266/dae5f6c0-9d02-11e6-997a-7ed92051b3cb.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1386843