### PR TITLE
 Use provider's tenant as root tenant for cloud tenant mapping

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -117,7 +117,7 @@ module ManageIQ::Providers
     end
 
     def sync_root_tenant
-      ems_tenant = source_tenant || Tenant.new(:parent => Tenant.root_tenant, :source => self)
+      ems_tenant = source_tenant || Tenant.new(:parent => tenant, :source => self)
 
       ems_tenant_name = "#{self.class.description} Cloud Provider #{name}"
 

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -51,6 +51,23 @@ describe EmsCloud do
         "#{ManageIQ::Providers::Openstack::CloudManager.description} Cloud Provider #{ems_cloud.name}"
       end
 
+      context "provider is not created under root tenant" do
+        let(:tenant) { FactoryGirl.build(:tenant, :parent => default_tenant) }
+        let(:ems_cloud_without_root_tenant) do
+          FactoryGirl.create(:ems_openstack, :tenant => tenant, :tenant_mapping_enabled => true)
+        end
+
+        it "creates provider's tenant under tenant of provider" do
+          ems_cloud_without_root_tenant.sync_cloud_tenants_with_tenants
+
+          ems_cloud_without_root_tenant.reload
+
+          expect(ems_cloud_without_root_tenant.source_tenant.parent).not_to be_nil
+          expect(ems_cloud_without_root_tenant.source_tenant.parent).not_to eq(default_tenant)
+          expect(ems_cloud_without_root_tenant.source_tenant.parent).to eq(tenant)
+        end
+      end
+
       it "creates tenant related to provider" do
         ems_cloud.sync_cloud_tenants_with_tenants
 


### PR DESCRIPTION
When we were creating tenant tree according to CloudTenants
so this tree has been created under root tenant(MyCompany) always.

Users can add provider unders their tenant which is not
root always.

So this PR is making provider's tenant as relative root tenant
for creating tenant tree from cloud tenants.

Tenant tree will be created under user's tenant which added the provider.

**Example**
RHOS provider has been add under `child_tenant`.
**before:**
cloud tenant mapping created tenant under MyCompany always
**after:** it is created under user's tenant(child_tenant) 
![screen shot 2016-11-07 at 13 06 47](https://cloud.githubusercontent.com/assets/14937244/20057338/420d69a6-a4eb-11e6-98be-4a4a82b5959c.png)



**Links**
[PR](https://github.com/ManageIQ/manageiq/pull/10779) of origin feature
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1390682

@miq-bot add_label tenancy, bug

@miq-bot assign @gtanzillo 
