### PR TITLE
Use settings for purging records

### DIFF
--- a/app/models/drift_state/purging.rb
+++ b/app/models/drift_state/purging.rb
@@ -4,14 +4,14 @@ module DriftState::Purging
 
   module ClassMethods
     def purge_mode_and_value
-      value = VMDB::Config.new("vmdb").config.fetch_path(:drift_states, :history, :keep_drift_states)
-      mode  = (value.nil? || value.number_with_method?) ? :date : :remaining
-      value = (value || 6.months).to_i_with_method.seconds.ago.utc if mode == :date
+      value = ::Settings.drift_states.history.keep_drift_states
+      mode  = value.number_with_method? ? :date : :remaining
+      value = value.to_i_with_method.seconds.ago.utc if mode == :date
       return mode, value
     end
 
     def purge_window_size
-      VMDB::Config.new("vmdb").config.fetch_path(:drift_states, :history, :purge_window_size) || 10000
+      ::Settings.drift_states.history.purge_window_size
     end
 
     def purge_timer

--- a/app/models/metric/purging.rb
+++ b/app/models/metric/purging.rb
@@ -1,6 +1,6 @@
 module Metric::Purging
   def self.purge_date(type)
-    value = VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, type.to_sym)
+    value = ::Settings.performance.history[type]
 
     case value
     when Numeric
@@ -21,17 +21,17 @@ module Metric::Purging
   end
 
   def self.purge_daily_timer(ts = nil)
-    ts ||= purge_date(:keep_daily_performances) || 6.months.ago.utc
+    ts ||= purge_date(:keep_daily_performances)
     purge_timer(ts, "daily")
   end
 
   def self.purge_hourly_timer(ts = nil)
-    ts ||= purge_date(:keep_hourly_performances) || 6.months.ago.utc
+    ts ||= purge_date(:keep_hourly_performances)
     purge_timer(ts, "hourly")
   end
 
   def self.purge_realtime_timer(ts = nil)
-    ts ||= purge_date(:keep_realtime_performances) || 4.hours.ago.utc
+    ts ||= purge_date(:keep_realtime_performances)
     purge_timer(ts, "realtime")
   end
 
@@ -47,7 +47,7 @@ module Metric::Purging
   end
 
   def self.purge_window_size
-    VMDB::Config.new("vmdb").config.fetch_path(:performance, :history, :purge_window_size) || 1000
+    ::Settings.performance.history.purge_window_size
   end
 
   def self.purge_scope(older_than, interval)

--- a/app/models/miq_report_result/purging.rb
+++ b/app/models/miq_report_result/purging.rb
@@ -4,14 +4,14 @@ module MiqReportResult::Purging
 
   module ClassMethods
     def purge_mode_and_value
-      value = VMDB::Config.new("vmdb").config.fetch_path(:reporting, :history, :keep_reports)
-      mode  = (value.nil? || value.number_with_method?) ? :date : :remaining
-      value = (value || 6.months).to_i_with_method.seconds.ago.utc if mode == :date
+      value = ::Settings.reporting.history.keep_reports
+      mode  = value.number_with_method? ? :date : :remaining
+      value = value.to_i_with_method.seconds.ago.utc if mode == :date
       return mode, value
     end
 
     def purge_window_size
-      VMDB::Config.new("vmdb").config.fetch_path(:reporting, :history, :purge_window_size) || 100
+      ::Settings.reporting.history.purge_window_size
     end
 
     def purge_timer

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -146,9 +146,9 @@ class MiqStorageMetric < ApplicationRecord
   private_class_method :metrics_count_by_date
 
   def self.purge_all_timer
-    purge_derived_metrics_by_date(purge_date(:keep_realtime_metrics) || 4.hours.ago.utc)
-    purge_hourly_metrics_rollups_by_date(purge_date(:keep_hourly_metrics) || 6.months.ago.utc)
-    purge_daily_metrics_rollups_by_date(purge_date(:keep_daily_metrics) || 6.months.ago.utc)
+    purge_derived_metrics_by_date(purge_date(:keep_realtime_metrics))
+    purge_hourly_metrics_rollups_by_date(purge_date(:keep_hourly_metrics))
+    purge_daily_metrics_rollups_by_date(purge_date(:keep_daily_metrics))
   end
 
   def self.purge_derived_metrics_by_date(older_than, window = nil)

--- a/app/models/vmdb_metric/purging.rb
+++ b/app/models/vmdb_metric/purging.rb
@@ -5,7 +5,7 @@ module VmdbMetric::Purging
   module ClassMethods
     def purge_date(interval)
       type  = "keep_#{interval}_metrics".to_sym
-      value = VMDB::Config.new("vmdb").config.fetch_path(:database, :metrics_history, type)
+      value = ::Settings.database.metrics_history[type]
       value = value.to_i.days if value.kind_of?(Fixnum) # Default unit is days
       value = value.to_i_with_method.seconds.ago.utc unless value.nil?
       value
@@ -18,13 +18,13 @@ module VmdbMetric::Purging
 
     def purge_daily_timer(ts = nil)
       interval = "daily"
-      ts ||= purge_date(interval) || 6.months.ago.utc
+      ts ||= purge_date(interval)
       purge_timer(ts, interval)
     end
 
     def purge_hourly_timer(ts = nil)
       interval = "hourly"
-      ts ||= purge_date(interval) || 6.months.ago.utc
+      ts ||= purge_date(interval)
       purge_timer(ts, interval)
     end
 
@@ -40,7 +40,7 @@ module VmdbMetric::Purging
     end
 
     def purge_window_size
-      VMDB::Config.new("vmdb").config.fetch_path(:database, :metrics_history, :purge_window_size) || 10000
+      ::Settings.database.metrics_history.purge_window_size
     end
 
     def purge_count(mode, value, interval)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -86,7 +86,7 @@
     :keep_daily_metrics: 6.months
     :keep_hourly_metrics: 6.months
     :purge_schedule: "50 * * * *"
-    :purge_window_size: 100000
+    :purge_window_size: 10000
 :drift_states:
   :history:
     :keep_drift_states: 6.months
@@ -1119,7 +1119,7 @@
     :keep_daily_metrics: 6.months
     :keep_hourly_metrics: 6.months
     :keep_realtime_metrics: 4.hours
-    :purge_window_size: 1000
+    :purge_window_size: 100
   :watchdog_interval: 1.minute
 :ui:
   :mark_translated_strings: false

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -29,14 +29,6 @@ describe MiqReportResult do
     end
 
     context "#purge_mode_and_value" do
-      it "with missing config value" do
-        settings.delete_path(:reporting, :history, :keep_reports)
-        stub_settings(settings)
-        Timecop.freeze(Time.now) do
-          expect(described_class.purge_mode_and_value).to eq([:date, 6.months.to_i.seconds.ago.utc])
-        end
-      end
-
       it "with date" do
         settings.store_path(:reporting, :history, :keep_reports, "1.day")
         stub_settings(settings)
@@ -53,14 +45,6 @@ describe MiqReportResult do
     end
 
     context "#purge_window_size" do
-      it "with missing config value" do
-        settings.delete_path(:reporting, :history, :purge_window_size)
-        stub_settings(settings)
-        Timecop.freeze(Time.now) do
-          expect(described_class.purge_window_size).to eq(100)
-        end
-      end
-
       it "with value" do
         settings.store_path(:reporting, :history, :purge_window_size, 1000)
         stub_settings(settings)


### PR DESCRIPTION
Use settings to purge records

I did need to remove 2 specs.
They were testing when settings has no value.
But the new way we handle settings, we put the default value into `settings.yaml`, so that no longer made sense.

/cc @yrudman FYI