### PR TITLE
[EUWE] add missing ActiveSupport::Concern to middle module

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
@@ -1,4 +1,6 @@
 module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations
+  extend ActiveSupport::Concern
+
   include_concern 'Guest'
   include_concern 'Power'
   include_concern 'Snapshot'


### PR DESCRIPTION
backporting this https://github.com/ManageIQ/manageiq/pull/11899 resulted in :red_circle: CI, because this missing `extend ActiveSupport::Concern` in `ManageIQ::Providers::Redhat::InfraManager::Vm::Operations` was introduced in another PR that should not be backported.