### PR TITLE
Remove full refresh from provisioning flow

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -24,7 +24,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
 
     if clone_complete?
       phase_context.delete(:clone_task_ref)
-      EmsRefresh.queue_refresh(dest_cluster.ext_management_system)
+      # Full refresh was removed from here because it is expensive on larger envs
+      # With this change we rely on eventing and tagreted refresh it triggers
       signal :poll_destination_in_vmdb
     else
       requeue_phase

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -70,7 +70,6 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine do
     @test_poll_clone_complete_setup ||= begin
       expect(task).to receive(:clone_complete?).and_return(false, false, true)
       expect(task).to receive(:requeue_phase).twice { requeue_phase }
-      expect(EmsRefresh).to receive(:queue_refresh).once
     end
 
     call_method


### PR DESCRIPTION
This patch is a bigger effort to reduce number of full refreshes which are very expensive for larger rhv environments.