### PR TITLE
bin/update - skip test:vmdb:setup if SKIP_TEST_RESET is in environment

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -43,8 +43,10 @@ chdir APP_ROOT do
   puts "\n== Seeding database =="
   system! "bin/rails db:seed GOOD_MIGRATIONS=skip"
 
-  puts "\n== Resetting tests =="
-  system! "bin/rails test:vmdb:setup"
+  unless ENV["SKIP_TEST_RESET"]
+    puts "\n== Resetting tests =="
+    system! "bin/rails test:vmdb:setup"
+  end
 
   unless ENV["SKIP_AUTOMATE_RESET"]
     puts "\n== Resetting Automate Domains =="


### PR DESCRIPTION
Same as `SKIP_AUTOMATE_RESET`, except for the test db setup.. this makes `bin/update` skip `test:vmdb:setup` when the `SKIP_TEST_RESET` environment variable is present.

The idea is that when testing PRs, there's no sense in waiting those extra 24 seconds for the test db to reset, so there should be a way to skip.