### PR TITLE
Enable orchestration message override

### DIFF
--- a/app/models/orchestration_stack/status.rb
+++ b/app/models/orchestration_stack/status.rb
@@ -50,8 +50,10 @@ class OrchestrationStack
         ['create_canceled', reason || 'Stack creation was canceled']
       elsif updated?
         ['update_complete', reason || 'OK']
-      else
+      elsif reason == 'Service_Template_Provisioning failed'
         ['failed', reason || 'Stack creation failed']
+      else
+        ['failed', reason]
       end
     end
   end


### PR DESCRIPTION
In previous versions of MIQ, it was possible to override the Service Template Provision Task failure message for orchestration tasks from within Automate.

The **normalized_status** function in app/models/orchestration_stack/status.rb overrides any failure message set in Automate, with 'Stack creation failed'.

This PR allows for any message other that 'Service_Template_Provisioning failed' to be set.