### PR TITLE
Rework parameters passed into a Schedule Automate Job

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -212,8 +212,8 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.starting_object = data.starting_object;
         $scope.scheduleModel.instance_name   = data.instance_name;
         $scope.scheduleModel.object_message  = data.object_message;
-        $scope.scheduleModel.object_request  = data.object_request;
-        $scope.scheduleModel.target_class    = data.tagert_class;
+        $scope.scheduleModel.object_request  = data.request;
+        $scope.scheduleModel.target_class    = data.target_class;
         $scope.scheduleModel.target_id       = data.target_id;
         $scope.scheduleModel.targets         = [];
         $scope.scheduleModel.filter_typ      = null;

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -213,8 +213,8 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.instance_name   = data.instance_name;
         $scope.scheduleModel.object_message  = data.object_message;
         $scope.scheduleModel.object_request  = data.request;
-        $scope.scheduleModel.target_class    = data.target_class;
-        $scope.scheduleModel.target_id       = data.target_id;
+        $scope.scheduleModel.target_class    = data.object_class;
+        $scope.scheduleModel.target_id       = data.object_id;
         $scope.scheduleModel.targets         = [];
         $scope.scheduleModel.filter_typ      = null;
         $scope.scheduleModel.attrs           = data.attrs;

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -4,7 +4,6 @@ module OpsController::Settings::AutomateSchedules
   def automate_schedules_set_vars
     schedule = params[:id] == "new" ? MiqSchedule.new : MiqSchedule.find_by(:id => params[:id])
     automate_request = fetch_automate_request_vars(schedule)
-
     render :json => {
       :starting_object => automate_request[:starting_object],
       :instance_names  => automate_request[:instance_names],
@@ -39,7 +38,6 @@ module OpsController::Settings::AutomateSchedules
     automate_request[:starting_object] = filter[:uri_parts][:namespace] || "SYSTEM/PROCESS"
     matching_instances = MiqAeClass.find_distinct_instances_across_domains(current_user,
                                                                            automate_request[:starting_object])
-
     automate_request[:instance_names] = matching_instances.collect(&:name).sort_by(&:downcase)
     automate_request[:instance_name]  = filter[:parameters][:instance_name] || "Request"
     automate_request[:object_message] = filter[:parameters][:object_message] || "create"

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -35,6 +35,7 @@ module OpsController::Settings::AutomateSchedules
     automate_request = {}
     # incase changing type of schedule
     filter = schedule.filter && schedule.filter.kind_of?(Hash) ? schedule.filter : {:uri_parts => {}, :parameters => {}}
+    filter[:parameters].symbolize_keys!
     automate_request[:starting_object] = filter[:uri_parts][:namespace] || "SYSTEM/PROCESS"
     matching_instances = MiqAeClass.find_distinct_instances_across_domains(current_user,
                                                                            automate_request[:starting_object])
@@ -42,7 +43,7 @@ module OpsController::Settings::AutomateSchedules
     automate_request[:instance_names] = matching_instances.collect(&:name).sort_by(&:downcase)
     automate_request[:instance_name]  = filter[:parameters][:instance_name] || "Request"
     automate_request[:object_message] = filter[:parameters][:object_message] || "create"
-    automate_request[:object_request] = filter[:parameters][:object_request] || ""
+    automate_request[:object_request] = filter[:parameters][:request] || ""
     automate_request[:target_class]   = filter[:parameters][:target_class] || nil
     automate_request[:target_classes] = {}
     CustomButton.button_classes.each { |db| automate_request[:target_classes][db] = ui_lookup(:model => db) }

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -10,9 +10,9 @@ module OpsController::Settings::AutomateSchedules
       :instance_name   => automate_request[:instance_name],
       :object_message  => automate_request[:object_message],
       :object_request  => automate_request[:object_request],
-      :target_class    => automate_request[:target_class],
+      :target_class    => automate_request[:object_class],
       :target_classes  => automate_request[:target_classes],
-      :target_id       => automate_request[:target_id],
+      :target_id       => automate_request[:object_id],
       :attrs           => automate_request[:attrs]
     }
   end
@@ -42,7 +42,7 @@ module OpsController::Settings::AutomateSchedules
     automate_request[:instance_name]  = filter[:parameters][:instance_name] || "Request"
     automate_request[:object_message] = filter[:parameters][:object_message] || "create"
     automate_request[:object_request] = filter[:parameters][:request] || ""
-    automate_request[:target_class]   = filter[:parameters][:target_class] || nil
+    automate_request[:target_class]   = filter[:parameters][:object_class] || nil
     automate_request[:target_classes] = {}
     CustomButton.button_classes.each { |db| automate_request[:target_classes][db] = ui_lookup(:model => db) }
     automate_request[:target_classes] = Array(automate_request[:target_classes].invert).sort
@@ -50,7 +50,7 @@ module OpsController::Settings::AutomateSchedules
       targets = Rbac.filtered(automate_request[:target_class]).select(:id, :name)
       automate_request[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
     end
-    automate_request[:target_id]      = filter[:parameters][:target_id] || ""
+    automate_request[:target_id]      = filter[:parameters][:object_id] || ""
     automate_request[:attrs]          = filter[:parameters][:attrs] || []
 
     if automate_request[:attrs].empty?

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -518,7 +518,6 @@ module OpsController::Settings::Schedules
           :instance_name  => params[:instance_name],
           :object_message => params[:object_message],
           :attrs          => attrs,
-          :readonly       => params[:readonly] == "true" ? true : false,
           :target_class   => params[:target_class] == "" ? nil : params[:target_class],
           :target_id      => params[:target_id]
         }

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -514,7 +514,7 @@ module OpsController::Settings::Schedules
           :message   => params[:object_message]
         },
         :parameters => {
-          :object_request => params[:object_request],
+          :request        => params[:object_request],
           :instance_name  => params[:instance_name],
           :object_message => params[:object_message],
           :attrs          => attrs,

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -24,8 +24,8 @@ module OpsController::Settings::Schedules
 
     if @selected_schedule.sched_action[:method] == 'automation_request'
       params = @selected_schedule.filter[:parameters]
-      @object_class = ui_lookup(:model => params[:target_class])
-      @object_name = params[:target_class].constantize.find_by(:id => params[:target_id]).name if params[:target_class]
+      @object_class = ui_lookup(:model => params[:object_class])
+      @object_name = params[:object_class].constantize.find_by(:id => params[:object_id]).name if params[:object_class]
     end
 
     if @selected_schedule.filter.kind_of?(MiqExpression)
@@ -518,9 +518,9 @@ module OpsController::Settings::Schedules
           :instance_name  => params[:instance_name],
           :object_message => params[:object_message],
           :attrs          => attrs,
-          :target_class   => params[:target_class] == "" ? nil : params[:target_class],
-          :target_id      => params[:target_id]
-        }
+          :object_class   => params[:target_class] == "" ? nil : params[:target_class],
+          :object_id      => params[:target_id]
+        }.merge!(attrs.to_h)
       }
     elsif %w(global my).include?(params[:filter_typ])  # Search filter chosen, set up relationship
       schedule.filter     = nil  # Clear out existing filter expression

--- a/app/views/ops/_schedule_show.html.haml
+++ b/app/views/ops/_schedule_show.html.haml
@@ -63,7 +63,7 @@
           .col-md-10
             %p.form-control-static
               - unless @selected_schedule.next_run_on.blank?
-                = h(@selected_schedule.filter[:parameters][:object_request])
+                = h(@selected_schedule.filter[:parameters][:request])
       %div
         = _("Object Attribute")
         .form-group

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -1,0 +1,61 @@
+describe OpsController do
+  let(:params) { {} }
+  let(:session) { {} }
+  let(:zone) { double("Zone", :name => "foo") }
+  let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
+  let(:schedule) { FactoryGirl.create(:miq_automate_schedule) }
+  let(:schedule_new) { MiqSchedule.new }
+  let(:user) { stub_user(:features => :all) }
+
+  include_context "valid session"
+
+  before do
+    allow(MiqServer).to receive(:my_server).and_return(server)
+    allow(server).to receive(:zone_id).and_return(1)
+    stub_user(:features => :all)
+  end
+
+  describe "#schedule_set_record_vars" do
+    context "set object_request as parameters[:request]" do
+      it "has a nil request for a new automate schedule" do
+        params[:id] = "new"
+        post :automate_schedules_set_vars, :params => params, :session => session
+
+        json = JSON.parse(response.body)
+        expect(json["object_request"]).to eq ""
+      end
+
+      it "has the correct request when looking up an existing automation schedule" do
+        params[:id] = schedule.id
+        post :automate_schedules_set_vars, :params => params, :session => session
+
+        json = JSON.parse(response.body)
+        expect(schedule.filter[:parameters]['request']).to eq "test_request"
+        expect(json["object_request"]).to eq "test_request"
+      end
+    end
+  end
+
+  describe "#fetch_automate_request_vars" do
+    include OpsController::Settings::AutomateSchedules
+    let(:ops) { OpsController.new }
+
+    before do
+      session = instance_double('ApplicationController', :session => {:userid => user.userid})
+      ops.instance_variable_set(:@current_user, user)
+      ops.instance_variable_set(:@_request, session)
+    end
+
+    it "transposes filter[:parameters][:request] to :object_request" do
+      automate_request = ops.fetch_automate_request_vars(schedule)
+      expect(schedule.filter[:parameters][:request]).to eq "test_request"
+      expect(automate_request[:object_request]).to eq "test_request"
+    end
+
+    it "instantiates an empty hash for a new schedule" do
+      automate_request = ops.fetch_automate_request_vars(schedule_new)
+      expect(schedule_new.filter).to be_nil
+      expect(automate_request[:object_request]).to eq ""
+    end
+  end
+end

--- a/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/automate_schedules_spec.rb
@@ -31,6 +31,7 @@ describe OpsController do
 
         json = JSON.parse(response.body)
         expect(schedule.filter[:parameters]['request']).to eq "test_request"
+        expect(schedule.filter[:parameters]['key1']).to eq 'value1'
         expect(json["object_request"]).to eq "test_request"
       end
     end

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -110,6 +110,33 @@ describe OpsController do
     end
   end
 
+  context "#schedule_set_record_vars" do
+    let(:zone) { double("Zone", :name => "foo") }
+    let(:server) { double("MiqServer", :logon_status => :ready, :id => 1, :my_zone => zone) }
+    let(:user) { stub_user(:features => :all) }
+    let(:schedule) { FactoryGirl.create(:miq_automate_schedule) }
+
+    before do
+      allow(MiqServer).to receive(:my_server).and_return(server)
+      allow(server).to receive(:zone_id).and_return(1)
+      stub_user(:features => :all)
+    end
+
+    it "returns automate parameters for an automation_request" do
+      params[:action_typ] = "automation_request"
+      filter_params = {
+        :starting_object => "SYSTEM/PROCESS",
+        :instance_name   => "test",
+        :object_request  => "test_request"
+      }
+      params.merge!(filter_params)
+      allow(controller).to receive(:params).and_return(params)
+      set_vars = controller.send(:schedule_set_record_vars, schedule)
+      expect(set_vars[:parameters]).to include(:request => filter_params[:object_request])
+      expect(set_vars[:uri_parts]).to include(:namespace => filter_params[:starting_object])
+    end
+  end
+
   context "#build_filtered_item_list" do
     settings = {}
     it "returns a filtered item list for MiqTemplate" do

--- a/spec/controllers/ops_controller/settings/schedules_spec.rb
+++ b/spec/controllers/ops_controller/settings/schedules_spec.rb
@@ -127,12 +127,15 @@ describe OpsController do
       filter_params = {
         :starting_object => "SYSTEM/PROCESS",
         :instance_name   => "test",
-        :object_request  => "test_request"
+        :object_request  => "test_request",
+        :attrs           => {"0"=>%w(key1 value1)},
+        :target_class    => "test_target",
+        :target_id       => "0100"
       }
       params.merge!(filter_params)
       allow(controller).to receive(:params).and_return(params)
       set_vars = controller.send(:schedule_set_record_vars, schedule)
-      expect(set_vars[:parameters]).to include(:request => filter_params[:object_request])
+      expect(set_vars[:parameters]).to include(:request => filter_params[:object_request], 'key1' => 'value1', :object_class => 'test_target', :object_id => '0100')
       expect(set_vars[:uri_parts]).to include(:namespace => filter_params[:starting_object])
     end
   end

--- a/spec/factories/miq_schedule.rb
+++ b/spec/factories/miq_schedule.rb
@@ -16,4 +16,16 @@ FactoryGirl.define do
     run_at              run_at
     sched_action        sched_action
   end
+
+  factory :miq_automate_schedule, :class => :MiqSchedule do
+    run_at = {:start_time   => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}}
+    sched_action = {:method => "automation_request"}
+    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :parameters => {'request' => 'test_request'}}
+    sequence(:name)     { |n| "automate_schedule_#{seq_padded_for_sorting(n)}" }
+    description         "test_automation"
+    towhat              "AutomationRequest"
+    run_at              run_at
+    sched_action        sched_action
+    filter              filter
+  end
 end

--- a/spec/factories/miq_schedule.rb
+++ b/spec/factories/miq_schedule.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
   factory :miq_automate_schedule, :class => :MiqSchedule do
     run_at = {:start_time   => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}}
     sched_action = {:method => "automation_request"}
-    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :parameters => {'request' => 'test_request'}}
+    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :parameters => {'request' => 'test_request', 'key1' => 'value1'}}
     sequence(:name)     { |n| "automate_schedule_#{seq_padded_for_sorting(n)}" }
     description         "test_automation"
     towhat              "AutomationRequest"

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -599,8 +599,10 @@ describe('scheduleFormController', function() {
         action_type: 'automation_request',
         starting_object: 'SYSTEM/PROCESS',
         request: 'test_request',
-        instance_name: 'Request',
+        instance_name: 'TestRequest',
         object_message: 'create',
+        object_class: 'test',
+        object_id:    '10',
         uri: 'uri',
         uri_prefix: 'uriPrefix'
       };
@@ -617,6 +619,8 @@ describe('scheduleFormController', function() {
         expect($scope.scheduleModel.instance_name).toEqual(data.instance_name);
         expect($scope.scheduleModel.object_message).toEqual(data.object_message);
         expect($scope.scheduleModel.object_request).toEqual(data.request);
+        expect($scope.scheduleModel.target_class).toEqual(data.object_class);
+        expect($scope.scheduleModel.target_id).toEqual(data.object_id);
       });
     });
 

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -594,6 +594,32 @@ describe('scheduleFormController', function() {
       });
     });
 
+    describe('when the action type is automation_request', function() {
+      var data = {
+        action_type: 'automation_request',
+        starting_object: 'SYSTEM/PROCESS',
+        request: 'test_request',
+        instance_name: 'Request',
+        object_message: 'create',
+        uri: 'uri',
+        uri_prefix: 'uriPrefix'
+      };
+      beforeEach(function() {
+        $httpBackend.whenPOST('/ops/automate_schedules_set_vars/new').respond(200, data);
+        $scope.scheduleModel.action_typ = 'automation_request';
+        $scope.actionTypeChanged();
+        $httpBackend.flush();
+      });
+
+      it('sets the scheduleModel with the Automation params', function() {
+        expect($scope.scheduleModel.instance_names).toEqual(data.instance_names);
+        expect($scope.scheduleModel.starting_object).toEqual(data.starting_object);
+        expect($scope.scheduleModel.instance_name).toEqual(data.instance_name);
+        expect($scope.scheduleModel.object_message).toEqual(data.object_message);
+        expect($scope.scheduleModel.object_request).toEqual(data.request);
+      });
+    });
+
     describe('when the action type is not db_backup', function() {
       beforeEach(function() {
         $scope.scheduleModel.action_typ = 'not_db_backup';


### PR DESCRIPTION
Automate expects parameters to pass in a 'request' message as opposed to 'object_request'
This was causing Automate methods to never run as the 'request' message could not get properly
evaluated

Note: There were lookups on `automate_request[:parameters][:request]` which needed to be `automate_request[:parameters]['request']` The other keys under `[:parameters]` were also changed which fixed an issue with 3 values not showing up during an edit.

Before

<img width="1404" alt="screen shot 2016-11-03 at 4 50 38 pm" src="https://cloud.githubusercontent.com/assets/697347/19984651/babb1a14-a1e5-11e6-85f8-28b5fb4cb1d9.png">

After

<img width="1300" alt="screen shot 2016-11-03 at 4 51 44 pm" src="https://cloud.githubusercontent.com/assets/697347/19984679/d7737908-a1e5-11e6-928b-583fc7026edb.png">

Additional Notes:

Reworked attrs, target_class, target_id
Automate Simulation expects an object to run against: It will also resolve to
and object if passed in object_class, object_id - This PR translates target_class, target_id

Automate Simulation also requires that the key value pairs are seeded through the :parameters hash
as their own key value pair.  The old way included a separate key `:attrs` that included the key value pairs passed in.

This change leaves the `:attrs` hash in place strictly to help the UI resolve what order to show while in edit mode.
The changes here translate the `:attrs` hash as unique key value pairs under `:parameters` as well.

Links
----------------
* [PT #133269363](https://www.pivotaltracker.com/story/show/133269363)
* https://bugzilla.redhat.com/show_bug.cgi?id=1391979