### PR TITLE
Explicitly activate disks added to oVirt VMs

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -106,6 +106,7 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
     {
       :bootable  => disk_spec["bootable"],
       :interface => "VIRTIO",
+      :active    => true,
       :disk      => {
         :provisioned_size => disk_spec["disk_size_in_mb"].to_i * 1024 * 1024,
         :sparse           => disk_spec["thin_provisioned"],


### PR DESCRIPTION
When a disk is added to an oVirt VM that is up it isn't activated by default.
This patch changes that, so that the disk is explicitly activated.

https://bugzilla.redhat.com/1390517