### PR TITLE
Move public class methods out of sections of code with private scope

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -468,6 +468,21 @@ class Classification < ApplicationRecord
     name.downcase.tr('^a-z0-9_:', '_')[0, NAME_MAX_LENGTH]
   end
 
+  def self.tag2human(tag)
+    c, e = tag.split("/")[2..-1]
+
+    cat = find_by_name(c)
+    cname = cat.nil? ? c.titleize : cat.description
+
+    ename = e.titleize
+    unless cat.nil?
+      ent = cat.find_entry_by_name(e)
+      ename = ent.description unless ent.nil?
+    end
+
+    "#{cname}: #{ename}"
+  end
+
   private
 
   def self.add_entries_from_hash(cat, entries)
@@ -505,21 +520,6 @@ class Classification < ApplicationRecord
 
   def tag2name(tag)
     File.split(tag).last unless tag.nil?
-  end
-
-  def self.tag2human(tag)
-    c, e = tag.split("/")[2..-1]
-
-    cat = find_by_name(c)
-    cname = cat.nil? ? c.titleize : cat.description
-
-    ename = e.titleize
-    unless cat.nil?
-      ent = cat.find_entry_by_name(e)
-      ename = ent.description unless ent.nil?
-    end
-
-    "#{cname}: #{ename}"
   end
 
   def find_tag

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -201,29 +201,6 @@ class LogFile < ApplicationRecord
     time.respond_to?(:strftime) ? time.strftime("%Y%m%d_%H%M%S") : "unknown"
   end
 
-  private
-
-  def get_post_method(uri)
-    return nil if uri.nil?
-
-    # Convert all backslashes in the URI to forward slashes
-    uri.tr!('\\', '/')
-
-    # Strip any leading and trailing whitespace
-    uri.strip!
-
-    URI.split(URI.encode(uri))[0]
-  end
-
-  def legacy_depot_hash
-    # TODO: Delete this and make FileDepotSmb and FileDepotNfs implement all of their upload/delete/etc. logic
-    {
-      :uri      => file_depot.uri,
-      :username => file_depot.authentication_userid,
-      :password => file_depot.authentication_password,
-    }
-  end
-
   def self._request_logs(options)
     taskid = options[:taskid]
     klass  = options.delete(:klass).to_s
@@ -266,5 +243,28 @@ class LogFile < ApplicationRecord
     msg = "Requested logs from: [#{resource}]"
     _log.info("#{log_header} #{msg}")
     task.update_status("Queued", "Ok", msg)
+  end
+
+  private
+
+  def get_post_method(uri)
+    return nil if uri.nil?
+
+    # Convert all backslashes in the URI to forward slashes
+    uri.tr!('\\', '/')
+
+    # Strip any leading and trailing whitespace
+    uri.strip!
+
+    URI.split(URI.encode(uri))[0]
+  end
+
+  def legacy_depot_hash
+    # TODO: Delete this and make FileDepotSmb and FileDepotNfs implement all of their upload/delete/etc. logic
+    {
+      :uri      => file_depot.uri,
+      :username => file_depot.authentication_userid,
+      :password => file_depot.authentication_password,
+    }
   end
 end

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -23,11 +23,11 @@ module ManageIQ
         options[self.class.ems_type]
       end
 
-      private
-
       def self.ems_type
         @ems_type ||= parent.ems_type.to_sym
       end
+
+      private
 
       def group_targets_by_ems(targets)
         non_ems_targets = targets.select { |t| !t.kind_of?(ExtManagementSystem) && t.respond_to?(:ext_management_system) }

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -59,6 +59,10 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
     raise MiqException::MiqInvalidCredentialsError, err.message, err.backtrace
   end
 
+  def self.refresh_ems(provider_ids)
+    EmsRefresh.queue_refresh(Array.wrap(provider_ids).collect { |id| [base_class, id] })
+  end
+
   private
 
   def ensure_managers
@@ -69,9 +73,5 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
     build_configuration_manager unless configuration_manager
     configuration_manager.name    = "#{name} Configuration Manager"
     configuration_manager.zone_id = zone_id
-  end
-
-  def self.refresh_ems(provider_ids)
-    EmsRefresh.queue_refresh(Array.wrap(provider_ids).collect { |id| [base_class, id] })
   end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/provision_workflow.rb
@@ -5,13 +5,13 @@ class ManageIQ::Providers::Google::CloudManager::ProvisionWorkflow < ::MiqProvis
     ems.each_with_object({}) { |f, h| h[f.id] = display_name_for_name_description(f) }
   end
 
+  def self.provider_model
+    ManageIQ::Providers::Google::CloudManager
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')
     super(message, {'platform' => 'google'})
-  end
-
-  def self.provider_model
-    ManageIQ::Providers::Google::CloudManager
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -41,12 +41,12 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
     raise MiqException::MiqCloudTenantDeleteError, e.to_s, e.backtrace
   end
 
-  private
-
   def self.connection_options
     connection_options = {:service => "Identity", :openstack_endpoint_type => 'adminURL'}
     connection_options
   end
+
+  private
 
   def connection_options
     self.class.connection_options

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -82,13 +82,13 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     validate_placement(field, values, dlg, fld, value)
   end
 
+  def self.provider_model
+    ManageIQ::Providers::Openstack::CloudManager
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')
     super(message, {'platform' => 'openstack'})
-  end
-
-  def self.provider_model
-    ManageIQ::Providers::Openstack::CloudManager
   end
 end

--- a/gems/pending/util/xml/miq_rexml.rb
+++ b/gems/pending/util/xml/miq_rexml.rb
@@ -64,8 +64,6 @@ class MIQRexml
     array.each { |v| addObjToXML(parentEle, eleName, v) }
   end
 
-  private
-
   def self.findRegElementInt(paths, ele)
     if paths.length > 0
       searchStr = paths[0].downcase

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -153,15 +153,15 @@ class MiqAeDomain < MiqAeNamespace
     "#{domain_name} (#{ref})"
   end
 
+  def self.any_enabled?
+    MiqAeDomain.enabled.count > 0
+  end
+
   private
 
   def squeeze_priorities
     ids = MiqAeDomain.where('priority > 0', :tenant => tenant).order('priority ASC').collect(&:id)
     MiqAeDomain.reset_priority_by_ordered_ids(ids)
-  end
-
-  def self.any_enabled?
-    MiqAeDomain.enabled.count > 0
   end
 
   def self.any_unlocked?


### PR DESCRIPTION
As part of https://github.com/ManageIQ/manageiq/pull/12041 we found some methods that were declared private, but were called from parts of the code that expected them to be public. This PR moves those offending methods to be public.

Links
----------------

* [Original Issue - Fixup Lint/IneffectiveAccessModifier (ex. private keyword before singleton methods)](https://github.com/ManageIQ/manageiq/issues/12035)
* [PR to tackle issue ^ ](https://github.com/ManageIQ/manageiq/pull/12041)

/cc @jrafanie 