### PR TITLE
Fix refresh when VMs are hidden

### DIFF
--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -75,7 +75,7 @@ module VmShowMixin
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name
     end
-    get_node_info(x_node)
+    get_node_info(@sb[@sb[:active_accord]].present? ? @sb[@sb[:active_accord]] : x_node)
   end
 
   def set_active_elements_authorized_user(tree_name, accord_name, add_nodes, klass, id)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1220,9 +1220,11 @@ module VmCommon
   def get_node_info(treenodeid)
     # resetting action that was stored during edit to determine what is being edited
     @sb[:action] = nil
-    @nodetype, id = if vm_selected && hide_vms
+    @nodetype, id = if (treenodeid.split('-')[0] == 'v' || treenodeid.split('-')[0] == 't')  && hide_vms
+                      @sb[@sb[:active_accord]] = treenodeid
                       parse_nodetype_and_id(treenodeid)
                     else
+                      @sb[@sb[:active_accord]] = nil
                       parse_nodetype_and_id(valid_active_node(treenodeid))
                     end
     model, title =  case x_active_tree.to_s
@@ -1354,6 +1356,7 @@ module VmCommon
 
     if !@in_a_form && !@sb[:action]
       id = vm_selected && hide_vms ? TreeBuilder.build_node_cid(@vm) : x_node
+      id = @sb[@sb[:active_accord]] if @sb[@sb[:active_accord]].present? && params[:action] != 'tree_select'
       get_node_info(id)
       type, _id = parse_nodetype_and_id(id)
       # set @delete_node since we don't rebuild vm tree

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -62,6 +62,16 @@ module VmCommon
     end
   end
 
+  # to reload currently displayed summary screen in explorer
+  def reload
+    @_params[:id] = if hide_vms && x_node.split('-')[1] != to_cid(params[:id]) && params[:id].present?
+                      'v-' + to_cid(params[:id])
+                    else
+                      x_node
+                    end
+    tree_select
+  end
+
   def show_timeline
     db = get_rec_cls
     @display = "timeline"

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -38,6 +38,31 @@ describe VmOrTemplateController do
     end
   end
 
+  context '#reload ' do
+    before do
+      login_as FactoryGirl.create(:user_with_group, :role => "operator")
+      allow(controller).to receive(:tree_select).and_return(nil)
+      @folder = FactoryGirl.create(:ems_folder)
+      @vm = FactoryGirl.create(:vm_cloud)
+    end
+
+    it 'sets params[:id] to hidden vm if its summary is displayed' do
+      User.current_user.settings[:display] = {:display_vms => false}
+      allow(controller).to receive(:x_node).and_return('f-' + @folder.id.to_s)
+      controller.instance_variable_set(:@_params, :id => @vm.id.to_s)
+      controller.reload
+      expect(controller.params[:id]).to eq('v-' + TreeBuilder.to_cid(@vm.id))
+    end
+
+    it 'sets params[:id] to x_node if vms are displayed in a tree' do
+      User.current_user.settings[:display] = {:display_vms => true}
+      allow(controller).to receive(:x_node).and_return('f-' + @folder.id.to_s)
+      controller.instance_variable_set(:@_params, :id => @folder.id.to_s)
+      controller.reload
+      expect(controller.params[:id]).to eq(controller.x_node)
+    end
+  end
+
   context "#show" do
     before :each do
       allow(User).to receive(:server_timezone).and_return("UTC")


### PR DESCRIPTION
After clicking Refresh button when VM is selected but isn't displayed in a tree its parent's info is rendered on the summary screen. Same for browser refresh button and coming back from another page.

- Before:
![screen shot 2016-11-08 at 4 19 51 pm](https://cloud.githubusercontent.com/assets/9210860/20104713/497aad36-a5cf-11e6-8e8f-e869486fe3ed.png)
 After clicking Refresh button
![screen shot 2016-11-08 at 4 20 12 pm](https://cloud.githubusercontent.com/assets/9210860/20104705/45cee602-a5cf-11e6-839b-c90b503027dc.png)
- After:
![screen shot 2016-11-08 at 4 19 51 pm](https://cloud.githubusercontent.com/assets/9210860/20104713/497aad36-a5cf-11e6-8e8f-e869486fe3ed.png)
 After clicking Refresh button
![screen shot 2016-11-08 at 4 19 51 pm](https://cloud.githubusercontent.com/assets/9210860/20104713/497aad36-a5cf-11e6-8e8f-e869486fe3ed.png)

This effects following trees:
Compute -> Infrastructure -> Virtual Machines -> VMs & Templates
Compute -> Cloud -> Instances -> Instances by Providers 
Compute -> Cloud -> Instances -> Images by Providers 

In VM Object, if you click the refresh button (not the browser refresh), it goes one level up in the tree:
https://bugzilla.redhat.com/show_bug.cgi?id=1389299

@miq-bot add_label bug, ui, euwe/yes, blocker