### PR TITLE
:vm_power_states just duplicates the power_states array

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -196,18 +196,12 @@ class Service < ApplicationRecord
   end
 
   def power_states_match?(action)
-    vm_power_states.uniq == map_power_states(action)
+    power_states.uniq == map_power_states(action)
   end
 
   def map_power_states(action)
     action_name = "#{action}_action"
     service_resources.map(&action_name.to_sym).uniq.map { |x| Service::ACTION_RESPONSE[x] }.map { |x| Service::POWER_STATE_MAP[x] }
-  end
-
-  def vm_power_states
-    [].tap do |power_state|
-      power_states.each { |state| power_state << state }
-    end
   end
 
   def update_progress(hash = {})

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -88,8 +88,8 @@ describe Service do
       @service_c1.save
     end
 
-    it "#vm_power_states" do
-      expect(@service.vm_power_states).to eq %w(on on)
+    it "#power_states" do
+      expect(@service.power_states).to eq %w(on on)
     end
 
     it "#update_progress" do
@@ -133,7 +133,7 @@ describe Service do
 
       it "returns the uniq value for the 'off' power state" do
         expect(@service).to receive(:map_power_states).with(:stop).and_return(["off"])
-        expect(@service).to receive(:vm_power_states).and_return(["off"])
+        expect(@service).to receive(:power_states).and_return(["off"])
         expect(@service.power_states_match?(:stop)).to be_truthy
       end
     end


### PR DESCRIPTION
Remove the method since the array doesn't need to be duplicated.