### PR TITLE
Make sure floating IP select box values are tracked by address, not id

### DIFF
--- a/app/views/vm_common/_associate_floating_ip.html.haml
+++ b/app/views/vm_common/_associate_floating_ip.html.haml
@@ -9,7 +9,7 @@
       .col-md-8
         %select{:name      => 'floating_ip',
                 'ng-model' => 'vmCloudModel.floating_ip',
-                'ng-options' => 'floating_ip.address as floating_ip.address for floating_ip in floating_ips track by floating_ip.id'}
+                'ng-options' => 'floating_ip.address for floating_ip in floating_ips track by floating_ip.address'}
 
   %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",

--- a/app/views/vm_common/_disassociate_floating_ip.html.haml
+++ b/app/views/vm_common/_disassociate_floating_ip.html.haml
@@ -9,7 +9,7 @@
       .col-md-8
         %select{:name      => 'floating_ip',
                 'ng-model' => 'vmCloudModel.floating_ip',
-                'ng-options' => 'floating_ip.address as floating_ip.address for floating_ip in floating_ips track by floating_ip.id'}
+                'ng-options' => 'floating_ip.address for floating_ip in floating_ips track by floating_ip.address'}
 
   %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
                   'paging_div_buttons_id'            => "angular_paging_div_buttons",


### PR DESCRIPTION
On the associate and disassociate floating IP forms, the select box was returning the database id rather than the IP address, resulting in the provider API receiving in invalid value instead of an IP. This PR fixes the angular directive used to create the select box.

https://bugzilla.redhat.com/show_bug.cgi?id=1392008