### PR TITLE
Travis JS failures - fail early when bower install fails

### DIFF
--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,2 +1,8 @@
 which bower || npm install -g bower
 bower install --allow-root -F --config.analytics=false
+STATUS=$?
+echo bower exit code: $STATUS
+
+# fail the whole test suite if bower install failed
+[ $STATUS = 0 ] || exit 1
+[ -d vendor/assets/bower_components ] || exit 1


### PR DESCRIPTION
Updating `tools/ci/setup_js_env` to fail the whole test suite if bower install fails.

This should at least make the `vmdb` (and `javascript`, others don't use that script) suite fail early when bower has not succeeded in getting all the dependencies.
