### PR TITLE
Hide unused paging_div on the Reports/Export/Widgets page

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -845,7 +845,7 @@ class ReportController < ApplicationController
     presenter[:right_cell_text] = @right_cell_text
 
     # Handle bottom cell
-    if (@in_a_form || @pages) || (@sb[:pages] && @html)
+    if ((@in_a_form || @pages) || (@sb[:pages] && @html)) && params[:id] != 'xx-exportwidgets'
       if @pages
         @ajax_paging_buttons = true # FIXME: this should not be done this way
         presenter.update(:paging_div, r[:partial => 'layouts/x_pagingcontrols'])


### PR DESCRIPTION
**Before:**
![screenshot from 2016-10-31 12-13-36](https://cloud.githubusercontent.com/assets/649130/19852451/aa290fa0-9f63-11e6-9744-da2f745036df.png)


**After:**
![screenshot from 2016-10-31 12-12-34](https://cloud.githubusercontent.com/assets/649130/19852444/9eb717e8-9f63-11e6-99b8-2404c6833c68.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1352844
