### PR TITLE
Missing i18n in saved reports

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -41,7 +41,7 @@ namespace :locale do
   end
 
   desc "Extract strings from various yaml files and store them in a ruby file for gettext:find"
-  task :extract_yaml_strings do
+  task :extract_yaml_strings => :environment do
     def update_output(string, file, output)
       return if string.nil? || string.empty?
       if output.key?(string)
@@ -74,6 +74,7 @@ namespace :locale do
       "db/fixtures/miq_product_features.*" => %w(name description),
       "db/fixtures/miq_report_formats.*"   => %w(description),
       "db/fixtures/notification_types.*"   => %w(message),
+      "product/reports/*/*.*"              => %w(headers menu_name title),
       "product/timelines/miq_reports/*.*"  => %w(title name headers),
       "product/views/*.*"                  => %w(title name headers)
     }

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -93,7 +93,7 @@ module Vmdb
       # table headings
       unless report.headers.nil?
         report.headers.each do |h|
-          html << "<th>" << CGI.escapeHTML(h.to_s) << "</th>"
+          html << "<th>" << CGI.escapeHTML(_(h.to_s)) << "</th>"
         end
         html << "</tr>"
         html << "</thead>"


### PR DESCRIPTION
Changes:
* new strings (headers & report names) extracted from `product/reports/*/*`
* translated report headers

Before:
![saved-reports-before](https://cloud.githubusercontent.com/assets/6648365/20060292/d6d5be6c-a4fa-11e6-85d7-dd56e6d26dbc.jpg)

After:
![saved-reports-after](https://cloud.githubusercontent.com/assets/6648365/20060295/dc41097e-a4fa-11e6-85c0-83043e628d55.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1391750