### PR TITLE
Fix the link to Infra Provider's VMs and Templates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1017,8 +1017,9 @@ module ApplicationHelper
       check_changes = args[:check_changes] || args[:check_changes].nil?
       tag_attrs[:onclick] = 'return miqCheckForChanges()' if check_changes
       content_tag(:li) do
+        link_args = {:display => args[:display], :vat => args[:vat]}.compact
         if args[:record] && restful_routed?(args[:record])
-          link_to(link_text, polymorphic_path(args[:record], :display => args[:display]), tag_attrs)
+          link_to(link_text, polymorphic_path(args[:record], link_args), tag_attrs)
         else
           link_to(link_text, link_params, tag_attrs)
         end


### PR DESCRIPTION
When user clicked on Relationships list navigation for VMs and Templates, it displayed Clusters.

https://bugzilla.redhat.com/show_bug.cgi?id=1392408