### PR TITLE
Add `protect_from_forgery` to satisfy Brakeman

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,8 +1,8 @@
 # used to serve static angular templates from under app/views/static/
 
 class StaticController < ActionController::Base
-  # Added to satisfy Brakeman
-  protect_from_forgery
+  # Added to satisfy Brakeman, https://github.com/presidentbeef/brakeman/pull/953
+  protect_from_forgery :with => :exception
 
   # hide_action is gone in Rails, but high_voltage is still using it.
   # https://github.com/thoughtbot/high_voltage/pull/214

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,9 @@
 # used to serve static angular templates from under app/views/static/
 
 class StaticController < ActionController::Base
+  # Added to satisfy Brakeman
+  protect_from_forgery
+
   # hide_action is gone in Rails, but high_voltage is still using it.
   # https://github.com/thoughtbot/high_voltage/pull/214
   def self.hide_action(*)


### PR DESCRIPTION
Brakeman flags StaticController as not being protected (even though it only serves GET requests). This change adds `protect_from_forgery` to get out of the red for now.

