### PR TITLE
Some providers are not associated with custom_attributes

### DIFF
--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module CustomAttributes
       def custom_attributes_query_resource(object)
-        object.custom_attributes
+        object.respond_to?(:custom_attributes) ? object.custom_attributes : []
       end
 
       def custom_attributes_add_resource(object, _type, _id, data = nil)

--- a/app/controllers/api/subcollections/custom_attributes.rb
+++ b/app/controllers/api/subcollections/custom_attributes.rb
@@ -6,7 +6,11 @@ module Api
       end
 
       def custom_attributes_add_resource(object, _type, _id, data = nil)
-        add_custom_attribute(object, data)
+        if object.respond_to?(:custom_attributes)
+          add_custom_attribute(object, data)
+        else
+          raise BadRequestError, "#{object.class.name} does not support management of custom attributes"
+        end
       end
 
       def custom_attributes_edit_resource(object, _type, id = nil, data = nil)
@@ -61,7 +65,11 @@ module Api
       end
 
       def find_custom_attribute(object, id, data)
-        (id.present? && id > 0) ? object.custom_attributes.find(id) : find_custom_attribute_by_data(object, data)
+        if object.respond_to?(:custom_attributes)
+          (id.present? && id > 0) ? object.custom_attributes.find(id) : find_custom_attribute_by_data(object, data)
+        else
+          raise BadRequestError, "#{object.class.name} does not support management of custom attributes"
+        end
       end
 
       def find_custom_attribute_by_data(object, data)

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -742,4 +742,15 @@ describe "Providers API" do
       expect(queue_jobs).to contain_exactly(an_object_having_attributes(:args => expected_args))
     end
   end
+
+  describe 'query Providers' do
+    describe 'query custom_attributes' do
+      let!(:generic_provider) { FactoryGirl.create(:provider) }
+      it 'does not blow-up on provider without custom_attributes' do
+        api_basic_authorize collection_action_identifier(:providers, :read, :get)
+        run_get(providers_url, :expand => 'resources,custom_attributes', :provider_class => 'provider')
+        expect_query_result(:providers, 1, 1)
+      end
+    end
+  end
 end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -753,4 +753,27 @@ describe "Providers API" do
       end
     end
   end
+
+  describe 'edit custom_attributes on providers' do
+    context 'provider_class=provider' do
+      let(:generic_provider) { FactoryGirl.create(:provider) }
+      let(:attr) { FactoryGirl.create(:custom_attribute) }
+      let(:url) do
+        # TODO: provider_class in params, when supported (https://github.com/brynary/rack-test/issues/150)
+        providers_url(generic_provider.id) + '/custom_attributes' + '?provider_class=provider'
+      end
+
+      it 'cannot add a custom_attribute' do
+        api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :add, :post)
+        run_post(url, gen_request(:add, :name => 'x'))
+        expect_bad_request("#{generic_provider.class.name} does not support management of custom attributes")
+      end
+
+      it 'cannot edit custom_attribute' do
+        api_basic_authorize subcollection_action_identifier(:providers, :custom_attributes, :edit, :post)
+        run_post(url, gen_request(:edit, :href => custom_attributes_url(attr.id)))
+        expect_bad_request("#{generic_provider.class.name} does not support management of custom attributes")
+      end
+    end
+  end
 end


### PR DESCRIPTION
I have audited API subcollections and found one more case similar to #12467.

The provider class `Provider` does not support custom_attributes, Thus any manipulation of custom_custom attributes on provider class `Provider` will fail similarly as in #12467.

@miq-bot add_label api, bug
@miq-bot assign @abellotti 