### PR TITLE
The save button is disabled when the retirement date is set to current or next day 

### DIFF
--- a/app/assets/javascripts/directives/checkchange.js
+++ b/app/assets/javascripts/directives/checkchange.js
@@ -50,10 +50,10 @@ var viewModelComparison = function(scope, ctrl) {
 };
 
 var viewModelDateComparison = function(scope, ctrl) {
-  var modelDate = moment(ctrl.$modelValue);
-  var copyDate = moment(scope.modelCopy[ctrl.$name]);
+  var modelDate = (ctrl.$modelValue != undefined) ? moment(ctrl.$modelValue) : null;
+  var copyDate = (scope.modelCopy[ctrl.$name] != undefined) ? moment(scope.modelCopy[ctrl.$name]) : null;
 
-  if (modelDate.diff(copyDate, 'days') == 0) {
+  if((modelDate && copyDate && (modelDate.diff(copyDate, 'days') == 0)) || (!modelDate && !copyDate)){
     scope.angularForm[scope['formchange_' + ctrl.$name]].$setPristine();
     scope.angularForm[scope['formchange_' + ctrl.$name]].$setUntouched();
     scope.angularForm.$pristine = true;

--- a/spec/javascripts/directives/checkchange_spec.js
+++ b/spec/javascripts/directives/checkchange_spec.js
@@ -28,5 +28,27 @@ describe('checkchange initialization', function() {
       expect(form.repo_path.$pristine).toBe(true);
       expect(form.$pristine).toBe(true);
     });
+
+    it('should set the value and form to a non-pristine state when a date is changed from undefined to current date', function() {
+      $scope.repoModel = {repo_path : undefined};
+      $scope.modelCopy = {repo_path : undefined};
+
+      $scope.$digest();
+      var newDate = new Date();
+      form.repo_path.$setViewValue(moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDay()]));
+      expect(form.repo_path.$pristine).toBe(false);
+      expect(form.$pristine).toBe(false);
+    });
+
+    it('should set the value and form to a pristine state when a date is unchanged', function() {
+      var newDate = new Date();
+      $scope.repoModel = {repo_path : undefined};
+      $scope.modelCopy = {repo_path : moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDay()]).toDate()};
+
+      $scope.$digest();
+      form.repo_path.$setViewValue(moment.utc([newDate.getFullYear(), newDate.getMonth(), newDate.getDay()]).toDate());
+      expect(form.repo_path.$pristine).toBe(true);
+      expect(form.$pristine).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
The save button is disabled when the retirement date is set to current or next day.
The here was caused by the fact that moment(undefined) is the same as moment() and returns the current date.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1384030

Steps for Testing/QA

Select the retirement date for any VM that has none set yet to the current date or the next day. The Save button is disabled before this fix.

