### PR TITLE
Restore missing Add Project button on Tenants

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1822,6 +1822,8 @@ module ApplicationHelper
     case pressed
     when "rbac_project_add", "rbac_tenant_add"
       "rbac_tenant_add"
+    else
+      pressed
     end
   end
 

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::Basic < Hash
   include ActionView::Helpers::TextHelper
 
-  delegate :role_allows?, :rbac_common_feature_for_buttons, :to => :@view_context
+  delegate :role_allows?, :to => :@view_context
 
   def initialize(view_context, view_binding, instance_data, props)
     @view_context  = view_context
@@ -19,7 +19,7 @@ class ApplicationHelper::Button::Basic < Hash
     return true if self[:type] == :buttonSelect
     # for each button in select checks RBAC, self[:child_id] represents the
     # button id for buttons inside select
-    return role_allows?(:feature => rbac_common_feature_for_buttons(self[:child_id])) unless self[:child_id].nil?
+    return role_allows?(:feature => self[:child_id]) unless self[:child_id].nil?
     # check RBAC on separate button
     role_allows?(:feature => self[:id])
   end

--- a/app/helpers/application_helper/button/basic.rb
+++ b/app/helpers/application_helper/button/basic.rb
@@ -1,7 +1,7 @@
 class ApplicationHelper::Button::Basic < Hash
   include ActionView::Helpers::TextHelper
 
-  delegate :role_allows?, :to => :@view_context
+  delegate :role_allows?, :rbac_common_feature_for_buttons, :to => :@view_context
 
   def initialize(view_context, view_binding, instance_data, props)
     @view_context  = view_context
@@ -19,7 +19,7 @@ class ApplicationHelper::Button::Basic < Hash
     return true if self[:type] == :buttonSelect
     # for each button in select checks RBAC, self[:child_id] represents the
     # button id for buttons inside select
-    return role_allows?(:feature => self[:child_id]) unless self[:child_id].nil?
+    return role_allows?(:feature => rbac_common_feature_for_buttons(self[:child_id])) unless self[:child_id].nil?
     # check RBAC on separate button
     role_allows?(:feature => self[:id])
   end

--- a/app/helpers/application_helper/button/tenant_add.rb
+++ b/app/helpers/application_helper/button/tenant_add.rb
@@ -3,7 +3,7 @@ class ApplicationHelper::Button::TenantAdd < ApplicationHelper::Button::GenericF
   delegate :role_allows?, :rbac_common_feature_for_buttons, :to => :@view_context
 
   def role_allows_feature?
-    return role_allows?(:feature => rbac_common_feature_for_buttons(self[:child_id]))
+    role_allows?(:feature => rbac_common_feature_for_buttons(self[:child_id]))
   end
 
   def visible?

--- a/app/helpers/application_helper/button/tenant_add.rb
+++ b/app/helpers/application_helper/button/tenant_add.rb
@@ -1,0 +1,12 @@
+class ApplicationHelper::Button::TenantAdd < ApplicationHelper::Button::GenericFeatureButton
+  needs :@record
+  delegate :role_allows?, :rbac_common_feature_for_buttons, :to => :@view_context
+
+  def role_allows_feature?
+    return role_allows?(:feature => rbac_common_feature_for_buttons(self[:child_id]))
+  end
+
+  def visible?
+    true
+  end
+end

--- a/app/helpers/application_helper/toolbar/tenant_center.rb
+++ b/app/helpers/application_helper/toolbar/tenant_center.rb
@@ -11,12 +11,16 @@ class ApplicationHelper::Toolbar::TenantCenter < ApplicationHelper::Toolbar::Bas
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add child Tenant to this Tenant'),
           t,
+          :klass     => ApplicationHelper::Button::TenantAdd,
+          :options   => {:feature => 'rbac_tenant_add'},
           :url_parms => "?tenant_type=tenant"),
         button(
           :rbac_project_add,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add Project to this Tenant'),
           t,
+          :klass     => ApplicationHelper::Button::TenantAdd,
+          :options   => {:feature => 'rbac_project_add'},
           :url_parms => "?tenant_type=project"),
         button(
           :rbac_tenant_edit,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -412,10 +412,8 @@ class ApplicationHelper::ToolbarBuilder
         return true
       end
     when :rbac_tree
-      common_buttons = %w(rbac_project_add rbac_tenant_add)
-      feature = common_buttons.include?(id) ? rbac_common_feature_for_buttons(id) : id
-      return true unless role_allows?(:feature => feature)
-      return true if common_buttons.include?(id) && @record.project?
+      return true unless role_allows?(:feature => rbac_common_feature_for_buttons(id))
+      return true if %w(rbac_project_add rbac_tenant_add).include?(id) && @record.project?
       return false
     when :vmdb_tree
       return !["db_connections", "db_details", "db_indexes", "db_settings"].include?(@sb[:active_tab])

--- a/spec/helpers/application_helper/buttons/tenant_add_spec.rb
+++ b/spec/helpers/application_helper/buttons/tenant_add_spec.rb
@@ -1,0 +1,32 @@
+describe ApplicationHelper::Button::TenantAdd do
+  describe '#role_allows_feature?' do
+    let(:session) { {} }
+    before do
+      MiqProductFeature.seed
+      feature = MiqProductFeature.find_all_by_identifier("rbac_tenant_add")
+      @view_context = setup_view_context_with_sandbox({})
+      @button = tenant_add_button
+
+      role   = FactoryGirl.create(:miq_user_role, :miq_product_features => feature)
+      group  = FactoryGirl.create(:miq_group, :miq_user_role => role)
+      @user = FactoryGirl.create(:user, :miq_groups => [group])
+    end
+
+    def tenant_add_button
+      described_class.new(@view_context,
+                          {},
+                          {'record' => FactoryGirl.create(:tenant)},
+                          {:options => {:feature => "rbac_project_add"}, :child_id => "rbac_project_add"})
+    end
+
+    it 'returns true for allowed features' do
+      login_as @user
+      expect(@button.role_allows_feature?).to be_truthy
+    end
+
+    it 'returns false for disallowed features' do
+      login_as FactoryGirl.create(:user, :role => 'EvmRole-user')
+      expect(@button.role_allows_feature?).to be_falsey
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -114,6 +114,18 @@ describe ApplicationHelper do
     end
   end
 
+  describe "#rbac_common_feature_for_buttons" do
+    %w(rbac_project_add rbac_tenant_add).each do |pressed|
+      it "returns the correct common button" do
+        expect(rbac_common_feature_for_buttons(pressed)).to eql("rbac_tenant_add")
+      end
+    end
+
+    it "returns the passed in argument if no common buttons are found" do
+      expect(rbac_common_feature_for_buttons("rbac_tenant_edit")).to eql("rbac_tenant_edit")
+    end
+  end
+
   describe "#model_to_controller" do
     subject { helper.model_to_controller(@record) }
 


### PR DESCRIPTION
Common button id's were not being accounted for in some role_allows? calls causing the Add Project button to go missing in some instances.

https://bugzilla.redhat.com/show_bug.cgi?id=1387088