### PR TITLE
Making the GTL links working for entities contained by middleware server

### DIFF
--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -9,7 +9,8 @@ class MiddlewareDomainController < ApplicationController
 
   def show
     return unless init_show
-    case params[:display]
+    @display = params[:display] unless params[:display].nil?
+    case @display
     when 'middleware_server_groups' then show_middleware_entities(MiddlewareServerGroup)
     else show_middleware
     end

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -133,7 +133,8 @@ class MiddlewareServerController < ApplicationController
 
   def show
     return unless init_show
-    case params[:display]
+    @display = params[:display] unless params[:display].nil?
+    case @display
     when 'middleware_datasources' then show_middleware_entities(MiddlewareDatasource)
     when 'middleware_deployments' then show_middleware_entities(MiddlewareDeployment)
     when 'middleware_messagings' then show_middleware_entities(MiddlewareMessaging)

--- a/app/controllers/middleware_server_group_controller.rb
+++ b/app/controllers/middleware_server_group_controller.rb
@@ -9,7 +9,8 @@ class MiddlewareServerGroupController < ApplicationController
 
   def show
     return unless init_show
-    case params[:display]
+    @display = params[:display] unless params[:display].nil?
+    case @display
     when 'middleware_servers' then show_middleware_entities(MiddlewareServer)
     else show_middleware
     end

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -57,7 +57,7 @@ module MiddlewareCommonMixin
   end
 
   def show_middleware_entities(klass)
-    @showtype = @display = klass.name.underscore.pluralize
+    @showtype = @display = params[:display] unless params[:display].nil?
     breadcrumb_title = _("%{name} (All %{title})") % {:name  => @record.name,
                                                       :title => display_name(@display)}
     drop_breadcrumb(:name => breadcrumb_title, :url => show_link(@record, :display => @display))


### PR DESCRIPTION
Clicking on gtl link can't copy the existing url params (in which we have the associated entity stored), so we need to store the previous display at controller field `@display`. It's ugly, but all the providers does that this way. Better approach would be imho allowing the `url_parms` in the button definitions to append the query param instead of replacing all the params as it is right now.

@miq-bot add_label providers/hawkular, bug, ui, euwe/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1393235