### PR TITLE
Middleware server running in domain should support only the power operations and monitoring.

### DIFF
--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -241,12 +241,18 @@ class MiddlewareServerController < ApplicationController
 
   def trigger_mw_operation(operation, mw_server, params = nil)
     mw_manager = mw_server.ext_management_system
+    path = mw_server.ems_ref
+
+    # in domain mode case we want to run the operation on the server-config DMR resource
+    if mw_server.in_domain?
+      path = path.sub(/%2Fserver%3D/, '%2Fserver-config%3D')
+    end
 
     op = mw_manager.public_method operation
     if params
-      op.call(mw_server.ems_ref, params)
+      op.call(path, params)
     else
-      op.call mw_server.ems_ref
+      op.call(path)
     end
   end
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -702,6 +702,10 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.provisionable?
       end
     when 'MiddlewareServer', 'MiddlewareDeployment', 'MiddlewareDatasource'
+      if %w(middleware_deployment_add middleware_jdbc_driver_add middleware_datasource_add).include?(id) &&
+         @record.try(:in_domain?)
+        return true
+      end
       return true if %w(middleware_server_shutdown middleware_server_restart middleware_server_stop
                         middleware_server_suspend middleware_server_resume middleware_server_reload
                         middleware_deployment_restart middleware_deployment_disable middleware_deployment_enable

--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -31,4 +31,8 @@ class MiddlewareServer < ApplicationRecord
     end
     false
   end
+
+  def in_domain?
+    !middleware_server_group.nil?
+  end
 end


### PR DESCRIPTION
This PR does two things:

1. it hides the add deployment, datasource and jdbc driver operations for the domain servers in the UI
2. it changes the path on which the operation is called in case it's called on the domain server, because while the server running in the standalone mode have the DMR path equal to the server resource. In case of domain, the resource called server-config needs to be used to run the operation. (change in the `middleware_server_controller.rb`)

https://bugzilla.redhat.com/show_bug.cgi?id=1381235

@miq-bot add_label providers/hawkular, bug, euwe/yes