### PR TITLE
fix fix_auth after pending gem was extracted

### DIFF
--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -13,6 +13,7 @@ end
 
 require 'active_support/all'
 require 'active_support/concern'
+require 'manageiq-gems-pending'
 require_relative '../lib/vmdb/settings/walker'
 require 'fix_auth/auth_model'
 require 'fix_auth/auth_config_model'


### PR DESCRIPTION
after the pending gem moved, it is not found by `fix_auth.rb`

before
------

```
bundle exec tools/fix_auth.rb --help
bundler: failed to load command: tools/fix_auth.rb (tools/fix_auth.rb)
LoadError: cannot load such file -- util/miq-password
  /Users/kbrock/src/manageiq/tools/fix_auth/auth_model.rb:1:in `require'
  /Users/kbrock/src/manageiq/tools/fix_auth/auth_model.rb:1:in `<top (required)>'
  tools/fix_auth.rb:17:in `require'
  tools/fix_auth.rb:17:in `<top (required)>
```

after
-----

```
bundle exec tools/fix_auth.rb --help
Usage: ruby tools/fix_auth.rb [options] [database1] [database2] [...]
       ruby tools/fix_auth.rb [options] -P new_password [database1] [...] to replace all password
```