### PR TITLE
Translated request types in request filter

### DIFF
--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -449,7 +449,7 @@ class MiqRequestController < ApplicationController
   end
 
   def request_types_for_model
-    MiqRequest::MODEL_REQUEST_TYPES[model_request_type_from_layout]
+    MiqRequest::MODEL_REQUEST_TYPES[model_request_type_from_layout].map { |k, v| [k, v.map { |x, y| [x, _(y)] }.to_h] }.to_h
   end
 
   def model_request_type_from_layout

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -44,34 +44,34 @@ class MiqRequest < ApplicationRecord
   MODEL_REQUEST_TYPES = {
     :Service        => {
       :MiqProvisionRequest                 => {
-        :template          => "VM Provision",
-        :clone_to_vm       => "VM Clone",
-        :clone_to_template => "VM Publish",
+        :template          => N_("VM Provision"),
+        :clone_to_vm       => N_("VM Clone"),
+        :clone_to_template => N_("VM Publish"),
       },
       :MiqProvisionConfiguredSystemRequest => {
-        :provision_via_foreman => "#{ui_lookup(:ui_title => 'foreman')} Provision"
+        :provision_via_foreman => N_("%{config_mgr_type} Provision") % {:config_mgr_type => ui_lookup(:ui_title => 'foreman')}
       },
       :VmReconfigureRequest                => {
-        :vm_reconfigure => "VM Reconfigure"
+        :vm_reconfigure => N_("VM Reconfigure")
       },
       :VmMigrateRequest                    => {
-        :vm_migrate => "VM Migrate"
+        :vm_migrate => N_("VM Migrate")
       },
       :ServiceTemplateProvisionRequest     => {
-        :clone_to_service => "Service Provision"
+        :clone_to_service => N_("Service Provision")
       },
       :ServiceReconfigureRequest           => {
-        :service_reconfigure => "Service Reconfigure"
+        :service_reconfigure => N_("Service Reconfigure")
       }
     },
     :Infrastructure => {
       :MiqHostProvisionRequest => {
-        :host_pxe_install => "Host Provision"
+        :host_pxe_install => N_("Host Provision")
       },
     },
     :Automate       => {
       :AutomationRequest => {
-        :automation => "Automation"
+        :automation => N_("Automation")
       }
     }
   }


### PR DESCRIPTION
Before:
![request-types-before](https://cloud.githubusercontent.com/assets/6648365/20065944/38de89f8-a510-11e6-8a23-4217637aaa3b.jpg)

After (not all request types are translated to Japanese at the moment):
![request-types-after](https://cloud.githubusercontent.com/assets/6648365/20065958/3e6ee246-a510-11e6-886e-d0bea008395c.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1391760