### PR TITLE
Change Region column name on the Cloud Providers list view

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1732,4 +1732,12 @@ module ApplicationHelper
     end
     true
   end
+
+  def translate_header_text(text)
+    if text == "Region"
+      I18n.t("product.name") + " " + _(text)
+    else
+     _(text)
+    end
+  end
 end

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -46,12 +46,13 @@
     %tr
       - grid_hash[:head].each do |h|
         %th{:class => h[:is_narrow] ? 'narrow' : ''}
+          - text = translate_header_text(h[:text])
           - if h[:sort]
             %a{:href => '#',
                :onclick => "miqGridSort(#{h[:col_idx] + 1})"}
-              = _(h[:text])
+              = text
           - else
-            = h[:text]
+            = text
 
           - if @sortcol && @sortcol == h[:col_idx]
             .pull-right


### PR DESCRIPTION
Change ```Region``` column name to ```ManageIQ/CFME Region``` as the Region was confusing for users.
GH issue related to the change: https://github.com/ManageIQ/manageiq/issues/10604

https://bugzilla.redhat.com/show_bug.cgi?id=1371209