### PR TITLE
Don't set @layout in accordion_select, as it's done in get_session_data

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -156,7 +156,6 @@ module ApplicationController::Explorer
 
   # Accordion selected in explorer
   def accordion_select(node_info = false)
-    @layout     = "explorer"
     @lastaction = "explorer"
     self.x_active_accord = params[:id].sub(/_accord$/, '')
     self.x_active_tree   = "#{self.x_active_accord}_tree"


### PR DESCRIPTION
The toolbars in Cloud Instances (show list) and infra VMs (show list) have disappeared, when user changed accordion.

Layout variable is set in the method(s) get_session_data

PR that introduced the bug: https://github.com/ManageIQ/manageiq/pull/12320
