### PR TITLE
Change typo in JMS Dount -> Count and plural for all columns

### DIFF
--- a/product/charts/miq_reports/vim_perf_daily_middleware_messaging_jms_topic.yaml
+++ b/product/charts/miq_reports/vim_perf_daily_middleware_messaging_jms_topic.yaml
@@ -49,12 +49,12 @@ col_order:
 # Column titles, in order
 headers:
 - Date/Time
-- Delivering Message Count
-- Durable Message Count
+- Delivering Messages Count
+- Durable Messages Count
 - Durable Subscription Count
 - Messages Count
 - Messages Added
-- Non Durable Messages Dount
+- Non Durable Messages Count
 - Non Durable Subscription Count
 - Subscription Count
 

--- a/product/charts/miq_reports/vim_perf_hourly_middleware_messaging_jms_topic.yaml
+++ b/product/charts/miq_reports/vim_perf_hourly_middleware_messaging_jms_topic.yaml
@@ -49,12 +49,12 @@ col_order:
 # Column titles, in order
 headers:
 - Date/Time
-- Delivering Message Count
-- Durable Message Count
+- Delivering Messages Count
+- Durable Messages Count
 - Durable Subscription Count
 - Messages Count
 - Messages Added
-- Non Durable Messages Dount
+- Non Durable Messages Count
 - Non Durable Subscription Count
 - Subscription Count
 

--- a/product/charts/miq_reports/vim_perf_realtime_middleware_messaging_jms_topic.yaml
+++ b/product/charts/miq_reports/vim_perf_realtime_middleware_messaging_jms_topic.yaml
@@ -49,12 +49,12 @@ col_order:
 # Column titles, in order
 headers:
 - Date/Time
-- Delivering Message Count
-- Durable Message Count
+- Delivering Messages Count
+- Durable Messages Count
 - Durable Subscription Count
 - Messages Count
 - Messages Added
-- Non Durable Messages Dount
+- Non Durable Messages Count
 - Non Durable Subscription Count
 - Subscription Count
 


### PR DESCRIPTION
When navigating to any kind of JMS Topic and Monitoring -> Utilization there was an Typo in last column:
`Non Durable Messages Dount -> Non Durable Messages Count`

Also different kind of singular and plural was used in this report, so instead of multiple ones, use only one:
`Mesaage -> Messages`

@miq-bot add_label providers/hawkular, bug, ui, euwe/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1392514