### PR TITLE
Prioritize rate with tag of VM when selecting from more rates 

### DIFF
--- a/app/models/chargeback/rates_cache.rb
+++ b/app/models/chargeback/rates_cache.rb
@@ -2,15 +2,39 @@ class Chargeback
   class RatesCache
     def get(perf)
       @rates ||= {}
-      @rates[perf.hash_features_affecting_rate] ||=
-        ChargebackRate.get_assigned_for_target(perf.resource,
-                                               :tag_list => perf.tag_list_with_prefix,
-                                               :parents  => perf.parents_determining_rate)
+      @rates[perf.hash_features_affecting_rate] ||= rates(perf)
+    end
 
-      if perf.resource_type == Container.name && @rates[perf.hash_features_affecting_rate].empty?
-        @rates[perf.hash_features_affecting_rate] = [ChargebackRate.find_by(:description => "Default", :rate_type => "Compute")]
+    private
+
+    def rates(metric_rollup_record)
+      rates = ChargebackRate.get_assigned_for_target(metric_rollup_record.resource,
+                                                     :tag_list => metric_rollup_record.tag_list_with_prefix,
+                                                     :parents  => metric_rollup_record.parents_determining_rate)
+
+      if metric_rollup_record.resource_type == Container.name && rates.empty?
+        rates = [ChargebackRate.find_by(:description => "Default", :rate_type => "Compute")]
       end
-      @rates[perf.hash_features_affecting_rate]
+
+      metric_rollup_record_tags = metric_rollup_record.tag_names.split("|")
+
+      unique_rates_by_tagged_resources(rates, metric_rollup_record_tags)
+    end
+
+    def unique_rates_by_tagged_resources(rates, metric_rollup_record_tags)
+      grouped_rates = rates.group_by(&:rate_type)
+
+      compute_rates = select_rate_by_tags(grouped_rates["Compute"] || [], metric_rollup_record_tags)
+      storage_rates = select_rate_by_tags(grouped_rates["Storage"] || [], metric_rollup_record_tags)
+
+      [compute_rates, storage_rates].flatten
+    end
+
+    def select_rate_by_tags(rates, metric_rollup_record_tags)
+      return rates if rates.empty? || rates.count == 1
+      return rates unless rates.all?(&:assigned_tags?) # Are rates assigned to tagged resources ?
+
+      rates.sort_by(&:description).detect { |rate| (rate.assigned_tags & metric_rollup_record_tags).present? }
     end
   end
 end

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -164,6 +164,17 @@ class ChargebackRate < ApplicationRecord
     get_assigned_tos != {:objects => [], :tags => [], :labels => []}
   end
 
+  def assigned_tags
+    get_assigned_tos[:tags].map do |x|
+      classification_entry_object = x.first
+      classification_entry_object.tag.send(:name_path)
+    end
+  end
+
+  def assigned_tags?
+    get_assigned_tos[:tags].present?
+  end
+
   ###########################################################
 
   private

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -15,7 +15,7 @@ describe ChargebackContainerImage do
     @container = FactoryGirl.create(:kubernetes_container, :container_group => @group, :container_image => @image)
     cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :single_value => true, :show => true)
     c = FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent_id => cat.id)
-    @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "compute")
+    @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
     ChargebackRate.set_assignments(:compute, [{ :cb_rate => @cbr, :tag => [c, "container_image"] }])
 
     @tag = c.tag

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -8,7 +8,7 @@ describe ChargebackContainerProject do
 
     @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => @ems)
 
-    @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "compute")
+    @cbr = FactoryGirl.create(:chargeback_rate, :rate_type => "Compute")
     temp = {:cb_rate => @cbr, :object => @ems}
     ChargebackRate.set_assignments(:compute, [temp])
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -859,6 +859,39 @@ describe ChargebackVm do
     end
   end
 
+  context 'more rates have been selected' do
+    let(:storage_chargeback_rate_1) { FactoryGirl.create(:chargeback_rate, :rate_type => "Storage") }
+    let(:storage_chargeback_rate_2) { FactoryGirl.create(:chargeback_rate, :rate_type => "Storage") }
+    let(:chargeback_vm)             { Chargeback::RatesCache.new }
+
+    let(:parent_classification) { FactoryGirl.create(:classification) }
+    let(:classification_1)      { FactoryGirl.create(:classification, :parent_id => parent_classification.id) }
+    let(:classification_2)      { FactoryGirl.create(:classification, :parent_id => parent_classification.id) }
+
+    let(:rate_assignment_options_1) { {:cb_rate => storage_chargeback_rate_1, :tag => [classification_1, "Storage"]} }
+    let(:rate_assignment_options_2) { {:cb_rate => storage_chargeback_rate_2, :tag => [classification_2, "Storage"]} }
+
+    let(:metric_rollup) do
+      FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => "2012-08-31T07:00:00Z",
+                         :parent_host_id => @host1.id, :parent_ems_cluster_id => @ems_cluster.id,
+                         :parent_ems_id => @ems.id, :parent_storage_id => @storage.id,
+                         :resource => @vm1)
+    end
+
+    before do
+      @storage.tag_with([classification_1.tag.name, classification_2.tag.name], :ns => '*')
+      ChargebackRate.set_assignments(:storage, [rate_assignment_options_1, rate_assignment_options_2])
+    end
+
+    it "return only one chargeback rate according to tag name of Vm" do
+      [rate_assignment_options_1, rate_assignment_options_2].each do |rate_assignment|
+        metric_rollup.tag_names = rate_assignment[:tag].first.tag.send(:name_path)
+        uniq_rates = chargeback_vm.send(:get, metric_rollup)
+        expect([rate_assignment[:cb_rate]]).to match_array(uniq_rates)
+      end
+    end
+  end
+
   context "Group by tags" do
     before  do
       @options[:interval] = "monthly"


### PR DESCRIPTION
There is a case that more rates can be selected
(for example when storage have more tags)
and in this case, values are accumulated together in report.

so this first way how to deterministically select just one rate
of storage and compute.

So when more rates are selected then
rate with matching tag of VM is used.

This is applied only when rates are assigned to any [ tagged resources](https://github.com/ManageIQ/manageiq/pull/12534/commits/c59b1112598eca55cba0f3f3c0438a63eaec2d78#diff-49a58c3ec7292e786821c05e285c6319R27
) and more rates was selected otherwise behavior is same as before.
