### PR TITLE
Fix for default GTL view settings for cloud key pair list

### DIFF
--- a/app/controllers/auth_key_pair_cloud_controller.rb
+++ b/app/controllers/auth_key_pair_cloud_controller.rb
@@ -182,7 +182,7 @@ class AuthKeyPairCloudController < ApplicationController
   end
 
   def show_list
-    process_show_list
+    process_show_list(:dbname => :authkeypaircloud)
   end
 
   # delete selected auth key pairs


### PR DESCRIPTION
The `dbname` value that is passed via `process_show_list` is used to retrieve the user defined GTL setting on the list.

https://bugzilla.redhat.com/show_bug.cgi?id=1391792