### PR TITLE
Delete the repo directory for Git based domains

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1842,6 +1842,7 @@ class MiqAeClassController < ApplicationController
   def delete_domain
     assert_privileges("miq_ae_domain_delete")
     aedomains = []
+    repositories = []
     if params[:id]
       aedomains.push(params[:id])
       self.x_node = "root"
@@ -1853,6 +1854,7 @@ class MiqAeClassController < ApplicationController
         next unless domain
         if domain.editable_properties?
           aedomains.push(domain.id)
+          repositories.push(domain.git_repository.id) if (domain.git_enabled?)
         else
           add_flash(_("Read Only %{model} \"%{name}\" cannot be deleted") %
             {:model => ui_lookup(:model => "MiqAeDomain"), :name => domain.name}, :error)
@@ -1860,6 +1862,7 @@ class MiqAeClassController < ApplicationController
       end
     end
     process_elements(aedomains, MiqAeDomain, 'destroy') unless aedomains.empty?
+    repositories.each { |id| git_based_domain_import_service.destroy_repository(id) }
     replace_right_cell([:ae])
   end
 

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -1854,7 +1854,7 @@ class MiqAeClassController < ApplicationController
         next unless domain
         if domain.editable_properties?
           aedomains.push(domain.id)
-          repositories.push(domain.git_repository.id) if (domain.git_enabled?)
+          repositories.push(domain.git_repository.id) if domain.git_enabled?
         else
           add_flash(_("Read Only %{model} \"%{name}\" cannot be deleted") %
             {:model => ui_lookup(:model => "MiqAeDomain"), :name => domain.name}, :error)

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -115,7 +115,6 @@ class GitBasedDomainImportService
     task.task_results
   end
 
-
   def self.available?
     MiqRegion.my_region.role_active?("git_owner")
   end

--- a/app/services/git_based_domain_import_service.rb
+++ b/app/services/git_based_domain_import_service.rb
@@ -72,16 +72,16 @@ class GitBasedDomainImportService
     MiqTask.generic_action_with_callback(task_options, queue_options)
   end
 
-  def queue_destroy_repository(git_repo_id)
+  def queue_destroy_domain(domain_id)
     task_options = {
-      :action => "Destroy git repository",
+      :action => "Destroy domain",
       :userid => User.current_user.userid
     }
 
     queue_options = {
-      :class_name  => "GitRepository",
+      :class_name  => "MiqAeDomain",
       :method_name => "destroy",
-      :instance_id => git_repo_id,
+      :instance_id => domain_id,
       :role        => "git_owner",
       :args        => []
     }
@@ -107,8 +107,8 @@ class GitBasedDomainImportService
     task.task_results
   end
 
-  def destroy_repository(git_repo_id)
-    task_id = queue_destroy_repository(git_repo_id)
+  def destroy_domain(domain_id)
+    task_id = queue_destroy_domain(domain_id)
     task = MiqTask.wait_for_taskid(task_id)
 
     raise MiqException::Error, task.message unless task.status == "Ok"

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -13,12 +13,11 @@ class MiqAeDomain < MiqAeNamespace
 
   validates_presence_of :tenant, :message => "object is needed to own the domain"
   after_destroy :squeeze_priorities
-  before_destroy :destroy_repository
   default_value_for :source,  USER_SOURCE
   default_value_for :enabled, false
   before_save :default_priority
   belongs_to :tenant
-  belongs_to :git_repository
+  belongs_to :git_repository, :dependent => :destroy
   validates_inclusion_of :source, :in => VALID_SOURCES
 
   EXPORT_EXCLUDE_KEYS = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/,
@@ -159,10 +158,6 @@ class MiqAeDomain < MiqAeNamespace
   def squeeze_priorities
     ids = MiqAeDomain.where('priority > 0', :tenant => tenant).order('priority ASC').collect(&:id)
     MiqAeDomain.reset_priority_by_ordered_ids(ids)
-  end
-
-  def destroy_repository
-    git_repository.destroy if git_repository
   end
 
   def self.any_enabled?

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -13,6 +13,7 @@ class MiqAeDomain < MiqAeNamespace
 
   validates_presence_of :tenant, :message => "object is needed to own the domain"
   after_destroy :squeeze_priorities
+  before_destroy :destroy_repository
   default_value_for :source,  USER_SOURCE
   default_value_for :enabled, false
   before_save :default_priority
@@ -158,6 +159,10 @@ class MiqAeDomain < MiqAeNamespace
   def squeeze_priorities
     ids = MiqAeDomain.where('priority > 0', :tenant => tenant).order('priority ASC').collect(&:id)
     MiqAeDomain.reset_priority_by_ordered_ids(ids)
+  end
+
+  def destroy_repository
+    git_repository.destroy if git_repository
   end
 
   def self.any_enabled?

--- a/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
+++ b/lib/miq_automation_engine/models/miq_ae_yaml_import.rb
@@ -79,8 +79,7 @@ class MiqAeYamlImport
     domain_obj = MiqAeDomain.find_by_fqname(domain_name, false)
     track_stats('domain', domain_obj)
     if domain_obj && !@preview && @options['overwrite']
-      domain_obj.destroy
-      domain_obj = nil
+      domain_obj.ae_namespaces.destroy_all
     end
     domain_obj ||= add_domain(domain_yaml, @tenant) unless @preview
     if @options['namespace']

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -415,7 +415,7 @@ describe MiqAeClassController do
     end
 
     it "Should only delete editable domains" do
-      expect(git_service).to receive(:destroy_repository).with(domain3.git_repository.id)
+      expect(git_service).to receive(:destroy_domain).with(domain3.id)
       controller.send(:delete_domain)
 
       flash_messages = assigns(:flash_array)

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -406,14 +406,18 @@ describe MiqAeClassController do
       domain1 = FactoryGirl.create(:miq_ae_system_domain_enabled)
 
       domain2 = FactoryGirl.create(:miq_ae_domain_enabled)
+      domain3 = FactoryGirl.create(:miq_ae_git_domain)
       controller.instance_variable_set(:@_params,
-                                       :miq_grid_checks => "aen-#{domain1.id}, aen-#{domain2.id}, aen-someid"
+                                       :miq_grid_checks => "aen-#{domain1.id}, aen-#{domain2.id}, aen-#{domain3.id}, aen-someid"
                                       )
       allow(controller).to receive(:replace_right_cell)
+      expect_any_instance_of(GitBasedDomainImportService).to receive(:destroy_repository).with(domain3.git_repository.id)
       controller.send(:delete_domain)
       flash_messages = assigns(:flash_array)
       expect(flash_messages.first[:message]).to include("cannot be deleted")
       expect(flash_messages.first[:level]).to eq(:error)
+      expect(flash_messages.second[:message]).to include("Delete successful")
+      expect(flash_messages.second[:level]).to eq(:success)
       expect(flash_messages.last[:message]).to include("Delete successful")
       expect(flash_messages.last[:level]).to eq(:success)
     end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -427,4 +427,17 @@ describe MiqAeDomain do
       end
     end
   end
+
+  describe "destroy_repository callback" do
+    let(:git_domain) { described_class.new(:git_repository => git_repository) }
+    let(:git_repository) { GitRepository.new }
+
+    context "callback gets called" do
+      it "#destroy" do
+        expect(git_repository).to receive(:destroy)
+
+        expect(git_domain.destroy).to eq(git_domain)
+      end
+    end
+  end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -427,17 +427,4 @@ describe MiqAeDomain do
       end
     end
   end
-
-  describe "destroy_repository callback" do
-    let(:git_domain) { described_class.new(:git_repository => git_repository) }
-    let(:git_repository) { GitRepository.new }
-
-    context "callback gets called" do
-      it "#destroy" do
-        expect(git_repository).to receive(:destroy)
-
-        expect(git_domain.destroy).to eq(git_domain)
-      end
-    end
-  end
 end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -6,7 +6,7 @@ describe GitBasedDomainImportService do
                               :url          => 'http://www.example.com')
     end
     let(:user) { double("User", :userid => userid, :id => 123) }
-    let(:domain) { FactoryGirl.build(:miq_ae_domain) }
+    let(:domain) { FactoryGirl.build(:miq_ae_git_domain, :id => 999) }
     let(:userid) { "fred" }
     let(:task) { double("MiqTask", :id => 123) }
     let(:ref_name) { 'the_branch_name' }
@@ -41,6 +41,19 @@ describe GitBasedDomainImportService do
       {
         :class_name  => "GitRepository",
         :instance_id => git_repo.id,
+        :method_name => method_name,
+        :role        => "git_owner",
+        :args        => []
+      }
+    end
+  end
+
+  shared_context "domain setup" do
+    let(:git_branches) { [] }
+    let(:queue_options) do
+      {
+        :class_name  => "MiqAeDomain",
+        :instance_id => domain.id,
         :method_name => method_name,
         :role        => "git_owner",
         :args        => []
@@ -206,10 +219,10 @@ describe GitBasedDomainImportService do
     end
   end
 
-  describe "destroy git repository" do
+  describe "destroy domain" do
     include_context "import setup"
-    include_context "repository setup"
-    let(:action) { 'Destroy git repository' }
+    include_context "domain setup"
+    let(:action) { 'Destroy domain' }
     let(:method_name) { 'destroy' }
     let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
 
@@ -219,16 +232,16 @@ describe GitBasedDomainImportService do
       allow(task).to receive(:task_results).and_return(true)
     end
 
-    it "#destroy_repository" do
+    it "#destroy_domain" do
       expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
 
-      expect(subject.destroy_repository(git_repo.id)).to be_truthy
+      expect(subject.destroy_domain(domain.id)).to be_truthy
     end
 
-    it "#queue_destroy_repository" do
+    it "#queue_destroy_domain" do
       expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
 
-      expect(subject.queue_destroy_repository(git_repo.id)).to eq(task.id)
+      expect(subject.queue_destroy_domain(domain.id)).to eq(task.id)
     end
   end
 end

--- a/spec/services/git_based_domain_import_service_spec.rb
+++ b/spec/services/git_based_domain_import_service_spec.rb
@@ -35,14 +35,13 @@ describe GitBasedDomainImportService do
     let(:message) { "Success" }
   end
 
-  shared_context "refresh setup" do
-    let(:action) { 'Refresh git repository' }
+  shared_context "repository setup" do
     let(:git_branches) { [] }
     let(:queue_options) do
       {
         :class_name  => "GitRepository",
         :instance_id => git_repo.id,
-        :method_name => "refresh",
+        :method_name => method_name,
         :role        => "git_owner",
         :args        => []
       }
@@ -160,7 +159,9 @@ describe GitBasedDomainImportService do
 
   describe "#queue_refresh" do
     include_context "import setup"
-    include_context "refresh setup"
+    include_context "repository setup"
+    let(:action) { 'Refresh git repository' }
+    let(:method_name) { 'refresh' }
     before do
       allow(User).to receive(:current_user).and_return(user)
     end
@@ -174,7 +175,9 @@ describe GitBasedDomainImportService do
 
   describe "#refresh" do
     include_context "import setup"
-    include_context "refresh setup"
+    include_context "repository setup"
+    let(:action) { 'Refresh git repository' }
+    let(:method_name) { 'refresh' }
     let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
 
     before do
@@ -200,6 +203,32 @@ describe GitBasedDomainImportService do
 
         expect { subject.refresh(git_repo.id) }.to raise_exception(MiqException::Error, message)
       end
+    end
+  end
+
+  describe "destroy git repository" do
+    include_context "import setup"
+    include_context "repository setup"
+    let(:action) { 'Destroy git repository' }
+    let(:method_name) { 'destroy' }
+    let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
+
+    before do
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:task_results).and_return(true)
+    end
+
+    it "#destroy_repository" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+      expect(subject.destroy_repository(git_repo.id)).to be_truthy
+    end
+
+    it "#queue_destroy_repository" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+
+      expect(subject.queue_destroy_repository(git_repo.id)).to eq(task.id)
     end
   end
 end


### PR DESCRIPTION
Each Git domain has a downloaded bare repository on the appliance with the git owner role.
When a domain is being deleted the bare repository directory should be deleted.

Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1392981
* 
* PR #12192 (depends on)

Steps for Testing/QA 
-------------------------------

Described in 
https://bugzilla.redhat.com/show_bug.cgi?id=1392981