### PR TITLE
Enable Timelines from accordion on Storage Managers page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1023,8 +1023,9 @@ module ApplicationHelper
         end
       end
     else
+      tag_attrs_disabled = {:title => args[:disabled_title]}
       content_tag(:li, :class => "disabled") do
-        link_to(link_text, "#")
+        link_to(link_text, "#", tag_attrs_disabled)
       end
     end
   end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -986,6 +986,13 @@ class ApplicationHelper::ToolbarBuilder
         return @report.present? && @report_result_id.present? &&
           MiqReportResult.find(@report_result_id).try(:miq_report_result_details).try(:length).to_i > 0 ? false : N_("No records found for this report")
       end
+    when "ExtManagementSystem"
+      case id
+      when "ems_storage_monitoring_choice"
+        unless @record.has_events? || @record.has_events?(:policy_events)
+          return N_("No Timeline data has been collected for Policy or Management Events")
+        end
+      end
     end
     false
   end

--- a/app/views/layouts/listnav/_ems_storage.html.haml
+++ b/app/views/layouts/listnav/_ems_storage.html.haml
@@ -14,7 +14,8 @@
           :text       => _('Timelines'),
           :record_id  => @record.id,
           :display    => 'timeline',
-          :title      => _("Show Timelines"))
+          :title      => _("Show Timelines"),
+          :disabled_title => _("No Timeline data has been collected for Policy or Management Events"))
 
     = miq_accordion_panel(_("Relationships"), false, "ems_rel") do
       %ul.nav.nav-pills.nav-stacked

--- a/app/views/layouts/listnav/_ems_storage.html.haml
+++ b/app/views/layouts/listnav/_ems_storage.html.haml
@@ -6,13 +6,13 @@
     = miq_accordion_panel(_("Properties"), false, "ems_prop") do
       %ul.nav.nav-pills.nav-stacked
         = li_link(:if => true,
-          :text       =>_('Summary'),
+          :text       => _('Summary'),
           :record_id  => @record.id,
           :display    => 'main',
           :title      => _("Show Summary"))
         = li_link(:if => (@record.has_events? || @record.has_events?(:policy_events)),
           :text       => _('Timelines'),
-          :record_i   => @record.id,
+          :record_id  => @record.id,
           :display    => 'timeline',
           :title      => _("Show Timelines"))
 


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1383388

Make Timelines clickable from accordion on Storage Managers
summary page when navigating to Storage -> Storage Managers
and choosing a storage manager from the list
because Timelines was broken and working only in monitoring tab.

The condition on
https://github.com/hstastna/manageiq/blob/master/app/views/layouts/listnav/_ems_storage.html.haml#L13 
was changed because it makes no sense to disable
Timelines page from accordion and enable the page only if
`(@record.has_events? || @record.has_events?(:policy_events))`.
In monitoring tab, Timelines page is enabled even if the condition above is false.

Before:
![timelines_before](https://cloud.githubusercontent.com/assets/13417815/20268528/d5a301d2-aa7f-11e6-93a8-c3436d4f077a.png)

After:
![timelines_after](https://cloud.githubusercontent.com/assets/13417815/20268660/64a11388-aa80-11e6-9f95-33760d7d2556.png)
![timelines_after2](https://cloud.githubusercontent.com/assets/13417815/20268667/67af3ee2-aa80-11e6-8cfe-2155a56650bf.png)



