### PR TITLE
Run a cockpit-ws as a worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ bin/*
 
 # config/
 config/apache
+config/cockpit
 config/database.yml*
 config/cable.yml
 config/vmdb.yml.db

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -81,6 +81,14 @@ class ContainerNode < ApplicationRecord
 
   def cockpit_url
     URI::HTTP.build(:host => kubernetes_hostname, :port => 9090)
+    address = kubernetes_hostname || name
+    miq_server = ext_management_system.nil? ? nil : ext_management_system.zone.remote_cockpit_ws_miq_server
+    if miq_server
+
+    end
+    MiqCockpit::WS.url(miq_server,
+                       MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
+                       address)
   end
 
   def evaluate_alert(_alert_id, _event)

--- a/app/models/miq_cockpit_ws_worker.rb
+++ b/app/models/miq_cockpit_ws_worker.rb
@@ -1,0 +1,61 @@
+require 'miq_apache'
+
+class MiqCockpitWsWorker < MiqWorker
+  require_nested :Runner
+  require_nested :Authenticator
+
+  APACHE_CONF_FILE = '/etc/httpd/conf.d/manageiq-redirects-cockpit'.freeze
+  self.required_roles = ['cockpit_ws']
+  self.maximum_workers_count = 1
+
+  def friendly_name
+    @friendly_name ||= "Cockpit Worker"
+  end
+
+  def self.can_start_cockpit_ws?
+    @supports_cockpit_ws ||= MiqCockpit::WS.can_start_cockpit_ws?
+  end
+
+  def self.should_start_worker?
+    return false unless has_required_role?
+    can_start_cockpit_ws?
+  end
+
+  def self.sync_workers
+    install_apache_proxy_config if MiqEnvironment::Command.supports_apache?
+    @workers = should_start_worker? ? 1 : 0
+    super
+  end
+
+  def self.install_apache_proxy_config
+    config_status = has_required_role?
+
+    # Only restart apache if status has changed
+    if @config_status != config_status
+      @config_status = config_status
+      if config_status
+        MiqCockpit::ApacheConfig.new(MiqCockpitWsWorker.worker_settings).save(APACHE_CONF_FILE)
+      elsif File.exist?(APACHE_CONF_FILE)
+        File.truncate(APACHE_CONF_FILE, 0)
+      end
+      MiqServer.my_server.queue_restart_apache
+    end
+  end
+
+  def kill
+    pid = Process.pid
+    Sys::ProcTable.ps.each do |process_struct|
+      next unless process_struct.ppid == pid
+      begin
+        _log.info("#{format_full_log_msg} -- killing child process: PID [#{process_struct.pid}]")
+        Process.kill(9, child_pid)
+      rescue Errno::ESRCH
+        _log.info("#{format_full_log_msg} -- child process with PID [#{process_struct.pid}] has been killed")
+      rescue => err
+        _log.info("#{format_full_log_msg} -- child process with PID [#{process_struct.pid}] has been killed, but with the following error: #{err}")
+      end
+    end
+
+    super
+  end
+end

--- a/app/models/miq_cockpit_ws_worker/authenticator.rb
+++ b/app/models/miq_cockpit_ws_worker/authenticator.rb
@@ -1,0 +1,67 @@
+module MiqCockpitWsWorker::Authenticator
+  def self.authenticate_for_host(token, host)
+    user_obj = user_for_token(token)
+    return {} unless user_obj
+
+    # is it a container deployment
+    creds = find_container_node_creds(user_obj, host)
+
+    # Is it a VM
+    creds = find_vm_creds(user_obj, host) if creds.nil?
+
+    {
+      :valid  => true,
+      :known  => !creds.nil?,
+      :key    => creds.try(:auth_key),
+      :userid => creds.try(:userid)
+    }
+  end
+
+  def self.ssh_command
+    MiqCockpit::WS::COCKPIT_SSH_PATH
+  end
+
+  # TODO: Do we need more user based permissions checks?
+  def find_container_node_creds(user_obj, host_or_ip)
+    raise "Looking up container nodes requires a valid user" unless user_obj
+    cdn_table = ContainerDeploymentNode.arel_table
+    cond = cdn_table[:name].eq(host_or_ip).or(cdn_table[:address].eq host_or_ip)
+    deployment = ContainerDeployment.joins(:container_deployment_nodes).find_by(cond)
+
+    if deployment
+      return deployment.ssh_auth ? deployment.ssh_auth : Authentication.new
+    elsif ContainerNode.exists?(:name => host_or_ip)
+      return Authentication.new
+    end
+  end
+
+  def creds_for_vm(vm)
+    return nil unless vm
+    creds = vm.container_deployment.nil? ? nil : vm.container_deployment.ssh_auth
+    creds = vm.respond_to?(:key_pairs) ? vm.key_pairs.first : nil unless creds
+    creds ? creds : Authentication.new
+  end
+
+  def find_vm(host_or_ip)
+    vms = Vm.find_all_by_mac_address_and_hostname_and_ipaddress(nil, nil, host_or_ip)
+    vms = Vm.find_all_by_mac_address_and_hostname_and_ipaddress(nil, host_or_ip, nil) unless vms.length == 1
+    vms.length == 1 ? vms[0] : nil
+  end
+
+  def find_vm_creds(user_obj, host_or_ip)
+    raise "Looking up VMs requires a valid user" unless user_obj
+    vm = find_vm(host_or_ip)
+    creds_for_vm(vm)
+  end
+
+  def user_for_token(token)
+    mgr = Api::Environment.user_token_service.token_mgr('api')
+    if mgr.token_valid?(token)
+      userid = mgr.token_get_info(token, :userid)
+      user_obj = User.find_by(:userid => userid)
+    end
+    user_obj
+  end
+
+  module_function :find_container_node_creds, :creds_for_vm, :find_vm, :find_vm_creds, :user_for_token
+end

--- a/app/models/miq_cockpit_ws_worker/runner.rb
+++ b/app/models/miq_cockpit_ws_worker/runner.rb
@@ -1,0 +1,182 @@
+class MiqCockpitWsWorker::Runner < MiqWorker::Runner
+  BINDING_ADDRESS = ENV['BINDING_ADDRESS'] || (Rails.env.production? ? "127.0.0.1" : "0.0.0.0")
+
+  def find_pids(cmd)
+    pids = Set.new
+    Sys::ProcTable.ps.each do |process_struct|
+      pids << process_struct.pid if cmd =~ (process_struct.try(:cmdline) || "")
+    end
+    pids
+  end
+
+  def do_before_work_loop
+    stop_active_cockpit_ws_processes
+    start_drb_service
+    start_cockpit_ws
+  end
+
+  def do_work
+    check_cockpit_ws
+  end
+
+  def before_exit(_message, _exit_code)
+    stop_cockpit_ws
+    stop_drb_service
+  end
+
+  def check_cockpit_ws
+    if cockpit_ws_alive?
+      begin
+        errbuf = @stderr.readpartial(1.megabyte) if @stderr && @stderr.ready?
+        outbuf = @stdout.readpartial(1.megabyte) if @stdout && @stdout.ready?
+      rescue EOFError
+        _log.info("#{log_prefix} got EOF process exiting")
+      end
+      outbuf.split("\n").each { |msg| $log.info  "cockpit-ws: #{msg.rstrip}" } if outbuf
+      errbuf.split("\n").each { |msg| $log.error "cockpit-ws: #{msg.rstrip}" } if errbuf
+    else
+      _log.info("#{log_prefix} Cockpit-ws Process gone. Restarting...")
+      start_cockpit_ws
+    end
+  end
+
+  def start_cockpit_ws
+    raise _("Cannot call start_cockpit_ws if a process already exists") if cockpit_ws_alive?
+    _log.info("#{log_prefix} Starting cockpit-ws Process")
+    start_cockpit_ws_process
+    _log.info("#{log_prefix} Started cockpit-ws Process")
+  end
+
+  def start_cockpit_ws_process
+    @pid, @stdout, @stderr = cockpit_ws_run
+  rescue => err
+    @stdout.close if @stdout
+    @stderr.close if @stderr
+    _log.error("#{log_prefix} cockpit-ws Process aborted because [#{err.message}]")
+    _log.log_backtrace(err)
+  end
+
+  def stop_cockpit_ws
+    if cockpit_ws_alive?
+      _log.info("#{log_prefix} Shutting down cockpit-ws process...pid=#{@pid}")
+      stop_cockpit_ws_process
+      _log.info("#{log_prefix} Shutting down cockpit-ws process...Complete")
+    end
+  end
+
+  def stop_cockpit_ws_process
+    return unless @pid
+    Process.kill("TERM", @pid)
+    wait_on_cockpit_ws
+  end
+
+  # Waits for a cockpit-ws process to stop.  The process is expected to be
+  #   in the act of shutting down, and thus it will wait 5 minutes
+  #   before issuing a kill.
+  def wait_on_cockpit_ws(pid)
+    pid ||= @pid
+    # TODO: Use Process.waitpid or one of its async variants
+    begin
+      Timeout.timeout(5.minutes.to_i) do
+        loop do
+          break unless process_alive?(pid)
+          sleep 1
+          heartbeat
+        end
+      end
+    rescue Timeout::Error
+      _log.info("#{log_prefix} Killing cockpit-ws process with pid=#{pid}")
+      Process.kill(9, pid)
+    end
+
+    begin
+      _, status = Process.waitpid2(pid)
+      _log.info("#{log_prefix} cockpit-ws Process with pid=#{pid} exited with a status=#{status}")
+    rescue Errno::ECHILD
+      _log.info("#{log_prefix} cockpit-ws Process with pid=#{pid} exited")
+    end
+
+    reset_process_info
+  end
+
+  def reset_process_info
+    @pid = @stdout = @stderr = nil
+  end
+
+  def find_cockpit_ws_processes
+    find_pids(/cockpit-ws --port/)
+  end
+
+  def stop_active_cockpit_ws_processes
+    find_cockpit_ws_processes.each do |pid|
+      _log.info("#{log_prefix} Killing active cockpit-ws process with pid=#{pid}")
+      Process.kill("TERM", pid)
+      wait_on_cockpit_ws(pid)
+    end
+  end
+
+  def cockpit_ws_alive?
+    if process_alive?(@pid)
+      true
+    else
+      reset_process_info
+      false
+    end
+  end
+
+  def process_alive?(pid)
+    return false if pid.nil?
+    process_struct = Sys::ProcTable.ps(pid)
+    return false if process_struct.nil?
+    return true if process_struct.state != "Z"
+
+    _log.info("#{log_prefix} waiting to die")
+    zombie_pid, status = Process.waitpid2(pid)
+    _log.info("#{log_prefix} cockpit-ws Process with pid=#{zombie_pid} exited with a status=#{status}")
+    false
+  end
+
+  def cockpit_ws_run
+    _log.info("#{log_prefix} cockpit-ws process starting")
+
+    opts = @worker_settings
+    cockpit_ws = MiqCockpit::WS.new(opts)
+    cockpit_ws.save_config
+
+    require 'open4'
+    env = {
+      "XDG_CONFIG_DIRS" => cockpit_ws.config_dir,
+      "DRB_URI"         => @drb_uri
+    }
+    pid, stdin, stdout, stderr = Open4.popen4(env, *cockpit_ws.command(BINDING_ADDRESS))
+    stdin.close
+
+    _log.info("#{log_prefix} cockpit-ws process started - pid=#{pid}")
+    return pid, stdout, stderr
+  end
+
+  def check_drb_service
+    alive = @drb_server ? @drb_server.alive? : false
+    unless alive
+      start_drb_service
+    end
+  end
+
+  def start_drb_service
+    require 'drb'
+    require 'drb/acl'
+
+    stop_drb_service
+    acl = ACL.new(%w(deny all allow 127.0.0.1/32))
+    @drb_server = DRb::DRbServer.new(@drb_uri || "druby://127.0.0.1:0",
+                                     MiqCockpitWsWorker::Authenticator, acl)
+    @drb_uri = @drb_server.uri
+    _log.info("#{log_prefix} Started drb Process at #{@drb_uri}")
+  end
+
+  def stop_drb_service
+    @drb_server.stop_service if @drb_server
+    @drb_server = nil
+    _log.info("#{log_prefix} stopped drb Process at #{@drb_uri}")
+  end
+end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -88,6 +88,7 @@ module MiqServer::EnvironmentManagement
       MiqUiWorker.install_apache_proxy_config
       MiqWebServiceWorker.install_apache_proxy_config
       MiqWebsocketWorker.install_apache_proxy_config
+      MiqCockpitWsWorker.install_apache_proxy_config
 
       # Because adding balancer members does a validation of the configuration
       # files and these files try to load the redirect files among others,

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -1,7 +1,7 @@
 module MiqServer::RoleManagement
   extend ActiveSupport::Concern
 
-  ROLES_NEEDING_APACHE = %w(user_interface web_services websocket embedded_ansible).freeze
+  ROLES_NEEDING_APACHE = %w(user_interface web_services websocket embedded_ansible cockpit_ws).freeze
 
   included do
     has_many :assigned_server_roles, :dependent => :destroy
@@ -46,6 +46,7 @@ module MiqServer::RoleManagement
     self.has_active_userinterface = self.has_active_role?("user_interface")
     self.has_active_websocket     = self.has_active_role?("websocket")
     self.has_active_webservices   = self.has_active_role?("web_services")
+    self.has_active_cockpit_ws    = self.has_active_role?("cockpit_ws")
     save
   end
 

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -74,6 +74,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     MiqVimBrokerWorker
     MiqVmdbStorageBridgeWorker
     MiqWebServiceWorker
+    MiqCockpitWsWorker
   ).freeze
 
   MONITOR_CLASS_NAMES_IN_KILL_ORDER = %w(
@@ -149,6 +150,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher
     MiqUiWorker
     MiqWebsocketWorker
+    MiqCockpitWsWorker
   ).freeze
 
   module ClassMethods

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -14,7 +14,11 @@ module Vm::Operations
   end
 
   def cockpit_url
-    URI::HTTP.build(:host => ipaddresses.first, :port => 9090).to_s
+    return if ipaddresses.blank?
+    miq_server = ext_management_system.nil? ? nil : ext_management_system.zone.remote_cockpit_ws_miq_server
+    MiqCockpit::WS.url(miq_server,
+                       MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
+                       ipaddresses.first)
   end
 
   def validate_collect_running_processes

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -82,6 +82,10 @@ class Zone < ApplicationRecord
     find_by(:name => "default")
   end
 
+  def remote_cockpit_ws_miq_server
+    role_active?("cockpit_ws") ? miq_servers.find_by(:has_active_cockpit_ws => true) : nil
+  end
+
   # The zone to use when inserting a record into MiqQueue
   def self.determine_queue_zone(options)
     if options.key?(:zone)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1358,3 +1358,5 @@
        :connection_pool_size: 14
        :memory_threshold: 1.gigabytes
        :nice_delta: 1
+    :cockpit_ws_worker:
+        :count: 1

--- a/db/fixtures/server_roles.csv
+++ b/db/fixtures/server_roles.csv
@@ -1,5 +1,6 @@
 name,description,max_concurrent,external_failover,role_scope
 automate,Automation Engine,0,false,region
+cockpit_ws,Cockpit,1,false,zone
 database_operations,Database Operations,0,false,region
 database_owner,Database Owner,1,false,database
 embedded_ansible,Embedded Ansible,1,false,region

--- a/db/migrate/20170516230854_cockpit_ws.rb
+++ b/db/migrate/20170516230854_cockpit_ws.rb
@@ -1,0 +1,5 @@
+class CockpitWs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :miq_servers, :has_active_cockpit_ws, :boolean
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5270,6 +5270,7 @@ miq_servers:
 - system_memory_used
 - system_swap_free
 - system_swap_used
+- has_active_cockpit_ws
 miq_sets:
 - id
 - name

--- a/lib/miq_cockpit.rb
+++ b/lib/miq_cockpit.rb
@@ -1,0 +1,194 @@
+require 'uri'
+require 'awesome_spawn'
+
+module MiqCockpit
+  class WS
+    DEFAULT_PORT = 9002
+
+    # Used when the cockpit-ws worker is not enabled
+    COCKPIT_PUBLIC_PORT = 9090
+
+    MIQ_REDIRECT_URL = "/dashboard/cockpit_redirect".freeze
+    COCKPIT_WS_PATH = '/usr/libexec/cockpit-ws'.freeze
+    COCKPIT_SSH_PATH = '/usr/libexec/cockpit-ssh'.freeze
+
+    attr_accessor :config_dir, :cockpit_dir
+
+    def self.can_start_cockpit_ws?
+      MiqEnvironment::Command.is_linux? &&
+        File.exist?(COCKPIT_WS_PATH) &&
+        File.exist?(COCKPIT_SSH_PATH)
+    end
+
+    def self.direct_url(address)
+      URI::HTTP.build(:host => address,
+                      :port => MiqCockpit::WS::COCKPIT_PUBLIC_PORT)
+    end
+
+    def self.server_address(miq_server)
+      address = miq_server.ipaddress
+      if miq_server.hostname && (::Settings.webservices.contactwith == 'hostname' || !address)
+        address = miq_server.hostname
+      end
+      address
+    end
+
+    def self.current_ui_server?(miq_server)
+      return false unless MiqServer.my_server == miq_server
+      miq_server.has_active_userinterface
+    end
+
+    def self.url_from_server(miq_server, opts)
+      opts ||= {}
+
+      # Assume we are using apache unless we are the only server
+      has_apache = current_ui_server?(miq_server) ? MiqEnvironment::Command.supports_apache? : true
+      cls = has_apache ? URI::HTTPS : URI::HTTP
+      cls.build(:host => server_address(miq_server),
+                :port => has_apache ? nil : opts[:port] || DEFAULT_PORT,
+                :path => MiqCockpit::ApacheConfig.url_root)
+    end
+
+    def self.url(miq_server, opts, address)
+      return MiqCockpit::WS.direct_url(address) if miq_server.nil?
+
+      opts ||= {}
+      url = if opts[:external_url]
+              URI.parse(opts[:external_url])
+            else
+              url_from_server(miq_server, opts)
+            end
+
+      # Make sure we have a path that ends in a /
+      url.path = MiqCockpit::ApacheConfig.url_root if url.path.empty?
+      url.path = "#{url.path}/" unless url.path.end_with?("/")
+
+      # Add address to path if needed, note this is a path
+      # not a querystring
+      url.path = "#{url.path}=#{address}" if address
+      url
+    end
+
+    def initialize(opts = {})
+      @opts = opts || {}
+      @config_dir = File.join(__dir__, "..", "config")
+      @cockpit_conf_dir = File.join(@config_dir, "cockpit")
+      FileUtils.mkdir_p(@cockpit_conf_dir)
+    end
+
+    def command(address)
+      args = { :port => @opts[:port] || DEFAULT_PORT.to_s }
+      if address
+        args[:address] = address
+      end
+      args[:no_tls] = nil
+
+      AwesomeSpawn.build_command_line(COCKPIT_WS_PATH, args)
+    end
+
+    def save_config
+      fname = File.join(@cockpit_conf_dir, "cockpit.conf")
+      update_config
+      File.write(fname, @config)
+    end
+
+    def web_ui_url
+      if @opts[:web_ui_url]
+        url = URI.parse(@opts[:web_ui_url])
+      else
+        server = MiqRegion.my_region.nil? ? nil : MiqRegion.my_region.remote_ui_miq_server
+        unless server.nil?
+          opts = { :port => 3000 }
+          url = MiqCockpit::WS.url_from_server(server, opts)
+        end
+      end
+      if url.nil?
+        ret = MiqCockpit::WS::MIQ_REDIRECT_URL
+      else
+        # Force the dashboard redirect path
+        url.path = MiqCockpit::WS::MIQ_REDIRECT_URL
+        ret = url.to_s
+      end
+      ret
+    end
+
+    def update_config
+      title = @opts[:title] || "ManageIQ Cockpit"
+
+      login_command = Rails.root.join("tools", "cockpit", "cockpit-auth-miq")
+
+      @config = <<-END_OF_CONFIG
+[Webservice]
+LoginTitle = #{title}
+UrlRoot = #{MiqCockpit::ApacheConfig::URL_ROOT}
+ProtocolHeader = X-Forwarded-Proto
+
+[Negotiate]
+Action = none
+
+[Basic]
+Action = none
+
+[Bearer]
+Action = remote-login-ssh
+
+[SSH-Login]
+command = #{login_command}
+authFD=10
+
+[OAuth]
+Url = #{web_ui_url}
+
+END_OF_CONFIG
+      @config
+    end
+
+    def setup_ssl
+      dir = File.join(@cockpit_conf_dir, "ws-certs.d")
+      FileUtils.mkdir_p(dir)
+      cert = File.open('certs/server.cer') { |f| OpenSSL::X509::Certificate.new(f).to_pem }
+      key = File.open('certs/server.cer.key') { |f| OpenSSL::PKey::RSA.new(f).to_pem }
+      contents = [cert, key].join("\n")
+      File.write(File.join(dir, "0-miq.cert"), contents)
+    end
+  end
+
+  class ApacheConfig
+    URL_ROOT = "cws".freeze
+
+    def self.url_root
+      "/#{URL_ROOT}/"
+    end
+
+    def initialize(opts = {})
+      @opts = opts || {}
+      update
+    end
+
+    def save(fname)
+      File.write(fname, @config)
+    end
+
+    def update
+      url = URI::HTTP.build(:host => "localhost",
+                            :port => @opts[:port] || WS::DEFAULT_PORT,
+                            :path => MiqCockpit::ApacheConfig.url_root)
+      http_url = url.to_s
+      url.scheme = "ws"
+      ws_url = url.to_s
+
+      @config = <<-END_OF_CONFIG
+    ProxyPreserveHost on
+    RequestHeader unset X-Forwarded-Proto
+    RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
+
+    <LocationMatch "^#{MiqCockpit::ApacheConfig.url_root}cockpi(t[^/]+|t)?/socket$">
+        ProxyPassMatch "#{ws_url}cockpi$1/socket"
+    </LocationMatch>
+
+    ProxyPass #{ApacheConfig.url_root} #{http_url}
+END_OF_CONFIG
+      @config
+    end
+  end
+end

--- a/spec/lib/miq_cockpit_spec.rb
+++ b/spec/lib/miq_cockpit_spec.rb
@@ -1,0 +1,177 @@
+describe MiqCockpit::WS do
+  before(:each) do
+    @server = FactoryGirl.create(:miq_server, :hostname => "hostname")
+    @miq_server = EvmSpecHelper.local_miq_server
+    @miq_server.ipaddress = "10.0.0.1"
+    @miq_server.has_active_userinterface = true
+  end
+
+  describe '#url' do
+    context "when using empty server" do
+      it "it uses direct url" do
+        expected = URI::HTTP.build(:host => "default-host",
+                                   :port => 9090,
+                                   :path => "/")
+        expect(MiqCockpit::WS.url(nil, nil, "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using empty opts" do
+      it "it uses defaults with apache" do
+        expected = URI::HTTPS.build(:host => "hostname",
+                                    :path => "/cws/=default-host")
+        expect(MiqCockpit::WS.url(@server, nil, "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using external_host with path" do
+      it "it uses it and preserves the path " do
+        expected = URI::HTTPS.build(:host => "custom-host",
+                                    :path => "/custom-path/=default-host")
+        expect(MiqCockpit::WS.url(@server,
+                                  {:external_url => "https://custom-host/custom-path"},
+                                  "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using external_host without path" do
+      it "it uses it with default path " do
+        expected = URI::HTTP.build(:host => "custom-host",
+                                   :path => "/cws/=default-host")
+        expect(MiqCockpit::WS.url(@server,
+                                  {:external_url => "http://custom-host"},
+                                  "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using the same server as the ui without apache" do
+      it "it uses defaults with apache" do
+        expected = URI::HTTP.build(:host => "10.0.0.1",
+                                   :port => 9002,
+                                   :path => "/cws/=default-host")
+        expect(MiqCockpit::WS.url(@miq_server, nil, "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using the same server as the ui with apache" do
+      it "it uses defaults with apache" do
+        expect(MiqEnvironment::Command).to receive(:is_appliance?).once.and_return(true)
+        expect(MiqEnvironment::Command).to receive(:supports_command?).once.and_return(true)
+        expected = URI::HTTPS.build(:host => "10.0.0.1",
+                                    :path => "/cws/=default-host")
+        expect(MiqCockpit::WS.url(@miq_server, nil, "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using custom port with apache" do
+      it "it uses https without port" do
+        expected = URI::HTTPS.build(:host => "hostname",
+                                    :path => "/cws/=default-host")
+        expect(MiqCockpit::WS.url(@server,
+                                  { :port => 8080 },
+                                  "default-host")).to eq(expected)
+      end
+    end
+
+    context "when using custom port with the same server without apache" do
+      it "it uses the port" do
+        with_port = URI::HTTP.build(:host => "10.0.0.1",
+                                    :port => 8080,
+                                    :path => "/cws/=default-host")
+        expect(MiqCockpit::WS.url(@miq_server,
+                                  { :port => 8080 },
+                                  "default-host")).to eq(with_port)
+      end
+    end
+  end
+
+  describe 'command' do
+    context "when using empty opts" do
+      it "it uses defaults" do
+        ins = MiqCockpit::WS.new
+        default_cmd = "#{MiqCockpit::WS::COCKPIT_WS_PATH} --port 9002 --address 127.0.0.1 --no-tls"
+        expect(ins.command("127.0.0.1")).to eq(default_cmd)
+      end
+    end
+
+    context "when using custom port" do
+      it "it sets command arguments" do
+        ins = MiqCockpit::WS.new(:port => "8000")
+        cmd = "#{MiqCockpit::WS::COCKPIT_WS_PATH} --port 8000 --no-tls"
+        expect(ins.command(nil)).to eq(cmd)
+      end
+    end
+  end
+
+  describe 'update_config' do
+    before(:each) do
+      @login_command = Rails.root.join("tools", "cockpit", "cockpit-auth-miq")
+    end
+
+    context "when using empty opts" do
+      it "it uses defaults" do
+        ins = MiqCockpit::WS.new(nil)
+        config = ins.update_config
+        expect(config).to include("\n[SSH-Login]\ncommand = #{@login_command}\n")
+        expect(config).to include("\n[Basic]\nAction = none\n")
+        expect(config).to include("\n[Negotiate]\nAction = none\n")
+        expect(config).to include("\nLoginTitle = ManageIQ Cockpit\n")
+        expect(config).to include("\nUrlRoot = cws\n")
+        expect(config).to include("\n[Bearer]\nAction = remote-login-ssh\n")
+        expect(config).to include("\n[OAuth]\nUrl = /dashboard/cockpit_redirect\n")
+      end
+    end
+
+    context "when using a active region" do
+      it "it uses the full domain for the url" do
+        MiqRegion.seed
+        server = FactoryGirl.create(:miq_server, :hostname => "hostname")
+        expect(MiqRegion.my_region).to receive(:remote_ui_miq_server).once.and_return(server)
+
+        ins = MiqCockpit::WS.new(nil)
+        config = ins.update_config
+        expect(config).to include("\n[OAuth]\nUrl = https://hostname/dashboard/cockpit_redirect\n")
+      end
+    end
+
+    context "when options are set" do
+      it "it uses them" do
+        ins = MiqCockpit::WS.new(:title      => "Custom Title",
+                                 :web_ui_url => "https://custom.url/")
+        config = ins.update_config
+        expect(config).to include("\nLoginTitle = Custom Title\n")
+        expect(config).to include("\n[OAuth]\nUrl = https://custom.url/dashboard/cockpit_redirect\n")
+      end
+    end
+  end
+end
+
+describe MiqCockpit::ApacheConfig do
+  describe '#url_root' do
+    context "always" do
+      it "returns" do
+        expect(MiqCockpit::ApacheConfig.url_root).to eq("/cws/")
+      end
+    end
+  end
+
+  describe 'update' do
+    context "when using defaults" do
+      it "it uses http and ws" do
+        ins = MiqCockpit::ApacheConfig.new(nil)
+        config = ins.update
+        expect(config).to include("ProxyPass /cws/ http://localhost:9002/cws/")
+        expect(config).to include('ProxyPassMatch "ws://localhost:9002/cws/cockpi$1/socket"')
+      end
+    end
+
+    context "when using custom port" do
+      it "it uses custom port" do
+        ins = MiqCockpit::ApacheConfig.new(:port => 9001)
+        config = ins.update
+        expect(config).to include("ProxyPass /cws/ http://localhost:9001/cws/")
+        expect(config).to include('ProxyPassMatch "ws://localhost:9001/cws/cockpi$1/socket"')
+      end
+    end
+  end
+end

--- a/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
+++ b/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
@@ -1,0 +1,108 @@
+describe MiqCockpitWsWorker::Authenticator do
+  describe '#authenticate_for_host' do
+    before(:each) do
+      @auth = MiqCockpitWsWorker::Authenticator
+      @user = FactoryGirl.create(:user, :userid => 1)
+      @token = Api::Environment.user_token_service.generate_token(1, "api")
+    end
+
+    context "when using bad token" do
+      it "fails to authenticate" do
+        expect(@auth.authenticate_for_host("bad", "host")).to eq({})
+      end
+    end
+
+    context "when host is" do
+      before do
+        @hardware = FactoryGirl.create(:hardware)
+        @vm = FactoryGirl.create(:vm_openstack, :hardware => @hardware)
+        @hardware.networks << FactoryGirl.create(:network, :ipaddress => "10.0.0.1", :hostname => "vm-host1")
+        @hardware.networks << FactoryGirl.create(:network, :ipaddress => "10.0.0.2", :hostname => "vm-host2")
+        @container_deployment = FactoryGirl.create(:container_deployment,
+                                                   :method_type => "non_managed",
+                                                   :version     => "v2",
+                                                   :kind        => "openshift-enterprise")
+
+        @vmkey = "-----BEGIN RSA PRIVATE KEY----- vm-key -----END RSA PRIVATE KEY-----"
+        @deploykey = "-----BEGIN RSA PRIVATE KEY----- deploy-key -----END RSA PRIVATE KEY-----"
+        @found = {
+          :valid  => true,
+          :known  => true,
+          :key    => nil,
+          :userid => nil,
+        }
+
+        @not_found = {
+          :valid  => true,
+          :known  => false,
+          :key    => nil,
+          :userid => nil,
+        }
+      end
+
+      it "not known returns that host is unknown" do
+        expect(@auth.authenticate_for_host(@token, "10.0.0.3")).to eq(@not_found)
+        expect(@auth.authenticate_for_host(@token, "vm-host3")).to eq(@not_found)
+      end
+
+      it "a known vm and has no auth returns that host is known without auth" do
+        expect(@auth.authenticate_for_host(@token, "10.0.0.1")).to eq(@found)
+        expect(@auth.authenticate_for_host(@token, "10.0.0.2")).to eq(@found)
+        expect(@auth.authenticate_for_host(@token, "vm-host1")).to eq(@found)
+        expect(@auth.authenticate_for_host(@token, "vm-host2")).to eq(@found)
+      end
+
+      it "a known vm with a key pair returns that host with auth" do
+        pair = FactoryGirl.create(:auth_key_pair_cloud,
+                                  :userid     => "vm",
+                                  :auth_key   => @vmkey,
+                                  :public_key => "public_key",
+                                  :type       => "AuthPrivateKey")
+        pair.vms << @vm
+      end
+
+      it "a container node name returns known vm with no auth" do
+        FactoryGirl.create(:container_node, :name => "kube-node.name")
+        expect(@auth.authenticate_for_host(@token, "kube-node.name")).to eq(@found)
+      end
+
+      it "a container deployment node address uses container deploy auth" do
+        FactoryGirl.create(:container_deployment_node,
+                           :address              => "cd-node.address",
+                           :container_deployment => @container_deployment)
+
+        expect(@auth.authenticate_for_host(@token, "cd-node.address")).to eq(@found)
+
+        @container_deployment.create_deployment_authentication("userid"     => "root",
+                                                               "auth_key"   => @deploykey,
+                                                               "public_key" => "public_key",
+                                                               "type"       => "AuthPrivateKey")
+
+        expect(@auth.authenticate_for_host(@token, "cd-node.address")).to eq(
+          :valid  => true,
+          :known  => true,
+          :key    => @deploykey,
+          :userid => "root",
+        )
+      end
+
+      it "a container deployment node vm uses container deployment auth" do
+        @container_deployment.create_deployment_authentication("userid"     => "root",
+                                                               "auth_key"   => @deploykey,
+                                                               "public_key" => "public_key",
+                                                               "type"       => "AuthPrivateKey")
+
+        FactoryGirl.create(:container_deployment_node,
+                           :vm                   => @vm,
+                           :container_deployment => @container_deployment)
+
+        expect(@auth.authenticate_for_host(@token, "vm-host1")).to eq(
+          :valid  => true,
+          :known  => true,
+          :key    => @deploykey,
+          :userid => "root",
+        )
+      end
+    end
+  end
+end

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -21,6 +21,7 @@ describe "Server Role Management" do
         user_interface,User Interface,0,false,region
         websocket,Websocket,0,false,region
         web_services,Web Services,0,false,region
+        cockpit_ws,Cockpit,1,false,region
       CSV
       allow(ServerRole).to receive(:seed_data).and_return(@csv)
       MiqRegion.seed
@@ -36,6 +37,11 @@ describe "Server Role Management" do
         expect(@miq_server.apache_needed?).to be_falsey
       end
 
+      it "true with only cockpit_ws active" do
+        allow(@miq_server).to receive_messages(:active_role_names => ["cockpit_ws"])
+        expect(@miq_server.apache_needed?).to be_truthy
+      end
+
       it "true with web_services active" do
         allow(@miq_server).to receive_messages(:active_role_names => ["web_services"])
         expect(@miq_server.apache_needed?).to be_truthy
@@ -43,6 +49,12 @@ describe "Server Role Management" do
 
       it "true with both web_services and user_interface active" do
         allow(@miq_server).to receive_messages(:active_role_names => ["web_services", "user_interface"])
+        expect(@miq_server.apache_needed?).to be_truthy
+      end
+
+      it "true with all three active" do
+        roles = %w("web_services user_interface cockpit_ws")
+        allow(@miq_server).to receive_messages(:active_role_names => roles)
         expect(@miq_server.apache_needed?).to be_truthy
       end
     end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -220,4 +220,29 @@ describe Zone do
       end
     end
   end
+
+  context "ConfigurationManagementMixin" do
+    describe "#remote_cockpit_ws_miq_server" do
+      before(:each) do
+        @csv = <<-CSV.gsub(/^\s+/, "")
+          name,description,max_concurrent,external_failover,role_scope
+          cockpit_ws,Cockpit,1,false,zone
+        CSV
+        allow(ServerRole).to receive(:seed_data).and_return(@csv)
+        ServerRole.seed
+        _, _, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      end
+
+      it "none when not enabled" do
+        expect(@zone.remote_cockpit_ws_miq_server).to eq(nil)
+      end
+
+      it "server when enabled" do
+        server = FactoryGirl.create(:miq_server, :has_active_cockpit_ws => true, :zone => @zone)
+        server.assign_role('cockpit_ws', 1)
+        server.activate_roles('cockpit_ws')
+        expect(@zone.remote_cockpit_ws_miq_server).to eq(server)
+      end
+    end
+  end
 end

--- a/tools/cockpit/cockpit-auth-miq
+++ b/tools/cockpit/cockpit-auth-miq
@@ -1,0 +1,274 @@
+#!/usr/bin/env ruby
+require "net/http"
+require "json"
+require "uri"
+require 'socket'
+require 'drb/drb'
+require 'time'
+require 'base64'
+require 'securerandom'
+
+MAX_AUTH_SIZE = 64 * 1024
+AUTH_FD = 10
+
+def send_auth_command(challenge, response, data)
+  cmd = { "command" => "authorize" }
+  cmd = cmd.merge(data) unless data.nil?
+
+  unless challenge.nil?
+    timestamp = Time.now.to_i
+    pid = Process.pid
+    cmd["cookie"] = "session#{pid}#{timestamp}"
+    cmd["challenge"] = challenge
+  end
+
+  unless response.nil?
+    cmd["response"] = response
+  end
+
+  text = JSON.dump(cmd)
+  size = text.length + 1
+  $stdout.write "#{size}\n\n#{text}"
+  $stdout.flush
+end
+
+def send_problem_init(problem, message, auth_result)
+  cmd = {
+    "command" => "init",
+    "problem" => problem
+  }
+
+  unless message.nil?
+    cmd["message"] = message
+  end
+
+  unless auth_result.nil?
+    cmd["auth-method-results"] = auth_result
+  end
+
+  text = JSON.dump(cmd)
+  size = text.length + 1
+  $stdout.write "#{size}\n\n#{text}"
+  $stdout.flush
+end
+
+def read_size(io)
+  size = 0
+  seen = 0
+
+  while seen < 8
+    t = io.readpartial(1)
+
+    unless t
+      return 0
+    end
+
+    if t == "\n"
+      break
+    end
+
+    if t.to_i.zero? && t != "0"
+      raise ArgumentError "Invalid frame: invalid size"
+    end
+
+    size = (size * 10) + t.to_i
+    seen += 1
+  end
+
+  if seen == 8
+    raise ArgumentError "Invalid frame: size too long"
+  end
+
+  size
+end
+
+def read_frame(fd)
+  io = IO.for_fd(fd)
+  size = read_size(io)
+
+  data = ""
+  while size > 0
+    d = io.readpartial(1)
+    size -= d.length
+    data += d
+  end
+  data
+end
+
+def read_auth_reply
+  data = read_frame(1)
+  cmd = JSON.parse(data)
+  if cmd["command"] != "authorize" || !cmd["cookie"] || !cmd["response"]
+    raise ArgumentError "Did not receive a valid authorize command"
+  end
+
+  cmd["response"]
+end
+
+def fetch_authorize_token
+  send_auth_command("*", nil, nil)
+  begin
+    data = read_auth_reply
+    parts = data.split(' ', 2)
+    token = parts[1]
+  rescue ArgumentError => e
+    send_problem_init("internal-error", e.to_s, nil)
+    raise
+  rescue JSON::ParserError => e
+    send_problem_init("internal-error", e.to_s, nil)
+    raise
+  end
+  token || ""
+end
+
+def launch_ssh_with_auth_fd(ios, ssh_command, host, user, password, key)
+  s1, s2 = UNIXSocket.socketpair(Socket::SOCK_SEQPACKET)
+  s2.syswrite(key ? key : password)
+
+  trap("CHLD", "IGNORE")
+
+  fork do
+    s1.close
+    loop do
+      begin
+        # Read from cockpit-ssh write to cockpit-ws
+        data, _ad = s2.recvfrom(MAX_AUTH_SIZE)
+        break unless data
+        ios.syswrite(data)
+
+        # Read from cockpit-ws write to cockpit-ssh
+        data = ios.readpartial(MAX_AUTH_SIZE)
+        break unless data
+        s2.send(data, 0)
+      rescue IOError
+        break
+      end
+    end
+
+    # Sockets may already be closed
+    begin
+      ios.close
+    rescue IOError
+    end
+
+    begin
+      s2.close
+    rescue IOError
+    end
+  end
+
+  s2.close
+  host = "#{user}@#{host}"
+  env = {
+    "COCKPIT_SSH_ALLOW_UNKNOWN"            => '1',
+    "COCKPIT_SSH_SUPPORTS_HOST_KEY_PROMPT" => '1',
+    "COCKPIT_AUTH_MESSAGE_TYPE"            => key ? 'private-key' : 'password'
+  }
+
+  exec(env, ssh_command, host,
+       3 => s1, 0 => $stdin, 1 => $stdout, 2 => $stderr)
+end
+
+def launch_ssh_with_authorize_cmd(ssh_command, host, user, password, key)
+  env = {
+    "COCKPIT_SSH_ALLOW_UNKNOWN" => '1'
+  }
+
+  host = "#{user}@#{host}"
+
+  auth_data = 'Basic ' + Base64.encode64("#{user}:#{password}").chomp unless password.nil?
+  auth_data = "host-key #{key}" unless key.nil?
+  send_auth_command(nil, auth_data, nil)
+  exec(env, ssh_command, host, 0 => $stdin, 1 => $stdout, 2 => $stderr)
+end
+
+def prompt_for_data(ios, json_req)
+  if ios.nil?
+    prompt = Base64.encode64(json_req['prompt']).chomp
+    id = SecureRandom.uuid
+    send_auth_command("x-conversation #{id} #{prompt}", nil, json_req)
+    data = read_auth_reply
+    parts = data.split(' ', 3)
+    if parts[0].downcase != "x-conversation" || parts[1] != id || !parts[2]
+      send_error(nil,
+                 "error"   => "internal-error",
+                 "message" => "invalid conversation response")
+    end
+    Base64.decode64(parts[2])
+  else
+    ios.syswrite(JSON.dump(json_req))
+    ios.readpartial(MAX_AUTH_SIZE)
+  end
+end
+
+def send_error(ios, error_json)
+  if ios.nil?
+    send_problem_init(error_json["error"], error_json["message"],
+                      error_json["auth-method-results"])
+  else
+    ios.syswrite(json.dump(error_json))
+  end
+  exit 1
+end
+
+def launch_ssh(ios, ssh_command, host, user, password, key)
+  if ios.nil?
+    launch_ssh_with_authorize_cmd(ssh_command, host, user, password, key)
+  else
+    launch_ssh_with_auth_fd(ios, ssh_command, host, user, password, key)
+  end
+end
+
+# Older cockpit-ws versions use a special auth fd
+# for authentication data. Newer versions use the
+# cockpit protocol on stdin/stdout.
+# We want to support both so try to talk AUTH_FD
+# first if that fails switch to stdin/stdout
+host = ARGV[-1]
+begin
+  ios = IO.for_fd(AUTH_FD)
+rescue Errno::EBADF
+  ios = nil
+end
+
+token = fetch_authorize_token if ios.nil?
+token = ios.readpartial(MAX_AUTH_SIZE) unless ios.nil?
+
+begin
+  cockpit_drb = DRbObject.new_with_uri(ENV["DRB_URI"])
+  results = cockpit_drb.authenticate_for_host(token, host)
+  ssh_command = cockpit_drb.ssh_command
+
+  if !results[:valid]
+    send_error(ios,
+               "error"               => "authentication-failed",
+               "message"             => "Token was not valid",
+               "auth-method-results" => { "password" => "not-tried", "token" => "denied" })
+
+  elsif !results[:known]
+    send_error(ios, "error" => "unknown-host")
+  end
+rescue => err
+  send_error(ios,
+             "error"   => "internal-error",
+             "message" => "Couldn't validate token: #{err}")
+end
+
+user = results[:userid]
+password = results[:password]
+key = results[:key]
+
+# Prompt for user if we didn't get one
+unless user
+  user = prompt_for_data(ios,
+                         'prompt'  => 'Please provide a username:',
+                         'echo'    => 1,
+                         'message' => 'Unable to determine the user to connect as.')
+end
+
+# Prompt for password if we didn't get one
+if !password && !key
+  password = prompt_for_data(ios, 'prompt' => 'Password:')
+end
+
+launch_ssh(ios, ssh_command, host, user, password, key)


### PR DESCRIPTION
Cockpit is an interactive linux server admin interface. http://cockpit-project.org/. It is generally pre-packaged for some of the more popular linux distros and can also be built from source (https://github.com/cockpit-project/cockpit)

ManageIQ currently links to cockpit by providing a web interface button. This takes users to https://domain.or.ip:9090. This does not work well for many common setups. Because

1) The target server must be reachable by the end-users machine via the browser. This doesn't work when the target servers are not routeable from the users network or behind firewalls where port 9090 is not exposed publicly.
2) The target server needs to expose a certificate that the user's browser trusts. This can be problematic especially when addressing machines directly by IP. Asking users to accept self-signed certificates is not good practice.

What the PR does is add a cockpit-ws (cockpit webservice) worker. cockpit-ws is a small webserver that handles incoming http and websocket connections and passes messages on their behalf to processes that speak the cockpit protocol  (https://github.com/cockpit-project/cockpit/blob/master/doc/protocol.md). These subprocess are managed by cockpit-ws and are unique per user session and target machine. In this setup they will always be cockpit-ssh. Users browsers communicate with cockpit-ws via http and websockets, if authenticated, those messages and are passed to the remote server using the cockpit-protocol via the ssh connection established by cockpit-ssh and any replies are relayed back to the browser by cockpit-ws. CPU usage is obviously traffic dependent but is generally low. Most the actual work is done on the target server what happens on the appliance is pretty much just message passing.

So the flow works like this. A user clicks that link in the MIQ ui, assuming they are logged in we generate a MIQ access token for them and redirect them to a sub-path. /cockpit-ws/=ip.or.domain#?access-token=token. Apache is configured to proxy requests to that url to cockpit-ws (or the appliance running cockpit-ws) instead of the miq ui worker servers. The cockpit-ws will serve the authentication page, see the token in the url and try to authenticate it by launching the configured authentication process (```tools/cockpit/cockpit-auth-miq```). This command uses drb to pass the received access token and the target server to the cockpit-ws worker. The worker validates that the token is in fact valid and that target server is known to MIQ. Additionally if MIQ already has authentication credentials for the target server those can be passed back as well. cockpit-auth-miq then prompts via the browser for any missing credentials and tries to connect to the target server via ssh by launching cockpit-ssh. If successful, the user will be logged in and can use cockpit on that machine.

The advantages we get by doing things this way are
1) There is only one SSL certificate that needs to be installed and trusted. The one already in use by MIQ.
2) Only the server running MIQ needs to have connectivity to the target machine. The users machine/browser only need to be able to reach MIQ.
3) SSO becomes a possibility.

This worker should be enabled any time you have a deployment where users want to use cockpit. Generally speaking you would only need one server running with this worker. 