### PR TITLE
Fixed  chargeback report generation for services

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -124,7 +124,7 @@ module MiqReport::Generator
     options[:mode] ||= "async"
     options[:report_source] ||= "Requested by user"
 
-    sync = VMDB::Config.new("vmdb").config[:product][:report_sync]
+    sync = options.delete(:report_sync) || VMDB::Config.new("vmdb").config[:product][:report_sync]
 
     task = MiqTask.create(:name => "Generate Report: '#{name}'")
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -364,6 +364,7 @@ class Service < ApplicationRecord
     _log.info "Generation of chargeback report for service #{name} started..."
     MiqReportResult.where(:name => chargeback_report_name).destroy_all
     report = MiqReport.new(chargeback_yaml)
+    options[:report_sync] = true
     report.queue_generate_table(options)
     _log.info "Report #{chargeback_report_name} generated"
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -412,6 +412,7 @@ describe Service do
 
       it "loads report template and initiate generation" do
         EvmSpecHelper.local_miq_server
+        allow(Chargeback).to receive(:build_results_for_report_chargeback)
         @service.generate_chargeback_report
         expect(MiqReportResult.count).to eq 1
         expect(MiqReportResult.first.name).to eq @service.chargeback_report_name
@@ -435,6 +436,7 @@ describe Service do
     describe "#chargeback_report" do
       it "returns chargeback report" do
         EvmSpecHelper.local_miq_server
+        allow(Chargeback).to receive(:build_results_for_report_chargeback)
         @service.generate_chargeback_report
         expect(@service.chargeback_report).to have_key(:results)
       end


### PR DESCRIPTION
Issue: 
We do not want to create persistent instance of ```MiqReport``` for Chargeback report for service since it would be available as custom report.
Adding report generation task to queue without persistent instance of report cause message to delivered to wrong method.

Generating Chargback for service is already running from queue (```Sevice.queue_chargeback_report_generation```) and adding it to another queue is not needed. Passing ```:report_sync => true``` to report generator which will bypass adding to reporting queue and alows to create ```MiqReportResult``` record without creating ```MiqReport```.
 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1393040

Fix: 
 - ```:report_sync``` may be present in options  for```MiqReport.queue_generate_table(options)``` call
- added ```:report_sync => true``` to options when calling ```Service#queue_generate_table(options)```


@miq-bot add-label bug, reporting euwe/yes

\cc @Fryguy @himdel
