### PR TITLE
Fixed Remove Catalog button text

### DIFF
--- a/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
+++ b/app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb
@@ -22,10 +22,10 @@ class ApplicationHelper::Toolbar::ServicetemplatecatalogsCenter < ApplicationHel
         button(
           :st_catalog_delete,
           'pficon pficon-delete fa-lg',
-          N_('Remove selected Catalog Items'),
-          N_('Remove Catalog Items'),
+          N_('Remove selected Catalogs'),
+          N_('Remove Catalogs'),
           :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Items will be permanently removed!"),
+          :confirm   => N_("Warning: The selected Catalogs will be permanently removed!"),
           :enabled   => false,
           :onwhen    => "1+"),
       ]


### PR DESCRIPTION
Configure drop-down button fixed to refer to Catalogs, not Items.

Also fixed Confirm Dialog text to mention Catalogs, not Items. 

https://bugzilla.redhat.com/show_bug.cgi?id=1380534

Attached are screen shots before and after. Button text prior to fix:
![remove catalog items button text prior to fix](https://cloud.githubusercontent.com/assets/552686/19824626/03610130-9d26-11e6-93e1-eda9cd649de6.png)

Remove Catalog Confirmation dialog text, prior to fix:
![remove catalogs confirmation dialog text prior to fix](https://cloud.githubusercontent.com/assets/552686/19824633/1576c86e-9d26-11e6-8304-53aa4da2879b.png)

Fixed button text:
![remove catalogs button text fixed](https://cloud.githubusercontent.com/assets/552686/19824640/28965374-9d26-11e6-902a-42872d8fc6ea.png)

Fixed Remove catalogs confirmation dialog text:
![remove catalogs confirmation dialog text fixed](https://cloud.githubusercontent.com/assets/552686/19824650/3c2eb2e6-9d26-11e6-8d14-e323ad3e2f9a.png)
