### PR TITLE
[DARGA] Backport pglogical replication enhancements for replication set locking

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -59,7 +59,10 @@ class PglogicalSubscription < ActsAsArModel
   def delete
     pglogical.subscription_drop(id, true)
     MiqRegion.destroy_region(connection, provider_region)
-    pglogical.node_drop(MiqPglogical.local_node_name, true) if self.class.count == 0
+    if self.class.count == 0
+      pglogical.node_drop(MiqPglogical.local_node_name, true)
+      pglogical.disable
+    end
   end
 
   def self.delete_all

--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -23,6 +23,11 @@ class PgLogicalRaw
     connection.enable_extension("pglogical_origin")
   end
 
+  def disable
+    connection.disable_extension("pglogical")
+    connection.disable_extension("pglogical_origin") if connection.postgresql_version < 90_500
+  end
+
   # Monitoring
   #
 

--- a/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
+++ b/lib/extensions/ar_adapter/ar_pglogical/pglogical_raw.rb
@@ -300,6 +300,18 @@ class PgLogicalRaw
     SQL
   end
 
+  def with_replication_set_lock(set_name)
+    connection.transaction(:requires_new => true) do
+      typed_exec(<<-SQL, set_name)
+        SELECT *
+        FROM pglogical.replication_set
+        WHERE set_name = $1
+        FOR UPDATE
+      SQL
+      yield
+    end
+  end
+
   private
 
   def typed_exec(sql, *params)

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -41,9 +41,11 @@ class MiqPglogical
   #   node and creating the replication set
   def configure_provider
     return if provider?
-    pglogical.enable
-    create_node unless node?
-    create_replication_set
+    @connection.transaction(:requires_new => true) do
+      pglogical.enable
+      create_node unless node?
+      create_replication_set
+    end
   end
 
   # Removes the replication configuration and pglogical node from the

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -52,6 +52,7 @@ class MiqPglogical
     return unless provider?
     pglogical.replication_set_drop(REPLICATION_SET_NAME)
     drop_node
+    pglogical.disable
   end
 
   # Lists the tables currently being replicated by pglogical

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -1,6 +1,8 @@
 require 'pg'
 
 class MiqPglogical
+  include Vmdb::Logging
+
   REPLICATION_SET_NAME = 'miq'.freeze
   SETTINGS_PATH = [:workers, :worker_base, :replication_worker, :replication].freeze
   NODE_PREFIX = "region_".freeze
@@ -84,7 +86,11 @@ class MiqPglogical
 
     # add tables to the set which are no longer excluded (or new)
     newly_included_tables.each do |table|
-      pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
+      begin
+        pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
+      rescue PG::UniqueViolation => e
+        _log.warn("Caught unique constraint error while adding #{table} to the replication set: #{e.message}")
+      end
     end
   end
 

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -89,11 +89,7 @@ class MiqPglogical
       # add tables to the set which are no longer excluded (or new)
       newly_included_tables.each do |table|
         _log.info("Adding #{table} to #{REPLICATION_SET_NAME} replication set")
-        begin
-          pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
-        rescue PG::UniqueViolation => e
-          _log.warn("Caught unique constraint error while adding #{table} to the replication set: #{e.message}")
-        end
+        pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
       end
     end
   end

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -81,11 +81,13 @@ class MiqPglogical
   def refresh_excludes
     # remove newly excluded tables from replication set
     newly_excluded_tables.each do |table|
+      _log.info("Removing #{table} from #{REPLICATION_SET_NAME} replication set")
       pglogical.replication_set_remove_table(REPLICATION_SET_NAME, table)
     end
 
     # add tables to the set which are no longer excluded (or new)
     newly_included_tables.each do |table|
+      _log.info("Adding #{table} to #{REPLICATION_SET_NAME} replication set")
       begin
         pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
       rescue PG::UniqueViolation => e

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -79,19 +79,21 @@ class MiqPglogical
 
   # Aligns the contents of the 'miq' replication set with the currently configured vmdb excludes
   def refresh_excludes
-    # remove newly excluded tables from replication set
-    newly_excluded_tables.each do |table|
-      _log.info("Removing #{table} from #{REPLICATION_SET_NAME} replication set")
-      pglogical.replication_set_remove_table(REPLICATION_SET_NAME, table)
-    end
+    pglogical.with_replication_set_lock(REPLICATION_SET_NAME) do
+      # remove newly excluded tables from replication set
+      newly_excluded_tables.each do |table|
+        _log.info("Removing #{table} from #{REPLICATION_SET_NAME} replication set")
+        pglogical.replication_set_remove_table(REPLICATION_SET_NAME, table)
+      end
 
-    # add tables to the set which are no longer excluded (or new)
-    newly_included_tables.each do |table|
-      _log.info("Adding #{table} to #{REPLICATION_SET_NAME} replication set")
-      begin
-        pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
-      rescue PG::UniqueViolation => e
-        _log.warn("Caught unique constraint error while adding #{table} to the replication set: #{e.message}")
+      # add tables to the set which are no longer excluded (or new)
+      newly_included_tables.each do |table|
+        _log.info("Adding #{table} to #{REPLICATION_SET_NAME} replication set")
+        begin
+          pglogical.replication_set_add_table(REPLICATION_SET_NAME, table, true)
+        rescue PG::UniqueViolation => e
+          _log.warn("Caught unique constraint error while adding #{table} to the replication set: #{e.message}")
+        end
       end
     end
   end

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -354,6 +354,7 @@ describe PglogicalSubscription do
       expect(MiqRegion).to receive(:destroy_region)
         .with(instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter), 0)
       expect(pglogical).to receive(:node_drop).with("region_#{MiqRegion.my_region_number}", true)
+      expect(pglogical).to receive(:disable)
 
       sub.delete
     end

--- a/spec/replication/util/ar_pglogical_spec.rb
+++ b/spec/replication/util/ar_pglogical_spec.rb
@@ -231,6 +231,22 @@ describe "ar_pglogical extension" do
             expect(connection.pglogical.tables_in_replication_set(set_name)).to eq(["test"])
           end
         end
+
+        describe "#with_replication_set_lock" do
+          it "takes a lock on the replication set table" do
+            connection.pglogical.with_replication_set_lock(set_name) do
+              result = connection.exec_query(<<-SQL)
+                SELECT 1
+                FROM pg_locks JOIN pg_class
+                  ON pg_locks.relation = pg_class.oid
+                WHERE
+                  pg_class.relname = 'replication_set' AND
+                  pg_locks.mode = 'RowShareLock'
+              SQL
+              expect(result.count).to eq(1)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/replication/util/ar_pglogical_spec.rb
+++ b/spec/replication/util/ar_pglogical_spec.rb
@@ -17,6 +17,12 @@ describe "ar_pglogical extension" do
     end
   end
 
+  describe "#enabled?" do
+    it "detects that the extensions are not enabled" do
+      expect(connection.pglogical.enabled?).to be false
+    end
+  end
+
   context "with the extensions enabled" do
     let(:node_name) { "test-node" }
     let(:node_dsn)  { "host=host.example.com dbname=vmdb_test" }
@@ -28,6 +34,13 @@ describe "ar_pglogical extension" do
     describe "#enabled?" do
       it "detects that the extensions are enabled" do
         expect(connection.pglogical.enabled?).to be true
+      end
+    end
+
+    describe "#disable" do
+      it "disables the pglogical extension" do
+        connection.pglogical.disable
+        expect(connection.extensions).not_to include("pglogical")
       end
     end
 

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -25,6 +25,12 @@ describe MiqPglogical do
       expect(pglogical.enabled?).to be true
       expect(pglogical.replication_sets).to include(described_class::REPLICATION_SET_NAME)
     end
+
+    it "does not enable the extension when an exception is raised" do
+      expect(subject).to receive(:create_replication_set).and_raise(PG::UniqueViolation)
+      expect { subject.configure_provider }.to raise_error(PG::UniqueViolation)
+      expect(pglogical.enabled?).to be false
+    end
   end
 
   context "when configured as a provider" do

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -99,6 +99,11 @@ describe MiqPglogical do
         subject.refresh_excludes
         expect(subject.included_tables).to include(table)
       end
+
+      it "continues if we attempt to add a table twice" do
+        expect(subject).to receive(:newly_included_tables).and_return([subject.included_tables.first])
+        expect { subject.refresh_excludes }.not_to raise_error
+      end
     end
   end
 

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -5,69 +5,94 @@ describe MiqPglogical do
   before do
     skip "pglogical must be installed" unless pglogical.installed?
     MiqServer.seed
-    subject.configure_provider
   end
 
   describe "#provider?" do
-    it "is true when a provider is configured" do
-      expect(subject.provider?).to be true
+    it "is false when a provider is not configured" do
+      expect(subject.provider?).to be false
     end
   end
 
   describe "#node?" do
-    it "is true when a provider is configured" do
-      expect(subject.node?).to be true
-    end
-  end
-
-  describe "#destroy_provider" do
-    it "removes the provider configuration" do
-      subject.destroy_provider
-      expect(subject.provider?).to be false
+    it "is false when a provider is not configured" do
       expect(subject.node?).to be false
-      expect(connection.extension_enabled?("pglogical")).to be false
     end
   end
 
-  describe "#create_replication_set" do
-    it "creates the correct initial set" do
-      expected_excludes = subject.configured_excludes
-      actual_excludes = connection.tables - subject.included_tables
-      expect(actual_excludes).to match_array(expected_excludes)
+  describe "#configure_provider" do
+    it "enables the extenstion and creates the replication set" do
+      subject.configure_provider
+      expect(pglogical.enabled?).to be true
+      expect(pglogical.replication_sets).to include(described_class::REPLICATION_SET_NAME)
     end
   end
 
-  describe "#refresh_excludes" do
-    it "adds a new non excluded table" do
-      connection.exec_query(<<-SQL)
-        CREATE TABLE test (id INTEGER PRIMARY KEY)
-      SQL
-      subject.refresh_excludes
-      expect(subject.included_tables).to include("test")
+  context "when configured as a provider" do
+    before do
+      subject.configure_provider
     end
 
-    it "removes a newly excluded table" do
-      table = subject.included_tables.first
-      new_excludes = subject.configured_excludes << table
-
-      c = MiqServer.my_server.get_config
-      c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
-      c.save
-
-      subject.refresh_excludes
-      expect(subject.included_tables).not_to include(table)
+    describe "#provider?" do
+      it "is true" do
+        expect(subject.provider?).to be true
+      end
     end
 
-    it "adds a newly included table" do
-      table = subject.configured_excludes.last
-      new_excludes = subject.configured_excludes - [table]
+    describe "#node?" do
+      it "is true" do
+        expect(subject.node?).to be true
+      end
+    end
 
-      c = MiqServer.my_server.get_config
-      c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
-      c.save
+    describe "#destroy_provider" do
+      it "removes the provider configuration" do
+        subject.destroy_provider
+        expect(subject.provider?).to be false
+        expect(subject.node?).to be false
+        expect(connection.extension_enabled?("pglogical")).to be false
+      end
+    end
 
-      subject.refresh_excludes
-      expect(subject.included_tables).to include(table)
+    describe "#create_replication_set" do
+      it "creates the correct initial set" do
+        expected_excludes = subject.configured_excludes
+        actual_excludes = connection.tables - subject.included_tables
+        expect(actual_excludes).to match_array(expected_excludes)
+      end
+    end
+
+    describe "#refresh_excludes" do
+      it "adds a new non excluded table" do
+        connection.exec_query(<<-SQL)
+          CREATE TABLE test (id INTEGER PRIMARY KEY)
+        SQL
+        subject.refresh_excludes
+        expect(subject.included_tables).to include("test")
+      end
+
+      it "removes a newly excluded table" do
+        table = subject.included_tables.first
+        new_excludes = subject.configured_excludes << table
+
+        c = MiqServer.my_server.get_config
+        c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
+        c.save
+
+        subject.refresh_excludes
+        expect(subject.included_tables).not_to include(table)
+      end
+
+      it "adds a newly included table" do
+        table = subject.configured_excludes.last
+        new_excludes = subject.configured_excludes - [table]
+
+        c = MiqServer.my_server.get_config
+        c.config.store_path(*described_class::SETTINGS_PATH, :exclude_tables, new_excludes)
+        c.save
+
+        subject.refresh_excludes
+        expect(subject.included_tables).to include(table)
+      end
     end
   end
 

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -23,10 +23,9 @@ describe MiqPglogical do
   describe "#destroy_provider" do
     it "removes the provider configuration" do
       subject.destroy_provider
-      expect(pglogical.nodes.num_tuples).to eq(0)
-      expect(pglogical.replication_sets).not_to include(described_class::REPLICATION_SET_NAME)
       expect(subject.provider?).to be false
       expect(subject.node?).to be false
+      expect(connection.extension_enabled?("pglogical")).to be false
     end
   end
 

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -99,11 +99,6 @@ describe MiqPglogical do
         subject.refresh_excludes
         expect(subject.included_tables).to include(table)
       end
-
-      it "continues if we attempt to add a table twice" do
-        expect(subject).to receive(:newly_included_tables).and_return([subject.included_tables.first])
-        expect { subject.refresh_excludes }.not_to raise_error
-      end
     end
   end
 


### PR DESCRIPTION
This is a backport for some issues with pglogical replication in the darga release.

In particular this backports the locking mechanism for editing the replication set which solves worker failures when the workers are adding or removing tables from the replication set concurrently.

There were some additional dependent changes that needed to also come back for this cherry-pick to apply cleanly.

The PRs backported by this PR are:
- https://github.com/ManageIQ/manageiq/pull/11595
- https://github.com/ManageIQ/manageiq/pull/12030
- https://github.com/ManageIQ/manageiq/pull/12280
- https://github.com/ManageIQ/manageiq/pull/12318

https://bugzilla.redhat.com/show_bug.cgi?id=1391997

@gtanzillo please review
/cc @chessbyte What should I do with the labels on the referenced PRs?