### PR TITLE
Fall-"back" to VMRC desktop client if no NPAPI plugin is available

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -115,14 +115,21 @@ module VmCommon
                   :mks_classid => get_vmdb_config[:server][:mks_classid]
                 )
               when "vmrc"
+                host = @record.ext_management_system.ipaddress || @record.ext_management_system.hostname
+                vmid = @record.ems_ref
                 {
-                  :host        => @record.ext_management_system.ipaddress ||
-                                  @record.ext_management_system.hostname,
+                  :host        => host,
                   :vmid        => @record.ems_ref,
                   :ticket      => j(params[:ticket]),
                   :api_version => @record.ext_management_system.api_version.to_s,
                   :os          => browser_info(:os),
-                  :name        => @record.name
+                  :name        => @record.name,
+                  :vmrc_uri    => URI::Generic.build(:scheme   => "vmrc",
+                                                     :userinfo => "clone:#{params[:ticket]}",
+                                                     :host     => host,
+                                                     :port     => 443,
+                                                     :path     => "/",
+                                                     :query    => "moid=#{vmid}")
                 }
               end
     render :template => "vm_common/console_#{console_type}",

--- a/app/views/vm_common/console_vmrc.html.haml
+++ b/app/views/vm_common/console_vmrc.html.haml
@@ -367,35 +367,41 @@
         // Start up VMRC
         vmrc = document.getElementById("vmrc");
 
-        vmNameTooltip = $("#vmNameTooltip");
-        var vmTitle = $("#vmTitle");
+        if (typeof vmrc.isReadyToStart === 'undefined') {
+          window.location.href = "#{j(vmrc_uri.to_s)}";
+          setTimeout(function () { window.close(); }, 8000);
+        } else {
+          vmNameTooltip = $("#vmNameTooltip");
+          var vmTitle = $("#vmTitle");
 
-        // set the title strings on the page
-        document.title = title;
-        vmTitle.text(title);
-        vmNameTooltip.text(title);
+          // set the title strings on the page
+          document.title = title;
+          vmTitle.text(title);
+          vmNameTooltip.text(title);
 
-        // Attach event listeners
-        $(window).resize(onWindowResized);
-        registerButton("fullScreenButton", fullScreen);
-        registerButton("cadButton", sendCAD);
+          // Attach event listeners
+          $(window).resize(onWindowResized);
+          registerButton("fullScreenButton", fullScreen);
+          registerButton("cadButton", sendCAD);
 
-        // Register tool tip
-        $("#vmName").hover(showTooltip, hideTooltip);
-        $("#vmNameTooltip").hover(showTooltip, hideTooltip);
+          // Register tool tip
+          $("#vmName").hover(showTooltip, hideTooltip);
+          $("#vmNameTooltip").hover(showTooltip, hideTooltip);
 
-        // Adjust CSS geometry
-        $("#buttonBar").height( $("#container").offset().top );
+          // Adjust CSS geometry
+          $("#buttonBar").height( $("#container").offset().top );
 
-        // This fixes IE7's inability to assign correct widths
-        justifyButtonWidths();
+          // This fixes IE7's inability to assign correct widths
+          justifyButtonWidths();
 
-        initVmrc();
+          initVmrc();
 
-        if (#{os == 'linux'}) {
-          $(vmrc).height( $(window).height() - ($("#container").offset().top + 10) );
-          $(vmrc).width( $(window).width() );
+          if (#{os == 'linux'}) {
+            $(vmrc).height( $(window).height() - ($("#container").offset().top + 10) );
+            $(vmrc).width( $(window).width() );
+          }
         }
+
 
       } catch (error) {
         hideSpinner();


### PR DESCRIPTION
So as chrome [retired the NPAPI](https://blog.chromium.org/2013/09/saying-goodbye-to-our-old-friend-npapi.html) a few years ago, the VMRC NPAPI plugin got [deprecated](https://developercenter.vmware.com/web/sdk/55/vmrc) and a standalone VMRC application has been released. Also there is a new HTML5 and WebSocket based client called [WebMKS](https://www.vmware.com/support/developer/html-console/).

This PR introduces a test for the existence of the old VMRC NPAPI plugin and if it's not present, it will fall-"back" to the new VMRC desktop client. This is done by redirecting the client to a  `vmrc://` URL. 

You can test this in the following way:
* Have an NPAPI-compatible web browser (IE, FF)
* Install the old VMRC pluin
* Try the VMRC console (should run in a browser)
* Uninstall the old VMRC pluggin
* Install the new VMRC desktop application (v8 and/or v9)
* Try the VMRC console (should run in a separate application)

https://bugzilla.redhat.com/show_bug.cgi?id=1345812