### PR TITLE
Wider fields in catalog item screen to accomodate longer strings

### DIFF
--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -6,7 +6,7 @@
     = render(:partial => 'layouts/ae_tree_select')
   .form-horizontal
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _('Name / Description')
       .col-md-8{:style => "padding: 0px;"}
         .col-md-4
@@ -27,7 +27,7 @@
           = _('Display in Catalog')
     = javascript_tag(javascript_focus('name'))
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _('Catalog')
       .col-md-4
         - available_catalogs = @edit[:new][:available_catalogs]
@@ -40,7 +40,7 @@
           miqInitSelectPicker();
           miqSelectPickerEvent('catalog_id', '#{url}')
     .form-group
-      %label.col-md-2.control-label
+      %label.col-md-3.control-label
         = _('Dialog')
       .col-md-4
         %p.form-control-static
@@ -54,7 +54,7 @@
             miqSelectPickerEvent('dialog_id', '#{url}')
     - if @edit[:new][:st_prov_type] == "generic"
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-3.control-label
           = _('Subtype')
         .col-md-4
           %p.form-control-static
@@ -71,7 +71,7 @@
     - if @edit[:new][:st_prov_type] == "generic_orchestration"
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-3.control-label
           = _('Orchestration Template')
         .col-md-8
           = select_tag('template_id',
@@ -83,7 +83,7 @@
       - if @edit[:new][:template_id]
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Provider')
           .col-md-8
             = select_tag('manager_id',
@@ -95,7 +95,7 @@
     - elsif @edit[:new][:st_prov_type] == "generic_ansible_tower"
       - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
       .form-group
-        %label.col-md-2.control-label
+        %label.col-md-3.control-label
           = _('Provider')
         .col-md-8
           = select_tag('manager_id',
@@ -107,7 +107,7 @@
       - if @edit[:new][:manager_id]
         - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Ansible Tower Job Template')
           .col-md-8
             = select_tag('template_id',
@@ -117,7 +117,7 @@
             :javascript
               miqSelectPickerEvent('template_id', '#{url}')
     .form-group
-      %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
+      %label.col-md-3.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
         = _('Provisioning Entry Point')
       .col-md-8{:title => @edit[:new][:fqname]}
         .input-group
@@ -139,7 +139,7 @@
                 %i.pficon.pficon-close
           %span.input-group-addon{:style => "visibility:hidden"}
     .form-group
-      %label.col-md-2.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
+      %label.col-md-3.control-label{:title => _("Reconfigure Entry Point (NameSpace/Class/Instance)")}
         = _('Reconfigure Entry Point')
       .col-md-8{:title => @edit[:new][:reconfigure_fqname]}
         .input-group
@@ -163,7 +163,7 @@
           %span.input-group-addon{:style => "visibility:hidden"}
 
     .form-group
-      %label.col-md-2.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
+      %label.col-md-3.control-label{:title => _("Retirement Entry Point (NameSpace/Class/Instance)")}
         = _('Retirement Entry Point')
       .col-md-8{:title => @edit[:new][:retire_fqname]}
         .input-group

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -19,48 +19,48 @@
         = _('Basic Information')
       .form-horizontal.static
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Name / Description')
           .col-md-8
             #{@record.name} / #{@record.description}
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Display in Catalog')
           .col-md-8
             &nbsp;
             = check_box_tag("display", true, @record.display, :disabled => true)
         - if @record.display
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Catalog')
             .col-md-8
               = h(@record.service_template_catalog ? @record.service_template_catalog.name : "<#{_('Unassigned')}>")
         .form-group
-          %label.col-md-2.control-label
+          %label.col-md-3.control-label
             = _('Dialog')
           .col-md-8
             = h(@sb[:dialog_label])
         - if @record.prov_type == "generic"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Subtype')
             .col-md-8
               = h(ServiceTemplate::GENERIC_ITEM_SUBTYPES[@record[:generic_subtype]])
         - if @record.prov_type == "generic_orchestration"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Orchestration Template')
             .col-md-8
               = h(@record.try(:orchestration_template).try(:name))
           - if @record.orchestration_manager
             .form-group
-              %label.col-md-2.control-label
+              %label.col-md-3.control-label
                 = _('Provider')
               .col-md-8
                 = h(@record.orchestration_manager.name)
         - elsif @record.prov_type == "generic_ansible_tower"
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Ansible Tower Job Template')
             .col-md-8
               = h(@record.try(:job_template).try(:name))
@@ -70,7 +70,7 @@
              [_("Retirement"),   :retire_fqname])
         - entry_points.each do |entry_points_op|
           .form-group
-            %label.col-md-2.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
+            %label.col-md-3.control-label{:title => _("%{entry_point} Entry Point (NameSpace/Class/Instance)") % {:entry_point => entry_points_op[0]}}
               #{entry_points_op[0]} #{_('Entry Point')}
             .col-md-8
               = h(@sb[entry_points_op[1]])
@@ -116,7 +116,7 @@
           = _('Basic Information')
         .form-horizontal.static
           .form-group
-            %label.col-md-2.control-label
+            %label.col-md-3.control-label
               = _('Long Description')
             .col-md-8
               = @record.long_description.to_s.html_safe


### PR DESCRIPTION
This especially helps in non-English locales.

https://bugzilla.redhat.com/show_bug.cgi?id=1247538

Before:
![catalog-item-before](https://cloud.githubusercontent.com/assets/6648365/19968663/d28bb5d2-a1d5-11e6-99e6-5ae8e873ea1b.jpg)

After:
![catalog-item-after](https://cloud.githubusercontent.com/assets/6648365/19968672/d8852bda-a1d5-11e6-99e1-2fe8be8b530d.jpg)
