### PR TITLE
Convert (foo.to_s || "new") to (foo || "new").to_s

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -116,7 +116,7 @@ module ApplicationController::Buttons
         page.replace("ab_form", :partial => "shared/buttons/ab_form")
       end
       if params[:visibility_typ]
-        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@custom_button.id.to_s || "new"), :action => "automate_button_field_changed"})
+        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@custom_button.id || "new").to_s, :action => "automate_button_field_changed"})
       end
       unless params[:target_class]
         @changed = (@edit[:new] != @edit[:current])

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -516,7 +516,7 @@ module MiqAeCustomizationController::Dialogs
       page << javascript_for_miq_button_visibility(changed)
 
       # replace select tag of default values
-      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id.to_s || "new"))
+      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id || "new").to_s)
       none =  [['<None>', nil]]
       values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]
@@ -556,7 +556,7 @@ module MiqAeCustomizationController::Dialogs
       page << javascript_for_miq_button_visibility(changed)
 
       # replace select tag of default values
-      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id.to_s || "new"))
+      url = url_for(:action => 'dialog_form_field_changed', :id => (@record.id || "new").to_s)
       none =  [['<None>', nil]]
       values = key[:values].empty? ? none : none + key[:values].collect(&:reverse)
       selected = @edit[:field_default_value]

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -161,12 +161,12 @@ class OpsController < ApplicationController
       @scan = @edit[:scan]
       case params[:tab].split("_")[0]
       when "new"
-        redirect_to(:action => "ap_new", :tab => params[:tab], :id => (@scan.id.to_s || "new"))
+        redirect_to(:action => "ap_new", :tab => params[:tab], :id => (@scan.id || "new").to_s)
       when "edit"
-        redirect_to(:action => "ap_edit", :tab => params[:tab], :id => (@scan.id.to_s || "new"))
+        redirect_to(:action => "ap_edit", :tab => params[:tab], :id => (@scan.id || "new").to_s)
       else
         @sb[:miq_tab] = "new#{params[:tab]}"
-        redirect_to(:action => "ap_edit", :tab => "edit#{params[:tab]}", :id => (@scan.id.to_s || "new"))
+        redirect_to(:action => "ap_edit", :tab => "edit#{params[:tab]}", :id => (@scan.id || "new").to_s)
       end
     else
       @sb[:active_tab] = params[:tab_id] || new_tab_id

--- a/app/controllers/report_controller/widgets.rb
+++ b/app/controllers/report_controller/widgets.rb
@@ -144,7 +144,7 @@ module ReportController::Widgets
       end
 
       if params[:visibility_typ]
-        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@widget.id.to_s || "new"), :action => "widget_form_field_changed"})
+        page.replace("form_role_visibility", :partial => "layouts/role_visibility", :locals => {:rec_id => (@widget.id || "new").to_s, :action => "widget_form_field_changed"})
       end
 
       javascript_for_timer_type(params[:timer_typ]).each { |js| page << js }


### PR DESCRIPTION
in 0517b67 (#11074), code like `"#{foo || "new"}"` got refactored to `(foo.to_s || "new")`, but unfortunately, that means a different thing if `foo` is `nil`. (Because `nil.to_s == ""` so `true`.)

Changing to use `(foo || "new").to_s` instead, which should be semantically equivalent to the original.

@jrafanie ping, this makes sense, right? :)