### PR TITLE
Let the relation autosave the verify_ssl value

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -13,6 +13,7 @@ class Provider < ApplicationRecord
 
   delegate :verify_ssl,
            :verify_ssl?,
+           :verify_ssl=,
            :url,
            :to => :default_endpoint
 
@@ -61,9 +62,5 @@ class Provider < ApplicationRecord
       raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "provider")}
     end
     managers.each { |manager| EmsRefresh.queue_refresh(manager) }
-  end
-
-  def verify_ssl=(new_value)
-    default_endpoint.update_attributes(:verify_ssl => new_value)
   end
 end


### PR DESCRIPTION
Allow the :autosave => true update the endpoint

Delegate verify_ssl= to the endpoint and leverage the relation to autosave
the default_endpoint.  update_attributes was creating a disconnected
endpoint record, so verify_credentials would create an endpoint then save
would raise a validation error.

https://bugzilla.redhat.com/show_bug.cgi?id=1388928