### PR TITLE
Replace api_auth_token factory with unused auth_token

### DIFF
--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -110,9 +110,4 @@ FactoryGirl.define do
   factory :auth_token do
     type "AuthToken"
   end
-
-  factory :api_auth_token, :parent => :auth_token do
-    name     "API Auth Token"
-    authtype "system_api"
-  end
 end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -178,7 +178,7 @@ describe MiqRegion do
 
     it "returns true if a key is configured" do
       FactoryGirl.create(
-        :api_auth_token,
+        :auth_token,
         :resource_id   => remote_region.id,
         :resource_type => "MiqRegion",
         :auth_key      => remote_key
@@ -200,10 +200,11 @@ describe MiqRegion do
 
     it "removes a key if configured" do
       FactoryGirl.create(
-        :api_auth_token,
+        :auth_token,
         :resource_id   => remote_region.id,
         :resource_type => "MiqRegion",
-        :auth_key      => remote_key
+        :auth_key      => remote_key,
+        :authtype      => "system_api"
       )
       expect(remote_region.auth_key_configured?).to be true
       remote_region.remove_auth_key

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -368,10 +368,11 @@ describe PglogicalSubscription do
 
       EvmSpecHelper.create_guid_miq_server_zone
       FactoryGirl.create(
-        :api_auth_token,
+        :auth_token,
         :resource_id   => remote_region.id,
         :resource_type => "MiqRegion",
-        :auth_key      => "this is the encryption key!"
+        :auth_key      => "this is the encryption key!",
+        :authtype      => "system_api"
       )
       expect(remote_region.auth_key_configured?).to be true
 


### PR DESCRIPTION
The auth_token factory is unused in the test code and serves only as a
kind of 'abstract' factory for that of api_auth_token. Furthermore, the
attributes supplied in the latter are illustrative but not necessary to
build a valid AuthToken object. Any attributes necessary for existing
tests to pass are better expressed in the tests themselves.

@miq-bot add-label test, technical debt
@miq-bot assign @jrafanie 

:scissors: 