### PR TITLE
Split up CI scripts

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,24 +1,16 @@
 set -v
 
-echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
-travis_retry gem install bundler -v ">= 1.11.1"
-
 if [[ -n "${GEM}" ]] ; then
   cd gems/${GEM}
 else
-  echo "1" > REGION
-  cp certs/v2_key.dev certs/v2_key
-  cp config/database.pg.yml config/database.yml
-  cp config/cable.yml.sample config/cable.yml
-  psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres
-  export BUNDLE_WITHOUT=development
+  source $TRAVIS_BUILD_DIR/tools/ci/setup_vmdb_configs.sh
 fi
-export BUNDLE_GEMFILE=${PWD}/Gemfile
+
+source $TRAVIS_BUILD_DIR/tools/ci/setup_ruby_env.sh
 
 # suites that need bower assets to work: javascript, vmdb
 if [[ "$TEST_SUITE" = "javascript" ]] || [[ "$TEST_SUITE" = "vmdb" ]]; then
-  which bower || npm install -g bower
-  bower install --allow-root -F --config.analytics=false
+  source $TRAVIS_BUILD_DIR/tools/ci/setup_js_env.sh
 fi
 
 set +v

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,0 +1,2 @@
+which bower || npm install -g bower
+bower install --allow-root -F --config.analytics=false

--- a/tools/ci/setup_ruby_env.sh
+++ b/tools/ci/setup_ruby_env.sh
@@ -1,0 +1,4 @@
+echo "gem: --no-ri --no-rdoc --no-document" > ~/.gemrc
+travis_retry gem install bundler -v ">= 1.11.1"
+export BUNDLE_WITHOUT=development
+export BUNDLE_GEMFILE=${PWD}/Gemfile

--- a/tools/ci/setup_vmdb_configs.sh
+++ b/tools/ci/setup_vmdb_configs.sh
@@ -1,0 +1,5 @@
+echo "1" > REGION
+cp certs/v2_key.dev certs/v2_key
+cp config/database.pg.yml config/database.yml
+cp config/cable.yml.sample config/cable.yml
+psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres


### PR DESCRIPTION
extracted from provider generator PR https://github.com/ManageIQ/manageiq/pull/12209

This is done to call those scripts as needed from a provider repo.
See https://github.com/ManageIQ/manageiq-providers-amazon/pull/71

@miq-bot assign jrafanie 
@miq-bot add_labels refactoring, pluggable providers
