### PR TITLE
Service Dialogs Copy API

### DIFF
--- a/app/controllers/api/service_dialogs_controller.rb
+++ b/app/controllers/api/service_dialogs_controller.rb
@@ -34,6 +34,15 @@ module Api
       service_dialog
     end
 
+    def copy_resource(type, id, data)
+      service_dialog = resource_search(id, type, Dialog)
+      attributes = data.dup
+      attributes['label'] = "Copy of #{service_dialog.label}" unless attributes.key?('label')
+      service_dialog.deep_copy(attributes).tap(&:save!)
+    rescue => err
+      raise BadRequestError, "Failed to copy service dialog - #{err}"
+    end
+
     private
 
     def set_additional_attributes

--- a/config/api.yml
+++ b/config/api.yml
@@ -1242,6 +1242,8 @@
         :identifier: dialog_new
       - :name: edit
         :identifier: dialog_edit
+      - :name: copy
+        :identifier: dialog_copy
     :resource_actions:
       :get:
       - :name: read
@@ -1253,6 +1255,8 @@
         :identifier: dialog_delete
       - :name: edit
         :identifier: dialog_edit
+      - :name: copy
+        :identifier: dialog_copy
       :delete:
       - :name: delete
         :identifier: dialog_delete


### PR DESCRIPTION
Copy action for the service dialogs API. uses `deep_copy` on the dialog model.

@miq-bot add_label enhancement, api, euwe/no 
@miq-bot assign @abellotti 
cc: @imtayadeway
