### PR TITLE
Link an instance to the service through the containing orchestration stack

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -344,7 +344,7 @@ module VmHelper::TextualSummary
 
   def textual_service
     h = {:label => _("Service"), :image => "service"}
-    service = @record.service || @record.try(:orchestration_stack).try(:service) || @record.try(:orchestration_stack).try(:root).try(:service)
+    service = @record.service
     if service.nil?
       h[:value] = _("None")
     else

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -140,6 +140,14 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raw_disassociate_floating_ip(ip_address)
   end
 
+  def service
+    super || orchestration_stack.try(:service)
+  end
+
+  def direct_service
+    super || orchestration_stack.try(:direct_service)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -46,11 +46,11 @@ class OrchestrationStack < ApplicationRecord
   end
 
   def direct_service
-    direct_services.first
+    direct_services.first || (root.direct_services.first if root != self)
   end
 
   def service
-    direct_service.try(:root_service)
+    direct_service.try(:root_service) || (root.direct_service.try(:root_service) if root != self)
   end
 
   def indirect_vms

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
@@ -1,20 +1,21 @@
 describe ManageIQ::Providers::CloudManager::OrchestrationStack do
-  describe 'direct_<resource> methods' do
-    let(:root_stack) do
-      stack1 = FactoryGirl.create(:orchestration_stack_cloud)
-      stack2 = FactoryGirl.create(:orchestration_stack_cloud, :parent => stack1)
-
-      FactoryGirl.create(:vm_cloud, :orchestration_stack => stack1)
-      FactoryGirl.create(:cloud_network, :orchestration_stack => stack1)
-      FactoryGirl.create(:security_group, :orchestration_stack => stack1)
-
-      FactoryGirl.create(:vm_cloud, :orchestration_stack => stack2)
-      FactoryGirl.create(:cloud_network, :orchestration_stack => stack2)
-      FactoryGirl.create(:security_group, :orchestration_stack => stack2)
-
-      stack1
+  let!(:root_stack) do
+    FactoryGirl.create(:orchestration_stack_cloud).tap do |stack|
+      FactoryGirl.create(:vm_cloud, :orchestration_stack => stack)
+      FactoryGirl.create(:cloud_network, :orchestration_stack => stack)
+      FactoryGirl.create(:security_group, :orchestration_stack => stack)
     end
+  end
 
+  let!(:child_stack) do
+    FactoryGirl.create(:orchestration_stack_cloud, :parent => root_stack).tap do |stack|
+      FactoryGirl.create(:vm_cloud, :orchestration_stack => stack)
+      FactoryGirl.create(:cloud_network, :orchestration_stack => stack)
+      FactoryGirl.create(:security_group, :orchestration_stack => stack)
+    end
+  end
+
+  describe 'direct_<resource> methods' do
     it 'defines a set of methods for vms' do
       expect(root_stack.direct_vms.size).to eq(1)
       expect(root_stack.vms.size).to eq(2)
@@ -31,6 +32,22 @@ describe ManageIQ::Providers::CloudManager::OrchestrationStack do
       expect(root_stack.direct_security_groups.size).to eq(1)
       expect(root_stack.security_groups.size).to eq(2)
       expect(root_stack.total_security_groups).to eq(2)
+    end
+  end
+
+  describe '#service and #direct_service' do
+    let(:root_service)  { FactoryGirl.create(:service) }
+    let(:child_service) { FactoryGirl.create(:service, :parent => root_service) }
+    before { child_service.add_resource!(root_stack) }
+
+    it 'finds the service for the stack' do
+      expect(root_stack.service).to eq(root_service)
+      expect(root_stack.direct_service).to eq(child_service)
+    end
+
+    it 'finds the service for the nested stack' do
+      expect(child_stack.service).to eq(root_service)
+      expect(child_stack.direct_service).to eq(child_service)
     end
   end
 end

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -1,9 +1,37 @@
 describe VmCloud do
+  subject { FactoryGirl.create(:vm_cloud) }
+
   it "#post_create_actions" do
     expect(subject).to receive(:reconnect_events)
     expect(subject).to receive(:classify_with_parent_folder_path)
     expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_create", :vm => subject)
 
     subject.post_create_actions
+  end
+
+  describe "#service and #direct_service" do
+    let(:service_root) { FactoryGirl.create(:service) }
+    let(:service)      { FactoryGirl.create(:service, :parent => service_root) }
+
+    context "provisioned through a vm provisioning service" do
+      before { service.add_resource!(subject) }
+
+      it "finds the service that provisioned the vm" do
+        expect(subject.service).to eq(service_root)
+        expect(subject.direct_service).to eq(service)
+      end
+    end
+
+    context "provisioned through an orchestration provisioning service" do
+      before do
+        stack = FactoryGirl.create(:orchestration_stack, :direct_vms => [subject])
+        service.add_resource!(stack)
+      end
+
+      it "finds the service that provisioned the stack" do
+        expect(subject.service).to eq(service_root)
+        expect(subject.direct_service).to eq(service)
+      end
+    end
   end
 end


### PR DESCRIPTION
The instance that is included in an orchestration stack was not directly linked to the provisioning service because the instance is not added to the `service_resources`. 

The fix is to patch the `Vm#service` and `Vm#direct_service` methods to find the service through the containing stack.

https://bugzilla.redhat.com/show_bug.cgi?id=1387342

@gmcculloug please review.