### PR TITLE
Translated 'Group' string in VM summary

### DIFF
--- a/app/helpers/vm_helper/textual_summary.rb
+++ b/app/helpers/vm_helper/textual_summary.rb
@@ -212,7 +212,7 @@ module VmHelper::TextualSummary
   end
 
   def textual_group
-    @record.miq_group.try(:description)
+    {:label => _("Group"), :value => @record.miq_group.try(:description)}
   end
 
   def textual_cluster


### PR DESCRIPTION
Before:
![vm-summary-before](https://cloud.githubusercontent.com/assets/6648365/20065652/2aa0615a-a50f-11e6-87c5-8f4e4d482d89.jpg)

After:
![vm-summary-after](https://cloud.githubusercontent.com/assets/6648365/20065664/30aea548-a50f-11e6-9566-4c7b4aa45ee5.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1391760