### PR TITLE
Fix calculation of average for used metrics 

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -144,8 +144,8 @@ class Chargeback < ActsAsArModel
         if !chargeback_fields_present && r.fixed?
           cost = 0
         else
-          metric_value = r.metric_value_by(metric_rollup_records)
           r.hours_in_interval = hours_in_interval
+          metric_value = r.metric_value_by(metric_rollup_records)
           cost = r.cost(metric_value) * hours_in_interval
         end
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -26,9 +26,8 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def avg_of_metric_from(metric_rollup_records)
-    record_count = metric_rollup_records.count
     metric_sum = metric_rollup_records.sum(&metric.to_sym)
-    metric_sum / record_count
+    metric_sum / @hours_in_interval
   end
 
   def metric_value_by(metric_rollup_records)

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -37,6 +37,10 @@ describe ChargebackContainerProject do
     Timecop.return
   end
 
+  def used_average_for(metric, hours_in_interval)
+    @project.metric_rollups.sum(&metric) / hours_in_interval
+  end
+
   context "Daily" do
     let(:hours_in_day) { 24 }
 
@@ -76,8 +80,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * hours_in_day)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day)
+      expect(subject.cpu_cores_used_metric).to eq(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
     end
 
     it "memory" do
@@ -93,8 +98,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.memory_used_metric).to eq(@memory_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(@memory_used * @hourly_rate * hours_in_day)
+      metric_used = used_average_for(:derived_memory_used, hours_in_day)
+      expect(subject.memory_used_metric).to eq(metric_used)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
     end
 
     it "net io" do
@@ -110,8 +116,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.net_io_used_metric).to eq(@net_usage_rate)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(@net_usage_rate * @hourly_rate * hours_in_day)
+      metric_used = used_average_for(:net_usage_rate_average, hours_in_day)
+      expect(subject.net_io_used_metric).to eq(metric_used)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
     end
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
@@ -179,8 +186,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
 
     it "memory" do
@@ -196,8 +204,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.memory_used_metric).to eq(@memory_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(@memory_used * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:derived_memory_used, @hours_in_month)
+      expect(subject.memory_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
 
     it "net io" do
@@ -213,8 +222,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.net_io_used_metric).to eq(@net_usage_rate)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(@net_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:net_usage_rate_average, @hours_in_month)
+      expect(subject.net_io_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
 
     let(:cbt) { FactoryGirl.create(:chargeback_tier,
@@ -280,8 +290,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
   end
 
@@ -330,8 +341,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
       expect(subject.tag_name).to eq('Production')
     end
   end


### PR DESCRIPTION
The average is calculated using the number of hours in the period instead of count of metric rollup records.

@miq-bot add_label bug, chargeback, blocker, euwe/yes
@mib-bot assign @gtanzillo 

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1390773

Steps for Testing/QA
-------------------------------
Example from BZ:
Report interval: daily
3 metric rollups records with cpu_usagemhz_rate_average values: 2685.44444444444, 2674.81111111111, 2675.01111111111

Average of CPU used for report interval: (2685.44444444444 + 2674.81111111111 + 2675.01111111111) / 24 (report daily interval) = 334.8027777777775

cost: 334.8027777777775 (Average of CPU used ) * $0.02(rate) * 24(daily report) = $160.70533333333321


