### PR TITLE
Allow cyclomatic complexity up to 11 (from 6)

### DIFF
--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -117,6 +117,7 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: true
+  Max: 11
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:


### PR DESCRIPTION
We're not in a position to nitpick methods in the 7-11 cycle range.
These methods are starting to grow too large and complicated but we're
aiming for codeclimate to point out code that doesn't meet a minimum
standard. To be honest, there is just too much noise for methods of questionable
complexity. We don't want to extract methods prematurely and we don't
want noise to get in the way of the real problems.  The good thing is
that unwieldy methods tend to grow over time so they might not be caught
today but they will eventually.

Let's see if this value gives us a better signal-to-noise ratio.