### PR TITLE
Custom supports methods shall not crash UI

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -221,7 +221,12 @@ module SupportsFeatureMixin
       define_method(method_name) do
         unsupported.delete(feature)
         if block_given?
-          instance_eval(&block)
+          begin
+            instance_eval(&block)
+          rescue => e
+            _log.log_backtrace(e)
+            unsupported_reason_add(feature, "Internal Error: #{e.message}")
+          end
         else
           unsupported_reason_add(feature, reason) unless is_supported
         end


### PR DESCRIPTION
`SupportsFeatureMixin` is used in many places in the application. For dynamic features CustomFeatureMixin allows blocks like the following.
```
    supports :x do
        provider.api_version.abilities.include? :x
    end
```
The problem occurs when an exception happens in the given block. As it does in https://bugzilla.redhat.com/show_bug.cgi?id=1394021

The supports methods are used in the UI and they are not expected to raise exceptions. The above mentioned bug crashes the vm details page.

Given our direction wrt code decentralization and pluggable features, I am afraid, our chances to keep custom supports blocks sane are deteriorating. That's why I advise for rescue.

@miq-bot add_label bug, ui, euwe/yes, blocker
