### PR TITLE
Disabling the operations for deployment and datasource entities in case of domain.

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -702,8 +702,10 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.provisionable?
       end
     when 'MiddlewareServer', 'MiddlewareDeployment', 'MiddlewareDatasource'
-      if %w(middleware_deployment_add middleware_jdbc_driver_add middleware_datasource_add).include?(id) &&
-         @record.try(:in_domain?)
+      if %w(middleware_deployment_add middleware_jdbc_driver_add middleware_datasource_add middleware_deployment_enable
+            middleware_datasource_remove middleware_deployment_restart middleware_deployment_disable
+            middleware_deployment_undeploy).include?(id) &&
+         (@record.try(:in_domain?) || @record.try(:middleware_server).try(:in_domain?))
         return true
       end
       return true if %w(middleware_server_shutdown middleware_server_restart middleware_server_stop


### PR DESCRIPTION
It should not be possible to perform following operations on entities that are under the domain server:

- `middleware_datasource_remove` (on server)
- `middleware_deployment_restart` (on the deployment)
- `middleware_deployment_disable` (on the deployment)
- `middleware_deployment_enable` (on the deployment)
- `middleware_deployment_undeploy` (on the deployment)

related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1390372
@miq-bot add_label providers/hawkular, bug, euwe/yes
@pilhuhn could you please look? It's pretty much the same as the PR #12312 