### PR TITLE
Add missing keys for about modal into Japanese and Chinese dictionaries

### DIFF
--- a/locale/ja.yml
+++ b/locale/ja.yml
@@ -4,4 +4,8 @@
 ja:
   product:
     name: ManageIQ
+    name_full: ManageIQ
+    copyright: "Copyright (c) 2016 ManageIQ. Sponsored by Red Hat Inc."
+    support_website: "http://www.manageiq.org"
+    support_website_text: "ManageIQ.org"
 

--- a/locale/zh_CN.yml
+++ b/locale/zh_CN.yml
@@ -1,3 +1,7 @@
 zh-CN:
   product:
     name: ManageIQ
+    name_full: ManageIQ
+    copyright: "CN- Copyright (c) 2016 ManageIQ。由红帽赞助。"
+    support_website: "http://www.manageiq.org"
+    support_website_text: "ManageIQ.org"


### PR DESCRIPTION
Before:
![about-before](https://cloud.githubusercontent.com/assets/6648365/19894279/b2e25d06-a04c-11e6-908b-888338ef0a6f.jpg)

After:
![about-after](https://cloud.githubusercontent.com/assets/6648365/19894284/b85e6112-a04c-11e6-8622-151375324f62.jpg)

Work in progress for now, since two strings need to be translated to Chinese / Japanese (I need
to reach out to translators).

https://bugzilla.redhat.com/show_bug.cgi?id=1385669