### PR TITLE
A proper way of picking available FloatingIP

### DIFF
--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -12,7 +12,7 @@ class FloatingIp < ApplicationRecord
   belongs_to :network_router
 
   def self.available
-    where(:vm_id => nil)
+    where(:vm_id => nil, :network_port_id => nil)
   end
 
   def name


### PR DESCRIPTION
Neither vm and network port has to be associated. There are
FloatingIps associated only to NetworkPort, these were offered
in provisioning dialog and failed.

Steps for Testing/QA [Optional]
-------------------------------

During provisioning (AWS) only real available FloatingIps should be offered

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1390203