### PR TITLE
Chargeback toolbar buttons moved from toolbar builder to separate class

### DIFF
--- a/app/helpers/application_helper/button/chargeback_download.rb
+++ b/app/helpers/application_helper/button/chargeback_download.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::ChargebackDownload < ApplicationHelper::Button::Basic
+    def role_allows_feature?
+      role_allows?(:feature => 'chargeback_rates')
+    end
+
+    def visible?
+      @view_context.x_active_tree == :cb_rates_tree
+    end
+end

--- a/app/helpers/application_helper/button/chargeback_rate_edit.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_edit.rb
@@ -1,9 +1,15 @@
-class ApplicationHelper::Button::ChargebackRateEdit < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::ChargebackRateEdit < ApplicationHelper::Button::ChargebackRates
+  needs :@record
+
+  def disabled?
+    if @record.default?
+      @error_message = _("Default Chargeback Rate cannot be edited.")
+    end
+    @error_message.present?
+  end
+
   def calculate_properties
     super
-    if @record.default?
-      self[:enabled] = false
-      self[:title] = N_("Default Chargeback Rate cannot be edited.")
-    end
+    self[:title] = @error_message if disabled?
   end
 end

--- a/app/helpers/application_helper/button/chargeback_rate_remove.rb
+++ b/app/helpers/application_helper/button/chargeback_rate_remove.rb
@@ -1,9 +1,15 @@
-class ApplicationHelper::Button::ChargebackRateRemove < ApplicationHelper::Button::Basic
+class ApplicationHelper::Button::ChargebackRateRemove < ApplicationHelper::Button::ChargebackRates
+  needs :@record
+
+  def disabled?
+    if @record.default?
+      @error_message = _("Default Chargeback Rate cannot be removed.")
+    end
+    @error_message.present?
+  end
+
   def calculate_properties
     super
-    if @record.default?
-      self[:enabled] = false
-      self[:title] = N_("Default Chargeback Rate cannot be removed.")
-    end
+    self[:title] = @error_message if disabled?
   end
 end

--- a/app/helpers/application_helper/button/chargeback_rates.rb
+++ b/app/helpers/application_helper/button/chargeback_rates.rb
@@ -1,0 +1,9 @@
+class ApplicationHelper::Button::ChargebackRates < ApplicationHelper::Button::Basic
+    def role_allows_feature?
+      role_allows?(:feature => 'chargeback_reports')
+    end
+
+    def visible?
+      @view_context.x_active_tree == :cb_reports_tree
+    end
+end

--- a/app/helpers/application_helper/toolbar/chargeback_center.rb
+++ b/app/helpers/application_helper/toolbar/chargeback_center.rb
@@ -12,12 +12,14 @@ class ApplicationHelper::Toolbar::ChargebackCenter < ApplicationHelper::Toolbar:
           'fa fa-file-text-o fa-lg',
           N_('Download this report in text format'),
           N_('Download as Text'),
+          :klass => ApplicationHelper::Button::ChargebackDownload,
           :url => "/render_txt"),
         button(
           :chargeback_download_csv,
           'fa fa-file-text-o fa-lg',
           N_('Download this report in CSV format'),
           N_('Download as CSV'),
+          :klass => ApplicationHelper::Button::ChargebackDownload,
           :url => "/render_csv"),
         button(
           :chargeback_download_pdf,
@@ -57,6 +59,7 @@ class ApplicationHelper::Toolbar::ChargebackCenter < ApplicationHelper::Toolbar:
           'fa fa-files-o fa-lg',
           t = N_('Copy this Chargeback Rate'),
           t,
+          :klass     => ApplicationHelper::Button::ChargebackRates,
           :url_parms => "main_div"),
         button(
           :chargeback_rates_delete,

--- a/app/helpers/application_helper/toolbar/chargebacks_center.rb
+++ b/app/helpers/application_helper/toolbar/chargebacks_center.rb
@@ -10,7 +10,8 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           :chargeback_rates_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Chargeback Rate'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::ChargebackRates),
         button(
           :chargeback_rates_edit,
           'pficon pficon-edit fa-lg',
@@ -18,7 +19,8 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           t,
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1"),
+          :onwhen    => "1",
+          :klass => ApplicationHelper::Button::ChargebackRates),
         button(
           :chargeback_rates_copy,
           'fa fa-files-o fa-lg',
@@ -26,7 +28,8 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           t,
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1"),
+          :onwhen    => "1",
+          :klass => ApplicationHelper::Button::ChargebackRates),
         button(
           :chargeback_rates_delete,
           'pficon pficon-delete fa-lg',
@@ -35,7 +38,8 @@ class ApplicationHelper::Toolbar::ChargebacksCenter < ApplicationHelper::Toolbar
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Chargeback Rate will be permanently removed!"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass => ApplicationHelper::Button::ChargebackRates)
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -387,22 +387,6 @@ class ApplicationHelper::ToolbarBuilder
     end
   end
 
-  def hide_button_cb(id)
-    case x_active_tree
-    when :cb_reports_tree
-      if role_allows?(:feature => "chargeback_reports") && ["chargeback_download_csv", "chargeback_download_pdf",
-                                                           "chargeback_download_text", "chargeback_report_only"].include?(id)
-        return false
-      end
-    when :cb_rates_tree
-      if role_allows?(:feature => "chargeback_rates") && ["chargeback_rates_copy", "chargeback_rates_delete",
-                                                         "chargeback_rates_edit", "chargeback_rates_new"].include?(id)
-        return false
-      end
-    end
-    true
-  end
-
   def hide_button_ops(id)
     case x_active_tree
     when :settings_tree
@@ -584,11 +568,6 @@ class ApplicationHelper::ToolbarBuilder
 
     if @layout == "miq_policy_rsop"
       return hide_button_rsop(id)
-    end
-
-    if id.starts_with?("chargeback_")
-      res = hide_button_cb(id)
-      return res
     end
 
     if @layout == "ops"


### PR DESCRIPTION
Toolbar buttons for Chargeback moved from toolbar builder to separate class

Links
----------------

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/133670225
