### PR TITLE
Translatable labels in check box tag

### DIFF
--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -27,7 +27,7 @@
                 .col-md-8
                   = check_box_tag("quadicons_#{icons_checkbox[2]}",
                                   true,
-                                  @edit[:new][:quadicons][icons_checkbox[2].to_sym], :data => {:on_text => 'Yes', :off_text => 'No'})
+                                  @edit[:new][:quadicons][icons_checkbox[2].to_sym], :data => {:on_text => _('Yes'), :off_text => _('No')})
                 :javascript
                   miqInitBootstrapSwitch("quadicons_#{icons_checkbox[2]}", "#{url}")
           .form-group

--- a/app/views/configuration/_ui_2.html.haml
+++ b/app/views/configuration/_ui_2.html.haml
@@ -70,7 +70,7 @@
                 = check_box_tag("display_vms",
                                  '1',
                                  @edit[:new][:display][:display_vms],
-                                 :data => {:on_text => 'Yes', :off_text => 'No'})
+                                 :data => {:on_text => _('Yes'), :off_text => _('No')})
                 .note
                   = _("Warning: Enabling this option may cause performance issues in large environments (i.e. thousands of VMs)")
                 :javascript

--- a/app/views/ops/_category_form.html.haml
+++ b/app/views/ops/_category_form.html.haml
@@ -36,7 +36,7 @@
           - checked = !!@edit[:new][:single_value]
           - disabled = true
           = check_box_tag("single_value", 'true', checked,
-                          :disabled                   => disabled, :data => {:on_text => 'Yes', :off_text => 'No'})
+                          :disabled                   => disabled, :data => {:on_text => _('Yes'), :off_text => _('No')})
         :javascript
           miqInitBootstrapSwitch('single_value', "#{url}")
       .form-group
@@ -44,7 +44,7 @@
           = _("Capture C & U Data by Tag")
         .col-md-8
           - checked = !!@edit[:new][:perf_by_tag]
-          = check_box_tag("perf_by_tag", true, checked, :data => {:on_text => 'Yes', :off_text => 'No'})
+          = check_box_tag("perf_by_tag", true, checked, :data => {:on_text => _('Yes'), :off_text => _('No')})
         :javascript
           miqInitBootstrapSwitch('perf_by_tag', "#{url}")
       .form-group
@@ -89,7 +89,7 @@
           = _("Show in Console")
         .col-md-8
           - checked = !!@edit[:new][:show]
-          = check_box_tag("show", true, checked, :data => {:on_text => 'Yes', :off_text => 'No'})
+          = check_box_tag("show", true, checked, :data => {:on_text => _('Yes'), :off_text => _('No')})
         :javascript
           miqInitBootstrapSwitch('show', "#{url}")
       .form-group
@@ -98,7 +98,7 @@
         .col-md-8
           - checked = !!@edit[:new][:single_value]
           = check_box_tag("single_value", true, checked,
-                          :disabled                   => disabled, :data => {:on_text => 'Yes', :off_text => 'No'})
+                          :disabled                   => disabled, :data => {:on_text => _('Yes'), :off_text => _('No')})
         :javascript
           miqInitBootstrapSwitch('single_value', "#{url}")
       .form-group
@@ -106,7 +106,7 @@
           = _("Capture C & U Data by Tag")
         .col-md-8
           - checked = !!@edit[:new][:perf_by_tag]
-          = check_box_tag("perf_by_tag", true, checked, :data => {:on_text => 'Yes', :off_text => 'No'})
+          = check_box_tag("perf_by_tag", true, checked, :data => {:on_text => _('Yes'), :off_text => _('No')})
         :javascript
           miqInitBootstrapSwitch('perf_by_tag', "#{url}")
 

--- a/app/views/ops/_settings_cu_collection_tab.html.haml
+++ b/app/views/ops/_settings_cu_collection_tab.html.haml
@@ -16,7 +16,7 @@
               = _("Collect for All %{clusters}") % {:clusters => clusters_title}
             .col-md-8
               = check_box_tag("all_clusters", true, @edit[:new][:all_clusters],
-                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => 'Yes', :off_text => 'No'})
+                              "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
             :javascript
               miqInitBootstrapSwitch('all_clusters', "#{url}")
           .note
@@ -44,7 +44,7 @@
               = _("Collect for All Datastores")
             .col-md-8
               = check_box_tag("all_storages", true, @edit[:new][:all_storages],
-                "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => 'Yes', :off_text => 'No'})
+                "data-miq_sparkle_on" => true, "data-miq_sparkle_off" => true, :data => {:on_text => _('Yes'), :off_text => _('No')})
             :javascript
               miqInitBootstrapSwitch('all_storages', "#{url}")
           #storages_div{:style => "display:#{@edit[:new][:all_storages] ? "none" : ""}"}

--- a/app/views/ops/_settings_custom_logos_tab.html.haml
+++ b/app/views/ops/_settings_custom_logos_tab.html.haml
@@ -82,6 +82,6 @@
       %label.col-md-2.control-label
         = _("Use Custom Login Text")
       .col-md-8
-        = check_box_tag("server_uselogintext", true, @edit[:new][:server][:use_custom_login_text], :data => {:on_text => 'Yes', :off_text => 'No'})
+        = check_box_tag("server_uselogintext", true, @edit[:new][:server][:use_custom_login_text], :data => {:on_text => _('Yes'), :off_text => _('No')})
       :javascript
         miqInitBootstrapSwitch('server_uselogintext', "#{url}")

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -100,7 +100,7 @@
         - session[:server_roles].sort_by { |_name, desc| desc }.each do |name, desc|
           - checked = !session[:selected_roles].nil? && session[:selected_roles].include?(name)
           = check_box_tag("server_roles_#{name}", "1", checked,
-                           :data => {:on_text => 'On', :off_text => 'Off', :size => 'mini'})
+                           :data => {:on_text => _('On'), :off_text => _('Off'), :size => 'mini'})
           :javascript
             miqInitBootstrapSwitch("server_roles_#{name}", "#{url}")
           = h(desc)
@@ -228,7 +228,7 @@
       .col-md-8
         = check_box_tag("smtp_enable_starttls_auto",
                         GenericMailer.default_for_enable_starttls_auto,
-                        @edit[:new][:smtp][:enable_starttls_auto], :data => {:on_text => 'Yes', :off_text => 'No'})
+                        @edit[:new][:smtp][:enable_starttls_auto], :data => {:on_text => _('Yes'), :off_text => _('No')})
       :javascript
         miqInitBootstrapSwitch('smtp_enable_starttls_auto', "#{url}")
 


### PR DESCRIPTION
This change makes our `Yes` and `No` labels in patternfly styled check box inputs translatable.