### PR TITLE
[WIP] Move icon selection from TreeNodeBuilder to model decorators

### DIFF
--- a/app/decorators/assigned_server_role_decorator.rb
+++ b/app/decorators/assigned_server_role_decorator.rb
@@ -1,0 +1,17 @@
+class AssignedServerRoleDecorator < Draper::Decorator
+  delegate_all
+
+  def fonticon
+    nil
+  end
+
+  def listicon_image
+    if active? && miq_server.started?
+      "100/on.png"
+    elsif miq_server.started?
+      "100/suspended.png"
+    else
+      "100/off.png"
+    end
+  end
+end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -202,6 +202,8 @@ class TreeNodeBuilder
   def node_icon(icon)
     if icon.start_with?("/")
       icon
+    elsif icon.start_with?("100/")
+      ActionController::Base.helpers.image_path(icon)
     else
       ActionController::Base.helpers.image_path("100/#{icon}")
     end

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -50,7 +50,7 @@ class TreeNodeBuilder
   # rubocop:disable LineLength, Style/BlockDelimiters, Style/BlockEndNewline
   # rubocop:disable Style/Lambda, Style/AlignParameters, Style/MultilineBlockLayout
   BUILD_NODE_HASH = {
-    "AssignedServerRole"     => -> { assigned_server_role_node(object) },
+    "AssignedServerRole"     => -> { assigned_server_role_node(object, object.decorate.listicon_image) },
     "AvailabilityZone"       => -> { generic_node(object.name,
                                                 "availability_zone.png",
                                                 _("Availability Zone: %{name}") % {:name => object.name}) },
@@ -515,9 +515,10 @@ class TreeNodeBuilder
     end
   end
 
-  def assigned_server_role_node(object)
+  def assigned_server_role_node(object, image)
     @node = {
       :key   => build_object_id,
+      :icon  => node_icon(image),
       :title => options[:tree] == :servers_by_role_tree ?
         "<strong>#{_('Server')}: #{object.name} [#{object.id}]</strong>" :
         "<strong>Role: #{object.server_role.description}</strong>"
@@ -534,15 +535,12 @@ class TreeNodeBuilder
                  end
     end
     if object.active? && object.miq_server.started?
-      @node[:icon] = ActionController::Base.helpers.image_path("100/on.png")
       @node[:title] += _(" (%{priority}active, PID=%{number})") % {:priority => priority, :number => object.miq_server.pid}
     else
       if object.miq_server.started?
-        @node[:icon] = ActionController::Base.helpers.image_path("100/suspended.png")
         @node[:title] += _(" (%{priority}available, PID=%{number})") % {:priority => priority,
                                                                         :number   => object.miq_server.pid}
       else
-        @node[:icon] = ActionController::Base.helpers.image_path("100/off.png")
         @node[:title] += _(" (%{priority}unavailable)") % {:priority => priority}
       end
       @node[:addClass] = "red" if object.priority == 1


### PR DESCRIPTION
This is a necessary step to have support for **SVG** and **FontIcon** node images in the new TreeView. It also opens up the possibility to refactor the ugly `BUILD_NODE_HASH` in the `TreeNodeBuilder`.

* [x] `AssignedServerRole` class used in the `servers_by_role_tree`
* [ ] *More nodes will come here ...*

I wasn't working with decorators before so I would like to ask @martinpovolny or @mzazrivec to verify this design. Also maybe @kbrock or @NickLaMuro could take a look on the performace side of this change as I'm moving some model operation methods to a different place.
