### PR TITLE
Fixed a bug when the URL doesn't have a path component

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -239,7 +239,7 @@ Methods updated/added: %{method_stats}") % stat_options, :success)
         flash_message = "Successfully found git repository, please choose a branch or tag"
         add_flash(_(flash_message), :success)
       rescue => err
-        git_repo.destroy if new_git_repo
+        git_repo.destroy if git_repo && new_git_repo
         add_flash(_("Error during repository fetch: #{err.message}"), :error)
       end
     end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -2,6 +2,7 @@ class GitRepository < ApplicationRecord
   include AuthenticationMixin
 
   validates :url, :format => URI::regexp(%w(http https)), :allow_nil => false
+  validate  :check_path
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
@@ -111,5 +112,11 @@ class GitRepository < ApplicationRecord
 
   def delete_repo_dir
     FileUtils.rm_rf(directory_name)
+  end
+
+  def check_path
+    return unless url
+    parsed = URI.parse(url)
+    errors.add(:url, "missing path component e.g. https://www.example.com/path") if parsed.path.blank?
   end
 end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -7,6 +7,10 @@ describe GitRepository do
     expect { FactoryGirl.create(:git_repository, :url => "abc") }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
+  it "invalid url, no path" do
+    expect { FactoryGirl.create(:git_repository, :url => "http://example.com") }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it "default dirname" do
     repo = FactoryGirl.create(:git_repository,
                               :url => "http://www.example.com/repos/manageiq")


### PR DESCRIPTION
Added validation to check that the user passed in URL has a path component.
e.g. http://www.example.com/path

The path is needed to build the Git Repository on the appliance.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1386254


Steps for Testing/QA
----------------------
In the Automate -> Import/Export UI Screen for the URL try the following combinations

1.  abc                                                                                should fail
2. http://www.example.com                                            should also fail
3. https://github.com/mkanoor/SimpleDomain              should work