### PR TITLE
Remove memory chart for Availiability Zones

### DIFF
--- a/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
@@ -1,5 +1,5 @@
 # Availability Zone Daily performance chart layouts
---- 
+---
 - :title: CPU (%)
   :type: Line
   :columns:
@@ -23,26 +23,7 @@
   :chart2:
     :type: Line
     :title: Instances
-    :columns: 
-    - derived_vm_count_on
-
-- :title: Memory (MB)
-  :type: Line
-  :columns:
-  - derived_memory_used
-  - min_derived_memory_used
-  - max_derived_memory_used
-  - trend_max_derived_memory_used
-  - resource.derived_memory_used_high_over_time_period
-  - resource.derived_memory_used_low_over_time_period
-  :menu:
-  - Chart-Current-Hourly:Hourly for this day
-  - Chart-VMs-topday:Top Instances on this day
-  - Display-VMs-on:Instances that were running
-  :chart2: 
-    :type: Line
-    :title: Instances
-    :columns: 
+    :columns:
     - derived_vm_count_on
 
 - :title: Disk I/O (KBps)
@@ -58,10 +39,10 @@
 #  - Timeline-Current-Daily:Daily events in this Availability Zone
 #  - Timeline-Current-Hourly:Hourly events in this Availability Zone
   - Display-VMs-on:Instances that were running
-  :chart2: 
+  :chart2:
     :type: Line
     :title: Instances
-    :columns: 
+    :columns:
     - derived_vm_count_on
 
 - :title: Network I/O (KBps)
@@ -77,10 +58,10 @@
 #  - Timeline-Current-Daily:Daily events in this Availability Zone
 #  - Timeline-Current-Hourly:Hourly events in this Availability Zone
   - Display-VMs-on:Instances that were running
-  :chart2: 
+  :chart2:
     :type: Line
     :title: Instances
-    :columns: 
+    :columns:
     - derived_vm_count_on
 
 - :title: Instances
@@ -88,7 +69,7 @@
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off
-  :menu: 
+  :menu:
   - Chart-Current-Hourly:Hourly for this day
   - Display-VMs-on:Instances that were running
   - Display-VMs-off:Instances that were stopped


### PR DESCRIPTION
Remove memory chart for Availiability Zones

Screenshot
----------------
Before:
![ec2_azone_memo](https://cloud.githubusercontent.com/assets/9535558/20267192/de8da8ac-aa79-11e6-9df7-88f39dd6306a.png)
After:
![screenshot from 2016-11-15 15-18-20](https://cloud.githubusercontent.com/assets/9535558/20309078/e1012d2a-ab46-11e6-8929-6b57456760c0.png)



Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1393574

Steps for Testing/QA
-------------------------------
1.Manage ec2.Enable C&U collection for ec2.
2.Collect C&U data for at least 2 hours and then view C&U graphs for 
Availability zones.
