### PR TITLE
Fix javascript parse error on a timeline screen

### DIFF
--- a/app/views/layouts/_timeline.html.haml
+++ b/app/views/layouts/_timeline.html.haml
@@ -4,7 +4,6 @@
     var json = JSON.parse('#{tl_json}'.replace(/&quot;/g, '"'));
     var start, end;
     if (!ManageIQ.calendar.calDateFrom || !ManageIQ.calendar.calDateTo) {
-    // set timeline to start one week ago and end today
     end = new Date();
     start = new Date(end - 24 * 60 * 60 * 1000 * 7);
     } else {


### PR DESCRIPTION
IE11 wouldn't deal correctly with a html comment inside a javascript code.

Reproducer:
* Use Internet Explorer 11 (not Firefox, not Chrome)
* Infra -> Provider -> Monitoring -> Timelines
* Choose 'Application' & Apply

https://bugzilla.redhat.com/show_bug.cgi?id=1389401