### PR TITLE
Ensure a response when git repository does not contain domains

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -131,8 +131,8 @@ class MiqAeToolsController < ApplicationController
       git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
 
       add_flash(_("Imported from git"), :info)
-    rescue MiqException::Error
-      add_flash(_("The selected branch or tag does not have valid domain object data"), :error)
+    rescue => error
+      add_flash(_("Error: import failed: %{message}") % {:message => error.message}, :error)
     end
 
     respond_to do |format|

--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -127,9 +127,13 @@ class MiqAeToolsController < ApplicationController
   end
 
   def import_via_git
-    git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
+    begin
+      git_based_domain_import_service.import(params[:git_repo_id], params[:git_branch_or_tag], current_tenant.id)
 
-    add_flash(_("Imported from git"), :info)
+      add_flash(_("Imported from git"), :info)
+    rescue MiqException::Error
+      add_flash(_("The selected branch or tag does not have valid domain object data"), :error)
+    end
 
     respond_to do |format|
       format.js { render :json => @flash_array.to_json, :status => 200 }

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -77,7 +77,8 @@ class GitBasedDomainImportService
     task = MiqTask.wait_for_taskid(task_id)
 
     domain = task.task_results
-    raise MiqException::Error, "Domain object not available from task results" unless domain.kind_of?(MiqAeDomain)
+    error_message = _("Selected branch or tag does not contain a valid domain")
+    raise MiqException::Error, error_message unless domain.kind_of?(MiqAeDomain)
     domain.update_attribute(:enabled, true)
   end
 

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -468,10 +468,32 @@ Methods updated/added: 10
       allow(GitBasedDomainImportService).to receive(:new).and_return(git_based_domain_import_service)
     end
 
-    it "delegates to the git based domain import service" do
-      tenant_id = controller.current_tenant.id
-      expect(git_based_domain_import_service).to receive(:import).with("123", "branch_or_tag", tenant_id)
-      post :import_via_git, :params => params, :xhr => true
+    context "when there are no errors while importing" do
+      before do
+        tenant_id = controller.current_tenant.id
+        allow(git_based_domain_import_service).to receive(:import).with("123", "branch_or_tag", tenant_id)
+      end
+
+      it "responds with a success message" do
+        post :import_via_git, :params => params, :xhr => true
+        expect(response.body).to eq([{:message => "Imported from git", :level => :info}].to_json)
+      end
+    end
+
+    context "when there are errors while importing" do
+      before do
+        tenant_id = controller.current_tenant.id
+        allow(git_based_domain_import_service).to receive(:import).with("123", "branch_or_tag", tenant_id).and_raise(
+          MiqException::Error
+        )
+      end
+
+      it "responds with an error message" do
+        post :import_via_git, :params => params, :xhr => true
+        expect(response.body).to eq(
+          [{:message => "The selected branch or tag does not have valid domain object data", :level => :error}].to_json
+        )
+      end
     end
   end
 end

--- a/spec/controllers/miq_ae_tools_controller_spec.rb
+++ b/spec/controllers/miq_ae_tools_controller_spec.rb
@@ -484,14 +484,14 @@ Methods updated/added: 10
       before do
         tenant_id = controller.current_tenant.id
         allow(git_based_domain_import_service).to receive(:import).with("123", "branch_or_tag", tenant_id).and_raise(
-          MiqException::Error
+          MiqException::Error, "kaboom"
         )
       end
 
       it "responds with an error message" do
         post :import_via_git, :params => params, :xhr => true
         expect(response.body).to eq(
-          [{:message => "The selected branch or tag does not have valid domain object data", :level => :error}].to_json
+          [{:message => "Error: import failed: kaboom", :level => :error}].to_json
         )
       end
     end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -87,11 +87,13 @@ describe GitBasedDomainImportService do
     context "when import fails and the task result is nil" do
       let(:git_branches) { [double("GitBranch", :name => ref_name)] }
 
-      it "raises exception" do
+      it "raises an exception with a message" do
         allow(task).to receive(:task_results).and_return(nil)
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
 
-        expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(MiqException::Error)
+        expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
+          MiqException::Error, "Selected branch or tag does not contain a valid domain"
+        )
       end
     end
   end


### PR DESCRIPTION
When importing a git repository that did not contain a domain structure, there would be a server error and the spinner would get stuck infinitely. This ensures we return a value from the server when the repository does not contain domains, with an appropriate error message.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1392617

Steps for Testing/QA
-------------------------------
All of the details are in the BZ but I will replicate them here for completeness:

1. Automate -> Import/Export
2. Use https://github.com/mkanoor/playbook for the repository
3. Submit
4. Select branch and then the origin/master branch.
5. Submit
6. See the spinner stuck, and there should be an error in evm.log.

@miq-bot assign @gmcculloug 

/cc @mkanoor 