### PR TITLE
For purging remaining records, use single query

### DIFF
--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -72,11 +72,6 @@ describe DriftState do
       end
     end
 
-    it "#purge_counts_for_remaining (used by tools - expensive, avoid)" do
-      expect(described_class.send(:purge_counts_for_remaining, 1))
-        .to eq(["VmOrTemplate", 1] => 1, ["VmOrTemplate", 2] => 2)
-    end
-
     context "#purge_count" do
       it "by remaining" do
         expect(described_class.purge_count(:remaining, 1)).to eq(3)

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -117,10 +117,6 @@ describe MiqReportResult do
       end
     end
 
-    it "#purge_counts_for_remaining (used by tools - avoid, it is very expensive)" do
-      expect(described_class.send(:purge_counts_for_remaining, 1)).to eq({1 => 1, 2 => 2})
-    end
-
     context "#purge_count (used by tools - avoid, it is very expensive)" do
       it "by remaining" do
         expect(described_class.purge_count(:remaining, 1)).to eq(3)


### PR DESCRIPTION
While purging report results by "remaining" we had a very bad N+1:

for drift states:

|        ms |    bytes |  objects |queries | query (ms) |     rows |`comments`
|       ---:|      ---:|      ---:|  ---:|      ---:|      ---:| ---
|  19,377.2 | 33,471,380* | 7,968,800 |6,413 | 12,702.1 |   16,481 |before
|   7,313.8 |  491,434 |    5,765 |   11 |  7,274.6 |    0      |after
| 62.3% | 99% | 99.9% | 99.9%| 42.7% | 100% | |

\* Memory usage does not reflect 3,732,622 freed objects. 


before:
-------

```ruby
remaining = 5 # keep 5 records
ids_to_delete = []
select("distinct(foreign_key)").map(&:foreign_key).flat_map do |foreign_key|
  last_id=where(:foreign_key=>foreign_key).order("id desc").offset(remaining).limit(1)
  ids_to_delete+=where(:foreign_key=>foreign_key).order("id DESC").where('id<?',last_id)
end
destroy_all(:id => ids_to_delete)
```

It brings back every id in the table in multiple queries with sorting
Windowing repeats many of these queries multiple times.

after
-----

```ruby
remaining = 5
# this is a sub query
# not the real sql - The offset is performed within each grouping (aka `RANK, PARTITION`)
ids_to_delete = "(SELECT id FROM table GROUP BY foreign_key OFFSET #{remaining})"
destroy_all(:id => ids_to_delete)
```

it brings back no records
the db does the algorithm above
this may be ANSI SQL, but it is advanced.

/cc @NickLaMuro 
