### PR TITLE
Automatic detection of hawkular endpoint

### DIFF
--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -396,7 +396,10 @@ module Mixins
       if ems.kind_of?(ManageIQ::Providers::ContainerManager)
         params[:cred_type] = ems.default_authentication_type if params[:cred_type] == "default"
         ems.hostname = hostname
-        hawkular_hostname = hostname if hawkular_hostname.blank?
+        if hawkular_hostname.blank?
+          default_key = params[:default_password] || ems.authentication_key
+          hawkular_hostname = get_hostname_from_routes(ems, hostname, port, default_key)
+        end
 
         default_endpoint = {:role => :default, :hostname => hostname, :port => port}
         hawkular_endpoint = {:role => :hawkular, :hostname => hawkular_hostname, :port => hawkular_api_port}
@@ -418,6 +421,11 @@ module Mixins
                    :hawkular    => hawkular_endpoint}
 
       build_connection(ems, endpoints, mode)
+    end
+
+    def get_hostname_from_routes(ems, hostname, port, token)
+      client = ems.class.raw_connect(hostname, port, :bearer => token)
+      client.get_routes(:name=>'hawkular-metrics').first.try(:spec).try(:host)
     end
 
     def build_connection(ems, endpoints, mode)

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -169,7 +169,24 @@ describe EmsCloudController do
 end
 
 describe EmsContainerController do
+  before :each do
+    allow(controller).to receive(:get_hostname_from_routes).and_return("myhawkularoute.com")
+  end
   context "::EmsCommon" do
+    context "#create" do
+      it "adding new provider without hawkular endpoint" do
+        controller.instance_variable_set(:@_params,
+                                         :name             => 'NimiCule',
+                                         :default_userid   => '_',
+                                         :default_hostname => 'mytest.com',
+                                         :default_api_port => '8443',
+                                         :default_password => 'valid-token',
+                                         :emstype          => @type)
+        ems = ManageIQ::Providers::Openshift::ContainerManager.new
+        controller.send(:set_ems_record_vars, ems)
+        expect(ems.connection_configurations.hawkular.endpoint.hostname).to eq('myhawkularoute.com')
+      end
+    end
     context "#update" do
       context "updates provider with new token" do
         after :each do


### PR DESCRIPTION
Added automatic detection of Hawkular hostname from route when endpoint is not specified.

When the user does not specify the Hawkular client hostname upon adding a new container provider (i.e. Hawkular endpoint is left blank) we had taken it from the hostname - this behavior is changed in this PR - now we are taking the hostname from the Route. 

cc: @yaacov @enoodle @simon3z 