### PR TITLE
Use constantize instead of Kernel.const_get to lookup Toolbar class

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -67,7 +67,7 @@ class ApplicationHelper::ToolbarBuilder
   # Parses the generic toolbars name and returns his class
   def predefined_toolbar_class(tb_name)
     class_name = 'ApplicationHelper::Toolbar::' + ActiveSupport::Inflector.camelize(tb_name.sub(/_tb$/, ''))
-    Kernel.const_get(class_name)
+    class_name.constantize
   end
 
   # According to toolbar name in parameter `toolbar_name` either returns class


### PR DESCRIPTION
If the `GenericObjectDefinition` model is auto-loaded by Rails before `ApplicationHelper::Toolbar::GenericObjectDefinition` then Kernel.const_get will return the model *not* the toolbar when called with `Kernel.const_get(“ApplicationHelper::Toolbar::GenericObjectDefinition”)` in other words:

```
[1] pry(main)> GenericObjectDefinition
=> GenericObjectDefinition(id: integer, name: string, description: string, properties: text, created_at: datetime, updated_at: datetime, region_number: integer, region_description: string)
[2] pry(main)> Kernel.const_get("ApplicationHelper::Toolbar::GenericObjectDefinition")
=> GenericObjectDefinition(id: integer, name: string, description: string, properties: text, created_at: datetime, updated_at: datetime, region_number: integer, region_description: string)
```

This causes a couple of test failures:
```
NoMethodError:
       undefined method `definition' for #<Class:0x007fb406e8bdb0>
     # ./app/helpers/application_helper/toolbar_builder.rb:21:in `build_toolbar'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:2071:in `block (4 levels) in <top (required)>'
     # ...
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:2081:in `block (4 levels) in <top (required)>'
```