### PR TITLE
Remove extraneous string from copyright info

### DIFF
--- a/locale/zh_CN.yml
+++ b/locale/zh_CN.yml
@@ -2,6 +2,6 @@ zh-CN:
   product:
     name: ManageIQ
     name_full: ManageIQ
-    copyright: "CN- Copyright (c) 2016 ManageIQ。由红帽赞助。"
+    copyright: "Copyright (c) 2016 ManageIQ。由红帽赞助。"
     support_website: "http://www.manageiq.org"
     support_website_text: "ManageIQ.org"


### PR DESCRIPTION
The string was incorrectly added in pull request #12330

https://bugzilla.redhat.com/show_bug.cgi?id=1385669