### PR TITLE
Sporadic failure during Automation Tests

### DIFF
--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -74,6 +74,7 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
   end
 
   def number_of_vms_from_dialog(root_svc, parent_task)
+    return nil unless root_svc.options[:dialog]
     value = root_svc.options[:dialog]["dialog_option_0_number_of_vms"]
     if parent_task.service_resource
       index = parent_task.service_resource.provision_index


### PR DESCRIPTION
Sporadic Automate Spec failure with the following stack trace.
The tasks were not getting generated

```
1) CatalogBundleInitialization Automate Method override service name and description
     [31mFailure/Error: raise MiqAeException::AbortInstantiation, msg[0m
     [31m[0m
     [31mMiqAeException::AbortInstantiation:[0m
     [31m  Method exited with rc=MIQ_ABORT[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_method.rb:137:in `process_ruby_method_results'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_method.rb:161:in `block in invoke_inline_ruby'[0m
     [36m# ./lib/miq_automation_engine/engine/drb_remote_invoker.rb:17:in `with_server'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_method.rb:157:in `invoke_inline_ruby'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_method.rb:9:in `invoke_inline'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_method.rb:64:in `invoke'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:465:in `invoke_method'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:364:in `block in process_method_raw'[0m
     [36m# ./gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'[0m
     [36m# ./gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:357:in `process_method_raw'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:370:in `process_method'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:311:in `block in process_filtered_fields'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:306:in `each'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:306:in `process_filtered_fields'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:302:in `process_fields'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_workspace.rb:152:in `instantiate'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:614:in `process_relationship_raw'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:350:in `process_relationship'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:311:in `block in process_filtered_fields'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:306:in `each'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:306:in `process_filtered_fields'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_object.rb:302:in `process_fields'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_workspace.rb:152:in `instantiate'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_workspace.rb:66:in `instantiate'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_engine.rb:23:in `block in instantiate'[0m
     [36m# ./gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'[0m
     [36m# ./gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'[0m
     [36m# ./lib/miq_automation_engine/engine/miq_ae_engine.rb:23:in `instantiate'[0m
     [36m# ./spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb:39:in `run_automate_method'[0m
     [36m# ./spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb:82:in `process_stp'[0m
     [36m# ./spec/automation/unit/method_validation/catalog_bundle_initialization_spec.rb:88:in `block (3 levels) in <top (required)>'[0m

```
