### PR TITLE
Revert "Fix broken copy function in automate"

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -265,8 +265,8 @@ class MiqAeClassController < ApplicationController
 
     @in_a_form = @in_a_form_fields = @in_a_form_props = false if params[:button] == "cancel" ||
                                                                  (["save", "add"].include?(params[:button]) && replace_trees)
-    open_parent_nodes(@record) if params[:action] == "x_show" || params[:button] == "copy"
-
+    add_nodes = open_parent_nodes(@record) if params[:button] == "copy" ||
+                                              params[:action] == "x_show"
     get_node_info(x_node) if !@in_a_form && @button != "reset"
 
     c_tb = build_toolbar(center_toolbar_filename) unless @in_a_form
@@ -275,6 +275,8 @@ class MiqAeClassController < ApplicationController
     presenter = ExplorerPresenter.new(
       :active_tree     => x_active_tree,
       :right_cell_text => @right_cell_text,
+      :remove_nodes    => add_nodes, # remove any existing nodes before adding child nodes to avoid duplication
+      :add_nodes       => add_nodes,
     )
     r = proc { |opts| render_to_string(opts) }
 
@@ -1669,7 +1671,7 @@ class MiqAeClassController < ApplicationController
       self.x_node = "#{TreeBuilder.get_prefix_for_model(@edit[:typ])}-#{to_cid(@record.id)}"
       @in_a_form = @changed = session[:changed] = false
       @sb[:action] = @edit = session[:edit] = nil
-      replace_right_cell([:ae])
+      replace_right_cell
     end
   end
 


### PR DESCRIPTION
So we somehow received two instances of the same BZ with @ZitaNemeckova:
https://bugzilla.redhat.com/show_bug.cgi?id=1390362
https://bugzilla.redhat.com/show_bug.cgi?id=1381157

[Her fix](https://github.com/ManageIQ/manageiq/pull/12436) is basically bypassing the faulty JS code by re-rendering the whole tree on the left side. This is quite an uneffective solution as it transfers much more data through the network. So my suggestion is to revert it in favor of [my fix](https://github.com/ManageIQ/manageiq/pull/12479).

**Note:** my PR is not yet backported to darga, but Zita's is!

This reverts commit 0e1e9d3d63421275965e80b801f4f6a6bce1b36b.
