### PR TITLE
Was missing a role identifier for reading virtual_templates resources.

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -1965,6 +1965,10 @@
       :post:
       - :name: query
         :identifier: virtual_template_show
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: virtual_template_show
   :arbitration_profiles:
     :description: Arbitration Profiles
     :identifier: ems_cloud_admin

--- a/spec/requests/api/virtual_templates_spec.rb
+++ b/spec/requests/api/virtual_templates_spec.rb
@@ -35,4 +35,27 @@ RSpec.describe 'Virtual Template API' do
       expect_query_result(:virtual_templates, 1, 1)
     end
   end
+
+  context 'virtual templates get' do
+    it "rejects resource get requests without appropriate role" do
+      api_basic_authorize
+
+      vt = FactoryGirl.create(:virtual_template, :ems_id => ems.id)
+
+      run_get(virtual_templates_url(vt.id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "accepts resource get requests with appropriate role" do
+      api_basic_authorize action_identifier(:virtual_templates, :read, :resource_actions, :get)
+
+      vt = FactoryGirl.create(:virtual_template, :ems_id => ems.id)
+
+      run_get(virtual_templates_url(vt.id))
+
+      expect(response).to have_http_status(:ok)
+      expect_result_to_have_keys(%w(id href))
+    end
+  end
 end


### PR DESCRIPTION
- Added the virtual_template_show role identifier for reading

          /api/virtual_templates/:id resources

https://bugzilla.redhat.com/show_bug.cgi?id=1392612