### PR TITLE
Don't need before(:each) in filter_vc_data spec

### DIFF
--- a/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresh_parser/filter_spec.rb
@@ -2,7 +2,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::RefreshParser::Filter do
   context "filter_vc_data" do
     let(:ems) { FactoryGirl.create(:ems_vmware) }
 
-    before(:each) do
+    before do
       @refresher = ems.refresher.new([ems])
       @refresher.instance_variable_set(:@vc_data, vc_data)
     end


### PR DESCRIPTION
Remove unnecessary `:each` in `filter_vc_data` spec test.

Followup PR to https://github.com/ManageIQ/manageiq/pull/12222 to address https://github.com/ManageIQ/manageiq/pull/12222#discussion_r86193245

cc @Fryguy 