### PR TITLE
Unify replace_right_cell signature.

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -18,7 +18,7 @@ module ApplicationController::Buttons
       add_flash(_("%{model_name} Group Reorder cancelled") % {:model_name => ui_lookup(:model => "CustomButton")})
       @edit = session[:edit] = nil  # clean out the saved info
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save"
       return unless load_edit("group_reorder", "replace_cell__explorer")
       # save group_index of each custombuttonset in set_data
@@ -43,7 +43,7 @@ module ApplicationController::Buttons
       add_flash(_("%{model_name} Group Reorder saved") % {:model_name => ui_lookup(:model => "CustomButton")})
       @edit = session[:edit] = nil  # clean out the saved info
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
-      replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+      replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
     else
       if params[:button] == "reset"
         @changed = session[:changed] = false
@@ -53,7 +53,7 @@ module ApplicationController::Buttons
       @in_a_form = true
       @lastaction = "automate_button"
       @layout = "miq_ae_automate_button"
-      replace_right_cell("group_reorder")
+      replace_right_cell(:nodetype => "group_reorder")
     end
   end
 
@@ -152,7 +152,7 @@ module ApplicationController::Buttons
       id.pop
       self.x_node = id.join("_")
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
-      replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+      replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
     else
       custom_button.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
       javascript_flash
@@ -208,7 +208,7 @@ module ApplicationController::Buttons
     if x_node.split('_').last == "ub"
       add_flash(_("'Unassigned Buttons Group' can not be deleted"), :error)
       get_node_info
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
       return
     end
     custom_button_set = CustomButtonSet.find(from_cid(params[:id]))
@@ -229,7 +229,7 @@ module ApplicationController::Buttons
       id.pop
       self.x_node = id.join("_")
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
-      replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+      replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
     else
       custom_button_set.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }
       javascript_flash
@@ -294,7 +294,7 @@ module ApplicationController::Buttons
     end
     @edit = session[:edit] = nil  # clean out the saved info
     ab_get_node_info(x_node) if x_active_tree == :ab_tree
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def group_button_add_save(typ)
@@ -332,7 +332,7 @@ module ApplicationController::Buttons
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "CustomButtonSet"), :name => @edit[:new][:description]})
         @edit = session[:edit] = nil  # clean out the saved info
         ab_get_node_info(x_node) if x_active_tree == :ab_tree
-        replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+        replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
       else
         @custom_button_set.errors.each do |field, msg|
           add_flash(_("Error during 'edit': %{field_name} %{error_message}") %
@@ -367,7 +367,7 @@ module ApplicationController::Buttons
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "CustomButtonSet"), :name => @edit[:new][:description]})
         @edit = session[:edit] = nil  # clean out the saved info
         ab_get_node_info(x_node) if x_active_tree == :ab_tree
-        replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+        replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
       else
         @custom_button_set.errors.each do |field, msg|
           add_flash(_("Error during 'add': %{field_name} %{error_name}") %
@@ -387,7 +387,7 @@ module ApplicationController::Buttons
     @in_a_form  = true
     @lastaction = "automate_button"
     @layout     = "miq_ae_automate_button"
-    replace_right_cell("button_edit")
+    replace_right_cell(:nodetype => "button_edit")
   end
 
   def group_create_update(typ)
@@ -415,7 +415,7 @@ module ApplicationController::Buttons
       end
       @edit = session[:edit] = nil  # clean out the saved info
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     elsif params[:button] == "add"
       assert_privileges("ab_button_new")
       @resolve = session[:resolve]
@@ -468,7 +468,7 @@ module ApplicationController::Buttons
           end
 
           ab_get_node_info(x_node) if x_active_tree == :ab_tree
-          replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+          replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
         else
           @custom_button.errors.each do |field, msg|
             add_flash(_("Error during 'add': %{error_message}") %
@@ -502,7 +502,7 @@ module ApplicationController::Buttons
           add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "CustomButton"), :name => @edit[:new][:description]})
           @edit = session[:edit] = nil  # clean out the saved info
           ab_get_node_info(x_node) if x_active_tree == :ab_tree
-          replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
+          replace_right_cell(:nodetype => x_node, :replace_trees => x_active_tree == :ab_tree ? [:ab] : [:sandt])
         else
           @custom_button.errors.each do |field, msg|
             add_flash(_("Error during 'edit': %{field_name} %{error_message}") %
@@ -524,7 +524,7 @@ module ApplicationController::Buttons
       drop_breadcrumb(:name => _("Edit of Button"), :url => "/miq_ae_customization/button_edit")
       @lastaction = "automate_button"
       @layout = "miq_ae_automate_button"
-      replace_right_cell("button_edit")
+      replace_right_cell(:nodetype => "button_edit")
     end
   end
 
@@ -566,7 +566,7 @@ module ApplicationController::Buttons
     if typ == "edit" && x_node.split('_').last == "ub"
       add_flash(_("'Unassigned Buttons Group' can not be edited"), :error)
       get_node_info
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
       return
     end
     group_set_form_vars
@@ -575,7 +575,7 @@ module ApplicationController::Buttons
     @layout = "miq_ae_automate_button"
     @sb[:button_groups] = nil
     @sb[:buttons] = nil
-    replace_right_cell("group_edit")
+    replace_right_cell(:nodetype => "group_edit")
   end
 
   def button_new_edit(typ)
@@ -596,7 +596,7 @@ module ApplicationController::Buttons
     @layout = "miq_ae_automate_button"
     @sb[:buttons] = nil
     @sb[:button_groups] = nil
-    replace_right_cell("button_edit")
+    replace_right_cell(:nodetype => "button_edit")
   end
 
   # Set form variables for button add/edit

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -179,7 +179,7 @@ module ApplicationController::CiProcessing
       if @edit[:explorer]
         ownership
         add_flash(_("All changes have been reset"), :warning)
-        request.parameters[:controller] == "service" ? replace_right_cell("ownership") : replace_right_cell
+        request.parameters[:controller] == "service" ? replace_right_cell(:nodetype => "ownership") : replace_right_cell
       else
         javascript_redirect :action        => 'ownership',
                             :flash_msg     => _("All changes have been reset"),

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -63,7 +63,7 @@ module ApplicationController::DialogRunner
       flash = _("All changes have been reset")
       if session[:edit][:explorer]
         add_flash(flash, :warning)
-        replace_right_cell("dialog_provision")
+        replace_right_cell(:action => "dialog_provision")
       else
         javascript_redirect :action => 'dialog_load', :flash_msg => flash, :flash_warning => true, :escape => false # redirect to miq_request show_list screen
       end
@@ -156,7 +156,7 @@ module ApplicationController::DialogRunner
     @in_a_form = true
     @changed = session[:changed] = true
     if @edit[:explorer]
-      replace_right_cell("dialog_provision")
+      replace_right_cell(:action => "dialog_provision")
     else
       javascript_redirect :action => 'dialog_load'
     end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -146,7 +146,7 @@ module ApplicationController::Explorer
     self.x_node = params[:id]
     if node_info
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     else
       replace_right_cell
     end
@@ -160,7 +160,7 @@ module ApplicationController::Explorer
     self.x_active_tree   = "#{self.x_active_accord}_tree"
     if node_info
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     else
       replace_right_cell
     end

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -164,7 +164,7 @@ module ApplicationController::Tags
     add_flash(_("All changes have been reset"), :warning) if params[:button] == "reset"
     if tagging_explorer_controller?
       @refresh_partial = "layouts/tagging"
-      replace_right_cell(@sb[:action]) if params[:button]
+      replace_right_cell(:action => @sb[:action]) if params[:button]
     else
       render "shared/views/tagging_edit"
     end
@@ -224,7 +224,7 @@ module ApplicationController::Tags
 
     get_node_info(x_node)
     @edit = nil
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   # Add/remove tags in a single transaction

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -123,7 +123,7 @@ class CatalogController < ApplicationController
       @tabactive = @edit[:new][:current_tab_key]
       @in_a_form = true
       session[:changed] = false
-      replace_right_cell("at_st_new")
+      replace_right_cell(:action => "at_st_new")
     end
   end
 
@@ -286,7 +286,7 @@ class CatalogController < ApplicationController
                    elements.length) % {:number => elements.length}) unless flash_errors?
     end
     params[:id] = nil
-    replace_right_cell(nil, trees_to_replace([:sandt, :svccat]))
+    replace_right_cell(:replace_trees => trees_to_replace([:sandt, :svccat]))
   end
 
   def st_edit
@@ -334,7 +334,7 @@ class CatalogController < ApplicationController
           @changed = session[:changed] = false
           @in_a_form = false
           @edit = session[:edit] = @record = nil
-          replace_right_cell(nil, trees_to_replace([:sandt, :svccat, :stcat]))
+          replace_right_cell(:replace_trees => trees_to_replace([:sandt, :svccat, :stcat]))
         else
           @st.errors.each do |field, msg|
             add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -352,7 +352,7 @@ class CatalogController < ApplicationController
         add_flash(_("All changes have been reset"), :warning)
       end
       @changed = session[:changed] = false
-      replace_right_cell("st_new")
+      replace_right_cell(:action => "st_new")
       return
     end
   end
@@ -590,14 +590,14 @@ class CatalogController < ApplicationController
       @changed = session[:changed] = false
       @in_a_form = false
       @edit = session[:edit] = nil
-      replace_right_cell(nil, trees_to_replace([:sandt, :svccat, :stcat]))
+      replace_right_cell(:replace_trees => trees_to_replace([:sandt, :svccat, :stcat]))
     when "reset", nil  # Reset or first time in
       st_catalog_set_form_vars
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
       @changed = session[:changed] = false
-      replace_right_cell("st_catalog_edit")
+      replace_right_cell(:action => "st_catalog_edit")
       return
     end
   end
@@ -657,18 +657,18 @@ class CatalogController < ApplicationController
       add_flash(_("Orchestration template \"%{name}\" is read-only and cannot be edited.") %
         {:name => @record.name}, :error)
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:action => x_node)
       return
     end
     ot_edit_set_form_vars(_("Editing %{record_name}"))
-    replace_right_cell("ot_edit")
+    replace_right_cell(:action => "ot_edit")
   end
 
   def ot_copy
     assert_privileges("orchestration_template_copy")
     ot_edit_set_form_vars(_("Copying %{record_name}"))
     @edit[:new][:name] = @edit[:current][:name] = _("Copy of %{name}") % {:name => @edit[:new][:name]}
-    replace_right_cell("ot_copy")
+    replace_right_cell(:action => "ot_copy")
   end
 
   def ot_edit_submit
@@ -730,7 +730,7 @@ class CatalogController < ApplicationController
     else
       self.x_node = "xx-#{template_to_node_name(elements[0])}"
     end
-    replace_right_cell(nil, trees_to_replace([:ot]))
+    replace_right_cell(:replace_trees => trees_to_replace([:ot]))
   end
 
   def ot_add
@@ -747,7 +747,7 @@ class CatalogController < ApplicationController
     @edit[:key] = "ot_add__new"
     @right_cell_text = _("Adding a new Orchestration Template")
     @in_a_form = true
-    replace_right_cell("ot_add")
+    replace_right_cell(:action => "ot_add")
   end
 
   def ot_add_submit
@@ -786,7 +786,7 @@ class CatalogController < ApplicationController
              :key    => "ot_edit__#{ot.id}",
              :rec_id => ot.id}
     @in_a_form = true
-    replace_right_cell("service_dialog_from_ot")
+    replace_right_cell(:action => "service_dialog_from_ot")
   end
 
   def service_dialog_from_ot_submit
@@ -915,7 +915,7 @@ class CatalogController < ApplicationController
       @changed = session[:changed] = false
       @in_a_form = false
       @edit = session[:edit] = @record = nil
-      replace_right_cell(nil, trees_to_replace([:sandt, :svccat, :stcat]))
+      replace_right_cell(:replace_trees => trees_to_replace([:sandt, :svccat, :stcat]))
     else
       st.errors.each do |field, msg|
         add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -1004,7 +1004,7 @@ class CatalogController < ApplicationController
         @changed = session[:changed] = false
         @in_a_form = false
         @edit = session[:edit] = nil
-        replace_right_cell(nil, trees_to_replace([:ot]))
+        replace_right_cell(:replace_trees => trees_to_replace([:ot]))
       end
     end
   end
@@ -1013,7 +1013,7 @@ class CatalogController < ApplicationController
     add_flash(_("All changes have been reset"), :warning)
     ot_edit_set_form_vars(_("Editing %{record_name}"))
     @changed = session[:changed] = false
-    replace_right_cell("ot_edit")
+    replace_right_cell(:action => "ot_edit")
   end
 
   def ot_copy_submit_cancel
@@ -1063,7 +1063,7 @@ class CatalogController < ApplicationController
         @changed = session[:changed] = false
         @in_a_form = false
         @edit = session[:edit] = nil
-        replace_right_cell(nil, trees_to_replace([:ot]))
+        replace_right_cell(:replace_trees => trees_to_replace([:ot]))
       end
     end
   end
@@ -1109,7 +1109,7 @@ class CatalogController < ApplicationController
         @changed = session[:changed] = false
         @in_a_form = false
         @edit = session[:edit] = nil
-        replace_right_cell(nil, trees_to_replace([:ot]))
+        replace_right_cell(:replace_trees => trees_to_replace([:ot]))
       end
     end
   end
@@ -1198,7 +1198,7 @@ class CatalogController < ApplicationController
       process_elements(elements, ServiceTemplateCatalog, "destroy") unless elements.empty?
     end
     params[:id] = nil
-    replace_right_cell(nil, trees_to_replace([:sandt, :svccat, :stcat]))
+    replace_right_cell(:replace_trees => trees_to_replace([:sandt, :svccat, :stcat]))
   end
 
   def trees_to_replace(trees)
@@ -1792,7 +1792,8 @@ class CatalogController < ApplicationController
   end
 
   # Replace the right cell of the explorer
-  def replace_right_cell(action = nil, replace_trees = [])
+  def replace_right_cell(options = {})
+    action, replace_trees = options.values_at(:action, :replace_trees)
     @explorer = true
 
     # FIXME: make this functional
@@ -2044,7 +2045,7 @@ class CatalogController < ApplicationController
     add_flash(_('All changes have been reset'), :warning) if params[:button] == "reset"
     @right_cell_text = _("Editing %{model} Tags for \"%{name}\"") % {:name  => ui_lookup(:models => @tagging),
                                                                      :model => current_tenant.name}
-    replace_right_cell(@sb[:action])
+    replace_right_cell(:action => @sb[:action])
   end
 
   menu_section :svc

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -143,7 +143,7 @@ class ChargebackController < ApplicationController
         @edit = session[:edit] = nil  # clean out the saved info
         session[:changed] =  @changed = false
         get_node_info(x_node)
-        replace_right_cell([:cb_rates])
+        replace_right_cell(:replace_trees => [:cb_rates])
       else
         @rate.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -243,7 +243,7 @@ class ChargebackController < ApplicationController
       cb_rates_list
       @right_cell_text = _("%{typ} %{model}") % {:typ   => x_node.split('-').last,
                                                  :model => ui_lookup(:models => 'ChargebackRate')}
-      replace_right_cell([:cb_rates])
+      replace_right_cell(:replace_trees => [:cb_rates])
     end
   end
 
@@ -783,7 +783,8 @@ class ChargebackController < ApplicationController
     cb_assign_params_to_edit(:tags)
   end
 
-  def replace_right_cell(replace_trees = [])
+  def replace_right_cell(options = {})
+    replace_trees = Array(options[:replace_trees])
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
     @explorer = true
     c_tb = build_toolbar(center_toolbar_filename)

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -29,7 +29,7 @@ class ContainerController < ApplicationController
     return if [:container_delete, :container_edit].include?(performed_action)
 
     if @refresh_partial
-      replace_right_cell(action)
+      replace_right_cell(:action => action)
     else
       unless @flash_array
         add_flash(_("Button not yet implemented %{model}: %{action}") % {:model => model, :action => action}, :error)
@@ -208,7 +208,8 @@ class ContainerController < ApplicationController
   end
 
   # Replace the right cell of the explorer
-  def replace_right_cell(action = nil, replace_trees = [])
+  def replace_right_cell(options = {})
+    action, replace_trees = options.values_at(:action, :replace_trees)
     @explorer = true
     # Set partial name, action and cell header
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action

--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -124,7 +124,7 @@ class InfraNetworkingController < ApplicationController
     @search_text = @sb[:infra_networking_search_text]["#{x_active_accord}_search_text"]
 
     load_or_clear_adv_search
-    replace_right_cell(x_node)
+    replace_right_cell(:action => x_node)
   end
 
   def load_or_clear_adv_search
@@ -433,7 +433,8 @@ class InfraNetworkingController < ApplicationController
     render :json => presenter.for_render
   end
 
-  def replace_right_cell(action = nil, presenter = nil)
+  def replace_right_cell(options = {})
+    action, presenter = options.values_at(:action, :presenter)
     @explorer = true
     @sb[:action] = action unless action.nil?
     if @sb[:action] || params[:display]

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -255,8 +255,9 @@ class MiqAeClassController < ApplicationController
     existing_node
   end
 
-  def replace_right_cell(replace_trees = [])
+  def replace_right_cell(options = {})
     @explorer = true
+    replace_trees = options[:replace_trees]
 
     # FIXME: is the following line needed?
     # replace_trees = @replace_trees if @replace_trees  #get_node_info might set this
@@ -596,7 +597,7 @@ class MiqAeClassController < ApplicationController
         session[:edit] = nil  # clean out the saved info
         @in_a_form = false
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqAeInstance"), :name => @ae_inst.name})
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
         return
       end
     when "reset"
@@ -642,7 +643,7 @@ class MiqAeClassController < ApplicationController
         AuditEvent.success(build_created_audit(add_aeinst, @edit))
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqAeInstance"), :name => add_aeinst.name})
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
         return
       end
     end
@@ -992,7 +993,7 @@ class MiqAeClassController < ApplicationController
         AuditEvent.success(build_saved_audit(ae_class, @edit))
         session[:edit] = nil  # clean out the saved info
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
         return
       end
     when "reset"
@@ -1003,7 +1004,7 @@ class MiqAeClassController < ApplicationController
       replace_right_cell
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     end
   end
 
@@ -1035,7 +1036,7 @@ class MiqAeClassController < ApplicationController
         AuditEvent.success(build_saved_audit(ae_class, @edit))
         session[:edit] = nil  # clean out the saved info
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
         return
       end
     when "reset"
@@ -1047,7 +1048,7 @@ class MiqAeClassController < ApplicationController
       replace_right_cell
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     end
   end
 
@@ -1077,7 +1078,7 @@ class MiqAeClassController < ApplicationController
         AuditEvent.success(build_saved_audit(ae_ns, @edit))
         session[:edit] = nil  # clean out the saved info
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
       end
     when "reset"
       ns_set_form_vars
@@ -1087,7 +1088,7 @@ class MiqAeClassController < ApplicationController
       replace_right_cell
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     end
   end
 
@@ -1124,7 +1125,7 @@ class MiqAeClassController < ApplicationController
         session[:edit] = nil  # clean out the saved info
         @sb[:form_vars_set] = false
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
         return
       end
     when "reset"
@@ -1173,7 +1174,7 @@ class MiqAeClassController < ApplicationController
     when "cancel"
       add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "MiqAeClass")})
       @in_a_form = false
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     when "add"
       add_aeclass = MiqAeClass.new
       set_record_vars(add_aeclass)                        # Set the record variables, but don't save
@@ -1191,11 +1192,11 @@ class MiqAeClassController < ApplicationController
       else
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqAeClass"), :name => add_aeclass.fqname})
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
       end
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     end
   end
 
@@ -1227,12 +1228,12 @@ class MiqAeClassController < ApplicationController
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqAeMethod"), :name => add_aemethod.name})
         @sb[:form_vars_set] = false
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
       end
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
       @sb[:form_vars_set] = false
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     end
   end
 
@@ -1255,7 +1256,7 @@ class MiqAeClassController < ApplicationController
       if add_ae_ns.valid? && !flash_errors? && add_ae_ns.save
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => add_ae_ns.class.name), :name  => add_ae_ns.name})
         @in_a_form = false
-        replace_right_cell([:ae])
+        replace_right_cell(:replace_trees => [:ae])
       else
         add_ae_ns.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -1485,7 +1486,7 @@ class MiqAeClassController < ApplicationController
       current_tenant.reset_domain_priority_by_ordered_ids(domains)
       add_flash(_("Priority Order was saved"))
       @sb[:action] = @in_a_form = @edit = session[:edit] = nil  # clean out the saved info
-      replace_right_cell([:ae])
+      replace_right_cell(:replace_trees => [:ae])
     when "reset", nil # Reset or first time in
       priority_edit_screen
       add_flash(_("All changes have been reset"), :warning) if params[:button] == "reset"
@@ -1588,7 +1589,7 @@ class MiqAeClassController < ApplicationController
 
     session[:edit] = nil
     @in_a_form = false
-    replace_right_cell([:ae])
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   private
@@ -1807,7 +1808,7 @@ class MiqAeClassController < ApplicationController
     end
 
     process_aeinstances(aeinstances, "destroy") unless aeinstances.empty?
-    replace_right_cell([:ae])
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   # Common aeclasses button handler routines
@@ -1833,7 +1834,7 @@ class MiqAeClassController < ApplicationController
     end
 
     process_aemethods(aemethods, "destroy") unless aemethods.empty?
-    replace_right_cell([:ae])
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   # Common aeclasses button handler routines
@@ -1866,7 +1867,7 @@ class MiqAeClassController < ApplicationController
     git_domains.each do |domain|
       process_element_destroy_via_queue(domain, domain.class, domain.name)
     end
-    replace_right_cell([:ae])
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   # Delete all selected or single displayed aeclasses(s)
@@ -1893,7 +1894,7 @@ class MiqAeClassController < ApplicationController
     end
     process_ae_ns(ae_ns, "destroy")     unless ae_ns.empty?
     process_aeclasses(ae_cs, "destroy") unless ae_cs.empty?
-    replace_right_cell([:ae])
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   def items_to_delete(selected)
@@ -2435,7 +2436,7 @@ class MiqAeClassController < ApplicationController
     domain_toggle_lock(params[:id], locked)
     add_flash(_("The selected %{model} were marked as %{action}") % {:model  => ui_lookup(:model => "MiqAeDomain"), :action => action},
               :info, true) unless flash_errors?
-    replace_right_cell([:ae])
+    replace_right_cell(:replace_trees => [:ae])
   end
 
   def domain_lock

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -56,7 +56,7 @@ class MiqAeCustomizationController < ApplicationController
       end
     end
     get_node_info
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def import_service_dialogs
@@ -81,7 +81,7 @@ class MiqAeCustomizationController < ApplicationController
       add_flash(_("Service dialog import cancelled"), :success)
     end
     get_node_info
-    replace_right_cell(x_node, [:dialogs])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:dialogs])
   end
 
   def export_service_dialogs
@@ -101,7 +101,7 @@ class MiqAeCustomizationController < ApplicationController
     self.x_active_accord = params[:id].sub(/_accord$/, '')
     self.x_active_tree   = "#{x_active_accord}_tree"
     get_node_info
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def explorer
@@ -140,9 +140,9 @@ class MiqAeCustomizationController < ApplicationController
       if @replace_tree
 
         # record being viewed and saved in @sb[:active_node] has been deleted outside UI from VMDB, need to refresh tree
-        replace_right_cell(x_node, [:dialogs])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:dialogs])
       else
-        replace_right_cell(x_node)
+        replace_right_cell(:nodetype => x_node)
       end
     else
       render :update do |page|
@@ -201,7 +201,8 @@ class MiqAeCustomizationController < ApplicationController
     @dialog_import_service ||= DialogImportService.new
   end
 
-  def replace_right_cell(nodetype, replace_trees = [])
+  def replace_right_cell(options = {})
+    nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
     # fixme, don't call all the time
     build_ae_tree(:automate, :automate_tree) # Build Catalog Items tree
     trees = {}

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -110,7 +110,7 @@ module MiqAeCustomizationController::Dialogs
     dialog_set_form_vars
     @in_a_form = true
     @sb[:node_typ] = nil
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   # Add new dialog
@@ -129,12 +129,12 @@ module MiqAeCustomizationController::Dialogs
     @edit[:key] = "dialog_edit__#{@record.id || "new"}"
     session[:changed] = @in_a_form = true
     @sb[:node_typ] = nil
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def change_tab
     get_node_info
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   # add resource to a dialog
@@ -177,7 +177,7 @@ module MiqAeCustomizationController::Dialogs
         @sb[:node_typ] = "element"
       end
 
-      replace_right_cell(x_node, [:dialog_edit])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:dialog_edit])
 
     else
       javascript_flash(:spinner_off => true)
@@ -198,7 +198,7 @@ module MiqAeCustomizationController::Dialogs
       @edit = session[:edit] = nil # clean out the saved info
       self.x_active_tree = :dialogs_tree
       get_node_info
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
 
     when 'add', 'save'
       id = params[:id] || 'new'
@@ -238,7 +238,7 @@ module MiqAeCustomizationController::Dialogs
         end
 
         get_node_info
-        replace_right_cell(x_node, [:dialogs])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:dialogs])
       end
 
     when 'reset', nil      # first time in or resettting
@@ -253,7 +253,7 @@ module MiqAeCustomizationController::Dialogs
       @sb[:node_typ] = nil
       add_flash(_("All changes have been reset"), :warning) if params[:button] == "reset"
       @in_a_form = true
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     end
   end
 
@@ -294,7 +294,7 @@ module MiqAeCustomizationController::Dialogs
     end
     dialog_edit_build_tree
     @sb[:edit_typ] = nil
-    replace_right_cell(x_node, [:dialog_edit])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:dialog_edit])
   end
 
   def dialog_resource_remove
@@ -364,7 +364,7 @@ module MiqAeCustomizationController::Dialogs
     end
     dialog_edit_set_form_vars
 
-    replace_right_cell(x_node, [:dialog_edit])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:dialog_edit])
   end
 
   # Reorder dialog resources
@@ -1359,7 +1359,7 @@ module MiqAeCustomizationController::Dialogs
         process_dialogs(dialogs, method)
       end
       get_node_info
-      replace_right_cell(x_node, [:dialogs])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:dialogs])
     else # showing 1 dialog
       if params[:id].nil? || Dialog.find_by_id(params[:id]).nil?
         add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:model => "Dialog")}, :error)
@@ -1374,7 +1374,7 @@ module MiqAeCustomizationController::Dialogs
           self.x_node = "root"
         end
         get_node_info
-        replace_right_cell(x_node, [:dialogs])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:dialogs])
       end
     end
     dialogs.count

--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -77,7 +77,7 @@ module MiqAeCustomizationController::OldDialogs
       end
 
       get_node_info
-      replace_right_cell(x_node, [:old_dialogs])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:old_dialogs])
     else # showing 1 vm
       if params[:id].nil? || MiqDialog.find_by_id(params[:id]).nil?
         add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:model => "MiqDialog")}, :error)
@@ -95,7 +95,7 @@ module MiqAeCustomizationController::OldDialogs
 
         self.x_node = "xx-MiqDialog_#{dialog.dialog_type}" if method == 'destroy' && !flash_errors?
         get_node_info
-        replace_right_cell(x_node, [:old_dialogs])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:old_dialogs])
       end
     end
     dialogs.count
@@ -182,7 +182,7 @@ module MiqAeCustomizationController::OldDialogs
     @dialog = MiqDialog.new
     old_dialogs_set_form_vars
     @in_a_form = true
-    replace_right_cell("odg-")
+    replace_right_cell(:nodetype => "odg-")
   end
 
   def old_dialogs_copy
@@ -215,12 +215,12 @@ module MiqAeCustomizationController::OldDialogs
     if @dialog.default == true
       add_flash(_("Default %{model} \"%{name}\" can not be edited") % {:model => ui_lookup(:model => "MiqDialog"), :name => @dialog.name}, :error)
       get_node_info
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
       return
     end
     old_dialogs_set_form_vars
     @in_a_form = true
-    replace_right_cell("odg-#{params[:id]}")
+    replace_right_cell(:nodetype => "odg-#{params[:id]}")
   end
 
   def old_dialogs_create
@@ -247,7 +247,7 @@ module MiqAeCustomizationController::OldDialogs
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqDialog"), :name => @dialog.name})
       end
       get_node_info
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "add", "save"
       # dialog = find_by_id_filtered(MiqDialog, params[:id])
       dialog = @dialog.id.blank? ? MiqDialog.new : MiqDialog.find(@dialog.id) # Get new or existing record
@@ -296,7 +296,7 @@ module MiqAeCustomizationController::OldDialogs
           end
         end
         get_node_info
-        replace_right_cell(x_node, [:old_dialogs])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:old_dialogs])
       end
     when "reset", nil # Reset or first time in
       add_flash(_("All changes have been reset"), :warning)

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -255,7 +255,7 @@ class MiqPolicyController < ApplicationController
     self.x_active_accord = params[:id].sub(/_accord$/, '')
     self.x_active_tree   = "#{self.x_active_accord}_tree"
     get_node_info(x_node)
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   def tree_select
@@ -266,16 +266,16 @@ class MiqPolicyController < ApplicationController
     self.x_node          = params[:id]
 
     get_node_info(x_node)
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   def search
     get_node_info(x_node)
     case x_active_tree
     when "profile", "event", "action", "alert"
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "policy", "condition", "alert_profile"
-      replace_right_cell("xx")
+      replace_right_cell(:nodetype => "xx")
     end
   end
 
@@ -471,8 +471,10 @@ class MiqPolicyController < ApplicationController
   end
 
   # replace_trees can be an array of tree symbols to be replaced
-  def replace_right_cell(nodetype, replace_trees = [], presenter = nil)
+  def replace_right_cell(options = {})
+    nodetype, replace_trees, presenter = options.values_at(:nodetype, :replace_trees, :presenter)
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
+    replace_trees = Array(replace_trees)
     @explorer = true
 
     # we need to be able to replace trees even if explorer has never been called on the current instance

--- a/app/controllers/miq_policy_controller/alert_profiles.rb
+++ b/app/controllers/miq_policy_controller/alert_profiles.rb
@@ -13,7 +13,7 @@ module MiqPolicyController::AlertProfiles
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqAlertSet"), :name => @alert_profile.description})
       end
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     when "reset", nil # Reset or first time in
       alert_profile_build_edit_screen
@@ -21,7 +21,7 @@ module MiqPolicyController::AlertProfiles
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("ap")
+      replace_right_cell(:nodetype => "ap")
       return
     end
 
@@ -58,17 +58,17 @@ module MiqPolicyController::AlertProfiles
         @edit = nil
         self.x_node = @new_alert_profile_node = "xx-#{alert_profile.mode}_ap-#{to_cid(alert_profile.id)}"
         get_node_info(@new_alert_profile_node)
-        replace_right_cell("ap", [:alert_profile])
+        replace_right_cell(:nodetype => "ap", :replace_trees => [:alert_profile])
       else
         alert_profile.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell("ap")
+        replace_right_cell(:nodetype => "ap")
       end
     when "move_right", "move_left", "move_allleft"
       handle_selection_buttons(:alerts)
       session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell("ap")
+      replace_right_cell(:nodetype => "ap")
     end
   end
 
@@ -81,7 +81,7 @@ module MiqPolicyController::AlertProfiles
       @assign = nil
       add_flash(_("Edit %{model} assignments cancelled by user") % {:model => ui_lookup(:model => "MiqAlertSet")})
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save"
       if @assign[:new][:assign_to].to_s.ends_with?("-tags") && !@assign[:new][:cat]
         add_flash(_("A Tag Category must be selected"), :error)
@@ -97,13 +97,13 @@ module MiqPolicyController::AlertProfiles
         get_node_info(x_node)
         @assign = nil
       end
-      replace_right_cell("ap")
+      replace_right_cell(:nodetype => "ap")
     when "reset", nil # Reset or first time in
       alert_profile_build_assign_screen
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("ap")
+      replace_right_cell(:nodetype => "ap")
     end
   end
 
@@ -123,7 +123,7 @@ module MiqPolicyController::AlertProfiles
     nodes.pop
     self.x_node = nodes.join("_")
     get_node_info(x_node)
-    replace_right_cell("xx", [:alert_profile])
+    replace_right_cell(:nodetype => "xx", :replace_trees => [:alert_profile])
   end
 
   def alert_profile_field_changed

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -13,7 +13,7 @@ module MiqPolicyController::Alerts
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqAlert"), :name => @alert.description})
       end
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save", "add"
       id = params[:id] && params[:button] != "add" ? params[:id] : "new"
       return unless load_edit("alert_edit__#{id}", "replace_cell__explorer")
@@ -30,12 +30,12 @@ module MiqPolicyController::Alerts
         @edit = nil
         @nodetype = "al"
         @new_alert_node = "al-#{to_cid(alert.id)}"
-        replace_right_cell("al", [:alert_profile, :alert])
+        replace_right_cell(:nodetype => "al", :replace_trees => [:alert_profile, :alert])
       else
         alert.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell("al")
+        replace_right_cell(:nodetype => "al")
       end
     when "reset", nil # Reset or first time in
       alert_build_edit_screen
@@ -43,7 +43,7 @@ module MiqPolicyController::Alerts
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("al")
+      replace_right_cell(:nodetype => "al")
     end
   end
 
@@ -66,7 +66,7 @@ module MiqPolicyController::Alerts
     process_alerts(alerts, "destroy") unless alerts.empty?
     @new_alert_node = self.x_node = "root"
     get_node_info(x_node)
-    replace_right_cell("root", [:alert_profile, :alert])
+    replace_right_cell(:nodetype => "root", :replace_trees => [:alert_profile, :alert])
   end
 
   def alert_field_changed

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -15,7 +15,7 @@ module MiqPolicyController::Conditions
       end
       @edit = nil
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     when "reset", nil # Reset or first time in
       condition_build_edit_screen
@@ -24,7 +24,7 @@ module MiqPolicyController::Conditions
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("co")
+      replace_right_cell(:nodetype => "co")
       return
     end
 
@@ -67,32 +67,32 @@ module MiqPolicyController::Conditions
           case x_active_tree
           when :condition_tree
             @new_condition_node = "xx-#{condition.towhat.downcase}_co-#{to_cid(condition.id)}"
-            replace_right_cell("co", [:condition])
+            replace_right_cell(:nodetype => "co", :replace_trees => [:condition])
           when :policy_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
             @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{node_ids["p"]}_co-#{to_cid(condition.id)}"
-            replace_right_cell("co", [:policy_profile, :policy, :condition])
+            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition])
           when :policy_profile_tree
             node_ids = @sb[:node_ids][x_active_tree]  # Get the selected node ids
             @new_profile_node = "pp-#{node_ids["pp"]}_p-#{node_ids["p"]}_co-#{to_cid(condition.id)}"
-            replace_right_cell("co", [:policy_profile, :policy, :condition])
+            replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition])
           end
         else
           condition_get_info(Condition.find(condition.id))
-          replace_right_cell("co", [:policy_profile, :policy, :condition])
+          replace_right_cell(:nodetype => "co", :replace_trees => [:policy_profile, :policy, :condition])
         end
       else
         condition.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell("co")
+        replace_right_cell(:nodetype => "co")
       end
     when "expression", "applies_to_exp"
       session[:changed] = (@edit[:new] != @edit[:current])
       @expkey = params[:button].to_sym
       @edit[:expression_table] = @edit[:new][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:new][:expression])
       @edit[:scope_table] = @edit[:new][:applies_to_exp] == {"???" => "???"} ? nil : exp_build_table(@edit[:new][:applies_to_exp])
-      replace_right_cell("co")
+      replace_right_cell(:nodetype => "co")
     end
   end
 
@@ -115,7 +115,7 @@ module MiqPolicyController::Conditions
     nodes = x_node.split("_")
     nodes.pop
     @new_policy_node = self.x_node = nodes.join("_")
-    replace_right_cell("p", [:policy_profile, :policy])
+    replace_right_cell(:nodetype => "p", :replace_trees => [:policy_profile, :policy])
   end
 
   def condition_delete
@@ -132,7 +132,7 @@ module MiqPolicyController::Conditions
     end
     process_conditions(conditions, "destroy") unless conditions.empty?
     get_node_info(@new_condition_node)
-    replace_right_cell("xx", [:condition])
+    replace_right_cell(:nodetype => "xx", :replace_trees => [:condition])
   end
 
   def condition_field_changed

--- a/app/controllers/miq_policy_controller/events.rb
+++ b/app/controllers/miq_policy_controller/events.rb
@@ -8,7 +8,7 @@ module MiqPolicyController::Events
       @edit = nil
       add_flash(_("Edit Event cancelled by user"))
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     when "reset", nil # Reset or first time in
       event_build_edit_screen
@@ -16,7 +16,7 @@ module MiqPolicyController::Events
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("ev")
+      replace_right_cell(:nodetype => "ev")
       return
     end
 
@@ -38,15 +38,15 @@ module MiqPolicyController::Events
       @nodetype = "ev"
       event_get_info(MiqEventDefinition.find(event.id))
       @edit = nil
-      replace_right_cell("ev", [:policy_profile, :policy])
+      replace_right_cell(:nodetype => "ev", :replace_trees => [:policy_profile, :policy])
     when "true_right", "true_left", "true_allleft", "true_up", "true_down", "true_sync", "true_async"
       handle_selection_buttons(:actions_true, :members_chosen_true, :choices_true, :choices_chosen_true)
       session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell("ev")
+      replace_right_cell(:nodetype => "ev")
     when "false_right", "false_left", "false_allleft", "false_up", "false_down", "false_sync", "false_async"
       handle_selection_buttons(:actions_false, :members_chosen_false, :choices_false, :choices_chosen_false)
       session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell("ev")
+      replace_right_cell(:nodetype => "ev")
     end
   end
 

--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -14,7 +14,7 @@ module MiqPolicyController::MiqActions
       end
       @sb[:action] = nil
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     when "reset", nil # Reset or first time in
       action_build_edit_screen
@@ -22,7 +22,7 @@ module MiqPolicyController::MiqActions
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("a")
+      replace_right_cell(:nodetype => "a")
       return
     end
 
@@ -49,7 +49,7 @@ module MiqPolicyController::MiqActions
         @edit = nil
         @nodetype = "a"
         @new_action_node = "a-#{to_cid(action.id)}"
-        replace_right_cell("a", params[:button] == "save" ? [:policy_profile, :policy, :action] : [:action])
+        replace_right_cell(:nodetype => "a", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy, :action] : [:action])
         @sb[:action] = nil
       else
         action.errors.each do |field, msg|
@@ -60,7 +60,7 @@ module MiqPolicyController::MiqActions
     when "move_right", "move_left", "move_allleft"
       action_handle_selection_buttons(:alerts)
       session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell("a")
+      replace_right_cell(:nodetype => "a")
     end
   end
 
@@ -77,7 +77,7 @@ module MiqPolicyController::MiqActions
     process_actions(actions, "destroy") unless actions.empty?
     @new_action_node = self.x_node = "root"
     get_node_info(x_node)
-    replace_right_cell("root", [:action])
+    replace_right_cell(:nodetype => "root", :replace_trees => [:action])
   end
 
   def action_field_changed

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -14,7 +14,7 @@ module MiqPolicyController::Policies
       end
       @edit = nil
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     when "reset", nil # Reset or first time in
       @sb[:action] = "policy_edit"
@@ -22,7 +22,7 @@ module MiqPolicyController::Policies
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("p")
+      replace_right_cell(:nodetype => "p")
       return
     end
 
@@ -67,25 +67,25 @@ module MiqPolicyController::Policies
         @nodetype = "p"
         case x_active_tree
         when :policy_profile_tree
-          replace_right_cell("p", [:policy_profile, :policy])
+          replace_right_cell(:nodetype => "p", :replace_trees => [:policy_profile, :policy])
         when :policy_tree
           @nodetype = "p"
           if params[:button] == "add"
             self.x_node = @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{to_cid(policy.id)}"
             get_node_info(@new_policy_node)
           end
-          replace_right_cell("p", params[:button] == "save" ? [:policy_profile, :policy] : [:policy])
+          replace_right_cell(:nodetype => "p", :replace_trees => params[:button] == "save" ? [:policy_profile, :policy] : [:policy])
         end
       else
         policy.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell("p")
+        replace_right_cell(:nodetype => "p")
       end
     when "move_right", "move_left", "move_allleft"
       handle_selection_buttons(:conditions)
       session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell("p")
+      replace_right_cell(:nodetype => "p")
     end
   end
 
@@ -108,7 +108,7 @@ module MiqPolicyController::Policies
       add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc})
       @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{to_cid(policy.id)}"
       get_node_info(@new_policy_node)
-      replace_right_cell("p", [:policy])
+      replace_right_cell(:nodetype => "p", :replace_tres => [:policy])
     end
   end
 
@@ -128,7 +128,7 @@ module MiqPolicyController::Policies
     add_flash(_("The selected %{models} was deleted") %
       {:models => ui_lookup(:models => "MiqPolicy")}) if @flash_array.nil?
     get_node_info(@new_policy_node)
-    replace_right_cell("xx", [:policy, :policy_profile])
+    replace_right_cell(:nodetype => "xx", :replace_tres => [:policy, :policy_profile])
   end
 
   def policy_field_changed

--- a/app/controllers/miq_policy_controller/policy_profiles.rb
+++ b/app/controllers/miq_policy_controller/policy_profiles.rb
@@ -13,7 +13,7 @@ module MiqPolicyController::PolicyProfiles
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqPolicySet"), :name => @profile.description})
       end
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     when "reset", nil # Reset or first time in
       profile_build_edit_screen
@@ -21,7 +21,7 @@ module MiqPolicyController::PolicyProfiles
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("pp")
+      replace_right_cell(:nodetype => "pp")
       return
     end
 
@@ -57,17 +57,17 @@ module MiqPolicyController::PolicyProfiles
         @edit = nil
         @nodetype = "pp"
         @new_profile_node = "pp-#{to_cid(profile.id)}"
-        replace_right_cell("pp", [:policy_profile])
+        replace_right_cell(:nodetype => "pp", :replace_trees => [:policy_profile])
       else
         profile.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell("pp")
+        replace_right_cell(:nodetype => "pp")
       end
     when "move_right", "move_left", "move_allleft"
       handle_selection_buttons(:policies)
       session[:changed] = (@edit[:new] != @edit[:current])
-      replace_right_cell("pp")
+      replace_right_cell(:nodetype => "pp")
     end
   end
 
@@ -86,7 +86,7 @@ module MiqPolicyController::PolicyProfiles
       {:models => ui_lookup(:models => "MiqPolicySet")}) if @flash_array.nil?
     self.x_node = @new_profile_node = 'root'
     get_node_info('root')
-    replace_right_cell('root', [:policy_profile])
+    replace_right_cell(:nodetype => 'root', :replace_trees => [:policy_profile])
   end
 
   def profile_field_changed

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -139,7 +139,7 @@ class OpsController < ApplicationController
     session[:changed] = false
     set_active_tab(x_node)
     get_node_info(x_node)
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   def tree_select
@@ -150,7 +150,7 @@ class OpsController < ApplicationController
     session[:changed] = false
     self.x_node = params[:id] # if x_active_tree == :vmdb_tree #params[:action] == "x_show"
     get_node_info(params[:id])
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   def change_tab(new_tab_id = nil)
@@ -176,10 +176,10 @@ class OpsController < ApplicationController
       @flash_array = nil if MiqServer.my_server(true).logon_status == :ready  # don't reset if flash array
       if x_active_tree == :settings_tree
         settings_get_info
-        replace_right_cell("root")
+        replace_right_cell(:nodetype => "root")
       elsif x_active_tree == :vmdb_tree
         db_get_info
-        replace_right_cell("root")
+        replace_right_cell(:nodetype => "root")
       elsif x_active_tree == :diagnostics_tree
         case @sb[:active_tab]
         when "diagnostics_roles_servers"
@@ -190,7 +190,7 @@ class OpsController < ApplicationController
           @sb[:diag_selected_id] = nil
         end
         diagnostics_set_form_vars
-        replace_right_cell("root")
+        replace_right_cell(:nodetype => "root")
       end
     end
   end
@@ -469,7 +469,8 @@ class OpsController < ApplicationController
     end
   end
 
-  def replace_right_cell(nodetype, replace_trees = []) # replace_trees can be an array of tree symbols to be replaced
+  def replace_right_cell(options = {}) # replace_trees can be an array of tree symbols to be replaced
+    nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
     # get_node_info might set this
     replace_trees = @replace_trees if @replace_trees
     @explorer = true

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -64,7 +64,7 @@ module OpsController::Diagnostics
     end
     @refresh_partial = "layouts/gtl"
     pm_get_workers
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
   alias_method :restart_workers, :pm_restart_workers
 
@@ -73,7 +73,7 @@ module OpsController::Diagnostics
     @lastaction = "refresh_workers"
     @refresh_partial = "layouts/gtl"
     pm_get_workers
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
   alias_method :refresh_workers, :pm_refresh_workers
 
@@ -88,7 +88,7 @@ module OpsController::Diagnostics
       add_flash(_("Edit Log Depot settings was cancelled by the user"))
       @record = nil
       diagnostics_set_form_vars
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save"
       pfx = @sb[:active_tab] == "diagnostics_collect_logs" ? "logdepot" : "dbbackup"
       id = params[:id] ? params[:id] : "new"
@@ -122,7 +122,7 @@ module OpsController::Diagnostics
         @edit = nil
         @record = nil
         diagnostics_set_form_vars
-        replace_right_cell(x_node)
+        replace_right_cell(:nodetype => x_node)
       end
     when "validate"
       id = params[:id] ? params[:id] : "new"
@@ -144,7 +144,7 @@ module OpsController::Diagnostics
       javascript_flash(:spinner_off => true)
     when nil # Reset or first time in
       @in_a_form = true
-      replace_right_cell("log_depot_edit")
+      replace_right_cell(:nodetype => "log_depot_edit")
     end
   end
 
@@ -619,14 +619,14 @@ module OpsController::Diagnostics
       end
     end
     get_node_info(x_node)
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   # Reload the selected node and redraw the screen via ajax
   def refresh_server_summary
     assert_privileges("refresh_server_summary")
     get_node_info(x_node)
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def pm_get_workers

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -112,7 +112,7 @@ module OpsController::OpsRbac
                     {:model => tenant_type_title_string(params[:divisible] == "true"), :name => @tenant.name})
       end
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save", "add"
       tenant = params[:id] != "new" ? Tenant.find_by_id(params[:id]) : Tenant.new
 
@@ -137,7 +137,7 @@ module OpsController::OpsRbac
         else
           get_node_info(x_node)
         end
-        replace_right_cell("root", [:rbac])
+        replace_right_cell(:nodetype => "root", :replace_trees => [:rbac])
       end
     when "reset", nil # Reset or first time in
       obj = find_checked_items
@@ -154,7 +154,7 @@ module OpsController::OpsRbac
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("tenant_edit")
+      replace_right_cell(:nodetype => "tenant_edit")
     end
   end
 
@@ -189,7 +189,7 @@ module OpsController::OpsRbac
       add_flash(_("Manage quotas for %{model}\ \"%{name}\" was cancelled by the user") %
                     {:model => tenant_type_title_string(@tenant.divisible), :name => @tenant.name})
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save", "add"
       tenant = Tenant.find_by_id(params[:id])
       begin
@@ -206,7 +206,7 @@ module OpsController::OpsRbac
         add_flash(_("Quotas for %{model} \"%{name}\" were saved") %
                       {:model => tenant_type_title_string(tenant.divisible), :name => tenant.name})
         get_node_info(x_node)
-        replace_right_cell("root", [:rbac])
+        replace_right_cell(:nodetype => "root", :replace_trees => [:rbac])
       end
     when "reset", nil # Reset or first time in
       obj = find_checked_items
@@ -219,7 +219,7 @@ module OpsController::OpsRbac
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("tenant_manage_quotas")
+      replace_right_cell(:nodetype => "tenant_manage_quotas")
     end
   end
 
@@ -300,7 +300,7 @@ module OpsController::OpsRbac
       self.x_node  = "xx-u"  # reset node to show list
     end
     get_node_info(x_node)
-    replace_right_cell(x_node, [:rbac])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:rbac])
   end
 
   def rbac_role_delete
@@ -320,7 +320,7 @@ module OpsController::OpsRbac
       self.x_node  = "xx-ur" if MiqUserRole.find_by_id(params[:id]).nil? # reset node to show list
     end
     get_node_info(x_node)
-    replace_right_cell(x_node, [:rbac])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:rbac])
   end
 
   # Show the main Users/Groups/Roles list view
@@ -361,7 +361,7 @@ module OpsController::OpsRbac
 
     process_tenants(tenants, "destroy") unless tenants.empty?
     get_node_info(x_node)
-    replace_right_cell(x_node, [:rbac])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:rbac])
   end
 
   def rbac_group_delete
@@ -382,7 +382,7 @@ module OpsController::OpsRbac
       self.x_node  = "xx-g" if MiqGroup.find_by_id(params[:id]).nil? # reset node to show list
     end
     get_node_info(x_node)
-    replace_right_cell(x_node, [:rbac])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:rbac])
   end
 
   def rbac_group_seq_edit
@@ -392,7 +392,7 @@ module OpsController::OpsRbac
       @edit = nil
       add_flash(_("Edit Sequence of User Groups was cancelled by the user"))
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save"
       return unless load_edit("rbac_group_edit__seq", "replace_cell__explorer")
       err = false
@@ -413,11 +413,11 @@ module OpsController::OpsRbac
         @_in_a_form = false
         @edit = session[:edit] = nil  # clean out the saved info
         get_node_info(x_node)
-        replace_right_cell(x_node)
+        replace_right_cell(:nodetype => x_node)
       else
         drop_breadcrumb(:name => _("Edit User Group Sequence"), :url => "/configuration/ldap_seq_edit")
         @in_a_form = true
-        replace_right_cell("group_seq")
+        replace_right_cell(:nodetype => "group_seq")
       end
     when "reset", nil # Reset or first time in
       rbac_group_seq_edit_screen
@@ -425,7 +425,7 @@ module OpsController::OpsRbac
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("group_seq")
+      replace_right_cell(:nodetype => "group_seq")
     end
   end
 
@@ -607,7 +607,7 @@ module OpsController::OpsRbac
     add_flash(_("All changes have been reset"), :warning)  if params[:button] == "reset"
     @sb[:pre_edit_node] = x_node  unless params[:button]  # Save active tree node before edit
     @right_cell_text = _("Editing %{model} for \"%{name}\"") % {:name => ui_lookup(:models => @tagging), :model => "#{current_tenant.name} Tags"}
-    replace_right_cell("root")
+    replace_right_cell(:nodetype => "root")
   end
 
   def rbac_edit_tags_cancel
@@ -617,7 +617,7 @@ module OpsController::OpsRbac
     self.x_node  = @sb[:pre_edit_node]
     get_node_info(x_node)
     @edit = nil # clean out the saved info
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   def rbac_edit_tags_save
@@ -646,7 +646,7 @@ module OpsController::OpsRbac
     self.x_node  = @sb[:pre_edit_node]
     get_node_info(x_node)
     @edit = nil # clean out the saved info
-    replace_right_cell(@nodetype)
+    replace_right_cell(:nodetype => @nodetype)
   end
 
   def rbac_edit_reset(operation, what, klass)
@@ -700,7 +700,7 @@ module OpsController::OpsRbac
     else
       @right_cell_text = _("Adding a new %{name}") % {:name => what.titleize}
     end
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def rbac_edit_save_or_add(what, rbac_suffix = what)
@@ -742,7 +742,7 @@ module OpsController::OpsRbac
       end
       # Get selected Node
       get_node_info(x_node)
-      replace_right_cell(x_node, [:rbac])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:rbac])
     else
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
       record.errors.each { |field, msg| add_flash("#{field.to_s.capitalize} #{msg}", :error) }

--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -141,7 +141,7 @@ module OpsController::Settings
     case params[:button]
     when "cancel"
       session[:edit] = @edit = nil
-      replace_right_cell("root")
+      replace_right_cell(:nodetype => "root")
     when "save"
       return unless load_edit("region_edit__#{params[:id]}", "replace_cell__explorer")
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
@@ -165,14 +165,14 @@ module OpsController::Settings
         add_flash(_("%{model} \"%{name}\" was saved") % {:model => ui_lookup(:model => "MiqRegion"), :name => @edit[:region].description})
         AuditEvent.success(build_saved_audit(@edit[:region], params[:button] == "edit"))
         @edit = session[:edit] = nil  # clean out the saved info
-        replace_right_cell("root", [:settings])
+        replace_right_cell(:nodetype => "root", :replace_trees => [:settings])
       end
     when "reset", nil # Reset or first time in
       region_set_form_vars
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("root")
+      replace_right_cell(:nodetype => "root")
     end
   end
 

--- a/app/controllers/ops_controller/settings/analysis_profiles.rb
+++ b/app/controllers/ops_controller/settings/analysis_profiles.rb
@@ -231,7 +231,7 @@ module OpsController::Settings::AnalysisProfiles
         #       @scan = @edit[:scan] = nil
         @scan = nil
         #       @edit = session[:edit] = nil  # clean out the saved info
-        replace_right_cell(@nodetype)
+        replace_right_cell(:nodetype => @nodetype)
       when "save", "add"
         id = params[:button] == "add" ? "new" : params[:id]
         return unless load_edit("ap_edit__#{id}", "replace_cell__explorer")
@@ -246,8 +246,6 @@ module OpsController::Settings::AnalysisProfiles
           @edit[:new] = ap_sort_array(@edit[:new])
           @edit[:current] = ap_sort_array(@edit[:current])
           @changed = session[:changed] = (@edit[:new] != @edit[:current])
-          # ap_build_edit_screen
-          # replace_right_cell("root",[:settings])
           javascript_flash
         else
           scanitemset = params[:button] == "add" ? ScanItemSet.new : ScanItemSet.find_by_id(@edit[:scan_id])    # get the current record
@@ -276,7 +274,7 @@ module OpsController::Settings::AnalysisProfiles
             @edit = session[:edit] = nil  # clean out the saved info
             self.x_node = "xx-sis" if params[:button] == "add"
             get_node_info(x_node)
-            replace_right_cell(x_node, [:settings])
+            replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
           else
             scanitemset.errors.each do |field, msg|
               add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -298,7 +296,7 @@ module OpsController::Settings::AnalysisProfiles
             if @scan.read_only
               add_flash(_("Sample %{model} \"%{name}\" can not be edited") % {:model => ui_lookup(:model => "ScanItemSet"), :name => @scan.name}, :error)
               get_node_info(x_node)
-              replace_right_cell(@nodetype)
+              replace_right_cell(:nodetype => @nodetype)
               return
             end
           else
@@ -342,7 +340,7 @@ module OpsController::Settings::AnalysisProfiles
         @edit[:new] = ap_sort_array(@edit[:new])
         @edit[:current] = ap_sort_array(@edit[:current])
         @changed = session[:changed] = (@edit[:new] != @edit[:current])
-        replace_right_cell("sie")
+        replace_right_cell(:nodetype => "sie")
       end
     end
   end
@@ -422,7 +420,7 @@ module OpsController::Settings::AnalysisProfiles
     end
     self.x_node = "xx-sis"
     get_node_info(x_node)
-    replace_right_cell(x_node, [:settings])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
   end
 
   private

--- a/app/controllers/ops_controller/settings/cap_and_u.rb
+++ b/app/controllers/ops_controller/settings/cap_and_u.rb
@@ -38,12 +38,12 @@ module OpsController::Settings::CapAndU
 
       add_flash(_("Capacity and Utilization Collection settings saved"))
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     elsif params[:button] == "reset"
       @changed = false
       add_flash(_("All changes have been reset"), :warning)
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     end
   end
 

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -476,7 +476,7 @@ module OpsController::Settings::Common
       end
       #     redirect_to :action => 'explorer', :flash_msg=>msg, :flash_error=>err, :no_refresh=>true
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
       return
     end
     if !%w(settings_advanced settings_rhn_edit settings_workers).include?(@sb[:active_tab]) &&
@@ -522,12 +522,12 @@ module OpsController::Settings::Common
         session[:changed] = @changed = false
         get_node_info(x_node)
         if @sb[:active_tab] == "settings_server"
-          replace_right_cell(@nodetype, [:diagnostics, :settings])
+          replace_right_cell(:nodetype => @nodetype, :replace_trees => [:diagnostics, :settings])
         elsif @sb[:active_tab] == "settings_custom_logos"
           javascript_redirect :action => 'explorer', :flash_msg => @flash_array[0][:message], :flash_error => @flash_array[0][:level] == :error, :escape => false # redirect to build the server screen
           return
         else
-          replace_right_cell(@nodetype)
+          replace_right_cell(:nodetype => @nodetype)
         end
       else
         @update.errors.each do |field, msg|
@@ -536,7 +536,7 @@ module OpsController::Settings::Common
         @changed = true
         session[:changed] = @changed
         get_node_info(x_node)
-        replace_right_cell(@nodetype)
+        replace_right_cell(:nodetype => @nodetype)
       end
     elsif @sb[:active_tab] == "settings_workers" &&
           x_node.split("-").first != "z"
@@ -562,19 +562,19 @@ module OpsController::Settings::Common
         end
         @changed = false
         get_node_info(x_node)
-        replace_right_cell(@nodetype)
+        replace_right_cell(:nodetype => @nodetype)
       else
         @update.errors.each do |field, msg|
           add_flash("#{field.titleize}: #{msg}", :error)
         end
         @changed = true
         get_node_info(x_node)
-        replace_right_cell(@nodetype)
+        replace_right_cell(:nodetype => @nodetype)
       end
     else
       @changed = false
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     end
   end
 
@@ -585,7 +585,7 @@ module OpsController::Settings::Common
       edit_rhn
     else
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     end
   end
 
@@ -595,7 +595,7 @@ module OpsController::Settings::Common
     @edit = nil
     settings_get_info('root')
     add_flash(_("Edit of Customer Information was cancelled"))
-    replace_right_cell('root')
+    replace_right_cell(:nodetype => 'root')
   end
 
   def settings_server_validate

--- a/app/controllers/ops_controller/settings/label_tag_mapping.rb
+++ b/app/controllers/ops_controller/settings/label_tag_mapping.rb
@@ -14,7 +14,7 @@ module OpsController::Settings::LabelTagMapping
       end
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save", "add"
       id = params[:id] ? params[:id] : "new"
       return unless load_edit("label_tag_mapping_edit__#{id}", "replace_cell__explorer")
@@ -46,7 +46,7 @@ module OpsController::Settings::LabelTagMapping
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("ltme")
+      replace_right_cell(:nodetype => "ltme")
     end
   end
 
@@ -157,7 +157,7 @@ module OpsController::Settings::LabelTagMapping
                                                        :name  => label_name})
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info
-      replace_right_cell("root")
+      replace_right_cell(:nodetype => "root")
     end
   end
 
@@ -175,7 +175,7 @@ module OpsController::Settings::LabelTagMapping
                                                        :name  => mapping.label_name})
       get_node_info(x_node)
       @lt_map = @edit = session[:edit] = nil # clean out the saved info
-      replace_right_cell("root")
+      replace_right_cell(:nodetype => "root")
     end
   end
 

--- a/app/controllers/ops_controller/settings/ldap.rb
+++ b/app/controllers/ops_controller/settings/ldap.rb
@@ -41,7 +41,7 @@ module OpsController::Settings::Ldap
       get_node_info(x_node)
       @ldap_region = nil
       @edit = session[:edit] = nil  # clean out the saved info
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save", "add"
       id = params[:id] ? params[:id] : "new"
       return unless load_edit("ldap_region_edit__#{id}", "replace_cell__explorer")
@@ -68,7 +68,7 @@ module OpsController::Settings::Ldap
           self.x_node = "lr-#{to_cid(@ldap_region.id)}"
           get_node_info(x_node)
         end
-        replace_right_cell("root", [:settings])
+        replace_right_cell(:nodetype => "root", :replace_trees => [:settings])
       else
         @ldap_region.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -86,7 +86,7 @@ module OpsController::Settings::Ldap
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("lre")
+      replace_right_cell(:nodetype => "lre")
     end
   end
 
@@ -123,7 +123,7 @@ module OpsController::Settings::Ldap
     end
     self.x_node = "xx-l"
     get_node_info(x_node)
-    replace_right_cell(x_node, [:settings])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
   end
 
   def ldap_domain_add
@@ -158,7 +158,7 @@ module OpsController::Settings::Ldap
       get_node_info(x_node)
       @ldap_domain = nil
       @edit = session[:edit] = nil  # clean out the saved info
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     elsif params[:button] == "save" || params[:button] == "add"
       id = params[:id] ? params[:id] : "new"
       return unless load_edit("ldap_domain_edit__#{id}", "replace_cell__explorer")
@@ -187,7 +187,7 @@ module OpsController::Settings::Ldap
           self.x_node = "ld-#{to_cid(@ldap_domain.id)}"
         end
         get_node_info(x_node)
-        replace_right_cell(x_node, [:settings])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
       else
         @ldap_domain.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -236,7 +236,7 @@ module OpsController::Settings::Ldap
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("lde")
+      replace_right_cell(:nodetype => "lde")
     end
   end
 
@@ -291,7 +291,7 @@ module OpsController::Settings::Ldap
     self.x_node = "lr-#{ld.ldap_region_id}"
     process_ldap_domains(ldap_domains, "destroy") unless ldap_domains.empty?
     get_node_info(x_node)
-    replace_right_cell(x_node, [:settings])
+    replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
   end
 
   # AJAX driven routine to select a classification entry

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -143,7 +143,7 @@ module OpsController::Settings::RHN
       @edit    = nil
       @sb[:active_tab] = 'settings_rhn'
       settings_get_info('root')
-      replace_right_cell('root')
+      replace_right_cell(:nodetype => 'root')
     end
   end
 
@@ -346,7 +346,7 @@ module OpsController::Settings::RHN
     @edit[:key] = "#{@sb[:active_tab]}__rhn_edit"
     @edit[:current] = copy_hash(@edit[:new])
     reset_repo_name_from_default
-    replace_right_cell('rhn')
+    replace_right_cell(:nodetype => 'rhn')
   end
 
   private

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -51,7 +51,7 @@ module OpsController::Settings::Schedules
       end
       get_node_info(x_node)
       @schedule = nil
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save", "add"
       schedule = params[:id] != "new" ? MiqSchedule.find_by_id(params[:id]) : MiqSchedule.new(:userid => session[:userid])
 
@@ -87,7 +87,7 @@ module OpsController::Settings::Schedules
           @selected_schedule = schedule
           get_node_info(x_node)
         end
-        replace_right_cell("root", [:settings])
+        replace_right_cell(:nodetype => "root", :replace_trees => [:settings])
       end
     when "reset", nil # Reset or first time in
       obj = find_checked_items
@@ -112,7 +112,7 @@ module OpsController::Settings::Schedules
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("se")
+      replace_right_cell(:nodetype => "se")
     end
   end
 
@@ -202,7 +202,7 @@ module OpsController::Settings::Schedules
       process_schedules(schedules, "destroy") unless schedules.empty?
       schedule_build_list
       settings_get_info("st")
-      replace_right_cell("root", [:settings])
+      replace_right_cell(:nodetype => "root", :replace_trees => [:settings])
     else # showing 1 schedule, delete it
       if params[:id].nil? || MiqSchedule.find_by_id(params[:id]).nil?
         add_flash(_("%{table} no longer exists") % {:table => ui_lookup(:table => "miq_schedule")}, :error)
@@ -213,7 +213,7 @@ module OpsController::Settings::Schedules
       process_schedules(schedules, "destroy") unless schedules.empty?
       self.x_node = "xx-msc"
       get_node_info(x_node)
-      replace_right_cell(x_node, [:settings])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:settings])
     end
   end
 
@@ -233,7 +233,7 @@ module OpsController::Settings::Schedules
     add_flash(msg, :info, true) unless flash_errors?
     schedule_build_list
     settings_get_info("st")
-    replace_right_cell("root")
+    replace_right_cell(:nodetype => "root")
   end
 
   def schedule_enable

--- a/app/controllers/ops_controller/settings/tags.rb
+++ b/app/controllers/ops_controller/settings/tags.rb
@@ -45,7 +45,7 @@ module OpsController::Settings::Tags
       end
       get_node_info(x_node)
       @category = @edit = session[:edit] = nil    # clean out the saved info
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save", "add"
       id = params[:id] ? params[:id] : "new"
       return unless load_edit("category_edit__#{id}", "replace_cell__explorer")
@@ -81,7 +81,7 @@ module OpsController::Settings::Tags
           add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "Classification"), :name => @category.description})
           get_node_info(x_node)
           @category = @edit = session[:edit] = nil    # clean out the saved info
-          replace_right_cell("root")
+          replace_right_cell(:nodetype => "root")
         end
       else
         update_category = Classification.find(@category.id)
@@ -102,7 +102,7 @@ module OpsController::Settings::Tags
           session[:edit] = nil  # clean out the saved info
           get_node_info(x_node)
           @category = @edit = session[:edit] = nil    # clean out the saved info
-          replace_right_cell("root")
+          replace_right_cell(:nodetype => "root")
         end
       end
     when "reset", nil # Reset or first time in
@@ -117,7 +117,7 @@ module OpsController::Settings::Tags
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("ce")
+      replace_right_cell(:nodetype => "ce")
     end
   end
 

--- a/app/controllers/ops_controller/settings/zones.rb
+++ b/app/controllers/ops_controller/settings/zones.rb
@@ -9,7 +9,7 @@ module OpsController::Settings::Zones
       add_flash((@zone && @zone.id) ? _("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:table => "miq_zone"), :name => @zone.name} :
           _("Add of new %{table} was cancelled by the user") % {:table => ui_lookup(:table => "miq_zone")})
       get_node_info(x_node)
-      replace_right_cell(@nodetype)
+      replace_right_cell(:nodetype => @nodetype)
     when "save", "add"
       assert_privileges("zone_#{params[:id] ? "edit" : "new"}")
       id = params[:id] ? params[:id] : "new"
@@ -36,21 +36,21 @@ module OpsController::Settings::Zones
         self.x_node = params[:button] == "save" ?
               "z-#{@zone.id}" : "xx-z"
         get_node_info(x_node)
-        replace_right_cell("root", [:settings, :diagnostics])
+        replace_right_cell(:nodetype => "root", :replace_trees => [:settings, :diagnostics])
       else
         @in_a_form = true
         @edit[:errors].each { |msg| add_flash(msg, :error) }
         @zone.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
         end
-        replace_right_cell("ze")
+        replace_right_cell(:nodetype => "ze")
       end
     when "reset", nil # Reset or first time in
       zone_build_edit_screen
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("ze")
+      replace_right_cell(:nodetype => "ze")
     end
   end
 
@@ -71,7 +71,7 @@ module OpsController::Settings::Zones
       @sb[:active_tab] = "settings_list"
       self.x_node = "xx-z"
       get_node_info(x_node)
-      replace_right_cell(x_node, [:settings, :diagnostics])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:settings, :diagnostics])
     end
   end
 

--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -183,7 +183,7 @@ class ProviderForemanController < ApplicationController
       else
         add_flash(_("%{model} \"%{name}\" was updated") % {:model => model, :name => @provider_cfgmgmt.name})
       end
-      replace_right_cell([:configuration_manager_providers])
+      replace_right_cell(:replace_trees => [:configuration_manager_providers])
     else
       @provider_cfgmgmt.errors.each do |field, msg|
         @sb[:action] = nil
@@ -276,7 +276,7 @@ class ProviderForemanController < ApplicationController
                          end
       replace_right_cell
     else
-      replace_right_cell([:configuration_manager_providers])
+      replace_right_cell(:replace_trees => [:configuration_manager_providers])
     end
   end
 
@@ -292,7 +292,7 @@ class ProviderForemanController < ApplicationController
     @search_text = @sb[:foreman_search_text]["#{x_active_accord}_search_text"]
 
     load_or_clear_adv_search
-    replace_right_cell([x_active_accord])
+    replace_right_cell(:replace_trees => [x_active_accord])
   end
 
   def load_or_clear_adv_search
@@ -798,7 +798,8 @@ class ProviderForemanController < ApplicationController
     presenter[:right_cell_text] = @right_cell_text
   end
 
-  def replace_right_cell(replace_trees = [])
+  def replace_right_cell(options = {})
+    replace_trees = options[:replace_trees]
     return if @in_a_form
     @explorer = true
     @in_a_form = false

--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -93,7 +93,8 @@ class PxeController < ApplicationController
     x_history_add_item(:id => node, :text => @right_cell_text)
   end
 
-  def replace_right_cell(nodetype, replace_trees = [])
+  def replace_right_cell(options = {})
+    nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
     # FIXME
 

--- a/app/controllers/pxe_controller/iso_datastores.rb
+++ b/app/controllers/pxe_controller/iso_datastores.rb
@@ -19,7 +19,7 @@ module PxeController::IsoDatastores
     @isd = IsoDatastore.new
     iso_datastore_set_form_vars
     @in_a_form = true
-    replace_right_cell("isd")
+    replace_right_cell(:nodetype => "isd")
   end
 
   def iso_datastore_edit
@@ -31,7 +31,7 @@ module PxeController::IsoDatastores
     iso_datastore_set_form_vars
     @in_a_form = true
     session[:changed] = false
-    replace_right_cell("isd")
+    replace_right_cell(:nodetype => "isd")
   end
 
   def iso_datastore_create
@@ -42,7 +42,7 @@ module PxeController::IsoDatastores
       @edit = session[:edit] = nil # clean out the saved info
       add_flash(_("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:model => "IsoDatastore")})
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     elsif params[:button] == "add"
       isd = params[:id] ? find_by_id_filtered(IsoDatastore, params[:id]) : IsoDatastore.new
       if @edit[:new][:ems_id].blank?
@@ -61,7 +61,7 @@ module PxeController::IsoDatastores
         @edit = session[:edit] = nil # clean out the saved info
 
         get_node_info(x_node)
-        replace_right_cell(x_node, [:iso_datastores])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:iso_datastores])
       else
         @in_a_form = true
         isd.errors.each do |field, msg|
@@ -108,7 +108,7 @@ module PxeController::IsoDatastores
       end
 
       get_node_info(x_node)
-      replace_right_cell(x_node, [:iso_datastores])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:iso_datastores])
     else # showing 1 vm
       if params[:id].nil? || IsoDatastore.find_by_id(params[:id]).nil?
         add_flash(_("%{model} no longer exists") % {:model => ui_lookup(:model => "IsoDatastore")},
@@ -125,7 +125,7 @@ module PxeController::IsoDatastores
           @single_delete = true unless flash_errors?
         end
         get_node_info(x_node)
-        replace_right_cell(x_node, [:iso_datastores])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:iso_datastores])
       end
     end
     isds.count
@@ -171,7 +171,7 @@ module PxeController::IsoDatastores
       add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "IsoImage"), :name => session[:edit][:img].name})
       @edit = session[:edit] = nil  # clean out the saved info
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save"
       return unless load_edit("iso_img_edit__#{params[:id]}", "replace_cell__explorer")
       update_img = find_by_id_filtered(IsoImage, params[:id])
@@ -182,7 +182,7 @@ module PxeController::IsoDatastores
         refresh_tree = @edit[:new][:default_for_windows] == @edit[:current][:default_for_windows] ? [] : [:iso_datastore]
         @edit = session[:edit] = nil  # clean out the saved info
         get_node_info(x_node)
-        replace_right_cell(x_node, refresh_tree)
+        replace_right_cell(:nodetype => x_node, :replace_trees => refresh_tree)
       else
         update_img.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -200,7 +200,7 @@ module PxeController::IsoDatastores
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("isi")
+      replace_right_cell(:nodetype => "isi")
     end
   end
 

--- a/app/controllers/pxe_controller/pxe_customization_templates.rb
+++ b/app/controllers/pxe_controller/pxe_customization_templates.rb
@@ -60,7 +60,7 @@ module PxeController::PxeCustomizationTemplates
     @ct = CustomizationTemplate.new
     template_set_form_vars
     @in_a_form = true
-    replace_right_cell("ct-")
+    replace_right_cell(:nodetype => "ct-")
   end
 
   def customization_template_copy
@@ -89,7 +89,7 @@ module PxeController::PxeCustomizationTemplates
     template_set_form_vars
     @in_a_form = true
     session[:changed] = false
-    replace_right_cell("ct-#{params[:id]}")
+    replace_right_cell(:nodetype => "ct-#{params[:id]}")
   end
 
   def template_create_update
@@ -103,7 +103,7 @@ module PxeController::PxeCustomizationTemplates
               add_flash(_("Add of new %{model} was cancelled by the user") %
                          {:model => ui_lookup(:model => "PxeCustomizationTemplate")})
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     elsif ["add", "save"].include?(params[:button])
       if params[:id]
         ct = find_by_id_filtered(CustomizationTemplate, params[:id])
@@ -131,7 +131,7 @@ module PxeController::PxeCustomizationTemplates
         @edit = session[:edit] = nil # clean out the saved info
         self.x_node = "xx-xx-#{to_cid(ct.pxe_image_type.id)}"
         get_node_info(x_node)
-        replace_right_cell(x_node, [:customization_templates])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:customization_templates])
       else
         @in_a_form = true
         ct.errors.each do |field, msg|
@@ -218,7 +218,7 @@ module PxeController::PxeCustomizationTemplates
       end
 
       get_node_info(x_node)
-      replace_right_cell(x_node, [:customization_templates])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:customization_templates])
     else # showing 1 vm
       if params[:id].nil? || CustomizationTemplate.find_by_id(params[:id]).nil?
         add_flash(_("%{model} no longer exists") % {:model => ui_lookup(:model => "PxeCustomizationTemplate")},
@@ -235,7 +235,7 @@ module PxeController::PxeCustomizationTemplates
           self.x_node = "xx-xx-#{to_cid(ct.pxe_image_type_id)}"
         end
         get_node_info(x_node)
-        replace_right_cell(x_node, [:customization_templates])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:customization_templates])
       end
     end
     templates.count

--- a/app/controllers/pxe_controller/pxe_image_types.rb
+++ b/app/controllers/pxe_controller/pxe_image_types.rb
@@ -17,7 +17,7 @@ module PxeController::PxeImageTypes
     @pxe_image_type = PxeImageType.new
     pxe_image_type_set_form_vars
     @in_a_form = true
-    replace_right_cell("pit")
+    replace_right_cell(:nodetype => "pit")
   end
 
   def pxe_image_type_edit
@@ -32,7 +32,7 @@ module PxeController::PxeImageTypes
       end
       @edit = session[:edit] = nil # clean out the saved info
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     elsif ["add", "save"].include?(params[:button])
       id = params[:id] || "new"
       return unless load_edit("pxe_image_type_edit__#{id}", "replace_cell__explorer")
@@ -51,7 +51,7 @@ module PxeController::PxeImageTypes
         @edit = session[:edit] = nil # clean out the saved info
         add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "PxeImageType"), :name => add_pxe.name})
         get_node_info(x_node)
-        replace_right_cell(x_node, [:pxe_image_types, :customization_templates])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:pxe_image_types, :customization_templates])
       else
         @in_a_form = true
         add_pxe.errors.each do |field, msg|
@@ -70,7 +70,7 @@ module PxeController::PxeImageTypes
       pxe_image_type_set_form_vars
       @in_a_form = true
       session[:changed] = false
-      replace_right_cell("pit")
+      replace_right_cell(:nodetype => "pit")
     end
   end
 
@@ -101,7 +101,7 @@ module PxeController::PxeImageTypes
       end
 
       get_node_info(x_node)
-      replace_right_cell("root", [:pxe_image_types, :customization_templates])
+      replace_right_cell(:nodetype => "root", :replace_trees => [:pxe_image_types, :customization_templates])
     else # showing 1 vm
       if params[:id].nil? || PxeImageType.find_by_id(params[:id]).nil?
         add_flash(_("%{model} no longer exists") % {:model => ui_lookup(:model => "PxeImageType")},
@@ -118,7 +118,7 @@ module PxeController::PxeImageTypes
           @single_delete = true unless flash_errors?
         end
         get_node_info(x_node)
-        replace_right_cell(x_node, [:pxe_image_types, :customization_templates])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:pxe_image_types, :customization_templates])
       end
     end
     pxes.count

--- a/app/controllers/pxe_controller/pxe_servers.rb
+++ b/app/controllers/pxe_controller/pxe_servers.rb
@@ -19,7 +19,7 @@ module PxeController::PxeServers
     @ps = PxeServer.new
     pxe_server_set_form_vars
     @in_a_form = true
-    replace_right_cell("ps")
+    replace_right_cell(:nodetype => "ps")
   end
 
   def pxe_server_edit
@@ -32,7 +32,7 @@ module PxeController::PxeServers
     pxe_server_set_form_vars
     @in_a_form = true
     session[:changed] = false
-    replace_right_cell("ps")
+    replace_right_cell(:nodetype => "ps")
   end
 
   def pxe_server_create_update
@@ -48,7 +48,7 @@ module PxeController::PxeServers
         add_flash(_("Add of new %{model} was cancelled by the user") % {:model => ui_lookup(:model => "PxeServer")})
       end
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     elsif ["add", "save"].include?(params[:button])
       pxe = params[:id] ? find_by_id_filtered(PxeServer, params[:id]) : PxeServer.new
       pxe_server_validate_fields
@@ -71,7 +71,7 @@ module PxeController::PxeServers
         @edit = session[:edit] = nil # clean out the saved info
 
         get_node_info(x_node)
-        replace_right_cell(x_node, [:pxe_servers])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:pxe_servers])
       else
         @in_a_form = true
         pxe.errors.each do |field, msg|
@@ -128,7 +128,7 @@ module PxeController::PxeServers
       end
 
       get_node_info(x_node)
-      replace_right_cell(x_node, [:pxe_servers])
+      replace_right_cell(:nodetype => x_node, :replace_trees => [:pxe_servers])
     else # showing 1 vm
       if params[:id].nil? || PxeServer.find_by_id(params[:id]).nil?
         add_flash(_("%{model} no longer exists") % {:model => ui_lookup(:model => "PxeServer")},
@@ -145,7 +145,7 @@ module PxeController::PxeServers
           @single_delete = true unless flash_errors?
         end
         get_node_info(x_node)
-        replace_right_cell(x_node, [:pxe_servers])
+        replace_right_cell(:nodetype => x_node, :replace_trees => [:pxe_servers])
       end
     end
     pxes.count
@@ -191,7 +191,7 @@ module PxeController::PxeServers
       add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "PxeImage"), :name => session[:edit][:img].name})
       @edit = session[:edit] = nil  # clean out the saved info
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save"
       return unless load_edit("pxe_img_edit__#{params[:id]}", "replace_cell__explorer")
       update_img = find_by_id_filtered(PxeImage, params[:id])
@@ -202,7 +202,7 @@ module PxeController::PxeServers
         refresh_trees = @edit[:new][:default_for_windows] == @edit[:current][:default_for_windows] ? [] : [:pxe_server]
         @edit = session[:edit] = nil  # clean out the saved info
         get_node_info(x_node)
-        replace_right_cell(x_node, refresh_trees)
+        replace_right_cell(:nodetype => x_node, :replace_trees => refresh_trees)
       else
         update_img.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -220,7 +220,7 @@ module PxeController::PxeServers
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("pi")
+      replace_right_cell(:nodetype => "pi")
     end
   end
 
@@ -242,7 +242,7 @@ module PxeController::PxeServers
       add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "WindowsImage"), :name => session[:edit][:wimg].name})
       @edit = session[:edit] = nil  # clean out the saved info
       get_node_info(x_node)
-      replace_right_cell(x_node)
+      replace_right_cell(:nodetype => x_node)
     when "save"
       return unless load_edit("pxe_wimg_edit__#{params[:id]}", "replace_cell__explorer")
       update_wimg = find_by_id_filtered(WindowsImage, params[:id])
@@ -252,7 +252,7 @@ module PxeController::PxeServers
         AuditEvent.success(build_saved_audit(update_wimg, @edit))
         @edit = session[:edit] = nil  # clean out the saved info
         get_node_info(x_node)
-        replace_right_cell(x_node)
+        replace_right_cell(:nodetype => x_node)
       else
         update_wimg.errors.each do |field, msg|
           add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -270,7 +270,7 @@ module PxeController::PxeServers
       if params[:button] == "reset"
         add_flash(_("All changes have been reset"), :warning)
       end
-      replace_right_cell("wi")
+      replace_right_cell(:nodetype => "wi")
     end
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -231,7 +231,7 @@ class ReportController < ApplicationController
       end
     end
 
-    replace_right_cell :partial => 'export_widgets'
+    replace_right_cell(:partial => 'export_widgets')
   end
 
   def import_widgets
@@ -249,7 +249,7 @@ class ReportController < ApplicationController
       add_flash(_("Widget import cancelled"), :info)
     end
 
-    replace_right_cell :partial => 'export_widgets'
+    replace_right_cell(:partial => 'export_widgets')
   end
 
   private ###########################

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -27,7 +27,7 @@ class ServiceController < ApplicationController
     return if [:service_delete, :service_edit, :service_reconfigure].include?(performed_action)
 
     if @refresh_partial
-      replace_right_cell(action)
+      replace_right_cell(:action => action)
     else
       add_flash(_("Button not yet implemented %{model_name}:%{action_name}") %
         {:model_name => model, :action_name => action}, :error) unless @flash_array
@@ -101,13 +101,13 @@ class ServiceController < ApplicationController
       else
         add_flash(_("Service \"%{name}\" was saved") % {:name => service.name})
       end
-      replace_right_cell(nil, [:svcs])
+      replace_right_cell(:replace_trees => [:svcs])
     when "reset", nil # Reset or first time in
       checked = find_checked_items
       checked[0] = params[:id] if checked.blank? && params[:id]
       @service = find_by_id_filtered(Service, checked[0])
       @in_a_form = true
-      replace_right_cell("service_edit")
+      replace_right_cell(:action => "service_edit")
       return
     end
   end
@@ -169,7 +169,7 @@ class ServiceController < ApplicationController
       process_elements(elements, Service, 'destroy') unless elements.empty?
     end
     params[:id] = nil
-    replace_right_cell(nil, [:svcs])
+    replace_right_cell(:replace_trees => [:svcs])
   end
 
   def get_record_display_name(record)
@@ -233,7 +233,8 @@ class ServiceController < ApplicationController
   end
 
   # Replace the right cell of the explorer
-  def replace_right_cell(action = nil, replace_trees = [])
+  def replace_right_cell(options = {})
+    action, replace_trees = options.values_at(:action, :replace_trees)
     @explorer = true
     partial, action_url, @right_cell_text = set_right_cell_vars(action) if action # Set partial name, action and cell header
     get_node_info(x_node) if !@edit && !@in_a_form && !params[:display]

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -262,7 +262,7 @@ class StorageController < ApplicationController
     @search_text = @sb[:storage_search_text]["#{x_active_accord}_search_text"]
 
     load_or_clear_adv_search
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def load_or_clear_adv_search
@@ -301,7 +301,7 @@ class StorageController < ApplicationController
 
     load_or_clear_adv_search
     apply_node_search_text if x_active_tree == :storage_tree
-    replace_right_cell(x_node)
+    replace_right_cell(:nodetype => x_node)
   end
 
   def tree_record
@@ -455,7 +455,9 @@ class StorageController < ApplicationController
     record.try(:id)
   end
 
-  def replace_right_cell(_nodetype = "root", replace_trees = [])
+  def replace_right_cell(options = {})
+    # FIXME: nodetype passed here, but not used
+    _nodetype, replace_trees = options.values_at(:nodetype, :replace_trees)
     replace_trees = @replace_trees if @replace_trees  # get_node_info might set this
     # FIXME
     @explorer = true

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1354,7 +1354,9 @@ module VmCommon
   end
 
   # Replace the right cell of the explorer
-  def replace_right_cell(action = nil, presenter = nil)
+  def replace_right_cell(options = {})
+    action, presenter = options.values_at(:action, :presenter)
+
     @explorer = true
     @sb[:action] = action unless action.nil?
     if @sb[:action] || params[:display]

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -414,7 +414,7 @@ describe MiqAeCustomizationController do
       end
 
       it "updates the dialogs tree" do
-        expect(controller).to receive(:replace_right_cell).with(nil, [:dialogs])
+        expect(controller).to receive(:replace_right_cell).with(:nodetype => nil, :replace_trees => [:dialogs])
         post :import_service_dialogs, :params => params, :xhr => true
       end
     end

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -206,7 +206,7 @@ describe MiqPolicyController do
       allow(controller).to receive(:render).and_return(nil)
       presenter = ExplorerPresenter.new(:active_tree => :policy_tree)
 
-      controller.send(:replace_right_cell, 'root', [:policy], presenter)
+      controller.send(:replace_right_cell, {:nodetype => 'root', :replace_trees => [:policy], :presenter => presenter})
       expect(presenter[:replace_partials]).to have_key('policy_tree_div')
     end
 
@@ -217,7 +217,7 @@ describe MiqPolicyController do
       allow(controller).to receive(:render).and_return(nil)
       presenter = ExplorerPresenter.new(:active_tree => :action_tree)
 
-      controller.send(:replace_right_cell, 'root', [:action], presenter)
+      controller.send(:replace_right_cell, {:nodetype => 'root', :replace_trees => [:action], :presenter => presenter})
       expect(presenter[:set_visible_elements][:toolbar]).to be_truthy
     end
 
@@ -228,7 +228,7 @@ describe MiqPolicyController do
       presenter = ExplorerPresenter.new(:active_tree => :alert_profile_tree)
       controller.send(:get_node_info, 'ap_xx-Storage')
       presenter[:right_cell_text] = 'foo'
-      controller.send(:replace_right_cell, 'xx', [:alert_profile], presenter)
+      controller.send(:replace_right_cell, {:nodetype => 'xx', :replace_trees => [:alert_profile], :presenter => presenter})
 
       expect(presenter[:right_cell_text]).not_to equal('foo')
       expect(presenter[:right_cell_text]).to_not be_nil

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -16,7 +16,7 @@ shared_examples "logs_collect" do |type|
   it "not running" do
     allow_any_instance_of(MiqServer).to receive(:status).and_return("stopped")
 
-    expect(controller).to receive(:replace_right_cell).with(active_node)
+    expect(controller).to receive(:replace_right_cell).with(:nodetype => active_node)
 
     controller.send(:logs_collect)
 
@@ -25,7 +25,7 @@ shared_examples "logs_collect" do |type|
 
   it "collection already in progress" do
     expect_any_instance_of(klass).to receive(:log_collection_active_recently?).and_return(true)
-    expect(controller).to receive(:replace_right_cell).with(active_node)
+    expect(controller).to receive(:replace_right_cell).with(:nodetype => active_node)
 
     controller.send(:logs_collect)
 
@@ -36,7 +36,7 @@ shared_examples "logs_collect" do |type|
     it "succeeds" do
       expect_any_instance_of(klass).to receive(:log_collection_active_recently?).and_return(false)
       expect_any_instance_of(klass).to receive(:synchronize_logs).with(user.userid, :context => klass.name)
-      expect(controller).to receive(:replace_right_cell).with(active_node)
+      expect(controller).to receive(:replace_right_cell).with(:nodetype => active_node)
 
       controller.send(:logs_collect)
 
@@ -46,7 +46,7 @@ shared_examples "logs_collect" do |type|
     it "collection raises and error" do
       expect_any_instance_of(klass).to receive(:log_collection_active_recently?).and_return(false)
       expect_any_instance_of(klass).to receive(:synchronize_logs).and_raise(StandardError)
-      expect(controller).to receive(:replace_right_cell).with(active_node)
+      expect(controller).to receive(:replace_right_cell).with(:nodetype => active_node)
 
       controller.send(:logs_collect)
 

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -188,7 +188,7 @@ describe OpsController do
       expect(controller).to receive(:handle_bottom_cell)
       expect(controller).to receive(:extra_js_commands)
       expect(controller).to receive(:render)
-      controller.send(:replace_right_cell, 'svr', [:settings])
+      controller.send(:replace_right_cell, {:nodetype => 'svr', :replace_trees => [:settings]})
       expect(response.status).to eq(200)
     end
   end

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -7,7 +7,7 @@ describe PxeController do
     it 'calls methods with x_node as param' do
       controller.instance_variable_set(:@_params, :id => 'root', :tree => :pxe_servers_tree)
       expect(controller).to receive(:get_node_info).with("root")
-      expect(controller).to receive(:replace_right_cell).with("root")
+      expect(controller).to receive(:replace_right_cell).with(:nodetype => "root")
       controller.tree_select
     end
   end
@@ -17,7 +17,7 @@ describe PxeController do
       controller.instance_variable_set(:@_params, :id => 'pxe_servers_accord', :tree => :pxe_servers_tree)
       allow(controller).to receive(:x_node).and_return('root')
       expect(controller).to receive(:get_node_info).with("root")
-      expect(controller).to receive(:replace_right_cell).with("root")
+      expect(controller).to receive(:replace_right_cell).with(:nodetype => "root")
       controller.accordion_select
     end
   end

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -164,7 +164,7 @@ describe VmOrTemplateController do
                                                                          :no_reset        => true,
                                                                          :submit_button   => true,
                                                                          :continue_button => false}).exactly(1).times
-      controller.send(:replace_right_cell, 'migrate', presenter)
+      controller.send(:replace_right_cell, {:action => 'migrate', :presenter => presenter})
       expect(presenter[:update_partials]).to have_key(:form_buttons_div)
     end
   end


### PR DESCRIPTION
To do something about and around `replace_right_cell` we need to have a single signature for the method in all controllers.

This PR aims to unify the signature w/o changing anything else.

Ping @h-kataria, @mzazrivec, @AparnaKarve, @lgalis 