### PR TITLE
Remove bootstrap script on datasource dialog form partials.

### DIFF
--- a/app/views/middleware_server/_add_datasource.html.haml
+++ b/app/views/middleware_server/_add_datasource.html.haml
@@ -27,6 +27,3 @@
           = render :partial => 'add_datasource_step1'
           = render :partial => 'add_datasource_step2'
           = render :partial => 'add_datasource_step3'
-
-:javascript
-  miq_bootstrap('#form_ds_add');

--- a/app/views/middleware_server/_add_jdbc_driver.html.haml
+++ b/app/views/middleware_server/_add_jdbc_driver.html.haml
@@ -104,6 +104,3 @@
                                   "ng-click"    => "addJdbcDriver()",
                                   :type         => "button"}
             = _("Deploy")
-
-:javascript
-  miq_bootstrap('#form_jdbc_add');


### PR DESCRIPTION
This prevents re-register angular controllers when `mw_server_form`  is bootstrapped if the controllers are created two times, the events will be triggered twice.

@miq-bot add_label providers/hawkular, ui