### PR TITLE
Fixed typo: striketrough -> strikethrough

### DIFF
--- a/app/assets/stylesheets/miq_tree.scss
+++ b/app/assets/stylesheets/miq_tree.scss
@@ -1,6 +1,6 @@
 .treeview > .list-group {
   .list-group-item {
-    &.striketrough {
+    &.strikethrough {
       text-decoration: line-through;
     }
     &.red {

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -291,7 +291,7 @@ class TreeNodeBuilder
       :title => text,
       :icon  => node_icon(image)
     }
-    @node[:addClass] = "striketrough" unless enabled
+    @node[:addClass] = "strikethrough" unless enabled
     @node[:expand] = true if options[:open_all]  # Start with all nodes open
     tooltip(tip)
   end


### PR DESCRIPTION
Introduced by [my commit](https://github.com/ManageIQ/manageiq/commit/973a1dda9a86f059ec391b55a36c9a38e4f3561c#diff-6bbd3303594f04c011bee55951dc3bb9R8) :disappointed: :cry: 