### PR TITLE
Hide chargeback container image reports

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -9,7 +9,6 @@ class MiqExpression
     BottleneckEvent
     ChargebackVm
     ChargebackContainerProject
-    ChargebackContainerImage
     CloudResourceQuota
     CloudTenant
     CloudVolume


### PR DESCRIPTION
Hides the 'chargeback for container images' feature from the user.
This is just in case we want to hide this feature in euwe branch until the openshift fix arrives
@bazulay @simon3z 