### PR TITLE
Disable parallel while we debug a travis only test failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
   - PARALLEL_TEST_PROCESSORS=2
   matrix:
-  - TEST_SUITE=vmdb PARALLEL=true
+  - TEST_SUITE=vmdb
   - TEST_SUITE=automation
   - TEST_SUITE=migrations
   - TEST_SUITE=brakeman


### PR DESCRIPTION
For now, it seems that disabling PARALLEL will allow us to get past this
failure.

In the vmdb TEST_SUITE line, adding the following seems to reliably
reproduce the error on travis but not locally :cry:

SPEC_OPTS="--fail-fast --seed 816 -f d"

```
  2) ApplicationHelper#build_toolbar when the toolbar to be built is a generic object toolbar includes the button group
     Failure/Error:
           toolbar_class.definition.each_with_index do |(name, group), group_index|
             next if group_skipped?(name)

             @sep_added = false
             @groups_added.push(group_index)
             case group
             when ApplicationHelper::Toolbar::Group
               group.buttons.each do |bgi|
                 build_button(bgi, group_index)
               end

     NoMethodError:
       undefined method `definition' for #<Class:0x0000001567c7c0>
     # ./app/helpers/application_helper/toolbar_builder.rb:21:in `build_toolbar'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:2071:in `block (4 levels) in <top (required)>'
```