### PR TITLE
Adds connection_options to OS Cloud VM

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -41,6 +41,25 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
     connection.servers.get(ems_ref)
   end
 
+  def with_provider_object
+    super(connection_options)
+  end
+
+  def with_provider_connection
+    super(connection_options)
+  end
+
+  def self.connection_options(cloud_tenant = nil)
+    connection_options = { :service => 'Compute' }
+    connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
+    connection_options
+  end
+
+  def connection_options
+    self.class.connection_options(cloud_tenant)
+  end
+  private :connection_options
+
   def self.calculate_power_state(raw_power_state)
     POWER_STATES[raw_power_state] || "unknown"
   end


### PR DESCRIPTION
Connections to OpenStack Cloud did not used cloud_tenant.name as parameter consistently
and so this caused issues with connecting to wrong tenant.

Adds with_provider_object, with_provider_connection,
connection_options and self.connection_options
to OpenStack Cloud VM model.
Adds tests for checking if correct tenant name is used.

connection_options contains defaults w/r/t cloud_tenant name.
This way fog will connect to correct CloudTenant.

Tested for these actions:
- start
- pause
- suspend
- shelve
- shelve offload
- soft reboot
- hard reboot
- delete
- migrate
- evacuate

Links
----------------
Solves
https://bugzilla.redhat.com/show_bug.cgi?id=1389392


Steps for Testing/QA
-------------------------------
1. Add OpenStack Cloud Provider using _non admin_ user with access to 2 or more different OpenStack tenants / projects.
2. Try different actions with VMs from different tenants.