### PR TITLE
Rewritten deprecated `Mime::HTML` to `Mime[:html]`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1970,7 +1970,7 @@ class ApplicationController < ActionController::Base
     session[:host_url] = request.host_with_port
     session[:tab_url] ||= {}
 
-    remember_tab if !request.xml_http_request? && request.get? && request.format == Mime::HTML
+    remember_tab if !request.xml_http_request? && request.get? && request.format == Mime[:html]
 
     # Get all of the global variables used by most of the controllers
     @pp_choices = PPCHOICES


### PR DESCRIPTION
```
[----] W, [2016-11-04T09:34:48.702376 #8494:2ab67bbb4ad4]  WARN -- : DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::HTML` to `Mime[:html]`. (called from get_global_session_data at /home/dhalasz/Repositories/ManageIQ/manageiq/app/controllers/application_controller.rb:1973)
```