### PR TITLE
Fix missing Smart State Analysis button on Cloud Instances list view

### DIFF
--- a/app/helpers/application_helper/button/basic_image.rb
+++ b/app/helpers/application_helper/button/basic_image.rb
@@ -1,7 +1,6 @@
 class ApplicationHelper::Button::BasicImage < ApplicationHelper::Button::Basic
   def visible?
-    @sb.fetch_path(:trees, :vandt_tree, :active_node).blank? ||
-      (@sb[:trees][:vandt_tree][:active_node] != "xx-arch" &&
-       @sb[:trees][:vandt_tree][:active_node] != "xx-orph")
+    active_node = @view_context.x_node
+    active_node.blank? || (active_node != "xx-arch" && active_node != "xx-orph")
   end
 end

--- a/app/helpers/application_helper/button/vm_instance_template_scan.rb
+++ b/app/helpers/application_helper/button/vm_instance_template_scan.rb
@@ -13,12 +13,10 @@ class ApplicationHelper::Button::VmInstanceTemplateScan < ApplicationHelper::But
   end
 
   def visible?
-    return true if @display == "instances"
     @record.supports_smartstate_analysis? && @record.has_proxy?
   end
 
   def disabled?
-    return false if @display == "instances"
     !(@record.supports_smartstate_analysis? && @record.has_active_proxy?)
   end
 end

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -25,8 +25,8 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :url_parms => "main_div",
           :confirm   => N_("Perform SmartState Analysis on the selected items?"),
           :enabled   => false,
-          :onwhen    => "1+",
-          :klass     => ApplicationHelper::Button::VmInstanceTemplateScan),
+          :klass     => ApplicationHelper::Button::BasicImage,
+          :onwhen    => "1+"),
         button(
           :instance_compare,
           'product product-compare fa-lg',

--- a/spec/helpers/application_helper/buttons/basic_image_spec.rb
+++ b/spec/helpers/application_helper/buttons/basic_image_spec.rb
@@ -1,27 +1,20 @@
 describe ApplicationHelper::Button::BasicImage do
   describe '#visible?' do
+    before do
+      @view_context = setup_view_context_with_sandbox({:trees => {:vandt_tree => {:active_node => "xx-arch"}},
+                                                       :active_tree => :vandt_tree})
+    end
     context "in list of archived VMs" do
-      before do
-        allow(ApplicationHelper).to receive(:get_record_cls).and_return(nil)
-        @sb = {:trees => {:vandt_tree => {:active_node => "xx-arch"}}}
-      end
-
       it "will be skipped" do
-        view_context = setup_view_context_with_sandbox({})
-        button = described_class.new(view_context, {}, {'sb' => @sb}, {})
+        button = described_class.new(@view_context, {}, {}, {})
         expect(button.visible?).to be_falsey
       end
     end
 
     context "in list of orphaned VMs" do
-      before do
-        allow(ApplicationHelper).to receive(:get_record_cls).and_return(nil)
-        @sb = {:trees => {:vandt_tree => {:active_node => "xx-arch"}}}
-      end
-
       it "will be skipped" do
-        view_context = setup_view_context_with_sandbox({})
-        button = described_class.new(view_context, {}, {'sb' => @sb}, {})
+        @view_context.x_node = "xx-orph"
+        button = described_class.new(@view_context, {}, {}, {})
         expect(button.visible?).to be_falsey
       end
     end


### PR DESCRIPTION
Use different class for ```instance_scan``` to display Smart State Analysis on Instance list view as the class used for one Instance (where we can detect if the button should be visible or not - depends on support of Smart State on the instance). 
 
https://bugzilla.redhat.com/show_bug.cgi?id=1389055