### PR TITLE
Routing Error for reload on infrastructure networking

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1760,6 +1760,7 @@ Vmdb::Application.routes.draw do
         listnav_search_selected
         panel_control
         quick_search
+        reload
         show
         show_list
         tag_edit_form_field_changed


### PR DESCRIPTION
Added route for 'reload' action on infra networking page.

https://bugzilla.redhat.com/show_bug.cgi?id=1383282