### PR TITLE
Automate - Notification for Service and VM Retirement errors.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__methods__/update_retirement_status.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method is a placeholder for updating the retirement status
+# Description: This method updates the vm retirement status.
 # Required inputs: status
 #
 
@@ -10,7 +10,7 @@ server = $evm.root['miq_server']
 state = $evm.current_object.class_name
 
 # Get current step
-step = $evm.current_object.current_field_name
+step = $evm.root['ae_state']
 
 # Get status from input field status
 status = $evm.inputs['status']
@@ -23,12 +23,24 @@ vm = $evm.root['vm']
 $evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}> Step:<#{step}>")
 $evm.log("info", "Status_State:<#{status_state}> Status:<#{status}>")
 
+# Update Status Message
+updated_message  = "Server [#{server.name}] "
+updated_message += "VM [#{vm.name}] " if vm
+updated_message += "Step [#{step}] "
+updated_message += "Status [#{status}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+
 # Update Status for on_error for all states other than the first state which is startretirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
   if step.downcase == 'startretirement'
-    $evm.log("info", "Cannot continue because VM is already retired or is being retired.")
+    msg = "Cannot continue because VM is "
+    msg += vm ? "#{vm.retirement_state}." : "nil."
+    $evm.log("info", msg)
+    updated_message += msg
+    $evm.create_notification(:level => "warning", :message => "VM Retirement Warning: #{updated_message}")
   else
+    $evm.create_notification(:level => "error", :message => "VM Retirement Error: #{updated_message}")
     vm.retirement_state = 'error' if vm
   end
 end

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/__methods__/update_service_retirement_status.rb
@@ -1,5 +1,5 @@
 #
-# Description: This method is a placeholder for retirement status update
+# Description: This method updates the retirement status.
 #
 
 # Get variables from Server object
@@ -11,7 +11,7 @@ service = $evm.root['service']
 state = $evm.current_object.class_name
 
 # Get current step
-step = $evm.current_object.current_field_name
+step = $evm.root['ae_state']
 
 # Get status from input field status
 status = $evm.inputs['status']
@@ -22,12 +22,24 @@ status_state = $evm.root['ae_status_state']
 $evm.log("info", "Server:<#{server.name}> Ae_Result:<#{$evm.root['ae_result']}> State:<#{state}> Step:<#{step}>")
 $evm.log("info", "Status_State:<#{status_state}> Status:<#{status}>")
 
+# Update Status Message
+updated_message  = "Server [#{server.name}] "
+updated_message += "Service [#{service.name}] " if service
+updated_message += "Step [#{step}] "
+updated_message += "Status [#{status}] "
+updated_message += "Current Retry Number [#{$evm.root['ae_state_retries']}]" if $evm.root['ae_result'] == 'retry'
+
 # Update Status for on_error for all states other than the first state which is start retirement
 # in the retirement state machine.
 if $evm.root['ae_result'] == 'error'
   if step.downcase == 'start retirement'
-    $evm.log("info", "Cannot continue because Service is already retired or is being retired.")
+    msg = "Cannot continue because Service is "
+    msg += service ? "#{service.retirement_state}." : "nil."
+    $evm.log("info", msg)
+    updated_message += msg
+    $evm.create_notification(:level => "warning", :message => "Service Retirement Warning: #{updated_message}")
   else
+    $evm.create_notification(:level => "error", :message => "Service Retirement Error: #{updated_message}")
     service.retirement_state = 'error' if service
   end
 end


### PR DESCRIPTION
Modified update_service_retirement method to send Notification when errors

occur in Service Retirement requests.

Previous Notification PR(s): 12306, 12347, 12370

<img width="314" alt="notification_retire_service" src="https://cloud.githubusercontent.com/assets/11841651/19970780/6c6c3618-a1b3-11e6-880a-3de9373f58cc.png">
