### PR TITLE
Add extra X-Angular-Request header to $http requests, don't use these to remember tab

### DIFF
--- a/app/assets/javascripts/miq_angular_application.js
+++ b/app/assets/javascripts/miq_angular_application.js
@@ -11,6 +11,7 @@ ManageIQ.angular.rxSubject = new Rx.Subject();
 
 function miqHttpInject(angular_app) {
   angular_app.config(['$httpProvider', function($httpProvider) {
+    $httpProvider.defaults.headers.common['X-Angular-Request'] = true;
     $httpProvider.defaults.headers.common['X-CSRF-Token'] = function() {
       return $('meta[name=csrf-token]').attr('content');
     };

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1967,7 +1967,7 @@ class ApplicationController < ActionController::Base
     session[:host_url] = request.host_with_port
     session[:tab_url] ||= {}
 
-    remember_tab if !request.xml_http_request? && request.get? && request.format == Mime[:html]
+    remember_tab if !request.xml_http_request? && request.get? && request.format == Mime[:html] && request.headers['X-Angular-Request'].nil?
 
     # Get all of the global variables used by most of the controllers
     @pp_choices = PPCHOICES


### PR DESCRIPTION
This is to address an issue found in #12117, where Angular `$http` requests were remembered by `remember_tab` (the functionality that handles clicking on the first level menu items).

That's beacuse those are not xml_http_requests and do pretend to ask for html content, so without this we have no way to distinguish them from the ones that should be remembered.

This will not affect angular access to the API nor downloading static templates, but may affect other places if there are any that use `$http` to actually go somewhere else (I don't think there are any though.).