### PR TITLE
During Refresh route calls to the correct appliance

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2453,6 +2453,10 @@ class MiqAeClassController < ApplicationController
     session[:changed] = true
 
     git_repo = MiqAeDomain.find(params[:id]).git_repository
+
+    git_based_domain_import_service.refresh(git_repo.id)
+
+    git_repo.reload
     @branch_names = git_repo.git_branches.collect(&:name)
     @tag_names = git_repo.git_tags.collect(&:name)
     @git_repo_id = git_repo.id

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -83,11 +83,9 @@ class GitBasedDomainImportService
 
   def refresh(git_repo_id)
     task_id = queue_refresh(git_repo_id)
-    MiqTask.wait_for_taskid(task_id)
+    task = MiqTask.wait_for_taskid(task_id)
 
-    task = MiqTask.find(task_id)
     raise MiqException::Error, task.message unless task.status == "Ok"
-
     task.task_results
   end
 

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -196,7 +196,7 @@ describe GitBasedDomainImportService do
       it "calls 'refresh' with the correct options and fails" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
 
-        expect{ subject.refresh(git_repo.id) }.to raise_exception(MiqException::Error, message)
+        expect { subject.refresh(git_repo.id) }.to raise_exception(MiqException::Error, message)
       end
     end
   end


### PR DESCRIPTION
From the UI when you click on Git domain it has an option to "Refresh with a new branch or tag".
This option should

1. Route the request to the correct appliance, to fetch the latest information about the git repository.
    This would pull down any new branches/tags on to the appliance
2. Display the branches/tags for the user to pick
3. After the user has selected the branch/tag the old domain is over written with the new contents.


Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1391541


Steps for Testing/QA
-------------------------------
1. Import a Git Automate domain
2. After Import modify the git repository to add a new branch or tag
3. Select "Refresh with a new branch or tag" from the Menu options
4. You should see the newly added branch or tag from Step 2
5. Import the new contents

https://bugzilla.redhat.com/show_bug.cgi?id=1391541