### PR TITLE
Don't use fetch, when you wish to fetch_path

### DIFF
--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -273,7 +273,7 @@ module VimPerformanceAnalysis
       options = @options
 
       if VimPerformanceAnalysis.needs_perf_data?(options[:vm_options])
-        perf_cols = [:cpu, :vcpus, :memory, :storage].collect { |t| options.fetch(:vm_options, t, :metric) }.compact
+        perf_cols = [:cpu, :vcpus, :memory, :storage].collect { |t| options.fetch_path(:vm_options, t, :metric) }.compact
       end
 
       vm_perf = VimPerformanceAnalysis.get_daily_perf(@vm, options[:range], options[:ext_options], perf_cols)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1378154

Addressing: 
```
FATAL -- : Error caught: [ArgumentError] wrong number of arguments (3 for 1..2)
app/models/vim_performance_analysis.rb:276:in `fetch'
app/models/vim_performance_analysis.rb:276:in `block in get_vm_needs'
app/models/vim_performance_analysis.rb:276:in `collect'
app/models/vim_performance_analysis.rb:276:in `get_vm_needs'
app/models/vim_performance_planning.rb:121:in `vm_metric_values'
app/controllers/miq_capacity_controller.rb:581:in `planning_get_vm_values'
app/controllers/miq_capacity_controller.rb:222:in `planning_option_changed'
```

Introduced in 88c28e0cef0748fea963b21d5b550ebeb5713ff5

@miq-bot add_label bug, metrics, euwe/yes, blocker
@miq-bot assign @gtanzillo 