### PR TITLE
Change menu roles editor to use TreeBuilderMenuRoles class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -715,16 +715,6 @@ class ApplicationController < ActionController::Base
     @sb[:rpt_menu] = get_reports_menu(group, tree_type, mode)
   end
 
-  # Gather information for the report accordions
-  def build_report_listnav(tree_type = "reports", tree = "listnav", mode = "menu")
-    populate_reports_menu(tree_type, mode)
-    if tree == "listnav" && tree_type == "timeline"
-      build_timeline_tree(@sb[:rpt_menu], tree_type)
-    else
-      build_menu_tree(@sb[:rpt_menu], tree_type)
-    end
-  end
-
   def reports_group_title
     tenant_name = current_tenant.name
     if current_user.admin_user?

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -709,7 +709,8 @@ class DashboardController < ApplicationController
 
   # Gather information for the report accordians
   def build_timeline_listnav
-    build_report_listnav("timeline")
+    populate_reports_menu("timeline", "menu")
+    build_timeline_tree(@sb[:rpt_menu], "timeline")
   end
 
   def build_timeline

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -616,7 +616,7 @@ module ReportController::Menus
   end
 
   def edit_folder
-    if params[:button] == "reset" || params[:button] == "default"  # resetting node in case reset button is pressed
+    if params[:button] == "reset" || params[:button] == "default" # resetting node in case reset button is pressed
       session[:node_selected] = "xx-b__Report Menus for #{session[:role_choice]}"
     end
 

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -344,10 +344,10 @@ module ReportController::Menus
   #
   def build_menu_roles_tree(rpt_menu = nil)
     TreeBuilderMenuRoles.new(
-      "menu_roles_tree",  # name
-      "menu_roles",       # type
-      @sb,                # sandbox
-      true,               # build
+      :menu_roles_tree, # name
+      :menu_roles,      # type
+      @sb,              # sandbox
+      true,             # build
       role_choice: session[:role_choice],
       rpt_menu: rpt_menu
     )

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -20,16 +20,17 @@ module ReportController::Menus
     menu_set_form_vars if ["explorer", "tree_select", "x_history"].include?(params[:action])
     @in_a_form = true
     if @menu_lastaction != "menu_editor"
-      @menu_roles_tree = TreeBuilder.convert_bs_tree(build_menu_tree(@edit[:new])).to_json
+      @menu_roles_tree = TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", @sb, session[:role_choice], @edit[:new])
     else
-      @menu_roles_tree = TreeBuilder.convert_bs_tree(build_menu_tree(@rpt_menu)).to_json # changing rpt_menu if changes have been commited to show updated tree with changes
+      # changing rpt_menu if changes have been commited to show updated tree with changes
+      @menu_roles_tree = TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", @sb, session[:role_choice])
     end
     @sb[:role_list_flag] = true if params[:id]
 
     if params[:node_id]
       session[:node_selected] = params[:node_id]
     elsif session[:node_selected].blank?
-      session[:node_selected] = "b__Report Menus for #{session[:role_choice]}"
+      session[:node_selected] = "xx-b__Report Menus for #{session[:role_choice]}"
     end
     @sb[:node_clicked] = (params[:node_clicked] == "1")
 
@@ -336,103 +337,16 @@ module ReportController::Menus
     end
   end
 
-  # menus tree for the group selected in the roles tree on left
+  # Builds menu for left column of right cell
+  # This has been largely replaced by TreeBuilderMenuRoles class,
+  # but is still called from ApplicationController.
+  #
   def build_menu_tree(rpt_menu, _tree_type = "reports")
-    @rpt_menu = []
-    @menu_roles_tree = nil
-    menus = []
-    rpt_menu.each do |r|
-      # create/modify new array that doesn't have custom reports folder, dont need custom folder in menu_editor
-      # add any new empty folders that were added
-      menus.push(r) if (r[1] && r[1].empty?) || (r[1] && !r[1].empty? && r[1][0].empty?) || (r[1] && !r[1].empty? && !r[1][0].empty? && r[1][0][0] != "Custom") # Check the second level menu for "Custom"
-    end
-    @tree_type = "menu"
-    @rpt_menu = menus
-    base_node = {
-      :key    => "b__Report Menus for #{session[:role_choice]}",
-      :title  => 'Top Level',
-      :icon   => ActionController::Base.helpers.image_path('100/folder.png'),
-      :expand => true,
-      :style  => 'background: #fff;
-                  padding: 2px 0 6px 2px;
-                  color:#4b4b4b;
-                  font-size:12px;
-                  font-weight:bold;'
-    }
+    # rpt_menu is already part of @sb, and passed to TreeBuilderMenuRoles through it.
+    tree = TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", @sb, session[:role_choice])
+    @rpt_menu = tree.rpt_menu
 
-    @tree = []
-    @branch = []
-    @parent_node = {}
-    menus.each do |r|
-      r.each_slice(2) do |menu, section|
-        @parent_node = TreeNodeBuilder.generic_tree_node(
-          "p__#{menu}",
-          menu,
-          'folder.png',
-          "Group: #{menu}",
-          :style => 'cursor: default;
-                     color: #4b4b4b;
-                     display: block;
-                     font-size:1.1em bold;
-                     font-weight:bold;
-                     height:22px;
-                     line-height: 22px;
-                     text-decoration:none;
-                     text-indent: 8px;
-                     vertical-align: top;
-                     width: 205px;'
-        )
-        if !section.nil? && section.class != String
-          section.each do |s|
-            if s.class == Array
-              s.each do |rec|
-                @branch_node = []
-                if rec.class == String
-                  @menu_node = TreeNodeBuilder.generic_tree_node(
-                    "s__#{menu}:#{rec}",
-                    rec,
-                    'folder.png',
-                    "Menu: #{rec}",
-                    :style => 'cursor:default;' # No cursor pointer
-                  )
-                else
-                  rec.each do |r|
-                    temp = rep_kids_menutree(r)
-                    @branch_node.push(temp) unless temp.nil? || temp.empty?
-                  end
-                  @menu_node[:children] = @branch_node unless @branch_node.nil? || @menu_node.include?(@branch_node)
-                end
-                @branch.push(@menu_node) unless @menu_node.nil? || @branch.include?(@menu_node)
-              end
-            elsif s.class == String
-              temp = rep_kids_menutree(s)
-              @branch.push(temp) unless temp.nil? || temp.empty?
-            end
-          end
-        end
-        @parent_node[:children] = @branch unless @branch.nil? || @parent_node.include?(@branch)
-        @tree.push(@parent_node) unless @parent_node.nil?
-        @branch = []
-      end
-    end
-    base_node[:children] = @tree
-    menu_roles_tree = base_node unless base_node.nil? || base_node.empty?
-    menu_roles_tree
-  end
-
-  def rep_kids_menutree(rec)
-    rpt = MiqReport.find_by_name(rec.strip)
-    @tag_node = {}
-    unless rpt.nil?
-      @tag_node = TreeNodeBuilder.generic_tree_node(
-        "r__#{rpt.id}_#{rpt.name}",
-        rpt.name,
-        'report.png',
-        "Report: #{rpt.name}",
-        :style => 'padding-bottom: 2px; padding-left: 0px;' # No cursor pointer
-      )
-    end
-    @tag_node
+    tree.hash_tree
   end
 
   def move_menu_cols_left
@@ -698,13 +612,13 @@ module ReportController::Menus
   end
 
   def edit_folder
-    session[:node_selected] = "b__Report Menus for #{session[:role_choice]}" if params[:button] == "reset" || params[:button] == "default"  # resetting node in case reset button is pressed
+    session[:node_selected] = "xx-b__Report Menus for #{session[:role_choice]}" if params[:button] == "reset" || params[:button] == "default"  # resetting node in case reset button is pressed
     @selected = session[:node_selected].split('__')
     @folders = []
     @edit[:folders] = []
 
     # calculating selected reports for selected folder
-    if session[:node_selected] == "b__Report Menus for #{session[:role_choice]}"
+    if session[:node_selected] == "xx-b__Report Menus for #{session[:role_choice]}"
       @edit[:new].each do |arr|
         if arr[0] != @sb[:grp_title]
           @folders.push(arr[0])

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -181,7 +181,9 @@ class TreeBuilder
     root = nodes.first
     root[:title], root[:tooltip], icon, options = root_options
     root[:icon] = ActionController::Base.helpers.image_path("100/#{icon || 'folder'}.png")
-    root[:cfmeNoClick] = options[:cfmeNoClick] if options.present? && options.key?(:cfmeNoClick)
+    if options.present?
+      root.merge!(options)
+    end
   end
 
   def set_locals_for_render

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -1,0 +1,155 @@
+class TreeBuilderMenuRoles < TreeBuilder
+  has_kids_for Hash, [:x_build_kids]
+
+  attr_reader :rpt_menu, :role_choice
+
+  def initialize(name, type, sandbox, role_choice, rpt_menu = nil)
+    @rpt_menu    = rpt_menu || sandbox[:rpt_menu]
+    @role_choice = role_choice
+
+    super(name, type, sandbox, true)
+  end
+
+  # Used for testing convenience and to satisfy need for
+  # tree data in controller
+
+  def hash_tree
+    @hash_tree ||= x_build_tree(@tree_state.x_tree(@name))
+  end
+
+  private
+
+  def set_locals_for_render
+    {
+      :tree_id       => "#{@name}box",
+      :tree_name     => @name.to_s,
+      :bs_tree       => @bs_tree,
+      :click_url     => "/report/menu_editor/",
+      :onclick       => "miqMenuEditor",
+      :cookie_prefix => "edit_",
+      :tree_state    => true,
+      :checkboxes    => false
+    }
+  end
+
+  # Set add_root to false, otherwise we need a root_options method
+  #
+  def tree_init_options(_tree_name)
+    { :lazy => false, :add_root => false }
+  end
+
+  # TreeBuilder Overrides
+
+  # Override this method to add our custom root.
+  # Our root (Top Level) needs a specific id to make the form work.
+  #
+  def x_build_tree(options)
+    # Tell super method to always give us child_nodes only.
+    options[:add_root] = false
+    nodes = super(options)
+
+    [x_build_actual_root_node(nodes)]
+  end
+
+  # This is really more like branches, we set the root above.
+  # TreeBuilder required method
+  #
+  def x_get_tree_roots(count_only = false, _options)
+    branches = menus.map do |i|
+      grandkids = i.last.kind_of?(Array) ? i.last : []
+
+      {
+        :id       => "p__#{i.first}",
+        :image    => "folder",
+        :text     => i.first,
+        :tooltip  => i.first,
+        :children => grandkids
+      }
+    end
+
+    count_only_or_objects(count_only, branches)
+  end
+
+  # Referenced by has_kids_for, builds nodes from branch kids and grandkids
+  #
+  def x_build_kids(parent, count_only = false)
+    items = parent[:children].map do |child|
+      if child.last.kind_of?(Array)
+        build_middle_child(parent[:text], child)
+      else
+        build_last_child(child)
+      end
+    end
+
+    count_only_or_objects(count_only, items)
+  end
+
+  def build_middle_child(parent_name, item)
+    {
+      :id       => "s__#{parent_name}:#{item.first}",
+      :image    => "folder",
+      :text     => item.first,
+      :tooltip  => item.first,
+      :children => item.last
+    }
+  end
+
+  def build_last_child(child)
+    {
+      :id          => child,
+      :image       => "report",
+      :text        => child,
+      :tooltip     => child,
+      :cfmeNoClick => true,
+      :children    => []
+    }
+  end
+
+  # Build a custom root node, :key is essential for form to work,
+  # otherwise we may have been able to use TreeBuilder methods
+  #
+  def x_build_actual_root_node(children)
+    {
+      :key         => "xx-b__Report Menus for #{role_choice}",
+      :title       => "Top Level",
+      :icon        => tree_icon,
+      :expand      => true,
+      :cfmeNoClick => false,
+      :children    => children
+    }
+  end
+
+  def tree_icon
+    ActionController::Base.helpers.image_path("100/folder.png")
+  end
+
+  # Translated code from old controller method
+  # builds the array we use in x_get_tree_roots
+  # -- @hayesr Nov 2016
+
+  # create/modify new array that doesn't have custom reports folder, dont need custom folder in menu_editor
+  # add any new empty folders that were added
+  def menus
+    rpt_menu.map { |item| item if conforming_item?(item) }.compact
+  end
+
+  # Checks array pairs for empty children
+  def conforming_item?(item)
+    present_and_empty?(item[1]) ||
+      present_not_empty_but_first_empty?(item[1]) ||
+      present_not_empty_and_not_custom?(item[1])
+  end
+
+  def present_and_empty?(item)
+    item && item.empty?
+  end
+
+  def present_not_empty_but_first_empty?(item)
+    item && !item.empty? && item[0].empty?
+  end
+
+  # Check the second level menu for "Custom"
+  def present_not_empty_and_not_custom?(item)
+    item && !item.empty? && !item[0].empty? && item[0][0] != "Custom"
+  end
+end

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -20,10 +20,12 @@ class TreeBuilderMenuRoles < TreeBuilder
   private
 
   def set_locals_for_render
-    super.merge!({
+    locals = {
       :click_url => "/report/menu_editor/",
       :onclick   => "miqMenuEditor"
-    })
+    }
+
+    super.merge!(locals)
   end
 
   def tree_init_options(_tree_name)
@@ -44,11 +46,11 @@ class TreeBuilderMenuRoles < TreeBuilder
       grandkids = i.last.kind_of?(Array) ? i.last : []
 
       {
-        :id       => "p__#{i.first}",
-        :image    => "folder",
-        :text     => i.first,
-        :tooltip  => i.first,
-        :data     => grandkids
+        :id      => "p__#{i.first}",
+        :image   => "folder",
+        :text    => i.first,
+        :tooltip => i.first,
+        :data    => grandkids
       }
     end
 
@@ -71,11 +73,11 @@ class TreeBuilderMenuRoles < TreeBuilder
 
   def build_middle_child(parent_name, item)
     {
-      :id       => "s__#{parent_name}:#{item.first}",
-      :image    => "folder",
-      :text     => item.first,
-      :tooltip  => item.first,
-      :data     => item.last
+      :id      => "s__#{parent_name}:#{item.first}",
+      :image   => "folder",
+      :text    => item.first,
+      :tooltip => item.first,
+      :data    => item.last
     }
   end
 

--- a/app/presenters/tree_builder_menu_roles.rb
+++ b/app/presenters/tree_builder_menu_roles.rb
@@ -1,13 +1,13 @@
 class TreeBuilderMenuRoles < TreeBuilder
-  has_kids_for Hash, [:x_build_kids]
+  has_kids_for Hash, [:x_get_tree_hash_kids]
 
   attr_reader :rpt_menu, :role_choice
 
-  def initialize(name, type, sandbox, role_choice, rpt_menu = nil)
+  def initialize(name, type, sandbox, build, role_choice:, rpt_menu: nil)
     @rpt_menu    = rpt_menu || sandbox[:rpt_menu]
     @role_choice = role_choice
 
-    super(name, type, sandbox, true)
+    super(name, type, sandbox, build)
   end
 
   # Used for testing convenience and to satisfy need for
@@ -20,39 +20,24 @@ class TreeBuilderMenuRoles < TreeBuilder
   private
 
   def set_locals_for_render
-    {
-      :tree_id       => "#{@name}box",
-      :tree_name     => @name.to_s,
-      :bs_tree       => @bs_tree,
-      :click_url     => "/report/menu_editor/",
-      :onclick       => "miqMenuEditor",
-      :cookie_prefix => "edit_",
-      :tree_state    => true,
-      :checkboxes    => false
-    }
+    super.merge!({
+      :click_url => "/report/menu_editor/",
+      :onclick   => "miqMenuEditor"
+    })
   end
 
-  # Set add_root to false, otherwise we need a root_options method
-  #
   def tree_init_options(_tree_name)
-    { :lazy => false, :add_root => false }
+    { :lazy => false, :add_root => true }
   end
 
-  # TreeBuilder Overrides
-
-  # Override this method to add our custom root.
-  # Our root (Top Level) needs a specific id to make the form work.
-  #
-  def x_build_tree(options)
-    # Tell super method to always give us child_nodes only.
-    options[:add_root] = false
-    nodes = super(options)
-
-    [x_build_actual_root_node(nodes)]
+  def root_options
+    ["Top Level", "Top Level", "folder", {:key => "xx-b__Report Menus for #{role_choice}"}]
   end
 
-  # This is really more like branches, we set the root above.
-  # TreeBuilder required method
+  # Typically another method will populate the children of a root object.
+  # Since our data is an array of Strings or Arrays, we don't have ids to tie
+  # parents to children. Therefore we include the children with the parent.
+  # The :data key was chosen to avoid future conflicts with the :children key.
   #
   def x_get_tree_roots(count_only = false, _options)
     branches = menus.map do |i|
@@ -63,7 +48,7 @@ class TreeBuilderMenuRoles < TreeBuilder
         :image    => "folder",
         :text     => i.first,
         :tooltip  => i.first,
-        :children => grandkids
+        :data     => grandkids
       }
     end
 
@@ -72,8 +57,8 @@ class TreeBuilderMenuRoles < TreeBuilder
 
   # Referenced by has_kids_for, builds nodes from branch kids and grandkids
   #
-  def x_build_kids(parent, count_only = false)
-    items = parent[:children].map do |child|
+  def x_get_tree_hash_kids(parent, count_only = false)
+    items = parent[:data].map do |child|
       if child.last.kind_of?(Array)
         build_middle_child(parent[:text], child)
       else
@@ -90,7 +75,7 @@ class TreeBuilderMenuRoles < TreeBuilder
       :image    => "folder",
       :text     => item.first,
       :tooltip  => item.first,
-      :children => item.last
+      :data     => item.last
     }
   end
 
@@ -101,26 +86,8 @@ class TreeBuilderMenuRoles < TreeBuilder
       :text        => child,
       :tooltip     => child,
       :cfmeNoClick => true,
-      :children    => []
+      :data        => []
     }
-  end
-
-  # Build a custom root node, :key is essential for form to work,
-  # otherwise we may have been able to use TreeBuilder methods
-  #
-  def x_build_actual_root_node(children)
-    {
-      :key         => "xx-b__Report Menus for #{role_choice}",
-      :title       => "Top Level",
-      :icon        => tree_icon,
-      :expand      => true,
-      :cfmeNoClick => false,
-      :children    => children
-    }
-  end
-
-  def tree_icon
-    ActionController::Base.helpers.image_path("100/folder.png")
   end
 
   # Translated code from old controller method

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -6,14 +6,7 @@
         %h3
           = _("Reports")
         #menu_roles_treebox.treeview-pf-hover.treeview-pf-select{:style => "overflow-y: hidden !important;"}
-      = render(:partial => "layouts/tree",
-        :locals         => {:tree_id => 'menu_roles_treebox',
-          :tree_name                 => 'menu_roles_tree',
-          :bs_tree                   => @menu_roles_tree,
-          :click_url                 => '/report/menu_editor/',
-          :onclick                   => 'miqMenuEditor',
-          :cookie_prefix             => "edit_",
-          :tree_state                => true})
+      = render(:partial => "layouts/tree", :locals => @menu_roles_tree.locals_for_render)
 
       = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
       = render :partial => "report/menu_form2"

--- a/app/views/report/_role_list.html.haml
+++ b/app/views/report/_role_list.html.haml
@@ -5,8 +5,7 @@
       .col-sm-5
         %h3
           = _("Reports")
-        #menu_roles_treebox.treeview-pf-hover.treeview-pf-select{:style => "overflow-y: hidden !important;"}
-      = render(:partial => "layouts/tree", :locals => @menu_roles_tree.locals_for_render)
+        = render(:partial => "shared/tree", :locals => {:tree => @menu_roles_tree, :name => @menu_roles_tree.name})
 
       = render :partial => "report/menu_form1", :locals => {:folders => @grid_folders}
       = render :partial => "report/menu_form2"

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -1,18 +1,31 @@
 describe ReportController do
-  context "::Menus" do
-    context "#menu_update" do
-      it "set menus to default" do
-        allow(controller).to receive(:menu_get_form_vars)
-        allow(controller).to receive(:get_tree_data)
-        allow(controller).to receive(:replace_right_cell)
-        controller.instance_variable_set(:@rpt_menu, [])
-        controller.instance_variable_set(:@edit, {:new => {}})
-        controller.instance_variable_set(:@sb, :new => {})
-        controller.instance_variable_set(:@_params, :button => "default")
-        expect(controller).to receive(:build_report_listnav).with "reports", "menu", "default"
-        controller.menu_update
-        expect(assigns(:flash_array).first[:message]).to include("default")
-      end
+  describe "#menu_update" do
+    let(:rpt_menu) do
+      [
+        [
+          "Configuration Management", [
+            ["Virtual Machines", ["VMs with Free Space > 50% by Department"]],
+          ]
+        ]
+      ]
+    end
+
+    before do
+      controller.instance_variable_set(:@edit, {:new => {}})
+      controller.instance_variable_set(:@sb, :new => {})
+      controller.instance_variable_set(:@_params, :button => "default")
+
+      @user = stub_user(features: :all)
+    end
+
+    it "set menus to default" do
+      expect(controller).to receive(:menu_get_form_vars)
+      expect(controller).to receive(:get_tree_data)
+      expect(controller).to receive(:replace_right_cell)
+      expect(controller).to receive(:get_reports_menu).with(@user.current_group, "reports", "default").and_return(rpt_menu)
+
+      controller.menu_update
+      expect(assigns(:flash_array).first[:message]).to include("default")
     end
   end
 end

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -11,7 +11,7 @@ describe ReportController do
     end
 
     before do
-      controller.instance_variable_set(:@edit, {:new => {}})
+      controller.instance_variable_set(:@edit, :new => {})
       controller.instance_variable_set(:@sb, :new => {})
       controller.instance_variable_set(:@_params, :button => "default")
 

--- a/spec/controllers/report_controller/menu_spec.rb
+++ b/spec/controllers/report_controller/menu_spec.rb
@@ -1,5 +1,5 @@
 describe ReportController do
-  context "#edit_folder" do
+  describe "#edit_folder" do
     before(:each) do
       controller.instance_variable_set(:@grid_folders, nil)
       session[:node_selected] = 'foo__bar'
@@ -20,7 +20,7 @@ describe ReportController do
     end
   end
 
-  context "#menu_folders" do
+  describe "#menu_folders" do
     it "can handle nil" do
       controller.instance_variable_set(:@edit, {:user_typ => true})
       out = controller.send(:menu_folders, [nil, 'foo'])
@@ -66,6 +66,5 @@ describe ReportController do
       expect(out).to eq([{:id => "i_A", :text => "A"},
                          {:id => "|-|i_B", :text => "B"}])
     end
-
   end
 end

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1127,7 +1127,6 @@ describe ReportController do
       allow(controller).to receive(:x_build_dyna_tree)
       last_build_time = Time.now.utc
       controller.instance_variable_set(:@sb, :rep_tree_build_time => last_build_time)
-      expect(controller).not_to receive(:build_report_listnav)
       expect(controller).not_to receive(:build_savedreports_tree)
       expect(controller).not_to receive(:build_db_tree)
       expect(controller).not_to receive(:build_widgets_tree)

--- a/spec/presenters/tree_builder_menu_roles_spec.rb
+++ b/spec/presenters/tree_builder_menu_roles_spec.rb
@@ -1,4 +1,5 @@
 # Describes TreeBuilderMenuRoles presenter
+# Currently requires unique keys for nodes
 # Example tree:
 
 # {
@@ -57,71 +58,72 @@ describe TreeBuilderMenuRoles do
     { :rpt_menu => rpt_menu }
   end
 
-  let(:instance) { TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", sandbox, "cloud-execs") }
+  let(:instance) { TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", sandbox, true, role_choice: "cloud-execs") }
+  let(:tree_hash) { JSON.parse(instance.tree_nodes) }
 
   describe "root node" do
-    subject { instance.hash_tree.first }
+    subject { tree_hash.first }
 
     it 'has the correct key' do
-      expect(subject[:key]).not_to be_nil
-      expect(subject[:key]).to eq "xx-b__Report Menus for cloud-execs"
+      expect(subject["key"]).not_to be_nil
+      expect(subject["key"]).to eq "xx-b__Report Menus for cloud-execs"
     end
 
     it 'has the correct title' do
-      expect(subject[:title]).to eq "Top Level"
+      expect(subject["text"]).to eq "Top Level"
     end
 
     it 'has children' do
-      expect(subject[:children]).not_to be_empty
+      expect(subject["nodes"]).not_to be_empty
     end
   end
 
   describe "1st level folder" do
-    subject { instance.hash_tree.first[:children].first }
+    subject { tree_hash.first["nodes"].first }
 
     it 'has the correct key' do
-      expect(subject[:key]).not_to be_nil
-      expect(subject[:key]).to eq "xx-p__Configuration Management"
+      expect(subject["key"]).not_to be_nil
+      expect(subject["key"]).to eq "xx-p__Configuration Management"
     end
 
     it 'has children' do
-      expect(subject[:children]).not_to be_empty
+      expect(subject["nodes"]).not_to be_empty
     end
   end
 
   describe "2nd level folder" do
-    subject { instance.hash_tree.first[:children].first[:children].first }
+    subject { tree_hash.first["nodes"].first["nodes"].first }
 
     it 'has the correct key' do
-      expect(subject[:key]).not_to be_nil
-      expect(subject[:key]).to eq "xx-s__Configuration Management:Virtual Machines"
+      expect(subject["key"]).not_to be_nil
+      expect(subject["key"]).to eq "xx-s__Configuration Management:Virtual Machines"
     end
 
     it 'has a key with parent name and colon' do
-      expect(subject[:key]).to match(/Configuration\sManagement:/)
+      expect(subject["key"]).to match(/Configuration\sManagement:/)
     end
 
     it 'has children' do
-      expect(subject[:children]).not_to be_empty
+      expect(subject["nodes"]).not_to be_empty
     end
   end
 
   describe "report leaf node" do
     subject do
-      instance.hash_tree.first[:children].first[:children].first[:children].first
+      tree_hash.first["nodes"].first["nodes"].first["nodes"].first
     end
 
     it 'has the correct key' do
-      expect(subject[:key]).not_to be_nil
-      expect(subject[:key]).to eq "xx-VMs with Free Space > 50% by Department"
+      expect(subject["key"]).not_to be_nil
+      expect(subject["key"]).to eq "xx-VMs with Free Space > 50% by Department"
     end
 
     it 'is not clickable' do
-      expect(subject[:cfmeNoClick]).to eq true
+      expect(subject["selectable"]).to eq false
     end
 
     it 'has no children' do
-      expect(subject[:children]).to be_nil
+      expect(subject["nodes"]).to be_nil
     end
   end
 

--- a/spec/presenters/tree_builder_menu_roles_spec.rb
+++ b/spec/presenters/tree_builder_menu_roles_spec.rb
@@ -1,0 +1,144 @@
+# Describes TreeBuilderMenuRoles presenter
+# Example tree:
+
+# {
+#   :key      => "xx-b__Report Menus for cloud-execs",
+#   :title    => "Top Level",
+#   :icon     => "/assets/100/folder.png",
+#   :expand   => true,
+#   :children => [
+#     {
+#       :key      => "xx-p__Configuration Management",
+#       :title    => "Configuration Management",
+#       :icon     => "/assets/100/folder.png",
+#       :tooltip  => "Group: Configuration Management",
+#       :children => [
+#         {
+#           :key      => "xx-s__Configuration Management:Virtual Machines",
+#           :title    => "Virtual Machines",
+#           :icon     => "/assets/100/folder.png",
+#           :tooltip  => "Menu: Virtual Machines",
+#           :children => [
+#             {
+#               :key          => "xx-VMs with Free Space > 50% by Department",
+#               :title        => "VMs with Free Space &gt; 50% by Department",
+#               :icon         => "/assets/100/report.png",
+#               :cfmeNoClick  => true,
+#               :expand       => nil
+#             },
+#             {
+#               :key          => "xx-VMs w/Free Space > 75% by Function",
+#               :title        => "VMs w/Free Space &gt; 75% by Function",
+#               :icon         => "/assets/100/report.png",
+#               :cfmeNoClick  => true,
+#               :expand       => nil
+#             }
+#           ]
+#         }
+#       ]
+#     }
+#   ]
+# }
+
+describe TreeBuilderMenuRoles do
+  let(:rpt_menu) do
+    [
+      [
+        "Configuration Management", [
+          ["Virtual Machines", ["VMs with Free Space > 50% by Department", "VMs w/Free Space > 75% by Function"]],
+          ["Hosts", ["Hosts Summary", "Host Summary with VM info"]],
+          ["Providers", ["Providers Summary", "Providers Hosts Relationships"]],
+        ]
+      ]
+    ]
+  end
+
+  let(:sandbox) do
+    { :rpt_menu => rpt_menu }
+  end
+
+  let(:instance) { TreeBuilderMenuRoles.new("menu_roles_tree", "menu_roles", sandbox, "cloud-execs") }
+
+  describe "root node" do
+    subject { instance.hash_tree.first }
+
+    it 'has the correct key' do
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-b__Report Menus for cloud-execs"
+    end
+
+    it 'has the correct title' do
+      expect(subject[:title]).to eq "Top Level"
+    end
+
+    it 'has children' do
+      expect(subject[:children]).not_to be_empty
+    end
+  end
+
+  describe "1st level folder" do
+    subject { instance.hash_tree.first[:children].first }
+
+    it 'has the correct key' do
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-p__Configuration Management"
+    end
+
+    it 'has children' do
+      expect(subject[:children]).not_to be_empty
+    end
+  end
+
+  describe "2nd level folder" do
+    subject { instance.hash_tree.first[:children].first[:children].first }
+
+    it 'has the correct key' do
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-s__Configuration Management:Virtual Machines"
+    end
+
+    it 'has a key with parent name and colon' do
+      expect(subject[:key]).to match(/Configuration\sManagement:/)
+    end
+
+    it 'has children' do
+      expect(subject[:children]).not_to be_empty
+    end
+  end
+
+  describe "report leaf node" do
+    subject do
+      instance.hash_tree.first[:children].first[:children].first[:children].first
+    end
+
+    it 'has the correct key' do
+      expect(subject[:key]).not_to be_nil
+      expect(subject[:key]).to eq "xx-VMs with Free Space > 50% by Department"
+    end
+
+    it 'is not clickable' do
+      expect(subject[:cfmeNoClick]).to eq true
+    end
+
+    it 'has no children' do
+      expect(subject[:children]).to be_nil
+    end
+  end
+
+  describe "render locals" do
+    subject { instance.locals_for_render }
+
+    it 'includes a json tree' do
+      parsed = JSON.parse(subject[:bs_tree])
+      expect(parsed).to be_a_kind_of Array
+    end
+
+    it 'points to report/menu_editor' do
+      expect(subject[:click_url]).to eq "/report/menu_editor/"
+    end
+
+    it 'uses miqMenuEditor to handle clicks' do
+      expect(subject[:onclick]).to eq "miqMenuEditor"
+    end
+  end
+end


### PR DESCRIPTION
Currently a long controller method builds the tree for the menu roles editor. This replaces that with a tested TreeBuilder class.

https://www.pivotaltracker.com/story/show/129518653

