### PR TITLE
fix adding vApp template

### DIFF
--- a/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/orchestration_template.rb
@@ -32,4 +32,13 @@ class ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate < Orchest
   def self.eligible_manager_types
     [ManageIQ::Providers::Vmware::CloudManager]
   end
+
+  def validate_format
+    if content
+      ovf_doc = MiqXml.load(content)
+      !ovf_doc.root.nil? && nil
+    end
+  rescue REXML::ParseException => err
+    err.message
+  end
 end

--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -42,5 +42,6 @@ FactoryGirl.define do
   factory :orchestration_template_vmware_cloud,
           :parent => :orchestration_template,
           :class  => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate" do
+    content File.read(Rails.root.join('spec/fixtures/orchestration_templates/vmware_parameters_ovf.xml'))
   end
 end

--- a/spec/factories/orchestration_template.rb
+++ b/spec/factories/orchestration_template.rb
@@ -39,7 +39,7 @@ FactoryGirl.define do
     content File.read(Rails.root.join('spec/fixtures/orchestration_templates/azure_parameters.json'))
   end
 
-  factory :orchestration_template_vmware_cloud,
+  factory :orchestration_template_vmware_cloud_with_content,
           :parent => :orchestration_template,
           :class  => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate" do
     content File.read(Rails.root.join('spec/fixtures/orchestration_templates/vmware_parameters_ovf.xml'))

--- a/spec/fixtures/orchestration_templates/vmware_parameters_ovf.xml
+++ b/spec/fixtures/orchestration_templates/vmware_parameters_ovf.xml
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://vcd-portal.vmware.local/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+    <ovf:References/>
+    <ovf:NetworkSection>
+        <ovf:Info>The list of logical networks</ovf:Info>
+        <ovf:Network ovf:name="none">
+            <ovf:Description>This is a special place-holder used for disconnected network interfaces.</ovf:Description>
+        </ovf:Network>
+    </ovf:NetworkSection>
+    <vcloud:CustomizationSection goldMaster="false" ovf:required="false">
+        <ovf:Info>VApp template customization section</ovf:Info>
+        <vcloud:CustomizeOnInstantiate>true</vcloud:CustomizeOnInstantiate>
+    </vcloud:CustomizationSection>
+    <vcloud:NetworkConfigSection ovf:required="false">
+        <ovf:Info>The configuration parameters for logical networks</ovf:Info>
+        <vcloud:NetworkConfig networkName="none">
+            <vcloud:Description>This is a special place-holder used for disconnected network interfaces.</vcloud:Description>
+            <vcloud:Configuration>
+                <vcloud:IpScopes>
+                    <vcloud:IpScope>
+                        <vcloud:IsInherited>false</vcloud:IsInherited>
+                        <vcloud:Gateway>196.254.254.254</vcloud:Gateway>
+                        <vcloud:Netmask>255.255.0.0</vcloud:Netmask>
+                        <vcloud:Dns1>196.254.254.254</vcloud:Dns1>
+                    </vcloud:IpScope>
+                </vcloud:IpScopes>
+                <vcloud:FenceMode>isolated</vcloud:FenceMode>
+            </vcloud:Configuration>
+            <vcloud:IsDeployed>false</vcloud:IsDeployed>
+        </vcloud:NetworkConfig>
+    </vcloud:NetworkConfigSection>
+    <vcloud:LeaseSettingsSection ovf:required="false">
+        <ovf:Info>Lease settings section</ovf:Info>
+        <vcloud:StorageLeaseInSeconds>7776000</vcloud:StorageLeaseInSeconds>
+        <vcloud:StorageLeaseExpiration>2016-12-11T14:22:25.960+02:00</vcloud:StorageLeaseExpiration>
+    </vcloud:LeaseSettingsSection>
+    <ovf:VirtualSystemCollection ovf:id="vapp_template">
+        <ovf:Info>A collection of virtual machines</ovf:Info>
+        <ovf:Name>sample_vapp_template</ovf:Name>
+        <ovf:StartupSection>
+            <ovf:Info>VApp startup section</ovf:Info>
+            <ovf:Item ovf:id="VM1" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+            <ovf:Item ovf:id="VM2" ovf:order="0" ovf:startAction="powerOn" ovf:startDelay="0" ovf:stopAction="powerOff" ovf:stopDelay="0"/>
+        </ovf:StartupSection>
+        <ovf:VirtualSystem ovf:id="VM1">
+            <ovf:Info>A virtual machine</ovf:Info>
+            <ovf:Name>VM1</ovf:Name>
+            <ovf:OperatingSystemSection ovf:id="101" vmw:osType="centos64Guest">
+                <ovf:Info>Specifies the operating system installed</ovf:Info>
+                <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+            </ovf:OperatingSystemSection>
+            <ovf:VirtualHardwareSection ovf:transport="">
+                <ovf:Info>Virtual hardware requirements</ovf:Info>
+                <ovf:System>
+                    <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                    <vssd:InstanceID>0</vssd:InstanceID>
+                    <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                    <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                </ovf:System>
+                <ovf:Item>
+                    <rasd:Address>00:50:56:01:00:4d</rasd:Address>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                    <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                    <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                    <rasd:InstanceID>1</rasd:InstanceID>
+                    <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                    <rasd:ResourceType>10</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+                    <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>SCSI Controller</rasd:Description>
+                    <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>2</rasd:InstanceID>
+                    <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+                    <rasd:ResourceType>6</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="16"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:Description>Hard disk</rasd:Description>
+                    <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                    <rasd:HostResource vcloud:capacity="16384" vcloud:busSubType="lsilogic" vcloud:busType="6"/>
+                    <rasd:InstanceID>2000</rasd:InstanceID>
+                    <rasd:Parent>2</rasd:Parent>
+                    <rasd:ResourceType>17</rasd:ResourceType>
+                    <rasd:VirtualQuantity>17179869184</rasd:VirtualQuantity>
+                    <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                    <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>IDE Controller</rasd:Description>
+                    <rasd:ElementName>IDE Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>3</rasd:InstanceID>
+                    <rasd:ResourceType>5</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>Floppy Drive</rasd:Description>
+                    <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>8000</rasd:InstanceID>
+                    <rasd:ResourceType>14</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                    <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                    <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                    <rasd:InstanceID>4</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>3</rasd:ResourceType>
+                    <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                    <rasd:Description>Memory Size</rasd:Description>
+                    <rasd:ElementName>2048 MB of memory</rasd:ElementName>
+                    <rasd:InstanceID>5</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>4</rasd:ResourceType>
+                    <rasd:VirtualQuantity>2048</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>CD/DVD Drive</rasd:Description>
+                    <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>3000</rasd:InstanceID>
+                    <rasd:Parent>3</rasd:Parent>
+                    <rasd:ResourceType>15</rasd:ResourceType>
+                </ovf:Item>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204522e-c748-6c34-d2b3-35d6020f5d9a"/>
+            </ovf:VirtualHardwareSection>
+            <vcloud:GuestCustomizationSection ovf:required="false">
+                <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                <vcloud:Enabled>false</vcloud:Enabled>
+                <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                <vcloud:VirtualMachineId>e9b55b85-640b-462c-9e7a-d18c47a7a5f3</vcloud:VirtualMachineId>
+                <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                <vcloud:AdminPasswordEnabled>true</vcloud:AdminPasswordEnabled>
+                <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                <vcloud:ComputerName>VM1</vcloud:ComputerName>
+            </vcloud:GuestCustomizationSection>
+            <vcloud:NetworkConnectionSection ovf:required="false">
+                <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                <vcloud:NetworkConnection needsCustomization="true" network="none">
+                    <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                    <vcloud:IsConnected>false</vcloud:IsConnected>
+                    <vcloud:MACAddress>00:50:56:01:00:4d</vcloud:MACAddress>
+                    <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                </vcloud:NetworkConnection>
+            </vcloud:NetworkConnectionSection>
+        </ovf:VirtualSystem>
+        <ovf:VirtualSystem ovf:id="VM2">
+            <ovf:Info>A virtual machine</ovf:Info>
+            <ovf:Name>VM2</ovf:Name>
+            <ovf:OperatingSystemSection ovf:id="112" vmw:osType="centos64Guest">
+                <ovf:Info>Specifies the operating system installed</ovf:Info>
+                <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+            </ovf:OperatingSystemSection>
+            <ovf:VirtualHardwareSection ovf:transport="">
+                <ovf:Info>Virtual hardware requirements</ovf:Info>
+                <ovf:System>
+                    <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+                    <vssd:InstanceID>0</vssd:InstanceID>
+                    <vssd:VirtualSystemIdentifier>CentOS7</vssd:VirtualSystemIdentifier>
+                    <vssd:VirtualSystemType>vmx-10</vssd:VirtualSystemType>
+                </ovf:System>
+                <ovf:Item>
+                    <rasd:Address>00:50:56:01:00:4c</rasd:Address>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Connection vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="NONE">none</rasd:Connection>
+                    <rasd:Description>Vmxnet3 ethernet adapter on "none"</rasd:Description>
+                    <rasd:ElementName>Network adapter 0</rasd:ElementName>
+                    <rasd:InstanceID>1</rasd:InstanceID>
+                    <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+                    <rasd:ResourceType>10</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="192"/>
+                    <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="true"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>SCSI Controller</rasd:Description>
+                    <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>2</rasd:InstanceID>
+                    <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+                    <rasd:ResourceType>6</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="160"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:Description>Hard disk</rasd:Description>
+                    <rasd:ElementName>Hard disk 1</rasd:ElementName>
+                    <rasd:HostResource vcloud:capacity="40960" vcloud:busSubType="lsilogicsas" vcloud:busType="6"/>
+                    <rasd:InstanceID>2000</rasd:InstanceID>
+                    <rasd:Parent>2</rasd:Parent>
+                    <rasd:ResourceType>17</rasd:ResourceType>
+                    <rasd:VirtualQuantity>42949672960</rasd:VirtualQuantity>
+                    <rasd:VirtualQuantityUnits>byte</rasd:VirtualQuantityUnits>
+                    <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:Address>0</rasd:Address>
+                    <rasd:Description>SATA Controller</rasd:Description>
+                    <rasd:ElementName>SATA Controller 0</rasd:ElementName>
+                    <rasd:InstanceID>3</rasd:InstanceID>
+                    <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
+                    <rasd:ResourceType>20</rasd:ResourceType>
+                    <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="33"/>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>CD/DVD Drive</rasd:Description>
+                    <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>16000</rasd:InstanceID>
+                    <rasd:Parent>3</rasd:Parent>
+                    <rasd:ResourceType>15</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AddressOnParent>0</rasd:AddressOnParent>
+                    <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+                    <rasd:Description>Floppy Drive</rasd:Description>
+                    <rasd:ElementName>Floppy Drive 1</rasd:ElementName>
+                    <rasd:HostResource/>
+                    <rasd:InstanceID>8000</rasd:InstanceID>
+                    <rasd:ResourceType>14</rasd:ResourceType>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+                    <rasd:Description>Number of Virtual CPUs</rasd:Description>
+                    <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+                    <rasd:InstanceID>4</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>3</rasd:ResourceType>
+                    <rasd:VirtualQuantity>2</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <ovf:Item>
+                    <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+                    <rasd:Description>Memory Size</rasd:Description>
+                    <rasd:ElementName>4096 MB of memory</rasd:ElementName>
+                    <rasd:InstanceID>5</rasd:InstanceID>
+                    <rasd:Reservation>0</rasd:Reservation>
+                    <rasd:ResourceType>4</rasd:ResourceType>
+                    <rasd:VirtualQuantity>4096</rasd:VirtualQuantity>
+                    <rasd:Weight>0</rasd:Weight>
+                </ovf:Item>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="virtualSMCPresent" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="nestedHVEnabled" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.powerOffType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.resetType" vmw:value="soft"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.standbyAction" vmw:value="checkpoint"/>
+                <vmw:Config ovf:required="false" vmw:key="powerOpInfo.suspendType" vmw:value="hard"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestShutdown" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.beforeGuestStandby" vmw:value="true"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
+                <vmw:Config ovf:required="false" vmw:key="tools.toolsUpgradePolicy" vmw:value="manual"/>
+                <vmw:Config ovf:required="false" vmw:key="uuid" vmw:value="4204a04c-cb69-b862-2a14-5d573643bf78"/>
+            </ovf:VirtualHardwareSection>
+            <vcloud:GuestCustomizationSection ovf:required="false">
+                <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+                <vcloud:Enabled>true</vcloud:Enabled>
+                <vcloud:ChangeSid>false</vcloud:ChangeSid>
+                <vcloud:VirtualMachineId>04f85cca-3f8d-43b4-8473-7aa099f95c1b</vcloud:VirtualMachineId>
+                <vcloud:JoinDomainEnabled>false</vcloud:JoinDomainEnabled>
+                <vcloud:UseOrgSettings>false</vcloud:UseOrgSettings>
+                <vcloud:AdminPasswordEnabled>false</vcloud:AdminPasswordEnabled>
+                <vcloud:AdminPasswordAuto>true</vcloud:AdminPasswordAuto>
+                <vcloud:ResetPasswordRequired>false</vcloud:ResetPasswordRequired>
+                <vcloud:ComputerName>VM2</vcloud:ComputerName>
+            </vcloud:GuestCustomizationSection>
+            <vcloud:NetworkConnectionSection ovf:required="false">
+                <ovf:Info>Specifies the available VM network connections</ovf:Info>
+                <vcloud:PrimaryNetworkConnectionIndex>0</vcloud:PrimaryNetworkConnectionIndex>
+                <vcloud:NetworkConnection needsCustomization="true" network="none">
+                    <vcloud:NetworkConnectionIndex>0</vcloud:NetworkConnectionIndex>
+                    <vcloud:IsConnected>false</vcloud:IsConnected>
+                    <vcloud:MACAddress>00:50:56:01:00:4c</vcloud:MACAddress>
+                    <vcloud:IpAddressAllocationMode>NONE</vcloud:IpAddressAllocationMode>
+                </vcloud:NetworkConnection>
+            </vcloud:NetworkConnectionSection>
+        </ovf:VirtualSystem>
+    </ovf:VirtualSystemCollection>
+</ovf:Envelope>

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_stack_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack do
   let(:ems) { FactoryGirl.create(:ems_vmware_cloud) }
-  let(:template) { FactoryGirl.create(:orchestration_template_vmware_cloud) }
+  let(:template) { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
   let(:orchestration_stack) do
     FactoryGirl.create(:orchestration_stack_vmware_cloud,
                        :ext_management_system => ems,

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
@@ -1,0 +1,27 @@
+describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
+  describe ".eligible_manager_types" do
+    it "lists the classes of eligible managers" do
+      ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.eligible_manager_types.each do |klass|
+        expect(klass <= ManageIQ::Providers::Vmware::CloudManager).to be_truthy
+      end
+    end
+  end
+
+  let(:valid_template) { FactoryGirl.create(:orchestration_template_vmware_cloud) }
+
+  describe '#validate_format' do
+    it 'passes validation if no content' do
+      template = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.new
+      expect(template.validate_format).to be_nil
+    end
+
+    it 'passes validation with correct OVF content' do
+      expect(valid_template.validate_format).to be_nil
+    end
+
+    it 'fails validations with incorrect OVF content' do
+      template = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.new(:content => "Invalid String")
+      expect(template.validate_format).not_to be_nil
+    end
+  end
+end

--- a/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
+++ b/spec/models/manageiq/providers/vmware/cloud_manager/orchestration_template_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate do
     end
   end
 
-  let(:valid_template) { FactoryGirl.create(:orchestration_template_vmware_cloud) }
+  let(:valid_template) { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
 
   describe '#validate_format' do
     it 'passes validation if no content' do

--- a/spec/presenters/tree_node_builder_spec.rb
+++ b/spec/presenters/tree_node_builder_spec.rb
@@ -775,7 +775,7 @@ describe TreeNodeBuilder do
     end
 
     it "ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate node" do
-      template = FactoryGirl.build(:orchestration_template_vmware_cloud)
+      template = FactoryGirl.build(:orchestration_template_vmware_cloud_with_content)
       node = TreeNodeBuilder.build(template, nil, {})
       expect(node).to eq(
         :key    => "-#{template.name}",

--- a/spec/services/orchestration_template_dialog_service_spec.rb
+++ b/spec/services/orchestration_template_dialog_service_spec.rb
@@ -3,7 +3,7 @@ describe OrchestrationTemplateDialogService do
   let(:template_hot)   { FactoryGirl.create(:orchestration_template_hot_with_content) }
   let(:template_azure) { FactoryGirl.create(:orchestration_template_azure_with_content) }
   let(:empty_template) { FactoryGirl.create(:orchestration_template_cfn) }
-  let(:template_vapp)  { FactoryGirl.create(:orchestration_template_vmware_cloud) }
+  let(:template_vapp)  { FactoryGirl.create(:orchestration_template_vmware_cloud_with_content) }
 
   describe "#create_dialog" do
     it "creates a dialog from hot template with stack basic info and parameters" do


### PR DESCRIPTION
Fixed adding vApp template. 
Bug description: https://bugzilla.redhat.com/show_bug.cgi?id=1389156

Added missing validate_format method for ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate