### PR TITLE
[DARGA] Fix missing ip addresses and allocation id ems ref

### DIFF
--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -16,7 +16,7 @@ class FloatingIp < ApplicationRecord
   belongs_to :network_router
 
   def self.available
-    where(:vm_id => nil)
+    where(:vm_id => nil, :network_port_id => nil)
   end
 
   def name

--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -64,7 +64,7 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
 
     if floating_ip
       _log.info("Associating floating IP address [#{floating_ip.address}] to #{for_destination}")
-      associate_floating_ip(floating_ip.address)
+      associate_floating_ip(floating_ip)
     end
 
     signal :post_create_destination

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/configuration.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/configuration.rb
@@ -1,7 +1,8 @@
 module ManageIQ::Providers::Openstack::CloudManager::Provision::Configuration
   def associate_floating_ip(ip_address)
+    # TODO(lsmola) this should be moved to FloatingIp model
     destination.with_provider_object do |instance|
-      instance.associate_address(ip_address)
+      instance.associate_address(ip_address.address)
     end
   end
 

--- a/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
+++ b/gems/manageiq-providers-amazon/app/models/manageiq/providers/amazon/cloud_manager/provision/configuration.rb
@@ -1,7 +1,12 @@
 module ManageIQ::Providers::Amazon::CloudManager::Provision::Configuration
   def associate_floating_ip(ip_address)
+    # TODO(lsmola) this should be moved to FloatingIp model
     destination.with_provider_object do |instance|
-      instance.client.associate_address(:instance_id => instance.instance_id, :public_ip => ip_address)
+      if ip_address.cloud_network_only?
+        instance.client.associate_address(:instance_id => instance.instance_id, :allocation_id => ip_address.ems_ref)
+      else
+        instance.client.associate_address(:instance_id => instance.instance_id, :public_ip => ip_address.address)
+      end
     end
   end
 

--- a/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
+++ b/gems/manageiq-providers-amazon/spec/models/manageiq/providers/amazon/cloud_manager/refresher_other_region_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(ExtManagementSystem.count).to eq(2)
     expect(Flavor.count).to eq(56)
     expect(AvailabilityZone.count).to eq(3)
-    expect(FloatingIp.count).to eq(1)
+    expect(FloatingIp.count).to eq(3)
     expect(AuthPrivateKey.count).to eq(2)
     expect(SecurityGroup.count).to eq(2)
     expect(FirewallRule.count).to eq(4)
@@ -66,7 +66,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
     expect(@ems.flavors.size).to eq(56)
     expect(@ems.availability_zones.size).to eq(3)
-    expect(@ems.floating_ips.size).to eq(1)
+    expect(@ems.floating_ips.size).to eq(3)
     expect(@ems.key_pairs.size).to eq(2)
     expect(@ems.security_groups.size).to eq(2)
     expect(@ems.vms_and_templates.size).to eq(3)
@@ -104,6 +104,14 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     expect(ip).to have_attributes(
       :address            => "54.215.0.230",
       :ems_ref            => "54.215.0.230",
+      :cloud_network_only => false
+    )
+
+    @ip = ManageIQ::Providers::Amazon::NetworkManager::FloatingIp.where(:address => "204.236.137.154").first
+    expect(@ip).to have_attributes(
+      :address            => "204.236.137.154",
+      :ems_ref            => "204.236.137.154",
+      :fixed_ip_address   => "10.191.129.95",
       :cloud_network_only => false
     )
   end
@@ -213,7 +221,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
 
     expect(v.ext_management_system).to eq(@ems)
     expect(v.availability_zone).to eq(@az)
-    expect(v.floating_ip).to be_nil
+    expect(v.floating_ip).to eq(@ip)
     expect(v.flavor).to eq(@flavor)
     expect(v.cloud_network).to          be_nil
     expect(v.cloud_subnet).to           be_nil


### PR DESCRIPTION
Fixing non working VPC floating IP assignment during AWS VM deployment.

Clean cherry-pick of:
https://github.com/ManageIQ/manageiq/pull/11024

Non clean cherry-pick of:
https://github.com/ManageIQ/manageiq-providers-amazon/pull/43
- there were too many chnages to AWS refresh, so I extracted only changes related to the BZ

Steps for Testing/QA [Optional]
-------------------------------

Fixes BZs: 
https://bugzilla.redhat.com/show_bug.cgi?id=1376526
https://bugzilla.redhat.com/show_bug.cgi?id=1376516

I tried to manually deploy Vm with VPC and NON VPC floating IP, works correctly.
