### PR TITLE
Fix rare fixed-rates calculation problem when missing cb fields

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -24,10 +24,9 @@ class ChargebackRateDetail < ApplicationRecord
   def charge(relevant_fields, chargeback_fields_present, metric_rollup_records, hours_in_interval)
     result = {}
     if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?
+      metric_value, cost = metric_and_cost_by(metric_rollup_records, hours_in_interval)
       if !chargeback_fields_present && fixed?
         cost = 0
-      else
-        metric_value, cost = metric_and_cost_by(metric_rollup_records, hours_in_interval)
       end
       metric_keys.each { |field| result[field] = metric_value }
       cost_keys.each   { |field| result[field] = cost }


### PR DESCRIPTION
The `true` branch of this `if`-`else` is very rare.

The problem was that we did not set `metric_value` in the `true` branch. That means we keep `metric_value` from the previous loop or `nil`. The `nil` value could crash the cb calculations as we would attempt to `0 + nil` a few lines later.

Introduced in f3506b7ce9713a90ed1061b5ad8cb57d6cd402ed.

/cc @lpichler 

@miq-bot add_label chargeback, bug
@miq-bot assign @gtanzillo 