### PR TITLE
Automate Provisioned Notifications - Use Automate notifications instead of event notifications.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/System/CommonMethods/StateMachineMethods.class/__methods__/task_finished.rb
@@ -9,10 +9,12 @@ final_message = "[#{$evm.root['miq_server'].name}] "
 case $evm.root['vmdb_object_type']
 when 'service_template_provision_task'
   final_message += "Service [#{@task.destination.name}] Provisioned Successfully"
+  $evm.create_notification(:type => :automate_service_provisioned, :subject => @task.destination) if @task.miq_request_task.nil?
 when 'miq_provision'
   final_message += "VM [#{@task.get_option(:vm_target_name)}] "
   final_message += "IP [#{@task.vm.ipaddresses.first}] " if @task.vm && !@task.vm.ipaddresses.blank?
   final_message += "Provisioned Successfully"
+  $evm.create_notification(:type => :automate_vm_provisioned, :subject => @task.vm)
 else
   final_message += $evm.inputs['message']
 end

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -4,7 +4,7 @@
   :expires_in: 7.days
   :level: :success
   :audience: tenant
-- :name: service_provisioned
+- :name: automate_service_provisioned
   :message: Service %{subject} has been provisioned.
   :expires_in: 7.days
   :level: :success
@@ -14,7 +14,7 @@
   :expires_in: 7.days
   :level: :success
   :audience: tenant
-- :name: vm_provisioned
+- :name: automate_vm_provisioned
   :message: Virtual Machine %{subject} has been provisioned.
   :expires_in: 7.days
   :level: :success

--- a/spec/automation/unit/method_validation/task_finished_spec.rb
+++ b/spec/automation/unit/method_validation/task_finished_spec.rb
@@ -14,6 +14,7 @@ describe "task_finished_status" do
   let(:miq_server) { EvmSpecHelper.local_miq_server }
   let(:ems) { FactoryGirl.create(:ems_vmware_with_authentication) }
   let(:vm_template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+  let(:vm) { FactoryGirl.create(:vm_vmware, :ext_management_system => ems) }
   let(:options) { {:src_vm_id => [vm_template.id, vm_template.name], :pass => 1} }
   let(:miq_provision_request) do
     FactoryGirl.create(:miq_provision_request,
@@ -27,19 +28,24 @@ describe "task_finished_status" do
     FactoryGirl.create(:miq_provision_vmware, :provision_type => 'template',
                        :state => 'pending', :status => 'Ok',
                        :miq_request => miq_provision_request,
-                       :options => options, :userid => user.userid)
+                       :options => options, :userid => user.userid, :vm => vm)
   end
 
   it "miq_provision method succeeds" do
+    type = :automate_vm_provisioned
+    FactoryGirl.create(:notification_type, :name => type)
+
+    msg = "[#{miq_server.name}] VM [] Provisioned Successfully"
     @args = "status=fred&ae_result=ok&MiqProvision::miq_provision=#{provision.id}&" \
             "MiqServer::miq_server=#{miq_server.id}&vmdb_object_type=miq_provision&" \
             "object=miq_provision&message=not used"
+    expect(Notification.count).to eq(0)
     add_call_method
     ws
     expect(provision.reload.status).to eq('Ok')
     expect(provision.state).to eq('finished')
-    msg = "[#{miq_server.name}] VM [] Provisioned Successfully"
     expect(miq_provision_request.reload.message).to eq(msg)
+    expect(Notification.find_by(:notification_type_id => NotificationType.find_by_name(type).id)).not_to be_nil
   end
 
   it "task_finished method input message" do

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -173,7 +173,7 @@ module MiqAeServiceSpec
         end
 
         it "invalid subject" do
-          expect { miq_ae_service.create_notification!(:type => :vm_provisioned, :subject => 'fred') }
+          expect { miq_ae_service.create_notification!(:type => :vm_retired, :subject => 'fred') }
             .to raise_error(ArgumentError, "Subject must be a valid Active Record object")
         end
 
@@ -206,7 +206,7 @@ module MiqAeServiceSpec
         end
 
         it "invalid subject" do
-          expect { miq_ae_service.create_notification(:type => :vm_provisioned, :subject => 'fred') }
+          expect { miq_ae_service.create_notification(:type => :vm_retired, :subject => 'fred') }
             .not_to raise_error
         end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -6,7 +6,7 @@ describe Notification, :type => :model do
   describe '.emit' do
     context 'successful' do
       let(:vm) { FactoryGirl.create(:vm, :tenant => tenant) }
-      let(:notification_type) { :vm_provisioned }
+      let(:notification_type) { :vm_retired }
 
       subject { Notification.create(:type => notification_type, :subject => vm) }
 


### PR DESCRIPTION
Renamed provisioned notification_types and add notification in task_finished common method.

Notifications are automatically generated for several events, including the vm_provisioned and service_provisioned events. 
The event provisioned notifications have a few issues: 
 * Events are raised when the service/vm is provisioned, not when the provisioning state machine has completed. This could result in a "provisioned successfully" notification on a failed provision if a post provision step were to fail. 
* The service provisioned event is raised multiple times which causes duplicate service provisioned notifications.  
* The timing also causes the notifications to be out of sync.

Renamed the notification_types for event generated notifications and added the provisioned successfully notification to the common task_finished method.

https://bugzilla.redhat.com/show_bug.cgi?id=1389312
before:
![screen shot 2016-11-03 at 4 44 41 pm](https://cloud.githubusercontent.com/assets/109132/19984468/df06a6f0-a1e4-11e6-9ae6-a3a77282ef16.png)


after:
![screen shot 2016-11-03 at 4 46 27 pm](https://cloud.githubusercontent.com/assets/109132/19984518/27fafc4e-a1e5-11e6-94c2-fcfc63e2d9b3.png)
