### PR TITLE
Remove version from aws-sdk gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.2.1",       :require => false
 gem "ansible_tower_client",           "~>0.4.0",       :require => false
-gem "aws-sdk",                        "~>2.2.19",      :require => false
+gem "aws-sdk",                        "~>2",           :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false


### PR DESCRIPTION
Remove version from aws-sdk gem, the needed version is determined by the amazon provider.