### PR TITLE
Use ::Settings directly in app/views/*

### DIFF
--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -139,7 +139,7 @@
                     = view_name
                   .col-md-8
                     %ul.list-inline= render_view_buttons(resource, @edit[:new][:views][resource])
-        - if get_vmdb_config[:product][:storage]
+        - if ::Settings.product.storage
           %fieldset
             %h3
               = _('Storage')

--- a/app/views/dashboard/saml_login.html.haml
+++ b/app/views/dashboard/saml_login.html.haml
@@ -1,4 +1,4 @@
-%html.login-pf{:class => get_vmdb_config[:server][:custom_login_logo] ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
+%html.login-pf{:class => ::Settings.server.custom_login_logo ? '' : 'rcue-login', :lang => I18n.locale.to_s.sub('-', '_')}
   %head
     = favicon_link_tag
     = stylesheet_link_tag 'application'

--- a/app/views/ems_cluster/_main.html.haml
+++ b/app/views/ems_cluster/_main.html.haml
@@ -2,7 +2,7 @@
 .row
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = render :partial => "shared/summary/textual", :locals => {:title => _("Storage Relationships"), :items => textual_group_storage_relationships}
   .col-md-12.col-lg-6
     = render :partial => "shared/summary/textual", :locals => {:title => _("Totals for %{hosts}") % {:hosts => title_for_hosts}, :items => textual_group_host_totals}

--- a/app/views/host/_main.html.haml
+++ b/app/views/host/_main.html.haml
@@ -4,7 +4,7 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
   .col-md-12.col-lg-6
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = render :partial => "shared/summary/textual", :locals => {:title => _("Storage Relationships"), :items => textual_group_storage_relationships}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Compliance"), :items => textual_group_compliance}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Security"), :items => textual_group_security}

--- a/app/views/layouts/_edit_email.html.haml
+++ b/app/views/layouts/_edit_email.html.haml
@@ -26,7 +26,7 @@
                            :maxlength         => MAX_DESC_LEN,
                            :class             => "form-control",
                            "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
-          = _("(Default: %{email_from})") % {:email_from => get_vmdb_config[:smtp][:from]}
+          = _("(Default: %{email_from})") % {:email_from => ::Settings.smtp.from}
   - if @edit[:new][:send_email]
     = render(:partial => "layouts/edit_to_email", :locals => {:action_url => action_url, :record => record})
   %hr

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -58,7 +58,7 @@
             -# Disable column sorting when embedded, for now
             %th
               = h(_(h))
-      - if get_vmdb_config[:product][:vmdb_connections_filter] && view.db == "VmdbDatabaseConnection"
+      - if ::Settings.product.vmdb_connections_filter && view.db == "VmdbDatabaseConnection"
         %tr
           - unless @embedded || @no_checkboxes
             %th

--- a/app/views/layouts/listnav/_ems_cluster.html.haml
+++ b/app/views/layouts/listnav/_ems_cluster.html.haml
@@ -74,7 +74,7 @@
             :display      => nil,
             :title        => _("Show %{cluster_title} drift history") % {:cluster_title => cluster_title})
 
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = miq_accordion_panel(_("Storage Relationships"), false, "host_inf_rel") do
         %ul.nav.nav-pills.nav-stacked
           - if role_allows?(:feature => "ontap_storage_system_show_list")

--- a/app/views/layouts/listnav/_host.html.haml
+++ b/app/views/layouts/listnav/_host.html.haml
@@ -62,7 +62,7 @@
           :display    => 'timeline',
           :record_id  => @record.id,
           :title      => _("Show Timelines"))
-        - if get_vmdb_config[:product][:proto]
+        - if ::Settings.product.proto
           = li_link(:count => @record.event_logs.count,
             :text          => _("ESX Logs"),
             :id            => @record.id,
@@ -118,7 +118,7 @@
             :record_id     => @record.id,
             :title         => _("Show %{host} drift history") % {:host => host_title})
 
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = miq_accordion_panel(_("Storage Relationships"), false, "host_inf_rel") do
         %ul.nav.nav-pills.nav-stacked
           - if role_allows?(:feature => "ontap_storage_system_show_list")

--- a/app/views/layouts/listnav/_storage.html.haml
+++ b/app/views/layouts/listnav/_storage.html.haml
@@ -32,7 +32,7 @@
             :display       => 'all_vms',
             :title         => _("Show registered VMs"))
 
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = miq_accordion_panel(_("Relationships"), false, "storage_inf_rel") do
         %ul.nav.nav-pills.nav-stacked
           - if role_allows?(:feature => "ontap_storage_system_show_list")

--- a/app/views/miq_policy/_action_options.html.haml
+++ b/app/views/miq_policy/_action_options.html.haml
@@ -19,7 +19,7 @@
             :maxlength         => MAX_DESC_LEN,
             :class             => "form-control",
             "data-miq_observe" => observe_with_interval)
-          = _("(Default: %{email_from})") % {:email_from => h(get_vmdb_config[:smtp][:from])}
+          = _("(Default: %{email_from})") % {:email_from => h(::Settings.smtp.from)}
       .form-group
         %label.control-label.col-md-2
           = _('To E-mail Address')

--- a/app/views/miq_policy/_alert_details.html.haml
+++ b/app/views/miq_policy/_alert_details.html.haml
@@ -182,7 +182,7 @@
               .col-md-8
                 %p.form-control-static
                   - if @alert.options[:notifications][:email][:from].blank?
-                    = _("(Default: %{email_from})") % {:email_from => h(get_vmdb_config[:smtp][:from])}
+                    = _("(Default: %{email_from})") % {:email_from => h(::Settings.smtp.from)}
                   - else
                     = h(@alert.options[:notifications][:email][:from])
             .form-group

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -212,7 +212,7 @@
 :javascript
   miq_tabs_init('#rbac_group_tabs');
 %script{:type => "text/javascript"}
-  - if get_vmdb_config[:authentication][:mode] == "httpd"
+  - if ::Settings.authentication.mode == "httpd"
     $('#user_id_ext_auth_form_group').show();
     $('#user_id_form_group').hide();
     $('#user_name_form_group').hide();

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -46,7 +46,7 @@
                            :class => "form-control",
                            "data-miq_observe" => observe_url_json)
     - if @edit
-      - db_mode = get_vmdb_config[:authentication][:mode]
+      - db_mode = ::Settings.authentication.mode
       - if db_mode == "database" || (db_mode != "database" && disabled)
         .form-group
           %label.col-md-2.control-label

--- a/app/views/ops/_settings_details_tab.html.haml
+++ b/app/views/ops/_settings_details_tab.html.haml
@@ -52,7 +52,7 @@
           %td{:onclick => "miqTreeActivateNode('settings_tree', 'xx-msc');", :title => _("View Schedules")}
             = _("Schedules")
             (#{h(@miq_schedules.size)})
-        - if get_vmdb_config[:product][:new_ldap]
+        - if ::Settings.product.new_ldap
           %tr
             %td.narrow{:onclick => "miqTreeActivateNode('settings_tree', 'xx-l');", :title => _("View LDAP Regions")}
               %i.pficon.pficon-regions

--- a/app/views/report/_show_schedule.html.haml
+++ b/app/views/report/_show_schedule.html.haml
@@ -21,7 +21,7 @@
       .col-md-10
         %p.form-control-static
           - if @schedule.sched_action[:options][:email][:from].blank?
-            = _("(Default: %{email_from})") % {:email_from => h(get_vmdb_config[:smtp][:from])}
+            = _("(Default: %{email_from})") % {:email_from => h(::Settings.smtp.from)}
           - else
             = h(@schedule.sched_action[:options][:email][:from])
   .form-group

--- a/app/views/storage/_main.html.haml
+++ b/app/views/storage/_main.html.haml
@@ -5,7 +5,7 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Information for Registered VMs"), :items => textual_group_registered_vms}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
   .col-md-12.col-lg-6
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = render :partial => "shared/summary/textual", :locals => {:title => _("Storage Relationships"), :items => textual_group_storage_relationships}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Content"), :items => textual_group_content}
     = render :partial => "shared/summary/textual_tags", :locals => {:title => _("Smart Management"), :items => textual_group_smart_management}

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -2,8 +2,8 @@
   #tab_div
     = render :partial => "layouts/flash_msg"
     .row
-      - desc = get_vmdb_config[:server][:custom_support_url_description]
-      - url  = get_vmdb_config[:server][:custom_support_url]
+      - desc = ::Settings.server.custom_support_url_description
+      - url  = ::Settings.server.custom_support_url
       - cond_url      = desc.present? && url.present?
       - if admin_user? || (!admin_user? && cond_url)
         .col-md-12

--- a/app/views/vm_common/_main.html.haml
+++ b/app/views/vm_common/_main.html.haml
@@ -4,7 +4,7 @@
     = render :partial => "shared/summary/textual", :locals => {:title => _("Properties"), :items => textual_group_properties}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Lifecycle"), :items => textual_group_lifecycle}
     = render :partial => "shared/summary/textual", :locals => {:title => _("Relationships"), :items => textual_group_relationships}
-    - if get_vmdb_config[:product][:storage]
+    - if ::Settings.product.storage
       = render :partial => "shared/summary/textual", :locals => {:title => _("Storage Relationships"), :items => textual_group_storage_relationships}
     = render :partial => "shared/summary/textual", :locals => {:title => _("VMsafe"), :items => textual_group_vmsafe}
     = render :partial => "shared/summary/textual_normal_operating_ranges", :locals => {:title => _("Normal Operating Ranges (over 30 days)"), :items => textual_group_normal_operating_ranges}


### PR DESCRIPTION
Replaced calls to ```get_vmdb_config``` with direct usage of ```::Settings``` in ```app/views/*```

@miq-bot add-label core

\cc @Fryguy 