### PR TITLE
Perform RBAC user filter check on requested ids before allowing reque…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2317,6 +2317,11 @@ class ApplicationController < ActionController::Base
           _("The user is not authorized for this task or item.") unless role_allows?(:feature => feature)
   end
 
+  def assert_rbac(user, klass, ids)
+    filtered, _ = Rbac.search(:targets => ids.map(&:to_i), :user => user, :class => klass, :results_format => :ids)
+    raise _("Unauthorized object or action") unless ids.length == filtered.length
+  end
+
   def previous_breadcrumb_url
     @breadcrumbs[-2][:url]
   end

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1920,6 +1920,8 @@ module ApplicationController::CiProcessing
       klass = Vm
     end
 
+    assert_rbac(current_user, get_rec_cls, objs)
+
     return if objs.empty?
 
     options = {:ids => objs, :task => task, :userid => session[:userid]}


### PR DESCRIPTION
This addresses a vulnerability where a user can change the targeted ids in the browser console to allow operations like power on/off on VMs that he is not entitled access.

https://bugzilla.redhat.com/show_bug.cgi?id=1382756

(cherry picked from commit 9376fbdd058b92c42922482f09a792f18f75467f)