### PR TITLE
Fix wrong urls when clicking entity on topology page

### DIFF
--- a/app/assets/javascripts/services/topology_service.js
+++ b/app/assets/javascripts/services/topology_service.js
@@ -39,17 +39,16 @@ ManageIQ.angular.app.service('topologyService', function() {
 
   this.geturl = function(d) {
     var entity_url = "";
-    var action = '/' + d.item.miq_id;
+    var action = '/';
+
     switch (d.item.kind) {
       case "ContainerManager":
-        action = '/' + d.item.miq_id;
         entity_url = "ems_container";
         break;
       case "NetworkManager":
         entity_url = "ems_network";
         break;
       case "MiddlewareManager":
-        action = '/' + d.item.miq_id;
         entity_url = "ems_middleware";
         break;
       case "InfraManager":
@@ -59,10 +58,10 @@ ManageIQ.angular.app.service('topologyService', function() {
         entity_url = "ems_cloud";
         break;
       default : // for non provider entities, use the show action
+        action = '/show/';
         entity_url = _.snakeCase(d.item.kind);
       }
-
-      return '/' + entity_url + action;
+      return '/' + entity_url + action + d.item.miq_id;
   };
 
   this.getSVG = function(d3) {


### PR DESCRIPTION
Fixed missing pages when clicking non-provider entity on topology page
https://bugzilla.redhat.com/show_bug.cgi?id=1394733

Reproducer:
1. Navigate to the summary page of any provider
2. Click the Topology link.
3. On the Topology page, double click provider entity.