### PR TITLE
Move process_service_order to an after_create hook

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -46,18 +46,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   def generate_request(state, values)
-    make_request(nil, values).tap do |request|
-      process_service_order(request, state) if request
-    end
-  end
-
-  def process_service_order(request, state)
-    case state
-    when ServiceOrder::STATE_ORDERED
-      ServiceOrder.order_immediately(request, @requester)
-    when ServiceOrder::STATE_CART
-      ServiceOrder.add_to_cart(request, @requester)
-    end
+    make_request(nil, values.merge(:cart_state => state))
   end
 
   def validate_dialog


### PR DESCRIPTION
This allows the ServiceOrder to be processed (created) on the correct region.

https://bugzilla.redhat.com/show_bug.cgi?id=1392078