### PR TITLE
Fix adding new dashboard widget with role/group visibility

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -635,8 +635,10 @@ class ApplicationController < ActionController::Base
       else
         redirect_to_action = lastaction
       end
-      model = self.class.model
-      if restful_routed?(model)
+
+      # there's no model for ResourceController - defaulting to traditional routing
+      model = self.class.model rescue nil
+      if model && restful_routed?(model)
         javascript_redirect polymorphic_path(model.find(params[:id]), :escape => false, :load_edit_err => true)
       else
         javascript_redirect :action => redirect_to_action, :id => params[:id], :escape => false, :load_edit_err => true

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -144,7 +144,7 @@ module ReportController::Widgets
       end
 
       if params[:visibility_typ]
-        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@widget.id.to_s || "new"), :action => "widget_form_field_changed"})
+        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@widget.id || "new").to_s, :action => "widget_form_field_changed"})
       end
 
       javascript_for_timer_type(params[:timer_typ]).each { |js| page << js }


### PR DESCRIPTION
Since #11074, changing visibliity type in new dashboard widget form (Cloud interl > Reports > Dashboard Widgets) makes the code use a wrong `form_field_changed` url - it changed from `*/widget_form_field_changed/new` to `*/widget_form_field_changed` when `@widget.id` is `nil` (new item), because `(nil.to_s || "new")` is always `""`, not `"new"`.

Fixing back :).

Also, fixes a crash when trying to notify about double session access, caused by assuming a controller always has an associated model. (Which ReportController hasn't.)

https://bugzilla.redhat.com/show_bug.cgi?id=1388144