### PR TITLE
Disable the 'add cloud volume' button when no ems supports it.

### DIFF
--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -6,13 +6,8 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::Bas
     end
   end
 
+  # disable button if no active providers support create action
   def disabled?
-    ems_clouds = EmsCloud.all
-    # if any connected provider supports this action,
-    # we can enable the button.
-    ems_clouds.each do |ems|
-      return false if CloudVolume.class_by_ems(ems).supports_create?
-    end
-    true
+    EmsCloud.all.none? { |ems| CloudVolume.class_by_ems(ems).supports_create? }
   end
 end

--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -1,0 +1,18 @@
+class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No cloud providers support creating cloud volumes.")
+    end
+  end
+
+  def disabled?
+    ems_clouds = EmsCloud.all
+    # if any connected provider supports this action,
+    # we can enable the button.
+    ems_clouds.each do |ems|
+      return false if CloudVolume.class_by_ems(ems).supports_create_volume?
+    end
+    true
+  end
+end

--- a/app/helpers/application_helper/button/cloud_volume_new.rb
+++ b/app/helpers/application_helper/button/cloud_volume_new.rb
@@ -11,7 +11,7 @@ class ApplicationHelper::Button::CloudVolumeNew < ApplicationHelper::Button::Bas
     # if any connected provider supports this action,
     # we can enable the button.
     ems_clouds.each do |ems|
-      return false if CloudVolume.class_by_ems(ems).supports_create_volume?
+      return false if CloudVolume.class_by_ems(ems).supports_create?
     end
     true
   end

--- a/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_volumes_center.rb
@@ -11,6 +11,7 @@ class ApplicationHelper::Toolbar::CloudVolumesCenter < ApplicationHelper::Toolba
                        'pficon pficon-add-circle-o fa-lg',
                        t = N_('Add a new Cloud Volume'),
                        t,
+                       :klass => ApplicationHelper::Button::CloudVolumeNew
                      ),
                      separator,
                      button(

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -3,6 +3,7 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
 
   include SupportsFeatureMixin
 
+  supports :create
   supports :backup_create
   supports :backup_restore
   supports :snapshot_create

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -68,6 +68,7 @@ module SupportsFeatureMixin
     :backup_create              => 'CloudVolume backup creation',
     :backup_restore             => 'CloudVolume backup restore',
     :cinder_service             => 'Cinder storage service',
+    :create_volume              => 'Cloud Volume Creation',
     :create_floating_ip         => 'Floating IP Creation',
     :create_host_aggregate      => 'Host Aggregate Creation',
     :create_network_router      => 'Network Router Creation',

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -68,7 +68,6 @@ module SupportsFeatureMixin
     :backup_create              => 'CloudVolume backup creation',
     :backup_restore             => 'CloudVolume backup restore',
     :cinder_service             => 'Cinder storage service',
-    :create_volume              => 'Cloud Volume Creation',
     :create_floating_ip         => 'Floating IP Creation',
     :create_host_aggregate      => 'Host Aggregate Creation',
     :create_network_router      => 'Network Router Creation',

--- a/spec/helpers/application_helper/buttons/cloud_volume_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_volume_new_spec.rb
@@ -1,0 +1,33 @@
+describe ApplicationHelper::Button::CloudVolumeNew do
+  describe '#disabled?' do
+    it "when at least one provider supports volume create then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be false
+    end
+
+    it "when no provider supports volume create then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when no provider supports volume create the button has an error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to eq("No cloud providers support creating cloud volumes.")
+    end
+
+    it "when at least one provider supports volume create, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
When no cloud providers have been added to MIQ, or none of the added cloud providers support creating new cloud volumes, the add button should be disabled.

(This uses the SupportsFeatureMixin for capability testing. For simplicity's sake, I've made the necessary change for Openstack to work with this. No other provider is affected by this change to the best of my knowledge, so it seems reasonable to include it here.)

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1383260
