### PR TITLE
fix for custom logo in header

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -73,7 +73,7 @@
 
 li.brand-white-label.whitelabeled {
   margin-top: 10px;
-  width: 350px;
+  width: 320px;
   height: 38px;
   background: url(/upload/custom_logo.png) right top no-repeat;
   background-size: auto 38px;

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -11,13 +11,13 @@
       %img.navbar-brand-name{:src => image_path("brand.svg"), :alt => "ManageIQ"}
   %nav.collapse.navbar-collapse
     %ul.nav.navbar-nav.navbar-right.navbar-iconic
+      %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
       %li{:class => "drawer-pf-trigger dropdown"}
         %a{:class => "nav-item-iconic drawer-pf-trigger-icon", :title => "{{vm.notificationsIndicatorTooltip}}", "ng-click" => "vm.toggleNotificationsList()"}
           %span.fa{"ng-class" => "{'fa-bell': vm.newNotifications, 'fa-bell-o': !vm.newNotifications}"}
           %span.badge.info{"ng-show" => "vm.newNotifications"}
             -# Small circle
             &#8226
-      %li{:class => "dropdown brand-white-label #{current_tenant.logo? ? "whitelabeled" : ""}"}
       %li.dropdown
         %a{:class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu1",  "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "true"}
           %span.fa.pficon-help


### PR DESCRIPTION
This PR repositions the custom logo to the left of the notification drawer icon. It also resizes the custom logo to prevent the header from wrapping in the mobile layout.

https://bugzilla.redhat.com/show_bug.cgi?id=1389287

Old

![screen shot 2016-11-03 at 10 51 02 am](https://cloud.githubusercontent.com/assets/1287144/19971259/e4be5e38-a1b4-11e6-9e65-5d534f094190.png)
![screen shot 2016-11-03 at 10 51 20 am](https://cloud.githubusercontent.com/assets/1287144/19971256/e4b2bc7c-a1b4-11e6-822b-c16759a1ffe4.png)

New

![screen shot 2016-11-03 at 10 50 31 am](https://cloud.githubusercontent.com/assets/1287144/19971258/e4bc4756-a1b4-11e6-902b-f64c971a43be.png)
![screen shot 2016-11-03 at 10 52 11 am](https://cloud.githubusercontent.com/assets/1287144/19971257/e4b4daca-a1b4-11e6-9409-94f4ba546e97.png)