### PR TITLE
Add daily to chargeback rate for 'per time' types

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -12,7 +12,12 @@ class ChargebackRateDetail < ApplicationRecord
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true
 
   FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric).freeze
-  PER_TIME_TYPES = {"hourly" => _("Hourly"), "weekly" => _("Weekly"), "monthly" => _("Monthly")}.freeze
+  PER_TIME_TYPES = {
+    "hourly"  => _("Hourly"),
+    "daily"   => _("Daily"),
+    "weekly"  => _("Weekly"),
+    "monthly" => _("Monthly")
+  }.freeze
 
   attr_accessor :hours_in_interval
 


### PR DESCRIPTION
Continuing of https://github.com/ManageIQ/manageiq/pull/11733
We also need daily option.

![screen shot 2016-11-02 at 11 51 14](https://cloud.githubusercontent.com/assets/14937244/19926119/2626a87a-a0f3-11e6-8bf2-a5c69abfcc7c.png)

@miq-bot assign @mzazrivec 
@miq-bot add_label euwe/yes, chargeback, enhancement, ui
