### PR TITLE
[DARGA] Fix trailing comma in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,6 +42,6 @@
     "es6-shim": "^0.35.0",
     "phantomjs-polyfill": "^0.0.2",
     "fetch": "^1.0.0",
-    "codemirror": "~5.19.0",
+    "codemirror": "~5.19.0"
   }
 }


### PR DESCRIPTION
The trailing comma causes... during `bower install`.. Removed.

```
bower@1.7.9 /home/travis/.nvm/v0.10.36/lib/node_modules/bower
bower EMALFORMED    Failed to read /home/travis/build/ManageIQ/manageiq/bower.json
```

(introduced in 5fe6823)