### PR TITLE
Incorrect link created for the quadicon on tagging form

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -51,6 +51,10 @@ module QuadiconHelper
     !quadicon_in_embedded_view? || quadicon_show_link_ivar?
   end
 
+  def quadicon_show_url?
+    !@quadicon_no_url
+  end
+
   def quadicon_policy_sim?
     !!@policy_sim
   end
@@ -303,6 +307,7 @@ module QuadiconHelper
   # Build a link with common quadicon options
   #
   def quadicon_link_to(url, sparkle: false, remote: false, options: {}, &block)
+    return if url.nil? && !quadicon_show_url?
     if sparkle
       options["data-miq_sparkle_on"] = true
       options["data-miq_sparkle_off"] = true

--- a/app/views/layouts/_protect.html.haml
+++ b/app/views/layouts/_protect.html.haml
@@ -21,4 +21,5 @@
 
   - if @politems
     - @embedded = true
+    - @quadicon_no_url = true
     = render :partial => "layouts/gtl"

--- a/app/views/layouts/_tag_edit_items.html.haml
+++ b/app/views/layouts/_tag_edit_items.html.haml
@@ -6,5 +6,6 @@
 
   - if @tagitems
     - @embedded = true
+    - @quadicon_no_url = true
     - @gtl_type ||= settings(:views, :tagging)
     = render :partial => "layouts/gtl"

--- a/app/views/shared/views/_ownership.html.haml
+++ b/app/views/shared/views/_ownership.html.haml
@@ -43,6 +43,7 @@
     = _('Affected Items')
   - if @ownershipitems
     - @embedded = true
+    - @quadicon_no_url = true
     - @gtl_type = settings(:views, :tagging)
     = render :partial => "layouts/gtl"
 

--- a/app/views/shared/views/_retire.html.haml
+++ b/app/views/shared/views/_retire.html.haml
@@ -51,6 +51,7 @@
 
   - if @retireitems
     - @embedded = true
+    - @quadicon_no_url = true
     = render :partial => "layouts/gtl"
 
   %table{:width => "100%"}

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -159,7 +159,6 @@ describe StorageController do
 
         main_content = JSON.parse(response.body)['updatePartials']['main_div']
         expect(main_content).to include("<h3>\n1 Datastore Being Tagged\n<\/h3>")
-        expect(main_content).to include("Name: #{datastore.name} | Datastores Type: ")
       end
 
       it 'can Perform a datastore Smart State Analysis from the datastore summary page' do

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -198,6 +198,25 @@ describe VmInfraController do
     expect(response).to render_template(:partial => 'layouts/_tagging')
   end
 
+  it 'The VM quadicons on the tagging screen do not links' do
+    classification = FactoryGirl.create(:classification, :name => "department", :description => "D    epartment")
+    @tag1 = FactoryGirl.create(:classification_tag,
+                               :name   => "tag1",
+                               :parent => classification)
+    @tag2 = FactoryGirl.create(:classification_tag,
+                               :name   => "tag2",
+                               :parent => classification)
+    get :show, :params => { :id => vm_vmware.id }
+    expect(response).to redirect_to(:action => 'explorer')
+
+    post :explorer
+    expect(response.status).to eq(200)
+
+    post :x_button, :params => { :pressed => 'vm_tag', :id => vm_vmware.id }
+    expect(response.status).to eq(200)
+    expect(response.body).to_not include('/vm_infra/x_button')
+  end
+
   it 'can Check VM Compliance' do
     get :show, :params => { :id => vm_vmware.id }
     expect(response).to redirect_to(:action => 'explorer')

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -562,6 +562,13 @@ describe QuadiconHelper do
 
         expect(subject).to have_selector('span')
       end
+
+      it 'has no links when @quadicon_no_url is true' do
+        @quadicon_no_url = true
+        @embedded = true
+        @showlinks = false
+        expect(subject).not_to include('href')
+      end
     end
 
     context "when not in embedded view" do


### PR DESCRIPTION
No link should be created on the tagging form for the tagged item quadicons.
This issue occurs after the first phase of the quadicon refactoring. The fix here introduces a new flag used only in select forms where the 'Affected Items' quadicons should have no links. The next phase of the refactoring should address this issue in a more generic way.

Links
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1389430

Steps for Testing/QA 
-------------------------------
Steps to Reproduce:
1. go to VMs
2. Select Multiple VMs
3. then select Policy>Edit Tags
4. then click on one of the VM in the "Selected VM Sections"

Actual results: you can select VM and fails..


Expected results: VM should not be clickable

