### PR TITLE
Changed to have consistency in keys in schema editor

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -703,7 +703,7 @@ class MiqAeClassController < ApplicationController
 
     @edit[:new][:fields] = @ae_class.ae_fields.sort_by { |a| [a.priority.to_i] }.collect do |fld|
       field_attributes.each_with_object({}) do |column, hash|
-        hash[column] = fld.send(column)
+        hash[column.to_sym] = fld.send(column)
       end
     end
 
@@ -1971,7 +1971,7 @@ class MiqAeClassController < ApplicationController
       field_attributes.each do |field|
         field_name = "field_#{field}".to_sym
         field_sym = field.to_sym
-        if field == "substitute"
+        if field == :substitute
           field_data[field_sym] = new_field[field_sym] = params[field_name] == "1" if params[field_name]
         elsif params[field_name]
           field_data[field_sym] = new_field[field_sym] = params[field_name]
@@ -1994,10 +1994,10 @@ class MiqAeClassController < ApplicationController
 
       @edit[:new][:fields].each_with_index do |fld, i|
         field_attributes.each do |field|
-          field_name = "fields_#{field}_#{i}".to_sym
+          field_name = "fields_#{field}_#{i}"
           field_sym = field.to_sym
           if field == "substitute"
-            fld[field_sym] = params[field_name].to_i == 1 if params[field_name]
+            fld[field_sym] = params[field_name] == "1" if params[field_name]
           elsif %w(aetype datatype).include?(field)
             var_name = "fields_#{field}#{i}"
             fld[field_sym] = params[var_name.to_sym] if params[var_name.to_sym]
@@ -2005,7 +2005,7 @@ class MiqAeClassController < ApplicationController
             fld[field_sym] = params[field_name] if params[field_name]
             fld[field_sym] = params["fields_password_value_#{i}".to_sym] if params["fields_password_value_#{i}".to_sym]
           else
-            fld[field] = params[field_name] if params[field_name]
+            fld[field_sym] = params[field_name] if params[field_name]
           end
         end
       end
@@ -2017,8 +2017,8 @@ class MiqAeClassController < ApplicationController
         return
       end
       new_fields = {}
-      field_attributes.each_with_object({}) { |field| new_fields[field] =
-        @edit[:new_field][field] || @edit[:new_field][field.to_sym]}
+      field_attributes.each_with_object({}) { |field| field = field.to_sym
+      new_fields[field] = @edit[:new_field][field]}
       @edit[:new][:fields].push(new_fields)
       @edit[:new_field] = session[:field_data] = {}
     end
@@ -2184,7 +2184,7 @@ class MiqAeClassController < ApplicationController
     fields = parent_fields(parent)
     highest_priority = fields.count
     @edit[:new][:fields].each_with_index do |fld, i|
-      if fld['id'].nil?
+      if fld[:id].nil?
         new_field = MiqAeField.new
         highest_priority += 1
         new_field.priority  = highest_priority
@@ -2194,11 +2194,12 @@ class MiqAeClassController < ApplicationController
           new_field.class_id = @ae_class.id
         end
       else
-        new_field = parent.nil? ? MiqAeField.find_by_id(fld['id']) : fields.detect { |f| f.id == fld['id'] }
+        new_field = parent.nil? ? MiqAeField.find_by_id(fld[:id]) : fields.detect { |f| f.id == fld[:id] }
       end
 
       field_attributes.each do |attr|
-        if attr == "substitute"
+        attr = attr.to_sym
+        if attr == :substitute
           new_field.send("#{attr}=", @edit[:new][:fields][i][attr])
         else
           new_field.send("#{attr}=", @edit[:new][:fields][i][attr]) if @edit[:new][:fields][i][attr]

--- a/app/views/miq_ae_class/_class_fields.html.haml
+++ b/app/views/miq_ae_class/_class_fields.html.haml
@@ -63,7 +63,7 @@
               %tr
                 %td
                   = link_to(image_tag(image_path("16/notequal-red.png"), :alt => (t = _("Click to delete this field from schema"))),
-                    {:action => "field_delete", :id => field['id'].to_s, :arr_id => i},
+                    {:action => "field_delete", :id => field[:id].to_s, :arr_id => i},
                     "data-miq_sparkle_on"  => true,
                     "data-miq_sparkle_off" => true,
                     :remote                => true,
@@ -72,9 +72,10 @@
                     :title                 => t)
                 - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                   %td
-                    - if %w(aetype datatype).include?(fname)
+                    - fname = fname.to_sym
+                    - if %w(aetype datatype).include?(fname.to_s)
                       - combo_name = "fields_#{fname}#{i}"
-                      - combo_options  = (fname == 'aetype' ? @combo_xml : @dtype_combo_xml)
+                      - combo_options  = (fname == :aetype ? @combo_xml : @dtype_combo_xml)
                       - combo_url  = "/miq_ae_class/fields_form_field_changed/#{@ae_class.id || 'new'}"
                       #form-group
                         = select_tag(combo_name,
@@ -83,11 +84,11 @@
                           :class  => "selectpicker")
                       :javascript
                         miqSelectPickerEvent("#{combo_name}", "#{combo_url}")
-                    - elsif fname == 'substitute'
-                      = check_box_tag("fields_#{fname}_#{i}", "1", field['substitute'],
+                    - elsif fname == :substitute
+                      = check_box_tag("fields_#{fname}_#{i}", "1", field[:substitute],
                         "data-miq_observe_checkbox" => {:url => url}.to_json)
-                    - elsif fname == 'default_value'
-                      - default_value = field['default_value']
+                    - elsif fname == :default_value
+                      - default_value = field[:default_value]
                       = text_field_tag("fields_default_value_#{i}", default_value,
                         :style             => field['datatype'] == "password" ? "display:none" : "",
                         "data-miq_observe" => obs)
@@ -118,21 +119,22 @@
                   :title                 => t)
               - %w(name aetype datatype default_value display_name description substitute collect message on_entry on_exit on_error max_retries max_time).each do |fname|
                 %td
-                  - if %w(aetype datatype).include?(fname)
+                  - fname = fname.to_sym
+                  - if %w(aetype datatype).include?(fname.to_s)
                     - combo_name = "field_#{fname}"
                     - combo_options  = @edit[:new]["#{fname}s".to_sym]
                     - combo_url  = "/miq_ae_class/fields_form_field_changed/#{@ae_class.id || 'new'}"
                     #form-group
                       = select_tag(combo_name,
-                          options_for_select(combo_options, session[:field_data][fname.to_sym]),
+                          options_for_select(combo_options, session[:field_data][fname]),
                           "title" => "Choose",
                           :class  => "selectpicker")
                     :javascript
                       miqSelectPickerEvent("#{combo_name}", "#{combo_url}")
-                  - elsif fname == 'substitute'
+                  - elsif fname == :substitute
                     - checked = !session[:field_data].blank? && session[:field_data][:substitute]
                     = check_box_tag("field_#{fname}", "1", checked, "data-miq_observe_checkbox" => {:url => url}.to_json)
-                  - elsif fname == 'default_value'
+                  - elsif fname == :default_value
                     = text_field_tag("field_default_value", session[:field_data][:default_value],
                       :style             => session[:field_data][:datatype] == "password" ? "display:none" : "",
                       "data-miq_observe" => obs)

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -480,9 +480,9 @@ describe MiqAeClassController do
     end
 
     it "Should not allow to create two schema fields with identical name" do
-      field = {"aetype"   => "attribute",
-               "datatype" => "string",
-               "name"     => "name01"}
+      field = {:aetype   => "attribute",
+               :datatype => "string",
+               :name     => "name01"}
       session[:edit][:new][:fields] = [field, field]
       controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
       controller.send(:update_fields)
@@ -490,10 +490,10 @@ describe MiqAeClassController do
     end
 
     it "Should not allow to add two parameters with identical name to a method" do
-      field = {"default_value" => nil,
-               "datatype"      => nil,
-               "name"          => "name01",
-               "method_id"     => @method.id}
+      field = {:default_value => nil,
+               :datatype      => nil,
+               :name          => "name01",
+               :method_id     => @method.id}
       session[:edit] = {
         :key         => "aemethod_edit__#{@method.id}",
         :ae_class_id => @cls.id,
@@ -509,10 +509,10 @@ describe MiqAeClassController do
     end
 
     it "Should not allow to add two parameters with identical name to a newly created method" do
-      field = {"default_value" => nil,
-               "datatype"      => nil,
-               "name"          => "name01",
-               "method_id"     => nil}
+      field = {:default_value => nil,
+               :datatype      => nil,
+               :name          => "name01",
+               :method_id     => nil}
       session[:edit] = {
         :key         => "aemethod_edit__new",
         :ae_class_id => @cls.id,
@@ -536,8 +536,11 @@ describe MiqAeClassController do
       stub_user(:features => :all)
       ns = FactoryGirl.create(:miq_ae_namespace)
       @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
-      @cls.ae_fields << FactoryGirl.create(:miq_ae_field, :name => 'fred',
-                                           :class_id => @cls.id, :priority => 1)
+      @cls.ae_fields << FactoryGirl.create(:miq_ae_field,
+                                           :name          => 'fred',
+                                           :class_id      => @cls.id,
+                                           :default_value => "Wilma",
+                                           :priority      => 1)
       @cls.save
       @method = FactoryGirl.create(:miq_ae_method, :name => "method01", :scope => "class",
         :language => "ruby", :class_id => @cls.id, :data => "exit MIQ_OK", :location => "inline")
@@ -547,10 +550,10 @@ describe MiqAeClassController do
     end
 
     it "update a method with inputs" do
-      field = {"default_value" => nil,
-               "datatype"      => nil,
-               "name"          => "name01",
-               "method_id"     => @method.id}
+      field = {:default_value => nil,
+               :datatype      => nil,
+               :name          => "name01",
+               :method_id     => @method.id}
       session[:edit] = {
         :key              => "aemethod_edit__#{@method.id}",
         :fields_to_delete => [],
@@ -571,9 +574,9 @@ describe MiqAeClassController do
     end
 
     it "update a class with fields" do
-      field = {"aetype"   => "attribute",
-               "datatype" => "string",
-               "name"     => "name01"}
+      field = {:aetype   => "attribute",
+               :datatype => "string",
+               :name     => "name01"}
       session[:edit] = {
         :key              => "aefields_edit__#{@cls.id}",
         :ae_class_id      => @cls.id,
@@ -588,6 +591,32 @@ describe MiqAeClassController do
       controller.send(:update_fields)
       expect(controller.send(:flash_errors?)).to be_falsey
       expect(response.status).to eq(200)
+    end
+
+    it "update a default value of existing class field" do
+      field = {:aetype        => "attribute",
+               :default_value => "Wilma",
+               :name          => "name01"}
+      session[:field_data] = field
+      session[:edit] = {
+        :key              => "aefields_edit__#{@cls.id}",
+        :ae_class_id      => @cls.id,
+        :fields_to_delete => [],
+        :new_field        => {},
+        :new              => {
+          :datatypes => [],
+          :aetypes   => [],
+          :fields    => [@cls.ae_fields.first]
+        }
+      }
+      controller.instance_variable_set(:@_params, "fields_default_value_0" => "Pebbles", :id => @cls.id)
+      allow(controller).to receive(:render)
+      controller.send(:fields_form_field_changed)
+      expect(@cls.ae_fields.first.default_value).to eq("Wilma")
+      controller.instance_variable_set(:@_params, :button => "save", :id => @cls.id)
+      controller.send(:update_fields)
+      @cls.reload
+      expect(@cls.ae_fields.first.default_value).to eq("Pebbles")
     end
   end
 
@@ -679,9 +708,9 @@ describe MiqAeClassController do
                                   :name     => "name02",
                                   :class_id => cls.id,
                                   :priority => 2)
-      field3 = {"aetype"   => "attribute",
-                "datatype" => "string",
-                "name"     => "name03"}
+      field3 = {:aetype   => "attribute",
+                :datatype => "string",
+                :name     => "name03"}
       edit = {:fields_to_delete => [], :new => {:fields => [field2, field3, field1]}}
       controller.instance_variable_set(:@edit, edit)
       controller.instance_variable_set(:@ae_class, cls)

--- a/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
@@ -1,0 +1,57 @@
+describe "miq_ae_class/_class_fields.html.haml" do
+  include Spec::Support::AutomationHelper
+
+  context 'display class fields' do
+    before do
+      assign(:sb,
+             :active_tab  => "schema",
+             :active_tree => :ae_tree,
+             :trees       => {:ae_tree => {:active_node => "aec-1"}})
+      ae_fields = {'ae_var1' => {:aetype => 'relationship', :datatype => 'string', :default_value => "Wilma"}}
+      create_ae_model(:ae_class     => "FRED",
+                      :ae_instances => [],
+                      :ae_fields    => ae_fields)
+
+      assign(:in_a_form, false)
+      assign(:ae_class, MiqAeClass.where(:name => 'FRED').first)
+    end
+
+    it "Check instance", :js => true do
+      render
+      expect(response).to have_text('ae_var1')
+      expect(response).to have_text('Wilma')
+    end
+  end
+
+  context 'loads class fields edit form' do
+    before do
+      assign(:sb,
+             :active_tab  => "schema",
+             :active_tree => :ae_tree,
+             :trees       => {:ae_tree => {:active_node => "aec-1"}})
+      ae_fields = {'ae_var1' => {:aetype => 'relationship', :datatype => 'string', :default_value => "Wilma"}}
+      create_ae_model(:ae_class     => "FRED",
+                      :ae_instances => [],
+                      :ae_fields    => ae_fields)
+
+      assign(:in_a_form_fields, true)
+      @ae_class = MiqAeClass.where(:name => 'FRED').first
+      assign(:edit,
+             :key              => "aefields_edit__#{@ae_class.id}",
+             :ae_class_id      => @ae_class.id,
+             :fields_to_delete => [],
+             :new              => {
+               :datatypes => [],
+               :aetypes   => [],
+               :fields    => [@ae_class.ae_fields.first]
+             })
+      @combo_xml = [["Assertion", "assertion", {"data-icon"=>"product product-assertion"}]]
+      @dtype_combo_xml = [["String", "string", {"data-icon"=>"product product-string"}]]
+    end
+
+    it "Check instance", :js => true do
+      render
+      expect(rendered).to have_selector('input#fields_default_value_0[value=\'Wilma\']')
+    end
+  end
+end


### PR DESCRIPTION
- Made changes to automate schema editor code to get/set all keys in @edit as symbols, some of the keys in existing code were symbols and others were strings, changed them all to be symbols.
- Added spec test to verify changes and fixed any existing broken spec tests.

https://bugzilla.redhat.com/show_bug.cgi?id=1389187

To recreate add Schema fields for a class, then try editing value of Default Value field, value does not get updated when save button is pressed.

@dclarizio please review.