### PR TITLE
Update ar_virtual#suppored_by_sql for bogus cols

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -39,9 +39,14 @@ module VirtualArel
       end
     end
 
+    # supported by sql if
+    # - it is an attribute alias
+    # - it is an attribute that is non virtual
+    # - it is an attribute that is virtual and has arel defined
     def attribute_supported_by_sql?(name)
       load_schema
-      !virtual_attribute?(name) || !!_virtual_arel[name.to_s]
+      attribute_alias?(name) ||
+        (has_attribute?(name) && (!virtual_attribute?(name) || !!_virtual_arel[name.to_s]))
     end
     private
 

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -497,6 +497,10 @@ describe VirtualFields do
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
       end
+
+      it "does not support bogus columns" do
+        expect(TestClass.attribute_supported_by_sql?(:bogus_junk)).to be_falsey
+      end
     end
 
     describe ".virtual_delegate" do

--- a/spec/models/mixins/virtual_total_mixin_spec.rb
+++ b/spec/models/mixins/virtual_total_mixin_spec.rb
@@ -44,7 +44,7 @@ describe VirtualTotalMixin do
     end
 
     it "is not defined in sql" do
-      expect(base_model.attribute_supported_by_sql?(:total_vms)).to be(true)
+      expect(base_model.attribute_supported_by_sql?(:total_vms)).to be(false)
     end
 
     def model_with_children(count)


### PR DESCRIPTION
Found this while working through #11445

TL;DR
----

`MiqExpression` asks if an attribute is supported by sql.
before: Unknown columns are currently returning `true`.
after: Unknown columns now return `false, this is not valid sql column`.

Details
-------

**before:**

When working in `MiqExpression` it asks if an attribute is supported by sql.
A custom column, which is not known by active record or our virtual attribute stuff is currently marked as supported by sql, when in fact it is not.

Turns out, any attribute that is unknown is assumed to be a valid attribute.
This is the way the current active record `arel_attribute` works. It assumes that if it is unknown, the developer knows what they are doing.

**after:**

Only aliases, non-virtual attributes, and virtual attributes with arel are returning true.
Custom columns correctly return that they are not supported by sql.

The reasoning behind this change is we specifically asked if a field is supported by sql. As we are using more and more dynamic content from the end user, being lenient is causing errors by trying to run invalid sql instead of performing the filtering in ruby.

**risk:**

If we pass in arel or a sql snippet then this would start returning false.