### PR TITLE
Disable MemoryReserveLockedToMax

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -115,7 +115,12 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
         set_spec_option(rai, :reservation, :memory_reserve, nil, :to_i)
       end
 
-      vmcs.memoryReservationLockedToMax = false if source.ext_management_system.api_version >= '5.0'
+      # Only explicitly disable #MemoryReservationLockedToMax if the memory reserve
+      # is less than the total vm memory
+      if get_option(:memory_reserve).to_i < get_option(:vm_memory).to_i
+        # memoryReservationLockedToMax was added in vSphere 5.0
+        vmcs.memoryReservationLockedToMax = false if source.ext_management_system.api_version >= '5.0'
+      end
     end
 
     _log.info("Calling VM reconfiguration")

--- a/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/provision/configuration/container.rb
@@ -114,6 +114,8 @@ module ManageIQ::Providers::Vmware::InfraManager::Provision::Configuration::Cont
         set_spec_option(rai, :limit,       :memory_limit,   nil, :to_i)
         set_spec_option(rai, :reservation, :memory_reserve, nil, :to_i)
       end
+
+      vmcs.memoryReservationLockedToMax = false if source.ext_management_system.api_version >= '5.0'
     end
 
     _log.info("Calling VM reconfiguration")


### PR DESCRIPTION
An option was added in vSphere 5.0 called `MemoryReservationLockedToMax` which ensures all memory is reserved for the guest as the guest memory size changes.  Some VCs fail the reconfigure task setting the memoryAllocation.reservation to be less than the total if `memoryReservationLockedToMax` is set.  The fix is to explicitly disable this value if the memory reservation is less than total guest memory.

~~Depends on: https://github.com/ManageIQ/manageiq-gems-pending/pull/8~~

https://bugzilla.redhat.com/show_bug.cgi?id=1384122