### PR TITLE
Fix the Edit path and RESTful handling of ems_network

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1706,6 +1706,8 @@ class ApplicationController < ActionController::Base
         javascript_redirect edit_ems_container_path(params[:id])
       elsif params[:pressed] == "ems_middleware_edit" && params[:id]
         javascript_redirect edit_ems_middleware_path(params[:id])
+      elsif params[:pressed] == "ems_network_edit" && params[:id]
+        javascript_redirect edit_ems_network_path(params[:id])
       elsif %w(arbitration_profile_edit arbitration_profile_new).include?(params[:pressed]) && params[:id]
         javascript_redirect :action => @refresh_partial, :id => params[:id], :show => @redirect_id
       else

--- a/app/helpers/application_helper/toolbar/ems_network_center.rb
+++ b/app/helpers/application_helper/toolbar/ems_network_center.rb
@@ -22,8 +22,7 @@ class ApplicationHelper::Toolbar::EmsNetworkCenter < ApplicationHelper::Toolbar:
           :ems_network_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Network Provider'),
-          t,
-          :url => "/edit"),
+          t),
         button(
           :ems_network_delete,
           'pficon pficon-delete fa-lg',


### PR DESCRIPTION
Edit of Network Manager from the Summary page was causing a routing exception since it was not being handled in a RESTful way, which was fixed in this PR.

Before:
<img width="1397" alt="screen shot 2016-11-02 at 10 37 18 am" src="https://cloud.githubusercontent.com/assets/1538216/19940674/bab6111e-a0ea-11e6-89e9-550986e12669.png">

After:
![image](https://cloud.githubusercontent.com/assets/1538216/19940712/d604e594-a0ea-11e6-93ab-f674ac1722de.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1391178