### PR TITLE
Add specs for loading virtual custom attributes from right side in expression

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -25,11 +25,15 @@ describe MiqExpression do
       exp2 = {"ENDS WITH" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_3}"}}
       exp3 = {"ENDS WITH" => {"field" => "#{klass}-#{virtual_custom_attribute_4}", "value" => "any_value"}}
 
-      expectation = expect { MiqExpression.new("AND" => [exp1, {"AND" => [exp2, exp3]}]) }
-
-      expectation.to change { vm.respond_to?(virtual_custom_attribute_2) }.from(false).to(true)
-      expectation.to change { vm.respond_to?(virtual_custom_attribute_3) }.from(false).to(true)
-      expectation.to change { vm.respond_to?(virtual_custom_attribute_4) }.from(false).to(true)
+      expect do
+        MiqExpression.new("AND" => [exp1, {"AND" => [exp2, exp3]}])
+      end.to change {
+        [
+          vm.respond_to?(virtual_custom_attribute_2),
+          vm.respond_to?(virtual_custom_attribute_3),
+          vm.respond_to?(virtual_custom_attribute_4)
+        ]
+      }.from([false, false, false]).to([true, true, true])
     end
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1,13 +1,35 @@
 describe MiqExpression do
   context "virtual custom attributes" do
-    let(:virtual_custom_attribute) { "virtual_custom_attribute_attribute" }
-    let(:klass)                    { Vm }
-    let(:vm)                       { FactoryGirl.create(:vm) }
+    let(:virtual_custom_attribute)   { "virtual_custom_attribute_attribute" }
+    let(:virtual_custom_attribute_1) { "virtual_custom_attribute_attribute_1" }
+    let(:virtual_custom_attribute_2) { "virtual_custom_attribute_attribute_2" }
+    let(:virtual_custom_attribute_3) { "virtual_custom_attribute_attribute_3" }
+    let(:virtual_custom_attribute_4) { "virtual_custom_attribute_attribute_4" }
+    let(:klass)                      { Vm }
+    let(:vm)                         { FactoryGirl.create(:vm) }
 
     it "automatically loads virtual custom attributes from MiqExpression on class" do
       expect do
         MiqExpression.new("EQUAL" => {"field" => "#{klass}-#{virtual_custom_attribute}", "value" => "foo"})
       end.to change { vm.respond_to?(virtual_custom_attribute) }.from(false).to(true)
+    end
+
+    it "automatically loads virtual custom attributes from right side in expression" do
+      expect do
+        MiqExpression.new("EQUAL" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_1}"})
+      end.to change { vm.respond_to?(virtual_custom_attribute_1) }.from(false).to(true)
+    end
+
+    it "automatically loads virtual custom attributes from right side in nested expression" do
+      exp1 = {"STARTS WITH" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_2}"}}
+      exp2 = {"ENDS WITH" => {"field" => "#{klass}-name", "value" => "#{klass}-#{virtual_custom_attribute_3}"}}
+      exp3 = {"ENDS WITH" => {"field" => "#{klass}-#{virtual_custom_attribute_4}", "value" => "any_value"}}
+
+      expectation = expect { MiqExpression.new("AND" => [exp1, {"AND" => [exp2, exp3]}]) }
+
+      expectation.to change { vm.respond_to?(virtual_custom_attribute_2) }.from(false).to(true)
+      expectation.to change { vm.respond_to?(virtual_custom_attribute_3) }.from(false).to(true)
+      expectation.to change { vm.respond_to?(virtual_custom_attribute_4) }.from(false).to(true)
     end
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -427,11 +427,12 @@ describe MiqExpression do
         end
 
         it "finds the correct instances for an gt expression with a custom attribute dynamic integer field" do
-          custom_attribute =  FactoryGirl.create(:custom_attribute, :name => "example", :value => 1)
+          custom_attribute =  FactoryGirl.create(:custom_attribute, :name => "example", :value => 10)
           vm1 = FactoryGirl.create(:vm, :memory_reserve => 2)
           vm1.custom_attributes << custom_attribute
           _vm2 = FactoryGirl.create(:vm, :memory_reserve => 0)
-          filter = MiqExpression.new(">" => {"field" => "VmOrTemplate-memory_reserve", "value" => "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}example"})
+          name_of_attribute = "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}example"
+          filter = MiqExpression.new("<" => {"field" => "VmOrTemplate-memory_reserve", "value" => name_of_attribute})
           result = Rbac.search(:targets => Vm, :filter => filter).first.first
           expect(filter.to_sql.last).to eq(:supported_by_sql => false)
           expect(result).to eq(vm1)

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,5 +1,26 @@
 describe Condition do
   describe ".subst" do
+    context "evaluation of virtual custom attributes from left and right side" do
+      let(:custom_attribute_1)         { FactoryGirl.create(:custom_attribute, :name => "attr_1", :value => 20) }
+      let(:custom_attribute_2)         { FactoryGirl.create(:custom_attribute, :name => "attr_2", :value => 30) }
+      let(:name_of_custom_attribute_1) { "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}attr_1" }
+      let(:name_of_custom_attribute_2) { "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}attr_2" }
+      let(:vm)                         { FactoryGirl.create(:vm, :memory_reserve => 10) }
+
+      before do
+        @filter = MiqExpression.new(">" => {"field" => name_of_custom_attribute_1,
+                                            "value" => name_of_custom_attribute_2})
+        vm.custom_attributes << custom_attribute_1
+        vm.custom_attributes << custom_attribute_2
+        vm.save
+      end
+
+      it "evaluates custom attributes" do
+        condition_to_evaluate = Condition.subst(@filter.to_ruby(nil), vm)
+        expect(condition_to_evaluate).to eq('20 > 30')
+      end
+    end
+
     context "expression with <find>" do
       before do
         @cluster = FactoryGirl.create(:ems_cluster)

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -5,19 +5,34 @@ describe Condition do
       let(:custom_attribute_2)         { FactoryGirl.create(:custom_attribute, :name => "attr_2", :value => 30) }
       let(:name_of_custom_attribute_1) { "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}attr_1" }
       let(:name_of_custom_attribute_2) { "VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}attr_2" }
-      let(:vm)                         { FactoryGirl.create(:vm, :memory_reserve => 10) }
-
-      before do
-        @filter = MiqExpression.new(">" => {"field" => name_of_custom_attribute_1,
-                                            "value" => name_of_custom_attribute_2})
-        vm.custom_attributes << custom_attribute_1
-        vm.custom_attributes << custom_attribute_2
-        vm.save
+      let!(:vm) do
+        FactoryGirl.create(:vm, :memory_reserve => 10, :custom_attributes => [custom_attribute_1, custom_attribute_2])
       end
 
-      it "evaluates custom attributes" do
-        condition_to_evaluate = Condition.subst(@filter.to_ruby(nil), vm)
+      before do
+        @filter_1 = MiqExpression.new(">" => {"field" => name_of_custom_attribute_1,
+                                              "value" => name_of_custom_attribute_2})
+
+        @filter_2 = MiqExpression.new(">" => {"field" => "VmOrTemplate-memory_reserve",
+                                              "value" => name_of_custom_attribute_2})
+
+        @filter_3 = MiqExpression.new(">" => {"field" => name_of_custom_attribute_1,
+                                              "value" => "VmOrTemplate-memory_reserve"})
+      end
+
+      it "evaluates custom attributes on both sides" do
+        condition_to_evaluate = Condition.subst(@filter_1.to_ruby(nil), vm)
         expect(condition_to_evaluate).to eq('20 > 30')
+      end
+
+      it "evaluates custom attribute on right side and integer column of VmOrTemplate on left side" do
+        condition_to_evaluate = Condition.subst(@filter_2.to_ruby(nil), vm)
+        expect(condition_to_evaluate).to eq('10 > 30')
+      end
+
+      it "evaluates custom attribute on left side and integer column of VmOrTemplate on right side" do
+        condition_to_evaluate = Condition.subst(@filter_3.to_ruby(nil), vm)
+        expect(condition_to_evaluate).to eq('20 > 10')
       end
     end
 


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq/pull/11369 we are loading 
 virtual custom attributes when MiqExpression object is created.

But according to https://github.com/ManageIQ/manageiq/pull/11445 we need also load them 
 when there are presented on right side.
```ruby
MiqExpression.new(">" => {"field" => "VmOrTemplate-memory_reserve", "value" => "VmOrTemplate-virtual_custom_attribute_example"})
```
For example in this test case https://github.com/ManageIQ/manageiq/pull/11445/files#diff-16778e6e2de5a476b5900435544a11b7R412

```VmOrTemplate-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}example"``` is always nil and converted to 0.

When you will put to `:value => 10` to [this](https://github.com/ManageIQ/manageiq/pull/11445/files#diff-16778e6e2de5a476b5900435544a11b7R408) spec it will not fail even it should. 

This situation was not covered by specs, so this PR is adding it.

🎁 @alongoldboim 

cc @kbrock @imtayadeway 

@miq-bot add_label core, enhancement
