### PR TITLE
env for static server

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,8 +11,9 @@ Vmdb::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.public_file_server.enabled = false
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS
   config.assets.compress = true


### PR DESCRIPTION
Rails `production.rb` has a hook to serve static files in production mode [[production.rb template]](https://github.com/rails/rails/blob/v5.0.0/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L19)

This PR follows the standard rails practices for this value.
While there are many changes we can adopt from the standard template, I'm aiming at just fixing my immediate need.

Detailed Description
---

I run production mode locally for performance numbers and I do not have apache setup.
I used to hack the configuration values in a `config/initializer` to serve up static assets.
This gets tricky since the configuration value needs to be changed early enough to manipulate the `Rack` stack.

When I change `production.rb`, since I am comparing different versions of the app, I have to keep checking out different versions and stashing my changes. So obviously, I prefer to introduce something outside our git checked in files.

My previous patches just stopped working. It is easier to to just follow the rails standard than try and come up with a way to enable serving static files.
