### PR TITLE
Support automate model git repositories without domain directory

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -147,7 +147,11 @@ class MiqAeYamlImport
   end
 
   def process_namespace(domain_obj, namespace_folder, _namespace_yaml, domain_name)
-    fqname = "#{domain_name}#{namespace_folder.sub(domain_folder(@domain_name), '')}"
+    fqname = if @domain_name == '.'
+               "#{domain_name}/#{namespace_folder}"
+             else
+               "#{domain_name}#{namespace_folder.sub(domain_folder(@domain_name), '')}"
+             end
     _log.info("Importing namespace: <#{fqname}>")
     namespace_obj = MiqAeNamespace.find_by_fqname(fqname, false)
     track_stats('namespace', namespace_obj)

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import_gitfs.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import_gitfs.rb
@@ -38,12 +38,21 @@ class MiqAeYamlImportGitfs < MiqAeYamlImport
   end
 
   def domain_files(domain)
-    glob_str = (domain == '*') ? File.join('**', DOMAIN_YAML_FILENAME) : File.join('**', domain, DOMAIN_YAML_FILENAME)
+    glob_str = if (domain == '*' || domain == '.') 
+                 File.join('**', DOMAIN_YAML_FILENAME)
+               else
+                 File.join('**', domain, DOMAIN_YAML_FILENAME)
+               end
     @files.select { |entry| File.fnmatch(glob_str, entry, @fn_flags) }
   end
 
   def namespace_files(parent_folder)
-    glob_str = File.join(parent_folder, "*", NAMESPACE_YAML_FILENAME)
+    glob_str = if parent_folder == '.'
+                 File.join("*", NAMESPACE_YAML_FILENAME)
+               else
+                 File.join(parent_folder, "*", NAMESPACE_YAML_FILENAME)
+               end
+
     @files.select { |entry| File.fnmatch(glob_str, entry, @fn_flags) }
   end
 

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import_gitfs.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import_gitfs.rb
@@ -38,7 +38,7 @@ class MiqAeYamlImportGitfs < MiqAeYamlImport
   end
 
   def domain_files(domain)
-    glob_str = if (domain == '*' || domain == '.') 
+    glob_str = if domain == '*' || domain == '.'
                  File.join('**', DOMAIN_YAML_FILENAME)
                else
                  File.join('**', domain, DOMAIN_YAML_FILENAME)


### PR DESCRIPTION
A user could build the Automate Git Repository with or without the top level domain directory.
This PR allows for a Git Repository to work with or without the top level directory.
## Links [Optional]
- https://bugzilla.redhat.com/show_bug.cgi?id=1389823
## Steps for Testing/QA [Optional]

Create a git repo without the top level directory
