### PR TITLE
Display name of a filter in Infrastructure Providers

### DIFF
--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -36,4 +36,7 @@ module ApplicationController::Filter
     :val2,
   ) do
   end
+  # TODO: expression is now manipulated with fetch_path
+  # We need to extract methods using fetch_path to Expression to avoid the fetch_path call
+  ApplicationController::Filter::Expression.send(:include, MoreCoreExtensions::Shared::Nested)
 end


### PR DESCRIPTION
fixing issue https://github.com/ManageIQ/manageiq/issues/12199

Display name of a choosen filter from My Filters which
was not displayed in Compute -> Infrastructure -> Providers
and also in many other places.

Before
![name_before](https://cloud.githubusercontent.com/assets/13417815/19862244/c56aed66-9f8f-11e6-9a3d-5c150cc1acb2.png)

After
![name_after](https://cloud.githubusercontent.com/assets/13417815/19862250/c883220c-9f8f-11e6-9ac3-5f78b0622afa.png)
