### PR TITLE
Paging bar styling cleanup

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -35,6 +35,10 @@
   }
 }
 
+.toolbar-pf#paging_div input#masterToggle {
+  margin-top: 6px;
+}
+
 .toolbar-pf#paging_div ul.pagination {
   margin: 0;
 }

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -56,14 +56,14 @@ module UiConstants
 
   # Per page choices and default
   PPCHOICES = [
-    [5, 5],
-    [10, 10],
-    [20, 20],
-    [50, 50],
-    [100, 100],
-    [200, 200],
-    [500, 500],
-    [1000, 1000]
+    ["5 items", 5],
+    ["10 items", 10],
+    ["20 items", 20],
+    ["50 items", 50],
+    ["100 items", 100],
+    ["200 items", 200],
+    ["500 items", 500],
+    ["1000 items", 1000]
   ]
 
   # Per page choices for task/jobs

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -82,7 +82,7 @@
                   = render :partial => "/layouts/tabs"
                 = render :partial => "layouts/angular/toolbar"
         .row.max-height
-          .col-sm-9.col-md-10.col-sm-push-3.col-md-push-2.max-height
+          .col-sm-10.col-md-9.col-sm-push-2.col-md-push-3.max-height
             #main-content.row
               .col-md-12
                 .row
@@ -106,7 +106,7 @@
                                         :headers    => @view.try(:headers),
                                         :button_div => 'center_tb'})
 
-          .col-sm-3.col-md-2.col-sm-pull-9.col-md-pull-10.sidebar-pf.sidebar-pf-left.max-height
+          .col-sm-2.col-md-3.col-sm-pull-10.col-md-pull-9.sidebar-pf.sidebar-pf-left.max-height
             = render :partial => "layouts/listnav"
 
     - elsif dashboard_no_listnav?

--- a/app/views/layouts/_pagingcontrols.html.haml
+++ b/app/views/layouts/_pagingcontrols.html.haml
@@ -1,150 +1,155 @@
 .col-md-12
-  .toolbar-pf-actions
-    - if !@embedded && @pages && @items_per_page != ONE_MILLION
-      - button_div ||= "center_tb"
-      - db ||= nil
-      - action_id    = action_url.split("/").last if action_url.include?("/")
+  - if !@embedded && @pages && @items_per_page != ONE_MILLION
+    - button_div ||= "center_tb"
+    - db ||= nil
+    - action_id    = action_url.split("/").last if action_url.include?("/")
 
-      - @pc_occ ||= 0
-      - @pc_occ += 1
+    - @pc_occ ||= 0
+    - @pc_occ += 1
 
-      %div{:id => "pc_div_#{@pc_occ}"}
-        - if @pc_occ == 1
-          .form-group
-            - if !@no_checkall && !@no_checkboxes
-              = render :partial => 'shared/master_toggle',
-                       :locals  => {:button_div => button_div,
-                                    :label      => _("(Check All)")}
-        - if @gtl_type != "list" && @view
-          .form-group{:style => "border-right: 0"}
-            = _('Sorted by: ')
-            = select_tag("sort_choice", options_for_select(@view.headers.map { |x| [_(x), x] }), :class => "selectpicker dropup")
+    .clearfix{:id => "pc_div_#{@pc_occ}"}
+      - if @pc_occ == 1
+        .pull-left.text-nowrap
+          - if !@no_checkall && !@no_checkboxes
+            = render :partial => 'shared/master_toggle',
+                     :locals  => {:button_div => button_div,
+                                  :label      => _("(Check All)")}
+      .pull-right
+        .form-group.text-nowrap
+          - if @gtl_type != "list" && @view
+            - sort_text = "#{@view.headers[@sortcol]} (#{@sortdir == "ASC" ? _("Asc") : _("Desc")})"
+            = select_tag("sort_choice",
+                        options_for_select([sort_text] + @view.headers),
+                       :class => "selectpicker dropup",
+                       "data-width" => "auto",
+                       )
             :javascript
               miqSelectPickerEvent("sort_choice", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
-        - unless db.blank?
-          - if %w(EmsInfra EmsCloud EmsCluster ResourcePool OntapStorageSystem OntapLogicalDisk CimBaseStorageExtent OntapStorageVolume StorageManager OntapFileShare SniaLocalFileSystem).include?(db)
-            - @db = db.underscore
-        - if @pc_occ == 1
-          .form-group
-            - unless @embedded
-              - if @sortdir == "ASC"
-                = _("Asc. by:")
-              - else
-                = _("Desc. by:")
-            = _(@view.headers[@sortcol])
-
-          .form-group.pull-right{:style => "border-right: 0"}
-            %ul.pagination
-              - if pages[:current] > 1
-                - if @ajax_paging_buttons
-                  %li.first
-                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => update_paging_url_parms(action_url, :page => 1)),
-                          :class   => "fa fa-angle-double-left",
-                          :alt     => _("First"),
-                          :title   => _("First")}
-                  %li.prev
-                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => update_paging_url_parms(action_url, :page => pages[:current] - 1)),
-                          :class   => "fa fa-angle-left",
-                          :alt     => _("Previous"),
-                          :title   => _("Previous")}
-                - elsif action_id
-                  %li.first
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1, :id => action_id)}')",
-                          :class   => "fa fa-angle-double-left",
-                          :alt     => _("First"),
-                          :title   => _("First")}
-                  %li.prev
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1, :id => action_id)}')",
-                          :class   => "fa fa-angle-left",
-                          :alt     => _("Previous"),
-                          :title   => _("Previous")}
+          -else
+            - if @pc_occ == 1
+              - unless @embedded
+                - if @sortdir == "ASC"
+                  %span.fa{:class => "fa-sort-alpha-asc"}
                 - else
-                  %li.first
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1)}')",
-                          :class   => "fa fa-angle-double-left",
-                          :alt     => _("First"),
-                          :title   => _("First")}
-                  %li.prev
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1)}')",
-                          :class   => "fa fa-angle-left",
-                          :alt     => _("Previous"),
-                          :title   => _("Previous")}
-              - else
-                %li.first.disabled
-                  %span{:class => "fa fa-angle-double-left"}
-                %li.prev.disabled
-                  %span{:class => "fa fa-angle-left"}
+                  %span.fa{:class => "fa-sort-alpha-desc"}
+              = _(@view.headers[@sortcol])
 
-              %li
-                %span
-                  - start_number = pages[:items] > 0 ? (pages[:perpage] * pages[:current]) - pages[:perpage] + 1 : 0
-                  - end_number = pages[:perpage] * pages[:current]
-                  - if start_number == pages[:items]
-                    = _("(Item %{start_number} of %{total_items})") % {:start_number => start_number, :total_items => pages[:items]}
+          - unless db.blank?
+            - if %w(EmsInfra EmsCloud EmsCluster ResourcePool OntapStorageSystem OntapLogicalDisk CimBaseStorageExtent OntapStorageVolume StorageManager OntapFileShare SniaLocalFileSystem).include?(db)
+              - @db = db.underscore
+
+        .form-group
+          = select_tag("ppsetting",
+                      options_for_select(@pp_choices, pages[:perpage]),
+                      "data-width" => "auto",
+                      :class       => "selectpicker dropup")
+          :javascript
+            miqSelectPickerEvent("ppsetting", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
+
+        .form-group.pull-right{:style => "border-right: 0"}
+          %ul.pagination
+            - if pages[:current] > 1
+              - if @ajax_paging_buttons
+                %li.first
+                  %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => update_paging_url_parms(action_url, :page => 1)),
+                        :class   => "fa fa-angle-double-left",
+                        :alt     => _("First"),
+                        :title   => _("First")}
+                %li.prev
+                  %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => update_paging_url_parms(action_url, :page => pages[:current] - 1)),
+                        :class   => "fa fa-angle-left",
+                        :alt     => _("Previous"),
+                        :title   => _("Previous")}
+              - elsif action_id
+                %li.first
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1, :id => action_id)}')",
+                        :class   => "fa fa-angle-double-left",
+                        :alt     => _("First"),
+                        :title   => _("First")}
+                %li.prev
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1, :id => action_id)}')",
+                        :class   => "fa fa-angle-left",
+                        :alt     => _("Previous"),
+                        :title   => _("Previous")}
+              - else
+                %li.first
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1)}')",
+                        :class   => "fa fa-angle-double-left",
+                        :alt     => _("First"),
+                        :title   => _("First")}
+                %li.prev
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1)}')",
+                        :class   => "fa fa-angle-left",
+                        :alt     => _("Previous"),
+                        :title   => _("Previous")}
+            - else
+              %li.first.disabled
+                %span{:class => "fa fa-angle-double-left"}
+              %li.prev.disabled
+                %span{:class => "fa fa-angle-left"}
+
+            %li
+              %span
+                - start_number = pages[:items] > 0 ? (pages[:perpage] * pages[:current]) - pages[:perpage] + 1 : 0
+                - end_number = pages[:perpage] * pages[:current]
+                - if start_number == pages[:items]
+                  = _("%{start_number} of %{total_items}") % {:start_number => start_number, :total_items => pages[:items]}
+                - else
+                  - if end_number > pages[:items]
+                    = _("%{start_number}-%{total_items} of %{total_items}") % {:start_number => start_number, :total_items => pages[:items]}
                   - else
-                    - if end_number > pages[:items]
-                      = _("(Items %{start_number}-%{total_items} of %{total_items})") % {:start_number => start_number, :total_items => pages[:items]}
-                    - else
-                      = "(Items %{start_number}-%{end_number} of %{total_items})" % {:start_number => start_number,
-                                                                                     :end_number   => end_number,
-                                                                                     :total_items  => pages[:items]}
-                  %input{:type => 'hidden', :name => 'limitstart', :value => '0'}
+                    = "%{start_number}-%{end_number} of %{total_items}" % {:start_number => start_number,
+                                                                                   :end_number   => end_number,
+                                                                                   :total_items  => pages[:items]}
+                %input{:type => 'hidden', :name => 'limitstart', :value => '0'}
 
-              - if pages[:current] < pages[:total]
-                - if @ajax_paging_buttons
-                  %li.next
-                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => update_paging_url_parms(action_url, :page => pages[:current] + 1)),
-                          :class   => "fa fa-angle-right",
-                          :alt     => _("Next"),
-                          :title   => _("Next")}
-                  %li.last
-                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => update_paging_url_parms(action_url, :page => pages[:total])),
-                          :class   => "fa fa-angle-double-right",
-                          :alt     => _("Last"),
-                          :title   => _("Last")}
-                - elsif action_id
-                  %li.next
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1, :id => action_id)}')",
-                          :class   => "fa fa-angle-right",
-                          :alt     => _("Next"),
-                          :title   => _("Next")}
-                  %li.last
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total], :id => action_id)}')",
-                          :class   => "fa fa-angle-double-right",
-                          :alt     => _("Last"),
-                          :title   => _("Last")}
-                - else
-                  %li.next
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1)}')",
-                          :class   => "fa fa-angle-right",
-                          :alt     => _("Next"),
-                          :title   => _("Next")}
-                  %li.last
-                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total])}')",
-                          :class   => "fa fa-angle-double-right",
-                          :alt     => _("Last"),
-                          :title   => _("Last")}
+            - if pages[:current] < pages[:total]
+              - if @ajax_paging_buttons
+                %li.next
+                  %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => update_paging_url_parms(action_url, :page => pages[:current] + 1)),
+                        :class   => "fa fa-angle-right",
+                        :alt     => _("Next"),
+                        :title   => _("Next")}
+                %li.last
+                  %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => update_paging_url_parms(action_url, :page => pages[:total])),
+                        :class   => "fa fa-angle-double-right",
+                        :alt     => _("Last"),
+                        :title   => _("Last")}
+              - elsif action_id
+                %li.next
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1, :id => action_id)}')",
+                        :class   => "fa fa-angle-right",
+                        :alt     => _("Next"),
+                        :title   => _("Next")}
+                %li.last
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total], :id => action_id)}')",
+                        :class   => "fa fa-angle-double-right",
+                        :alt     => _("Last"),
+                        :title   => _("Last")}
               - else
-                %li.next.disabled
-                  %span{:class => "fa fa-angle-right"}
-                %li.last.disabled
-                  %span{:class => "fa fa-angle-double-right"}
+                %li.next
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1)}')",
+                        :class   => "fa fa-angle-right",
+                        :alt     => _("Next"),
+                        :title   => _("Next")}
+                %li.last
+                  %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total])}')",
+                        :class   => "fa fa-angle-double-right",
+                        :alt     => _("Last"),
+                        :title   => _("Last")}
+            - else
+              %li.next.disabled
+                %span{:class => "fa fa-angle-right"}
+              %li.last.disabled
+                %span{:class => "fa fa-angle-double-right"}
 
-          .form-group.pull-right
-            = _('Items per page:')
-            = select_tag("ppsetting",
-                        options_for_select(@pp_choices, pages[:perpage]),
-                        "data-width" => "auto",
-                        :class       => "selectpicker dropup")
-            :javascript
-              miqSelectPickerEvent("ppsetting", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
-      :javascript
-        miqInitSelectPicker();
+    :javascript
+      miqInitSelectPicker();

--- a/app/views/layouts/_x_pagingcontrols.html.haml
+++ b/app/views/layouts/_x_pagingcontrols.html.haml
@@ -1,33 +1,42 @@
 .col-md-12
-  .toolbar-pf-actions
-    - if @pages && @items_per_page != ONE_MILLION && @pages[:items] > 0
-      - button_div ||= "center_tb"
-      - action_url ||= "explorer"
-      - pages = @pages
-      - if action_url.include?("/")
-        - action_method = action_url.split("/").first
-        - action_id = action_url.split("/").last
-      - url = action_id ? url_for(:action => action_method, :id => action_id) : url_for(:action => action_url)
-      - @pc_occ ||= 0
-      - @pc_occ += 1
-      %div{:id => "pc_div_#{@pc_occ}"}
-        - if @pc_occ == 1
-          .form-group
-            - if ! @no_checkall && ! @no_checkboxes
-              = render :partial => 'shared/master_toggle',
-                       :locals  => {:button_div => button_div,
-                                    :label      => _("Check All")}
-          .form-group{:style => "border-right: 0"}
-            = _('Sorted by: ')
-            - sort_text = "#{@view.headers[@sortcol]} (#{@sortdir == "ASC" ? _("Asc.") : _("Desc.")})"
-            - if @gtl_type != "list" && @view
-              = select_tag("sort_choice",
-                          options_for_select([sort_text] + @view.headers),
-                          :class => "selectpicker dropup")
-              :javascript
-                miqSelectPickerEvent("sort_choice", "#{url}", {beforeSend: true, complete: true})
-            - elsif @gtl_type == "list" && @view
-              = h(sort_text)
+  - if @pages && @items_per_page != ONE_MILLION && @pages[:items] > 0
+    - button_div ||= "center_tb"
+    - action_url ||= "explorer"
+    - pages = @pages
+    - if action_url.include?("/")
+      - action_method = action_url.split("/").first
+      - action_id = action_url.split("/").last
+    - url = action_id ? url_for(:action => action_method, :id => action_id) : url_for(:action => action_url)
+    - @pc_occ ||= 0
+    - @pc_occ += 1
+
+    .clearfix{:id => "pc_div_#{@pc_occ}"}
+      - if @pc_occ == 1
+        .pull-left.text-nowrap
+          - if ! @no_checkall && ! @no_checkboxes
+            = render :partial => 'shared/master_toggle',
+                     :locals  => {:button_div => button_div,
+                                  :label      => _("Check All")}
+      .pull-right
+        .form-group.text-nowrap
+          - if @gtl_type != "list" && @view
+            - sort_text = "#{@view.headers[@sortcol]} (#{@sortdir == "ASC" ? _("Asc") : _("Desc")})"
+            = select_tag("sort_choice",
+                        options_for_select([sort_text] + @view.headers),
+                        :class => "selectpicker dropup btn-group", "data-width" => "auto")
+            :javascript
+              miqSelectPickerEvent("sort_choice", "#{url}", {beforeSend: true, complete: true})
+          -else
+            = @view.headers[@sortcol]
+            - font_icon = @sortdir == "ASC" ? "asc" :"desc"
+            %span.fa{:class => "fa-sort-alpha-#{font_icon}"}
+        .form-group
+          = select_tag("ppsetting",
+                      options_for_select(@pp_choices, pages[:perpage]),
+                      "data-width" => "auto",
+                      :class       => "selectpicker dropup")
+          :javascript
+            miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
         .form-group.pull-right{:style => "border-right: 0"}
           %ul.pagination
             %li.first
@@ -59,12 +68,12 @@
                   - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
                   - end_number = pages[:perpage] * pages[:current]
                   - if start_number == pages[:items]
-                    = _("Showing %{start_number} of %{total_items} items") % {:start_number => start_number, :total_items => pages[:items]}
+                    = _("%{start_number} of %{total_items}") % {:start_number => start_number, :total_items => pages[:items]}
                   - else
                     - if end_number > pages[:items]
-                      = _("Showing %{start_number}-%{end_number} of %{total_items} items") % {:start_number => start_number, :end_number => pages[:items], :total_items => pages[:items]}
+                      = _("%{start_number}-%{end_number} of %{total_items}") % {:start_number => start_number, :end_number => pages[:items], :total_items => pages[:items]}
                     - else
-                      = _("Showing %{start_number}-%{end_number} of %{total_items} items") % {:start_number => start_number, :end_number => end_number, :total_items => pages[:items]}
+                      = _("%{start_number}-%{end_number} of %{total_items}") % {:start_number => start_number, :end_number => end_number, :total_items => pages[:items]}
                   %input{:name => "limitstart", :type => "hidden", :value => "0"}/
 
               - if pages[:current] < pages[:total]
@@ -90,15 +99,6 @@
                 %li.last.disabled
                   %span{:class => "i fa fa-angle-double-right"}
 
-        .form-group.pull-right
-          = _('Items per page:')
-          = select_tag("ppsetting",
-                      options_for_select(@pp_choices, pages[:perpage]),
-                      "data-width" => "auto",
-                      :class       => "selectpicker dropup")
-          :javascript
-            miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
-
-    = render(:partial => '/layouts/x_form_buttons')
-    :javascript
-      miqInitSelectPicker();
+  = render(:partial => '/layouts/x_form_buttons')
+  :javascript
+    miqInitSelectPicker();

--- a/spec/controllers/infra_network_controller_spec.rb
+++ b/spec/controllers/infra_network_controller_spec.rb
@@ -42,7 +42,7 @@ describe InfraNetworkingController do
         allow(controller).to receive(:current_page).and_return(2)
         get :explorer, :params => {:page => '2'}
         expect(response.status).to eq(200)
-        expect(response.body).to include("<li>\n<span>\nShowing 6-7 of 7 items\n<input name='limitstart' type='hidden' value='0'>\n</span>\n</li>")
+        expect(response.body).to include("<li>\n<span>\n6-7 of 7\n<input name='limitstart' type='hidden' value='0'>\n</span>\n</li>")
       end
     end
 

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -137,7 +137,7 @@ describe StorageController do
         allow(controller).to receive(:current_page).and_return(2)
         get :explorer, :params => {:page => '2'}
         expect(response.status).to eq(200)
-        expect(response.body).to include("<li>\n<span>\nShowing 6-7 of 7 items\n<input name='limitstart' type='hidden' value='0'>\n</span>\n</li>")
+        expect(response.body).to include("<li>\n<span>\n6-7 of 7\n<input name='limitstart' type='hidden' value='0'>\n</span>\n</li>")
       end
 
       it "it handles x_button tagging" do


### PR DESCRIPTION
The PR consolidates items in the paging bars (explorer and non-explorer) to prevent items from disappearing when reducing the view port down to the point at which the desktop layout switches to mobile layout (less than 768px) It also introduces Patternfly toolbar indicator for ascending/descending in Table View.

https://bugzilla.redhat.com/show_bug.cgi?id=1391535

Old (Table View)
![screen shot 2016-11-10 at 3 15 40 pm](https://cloud.githubusercontent.com/assets/1287144/20192625/a3294d8a-a758-11e6-82eb-8f47d1a734c9.png)

Old (Grid View)
![screen shot 2016-11-10 at 3 15 54 pm](https://cloud.githubusercontent.com/assets/1287144/20192624/a31ff208-a758-11e6-8712-5a9c8eaa01a1.png)



New (Table View)
![screen shot 2016-11-10 at 3 12 12 pm](https://cloud.githubusercontent.com/assets/1287144/20192527/3c6d184c-a758-11e6-84e6-84e3d6f2aa33.png)

New (Grid View)
![screen shot 2016-11-10 at 3 11 59 pm](https://cloud.githubusercontent.com/assets/1287144/20192528/3c7b0402-a758-11e6-9878-f3257afaf2f4.png)