### PR TITLE
[WIP] Use aggregates for aggregate_mixin

### DIFF
--- a/app/models/mixins/aggregation_mixin/methods.rb
+++ b/app/models/mixins/aggregation_mixin/methods.rb
@@ -39,11 +39,8 @@ module AggregationMixin
     end
 
     def aggregate_hardware(from, field, targets = nil)
-      from      = from.to_s.singularize
-      select    = field == :aggregate_cpu_speed ? "cpu_total_cores, cpu_speed" : field
-      targets ||= send("all_#{from.pluralize}")
-      hdws      = Hardware.where(from.singularize => targets).select(select)
-      hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
+      targets ||= send("all_#{from.to_s.pluralize}")
+      Hardware.where(from.to_s.singularize => targets).sum(field)
     end
 
     def lans


### PR DESCRIPTION
blockers:
- [x] #12909
- [x] #12910
- [x] #16921 relatated specs (non- blocker)
- [x] #20146

# Before

This one brings backs all hardware records to calculate sums. ala `inject(&:+)`

# After

This PR calculates the `SUM` in the database.

# Concerns

- We may need to convert these database values to bigint, or at least cast them to avoid overflow.
- Would prefer to convert these over to `virtual_aggregation` instead.
- It makes more sense to just directly querying these values. e.g.: `ems.vm_hardwares.sum(:cpu)`.
- There are also 3 other aggregate mixins as well.

# Performance

In non-production mode, this has a difference of 2 seconds vs 700ms. In production mode, this has a difference of 205ms vs 139.5.

`/ems_infra/509000000000043`

|     ms |queries | query (ms) |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|  205.4 |   39 |  54.6 |    2,544 |before
|  139.5 |   38 |  27.3 |       36 |after
|32.1% | n/a | 50.0% | 99% | difference

# detailed numbers

|     ms |queries | query (ms) |     rows |**before**
|    ---:|  ---:|   ---:|      ---:| ---
|  205.4 |   39 |  54.6 |    2,544 |`GET http://localhost:3000/ems_infra/509000000000043`
|  123.0 | (18) |  44.9 |    2,514 |`..Rendering: shared/views/ems_common/show`
|    0.7 |    1 |   0.7 |     (627)  |`...SELECT "hosts".id  -- [73]`
|    7.6 |    1 |   2.3 |      627 |`...SELECT cpu_total_cores, cpu_speed  -- [10741]`
|    7.1 |    1 |   1.8 |      627 |`...SELECT "hardwares"."memory_mb"  -- [10738]`
|    6.5 |    1 |   2.2 |      627 |`...SELECT "hardwares"."cpu_sockets"  -- [10740]`
|    7.6 |    1 |   2.3 |      627 |`...SELECT "hardwares"."cpu_total_cores"  -- [10744]`

|     ms |queries | query (ms) |     rows |**after**
|    ---:|  ---:|   ---:|      ---:| ---
|  139.5 |   38 |  27.3 |       36 |`GET http://localhost:3000/ems_infra/509000000000043`
|   62.3 | (17) |  19.8 |        6 |`..Rendering: shared/views/ems_common/show`
|    2.0 |    1 |   2.0 |    (1)     |`...SELECT SUM(("hardwares"."cpu_total_cores" * "hardwares"."cpu_speed"))  -- [195]`
|    2.1 |    1 |   2.1 |    (1)   |`...SELECT SUM("hardwares"."memory_mb")  -- [161]`
|    1.5 |    1 |   1.5 |     (1)  |`...SELECT SUM("hardwares"."cpu_sockets")  -- [163]`
|    1.6 |    1 |   1.6 |    (1)   |`...SELECT SUM("hardwares"."cpu_total_cores")  -- [167]`

UPDATE: trimmed down the details. (36 queries is a lot to digest in the before / after)
UPDATE: rewrote description