### PR TITLE
Fix wrong urls when clicking entities on topology page

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -39,17 +39,16 @@ ManageIQ.angular.app.service('topologyService', function() {
 
   this.geturl = function(d) {
     var entity_url = "";
-    var action = '/' + d.item.miq_id;
+    var action = '/';
+
     switch (d.item.kind) {
       case "ContainerManager":
-        action = '/' + d.item.miq_id;
         entity_url = "ems_container";
         break;
       case "NetworkManager":
         entity_url = "ems_network";
         break;
       case "MiddlewareManager":
-        action = '/' + d.item.miq_id;
         entity_url = "ems_middleware";
         break;
       case "InfraManager":
@@ -59,10 +58,11 @@ ManageIQ.angular.app.service('topologyService', function() {
         entity_url = "ems_cloud";
         break;
       default : // for non provider entities, use the show action
+        action = '/show/';
         entity_url = _.snakeCase(d.item.kind);
       }
 
-      return '/' + entity_url + action;
+      return '/' + entity_url + action + d.item.miq_id;
   };
 
   this.getSVG = function(d3) {

--- a/app/models/ontap_flex_vol_extent.rb
+++ b/app/models/ontap_flex_vol_extent.rb
@@ -48,45 +48,26 @@ class OntapFlexVolExtent < CimStorageExtent
     ontap_concrete_extent
   end
 
-  delegate :base_storage_extents, :to => :ontap_logical_disk
-
-  delegate :base_storage_extents_size, :to => :ontap_logical_disk
-
-  delegate :file_system, :to => :ontap_logical_disk
-
-  delegate :file_shares, :to => :ontap_logical_disk
-
-  delegate :file_shares_size, :to => :ontap_logical_disk
-
-  delegate :cim_datastores, :to => :ontap_logical_disk
-
-  delegate :cim_datastores_size, :to => :ontap_logical_disk
-
-  delegate :storages, :to => :ontap_logical_disk
-
-  delegate :storages_size, :to => :ontap_logical_disk
-
-  delegate :cim_virtual_disks, :to => :ontap_logical_disk
-
-  delegate :cim_virtual_disks_size, :to => :ontap_logical_disk
-
-  delegate :virtual_disks, :to => :ontap_logical_disk
-
-  delegate :virtual_disks_size, :to => :ontap_logical_disk
-
-  delegate :cim_vms, :to => :ontap_logical_disk
-
-  delegate :cim_vms_size, :to => :ontap_logical_disk
-
-  delegate :vms, :to => :ontap_logical_disk
-
-  delegate :vms_size, :to => :ontap_logical_disk
-
-  delegate :cim_hosts, :to => :ontap_logical_disk
-
-  delegate :cim_hosts_size, :to => :ontap_logical_disk
-
-  delegate :hosts, :to => :ontap_logical_disk
-
-  delegate :hosts_size, :to => :ontap_logical_disk
+  delegate :base_storage_extents,
+           :base_storage_extents_size,
+           :cim_datastores,
+           :cim_datastores_size,
+           :cim_hosts,
+           :cim_hosts_size,
+           :cim_virtual_disks,
+           :cim_virtual_disks_size,
+           :cim_vms,
+           :cim_vms_size,
+           :file_shares,
+           :file_shares_size,
+           :file_system,
+           :hosts,
+           :hosts_size,
+           :storages,
+           :storages_size,
+           :virtual_disks,
+           :virtual_disks_size,
+           :vms,
+           :vms_size,
+           :to => :ontap_logical_disk
 end


### PR DESCRIPTION
Fixed missing pages when clicking non-provider entity on topology page

Reproducer:
1. Navigate to the summary page of any provider
2. Click the Topology link.
3. On the Topology page, double click provider entity.