### PR TITLE
Event building code fix for OOTB reports with db EventStream/PolicyEvent

### DIFF
--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -31,7 +31,9 @@ module ReportFormatter
         col = tlfield.last                             # Not a subtable, just grab the field name
       end
 
-      if mri.db == "EventStream" || mri.db == "PolicyEvent"
+      # some of the OOTB reports have db as EventStream or PolicyEvent,
+      # those do not have event categories, so need to go thru else block for such reports.
+      if (mri.db == "EventStream" || mri.db == "PolicyEvent") && mri.rpt_options[:categories]
         mri.rpt_options[:categories].each do |_, options|
           @events_data = []
           all_events = mri.table.data.select { |e| options[:event_groups].include?(e.event_type) }


### PR DESCRIPTION
Need to skip building grouping of events in timeline for OOTB reports with db as EventStream/PolicyEvent. Events in these reports are not based on categories, all events in such reports are shown in one single group.

https://bugzilla.redhat.com/show_bug.cgi?id=1394316

@dclarizio please review, you can import attached report to recreate/test the fix.
[Reports_20161111_182327.yaml.zip](https://github.com/ManageIQ/manageiq/files/586500/Reports_20161111_182327.yaml.zip)

before:
![before](https://cloud.githubusercontent.com/assets/3450808/20225838/728d2ffa-a813-11e6-9eaf-cf7cfd7fa342.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/20225820/58d5ef70-a813-11e6-8c89-e8744aa1e011.png)

