### PR TITLE
Fix wrong url when clicking provider on topology page

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -39,7 +39,7 @@ ManageIQ.angular.app.service('topologyService', function() {
 
   this.geturl = function(d) {
     var entity_url = "";
-    var action = '/show/' + d.item.miq_id;
+    var action = '/' + d.item.miq_id;
     switch (d.item.kind) {
       case "ContainerManager":
         action = '/' + d.item.miq_id;
@@ -50,6 +50,12 @@ ManageIQ.angular.app.service('topologyService', function() {
         break;
       case "MiddlewareManager":
         entity_url = "ems_middleware";
+        break;
+      case "InfraManager":
+        entity_url = "ems_infra";
+        break;
+      case "CloudManager":
+        entity_url = "ems_cloud";
         break;
       default : // for non provider entities, use the show action
         entity_url = _.snakeCase(d.item.kind);


### PR DESCRIPTION
Fixed missing page error when double clicking provider entity on topology page

Reproducer:
1.Navigate to the summary page of any provider
2.Click the Topology link.
3.On the Topology page, click provider entity.
https://bugzilla.redhat.com/show_bug.cgi?id=1389463 
solved for all Providers (not only for Infra)