### PR TITLE
Allow the retirement date to be cleared

### DIFF
--- a/app/assets/javascripts/directives/miq_calendar.js
+++ b/app/assets/javascripts/directives/miq_calendar.js
@@ -26,8 +26,9 @@ ManageIQ.angular.app.directive('miqCalendar', function() {
         }
       });
 
-      scope.$watch(attr.ngModel, function(_value) {
-        elem.datepicker('update');
+      scope.$watch(attr.ngModel, function(value) {
+        if(value)
+          elem.datepicker('update');
       });
 
       if (attr.miqCalDateFrom) {

--- a/spec/javascripts/directives/miq_calendar_spec.js
+++ b/spec/javascripts/directives/miq_calendar_spec.js
@@ -37,10 +37,17 @@ describe('miq-calendar test', function() {
       expect($.fn.datepicker).toHaveBeenCalledWith('update');
     });
 
+    it('do not call update datepicker when the date is cleared', function() {
+      scope.testModel.test_date = null;
+      scope.$digest();
+      expect($.fn.datepicker).not.toHaveBeenCalled();
+    });
+
     it('should update datepicker when the start date in model changes', function() {
       var d = new Date(Date.UTC(2010, 8, 30));
       scope.testModel.start_date = d;
       scope.$digest();
+
       expect($.fn.datepicker).toHaveBeenCalledWith('setStartDate', d);
     });
 


### PR DESCRIPTION
Allow the retirement date to be cleared

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1384028

Steps for Testing
-------------------------------
Set and save the retirement date for a VM
Reopen the Set Retirement for and clear the date field. The Save button is not enabled before this fix.


