### PR TITLE
Automate - Notification for VM Provisioning error.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
@@ -19,3 +19,8 @@ updated_message += "Message [#{prov.message}] "
 updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
 prov.miq_request.user_message = updated_message
 prov.message = status
+
+if $evm.root['ae_result'] == "error"
+  $evm.create_notification(:level => "error", :subject => prov.miq_request, \
+                           :message => "VM Provision Error: #{updated_message}")
+end

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_Template.class/__methods__/update_provision_status.rb
@@ -19,3 +19,8 @@ updated_message += "Message [#{prov.message}] "
 updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
 prov.miq_request.user_message = updated_message
 prov.message = status
+
+if $evm.root['ae_result'] == "error"
+  $evm.create_notification(:level => "error", :subject => prov.miq_request, \
+                           :message => "VM Provision Error: #{updated_message}")
+end

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/StateMachines/VMProvision_VM.class/__methods__/update_provision_status.rb
@@ -19,3 +19,8 @@ updated_message += "Message [#{prov.message}] "
 updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
 prov.miq_request.user_message = updated_message
 prov.message = status
+
+if $evm.root['ae_result'] == "error"
+  $evm.create_notification(:level => "error", :subject => prov.miq_request, \
+                           :message => "VM Provision Error: #{updated_message}")
+end

--- a/spec/automation/unit/method_validation/update_provision_status_vm_cloud_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_cloud_spec.rb
@@ -47,6 +47,18 @@ describe "update_provision_status" do
       msg = "[#{miq_server.name}] VM [] Step [] Status [#{provision.message}] Message [] "
       expect(miq_provision_request.reload.message).to eq(msg)
     end
+    it "method succeeds with error" do
+      type = :automate_user_error
+      FactoryGirl.create(:notification_type, :name => type)
+
+      @args = "status=fred&ae_result=error&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
+      expect(Notification.count).to eq(0)
+      add_call_method
+      ws
+      expect(provision.reload.status).to eq('Ok')
+      expect(Notification.find_by(:notification_type_id => NotificationType.find_by_name(type).id)).not_to be_nil
+    end
   end
 
   context "without a provision object" do

--- a/spec/automation/unit/method_validation/update_provision_status_vm_infra_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_infra_spec.rb
@@ -47,6 +47,18 @@ describe "update_provision_status" do
       msg = "[#{miq_server.name}] VM [] Step [] Status [#{provision.message}] Message [] "
       expect(miq_provision_request.reload.message).to eq(msg)
     end
+    it "method succeeds with error" do
+      type = :automate_user_error
+      FactoryGirl.create(:notification_type, :name => type)
+
+      @args = "status=fred&ae_result=error&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
+      expect(Notification.count).to eq(0)
+      add_call_method
+      ws
+      expect(provision.reload.status).to eq('Ok')
+      expect(Notification.find_by(:notification_type_id => NotificationType.find_by_name(type).id)).not_to be_nil
+    end
   end
 
   context "without a provision object" do

--- a/spec/automation/unit/method_validation/update_provision_status_vm_template_infra_spec.rb
+++ b/spec/automation/unit/method_validation/update_provision_status_vm_template_infra_spec.rb
@@ -47,6 +47,18 @@ describe "update_provision_status" do
       msg = "[#{miq_server.name}] VM [] Step [] Status [#{provision.message}] Message [] "
       expect(miq_provision_request.reload.message).to eq(msg)
     end
+    it "method succeeds with error" do
+      type = :automate_user_error
+      FactoryGirl.create(:notification_type, :name => type)
+
+      @args = "status=fred&ae_result=error&MiqProvision::miq_provision=#{provision.id}&" \
+              "MiqServer::miq_server=#{miq_server.id}"
+      expect(Notification.count).to eq(0)
+      add_call_method
+      ws
+      expect(provision.reload.status).to eq('Ok')
+      expect(Notification.find_by(:notification_type_id => NotificationType.find_by_name(type).id)).not_to be_nil
+    end
   end
 
   context "without a provision object" do


### PR DESCRIPTION
Modified 3 update_provision_status methods to generate a notification for VMs in error.

Message is 'VM Provision Error:' and the enhanced status message for the UI.

Previous Notification PR:  12306
![screen shot 2016-11-01 at 5 48 10 pm](https://cloud.githubusercontent.com/assets/11841651/19909827/c35e23d2-a05f-11e6-8eca-a34a28a35946.png)
