### PR TITLE
Drop unused options comming to assignment calculations

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -84,7 +84,7 @@ class MiqAlert < ApplicationRecord
     end
 
     alert_assignments[key] ||= begin
-      profiles  = MiqAlertSet.assigned_to_target(target, :find_options => {:conditions => ["mode = ?", target.class.base_model.name], :select => "id"})
+      profiles  = MiqAlertSet.assigned_to_target(target)
       alert_ids = profiles.collect { |p| p.members.pluck(:id) }.flatten.uniq
 
       if alert_ids.empty?


### PR DESCRIPTION
These options (`:find_options` and `:select`) are never read by anyone in the caller stack.

This is another :expressionless:  leftover of 298c2d97ba58dc986144cc38abb7bf133f51229a.

@miq-bot add_label core, technical debt, euwe/no