### PR TITLE
Pass storage domains collection in disks RHV api request

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -110,7 +110,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
         :provisioned_size => disk_spec["disk_size_in_mb"].to_i * 1024 * 1024,
         :sparse           => disk_spec["thin_provisioned"],
         :format           => disk_spec["format"],
-        :storage_domain   => {:id => ems_storage_uid}
+        :storage_domains  => [:id => ems_storage_uid]
       }
     }
   end


### PR DESCRIPTION
Althought both :storage_domain and :storage_domains are allowed in RHV
api for disks attachments requests, only the storage domain which is
delivered in the collection (:storage_domains) is being respected.

http://bugzilla.redhat.com/1388860