### PR TITLE
Refactoring to use queue_event with filtered? method instead of process_event method

### DIFF
--- a/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/event_catcher/runner.rb
@@ -23,15 +23,9 @@ class ManageIQ::Providers::Google::CloudManager::EventCatcher::Runner <
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered?(event)
-      _log.info(
-        "#{log_prefix} Skipping filtered Google event #{parse_event_type(event)} for #{parse_resource_id(event)}"
-      )
-    else
-      _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
-      EmsEvent.add_queue('add_google', @cfg[:ems_id], event)
-    end
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event #{parse_event_type(event)} for #{parse_resource_id(event)}"
+    EmsEvent.add_queue('add_google', @cfg[:ems_id], event)
   end
 
   private

--- a/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/event_catcher_mixin.rb
@@ -47,14 +47,14 @@ module ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcherMixin
     reset_event_monitor_handle
   end
 
-  def process_event(event)
+  def queue_event(event)
     event_data = extract_event_data(event)
-    if event_data.nil?
-      _log.debug "#{log_prefix} Discarding event [#{event_data}]"
-    else
-      _log.info "#{log_prefix} Queuing event [#{event_data}]"
-      EmsEvent.add_queue('add_kubernetes', @cfg[:ems_id], event_data)
-    end
+    _log.info "#{log_prefix} Queuing event [#{event_data}]"
+    EmsEvent.add_queue('add_kubernetes', @cfg[:ems_id], event_data)
+  end
+
+  def filtered?(event)
+    extract_event_data(event).nil?
   end
 
   # Returns hash, or nil if event should be discarded.

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -48,28 +48,28 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered_events.include?(event.payload["event_type"])
-      _log.debug "#{log_prefix} Skipping caught event [#{event.payload["event_type"]}]"
-    else
-      _log.info "#{log_prefix} Caught event [#{event.payload["event_type"]}]"
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event [#{event.payload["event_type"]}]"
 
-      event_hash = {}
-      # copy content
-      content = event.payload
-      event_hash[:content] = content.reject { |k, _v| k.start_with? "_context_" }
+    event_hash = {}
+    # copy content
+    content = event.payload
+    event_hash[:content] = content.reject { |k, _v| k.start_with? "_context_" }
 
-      # copy context
-      event_hash[:context] = {}
-      content.select { |k, _v| k.start_with? "_context_" }.each_pair do |k, v|
-        event_hash[:context][k] = v
-      end
-
-      # copy attributes
-      event_hash[:user_id]      = event.metadata[:user_id]
-      event_hash[:priority]     = event.metadata[:priority]
-      event_hash[:content_type] = event.metadata[:content_type]
-      add_openstack_queue(event_hash)
+    # copy context
+    event_hash[:context] = {}
+    content.select { |k, _v| k.start_with? "_context_" }.each_pair do |k, v|
+      event_hash[:context][k] = v
     end
+
+    # copy attributes
+    event_hash[:user_id]      = event.metadata[:user_id]
+    event_hash[:priority]     = event.metadata[:priority]
+    event_hash[:content_type] = event.metadata[:content_type]
+    add_openstack_queue(event_hash)
+  end
+
+  def filtered?(event)
+    filtered_events.include?(event.payload["event_type"])
   end
 end

--- a/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_catcher/runner.rb
@@ -39,12 +39,12 @@ class ManageIQ::Providers::Redhat::InfraManager::EventCatcher::Runner < ManageIQ
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered_events.include?(event[:name])
-      _log.info "#{log_prefix} Skipping caught event [#{event[:name]}]"
-    else
-      _log.info "#{log_prefix} Caught event [#{event[:name]}]"
-      EmsEvent.add_queue('add_rhevm', @cfg[:ems_id], event.to_hash)
-    end
+  def queue_event(event)
+    log.info "#{log_prefix} Caught event [#{event[:name]}]"
+    EmsEvent.add_queue('add_rhevm', @cfg[:ems_id], event.to_hash)
+  end
+
+  def filtered?(event)
+    filtered_events.include?(event[:name])
   end
 end

--- a/app/models/manageiq/providers/vmware/cloud_manager/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager/event_catcher_mixin.rb
@@ -52,13 +52,13 @@ module ManageIQ::Providers::Vmware::CloudManager::EventCatcherMixin
     reset_event_monitor_handle
   end
 
-  def process_event(event)
-    if filtered_events.include?(event.type)
-      _log.info "Skipping caught event [#{event.type}]"
-    else
-      _log.info "Caught event [#{event.type}]"
-      add_to_worker_queue(event)
-    end
+  def queue_event(event)
+    _log.info "Caught event [#{event.type}]"
+    add_to_worker_queue(event)
+  end
+
+  def filtered?(event)
+    filtered_events.include?(event.type)
   end
 
   def add_to_worker_queue(event)


### PR DESCRIPTION
The process_event method is already defined in ManageIQ::Providers::BaseManager::EventCatcher::Runner. Hence there is no need for custom implementation of it. Instead added the queue_event method which overrides the Base Runner Class, and it is used in process_event method.

