### PR TITLE
Use ::Settings in app/controllers

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -79,7 +79,7 @@ module Api
     def validate_user_create_data(data)
       validate_user_data(data)
       req_attrs = %w(name userid group)
-      req_attrs << "password" if VMDB::Config.new("vmdb").config.fetch_path(:authentication, :mode) == "database"
+      req_attrs << "password" if ::Settings.authentication.mode == "database"
       bad_attrs = []
       req_attrs.each { |attr| bad_attrs << attr if data[attr].blank? }
       raise BadRequestError, "Missing attribute(s) #{bad_attrs.join(', ')} for creating a user" if bad_attrs.present?

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -589,7 +589,7 @@ class ConfigurationController < ApplicationController
       @edit[:new][:quadicons][:host] = params[:quadicons_host] == "true" if params[:quadicons_host]
       @edit[:new][:quadicons][:vm] = params[:quadicons_vm] == "true" if params[:quadicons_vm]
       @edit[:new][:quadicons][:miq_template] = params[:quadicons_miq_template] == "true" if params[:quadicons_miq_template]
-      if get_vmdb_config[:product][:proto] # Hide behind proto setting - Sprint 34
+      if ::Settings.product.proto # Hide behind proto setting - Sprint 34
         @edit[:new][:quadicons][:service] = params[:quadicons_service] == "true" if params[:quadicons_service]
       end
       @edit[:new][:quadicons][:storage] = params[:quadicons_storage] == "true" if params[:quadicons_storage]

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -332,7 +332,7 @@ class DashboardController < ApplicationController
       return
     end
 
-    if get_vmdb_config[:product][:allow_passed_in_credentials]  # Only pre-populate credentials if setting is turned on
+    if ::Settings.product.allow_passed_in_credentials # Only pre-populate credentials if setting is turned on
       @user_name     = params[:user_name]
       @user_password = params[:user_password]
     end
@@ -445,10 +445,10 @@ class DashboardController < ApplicationController
     }
 
     if params[:user_name].blank? && params[:user_password].blank? &&
-      request.headers["X-Remote-User"].blank? &&
-      get_vmdb_config[:authentication][:mode] == "httpd" &&
-      get_vmdb_config[:authentication][:sso_enabled] &&
-      params[:action] == "authenticate"
+       request.headers["X-Remote-User"].blank? &&
+       ::Settings.authentication.mode == "httpd" &&
+       ::Settings.authentication.sso_enabled &&
+       params[:action] == "authenticate"
 
       javascript_redirect root_path
       return

--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -518,11 +518,10 @@ module OpsController::OpsRbac
 
   def rbac_group_user_lookup
     rbac_group_user_lookup_field_changed
-    auth = get_vmdb_config[:authentication]
     if @edit[:new][:user].nil? || @edit[:new][:user] == ""
       add_flash(_("User must be entered to perform LDAP Group Look Up"), :error)
     end
-    if auth[:mode] != "httpd"
+    if ::Settings.authentication.mode != "httpd"
       if @edit[:new][:user_id].nil? || @edit[:new][:user_id] == ""
         add_flash(_("Username must be entered to perform LDAP Group Look Up"), :error)
       end
@@ -536,7 +535,7 @@ module OpsController::OpsRbac
       @record = MiqGroup.find_by_id(@edit[:group_id])
       @sb[:roles] = @edit[:roles]
       begin
-        if auth[:mode] == "httpd"
+        if ::Settings.authentication.mode == "httpd"
           @edit[:ldap_groups_by_user] = MiqGroup.get_httpd_groups_by_user(@edit[:new][:user])
         else
           @edit[:ldap_groups_by_user] = MiqGroup.get_ldap_groups_by_user(@edit[:new][:user],

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -96,7 +96,7 @@ module VmCommon
 
   # Launch a VM console
   def console
-    console_type = get_vmdb_config.fetch_path(:server, :remote_console_type).downcase
+    console_type = ::Settings.server.remote_console_type.downcase
     params[:task_id] ? console_after_task(console_type) : console_before_task(console_type)
   end
   alias_method :vmrc_console, :console  # VMRC needs its own URL for RBAC checking
@@ -116,13 +116,13 @@ module VmCommon
   end
 
   def launch_vmware_console
-    console_type = get_vmdb_config.fetch_path(:server, :remote_console_type).downcase
+    console_type = ::Settings.server.remote_console_type.downcase
     @vm = @record = identify_record(params[:id], VmOrTemplate)
     options = case console_type
               when "mks"
                 @sb[:mks].update(
-                  :version     => get_vmdb_config[:server][:mks_version],
-                  :mks_classid => get_vmdb_config[:server][:mks_classid]
+                  :version     => ::Settings.server.mks_version,
+                  :mks_classid => ::Settings.server.mks_classid
                 )
               when "vmrc"
                 host = @record.ext_management_system.ipaddress || @record.ext_management_system.hostname
@@ -146,12 +146,6 @@ module VmCommon
            :layout   => false,
            :locals   => options
   end
-
-  def websocket_use_ssl?
-    ssl_requested = get_vmdb_config.fetch_path(:server, :websocket, :encrypt)
-    request.ssl? ? ssl_requested != false : ssl_requested == true
-  end
-  private :websocket_use_ssl?
 
   def hide_vms
     !User.current_user.settings.fetch_path(:display, :display_vms) # default value is false

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -157,7 +157,6 @@ describe DashboardController do
     it "returns flash message when user does not have access to any features" do
       user = FactoryGirl.create(:user, :role => "test")
       allow(User).to receive(:authenticate).and_return(user)
-      allow(controller).to receive(:get_vmdb_config).and_return(:product => {})
       validation = controller.send(:validate_user, user)
       expect(validation.flash_msg).to include("The user's role is not authorized for any access")
     end
@@ -177,7 +176,6 @@ describe DashboardController do
     it "returns url for the user and sets user's group/role id in session" do
       user = FactoryGirl.create(:user, :role => "test")
       allow(User).to receive(:authenticate).and_return(user)
-      allow(controller).to receive(:get_vmdb_config).and_return(:product => {})
       skip_data_checks('some_url')
       validation = controller.send(:validate_user, user)
       expect(controller.current_group_id).to eq(user.current_group_id)

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -247,7 +247,6 @@ describe OpsController do
     MiqRegion.seed
     EvmSpecHelper.local_miq_server
     login_as FactoryGirl.create(:user, :features => "ops_rbac")
-    allow(controller).to receive(:get_vmdb_config).and_return(:product => {})
   end
 
   context "#explorer" do


### PR DESCRIPTION
Replaced calls to ```get_vmdb_config``` with direct usage of ```::Settings``` in ```app/controllers/*```

@miq-bot add-label core

\cc @Fryguy