### PR TITLE
Allow controllers to specify supports? filters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1577,20 +1577,20 @@ class ApplicationController < ActionController::Base
 
     # Save the paged_view_search_options for download buttons to use later
     session[:paged_view_search_options] = {
-      :parent                => parent ? minify_ar_object(parent) : nil, # Make a copy of parent object (to avoid saving related objects)
-      :parent_method         => options[:parent_method],
-      :targets_hash          => true,
-      :association           => association,
-      :filter                => get_view_filter(options[:filter]),
-      :sub_filter            => get_view_process_search_text(view),
-      :supports_filter       => options[:supports_filter],
-      :page                  => options[:all_pages] ? 1 : @current_page,
-      :per_page              => options[:all_pages] ? ONE_MILLION : @items_per_page,
-      :where_clause          => get_view_where_clause(options[:where_clause]),
-      :named_scope           => options[:named_scope],
-      :display_filter_hash   => options[:display_filter_hash],
-      :userid                => session[:userid],
-      :match_via_descendants => options[:match_via_descendants]
+      :parent                    => parent ? minify_ar_object(parent) : nil, # Make a copy of parent object (to avoid saving related objects)
+      :parent_method             => options[:parent_method],
+      :targets_hash              => true,
+      :association               => association,
+      :filter                    => get_view_filter(options[:filter]),
+      :sub_filter                => get_view_process_search_text(view),
+      :supported_features_filter => options[:supported_features_filter],
+      :page                      => options[:all_pages] ? 1 : @current_page,
+      :per_page                  => options[:all_pages] ? ONE_MILLION : @items_per_page,
+      :where_clause              => get_view_where_clause(options[:where_clause]),
+      :named_scope               => options[:named_scope],
+      :display_filter_hash       => options[:display_filter_hash],
+      :userid                    => session[:userid],
+      :match_via_descendants     => options[:match_via_descendants]
     }
     # Call paged_view_search to fetch records and build the view.table and additional attrs
     view.table, attrs = view.paged_view_search(session[:paged_view_search_options])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1583,6 +1583,7 @@ class ApplicationController < ActionController::Base
       :association           => association,
       :filter                => get_view_filter(options[:filter]),
       :sub_filter            => get_view_process_search_text(view),
+      :supports_filter       => options[:supports_filter],
       :page                  => options[:all_pages] ? 1 : @current_page,
       :per_page              => options[:all_pages] ? ONE_MILLION : @items_per_page,
       :where_clause          => get_view_where_clause(options[:where_clause]),

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -128,10 +128,6 @@ module MiqReport::Search
 
   def filter_results(results, supports_filter)
     return results if supports_filter.nil?
-    filtered_results = []
-    results.each do |result|
-      filtered_results << result if result.send(supports_filter.to_sym)
-    end
-    filtered_results
+    results.select { |result| result.send(supports_filter) }
   end
 end

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -124,6 +124,8 @@ module MiqReport::Search
     return table, attrs
   end
 
+  private
+
   def filter_results(results, supports_filter)
     return results if supports_filter.nil?
     filtered_results = []

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -123,12 +123,12 @@ module MiqReport::Search
     _log.debug("Attrs: #{attrs.merge(:targets_hash => "...").inspect}")
     return table, attrs
   end
-  
+
   def filter_results(results, supports_filter)
     return results if supports_filter.nil?
     filtered_results = []
     results.each do |result|
-      filtered_results << result if result.send("#{supports_filter}".to_sym)
+      filtered_results << result if result.send(supports_filter.to_sym)
     end
     filtered_results
   end

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -99,9 +99,9 @@ module MiqReport::Search
     else
       targets = db_class
     end
-    supports_filter       = search_options.delete(:supports_filter) if search_options[:supports_filter]
+    supported_features_filter = search_options.delete(:supported_features_filter) if search_options[:supported_features_filter]
     search_results, attrs = Rbac.search(search_options.merge(:targets => targets))
-    filtered_results      = filter_results(search_results, supports_filter)
+    filtered_results      = filter_results(search_results, supported_features_filter)
 
     if order.nil?
       options[:limit]   = limit
@@ -126,8 +126,8 @@ module MiqReport::Search
 
   private
 
-  def filter_results(results, supports_filter)
-    return results if supports_filter.nil?
-    results.select { |result| result.send(supports_filter) }
+  def filter_results(results, supported_features_filter)
+    return results if supported_features_filter.nil?
+    results.select { |result| result.send(supported_features_filter) }
   end
 end


### PR DESCRIPTION
As part of work for a separate PR (to be added soon) the ability to have controllers specify a "supports_feature?" filter is being added.  When the UI obtains a list of objects to display in MiqReport::Search they will be filtered via the specified "supports_feature?" filter prior to building the
table.

The first use of this will be to determine if StorageManagers support either block storage or object storage in order to display one or the other but not both.  As further types of StorageManagers are added this feature will continue to be used.

@roliveri @Fryguy  @h-kataria @dclarizio please review.  @juliancheal FYI - I think you were looking at something like this.