### PR TITLE
Wider fields in new zone form to accomodate longer strings

### DIFF
--- a/app/views/ops/_zone_form.html.haml
+++ b/app/views/ops/_zone_form.html.haml
@@ -5,7 +5,7 @@
   = _("Zone Information")
 .form-horizontal
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Name")
     .col-md-8
       = text_field_tag("name",
@@ -17,7 +17,7 @@
       - unless @zone.id
         = javascript_tag(javascript_focus('name'))
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Description")
     .col-md-8
       = text_field_tag("description",
@@ -28,7 +28,7 @@
       - if @zone.id && @zone.name.downcase != "default"
         = javascript_tag(javascript_focus('description'))
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("SmartProxy Server IP")
     .col-md-8
       = text_field_tag("proxy_server_ip",
@@ -43,7 +43,7 @@
   = _("NTP Servers")
 .form-horizontal
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Servers")
     .col-md-8
       = text_field_tag("ntp_server_1",
@@ -70,7 +70,7 @@
   = _("Credentials - Windows Domain")
 .form-horizontal
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Username")
     .col-md-8
       = text_field_tag("userid",
@@ -79,7 +79,7 @@
                         :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Password")
     .col-md-8
       = password_field_tag("password",
@@ -88,7 +88,7 @@
                         :class => "form-control",
                         "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Verify Password")
     .col-md-8
       = password_field_tag("verify",
@@ -101,7 +101,7 @@
   = _("Settings")
 .form-horizontal
   .form-group
-    %label.control-label.col-md-2
+    %label.control-label.col-md-3
       = _("Max Active VM Scans")
     .col-md-8
       = select_tag('max_scans',


### PR DESCRIPTION
Especially helpful in non-English locales (such as Japanese).

https://bugzilla.redhat.com/show_bug.cgi?id=1247074

Before:
![new-zone-before](https://cloud.githubusercontent.com/assets/6648365/19969285/5bdd67b6-a1d8-11e6-9830-39b97c0c2651.jpg)

After:
![new-zone-after](https://cloud.githubusercontent.com/assets/6648365/19969293/6056eb00-a1d8-11e6-8274-adf9245e9dbd.jpg)
