### PR TITLE
Update "Custom Logos" screen to use bootstrap-switch

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -858,8 +858,8 @@ module OpsController::Settings::Common
       w = wb[:websocket_worker]
       w[:count] = params[:websocket_worker_count].to_i if params[:websocket_worker_count]
     when "settings_custom_logos"                                            # Custom Logo tab
-      new[:server][:custom_logo] = (params[:server_uselogo] == "1") if params[:server_uselogo]
-      new[:server][:custom_login_logo] = (params[:server_useloginlogo] == "1") if params[:server_useloginlogo]
+      new[:server][:custom_logo] = (params[:server_uselogo] == "true") if params[:server_uselogo]
+      new[:server][:custom_login_logo] = (params[:server_useloginlogo] == "true") if params[:server_useloginlogo]
       new[:server][:use_custom_login_text] = (params[:server_uselogintext] == "true") if params[:server_uselogintext]
       if params[:login_text]
         new[:server][:custom_login_text] = params[:login_text]
@@ -1082,6 +1082,12 @@ module OpsController::Settings::Common
       @edit[:key] = "#{@sb[:active_tab]}_edit__#{@sb[:selected_server_id]}"
       if @edit[:current].config[:server][:custom_logo].nil?
         @edit[:current].config[:server][:custom_logo] = false # Set default custom_logo flag
+      end
+      if @edit[:current].config[:server][:custom_login_logo].nil?
+        @edit[:current].config[:server][:custom_login_logo] = false # Set default custom_logo flag
+      end
+      if @edit[:current].config[:server][:use_custom_login_text].nil?
+        @edit[:current].config[:server][:use_custom_login_text] = false # Set default custom_logo flag
       end
       @logo_file = @@logo_file
       @login_logo_file = @@login_logo_file

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -25,8 +25,7 @@
         %label.col-md-2.control-label
           = _("Use Custom Logo Image")
         .col-md-8
-          = check_box_tag("server_uselogo", "1", @edit[:new][:server][:custom_logo],
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
+          = check_box_tag("server_uselogo", true, @edit[:new][:server][:custom_logo], :data => {:on_text => 'Yes', :off_text => 'No'})
   %hr/
   %h3= _("Custom Login Background Image")
   - if File.exist?(@login_logo_file)
@@ -60,9 +59,8 @@
       .form-group
         %label.col-md-2.control-label
           = _("Use Custom Login Background Image")
-        .form-group
-          = check_box_tag("server_useloginlogo", "1", @edit[:new][:server][:custom_login_logo],
-                          "data-miq_observe_checkbox" => {:url => url}.to_json)
+        .col-md-8
+          = check_box_tag("server_useloginlogo", true, @edit[:new][:server][:custom_login_logo], :data => {:on_text => 'Yes', :off_text => 'No'})
   %hr/
   %h3
     = _("Custom Login Panel Text (")
@@ -84,4 +82,6 @@
       .col-md-8
         = check_box_tag("server_uselogintext", true, @edit[:new][:server][:use_custom_login_text], :data => {:on_text => 'Yes', :off_text => 'No'})
       :javascript
-        miqInitBootstrapSwitch('server_uselogintext', "#{url}")
+        miqInitBootstrapSwitch('server_uselogintext', "#{url}");
+        miqInitBootstrapSwitch('server_uselogo', "#{url}");
+        miqInitBootstrapSwitch('server_useloginlogo', "#{url}");


### PR DESCRIPTION
This PR replaces the remaining 2 checkboxes on the  Custom Logos screen with switches.

https:/bugzilla.redhat.com/show_bug.cgi?id=1389289

Old
![screen shot 2016-11-04 at 1 31 33 pm](https://cloud.githubusercontent.com/assets/1287144/20015819/52c3ef54-a293-11e6-811c-e4c35f99bc5b.png)


New
![screen shot 2016-11-04 at 1 31 03 pm](https://cloud.githubusercontent.com/assets/1287144/20015818/52c140e2-a293-11e6-9c1b-47d478025956.png)
