### PR TITLE
Gitignore the new Service UI location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ public/test_grid.xml
 public/test_grid-0.xml
 public/upload
 public/pictures/
-public/self_service/
+public/ui/
 
 # public/dhtmlx/
 public/dhtmlx/dhtmlxtoolbar.js.orig


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq-ui-service/pull/261, the service UI no longer builds to `public/self_service` but to `public/ui/service` .. updating gitignore to reflect that.

(Putting `ui/` instead of `ui/service` on the assumption that if we have another UI that needs to **not** be gitignored, it should not live under `public/` anyway.)

Cc @AllenBW 