### PR TITLE
Fixed regression in automate tree node selectability

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -468,10 +468,12 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    tree_klass = name == :ae_tree ? TreeBuilderAeClass : TreeBuilderAutomate
-    tree = tree_klass.new(name, type, @sb)
-    @automate_tree = tree if name == :automate_tree
-    tree
+    if name == :ae_tree
+      TreeBuilderAeClass.new(name, type, @sb)
+    else
+      node_builder = TreeBuilderAutomate.select_node_builder(controller_name)
+      @automate_tree = TreeBuilderAutomate.new(name, type, @sb, true, :node_builder => node_builder)
+    end
   end
 
   # moved this method here so it can be accessed from pxe_server controller as well

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -137,8 +137,8 @@ class TreeBuilder
   # Add child nodes to the active tree below node 'id'
   def self.tree_add_child_nodes(sandbox, klass_name, id, controller)
     args = [sandbox[:active_tree].to_s, sandbox[:active_tree].to_s.sub(/_tree$/, ''), sandbox, false]
-    if klass_name == 'TreeBuilderAeClass'
-      args << { :node_builder => TreeBuilderAeClass.select_node_builder(controller, sandbox[:action]) }
+    if klass_name == 'TreeBuilderAutomate'
+      args << { :node_builder => TreeBuilderAutomate.select_node_builder(controller) }
     end
     tree = klass_name.constantize.new(*args)
     tree.x_get_child_nodes(id)

--- a/app/presenters/tree_builder_ae_class.rb
+++ b/app/presenters/tree_builder_ae_class.rb
@@ -7,15 +7,6 @@ class TreeBuilderAeClass < TreeBuilder
     super(name, type, sandbox, build)
   end
 
-  def self.select_node_builder(controller, action)
-    case controller
-    when 'catalog'
-      TreeNodeBuilderAeClassCatalog
-    when 'miq_ae_class'
-      TreeNodeBuilderAeClass if action == 'miq_ae_class_copy'
-    end
-  end
-
   def node_builder
     @node_builder ? @node_builder : super
   end

--- a/app/presenters/tree_builder_automate.rb
+++ b/app/presenters/tree_builder_automate.rb
@@ -12,4 +12,13 @@ class TreeBuilderAutomate < TreeBuilderAeClass
                   :base_id      => "root",
                   :highlighting => true)
   end
+
+  def self.select_node_builder(controller)
+    case controller
+    when 'catalog'
+      TreeNodeBuilderAutomateCatalog
+    when 'miq_ae_class'
+      TreeNodeBuilderAutomate
+    end
+  end
 end

--- a/app/presenters/tree_node_builder_automate.rb
+++ b/app/presenters/tree_node_builder_automate.rb
@@ -1,4 +1,4 @@
-class TreeNodeBuilderAeClass < TreeNodeBuilder
+class TreeNodeBuilderAutomate < TreeNodeBuilder
   include CompressedIds
 
   def miq_ae_node(enabled, text, image, tip)

--- a/app/presenters/tree_node_builder_automate_catalog.rb
+++ b/app/presenters/tree_node_builder_automate_catalog.rb
@@ -1,4 +1,4 @@
-class TreeNodeBuilderAeClassCatalog < TreeNodeBuilderAeClass
+class TreeNodeBuilderAutomateCatalog < TreeNodeBuilderAutomate
   private
 
   def noclick_node?(key)

--- a/spec/presenters/tree_builder_automate_spec.rb
+++ b/spec/presenters/tree_builder_automate_spec.rb
@@ -1,0 +1,17 @@
+describe TreeBuilderAutomate do
+  include Spec::Support::AutomationHelper
+
+  describe '.select_node_builder' do
+    subject { described_class.select_node_builder(controller) }
+
+    context 'called from catalog controller' do
+      let(:controller) { 'catalog' }
+      it { expect(subject).to eq(TreeNodeBuilderAutomateCatalog) }
+    end
+
+    context 'called from automate controller' do
+      let(:controller) { 'miq_ae_class' }
+      it { expect(subject).to eq(TreeNodeBuilderAutomate) }
+    end
+  end
+end


### PR DESCRIPTION
The `TreeBuilderAutomate` is used in two modals:
* when selecting entry points for a catalog item-> no click if not a valid entry point
* when selecting destination for automate class/instance copying -> no click if not a valid destination

This no click functionality was broken by [this commit](https://github.com/ManageIQ/manageiq/pull/10590/files#diff-55c5b7aecfb519d0e4880eaf2788eb6eL489) and I'm re-enabling it in this PR.
