### PR TITLE
Changed Red Hat provider description

### DIFF
--- a/app/helpers/application_helper/discover.rb
+++ b/app/helpers/application_helper/discover.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
         "ipmi"            => _("IPMI"),
         "kvm"             => _("KVM"),
         "msvirtualserver" => _("MS vCenter"),
-        "rhevm"           => _("Red Hat Enterprise Virtualization Manager"),
+        "rhevm"           => _("Red Hat Virtualization Manager"),
         "scvmm"           => _("Microsoft System Center VMM"),
         "virtualcenter"   => _("VMware vCenter"),
         "vmwareserver"    => _("VMware Server"),

--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -31,7 +31,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   end
 
   def self.description
-    @description ||= "Red Hat Enterprise Virtualization Manager".freeze
+    @description ||= "Red Hat Virtualization Manager".freeze
   end
 
   def self.default_blacklisted_event_names

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -374,7 +374,7 @@ describe EmsInfraController do
         edit[:new][:name] = "abc"
         edit[:ems_types] = {"scvmm"           => "Microsoft System Center VMM",
                             "openstack_infra" => "OpenStack Platform Director",
-                            "rhevm"           => "Red Hat Enterprise Virtualization Manager",
+                            "rhevm"           => "Red Hat Virtualization Manager",
                             "vmwarews"        => "VMware vCenter"}
         controller.instance_variable_set(:@edit, edit)
         post :form_field_changed, :params => { :id => "new", :server_emstype => "scvmm" }

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -37,7 +37,7 @@ describe ExtManagementSystem do
       "openstack_network"           => "OpenStack Network",
       "physical_infra_manager"      => "PhysicalInfraManager", # TODO: (julian) remove once we have a physical_infra_manager implementation
       "nuage_network"               => "Nuage Network Manager",
-      "rhevm"                       => "Red Hat Enterprise Virtualization Manager",
+      "rhevm"                       => "Red Hat Virtualization Manager",
       "scvmm"                       => "Microsoft System Center VMM",
       "vmwarews"                    => "VMware vCenter",
       "vmware_cloud"                => "VMware vCloud",

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Redhat::InfraManager do
   end
 
   it ".description" do
-    expect(described_class.description).to eq('Red Hat Enterprise Virtualization Manager')
+    expect(described_class.description).to eq('Red Hat Virtualization Manager')
   end
 
   describe ".metrics_collector_queue_name" do


### PR DESCRIPTION
Changed 'Red Hat Enterprise Virtualization Manager' to 'Red Hat
Virtualization Manager' in Red Hat provider description.

https://bugzilla.redhat.com/show_bug.cgi?id=1372992