### PR TITLE
[DARGA] Backport model code from PR #11992 and #12114

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -789,7 +789,7 @@ module OpsController::OpsRbac
                     when "user"
                       get_view(User, :named_scope => :in_my_region)
                     when "group"
-                      get_view(MiqGroup, :named_scope => :non_tenant_groups)
+                      get_view(MiqGroup, :named_scope => :non_tenant_groups_in_my_region)
                     when "role"
                       get_view(MiqUserRole)
                     when "tenant"
@@ -971,7 +971,9 @@ module OpsController::OpsRbac
     @edit[:new][:password] = @user.password unless @sb[:typ] == "copy"
     @edit[:new][:verify] = @user.password unless @sb[:typ] == "copy"
 
-    @edit[:groups] = MiqGroup.non_tenant_groups.sort_by { |g| g.description.downcase }.collect { |g| [g.description, g.id] }
+    @edit[:groups] = MiqGroup.non_tenant_groups_in_my_region
+                             .sort_by { |g| g.description.downcase }
+                             .collect { |g| [g.description, g.id] }
     @edit[:new][:group] = @user.current_group ? @user.current_group.id : nil
 
     @edit[:current] = copy_hash(@edit[:new])

--- a/app/controllers/report_controller/dashboards.rb
+++ b/app/controllers/report_controller/dashboards.rb
@@ -233,7 +233,7 @@ module ReportController::Dashboards
       @db_nodes["All Groups"][:text] = "All Groups"
     elsif @sb[:nodes].length == 2 && @sb[:nodes].last == "g"
       # All groups node is selected
-      @miq_groups = rbac_filtered_objects(MiqGroup.non_tenant_groups)
+      @miq_groups = rbac_filtered_objects(MiqGroup.non_tenant_groups_in_my_region)
       @right_cell_div  = "db_list"
       @right_cell_text = _("All %{models}") % {:models => ui_lookup(:models => "MiqGroup")}
     elsif @sb[:nodes].length == 3 && @sb[:nodes][1] == "g_g"

--- a/app/controllers/report_controller/reports.rb
+++ b/app/controllers/report_controller/reports.rb
@@ -409,7 +409,7 @@ module ReportController::Reports
   end
 
   def menu_repname_update(old_name, new_name)
-    all_roles = MiqGroup.non_tenant_groups
+    all_roles = MiqGroup.non_tenant_groups_in_my_region
     all_roles.each do |role|
       rec = MiqGroup.find_by_description(role.name)
       menu = rec.settings[:report_menus] if rec.settings

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -290,7 +290,7 @@ module ReportController::Widgets
         end
       elsif @widget.visibility && @widget.visibility[:groups]
         @sb[:groups] = []
-        MiqGroup.non_tenant_groups.sort_by(&:description).each do |r|
+        MiqGroup.non_tenant_groups_in_my_region.sort_by(&:description).each do |r|
           @sb[:groups].push(r.description) if @widget.visibility[:groups].include?(r.description)
         end
       end
@@ -337,7 +337,7 @@ module ReportController::Widgets
         end
       elsif @widget.visibility[:groups]
         @edit[:new][:visibility_typ] = "group"
-        groups = MiqGroup.where(:description => @widget.visibility[:groups])
+        groups = MiqGroup.in_my_region.where(:description => @widget.visibility[:groups])
         @edit[:new][:groups] = groups.collect { |group| to_cid(group.id) }.sort
       end
     end
@@ -346,7 +346,7 @@ module ReportController::Widgets
       .collect { |r| {r.name => to_cid(r.id)} }
 
     @edit[:sorted_groups] =
-      MiqGroup.non_tenant_groups.sort_by { |g| g.description.downcase }
+      MiqGroup.non_tenant_groups_in_my_region.sort_by { |g| g.description.downcase }
       .collect { |g| {g.description => to_cid(g.id)} }
 
     # Schedule Box - create new sched for copy/new, use existing for edit

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -20,7 +20,7 @@ class MiqGroup < ApplicationRecord
 
   delegate :self_service?, :limited_self_service?, :to => :miq_user_role, :allow_nil => true
 
-  validates :description, :presence => true, :uniqueness => true
+  validates :description, :presence => true, :uniqueness => {:conditions => -> { in_my_region } }
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
 
@@ -190,6 +190,10 @@ class MiqGroup < ApplicationRecord
   # @return true if this is a default tenant group
   def tenant_group?
     group_type == TENANT_GROUP
+  end
+
+  def self.non_tenant_groups_in_my_region
+    in_my_region.non_tenant_groups
   end
 
   # Asks about the tenant's default_miq_group

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -39,7 +39,7 @@ class TreeBuilderOpsRbac < TreeBuilder
     objects =
       case object_hash[:id]
       when "u"  then rbac_filtered_objects(User.in_my_region)
-      when "g"  then rbac_filtered_objects(MiqGroup.non_tenant_groups)
+      when "g"  then rbac_filtered_objects(MiqGroup.non_tenant_groups_in_my_region)
       when "ur" then MiqUserRole.all
       when "tn" then Tenant.with_current_tenant
       end

--- a/app/presenters/tree_builder_report_roles.rb
+++ b/app/presenters/tree_builder_report_roles.rb
@@ -19,7 +19,7 @@ class TreeBuilderReportRoles < TreeBuilder
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
     user  = User.current_user
-    roles = user.super_admin_user? ? MiqGroup.non_tenant_groups : [user.current_group]
+    roles = user.super_admin_user? ? MiqGroup.non_tenant_groups_in_my_region : [user.current_group]
     count_only_or_objects(count_only, roles.sort_by { |o| o.name.downcase }, 'name')
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1327,7 +1327,6 @@
         - miq_enterprises
         - miq_event_definitions
         - miq_globals
-        - miq_groups
         - miq_policies
         - miq_policy_contents
         - miq_product_features

--- a/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
+++ b/spec/support/examples_group/shared_examples_for_ownership_mixin.rb
@@ -13,6 +13,63 @@ shared_examples "miq ownership" do
       build_ownership_users_and_groups
     end
 
+    describe ".user_or_group_owned" do
+      let(:factory) { described_class.name == "Vm" ? :vm_vmware : described_class.table_name.singularize }
+      let(:owned_resource) { FactoryGirl.create(factory) }
+      let(:owning_user) do
+        FactoryGirl.create :user, :userid => "user_owner", :miq_groups => FactoryGirl.create_list(:miq_group, 1)
+      end
+      let(:group) { owning_user.current_group }
+
+      context "by user in this region" do
+        it "returns resource owned by user" do
+          owned_resource.evm_owner = owning_user
+          owned_resource.save!
+
+          expect(described_class.user_or_group_owned(owning_user, nil)).to eq([owned_resource])
+        end
+
+        it "returns resource owned by user or group" do
+          owned_resource.evm_owner = owning_user
+          owned_resource.save!
+
+          expect(described_class.user_or_group_owned(owning_user, owning_user.current_group)).to eq([owned_resource])
+        end
+      end
+
+      context "by user in a remote region" do
+        let(:remote_owning_user) { FactoryGirl.create :user, :id => remote_id, :userid => "remote_user_owner" }
+        let(:remote_id) do
+          my_region_number     = ApplicationRecord.my_region_number
+          remote_region_number = my_region_number + 1
+          ApplicationRecord.region_to_range(remote_region_number).first
+        end
+
+        it "returns resource owned by user" do
+          owned_resource.id = remote_id
+          owned_resource.evm_owner = remote_owning_user
+          owned_resource.save!
+
+          expect(owned_resource.evm_owner_id).not_to eq(owning_user.id)
+          expect(described_class.user_or_group_owned(remote_owning_user, nil)).to eq([owned_resource])
+        end
+
+        it "returns resource owned by user or group" do
+          remote_owning_user.current_group = remote_owning_user.miq_groups.first
+          remote_owning_user.save!
+
+          owned_resource.id = remote_id
+          owned_resource.evm_owner = remote_owning_user
+          owned_resource.save!
+
+          owned_resource.update!(:miq_group => group)
+
+          expect(owned_resource.evm_owner_id).not_to eq(owning_user.id)
+          expect(described_class.user_or_group_owned(owning_user, owning_user.current_group)).to eq([owned_resource])
+        end
+      end
+    end
+
     describe ".owned_by_current_ldap_group" do
       before { User.current_user = user }
 


### PR DESCRIPTION
Description
-----------
Backports ManageIQ/manageiq#11992 , ManageIQ/manageiq#12114 and  ManageIQ/manageiq#12106 to allow for `pglogical` to work properly... I think...

Includes the updates from ManageIQ/manageiq#11992 for the OwnershipMixin, and also includes the (minimal) necessary updates to allow it to work:  updating the arel for the evm_owner_userid virtual_column, which was handled by virtual_delegates in the newer releases.  The same was done for ManageIQ/manageiq#12114 and it's `virtual_column`.

PR ManageIQ/manageiq#12106 is simply brought in normally, but needed to be done manually to handle updates that have happened to the codebase in those files in master since darga.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/11992 (first backported PR)
* https://github.com/ManageIQ/manageiq/pull/12114 (second backported PR)
* https://github.com/ManageIQ/manageiq/pull/12106 (third backported PR)
* https://github.com/ManageIQ/manageiq/pull/10476 (pre-req if we backported the PR normally)
* https://github.com/ManageIQ/manageiq/pull/11243 (dependency of the first two PRs.  Functionality added manually)
* https://github.com/ManageIQ/manageiq/pull/12088 (test refactoring that affected backporting the tests)
* https://github.com/ManageIQ/manageiq/pull/10704 and https://github.com/ManageIQ/manageiq/pull/10685 (these were the updates to make `owned_by_current_ldap_group` and `owned_by_current_user` `virtual_attributes` with AREL support.)