### PR TITLE
Remove extra comma in remote_console.rb

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/remote_console.rb
@@ -36,7 +36,7 @@ class ManageIQ::Providers::Redhat::InfraManager::Vm
         :url_secret => SecureRandom.hex,
         :ssl        => display[:secure_port].present?
       }
-      host_address = display[:address],
+      host_address = display[:address]
       host_port    = display[:secure_port] || display[:port]
 
       SystemConsole.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)


### PR DESCRIPTION
Commit 37d1784f3d561ad0458d3fc049b4274fddc2434b that moved the initialization
code of host_address in RemoteConsole#remote_console_acquire_ticket left the
comma in a place that caused the `host_address` to be initailized with an array
`[host_address, port]` instead of `host_address` which in turn caused the
WebsocketProxy to break (connecting to invalid address).