### PR TITLE
Fixed setting of start date in JS code

### DIFF
--- a/app/views/layouts/_timeline.html.haml
+++ b/app/views/layouts/_timeline.html.haml
@@ -6,7 +6,7 @@
     if (!ManageIQ.calendar.calDateFrom || !ManageIQ.calendar.calDateTo) {
     // set timeline to start one week ago and end today
     end = new Date();
-    start = end - 24 * 60 * 60 * 1000 * 7;
+    start = new Date(end - 24 * 60 * 60 * 1000 * 7);
     } else {
     start = new Date(ManageIQ.calendar.calDateFrom);
     end = new Date(ManageIQ.calendar.calDateTo);


### PR DESCRIPTION
Previous code was setting an offset, needed to convert offset into a date object, this was causing a JS error on screens such as Bottlenecks Timelines, Reports Timelines & in Sample timeline preview in reports editor.

https://bugzilla.redhat.com/show_bug.cgi?id=1389850

@dclarizio please review, issue was introduced in https://github.com/ManageIQ/manageiq/pull/11623/commits/a21fa0420a54e2ab63c36a5ffb15376b91947c54 under https://github.com/ManageIQ/manageiq/pull/11623

before:
![bottlenecks_timeline_before](https://cloud.githubusercontent.com/assets/3450808/19904087/a229d0ca-a047-11e6-900c-6106a092eb8c.png)
![reports_timelines_before](https://cloud.githubusercontent.com/assets/3450808/19904086/a228ff24-a047-11e6-9a0c-6e446e2ba03b.png)

after:
![bottlenecks_timeline_after](https://cloud.githubusercontent.com/assets/3450808/19903403/f5f40ae8-a044-11e6-9611-0099061ef47d.png)
![report_timelines_after](https://cloud.githubusercontent.com/assets/3450808/19903404/f5fa7fd6-a044-11e6-80af-3706061454ef.png)
