### PR TITLE
Wider fields in roles by server tab

### DIFF
--- a/app/views/ops/_selected_by_roles.html.haml
+++ b/app/views/ops/_selected_by_roles.html.haml
@@ -22,17 +22,17 @@
         %img{:src => image_path('100/evmserver.png')}/
       .col-md-8
         .form-group
-          %label.col-md-4.control-label= Dictionary.gettext('MiqServer', :type => :model, :notfound => :titleize)
+          %label.col-md-5.control-label= Dictionary.gettext('MiqServer', :type => :model, :notfound => :titleize)
           .col-md-8
             = h("#{rec.miq_server.name} [#{rec.miq_server.id}]")
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Status")
           .col-md-8
             = h(rec.miq_server.status)
         - if rec.master_supported?
           .form-group
-            %label.col-md-4.control-label
+            %label.col-md-5.control-label
               = _("Priority")
             .col-md-8
               - if rec.priority == 1
@@ -42,44 +42,44 @@
               - else
                 = _("normal")
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Process ID")
           .col-md-8
             = h(rec.miq_server.pid)
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Started On")
           .col-md-8
             - t = rec.miq_server.started_on
             = h(t.blank? ? "" : format_timezone(t))
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Stopped On")
           .col-md-8
             - t = rec.miq_server.stopped_on
             = h(t.blank? ? "" : format_timezone(t))
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Memory Usage")
           .col-md-8
             = h(rec.miq_server["memory_usage"])
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Memory Size")
           .col-md-8
             = h(rec.miq_server["memory_size"])
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("CPU Time")
           .col-md-8
             = h(rec.miq_server["cpu_time"])
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("CPU Percent")
           .col-md-8
             = h(rec.miq_server["percent_cpu"])
         .form-group
-          %label.col-md-4.control-label
+          %label.col-md-5.control-label
             = _("Version / Build")
           .col-md-8
             = h(rec.miq_server["version"])


### PR DESCRIPTION
This change is to accomodate longer strings, especially for non-English locales.

https://bugzilla.redhat.com/show_bug.cgi?id=1288024

Before:
![roles-before](https://cloud.githubusercontent.com/assets/6648365/19966427/0b75813e-a1cc-11e6-89ed-00e18c03d131.jpg)

After:
![roles-after](https://cloud.githubusercontent.com/assets/6648365/19966443/1313f560-a1cc-11e6-9d67-837aaf790c22.jpg)
