### PR TITLE
Change SSA to support NFS41 datastore

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -363,7 +363,7 @@ class JobProxyDispatcher
         queue_signal(job, {:args => [:abort, msg, "error"]})
         return []
       else
-        unless %w(VSAN VMFS NAS NFS ISCSI DIR FCP CSVFS NTFS GLUSTERFS).include?(@vm.storage.store_type)
+        unless %w(VSAN VMFS NAS NFS NFS41 ISCSI DIR FCP CSVFS NTFS GLUSTERFS).include?(@vm.storage.store_type)
           msg = "Vm storage type [#{@vm.storage.store_type}] unsupported [#{job.target_id}], aborting job [#{job.guid}]."
           queue_signal(job, {:args => [:abort, msg, "error"]})
           return []

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -70,7 +70,7 @@ class Storage < ApplicationRecord
   virtual_column :total_unmanaged_vms,            :type => :integer  # uses is handled via class method that aggregates
   virtual_column :count_of_vmdk_disk_files,       :type => :integer
 
-  SUPPORTED_STORAGE_TYPES = %w( VMFS NFS FCP ISCSI GLUSTERFS )
+  SUPPORTED_STORAGE_TYPES = %w( VMFS NFS NFS41 FCP ISCSI GLUSTERFS )
 
   supports :smartstate_analysis do
     if ext_management_systems.blank? || !ext_management_system.class.supports_smartstate_analysis?

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1233,6 +1233,7 @@ class VmOrTemplate < ApplicationRecord
     when "VMFS"  then "[#{storage.name}] #{location}"
     when "VSAN"  then "[#{storage.name}] #{location}"
     when "NFS"   then "[#{storage.name}] #{location}"
+    when "NFS41" then "[#{storage.name}] #{location}"
     when "NTFS"  then "[#{storage.name}] #{location}"
     when "CSVFS" then "[#{storage.name}] #{location}"
     when "NAS"   then File.join(storage.name, location)


### PR DESCRIPTION
Enable SSA to scan:
1. Datastores of type NFS41;
2. VMs sitting in the datastore of type NFS41

https://bugzilla.redhat.com/show_bug.cgi?id=1354039
