### PR TITLE
Fix history button in vm infra page

### DIFF
--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -75,7 +75,7 @@ module VmShowMixin
       self.x_active_tree ||= feature.tree_list_name
       self.x_active_accord ||= feature.accord_name
     end
-    get_node_info(@sb[@sb[:active_accord]].present? ? @sb[@sb[:active_accord]] : x_node)
+    get_node_info(x_node_right_cell)
   end
 
   def set_active_elements_authorized_user(tree_name, accord_name, add_nodes, klass, id)

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1655,6 +1655,11 @@ module VmCommon
     end
   end
 
+  # return correct node to right cell
+  def x_node_right_cell
+    @sb[@sb[:active_accord]].present? ? @sb[@sb[:active_accord]] : x_node
+  end
+
   # set partial name and cell header for edit screens
   def set_right_cell_vars
     name = @record.try(:name).to_s
@@ -1743,7 +1748,10 @@ module VmCommon
       partial = "layouts/performance"
       header = _("Capacity & Utilization data for %{vm_or_template} \"%{name}\"") %
         {:vm_or_template => ui_lookup(:table => table), :name => name}
-      x_history_add_item(:id => x_node, :text => header, :button => params[:pressed], :display => params[:display])
+      x_history_add_item(:id      => x_node_right_cell,
+                         :text    => header,
+                         :button  => params[:pressed],
+                         :display => params[:display])
       action = nil
     when "policy_sim"
       if params[:action] == "policies"
@@ -1789,7 +1797,9 @@ module VmCommon
       partial = "layouts/tl_show"
       header = _("Timelines for %{virtual_machine} \"%{name}\"") %
         {:virtual_machine => ui_lookup(:table => table), :name => name}
-      x_history_add_item(:id => x_node, :text => header, :button => params[:pressed])
+      x_history_add_item(:id     => x_node_right_cell,
+                         :text   => header,
+                         :button => params[:pressed])
       action = nil
     else
       # now take care of links on summary screen
@@ -1809,7 +1819,10 @@ module VmCommon
           :item_name      => @item.kind_of?(ScanHistory) ? @item.started_on.to_s : @item.name,
           :action         => action_type(@sb[:action], 1)
         }
-        x_history_add_item(:id => x_node, :text => header, :action => @sb[:action], :item => @item.id)
+        x_history_add_item(:id     => x_node_right_cell,
+                           :text   => header,
+                           :action => @sb[:action],
+                           :item   => @item.id)
       else
         header = _("\"%{action}\" for %{vm_or_template} \"%{name}\"") % {
           :vm_or_template => ui_lookup(:table => table),
@@ -1817,9 +1830,13 @@ module VmCommon
           :action         => action_type(@sb[:action], 2)
         }
         if @display && @display != "main"
-          x_history_add_item(:id => x_node, :text => header, :display => @display)
-        else
-          x_history_add_item(:id => x_node, :text => header, :action => @sb[:action]) if @sb[:action] != "drift_history"
+          x_history_add_item(:id      => x_node_right_cell,
+                             :text    => header,
+                             :display => @display)
+        elsif @sb[:action] != "drift_history"
+          x_history_add_item(:id     => x_node_right_cell,
+                             :text   => header,
+                             :action => @sb[:action])
         end
       end
       action = nil


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/manageiq/pull/11387 

Compute -> Infrastructure -> Virtual Machine
Click on any VM
Click on its Snapshots
Click on another node in left tree
Click back button and choose one with `Snapshots`

All `x_history_add_item` that take id of VM/Template were corrected.

(`aa` is a VM, `centos-6-v20150325` is parent node of VM.)
Before: 
![screen shot 2016-11-14 at 4 05 39 pm](https://cloud.githubusercontent.com/assets/9210860/20269622/40a65ed0-aa84-11e6-9cfb-0932ff0573de.png)
Snapshots of parent node of VM.

After:
![screen shot 2016-11-14 at 3 50 08 pm](https://cloud.githubusercontent.com/assets/9210860/20269580/18a3d020-aa84-11e6-8724-426d3e8e0cac.png)
Snapshots of VM.

This PR needs https://github.com/ManageIQ/manageiq/pull/12504 to work.

https://bugzilla.redhat.com/show_bug.cgi?id=1393708

@miq-bot add_label ui, bug, blocker, euwe/yes
