### PR TITLE
Properly generates the url to a Middleware Manager Provider.

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -49,6 +49,7 @@ ManageIQ.angular.app.service('topologyService', function() {
         entity_url = "ems_network";
         break;
       case "MiddlewareManager":
+        action = '/' + d.item.miq_id;
         entity_url = "ems_middleware";
         break;
       default : // for non provider entities, use the show action


### PR DESCRIPTION
Topology links to a Middleware provider were wrong, this PR fixes the link.
Changes `https://localhost/ems_middleware/show/2`
to `https://localhost/ems_middleware/2`

Fixes #12498