### PR TITLE
Fix OpenStack node power operations

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/host_operations_mixin.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host_operations_mixin.rb
@@ -55,7 +55,7 @@ module ManageIQ::Providers::Openstack::InfraManager::HostOperationsMixin
     _dummy, t = Benchmark.realtime_block(:total_time) do
       begin
         connection = ext_management_system.openstack_handle.detect_baremetal_service
-        response = connection.set_node_power_state(name, power_state)
+        response = connection.set_node_power_state(uid_ems, power_state)
 
         if response.status == 202
           status = "Success"


### PR DESCRIPTION
Power operations fails if a node is in "active" provision state.
When active, the node's name includes additional text describing
its role. When name is used as the uuid for Ironic, it causes
issues because the additional text isn't part of the uuid.

The solution is to use uid_ems which is the Ironic uuid.

https://bugzilla.redhat.com/show_bug.cgi?id=1394429