### PR TITLE
VM Reconfigure Request not working

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -474,7 +474,7 @@ class MiqRequest < ApplicationRecord
   def self.find_source_id_from_values(values)
     MiqRequestMixin.get_option(:src_vm_id, nil, values) ||
       MiqRequestMixin.get_option(:src_id, nil, values) ||
-      MiqRequestMixin.get_option(:src_ids, nil, values).try(:first)
+      MiqRequestMixin.get_option(:src_ids, nil, values)
   end
   private_class_method :find_source_id_from_values
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -59,6 +59,11 @@ describe MiqRequest do
       end
     end
 
+    it ".find_source_id_from_values with :src_ids" do
+      src_id_hash = {:src_ids => [101, 102, 103]}
+      expect(described_class.send(:find_source_id_from_values, src_id_hash)).to eq(101)
+    end
+
     it "#call_automate_event_queue" do
       allow(MiqServer).to receive(:my_zone).and_return("New York")
 


### PR DESCRIPTION
Remove try(:first) on the result of MiqRequestMixin.get_option(:src_ids, nil, values), as the get_option already returns first for arrays

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1389303

Steps for Testing/QA
-------------------------------

Steps to Reproduce:
1. Go to a VM (Vmware or Rhev)
2. Select Configuration>Reconfigure this VM
3. change something and click submit

Actual results: nothing is happening
Expected results: VM is reconfigured

