### PR TITLE
Adding the transaction around the automate import_domain method.

### DIFF
--- a/app/controllers/miq_ae_tools_controller.rb
+++ b/app/controllers/miq_ae_tools_controller.rb
@@ -152,14 +152,17 @@ class MiqAeToolsController < ApplicationController
           params[:selected_domain_to_import_to],
           selected_namespaces.sort
         )
+        if import_stats.nil?
+          add_flash(_("Error: Datastore import was not successful"), :error)
+        else
+          stat_options = generate_stat_options(import_stats)
 
-        stat_options = generate_stat_options(import_stats)
-
-        add_flash(_("Datastore import was successful.
+          add_flash(_("Datastore import was successful.
 Namespaces updated/added: %{namespace_stats}
 Classes updated/added: %{class_stats}
 Instances updated/added: %{instance_stats}
 Methods updated/added: %{method_stats}") % stat_options, :success)
+        end
       else
         add_flash(_("Error: Datastore import file upload expired"), :error)
       end

--- a/app/services/automate_import_service.rb
+++ b/app/services/automate_import_service.rb
@@ -30,11 +30,11 @@ class AutomateImportService
     reject_unrelated_namespaces(ae_import, domain_name_to_import_from, namespace_list)
     reject_unrelated_classes(ae_import, domain_name_to_import_from, class_list)
 
-    ae_import.import
+    result = ae_import.import
 
     File.delete("automate_temporary_zip.zip")
 
-    ae_import.import_stats
+    result.nil? ? nil : ae_import.import_stats
   end
 
   def store_for_import(file_contents)

--- a/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_yaml_import_spec.rb
@@ -2,6 +2,7 @@ describe MiqAeYamlImport do
   let(:domain) { "domain" }
   let(:options) { {} }
   let(:miq_ae_yaml_import) { described_class.new(domain, options) }
+  let(:options) { {"overwrite" => true, "tenant" => Tenant.root_tenant} }
 
   before do
     EvmSpecHelper.local_guid_miq_server_zone
@@ -9,10 +10,31 @@ describe MiqAeYamlImport do
 
   describe "#new_domain_name_valid?" do
     context "when the options hash overwrite is true" do
-      let(:options) { {"overwrite" => true, "tenant" => Tenant.root_tenant} }
-
       it "returns true" do
         expect(miq_ae_yaml_import.new_domain_name_valid?).to be_truthy
+      end
+    end
+  end
+
+  describe "transaction rollback" do
+    context "#import" do
+      let(:path) { "path" }
+      it "old namespace is preserved" do
+        dom = FactoryGirl.create(:miq_ae_domain, :name => domain)
+        domain_yaml = {
+          'object_type' => 'domain',
+          'version'     => '1.0',
+          'object'      => {'attributes' => dom.attributes}
+        }
+        ns = FactoryGirl.create(:miq_ae_namespace, :parent => dom)
+        FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
+
+        allow(miq_ae_yaml_import).to receive(:domain_folder).with(domain).and_return(path)
+        allow(miq_ae_yaml_import).to receive(:namespace_files).with(path) { raise ArgumentError }
+        allow(miq_ae_yaml_import).to receive(:read_domain_yaml).with(path, domain) { domain_yaml }
+        expect { miq_ae_yaml_import.import }.to raise_exception(ArgumentError)
+        dom.reload
+        expect(dom.ae_namespaces.first.id).to eq(ns.id)
       end
     end
   end

--- a/spec/services/automate_import_service_spec.rb
+++ b/spec/services/automate_import_service_spec.rb
@@ -51,7 +51,7 @@ describe AutomateImportService do
       ])
       allow(miq_ae_import).to receive(:remove_entry)
       allow(miq_ae_import).to receive(:update_sorted_entries)
-      allow(miq_ae_import).to receive(:import)
+      allow(miq_ae_import).to receive(:import).and_return(true)
     end
 
     it "removes unrelated entries" do


### PR DESCRIPTION
## Purpose or Intent
Making the automate import_domain method to be "atomic" by adding the transaction around the method to avoid having the wrong database state after the failed import.
