### PR TITLE
[WIP] Container topology: fix parsing of JSON endpoint URL.

### DIFF
--- a/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
+++ b/app/assets/javascripts/controllers/container_topology/container_topology_controller.js
@@ -20,6 +20,9 @@ function ContainerTopologyCtrl($scope, $http, $interval, $location, topologyServ
     var pathname = $window.location.pathname.replace(/\/$/, '');
     if (pathname.match(/show$/)) {
       id = '';
+    } else if (pathname.match(/show\/(\d+)$/)) {
+      // search for pattern /<controller>/show/<id>$
+      id = '/' + (/show\/(\d+)$/.exec(pathname)[1]);
     } else {
       // search for pattern ^/<controler>/<id>$ in the pathname
       id = '/' + (/^\/[^\/]+\/(\d+)$/.exec(pathname)[1]);


### PR DESCRIPTION
Fix for issue introduced in https://github.com/ManageIQ/manageiq/issues/10895

ping @zeari 

TODO

---

need to fix the links from toolbar and the textual summary to be in the form of 
`http://localhost:3000/container_topology/show/10000000000037`