### PR TITLE
Timeline event info no longer only appears on first click

### DIFF
--- a/app/assets/javascripts/miq_timeline.js
+++ b/app/assets/javascripts/miq_timeline.js
@@ -15,9 +15,13 @@
 
   function eventClick(el) {
     var table = '<table class="table table-striped table-bordered">';
+    // clear all popovers on new click
+    $('[data-toggle="popover"]').popover('hide');
+
     $(d3.event.target).popover('toggle');
-    $(d3.event.target).on('shown.bs.popover', function () {
-      $(document).on('click', hidePopover);
+
+    $(d3.event.target).on('shown.bs.popover', { target: d3.event.target }, function (event) {
+      $(document).on('click', { target: event.data.target }, hidePopover);
     });
 
     if (el.hasOwnProperty("events")) {
@@ -40,8 +44,9 @@
     $('#legend').html(table);
   }
 
-  function hidePopover() {
-    $('[data-toggle="popover"]').popover('hide');
+  function hidePopover(event) {
+    $(event.data.target).popover('hide');
+    $(event.data.target).off('shown.bs.popover');
     $(document).off('click', hidePopover);
   }
 


### PR DESCRIPTION
Fix BZ139194 - event info was not visible in popover after the first click.  The events are captured correctly now.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1391943

Steps for Testing/QA
-------------------------------

Multiple events need to be visible in any timeline view, this can be easily reproduced by clicking the first event and then a second event.  No more popovers were visible afterwards.  Please ensure that clicking second events hides the first and shows the second and clicking on the timeline canvas closes any popovers.