### PR TITLE
Update bower_components to vendor and self_service to ui/service paths

### DIFF
--- a/gems/pending/spec/util/miq_apache/conf_spec.rb
+++ b/gems/pending/spec/util/miq_apache/conf_spec.rb
@@ -40,7 +40,7 @@ describe MiqApache::Conf do
     it "sets root balancer correctly" do
       default_options = {:cluster => 'evmcluster_ui', :redirects => %w(/)}
       output = MiqApache::Conf.create_redirects_config(default_options).lines.to_a
-      expect(output).to include("RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts|bower_components|gettext)) /self_service/index.html [L]\n")
+      expect(output).to include("RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/proxy_pages\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/saml2\n")
       expect(output).to include("RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n")

--- a/gems/pending/util/miq_apache/miq_apache.rb
+++ b/gems/pending/util/miq_apache/miq_apache.rb
@@ -206,7 +206,8 @@ module MiqApache
     def self.create_redirects_config(opts = {})
       opts[:redirects].to_miq_a.each_with_object("") do |redirect, content|
         if redirect == "/"
-          content << "RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts|bower_components|gettext)) /self_service/index.html [L]\n"
+          content << "RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext))
+                      /ui/service/index.html [L]\n"
           content << "RewriteCond \%{REQUEST_URI} !^/ws\n"
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
           content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"

--- a/gems/pending/util/miq_apache/miq_apache.rb
+++ b/gems/pending/util/miq_apache/miq_apache.rb
@@ -206,8 +206,7 @@ module MiqApache
     def self.create_redirects_config(opts = {})
       opts[:redirects].to_miq_a.each_with_object("") do |redirect, content|
         if redirect == "/"
-          content << "RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext))
-                      /ui/service/index.html [L]\n"
+          content << "RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]\n"
           content << "RewriteCond \%{REQUEST_URI} !^/ws\n"
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
           content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"


### PR DESCRIPTION
Unprocessed service dependencies are now built into a folder `vendor` this was previously called `bower_components`.

Updated rewrite rule to point to correct folder (self_service no longer exists)

👀 of @himdel @Fryguy @simaishi and all 👨‍👩‍👧‍👦  welcome! (but required from former 😉 )

Links
----------------
* https://github.com/ManageIQ/manageiq-ui-service/pull/296#discussion_r85765514