### PR TITLE
Expose custom_attribute methods to ext_management_system service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ext_management_system.rb
@@ -2,6 +2,8 @@ module MiqAeMethodService
   class MiqAeServiceExtManagementSystem < MiqAeServiceModelBase
     require_relative "mixins/miq_ae_service_inflector_mixin"
     include MiqAeServiceInflectorMixin
+    require_relative "mixins/miq_ae_service_custom_attribute_mixin"
+    include MiqAeServiceCustomAttributeMixin
 
     expose :storages,             :association => true
     expose :hosts,                :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceHost < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_service_custom_attribute_mixin"
+    include MiqAeServiceCustomAttributeMixin
+
     expose :storages,              :association => true
     expose :read_only_storages
     expose :writable_storages
@@ -71,22 +74,6 @@ module MiqAeMethodService
         :args        => [attribute, value]
       ) if @object.is_vmware?
       true
-    end
-
-    def custom_keys
-      object_send(:miq_custom_keys)
-    end
-
-    def custom_get(key)
-      object_send(:miq_custom_get, key)
-    end
-
-    def custom_set(key, value)
-      ar_method do
-        @object.miq_custom_set(key, value)
-        @object.save
-      end
-      value
     end
 
     def ssh_exec(script)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_group.rb
@@ -1,24 +1,11 @@
 module MiqAeMethodService
   class MiqAeServiceMiqGroup < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_service_custom_attribute_mixin"
+    include MiqAeServiceCustomAttributeMixin
+
     expose :users,  :association => true
     expose :vms,    :association => true
     expose :tenant, :association => true
     expose :filters, :method => :get_filters
-
-    def custom_keys
-      object_send(:miq_custom_keys)
-    end
-
-    def custom_get(key)
-      object_send(:miq_custom_get, key)
-    end
-
-    def custom_set(key, value)
-      ar_method do
-        @object.miq_custom_set(key, value)
-        @object.save
-      end
-      value
-    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -2,6 +2,8 @@ module MiqAeMethodService
   class MiqAeServiceService < MiqAeServiceModelBase
     require_relative "mixins/miq_ae_service_retirement_mixin"
     include MiqAeServiceRetirementMixin
+    require_relative "mixins/miq_ae_service_custom_attribute_mixin"
+    include MiqAeServiceCustomAttributeMixin
 
     expose :retire_service_resources
     expose :automate_retirement_entrypoint
@@ -20,9 +22,6 @@ module MiqAeMethodService
     expose :indirect_service_children, :association => true
     expose :parent_service,            :association => true
     expose :tenant,                    :association => true
-    expose :custom_keys,               :method => :miq_custom_keys
-    expose :custom_get,                :method => :miq_custom_get
-    expose :custom_set,                :method => :miq_custom_set, :override_return => true
 
     CREATE_ATTRIBUTES = [:name, :description, :service_template]
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_user.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_user.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceUser < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_service_custom_attribute_mixin"
+    include MiqAeServiceCustomAttributeMixin
+
     expose :current_group,  :association => true
     expose :current_tenant, :association => true
     expose :vms,            :association => true
@@ -26,22 +29,6 @@ module MiqAeMethodService
         value     = MiqLdap.get_attr(ldap_user, name.to_sym)
         value.nil? ? nil : value.dup
       end
-    end
-
-    def custom_keys
-      object_send(:miq_custom_keys)
-    end
-
-    def custom_get(key)
-      object_send(:miq_custom_get, key)
-    end
-
-    def custom_set(key, value)
-      ar_method do
-        @object.miq_custom_set(key, value)
-        @object.save
-      end
-      value
     end
 
     def miq_group

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -6,6 +6,8 @@ module MiqAeMethodService
     include MiqAeServiceRetirementMixin
     require_relative "mixins/miq_ae_service_inflector_mixin"
     include MiqAeServiceInflectorMixin
+    require_relative "mixins/miq_ae_service_custom_attribute_mixin"
+    include MiqAeServiceCustomAttributeMixin
 
     expose :ext_management_system, :association => true
     expose :storage,               :association => true
@@ -132,23 +134,6 @@ module MiqAeMethodService
         :args        => [attribute, value]
       )
       true
-    end
-
-    def custom_keys
-      object_send(:miq_custom_keys)
-    end
-
-    def custom_get(key)
-      object_send(:miq_custom_get, key)
-    end
-
-    def custom_set(key, value)
-      _log.info "Setting EVM Custom Key on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> with key=#{key.inspect} to #{value.inspect}"
-      ar_method do
-        @object.miq_custom_set(key, value)
-        @object.save
-      end
-      value
     end
 
     def owner=(owner)

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_custom_attribute_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_custom_attribute_mixin.rb
@@ -1,0 +1,9 @@
+module MiqAeServiceCustomAttributeMixin
+  extend ActiveSupport::Concern
+
+  included do
+    expose :custom_keys, :method => :miq_custom_keys
+    expose :custom_get,  :method => :miq_custom_get
+    expose :custom_set,  :method => :miq_custom_set, :override_return => true
+  end
+end


### PR DESCRIPTION
Create service_model mixin for exposing custom_attribute methods.  
- Updated existing models to use mixin.  
- Added mixin to `ext_management_system` service model to support functionality added in PR #10503

Links
----------------
http://talk.manageiq.org/t/acess-drb-remote-object/1869
