### PR TITLE
Use the ref name in the display name

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -150,7 +150,7 @@ class MiqAeDomain < MiqAeNamespace
 
   def display_name
     return self[:display_name] unless git_enabled?
-    "#{domain_name} (#{latest_ref_info['name']})"
+    "#{domain_name} (#{ref})"
   end
 
   private

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -406,19 +406,15 @@ describe MiqAeDomain do
         described_class.new(
           :name           => "Domain name",
           :git_repository => git_repository,
-          :ref            => "not nil",
+          :ref            => "branch1",
           :ref_type       => "branch"
         )
       end
 
       let(:git_repository) { GitRepository.new }
 
-      before do
-        allow(git_repository).to receive(:branch_info).with("not nil").and_return("name" => "branch_name")
-      end
-
-      it "returns the domain name with the latest ref name info" do
-        expect(domain.display_name).to eq("Domain name (branch_name)")
+      it "returns the domain name with the current ref name" do
+        expect(domain.display_name).to eq("Domain name (branch1)")
       end
     end
 


### PR DESCRIPTION
Use the ref name stored with the MiqAeDomain instance instead of fetching the latest information over the network every time we have to display the domain name.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1391208


Steps for Testing/QA [Optional]
-------------------------------
* Fetch a Git Domain
* Sever the network connection to the GIT Server
* Bring up the Automate Explorer to list the domains