### PR TITLE
[DARGA] Fix Instance provisioning fails on missing AZ

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -233,7 +233,7 @@ module Openstack
     end
 
     def availability_zones_count
-      3 # This is affected by conf files only, so needs to be hardcoded value
+      2 # This is affected by conf files only, so needs to be hardcoded value
     end
 
     def assert_table_counts
@@ -358,7 +358,7 @@ module Openstack
       # standard openstack AZs have their ems_ref set to their name ("nova" in the test case)...
       # the "null" openstack AZ has a unique ems_ref and name
       expect(@nova_az).to have_attributes(
-        :ems_ref => "compute-#{@nova_az.name}"
+        :ems_ref => @nova_az.name
       )
     end
 


### PR DESCRIPTION
Availability Zones got updated its ems_ref field in refresh to be different to one in
OpenStack which caused error when selecting some AZ in an Instance provision form.

This fix returns refresh to previous behaviour which does not change AZ ems_ref and
keeps AZ from volume and compute service as a one object if it matches by id/name.

Darga port of
https://github.com/ManageIQ/manageiq/pull/12155

https://bugzilla.redhat.com/show_bug.cgi?id=1381624