### PR TITLE
Fix OpenStack event filtering

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -90,6 +90,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def self.default_blacklisted_event_names
     %w(
+      identity.authenticate
       scheduler.run_instance.start
       scheduler.run_instance.scheduled
       scheduler.run_instance.end

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -49,8 +49,8 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
   end
 
   def process_event(event)
-    if filtered_events.include?(event.payload[:event_type])
-      _log.info "#{log_prefix} Skipping caught event [#{event.payload["event_type"]}]"
+    if filtered_events.include?(event.payload["event_type"])
+      _log.debug "#{log_prefix} Skipping caught event [#{event.payload["event_type"]}]"
     else
       _log.info "#{log_prefix} Caught event [#{event.payload["event_type"]}]"
 


### PR DESCRIPTION
OpenStack event filtering was looking up the event_type from the event_payload using `:event_type` (symbol).  However, the event_type is keyed by string (`"event_type"`).

This causes the event filtering to fail, allowing all events through to the process_event method and into the event_streams table.  This patch changes the `Openstack::EventCatcher` to use string hash keys when looking up the `event_type` during filtering.

Skipped events are now logged at `debug` level instead of `info`.  In the lab environment where this was occurring, there were >100,000 `identity.authenticate` events in 12 hours.

Additionally, this fix adds `identity.authenticate` as a predefined filtered event for OpenStack.  As of OSP 9, `identity.authenticate` is a common event emitted from KeyStone used for internal auditing that should be ignored by ManageIQ.

https://bugzilla.redhat.com/show_bug.cgi?id=1389848
