### PR TITLE
Upgrade rake to 11, and haml_lint to 0.18.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ end
 #
 unless ENV["APPLIANCE"]
   group :development do
-    gem "haml_lint",        "~>0.16.1", :require => false
+    gem "haml_lint",        "~>0.18.0", :require => false
     gem "rubocop",          "~>0.37.2", :require => false
     gem "scss_lint",        "~>0.48.0", :require => false
   end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -37,7 +37,7 @@ gem "parallel",                "~>1.9",             :require => false # For Ovir
 gem "pg",                      "~>0.18.2",          :require => false
 gem "pg-dsn_parser",           "~>0.1.0",           :require => false
 gem "psych",                   "~>2.0.12"
-gem "rake",                    "~>10.1"
+gem "rake",                    ">=11.0"
 gem "rbvmomi",                 "~>1.9.4",           :require => false
 gem "rest-client",             "~>2.0.0",           :require => false
 gem "rubyzip",                 "~>1.2.0",           :require => false


### PR DESCRIPTION
This upgrades our rake dependency from 10.x to 11.x. It also upgrades haml_lint, mostly because the current version has a dependency on rake 10.x.

rake changes:

https://github.com/ruby/rake/blob/master/History.rdoc

haml_lint changes:

https://github.com/brigade/haml-lint/blob/master/CHANGELOG.md