### PR TITLE
Remove any region data before creating a subscription

### DIFF
--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -280,7 +280,7 @@ describe PglogicalSubscription do
       allow(pglogical).to receive(:subscriptions).and_return([])
       allow(pglogical).to receive(:enabled?).and_return(true)
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
-      allow(MiqRegionRemote).to receive(:region_number_from_sequence).and_return(2, 3, 4)
+      allow(MiqRegionRemote).to receive(:region_number_from_sequence).and_return(2, 2, 3, 3)
       with_valid_schemas
 
       # node created
@@ -315,7 +315,7 @@ describe PglogicalSubscription do
       allow(pglogical).to receive(:subscriptions).and_return([])
       allow(pglogical).to receive(:enabled?).and_return(true)
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
-      allow(MiqRegionRemote).to receive(:region_number_from_sequence).and_return(2, 3, 4)
+      allow(MiqRegionRemote).to receive(:region_number_from_sequence).and_return(2, 2, 3, 3, 4, 4)
       with_valid_schemas
 
       # node created


### PR DESCRIPTION
This will make sure that the subscription create process doesn't fail while running the initial data sync which is an unrecoverable error for pglogical.

This usually happens because of a unique constraint violation when upgrading from rubyrep to pglogical replication.

To test this I just inserted a row from the remote region into the global database (in this case in the `miq_groups` table) before adding the subscription. Before this change the replication sync would fail, but after it succeeds because the row was removed before the sync started.

@gtanzillo please review
/cc @lcouzens 