### PR TITLE
RBAC support for Automate Service Models

### DIFF
--- a/lib/miq_automation_engine/engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/drb_remote_invoker.rb
@@ -21,6 +21,17 @@ module MiqAeEngine
       teardown if num_methods == 0
     end
 
+    # This method is called by the client thread that runs for each request
+    # coming into the server.
+    # See https://github.com/ruby/ruby/blob/trunk/lib/drb/drb.rb#L1658
+    # Previously we had used DRb.front but that gets compromised when multiple
+    # DRb servers are running in the same process.
+    def self.workspace
+      if Thread.current['DRb'] && Thread.current['DRb']['server']
+        Thread.current['DRb']['server'].front.workspace
+      end
+    end
+
     private
 
     # invocation

--- a/lib/miq_automation_engine/engine/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service.rb
@@ -1,6 +1,7 @@
 require_relative 'miq_ae_service/miq_ae_service_model_legacy'
 require_relative 'miq_ae_service/miq_ae_service_object_common'
 require_relative 'miq_ae_service/miq_ae_service_vmdb'
+require_relative 'miq_ae_service/miq_ae_service_rbac'
 module MiqAeMethodService
   class Deprecation < Vmdb::Deprecation
     def self.default_log
@@ -25,6 +26,7 @@ module MiqAeMethodService
     include DRbUndumped
     include MiqAeMethodService::MiqAeServiceModelLegacy
     include MiqAeMethodService::MiqAeServiceVmdb
+    include MiqAeMethodService::MiqAeServiceRbac
 
     attr_accessor :logger
 
@@ -59,7 +61,10 @@ module MiqAeMethodService
       @persist_state_hash    = ws.persist_state_hash
       @logger                = logger
       self.class.add(self)
+      ws.disable_rbac
     end
+
+    delegate :enable_rbac, :disable_rbac, :rbac_enabled?, :to =>  :@workspace
 
     def stdout
       @stdout ||= Vmdb::Loggers::IoLogger.new(logger, :info, "Method STDOUT:")

--- a/lib/miq_automation_engine/engine/miq_ae_service/miq_ae_service_rbac.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service/miq_ae_service_rbac.rb
@@ -1,0 +1,54 @@
+module MiqAeMethodService
+  module MiqAeServiceRbac
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def find_ar_object_by_id(id)
+        if rbac_enabled?
+          Rbac.filtered(model.where(:id => id), :user => workspace.ae_user).first
+        else
+          model.find(*id)
+        end
+      end
+
+      def all
+        objs = rbac_enabled? ? Rbac.filtered(model, :user => workspace.ae_user) : model.all
+        wrap_results(objs)
+      end
+
+      def count
+        rbac_enabled? ? Rbac.filtered(model, :user => workspace.ae_user).count : model.count
+      end
+
+      def first
+        objs = rbac_enabled? ? Rbac.filtered(model, :user => workspace.ae_user, :limit => 1) : model
+        wrap_results(objs.first)
+      end
+
+      def filter_objects(objs)
+        if objs.nil?
+          objs
+        elsif objs.kind_of?(Array) || objs.kind_of?(ActiveRecord::Relation)
+          rbac_enabled? ? Rbac.filtered(objs, :user => workspace.ae_user) : objs
+        else
+          rbac_enabled? ? Rbac.filtered_object(objs, :user => workspace.ae_user) : objs
+        end
+      end
+
+      def workspace
+        MiqAeEngine::MiqAeWorkspaceRuntime.current || MiqAeEngine::DrbRemoteInvoker.workspace
+      end
+
+      def workspace_from_drb_thread
+        DRb.front.workspace
+      rescue DRb::DRbServerNotFound => err
+        $miq_ae_logger.warn("Could not fetch DRb front object #{err}")
+        nil
+      end
+
+      def rbac_enabled?
+        workspace && workspace.rbac_enabled?
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_service/miq_ae_service_rbac.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service/miq_ae_service_rbac.rb
@@ -39,13 +39,6 @@ module MiqAeMethodService
         MiqAeEngine::MiqAeWorkspaceRuntime.current || MiqAeEngine::DrbRemoteInvoker.workspace
       end
 
-      def workspace_from_drb_thread
-        DRb.front.workspace
-      rescue DRb::DRbServerNotFound => err
-        $miq_ae_logger.warn("Could not fetch DRb front object #{err}")
-        nil
-      end
-
       def rbac_enabled?
         workspace && workspace.rbac_enabled?
       end

--- a/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_service_model_base.rb
@@ -16,9 +16,10 @@ module MiqAeMethodService
     include DRbUndumped    # Ensure that Automate Method can get at instances over DRb
     include MiqAeServiceObjectCommon
     include Vmdb::Logging
+    include MiqAeMethodService::MiqAeServiceRbac
 
     def self.method_missing(m, *args)
-      return wrap_results(model.send(m, *args)) if class_method_exposed?(m)
+      return wrap_results(filter_objects(model.send(m, *args))) if class_method_exposed?(m)
       super
     rescue ActiveRecord::RecordNotFound
       raise MiqAeException::ServiceNotFound, "Service Model not found"
@@ -35,7 +36,7 @@ module MiqAeMethodService
 
     # Expose the ActiveRecord find, all, count, and first
     def self.class_method_exposed?(m)
-      allowed_find_method?(m.to_s) || [:where, :find, :all, :count, :first].include?(m)
+      allowed_find_method?(m.to_s) || [:where, :find].include?(m)
     end
 
     private_class_method :class_method_exposed?
@@ -121,7 +122,7 @@ module MiqAeMethodService
           method = options[:method] || method_name
           ret = object_send(method, *params)
           return options[:override_return] if options.key?(:override_return)
-          wrap_results(ret)
+          wrap_results(self.class.filter_objects(ret))
         end
       end
     end
@@ -197,7 +198,7 @@ module MiqAeMethodService
       if obj.kind_of?(ActiveRecord::Base) && !obj.kind_of?(ar_klass)
         raise ArgumentError.new("#{ar_klass.name} Object expected, but received #{obj.class.name}")
       end
-      @object = obj.kind_of?(ar_klass) ? obj : ar_method { ar_klass.find_by_id(obj.to_i) }
+      @object = obj.kind_of?(ar_klass) ? obj : ar_method { self.class.find_ar_object_by_id(obj.to_i) }
       raise MiqAeException::ServiceNotFound, "#{ar_klass.name} Object [#{obj}] not found" if @object.nil?
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -52,6 +52,7 @@ module MiqAeEngine
       @current_state_info = {}
       @state_machine_objects = []
       @ae_user = nil
+      @rbac = false
     end
 
     delegate :prepend_namespace=, :to =>  :@dom_search
@@ -60,12 +61,39 @@ module MiqAeEngine
       @readonly
     end
 
+    def self.current=(ws)
+      Thread.current.thread_variable_set(:current_workspace, ws)
+    end
+
+    def self.current
+      Thread.current.thread_variable_get(:current_workspace)
+    end
+
+    def self.clear_stored_workspace
+      self.current = nil
+    end
+
     def self.instantiate(uri, user, attrs = {})
       User.current_user = user
       workspace = MiqAeWorkspaceRuntime.new(attrs)
       workspace.instantiate(uri, user, nil)
+      self.current = workspace
       workspace
     rescue MiqAeException
+    ensure
+      clear_stored_workspace
+    end
+
+    def rbac_enabled?
+      @rbac
+    end
+
+    def enable_rbac
+      @rbac = true
+    end
+
+    def disable_rbac
+      @rbac = false
     end
 
     DATASTORE_CACHE = true

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -62,11 +62,11 @@ module MiqAeEngine
     end
 
     def self.current=(ws)
-      Thread.current.thread_variable_set(:current_workspace, ws)
+      Thread.current[:current_workspace] = ws
     end
 
     def self.current
-      Thread.current.thread_variable_get(:current_workspace)
+      Thread.current[:current_workspace]
     end
 
     def self.clear_stored_workspace

--- a/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/drb_remote_invoker_spec.rb
@@ -2,7 +2,9 @@ module DrbRemoteInvokerSpec
   include MiqAeEngine
   describe MiqAeEngine::DrbRemoteInvoker do
     it "setup/teardown drb_for_ruby_method clears DRb threads" do
-      invoker = described_class.new(double("workspace", :persist_state_hash => {}))
+      workspace = double("workspace", :persist_state_hash => {})
+      allow(workspace).to receive(:disable_rbac).with(no_args)
+      invoker = described_class.new(workspace)
 
       timer_thread = nil
 

--- a/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_method_spec.rb
@@ -15,6 +15,9 @@ describe MiqAeEngine::MiqAeMethod do
 
         def persist_state_hash
         end
+
+        def disable_rbac
+        end
       end.new
 
       logger_klass = Class.new do

--- a/spec/lib/miq_automation_engine/engine/miq_ae_service/miq_ae_service_rbac_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_service/miq_ae_service_rbac_spec.rb
@@ -1,0 +1,87 @@
+module MiqAeServiceModelSpec
+  include MiqAeEngine
+  describe MiqAeMethodService::MiqAeServiceVmOrTemplate do
+    include Spec::Support::AutomationHelper
+    before do
+      vm11
+      vm21
+      user1
+      user2
+    end
+
+    let(:options) { {} }
+
+    let(:default_tenant) { Tenant.seed }
+
+    let(:tenant1) { FactoryGirl.create(:tenant) }
+    let(:group1) { FactoryGirl.create(:miq_group, :tenant => tenant1) }
+    let(:ems1)   { FactoryGirl.create(:ext_management_system, :tenant => tenant1) }
+    let(:host1)   { FactoryGirl.create(:host) }
+    let(:user1) { FactoryGirl.create(:user, :miq_groups => [group1], :settings => {:display => {:timezone => "UTC"}}) }
+    let(:vm11) { FactoryGirl.create(:vm_vmware, :tenant => tenant1, :host => host1, :miq_group => group1) }
+    let(:vm12) { FactoryGirl.create(:vm_vmware, :tenant => tenant1, :host => host1, :miq_group => group1) }
+    let(:vm13) { FactoryGirl.create(:vm_vmware, :tenant => tenant1, :host => host1, :miq_group => group1) }
+
+    let(:tenant2) { FactoryGirl.create(:tenant) }
+    let(:group2) { FactoryGirl.create(:miq_group, :tenant => tenant2) }
+    let(:user2) { FactoryGirl.create(:user, :miq_groups => [group2], :settings => {:display => {:timezone => "UTC"}}) }
+    let(:ems2) { FactoryGirl.create(:ext_management_system, :tenant => tenant2) }
+    let(:host2) { FactoryGirl.create(:host) }
+    let(:vm21) { FactoryGirl.create(:vm_vmware, :tenant => tenant2, :host => host2, :miq_group => group2) }
+    let(:vm22) { FactoryGirl.create(:vm_vmware, :tenant => tenant2, :host => host2, :miq_group => group2) }
+    let(:vm23) { FactoryGirl.create(:vm_vmware, :tenant => tenant2, :host => host2, :miq_group => group2) }
+
+    context "automate methods - enable rbac" do
+      def collect_ids_with_rbac
+        <<-'RUBY'
+          $evm.enable_rbac
+          $evm.root['vm_ids'] = $evm.vmdb('vm').all.collect(&:id)
+        RUBY
+      end
+
+      it 'filter all vms for a user via method with rbac' do
+        vm12
+        vm13
+        vm22
+        create_ae_model_with_method(:name => 'FLINTSTONE', :ae_namespace => 'FRED',
+                                    :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                    :method_name => 'OBELIX',
+                                    :method_script => collect_ids_with_rbac)
+        ws = MiqAeEngine.instantiate("/FRED/WILMA/DOGMATIX", user2)
+        ids = [vm21.id, vm22.id]
+        expect(ws.root("vm_ids")).to match_array(ids)
+      end
+
+      after do
+        MiqAeEngine::MiqAeWorkspaceRuntime.current = nil
+      end
+    end
+
+    context "disable rbac - automate method" do
+      def collect_ids_without_rbac
+        <<-'RUBY'
+          # RBAC is disabled by default
+          # $evm.disable_rbac
+          $evm.root['vm_ids'] = $evm.vmdb('vm').all.collect(&:id)
+        RUBY
+      end
+
+      it 'filter all vms for a user via method without rbac' do
+        vm12
+        vm13
+        vm22
+        create_ae_model_with_method(:name => 'FLINTSTONE', :ae_namespace => 'FRED',
+                                    :ae_class => 'WILMA', :instance_name => 'DOGMATIX',
+                                    :method_name => 'OBELIX',
+                                    :method_script => collect_ids_without_rbac)
+        ws = MiqAeEngine.instantiate("/FRED/WILMA/DOGMATIX", user2)
+        ids = [vm11.id, vm21.id, vm22.id, vm12.id, vm13.id]
+        expect(ws.root("vm_ids")).to match_array(ids)
+      end
+
+      after do
+        MiqAeEngine::MiqAeWorkspaceRuntime.current = nil
+      end
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -166,6 +166,7 @@ module MiqAeServiceSpec
       before do
         NotificationType.seed
         allow(User).to receive_messages(:server_timezone => 'UTC')
+        allow(workspace).to receive(:disable_rbac)
       end
 
       let(:options) { {} }
@@ -181,38 +182,32 @@ module MiqAeServiceSpec
 
       context "#create_notification!" do
         it "invalid type" do
-          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification!(:type => :invalid_type, :subject => vm) }
             .to raise_error(ArgumentError, "Invalid notification type specified")
         end
 
         it "invalid subject" do
-          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification!(:type => :vm_retired, :subject => 'fred') }
             .to raise_error(ArgumentError, "Subject must be a valid Active Record object")
         end
 
         it "default type of automate_user_info" do
-          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification!(:message => msg_text)
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_user_info" do
-          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification!(:level => 'success', :audience => 'user', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_tenant_info" do
-          allow(workspace).to receive(:disable_rbac)
           expect(user).to receive(:tenant).and_return(Tenant.root_tenant)
           result = miq_ae_service.create_notification!(:level => 'success', :audience => 'tenant', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_global_info" do
-          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification!(:level => 'success', :audience => 'global', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
@@ -220,19 +215,16 @@ module MiqAeServiceSpec
 
       context "#create_notification" do
         it "invalid type" do
-          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification(:type => :invalid_type, :subject => vm) }
             .not_to raise_error
         end
 
         it "invalid subject" do
-          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification(:type => :vm_retired, :subject => 'fred') }
             .not_to raise_error
         end
 
         it "default type of automate_user_info" do
-          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification(:message => msg_text)
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
           ui_representation = result.object_send(:to_h)
@@ -241,20 +233,17 @@ module MiqAeServiceSpec
         end
 
         it "type of automate_user_info" do
-          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification(:level => 'success', :audience => 'user', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_tenant_info" do
-          allow(workspace).to receive(:disable_rbac)
           expect(user).to receive(:tenant).and_return(Tenant.root_tenant)
           result = miq_ae_service.create_notification(:level => 'success', :audience => 'tenant', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_global_info" do
-          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification(:level => 'success', :audience => 'global', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -41,24 +41,29 @@ module MiqAeServiceSpec
 
   describe MiqAeService do
     context "#service_model" do
-      let(:miq_ae_service) { MiqAeService.new(double('ws', :persist_state_hash => {})) }
+      let(:workspace) { double('ws', :persist_state_hash => {}) }
+      let(:miq_ae_service) { MiqAeService.new(workspace) }
       let(:prefix) { "MiqAeMethodService::MiqAeService" }
 
       it "loads base model" do
+        allow(workspace).to receive(:disable_rbac)
         expect(miq_ae_service.service_model(:VmOrTemplate)).to   be(MiqAeMethodService::MiqAeServiceVmOrTemplate)
         expect(miq_ae_service.service_model(:vm_or_template)).to be(MiqAeMethodService::MiqAeServiceVmOrTemplate)
       end
 
       it "loads sub-classed model" do
+        allow(workspace).to receive(:disable_rbac)
         expect(miq_ae_service.service_model(:Vm)).to be(MiqAeMethodService::MiqAeServiceVm)
         expect(miq_ae_service.service_model(:vm)).to be(MiqAeMethodService::MiqAeServiceVm)
       end
 
       it "loads model with mapped name" do
+        allow(workspace).to receive(:disable_rbac)
         expect(miq_ae_service.service_model(:ems)).to be(MiqAeMethodService::MiqAeServiceExtManagementSystem)
       end
 
       it "loads name-spaced model by mapped name" do
+        allow(workspace).to receive(:disable_rbac)
         MiqAeMethodService::Deprecation.silence do
           expect(miq_ae_service.service_model(:ems_openstack)).to be(
             MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager)
@@ -68,6 +73,7 @@ module MiqAeServiceSpec
       end
 
       it "loads name-spaced model by fully-qualified name" do
+        allow(workspace).to receive(:disable_rbac)
         expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager)).to    be(
           MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager)
         expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager_Vm)).to be(
@@ -75,16 +81,19 @@ module MiqAeServiceSpec
       end
 
       it "raises error on invalid service_model name" do
+        allow(workspace).to receive(:disable_rbac)
         expect { miq_ae_service.service_model(:invalid_model) }.to raise_error(NameError)
       end
 
       it "loads all mapped models" do
+        allow(workspace).to receive(:disable_rbac)
         MiqAeMethodService::MiqAeService::LEGACY_MODEL_NAMES.values.each do |model_name|
           expect { "MiqAeMethodService::MiqAeService#{model_name}".constantize }.to_not raise_error
         end
       end
 
       it "loads cloud networks" do
+        allow(workspace).to receive(:disable_rbac)
         items = %w(
           ManageIQ_Providers_Openstack_NetworkManager_CloudNetwork
           ManageIQ_Providers_Openstack_NetworkManager_CloudNetwork_Private
@@ -146,6 +155,7 @@ module MiqAeServiceSpec
       let(:ns) { "fred" }
 
       it "set namespace" do
+        allow(workspace).to receive(:disable_rbac)
         allow(workspace).to receive(:persist_state_hash).and_return({})
         expect(workspace).to receive(:prepend_namespace=).with(ns)
 
@@ -171,32 +181,38 @@ module MiqAeServiceSpec
 
       context "#create_notification!" do
         it "invalid type" do
+          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification!(:type => :invalid_type, :subject => vm) }
             .to raise_error(ArgumentError, "Invalid notification type specified")
         end
 
         it "invalid subject" do
+          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification!(:type => :vm_retired, :subject => 'fred') }
             .to raise_error(ArgumentError, "Subject must be a valid Active Record object")
         end
 
         it "default type of automate_user_info" do
+          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification!(:message => msg_text)
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_user_info" do
+          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification!(:level => 'success', :audience => 'user', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_tenant_info" do
+          allow(workspace).to receive(:disable_rbac)
           expect(user).to receive(:tenant).and_return(Tenant.root_tenant)
           result = miq_ae_service.create_notification!(:level => 'success', :audience => 'tenant', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_global_info" do
+          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification!(:level => 'success', :audience => 'global', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
@@ -204,16 +220,19 @@ module MiqAeServiceSpec
 
       context "#create_notification" do
         it "invalid type" do
+          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification(:type => :invalid_type, :subject => vm) }
             .not_to raise_error
         end
 
         it "invalid subject" do
+          allow(workspace).to receive(:disable_rbac)
           expect { miq_ae_service.create_notification(:type => :vm_retired, :subject => 'fred') }
             .not_to raise_error
         end
 
         it "default type of automate_user_info" do
+          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification(:message => msg_text)
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
           ui_representation = result.object_send(:to_h)
@@ -222,17 +241,20 @@ module MiqAeServiceSpec
         end
 
         it "type of automate_user_info" do
+          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification(:level => 'success', :audience => 'user', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_tenant_info" do
+          allow(workspace).to receive(:disable_rbac)
           expect(user).to receive(:tenant).and_return(Tenant.root_tenant)
           result = miq_ae_service.create_notification(:level => 'success', :audience => 'tenant', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end
 
         it "type of automate_global_info" do
+          allow(workspace).to receive(:disable_rbac)
           result = miq_ae_service.create_notification(:level => 'success', :audience => 'global', :message => 'test')
           expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceNotification)
         end


### PR DESCRIPTION
Filters service model objects based on the current user passed into
Automate.
The previous PR was reverted.

Previously we were using DRb.front to access the front object from DRb client threads, this PR uses a thread variable that DRb server sets when dispatching new client request threads. 


Links

* https://www.pivotaltracker.com/n/projects/1613499/stories/131205637
* https://bugzilla.redhat.com/show_bug.cgi?id=1306274
* https://bugzilla.redhat.com/show_bug.cgi?id=1327725
* Old PR #11549 
* Reverted PR #12091