### PR TITLE
Policy simulation screen: adjust selectbox width automatically to accomodate longer strings

### DIFF
--- a/app/views/layouts/_policy_sim.html.haml
+++ b/app/views/layouts/_policy_sim.html.haml
@@ -14,7 +14,8 @@
             = select_tag("profile_id",
                          options_for_select(@all_profs.invert.sort_by { |desc, _id| desc.downcase }, "select"),
                          "data-miq_observe" => {:url => url}.to_json,
-                         "class"            => "selectpicker")
+                         "class"            => "selectpicker",
+                         "data-width"       => "auto")
             :javascript
               miqInitSelectPicker();
               miqSelectPickerEvent("profile_id", "#{url}", {beforeSend: true, complete: true});


### PR DESCRIPTION
Before:
![policy-simulation-before](https://cloud.githubusercontent.com/assets/6648365/19943339/4759382a-a137-11e6-960c-ed626d5fff38.jpg)

After:
![policy-simulation-after](https://cloud.githubusercontent.com/assets/6648365/19943348/4e8218ce-a137-11e6-871d-4f1285ec1549.jpg)

Visible especially in non-English locales (Japanese for example).

https://bugzilla.redhat.com/show_bug.cgi?id=1386601