### PR TITLE
Rebuild timeline options when Apply button is pressed.

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -6,6 +6,7 @@ module ApplicationController::Timelines
     @record = identify_tl_or_perf_record
     @tl_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
     @tl_options.tl_show = params[:tl_show] ? params[:tl_show] : "timeline"
+    tl_build_timeline
     @tl_options.date.update_from_params(params)
 
     if @tl_options.management_events?
@@ -14,13 +15,7 @@ module ApplicationController::Timelines
       @tl_options.policy.update_from_params(params)
     end
 
-    if @tl_options.management_events? && @tl_options.mngt.categories.blank?
-      # add_flash(_("At least one filter must be selected"), :warning)
-    elsif @tl_options.policy_events?
-      if @tl_options.policy.categories.blank?
-        tl_build_timeline('n')
-      end
-    else
+    if (@tl_options.management_events? && !@tl_options.mngt.categories.blank?) || (@tl_options.policy_events? && !@tl_options.policy.categories.blank?)
       tl_gen_timeline_data(refresh = "n")
       return unless @timeline
     end

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -1,0 +1,28 @@
+describe ApplicationController, "#Timelines" do
+  describe EmsInfraController do
+    context "#tl_chooser" do
+      it "resets timeline options correctly when apply button is pressed" do
+        ems = FactoryGirl.create(:ems_openstack_infra)
+        controller.instance_variable_set(:@tl_options,
+                                         ApplicationController::Timelines::Options.new)
+        options            = assigns(:tl_options)
+        dt                 = Time.zone.now
+        options.date       = ApplicationController::Timelines::DateOptions.new
+        options.date.end   = dt
+        options.date.start = dt
+
+        controller.instance_variable_set(:@_params, :id => ems.id, :tl_show => "policy_timeline")
+        expect(controller).to receive(:render)
+
+        expect(options.date[:start]).to eq(dt)
+        expect(options.date[:end]).to eq(dt)
+
+        controller.send(:tl_chooser)
+
+        options = assigns(:tl_options)
+        expect(options.date[:start]).to eq(nil)
+        expect(options.date[:end]).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Need to rebuild timeline options when reset button is pressed so that date is reset when switching between Managament Events/Policy Event timelines.

https://bugzilla.redhat.com/show_bug.cgi?id=1392048

@dclarizio please review/test. 
**To recreate:** Go to timelines view for a provider or another entity, view Management Events timelines, then switch type to Policy Events. Even tho there are no Policy Events in db it doesn't show Flash message on the screen. Now go back to list of providers and come back to same Timeline view this time it will show Flash message even when no event were selected yet.
**Fix:** After fix it shows Flash message after apply button is pressed and there are no Policy events in db. When returning to screen it doesn't show false flash message.