### PR TITLE
EmsCommon#edit - catch exceptions from find_by_id_filtered and show a flash

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -229,7 +229,13 @@ module EmsCommon
   def edit
     @doc_url = provider_documentation_url
     assert_privileges("#{permission_prefix}_edit")
-    @ems = find_by_id_filtered(model, params[:id])
+    begin
+      @ems = find_by_id_filtered(model, params[:id])
+    rescue => err
+      return redirect_to(:action      => @lastaction || "show_list",
+                         :flash_msg   => err.message,
+                         :flash_error => true)
+    end
     set_form_vars
     @in_a_form = true
     session[:changed] = false


### PR DESCRIPTION
When trying to edit a provider that has since been deleted, you get a 500 screen now.

Catching the exception and redirecting to `@lastaction` with an error flash.

https://bugzilla.redhat.com/show_bug.cgi?id=1386232

---

A way to test without removing a provider is by running.. in the browser console.

`miqJqueryRequest('/ems_cloud/button?pressed=ems_cloud_edit', {data: { miq_grid_checks: '10r123' }})`

(where `10r123` is a *non*existent provider id)