### PR TITLE
Enables travis caches for the bower_components dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: ruby
 rvm:
 - '2.3.1'
 sudo: false
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - vendor/assets/bower_components
+before_cache:
+- cat bower.json > vendor/assets/bower_components/bower.json
 env:
   global:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000

--- a/tools/ci/setup_js_env.sh
+++ b/tools/ci/setup_js_env.sh
@@ -1,8 +1,18 @@
 which bower || npm install -g bower
-bower install --allow-root -F --config.analytics=false
-STATUS=$?
-echo bower exit code: $STATUS
 
-# fail the whole test suite if bower install failed
-[ $STATUS = 0 ] || exit 1
-[ -d vendor/assets/bower_components ] || exit 1
+# Check if the bower cache is valid, otherwise delete it
+if ! cmp --silent bower.json vendor/assets/bower_components/bower.json; then
+  rm -rf vendor/assets/bower_components
+fi
+
+if [ -d vendor/assets/bower_components ]; then
+  echo "bower assets installed... moving on."
+else
+  bower install --allow-root -F --config.analytics=false
+  STATUS=$?
+  echo bower exit code: $STATUS
+
+  # fail the whole test suite if bower install failed
+  [ $STATUS = 0 ] || exit 1
+  [ -d vendor/assets/bower_components ] || exit 1
+fi


### PR DESCRIPTION
Purpose
-------
Speed up travis builds by caching bower assets while also avoiding being rate limited by github and using them as a dependency when our assets remain unchanged for many of the builds.

This PR does a few things to accomplish that:

- Updates the `cache` config into the `.travis.yml` to handle both bundler and an arbitrary directory of `vendor/assets/bower_components`
- Store `bower.json` file in that dir as part of the cache
- Compares the `bower.json` that is for the build to the one that is stored in the cache to determine if the cache should be used, otherwise use `bower` to rebuild the `vendor/assets/bower_components`
- Skips running `bower install` if `vendor/assets/bower_components` exists.  If the cache is out of date, as mentioned above, the dir will be blown away and rebuilt.

Links
-----
* https://docs.travis-ci.com/user/caching/#Enabling-multiple-caching-features
* https://travis-ci.org/NickLaMuro/manageiq/builds/174334809
* Related:  https://github.com/ManageIQ/manageiq/pull/12509


Steps for Testing/QA
--------------------
* Check the travis log for this and confirm that it caches things in a similar fashion to the build linked above.
* You can restart the build after it has completed successfully, and check the logs to see that bower was not called once a cache is successfully created.