### PR TITLE
Allow to display Compare and Drift buttons without RBAC check

### DIFF
--- a/app/helpers/application_helper/toolbar/compare_center.rb
+++ b/app/helpers/application_helper/toolbar/compare_center.rb
@@ -5,6 +5,7 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       'product product-compare_all fa-lg',
       N_('All attributes'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "compare_miq_all",
       :url_parms => "?id=\#{$vms_comp}&compare_task=all"),
     twostate(
@@ -12,6 +13,7 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       'product product-compare_diff fa-lg',
       N_('Attributes with different values'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "compare_miq_differences",
       :url_parms => "?id=\#{$vms_comp}&compare_task=different"),
     twostate(
@@ -19,6 +21,7 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       'product product-compare_same fa-lg',
       N_('Attributes with same values'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "compare_miq_same",
       :url_parms => "?id=\#{$vms_comp}&compare_task=same"),
   ])
@@ -28,12 +31,14 @@ class ApplicationHelper::Toolbar::CompareCenter < ApplicationHelper::Toolbar::Ba
       'fa fa-bars fa-lg',
       N_('Details Mode'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url => "compare_mode"),
     twostate(
       :comparemode_exists,
       'product product-exists fa-lg',
       N_('Exists Mode'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url => "compare_mode"),
   ])
 end

--- a/app/helpers/application_helper/toolbar/compare_view.rb
+++ b/app/helpers/application_helper/toolbar/compare_view.rb
@@ -5,12 +5,14 @@ class ApplicationHelper::Toolbar::CompareView < ApplicationHelper::Toolbar::Basi
       'product product-view_expanded fa-lg',
       N_('Expanded View'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url => "compare_compress"),
     twostate(
       :compare_compressed,
       'fa fa-bars fa-rotate-90 fa-lg',
       N_('Compressed View'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url => "compare_compress"),
   ])
   button_group('compare_downloading', [

--- a/app/helpers/application_helper/toolbar/drift_center.rb
+++ b/app/helpers/application_helper/toolbar/drift_center.rb
@@ -5,6 +5,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       'product product-compare_all fa-lg',
       N_('All attributes'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_all",
       :url_parms => "?id=\#{$vms_comp}&compare_task=all&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
     twostate(
@@ -12,6 +13,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       'product product-compare_diff fa-lg',
       N_('Attributes with different values'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_differences",
       :url_parms => "?id=\#{$vms_comp}&compare_task=different&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
     twostate(
@@ -19,6 +21,7 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       'product product-compare_same fa-lg',
       N_('Attributes with same values'),
       nil,
+      :klass     => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url       => "drift_same",
       :url_parms => "?id=\#{$vms_comp}&compare_task=same&db=\#{@compare_db}&id=\#{@drift_obj.id}"),
   ])
@@ -28,12 +31,14 @@ class ApplicationHelper::Toolbar::DriftCenter < ApplicationHelper::Toolbar::Basi
       'fa fa-bars fa-lg',
       N_('Details Mode'),
       nil,
+      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url => "drift_mode"),
     twostate(
       :driftmode_exists,
       'product product-exists fa-lg',
       N_('Exists Mode'),
       nil,
+      :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck,
       :url => "drift_mode"),
   ])
 end


### PR DESCRIPTION
Added class `ButtonWithoutRbacCheck` to toolbar buttons on Compare screens

## Screenshots

### Drift

Before:
![screenshot from 2016-11-07 11-30-15](https://cloud.githubusercontent.com/assets/1187051/20054601/f0b21550-a4dd-11e6-9f91-cd9dc26320d2.png)

After:
![screenshot from 2016-11-07 11-28-00](https://cloud.githubusercontent.com/assets/1187051/20054604/f1ec57fa-a4dd-11e6-86f9-34cc2839f13a.png)

___

### Compare

Before:
![screenshot from 2016-11-07 11-34-09](https://cloud.githubusercontent.com/assets/1187051/20054694/4cff5692-a4de-11e6-9f38-475ad5b3df44.png)

After:
![screenshot from 2016-11-07 11-35-12](https://cloud.githubusercontent.com/assets/1187051/20054695/4de1c18a-a4de-11e6-89e6-fc687df77baa.png)

Links
----------------
Fixes: #12278
https://bugzilla.redhat.com/show_bug.cgi?id=1381209

Steps for Testing/QA
-------------------------------
Compute → Infrastructure → Hosts/Nodes → [select two records] → Compare Selected items
