### PR TITLE
Write repmgr conf and pgpass when configuring a primary database server

### DIFF
--- a/gems/pending/appliance_console/database_replication.rb
+++ b/gems/pending/appliance_console/database_replication.rb
@@ -8,6 +8,7 @@ module ApplianceConsole
     include ApplianceConsole::Logging
 
     REPMGR_CONFIG = '/etc/repmgr.conf'.freeze
+    REPMGR_LOG    = '/var/log/repmgr/repmgrd.log'.freeze
 
     attr_accessor :cluster_name, :node_number, :database_name, :database_user,
                   :database_password, :primary_host
@@ -52,6 +53,10 @@ Replication Server Configuration
         f.puts("conninfo='host=#{host} user=#{database_user} dbname=#{database_name}'")
         f.puts("use_replication_slots=1")
         f.puts("pg_basebackup_options='--xlog-method=stream'")
+        f.puts("failover=automatic\n")
+        f.puts("promote_command='repmgr standby promote'\n")
+        f.puts("follow_command='repmgr standby follow'\n")
+        f.puts("logfile=#{REPMGR_LOG}\n")
       end
       true
     end

--- a/gems/pending/appliance_console/database_replication.rb
+++ b/gems/pending/appliance_console/database_replication.rb
@@ -9,6 +9,7 @@ module ApplianceConsole
 
     REPMGR_CONFIG = '/etc/repmgr.conf'.freeze
     REPMGR_LOG    = '/var/log/repmgr/repmgrd.log'.freeze
+    PGPASS_FILE   = '/var/lib/pgsql/.pgpass'.freeze
 
     attr_accessor :cluster_name, :node_number, :database_name, :database_user,
                   :database_password, :primary_host
@@ -73,6 +74,16 @@ Replication Server Configuration
         return false
       end
       true
+    end
+
+    def write_pgpass_file
+      File.open(PGPASS_FILE, "w") do |f|
+        f.write("*:*:#{database_name}:#{database_user}:#{database_password}\n")
+        f.write("*:*:replication:#{database_user}:#{database_password}\n")
+      end
+
+      FileUtils.chmod(0600, PGPASS_FILE)
+      FileUtils.chown("postgres", "postgres", PGPASS_FILE)
     end
 
     private

--- a/gems/pending/appliance_console/database_replication_primary.rb
+++ b/gems/pending/appliance_console/database_replication_primary.rb
@@ -36,7 +36,8 @@ module ApplianceConsole
       say("Configuring Primary Replication Server...")
       generate_cluster_name &&
         create_config_file(primary_host) &&
-        initialize_primary_server
+        initialize_primary_server &&
+        write_pgpass_file
     end
 
     def initialize_primary_server

--- a/gems/pending/appliance_console/database_replication_standby.rb
+++ b/gems/pending/appliance_console/database_replication_standby.rb
@@ -12,7 +12,6 @@ module ApplianceConsole
     REGISTER_CMD    = 'repmgr standby register'.freeze
     PGPASS_FILE     = '/var/lib/pgsql/.pgpass'.freeze
     REPMGRD_SERVICE = 'rh-postgresql95-repmgr'.freeze
-    REPMGRD_LOG     = '/var/log/repmgr/repmgrd.log'.freeze
 
     attr_accessor :standby_host, :run_repmgrd_configuration
 
@@ -97,18 +96,8 @@ module ApplianceConsole
 
     def configure_repmgrd
       return true unless run_repmgrd_configuration
-      write_repmgrd_config
       write_pgpass_file
       start_repmgrd
-    end
-
-    def write_repmgrd_config
-      File.open(REPMGR_CONFIG, "a") do |f|
-        f.write("failover=automatic\n")
-        f.write("promote_command='repmgr standby promote'\n")
-        f.write("follow_command='repmgr standby follow'\n")
-        f.write("logfile=#{REPMGRD_LOG}\n")
-      end
     end
 
     def write_pgpass_file

--- a/gems/pending/spec/appliance_console/database_replication_primary_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_primary_spec.rb
@@ -66,28 +66,8 @@ describe ApplianceConsole::DatabaseReplicationPrimary do
       expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:initialize_primary_server).and_return(true)
+      expect(subject).to receive(:write_pgpass_file).and_return(true)
       expect(subject.activate).to be true
-    end
-
-    it "returns false when create_config_file fails" do
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
-      expect(subject).to receive(:create_config_file).and_return(false)
-      expect(subject).to_not receive(:initialize_primary_server)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when generate_cluster_name fails" do
-      expect(subject).to receive(:generate_cluster_name).and_return(false)
-      expect(subject).to_not receive(:create_config_file)
-      expect(subject).to_not receive(:initialize_primary_server)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when initialize_primary_server fails" do
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
-      expect(subject).to receive(:create_config_file).and_return(true)
-      expect(subject).to receive(:initialize_primary_server).and_return(false)
-      expect(subject.activate).to be false
     end
   end
 

--- a/gems/pending/spec/appliance_console/database_replication_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_spec.rb
@@ -57,6 +57,21 @@ describe ApplianceConsole::DatabaseReplication do
   end
 
   context "#create_config_file" do
+    let(:expected_config_file) do
+      <<-EOS.strip_heredoc
+        cluster=clustername
+        node=nodenumber
+        node_name=host
+        conninfo='host=host user=user dbname=databasename'
+        use_replication_slots=1
+        pg_basebackup_options='--xlog-method=stream'
+        failover=automatic
+        promote_command='repmgr standby promote'
+        follow_command='repmgr standby follow'
+        logfile=/var/log/repmgr/repmgrd.log
+      EOS
+    end
+
     before do
       subject.cluster_name      = "clustername"
       subject.node_number       = "nodenumber"
@@ -73,28 +88,13 @@ describe ApplianceConsole::DatabaseReplication do
     end
 
     it "should correctly populate the config file" do
-      expected_config_file = "cluster=clustername\n"
-      expected_config_file << "node=nodenumber\n"
-      expected_config_file << "node_name=host\n"
-      expected_config_file << "conninfo='host=host user=user dbname=databasename'\n"
-      expected_config_file << "use_replication_slots=1\n"
-      expected_config_file << "pg_basebackup_options='--xlog-method=stream'\n"
-
       subject.create_config_file("host")
-
       expect(File.read(@temp_file.path)).to eq(expected_config_file)
     end
 
     it "should overwrite an existing config file" do
-      expected_config_file = "cluster=clustername\n"
-      expected_config_file << "node=nodenumber\n"
-      expected_config_file << "node_name=differenthostname\n"
-      expected_config_file << "conninfo='host=differenthostname user=user dbname=databasename'\n"
-      expected_config_file << "use_replication_slots=1\n"
-      expected_config_file << "pg_basebackup_options='--xlog-method=stream'\n"
-
-      subject.create_config_file("host")
       subject.create_config_file("differenthostname")
+      subject.create_config_file("host")
 
       expect(File.read(@temp_file.path)).to eq(expected_config_file)
     end

--- a/gems/pending/spec/appliance_console/database_replication_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_spec.rb
@@ -115,4 +115,33 @@ describe ApplianceConsole::DatabaseReplication do
       expect(subject.generate_cluster_name).to be_falsey
     end
   end
+
+  context "#write_pgpass_file" do
+    let(:pgpass_path) { Tempfile.new("pgpass").path }
+
+    before do
+      stub_const("#{described_class}::PGPASS_FILE", pgpass_path)
+    end
+
+    after do
+      FileUtils.rm_f(pgpass_path)
+    end
+
+    it "writes the .pgpass file correctly" do
+      subject.database_name     = "dbname"
+      subject.database_user     = "someuser"
+      subject.database_password = "secret"
+
+      expect(FileUtils).to receive(:chown).with("postgres", "postgres", pgpass_path)
+      subject.write_pgpass_file
+
+      expect(File.read(pgpass_path)).to eq(<<-EOS.gsub(/^\s+/, ""))
+        *:*:dbname:someuser:secret
+        *:*:replication:someuser:secret
+      EOS
+
+      pgpass_stat = File.stat(pgpass_path)
+      expect(pgpass_stat.mode.to_s(8)).to eq("100600")
+    end
+  end
 end

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -58,81 +58,29 @@ describe ApplianceConsole::DatabaseReplicationStandby do
   end
 
   context "#activate" do
-    it "returns true when configure succeed" do
+    it "returns true when configure succeeds" do
+      subject.run_repmgrd_configuration = false
       expect(subject).to receive(:data_dir_empty?).and_return(true)
       expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:clone_standby_server).and_return(true)
       expect(subject).to receive(:start_postgres).and_return(true)
       expect(subject).to receive(:register_standby_server).and_return(true)
-      expect(subject).to receive(:configure_repmgrd).and_return(true)
+      expect(subject).to receive(:write_pgpass_file).and_return(true)
       expect(subject.activate).to be true
     end
 
-    it "returns false when data_dir_empty? fails" do
-      expect(subject).to receive(:data_dir_empty?).and_return(false)
-      expect(subject).to_not receive(:generate_cluster_name)
-      expect(subject).to_not receive(:create_config_file)
-      expect(subject).to_not receive(:clone_standby_server)
-      expect(subject).to_not receive(:start_postgres)
-      expect(subject).to_not receive(:register_standby_server)
-      expect(subject).to_not receive(:configure_repmgrd)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when generate_cluster_name fails" do
-      expect(subject).to receive(:data_dir_empty?).and_return(true)
-      expect(subject).to receive(:generate_cluster_name).and_return(false)
-      expect(subject).to_not receive(:create_config_file)
-      expect(subject).to_not receive(:clone_standby_server)
-      expect(subject).to_not receive(:start_postgres)
-      expect(subject).to_not receive(:register_standby_server)
-      expect(subject).to_not receive(:configure_repmgrd)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when create_config_file fails" do
-      expect(subject).to receive(:data_dir_empty?).and_return(true)
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
-      expect(subject).to receive(:create_config_file).and_return(false)
-      expect(subject).to_not receive(:clone_standby_server)
-      expect(subject).to_not receive(:start_postgres)
-      expect(subject).to_not receive(:register_standby_server)
-      expect(subject).to_not receive(:configure_repmgrd)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when clone_standby_server fails" do
-      expect(subject).to receive(:data_dir_empty?).and_return(true)
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
-      expect(subject).to receive(:create_config_file).and_return(true)
-      expect(subject).to receive(:clone_standby_server).and_return(false)
-      expect(subject).to_not receive(:start_postgres)
-      expect(subject).to_not receive(:register_standby_server)
-      expect(subject).to_not receive(:configure_repmgrd)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when start_postgres fails" do
-      expect(subject).to receive(:data_dir_empty?).and_return(true)
-      expect(subject).to receive(:generate_cluster_name).and_return(true)
-      expect(subject).to receive(:create_config_file).and_return(true)
-      expect(subject).to receive(:clone_standby_server).and_return(true)
-      expect(subject).to receive(:start_postgres).and_return(false)
-      expect(subject).to_not receive(:register_standby_server)
-      expect(subject).to_not receive(:configure_repmgrd)
-      expect(subject.activate).to be false
-    end
-
-    it "returns false when register_standby_server fails" do
+    it "runs #start_repmgrd when run_repmgrd_configuration is set" do
+      subject.run_repmgrd_configuration = true
       expect(subject).to receive(:data_dir_empty?).and_return(true)
       expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:clone_standby_server).and_return(true)
       expect(subject).to receive(:start_postgres).and_return(true)
-      expect(subject).to receive(:register_standby_server).and_return(false)
-      expect(subject).to_not receive(:configure_repmgrd)
-      expect(subject.activate).to be false
+      expect(subject).to receive(:register_standby_server).and_return(true)
+      expect(subject).to receive(:write_pgpass_file).and_return(true)
+      expect(subject).to receive(:start_repmgrd).and_return(true)
+      expect(subject.activate).to be true
     end
   end
 
@@ -213,13 +161,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(service).to receive(:enable).and_return(service)
       expect(service).to receive(:start).and_return(service)
       expect(subject.start_postgres).to be_truthy
-    end
-  end
-
-  context "#configure_repmgrd" do
-    it "returns true if not setup to do the configuration" do
-      subject.run_repmgrd_configuration = false
-      expect(subject.configure_repmgrd).to be true
     end
   end
 

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -223,35 +223,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
   end
 
-  context "#write_pgpass_file" do
-    let(:pgpass_path) { Tempfile.new("pgpass").path }
-
-    before do
-      stub_const("#{described_class}::PGPASS_FILE", pgpass_path)
-    end
-
-    after do
-      FileUtils.rm_f(pgpass_path)
-    end
-
-    it "writes the .pgpass file correctly" do
-      subject.database_name     = "dbname"
-      subject.database_user     = "someuser"
-      subject.database_password = "secret"
-
-      expect(FileUtils).to receive(:chown).with("postgres", "postgres", pgpass_path)
-      subject.write_pgpass_file
-
-      expect(File.read(pgpass_path)).to eq(<<-EOS.gsub(/^\s+/, ""))
-        *:*:dbname:someuser:secret
-        *:*:replication:someuser:secret
-      EOS
-
-      pgpass_stat = File.stat(pgpass_path)
-      expect(pgpass_stat.mode.to_s(8)).to eq("100600")
-    end
-  end
-
   context "#start_repmgrd" do
     it "starts and enables repmgrd" do
       service = double(SPEC_NAME)

--- a/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
+++ b/gems/pending/spec/appliance_console/database_replication_standby_spec.rb
@@ -223,32 +223,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
   end
 
-  context "#write_repmgrd_config" do
-    let(:config_path) { Tempfile.new("repmgr_config").path }
-
-    before do
-      stub_const("ApplianceConsole::DatabaseReplication::REPMGR_CONFIG", config_path)
-    end
-
-    after do
-      FileUtils.rm_f(config_path)
-    end
-
-    it "appends the correct data to the config file" do
-      File.write(config_path, "some other stuff here\n")
-
-      subject.write_repmgrd_config
-
-      expect(File.read(config_path)).to eq(<<-EOS.strip_heredoc)
-        some other stuff here
-        failover=automatic
-        promote_command='repmgr standby promote'
-        follow_command='repmgr standby follow'
-        logfile=/var/log/repmgr/repmgrd.log
-      EOS
-    end
-  end
-
   context "#write_pgpass_file" do
     let(:pgpass_path) { Tempfile.new("pgpass").path }
 


### PR DESCRIPTION
When a primary server fails and a failover is executed it is typical to reintroduce the failed primary server as a standby if the failure is recoverable.

Some of the configuration edits made when configuring a standby also should be done when configuring a primary server to deal with this situation.

These config changes are safe to make when the server is running as a primary and will allow us to reintroduce the server as a standby without having to make the changes manually.

@gtanzillo @jvlcek please review