### PR TITLE
Fixed code that was gathering events for each selected category

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -30,25 +30,16 @@ module ReportFormatter
       else
         col = tlfield.last                             # Not a subtable, just grab the field name
       end
-      new_event_type = current_event_type = ""
 
       if mri.db == "EventStream" || mri.db == "PolicyEvent"
-        mri.table.data.sort_by(&:event_type).each_with_index do |row, _d_idx|
-          mri.rpt_options[:categories].each do |_, options|
-            current_event_type = options[:display_name] if options[:event_groups].include?(row.event_type)
-            @events.push(:name => options[:display_name],
-                         :data => []) if @events.blank? ||
-                                         @events.select { |i| i[:name] == options[:display_name] }.blank?
-          end
-
-          tl_event(row, col)   # Add this row to the tl event xml
-
-          next if new_event_type == current_event_type
-
-          event = @events.select { |i| i[:name] == current_event_type }
-          event[0][:data].push(@events_data).flatten
-          new_event_type = current_event_type
+        mri.rpt_options[:categories].each do |_, options|
           @events_data = []
+          all_events = mri.table.data.select { |e| options[:event_groups].include?(e.event_type) }
+          all_events.each do |row|
+            tl_event(row, col) # Add this row to the tl event xml
+          end
+          @events.push(:name => options[:display_name],
+                       :data => [@events_data])
         end
       else
         mri.table.data.each_with_index do |row, _d_idx|

--- a/lib/report_formatter/timeline_message.rb
+++ b/lib/report_formatter/timeline_message.rb
@@ -105,6 +105,7 @@ module ReportFormatter
       if @row[@column].kind_of?(Time) || TIMELINE_TIME_COLUMNS.include?(@column)
         format_timezone(Time.parse(@row[@column].to_s).utc, @flags[:time_zone], "gtl")
       else
+        @row[@column].to_s.tr!('"', "'")
         @row[@column].to_s.gsub('/', "\\\\/")
         @row[@column].to_s.gsub('\\', "\\\\\\")
       end


### PR DESCRIPTION
Changed code that was looping thru records to gather timeline events for each selected category, previously it was skipping thru some of the categories with the way code was looping thru random events in Ruport dfata table. Also replaced double-quotes in the timeline event data with single-quote, new timeline widget does not like double quotes in the description.
Added spec test to verify counts of events.

https://bugzilla.redhat.com/show_bug.cgi?id=1391621

@dclarizio please review/test.

before
![before](https://cloud.githubusercontent.com/assets/3450808/20119137/52602b32-a5d5-11e6-9748-55b568c46648.png)

after
![after](https://cloud.githubusercontent.com/assets/3450808/20119142/57371436-a5d5-11e6-8440-aed864d38d48.png)
