### PR TITLE
Automate - Notification for Service Provisioning error.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Provisioning/StateMachines/ServiceProvision_Template.class/__methods__/update_serviceprovision_status.rb
@@ -22,3 +22,8 @@ updated_message += "Message [#{prov.message}] "
 updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
 prov.miq_request.user_message = updated_message
 prov.message = status
+
+if $evm.root['ae_result'] == "error"
+  $evm.create_notification(:level => "error", :subject => prov.miq_request, \
+                           :message => "Service Provision Error: #{updated_message}")
+end

--- a/spec/automation/unit/method_validation/update_service_provision_status_orchestration_spec.rb
+++ b/spec/automation/unit/method_validation/update_service_provision_status_orchestration_spec.rb
@@ -38,6 +38,20 @@ describe "update_serviceprovision_status" do
       msg = "Server [#{miq_server.name}] Service [#{service_orchestration.name}] Step [] Status [fred] Message [] "
       expect(request.reload.message).to eq(msg)
     end
+
+    it "request message set properly with error" do
+      type = :automate_user_error
+      FactoryGirl.create(:notification_type, :name => type)
+
+      @args = "status=fred&ae_result=error&MiqRequestTask::service_template_provision_task=#{miq_request_task.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
+      expect(Notification.count).to eq(0)
+      add_call_method
+      ws
+      msg = "Server [#{miq_server.name}] Service [#{service_orchestration.name}] Step [] Status [fred] Message [] "
+      expect(request.reload.message).to eq(msg)
+      expect(Notification.find_by(:notification_type_id => NotificationType.find_by_name(type).id)).not_to be_nil
+    end
   end
 
   context "without a stp request object" do


### PR DESCRIPTION
Modified update_serviceprovision_status to generate a notification for services in error.

Message is 'Service Provision Error:' and the enhanced status message for the UI.


![image](https://cloud.githubusercontent.com/assets/11841651/19861287/5ed8840a-9f62-11e6-9778-bf78ebdd9295.png)
