### PR TITLE
remove redefinition of schemaMigration

### DIFF
--- a/spec/lib/extensions/ar_column_names_spec.rb
+++ b/spec/lib/extensions/ar_column_names_spec.rb
@@ -1,8 +1,5 @@
 describe "ar_column_names extension" do
   context "With an empty test class" do
-    before(:each) { class ::SchemaMigration < ActiveRecord::Base; end }
-    after(:each)  { Object.send(:remove_const, :SchemaMigration) }
-
     it "should have the correct column names symbols" do
       expect(SchemaMigration.column_names_symbols).to eq([:version])
     end


### PR DESCRIPTION
This fixes #12443 (which loads all classes)

The `SchemaMigration` class is defined in `app/models` which is part of the build suite.
It was causing issues when that model is loaded before running this test.