### PR TITLE
Fix legend buttons for Infra Topology

### DIFF
--- a/app/views/infra_topology/show.html.haml
+++ b/app/views/infra_topology/show.html.haml
@@ -13,7 +13,7 @@
             -# pficon-host
             %text{:y => "8"} &#xE600;
         %label
-          = _("Roles")
+          = _("Nodes")
       %kubernetes-topology-icon{tooltipOptions, :kind => "EmsCluster"}
         %svg.kube-topology
           %g.EntityLegend.Infra
@@ -21,7 +21,7 @@
             -# pficon-cluster
             %text{:y => "9"} &#xE620;
         %label
-          = _("Nodes")
+          = _("Roles")
       %kubernetes-topology-icon{tooltipOptions, :kind => "Tag"}
         %svg.kube-topology
           %g.EntityLegend.Network.FloatingIp


### PR DESCRIPTION
Fixed wrong names of legend buttons in topology (Infra Provider)
![legend_buttons](https://cloud.githubusercontent.com/assets/8054645/20211472/014918b8-a7ff-11e6-9a2e-2b3f6421f3f5.jpg)

https://bugzilla.redhat.com/show_bug.cgi?id=1391123