### PR TITLE
Delete unnecessary chargeback_vm factory

### DIFF
--- a/spec/factories/chargeback_vm.rb
+++ b/spec/factories/chargeback_vm.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :chargeback_vm do
-  end
-end

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -843,7 +843,7 @@ describe ChargebackVm do
 
   describe "#get_rates" do
     let(:chargeback_rate)         { FactoryGirl.create(:chargeback_rate, :rate_type => "Compute") }
-    let(:chargeback_vm)           { FactoryGirl.build(:chargeback_vm) }
+    let(:chargeback_vm)           { ChargebackVm.new }
     let(:rate_assignment_options) { {:cb_rate => @cbr, :object => Tenant.root_tenant} }
     let(:metric_rollup) do
       FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => "2012-08-31T07:00:00Z", :tag_names => "environment/prod",


### PR DESCRIPTION
`ChargebackVm` is a poor fit for Factory Girl:

* it will blow up if invoked with `FactoryGirl.create` (it's not an AR
  model)
* it has no validations on its attributes
* if it ever becomes cumbersome to build `ChargebackVm` objects, a
  custom factory method may be a better fit

@miq-bot add-label test, technical debt
@miq-bot assign @jrafanie 

:scissors: 