### PR TITLE
Preload models in ci before the suite

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,7 @@ RSpec.configure do |config|
   end
 
   if ENV["TRAVIS"] && ENV["TEST_SUITE"] == "vmdb"
-    config.after(:suite) do
+    config.before(:suite) do
       require Rails.root.join("spec/coverage_helper.rb")
     end
   end


### PR DESCRIPTION
blocked:
- [x] #12461 (first commit)
- [x] #12973 (second commit)

The "slowest tests" are consistently inconsistent.

The tests that run first also include time to include their respective classes. This inflates their runtimes. So the list of the slowest tests were not consistent.

This loads the classes before running any tests, so the class load time will not be included in any tests.
The hypothesis is the tests will have a more consistent runtime and the slowest tests will be the slowest tests rather than the tests that had to load the classes.
