### PR TITLE
Fix CU secondary chart labels and size

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1664,9 +1664,9 @@ function chartData(type, data, data2) {
   if (_.isObject(config.tooltip)) {
     config.tooltip.contents = undefined;
   }
-  var ret = _.defaultsDeep({}, data, config, data2);
   // some PatternFly default configs define size of chart
-  ret.size = {};
+  config.size = {};
+  var ret = _.defaultsDeep({}, data, config, data2);
   return ret;
 }
 

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -22,16 +22,17 @@ module ReportFormatter
       @counter ||= 0
       @counter += 1
       series_id = @counter.to_s
+      limit = pie_type? ? LEGEND_LENGTH : LABEL_LENGTH
 
       if chart_is_2d?
         mri.chart[:data][:columns] << [series_id, *data.map { |a| a[:value] }]
-        mri.chart[:data][:names][series_id] = slice_legend(label)
+        mri.chart[:data][:names][series_id] = slice_legend(label, limit)
         mri.chart[:miq][:name_table][series_id] = label
       else
         data.each_with_index do |a, index|
           id = index.to_s
           mri.chart[:data][:columns].push([id, a[:value]])
-          mri.chart[:data][:names][id] = slice_legend(a[:tooltip])
+          mri.chart[:data][:names][id] = slice_legend(a[:tooltip], limit)
           mri.chart[:miq][:name_table][id] = a[:tooltip]
         end
       end


### PR DESCRIPTION
Fix labels and size of secondary charts in Capacity and Utilization.

Links
-------------------------------
https://bugzilla.redhat.com/show_bug.cgi?id=1393011

Steps for Testing/QA
-------------------------------
1. Go to a Cluster or a Host that has C&U data
2. Display the Utilization charts

Screenshot
-------------------------------
Before:
![5 7 charts](https://cloud.githubusercontent.com/assets/9535558/20133165/a9674f32-a666-11e6-98f3-0275ac5a4935.png)

After:

![screenshot from 2016-11-09 10-23-03](https://cloud.githubusercontent.com/assets/9535558/20133171/ad750d80-a666-11e6-94fa-618ba4588c92.png)

