### PR TITLE
Expose authentication_key in EMS service model

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
@@ -17,6 +17,7 @@ module MiqAeMethodService
     expose :authentication_userid
     expose :authentication_password
     expose :authentication_password_encrypted
+    expose :authentication_key
     expose :refresh, :method => :refresh_ems
     expose :provider, :association => true
   end


### PR DESCRIPTION
Expose authentication_key in ext_management_system service model to allow use in Automate.

authentication_key is used for the OpenShift provider, in the same fashion as authentication_user and authentication_password are for other providers.