### PR TITLE
[WIP] Check if EMS is able to collect metrics before queuing metric capture message

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -23,6 +23,20 @@ module ManageIQ::Providers
     supports :provisioning
     supports :smartstate_analysis
 
+    def has_authentication_type?(type)
+      case type
+        when :metrics
+          begin
+            self.class::MetricsCapture.new(self).perf_init_vim
+            true
+          rescue
+            false
+          end
+        else
+          super
+      end
+    end
+
     def self.ems_type
       @ems_type ||= "vmwarews".freeze
     end

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -109,7 +109,7 @@ module Metric::Targets
   def self.capture_host_targets(zone)
     # NOTE: if capture_storage_targets takes only enabled hosts
     # merge only_enabled into this method
-    zone.ext_management_systems.flat_map(&:hosts)
+    zone.ext_management_systems.select { |e| e.has_authentication_type?(:metrics) }.flat_map(&:hosts)
   end
 
   # @param [Host] all hosts that have an ems


### PR DESCRIPTION
The idea is not to flood the provider and appliance logs with failed attempts if credentials is not permitted for metric collection.

This WIP is overriding `has_authentication_type?` (And need a default `:metrics` type answer for other managers).  But welcome better approaches.

https://bugzilla.redhat.com/show_bug.cgi?id=1391994