### PR TITLE
Support delete backing in reconfigure vm disks

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -130,7 +130,9 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
 
   def remove_disks(disks, vm)
     with_disk_attachments_service(vm) do |service|
-      disks.each { |disk_id| service.attachment_service(disk_id).remove }
+      disks.each do |disk|
+        service.attachment_service(disk["disk_name"]).remove(:detach_only => !disk["delete_backing"])
+      end
     end
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/reconfigure.rb
@@ -28,13 +28,9 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure
       "numCoresPerSocket" => (task_options[:cores_per_socket].to_i if task_options[:cores_per_socket]),
       "memoryMB"          => (task_options[:vm_memory].to_i if task_options[:vm_memory]),
       "numCPUs"           => (task_options[:number_of_cpus].to_i if task_options[:number_of_cpus]),
-      "disksRemove"       => (spec_for_removed_disks(task_options[:disk_remove]) if task_options[:disk_remove]),
+      "disksRemove"       => task_options[:disk_remove],
       "disksAdd"          => (spec_for_added_disks(task_options[:disk_add]) if task_options[:disk_add])
     }
-  end
-
-  def spec_for_removed_disks(disks)
-    disks.map { |disk| disk["disk_name"] }
   end
 
   def spec_for_added_disks(disks)

--- a/app/views/vm_common/_reconfigure.html.haml
+++ b/app/views/vm_common/_reconfigure.html.haml
@@ -128,7 +128,7 @@
           %th= _('Size')
           %th.narrow
           %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Dependent')
-          %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}= _('Delete Backing')
+          %th.narrow= _('Delete Backing')
           %th.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}= _('Bootable')
           %th= _('Actions')
         %tbody
@@ -178,13 +178,13 @@
                      "type"      => "checkbox",
                      "name"      => "cb_dependent",
                      "ng-model"  => "reconfigureModel.cb_dependent"}
+            %td.narrow
             %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'redhat'}
               %input{"bs-switch" => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",
                      "name"          => "cb_bootable",
                      "ng-model"      => "reconfigureModel.cb_bootable"}
-            %td.narrow
             %td.action-cell
               %button.btn.btn-default.btn-block.btn-sm{:type => "button", "ng-click" => "addDisk()", "ng-disabled" => "rowForm.dvcSize.$invalid"}= _(' Add ')
           %tr{"ng-repeat" => "disk in reconfigureModel.vmdisks", "ng-class" => "{'danger': disk.add_remove == 'remove', 'active': disk.add_remove == 'add'}"}
@@ -207,7 +207,7 @@
                      "switch-active" => "{{disk.add_remove!='add'}}",
                      "ng-readonly"   => "disk.add_remove=='add'",
                      "ng-if"         => "disk.add_remove=='add'"}
-            %td.narrow{"ng-if" => @reconfigitems.first.vendor == 'vmware'}
+            %td.narrow
               %input{"bs-switch"     => "",
                      :data           => {:on_text => 'Yes', :off_text => 'No', :size => 'mini'},
                      "type"          => "checkbox",

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm/reconfigure_spec.rb
@@ -65,7 +65,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm::Reconfigure do
 
     it "disksRemove" do
       expect(subject["disksRemove"].size).to eq(1)
-      expect(subject["disksRemove"][0]).to eq("2520b46a-799b-472d-89ce-d47f5b65ee5e")
+      expect(subject["disksRemove"][0]["disk_name"]).to eq("2520b46a-799b-472d-89ce-d47f5b65ee5e")
+      expect(subject["disksRemove"][0]["delete_backing"]).to be_falsey
     end
   end
 


### PR DESCRIPTION
Support 'Delete Backing' option for RHV VM Reconfigure

The 'Delete Backing' option determines if the disk should be removed
from the data store or be kept on the data store and detached from the
virtual machine.

RHV exposes the 'detach_only' property which serves the exact purpose.

http://bugzilla.redhat.com/1390260
![selection_143](https://cloud.githubusercontent.com/assets/316242/19966905/8d9492f4-a1d6-11e6-99ca-4eb143bc8c4e.png)
