### PR TITLE
Default Filters can be saved or reset

### DIFF
--- a/app/assets/javascripts/miq_tree.js
+++ b/app/assets/javascripts/miq_tree.js
@@ -216,8 +216,8 @@ function miqOnClickTimelineSelection(id) {
 
 // OnCheck handler for the belongs to drift/compare sections tree
 function miqOnCheckSections(_tree_name, key, checked, all_checked) {
-  var url = ManageIQ.tree.checkUrl + '?id=' + key + '&check=' + checked + '&all_checked=' + all_checked;
-  miqJqueryRequest(url);
+  var url = ManageIQ.tree.checkUrl + '?id=' + encodeURIComponent(key) + '&check=' + checked;
+  miqJqueryRequest(url, {data: {all_checked: all_checked}});
   return true;
 }
 

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -640,12 +640,12 @@ module ApplicationController::Compare
   # AJAX driven routine to check for changes in ANY field on the form
   def sections_field_changed
     @keep_compare = true
-    set_checked_sections
     if params[:check] == "drift"
       drift_checked
     elsif params[:check] == "compare_miq"
       compare_checked
     else
+      set_checked_sections
       render :update do |page|
         page << javascript_prologue
         page << "miqSparkle(false);"
@@ -655,10 +655,9 @@ module ApplicationController::Compare
   end
 
   def set_checked_sections
-    if params[:check] != "drift" && params[:check] != "compare_miq" && params[:all_checked]
-      arr = params[:all_checked].split(',')
+    if params[:all_checked]
       session[:selected_sections] = []
-      arr.each do |a|
+      params[:all_checked].each do |a|
         s = a.split(':')
         if s.length > 1
           session[:selected_sections].push(s[1])


### PR DESCRIPTION
My Settings -> Default Filters tab -> check a lot of filters (all of them is best) -> should set 414 error `Request URI too long`
![cats-as-error-message-414](https://cloud.githubusercontent.com/assets/9210860/20095189/ca622cf6-a5a4-11e6-96cb-52796345665a.jpg)

Before: IDs of all checked checkboxes in Default Filters tree and Section tree were passed in URI
After: IDs are moved to Post Data

@miq-bot add_label ui, bug, euwe/yes, blocker

Default Filters can not be saved or reset:
https://bugzilla.redhat.com/show_bug.cgi?id=1389225