### PR TITLE
Increased DB connection pool from 8 to 11 for websocket worker

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1428,6 +1428,6 @@
       :memory_threshold: 1.gigabytes
       :nice_delta: 1
     :websocket_worker:
-       :connection_pool_size: 14
+       :connection_pool_size: 11
        :memory_threshold: 1.gigabytes
        :nice_delta: 1


### PR DESCRIPTION
ActionCable uses up to 5 workers for sending the notifications
and it runs on top of Puma which has up to 5 threads. We also need
two more connections for remote consoles. One for the endpoint
selection in the Rack middleware and one for the internal thread
cleanup function that deletes remote console DB records.