### PR TITLE
Correct way to load data for chart menu clicks

### DIFF
--- a/app/assets/javascripts/miq_c3.js
+++ b/app/assets/javascripts/miq_c3.js
@@ -8,7 +8,6 @@ function load_c3_charts() {
       if (data != null) {
         load_c3_chart(data.xml, chart_id);
 
-
         chart_id += "_2";
         if (typeof (data.xml2) !== "undefined") {
           data.xml2.miq.flat_chart = true;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1619,17 +1619,11 @@ class ApplicationController < ActionController::Base
   def get_view_where_clause(default_where_clause)
     # If doing charts, limit the records to ones showing in the chart
     if session[:menu_click] && session[:sandboxes][params[:sb_controller]][:chart_reports]
-      click_parts = session[:menu_click].split('_')
-      click_last  = click_parts.last.split('-')
-
+      click_parts = session[:menu_click]
       chart_reports = session[:sandboxes][params[:sb_controller]][:chart_reports]
-      legend_idx    = click_last.first.to_i
-      data_idx      = click_last[-2].to_i
-      chart_idx     = click_last.last.to_i
-
-      _, model, typ = click_parts.first.split('-')
-      report        = chart_reports.kind_of?(Array) ? chart_reports[chart_idx] : chart_reports
-      data_row      = report.table.data[data_idx]
+      legend_idx, data_idx, chart_idx, _cmd, model, typ = parse_chart_click(Array(click_parts).first)
+      report = chart_reports.kind_of?(Array) ? chart_reports[chart_idx] : chart_reports
+      data_row = report.table.data[data_idx]
 
       if typ == "bytag"
         ["\"#{model.downcase.pluralize}\".id IN (?)",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1389315

```
[----] F, [2016-11-08T11:18:05.396722 #4428:2acf1376f1f8] FATAL -- : Error caught: [NoMethodError] undefined method `downcase' for nil:NilClass
/home/rblanco/devel/manageiq/app/controllers/application_controller.rb:1639:in `get_view_where_clause'
/home/rblanco/devel/manageiq/app/controllers/application_controller.rb:1590:in `get_view'
/home/rblanco/devel/manageiq/app/controllers/application_controller/ci_processing.rb:1617:in `process_show_list'
/home/rblanco/devel/manageiq/app/controllers/vm_controller.rb:16:in `show_list'
```

In pull request #11400 @PanSpagetka has introduced a new way to pass the data from charts. I'm applying the same changes in this pull request fixing the issue with undefined method 'downcase' for nil:NilClass

Links
----------------
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1389315

Related to:
*(Following changes from PR)*: #11400 
https://bugzilla.redhat.com/show_bug.cgi?id=1392046
https://bugzilla.redhat.com/show_bug.cgi?id=1389331

Steps for Testing/QA
-------------------------------

Before:
![screencast from 2016-11-08 13-09-17](https://cloud.githubusercontent.com/assets/1187051/20098539/b0aee140-a5b4-11e6-9c85-d87d95f876e6.gif)

After:
![screencast from 2016-11-08 11-48-07](https://cloud.githubusercontent.com/assets/1187051/20096368/cdb086e6-a5a9-11e6-98ff-695829fe1088.gif)


@PanSpagetka can you review?