### PR TITLE
Expose a group's filters in automate.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_group.rb
@@ -3,6 +3,7 @@ module MiqAeMethodService
     expose :users,  :association => true
     expose :vms,    :association => true
     expose :tenant, :association => true
+    expose :filters, :method => :get_filters
 
     def custom_keys
       object_send(:miq_custom_keys)


### PR DESCRIPTION
Instead of exposing the Entitlement object to the automate service model, filters is exposed to a group via a method call.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1390678

cc @gmcculloug 