### PR TITLE
Using the right name of the domain during the middleware provider's refresh

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/refresh_parser.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers
         @data[:middleware_server_groups] = []
         @ems.feeds.each do |feed|
           @ems.domains(feed).each do |domain|
-            parsed_domain = parse_middleware_domain(domain)
+            parsed_domain = parse_middleware_domain(feed, domain)
             fetch_server_groups(feed)
 
             # add the server groups to the domain
@@ -249,9 +249,9 @@ module ManageIQ::Providers
         parse_base_item(datasource).merge(specific)
       end
 
-      def parse_middleware_domain(domain)
+      def parse_middleware_domain(feed, domain)
         specific = {
-          :name      => domain.properties['Name'],
+          :name      => parse_domain_name(feed),
           :type_path => domain.type_path,
         }
         parse_base_item(domain).merge(specific)
@@ -307,6 +307,10 @@ module ManageIQ::Providers
 
       def parse_domain_server_name(name)
         name.sub(%r{^.*\/server=}, '')
+      end
+
+      def parse_domain_name(name)
+        name.sub(/^[^\.]+\./, '')
       end
 
       def parse_standalone_server_name(name)

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresh_parser_spec.rb
@@ -77,14 +77,14 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::RefreshParser do
                               :properties => properties,
                               :type_path  => type_path)
       parsed_domain = {
-        :name       => 'master',
+        :name       => 'Unnamed Domain',
         :feed       => feed,
         :type_path  => type_path,
         :nativeid   => id,
         :ems_ref    => path,
         :properties => properties,
       }
-      expect(parser.send(:parse_middleware_domain, domain)).to eq(parsed_domain)
+      expect(parser.send(:parse_middleware_domain, 'master.Unnamed Domain', domain)).to eq(parsed_domain)
     end
   end
 

--- a/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/middleware_manager/refresher_spec.rb
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_datasource(ems, nativeid)
-    datasource = ems.middleware_datasources.find_by_nativeid(nativeid)
+    datasource = ems.middleware_datasources.find_by(:nativeid => nativeid)
     expect(datasource).to have_attributes(
       :name     => 'Datasource [ExampleDS]',
       :nativeid => nativeid
@@ -59,9 +59,9 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_domain
-    domain = @ems_hawkular.middleware_domains.find_by_name('master')
+    domain = @ems_hawkular.middleware_domains.find_by(:feed => 'master.Unnamed%20Domain')
     expect(domain).to have_attributes(
-      :name     => 'master',
+      :name     => 'Unnamed Domain',
       :nativeid => 'Local~/host=master',
     )
     expect(domain.properties).not_to be_nil
@@ -73,7 +73,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_server_group(domain)
-    server_group = domain.middleware_server_groups.find_by_name('main-server-group')
+    server_group = domain.middleware_server_groups.find_by(:name => 'main-server-group')
     expect(server_group).to have_attributes(
       :name     => 'main-server-group',
       :nativeid => 'Local~/server-group=main-server-group',
@@ -83,7 +83,7 @@ describe ManageIQ::Providers::Hawkular::MiddlewareManager::Refresher do
   end
 
   def assert_specific_domain_server
-    server = @ems_hawkular.middleware_servers.find_by_name('server-three')
+    server = @ems_hawkular.middleware_servers.find_by(:name => 'server-three')
     expect(server).to have_attributes(
       :name     => 'server-three',
       :nativeid => 'Local~/host=master/server=server-three',


### PR DESCRIPTION
This fixes the name of the domain. Before, it used the name of the domain controller, now it parses the name of the domain from the feed id, where it's the second part after the '.' (dot)

`feed_id ~ name-of-the-domain-controller.name-of-the-domain`

Fixes #12356 
@miq-bot add_label providers/hawkular, bug, euwe/yes