### PR TITLE
Add tags as columns in containerImageChargeback

### DIFF
--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -59,7 +59,8 @@ class ChargebackContainerImage < Chargeback
       "project_uid"   => project.ems_ref,
       "provider_name" => perf.parent_ems.try(:name),
       "provider_uid"  => perf.parent_ems.try(:name),
-      "archived"      => project.archived? ? _("Yes") : _("No")
+      "archived"      => project.archived? ? _("Yes") : _("No"),
+      "entity"        => image
     }
 
     [key, extra_fields]

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -253,7 +253,8 @@ class MiqExpression
     'VmOrTemplate'                                => 'vm',
     'ManageIQ::Providers::CloudManager::Vm'       => 'vm',
     'ManageIQ::Providers::InfraManager::Vm'       => 'vm',
-    'ContainerProject'                            => 'container_project'
+    'ContainerProject'                            => 'container_project',
+    'ContainerImage'                              => 'container_image'
   }
   EXCLUDE_FROM_RELATS = {
     "ManageIQ::Providers::CloudManager" => ["hosts", "ems_clusters", "resource_pools"]


### PR DESCRIPTION
Same as #10940 but for Container images
This adds tags as available fields\columns in Container image chargeback reports

![screencapture-localhost-3000-report-explorer-1477932621766](https://cloud.githubusercontent.com/assets/11256940/19860707/749b7dc6-9f92-11e6-9a9d-013df6f9447a.png)

@gtanzillo Please review
cc @simon3z 
@miq-bot add_label providers/containers, chargeback