### PR TITLE
Make simulate form fields wider to accomodate Japanese strings

### DIFF
--- a/app/views/layouts/_ae_resolve_options.html.haml
+++ b/app/views/layouts/_ae_resolve_options.html.haml
@@ -9,7 +9,7 @@
     %h3
       = _("Object Details")
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _("System/Process")
       .col-md-8
         = select_tag('instance_name',
@@ -22,7 +22,7 @@
           miqInitSelectPicker();
           miqSelectPickerEvent('instance_name', "#{url}")
   .form-group
-    %label.col-md-2.control-label
+    %label.col-md-3.control-label
       = _("Message")
     .col-md-8
       = text_field_tag("object_message",
@@ -34,7 +34,7 @@
       - unless is_browser_ie?
         = javascript_tag("if (!$('#description').length) #{javascript_focus('object_message')}")
   .form-group
-    %label.col-md-2.control-label
+    %label.col-md-3.control-label
       = _("Request")
     .col-md-8
       = text_field_tag("object_request",
@@ -49,7 +49,7 @@
       = _("Object Attribute")
     .form-horizontal
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-3.control-label
           = _("Type")
         .col-md-8
           = ui_lookup(:model => @resolve[:target_class])
@@ -59,7 +59,7 @@
       = _("Object Attribute")
     .form-horizontal
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-3.control-label
           = _("Type")
         .col-md-8
           = select_tag('target_class',
@@ -73,7 +73,7 @@
             miqSelectPickerEvent('target_class', "#{url}")
       - if resolve[:new][:target_class] && !resolve[:new][:target_class].blank? && resolve[:targets]
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _("Selection")
           .col-md-8
             = select_tag('target_id',
@@ -91,7 +91,7 @@
     = _("Simulation Parameters")
   .form-horizontal
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _("Execute Methods")
       .col-md-8
         = check_box_tag("readonly",
@@ -106,7 +106,7 @@
     - f = "attribute_" + (i + 1).to_s
     - v = "value_" + (i + 1).to_s
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = (i + 1).to_s
       .col-md-4
         = text_field_tag(f,


### PR DESCRIPTION
This change is to avoid incorrect word breaks in Japanese text.

https://bugzilla.redhat.com/show_bug.cgi?id=1386649

Before:
![simulate-before](https://cloud.githubusercontent.com/assets/6648365/19900357/7c2799d6-a063-11e6-91c8-865c62d0ce5e.jpg)

After:
![simulate-after](https://cloud.githubusercontent.com/assets/6648365/19900370/831f32bc-a063-11e6-81cc-8baa8404e417.jpg)

@epwinchell Please review the style changes. Thanks.