### PR TITLE
check if provider responds to cloud_networks in subcollection

### DIFF
--- a/app/controllers/api/subcollections/cloud_networks.rb
+++ b/app/controllers/api/subcollections/cloud_networks.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module CloudNetworks
       def cloud_networks_query_resource(object)
-        object.cloud_networks
+        object.respond_to?(:cloud_networks) ? object.cloud_networks : []
       end
     end
   end

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -43,5 +43,46 @@ RSpec.describe 'Cloud Networks API' do
 
       expect_single_resource_query('name' => network.name, 'id' => network.id, 'ems_ref' => network.ems_ref)
     end
+
+    it 'successfully returns providers on query when providers do not have cloud_networks attribute' do
+      FactoryGirl.create(:ems_openshift) # Openshift does not respond to #cloud_networks
+      FactoryGirl.create(:ems_amazon_with_cloud_networks) # Provider with cloud networks
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      run_get providers_url, :expand => 'resources,cloud_networks'
+
+      expected = {
+        'resources' => a_collection_including(
+          a_hash_including(
+            'type'           => 'ManageIQ::Providers::Amazon::CloudManager',
+            'cloud_networks' => a_collection_including
+          ),
+          a_hash_including(
+            'type' => 'ManageIQ::Providers::Openshift::ContainerManager'
+          )
+        )
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'returns empty resources array when querying on a provider with no cloud_networks attribute' do
+      openshift = FactoryGirl.create(:ems_openshift)
+      openshift_cloud_networks_url = "#{providers_url(openshift.id)}/cloud_networks"
+
+      api_basic_authorize collection_action_identifier(:providers, :read, :get)
+
+      run_get openshift_cloud_networks_url, :expand => 'resources'
+
+      expected = {
+        'name'      => 'cloud_networks',
+        'count'     => 0,
+        'subcount'  => 0,
+        'resources' => []
+      }
+
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
   end
 end


### PR DESCRIPTION
Ensures that a provider responds to `cloud_networks` before calling it so it does not cause an `internal_server_error`

@miq-bot assign @abellotti 
@miq-bot add_label api, bug, euwe/yes 

Links 
----------------
* Closes #12456 


