### PR TITLE
List vms or templates when filter for provider is selected

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -523,7 +523,7 @@ module Rbac
         # typically, this is the only one we want:
         vcmeta = vcmeta_list.last
 
-        if vcmeta.kind_of?(Host) && klass <= VmOrTemplate
+        if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) } && klass <= VmOrTemplate
           vcmeta.send(association_name).to_a
         else
           vcmeta_list.grep(klass) + vcmeta.descendants.grep(klass)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -590,6 +590,27 @@ describe Rbac::Filterer do
         end
       end
 
+      context "when applying a filter to the provider" do
+        let(:ems_cloud) { FactoryGirl.create(:ems_cloud) }
+
+        let!(:vm_1) do
+          FactoryGirl.create(:vm, :ext_management_system => ems_cloud)
+        end
+
+        let!(:vm_2) do
+          FactoryGirl.create(:vm, :ext_management_system => ems_cloud)
+        end
+
+        it "returns all host's VMs and templates when host filter is set up" do
+          group.entitlement = Entitlement.new
+          group.entitlement.set_managed_filters([])
+          group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|#{ems_cloud.name}"])
+          group.save!
+
+          expect(described_class.search(:class => Vm, :user => user).first).to match_array([vm_1, vm_2])
+        end
+      end
+
       context "when applying a filter to the host and it's cluster (FB17114)" do
         before(:each) do
           @ems = FactoryGirl.create(:ems_vmware, :name => 'ems')


### PR DESCRIPTION
we have these settings of nosuper-admin user's group, there is selected RHOS(more info in BZ)

![screen shot 2016-11-08](https://cloud.githubusercontent.com/assets/14937244/20104990/4df305a6-a5d0-11e6-93d1-ef278b8b6aef.png)

and then we was not able to display provider's instances because it leads 
to https://github.com/ManageIQ/manageiq/blob/master/lib/rbac/filterer.rb#L529
`vcmeta` is instance of RHOS provider and we are not using relationship table there.

But we can ask for vms (`association_name`) directly so added condition [here](https://github.com/ManageIQ/manageiq/pull/12493/commits/767a12603202c1d8a0260658dfae020492f0b494#diff-8d948055de14ced0e63abf9637a9a788R526)

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1386736

