### PR TITLE
Increase worker memory thresholds to avoid frequent restarts.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1232,7 +1232,7 @@
       :gc_interval: 15.minutes
       :heartbeat_freq: 10.seconds
       :heartbeat_timeout: 2.minutes
-      :memory_threshold: 200.megabytes
+      :memory_threshold: 400.megabytes
       :nice_delta: 10
       :parent_time_threshold: 3.minutes
       :poll: 3.seconds
@@ -1242,7 +1242,6 @@
       :starting_timeout: 10.minutes
     :ems_refresh_core_worker:
       :poll: 1.seconds
-      :memory_threshold: 400.megabytes
       :nice_delta: 1
       :thread_shutdown_timeout: 10.seconds
     :event_catcher:
@@ -1331,7 +1330,7 @@
       :defaults:
         :cpu_usage_threshold: 100.percent
         :dequeue_method: :drb
-        :memory_threshold: 400.megabytes
+        :memory_threshold: 500.megabytes
         :poll_method: :normal
         :queue_timeout: 10.minutes
       :ems_metrics_collector_worker:
@@ -1354,7 +1353,7 @@
         :ems_metrics_collector_worker_vmware: {}
       :ems_metrics_processor_worker:
         :count: 2
-        :memory_threshold: 400.megabytes
+        :memory_threshold: 600.megabytes
         :nice_delta: 7
         :poll_method: :escalate
       :ems_refresh_worker:
@@ -1401,6 +1400,7 @@
         :poll_method: :normal
         :queue_timeout: 60.minutes
       :priority_worker:
+        :memory_threshold: 600.megabytes
         :count: 2
         :nice_delta: 1
         :poll: 1.seconds
@@ -1434,7 +1434,7 @@
       :job_timeout_interval: 60.seconds
       :log_active_configuration_interval: 1.days
       :log_database_statistics_interval: 1.days
-      :memory_threshold: 300.megabytes
+      :memory_threshold: 500.megabytes
       :nice_delta: 3
       :orchestration_stack_retired_interval: 10.minutes
       :load_balancer_retired_interval: 10.minutes


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1391687

The prior values had not been increased to account for newer ruby
versions that utilize a generational garbage collector which consumes
more memory.

Change default worker from 200 to 400 MB.
ems_refresh_core_worker inherits this 400 MB default.

Change default queue worker from 400 to 500 MB.
generic_worker inherits this 500 MB value.

Change ems_metrics_processor_worker from 400 to 600 MB.
Change priority_worker from the old inherited queue worker value of 400
to a customized 600 MB.

Change schedule_worker from 300 to 500 MB.