### PR TITLE
Support hash values in dropdown orchestration dialog fields

### DIFF
--- a/app/services/orchestration_template_dialog_service.rb
+++ b/app/services/orchestration_template_dialog_service.rb
@@ -213,7 +213,8 @@ class OrchestrationTemplateDialogService
   end
 
   def create_parameter_dropdown_list(parameter, group, position, dropdown)
-    dropdown_list = dropdown.allowed_values.collect { |v| [v, v] }
+    values = dropdown.allowed_values
+    dropdown_list = values.kind_of?(Hash) ? values.to_a : values.collect { |v| [v, v] } 
     group.dialog_fields.build(
       :type           => "DialogFieldDropDownList",
       :name           => "param_#{parameter.name}",


### PR DESCRIPTION
Allowed values passed to the`OrchestrationTemplate::OrchestrationParameter` are a way of limiting the user to a predefined list of supported values. These values are presented in a dropdown whose values are the same as the text descriptions.

In order to allow specifying these values as specific keys (IDs), this patch adds support for hash objects in the list of allowed values. If a hash object is detected, its key will be used as a value for the dropdown and its value as the text representation shown to the user.

This patch does not break legacy use and adds a set of specific tests for different cases.

This PR is introduced to allow #12273 to use the network IDs instead of network names for the dropdown values.

@miq-bot add_label orchestration, ui, enhancement