### PR TITLE
Expose miq_groups to Automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_user.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_user.rb
@@ -3,6 +3,7 @@ module MiqAeMethodService
     expose :current_group,  :association => true
     expose :current_tenant, :association => true
     expose :vms,            :association => true
+    expose :miq_groups,     :association => true
     expose :miq_requests,   :association => true
     expose :name
     expose :email

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_user_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_user_spec.rb
@@ -3,6 +3,10 @@ module MiqAeServiceUserSpec
     let(:user)         { FactoryGirl.create(:user_admin) }
     let(:service_user) { MiqAeMethodService::MiqAeServiceUser.find(user.id) }
 
+    it "#miq_groups" do
+      expect(described_class.instance_methods).to include(:miq_groups)
+    end
+
     ["current_group", "miq_group"].each do |group|
       it "##{group}" do
         user # create before setting expectation


### PR DESCRIPTION
This PR exposes a user's groups to the Automate engine, addressing a use case presented on ManageIQ Talk.

Links
----------------
* http://talk.manageiq.org/t/how-to-get-multi-groups-of-a-user-in-automation/1799

Steps for Testing/QA 
-------------------------------
Display a user's groups in an Automate method:

```ruby
groups = $evm.vmdb(:user).first.miq_groups
$evm.log(:info, "Displaying the user's groups: #{groups.inspect}")
```