### PR TITLE
Use memory store for assets in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,11 @@ Vmdb::Application.configure do
   config.public_file_server.enabled = true
   config.static_cache_control = "public, max-age=3600"
 
+  # Avoid potential warnings and race conditions
+  config.assets.configure do |env|
+    env.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+  end
+
   # Log error messages when you accidentally call methods on nil
   config.whiny_nils = true
 


### PR DESCRIPTION
This is an attempt to resolve sporadic test failures caused by the Azure specs. This appears to be a race condition caused by the clear_caches method that is being called within the specs, which then tries to clear the asset cache.

By altering the store, I'm hoping to avoid the issue altogether.