### PR TITLE
Lock the replication set when making changes

### DIFF
--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -302,6 +302,18 @@ class PgLogicalRaw
     SQL
   end
 
+  def with_replication_set_lock(set_name)
+    connection.transaction(:requires_new => true) do
+      typed_exec(<<-SQL, set_name)
+        SELECT *
+        FROM pglogical.replication_set
+        WHERE set_name = $1
+        FOR UPDATE
+      SQL
+      yield
+    end
+  end
+
   private
 
   def typed_exec(sql, *params)

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -90,11 +90,7 @@ class MiqPglogical
       # add tables to the set which are no longer excluded (or new)
       newly_included_tables.each do |table|
         _log.info("Adding #{table} to #{REPLICATION_SET_NAME} replication set")
-        begin
-          pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
-        rescue PG::UniqueViolation => e
-          _log.warn("Caught unique constraint error while adding #{table} to the replication set: #{e.message}")
-        end
+        pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
       end
     end
   end

--- a/spec/replication/util/ar_pglogical_spec.rb
+++ b/spec/replication/util/ar_pglogical_spec.rb
@@ -226,6 +226,22 @@ describe "ar_pglogical extension" do
             expect(connection.pglogical.tables_in_replication_set(set_name)).to eq(["test"])
           end
         end
+
+        describe "#with_replication_set_lock" do
+          it "takes a lock on the replication set table" do
+            connection.pglogical.with_replication_set_lock(set_name) do
+              result = connection.exec_query(<<-SQL)
+                SELECT 1
+                FROM pg_locks JOIN pg_class
+                  ON pg_locks.relation = pg_class.oid
+                WHERE
+                  pg_class.relname = 'replication_set' AND
+                  pg_locks.mode = 'RowShareLock'
+              SQL
+              expect(result.count).to eq(1)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -100,11 +100,6 @@ describe MiqPglogical do
         subject.refresh_excludes
         expect(subject.included_tables).to include(table)
       end
-
-      it "continues if we attempt to add a table twice" do
-        expect(subject).to receive(:newly_included_tables).and_return([subject.included_tables.first])
-        expect { subject.refresh_excludes }.not_to raise_error
-      end
     end
   end
 


### PR DESCRIPTION
This PR creates a method for taking a row lock on a replication set in order to properly synchronize multiple processes which may be editing the contents of a replication set at the same time.

This will allow multiple worker processes as well as workers on multiple servers to edit the replication set without error due to attempting to add a table which is already present or remove a table which is not present in the set.

This also removes the need to explicitly catch issues due to unique constraint failures when adding a table to the replication set.

 https://bugzilla.redhat.com/show_bug.cgi?id=1387420
(see also https://bugzilla.redhat.com/show_bug.cgi?id=1380475)