### PR TITLE
Check the dialog_fields labels without regard to order

### DIFF
--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -33,19 +33,10 @@ describe DialogGroup do
           { 'name' => 'new field', 'label' => 'new field label' }
         ]
       end
-
-      it 'updates a the dialog fields with an id' do
+      it 'creates or updates the dialog fields' do
         dialog_group.update_dialog_fields(updated_fields)
-
         dialog_group.reload
-        expect(dialog_group.dialog_fields.first.label).to eq('updated_field_label')
-        expect(dialog_group.dialog_fields.last.label).to eq('updated_field_label')
-      end
-
-      it 'creates a new dialog field from the dialog fields without an id' do
-        expect do
-          dialog_group.update_dialog_fields(updated_fields)
-        end.to change(dialog_group.reload.dialog_fields, :count).by(1)
+        expect(dialog_group.dialog_fields.collect(&:label)).to match_array(['updated_field_label', 'updated_field_label', 'new field label'])
       end
     end
 


### PR DESCRIPTION
Fixes a sporadic test failure:
```
  1) DialogGroup#update_dialog_fields a collection of dialog fields containing two objects with ids and one without an id updates a the dialog fields with an id
     Failure/Error: expect(dialog_group.dialog_fields.first.label).to eq('updated_field_label')

       expected: "updated_field_label"
            got: "new field label"

       (compared using ==)
     # ./spec/models/dialog_group_spec.rb:41:in `block (4 levels) in <top (required)>'
```
This was added in #11833. (therefore euwe/no)

cc @jntullo Maybe we shouldn't use `.first` or `.last` in tests or code where order is important.  I'm not fixing that here but it's worth looking into.

Note, we saw this fail in #12041.