### PR TITLE
[DARGA] remove extra default authentication

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb
@@ -71,7 +71,7 @@ module ManageIQ::Providers::Kubernetes::ContainerManagerMixin
 
   def verify_credentials(auth_type = nil, options = {})
     options = options.merge(:auth_type => auth_type)
-    if options[:auth_type] == "hawkular"
+    if options[:auth_type].to_s == "hawkular"
       verify_hawkular_credentials
     else
       with_provider_connection(options, &:api_valid?)


### PR DESCRIPTION
Remove the extra "default" authentication created when editing a container provider.

A darga port of:
https://github.com/ManageIQ/manageiq/pull/11504
 
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1391265
