### PR TITLE
ChargebackRateDetail should take care of charging

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -146,7 +146,7 @@ class Chargeback < ActsAsArModel
         else
           r.hours_in_interval = hours_in_interval
           metric_value = r.metric_value_by(metric_rollup_records)
-          cost = r.cost(metric_value) * hours_in_interval
+          cost = r.hourly_cost(metric_value) * hours_in_interval
         end
 
         accumulate_metrics_and_costs_per_rate(r.rate_name, r.group, metric_value, cost)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -144,9 +144,7 @@ class Chargeback < ActsAsArModel
         if !chargeback_fields_present && r.fixed?
           cost = 0
         else
-          r.hours_in_interval = hours_in_interval
-          metric_value = r.metric_value_by(metric_rollup_records)
-          cost = r.hourly_cost(metric_value) * hours_in_interval
+          metric_value, cost = r.metric_and_cost_by(metric_rollup_records, hours_in_interval)
         end
 
         accumulate_metrics_and_costs_per_rate(r.rate_name, r.group, metric_value, cost)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -155,7 +155,7 @@ class Chargeback < ActsAsArModel
   def accumulate_metrics_and_costs_per_rate(rate, metric, cost)
     col_hash = {}
 
-    defined_column_for_report = (self.class.report_col_options.keys & [rate.metric_keys[0], rate.cost_keys[0]]).present?
+    defined_column_for_report = (relevant_fields & [rate.metric_keys[0], rate.cost_keys[0]]).present?
 
     if defined_column_for_report
       rate.metric_keys.each { |col| col_hash[col] = metric }
@@ -228,5 +228,11 @@ class Chargeback < ActsAsArModel
     define_method(custom_attribute.to_sym) do
       entity.send(custom_attribute)
     end
+  end
+
+  private
+
+  def relevant_fields
+    @relevant_fields ||= self.class.report_col_options.keys.to_set
   end
 end # class Chargeback

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -147,24 +147,19 @@ class Chargeback < ActsAsArModel
           metric_value, cost = r.metric_and_cost_by(metric_rollup_records, hours_in_interval)
         end
 
-        accumulate_metrics_and_costs_per_rate(r.rate_name, r.group, metric_value, cost)
+        accumulate_metrics_and_costs_per_rate(r, metric_value, cost)
       end
     end
   end
 
-  def accumulate_metrics_and_costs_per_rate(rate_name, rate_group, metric, cost)
-    cost_key         = "#{rate_name}_cost"    # metric cost value (e.g. Storage [Used|Allocated|Fixed] Cost)
-    metric_key       = "#{rate_name}_metric"  # metric value (e.g. Storage [Used|Allocated|Fixed])
-    cost_group_key   = "#{rate_group}_cost"   # for total of metric's costs (e.g. Storage Total Cost)
-    metric_group_key = "#{rate_group}_metric" # for total of metrics (e.g. Storage Total)
-
+  def accumulate_metrics_and_costs_per_rate(rate, metric, cost)
     col_hash = {}
 
-    defined_column_for_report = (self.class.report_col_options.keys & [metric_key, cost_key]).present?
+    defined_column_for_report = (self.class.report_col_options.keys & [rate.metric_keys[0], rate.cost_keys[0]]).present?
 
     if defined_column_for_report
-      [metric_key, metric_group_key].each             { |col| col_hash[col] = metric }
-      [cost_key,   cost_group_key, 'total_cost'].each { |col| col_hash[col] = cost }
+      rate.metric_keys.each { |col| col_hash[col] = metric }
+      rate.cost_keys.each   { |col| col_hash[col] = cost }
     end
 
     col_hash.each do |k, val|

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -210,6 +210,12 @@ class ChargebackRateDetail < ApplicationRecord
     !error
   end
 
+  def metric_and_cost_by(metric_rollup_records, hours_in_interval)
+    @hours_in_interval = hours_in_interval
+    metric_value = metric_value_by(metric_rollup_records)
+    [metric_value, hourly_cost(metric_value) * hours_in_interval]
+  end
+
   private
 
   def first_tier?(tier,tiers)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -22,14 +22,13 @@ class ChargebackRateDetail < ApplicationRecord
   attr_accessor :hours_in_interval
 
   def charge(relevant_fields, chargeback_fields_present, metric_rollup_records, hours_in_interval)
-    if !chargeback_fields_present && fixed?
-      cost = 0
-    else
-      metric_value, cost = metric_and_cost_by(metric_rollup_records, hours_in_interval)
-    end
-
     result = {}
     if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?
+      if !chargeback_fields_present && fixed?
+        cost = 0
+      else
+        metric_value, cost = metric_and_cost_by(metric_rollup_records, hours_in_interval)
+      end
       metric_keys.each { |field| result[field] = metric_value }
       cost_keys.each   { |field| result[field] = cost }
     end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -74,7 +74,7 @@ class ChargebackRateDetail < ApplicationRecord
     :yearly  => "Year"
   }
 
-  def cost(value)
+  def hourly_cost(value)
     return 0.0 unless self.enabled?
 
     value = 1.0 if fixed?

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -210,6 +210,17 @@ class ChargebackRateDetail < ApplicationRecord
     !error
   end
 
+  def metric_keys
+    ["#{rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])
+     "#{group}_metric"]     # total of metric's group (e.g. Storage Total)
+  end
+
+  def cost_keys
+    ["#{rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
+     "#{group}_cost",       # cost associated with metric's group (e.g. Storage Total Cost)
+     'total_cost']
+  end
+
   def metric_and_cost_by(metric_rollup_records, hours_in_interval)
     @hours_in_interval = hours_in_interval
     metric_value = metric_value_by(metric_rollup_records)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -210,6 +210,8 @@ class ChargebackRateDetail < ApplicationRecord
     !error
   end
 
+  private
+
   def first_tier?(tier,tiers)
     tier == tiers.first
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -26,7 +26,7 @@ describe ChargebackRateDetail do
 
   let(:hours_in_month) { 720 }
 
-  it "#cost" do
+  it '#hourly_cost' do
     cvalue   = 42.0
     fixed_rate = 5.0
     variable_rate = 8.26
@@ -46,13 +46,13 @@ describe ChargebackRateDetail do
                              :fixed_rate                => fixed_rate,
                              :variable_rate             => variable_rate)
     cbd.update(:chargeback_tiers => [cbt])
-    expect(cbd.cost(cvalue)).to eq(cvalue * cbd.hourly(variable_rate) + cbd.hourly(fixed_rate))
+    expect(cbd.hourly_cost(cvalue)).to eq(cvalue * cbd.hourly(variable_rate) + cbd.hourly(fixed_rate))
 
     cbd.group = 'fixed'
-    expect(cbd.cost(cvalue)).to eq(cbd.hourly(variable_rate) + cbd.hourly(fixed_rate))
+    expect(cbd.hourly_cost(cvalue)).to eq(cbd.hourly(variable_rate) + cbd.hourly(fixed_rate))
 
     cbd.enabled = false
-    expect(cbd.cost(cvalue)).to eq(0.0)
+    expect(cbd.hourly_cost(cvalue)).to eq(0.0)
   end
 
   it "#hourly" do
@@ -195,7 +195,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
                                       :per_time                          => 'monthly',
                                       :chargeback_rate_detail_measure_id => cbdm.id,
                                       :hours_in_interval                 => hours_in_month)
-    expect(cbd_bytes.cost(100)).to eq(cbd_gigabytes.cost(100))
+    expect(cbd_bytes.hourly_cost(100)).to eq(cbd_gigabytes.hourly_cost(100))
   end
 
   it "#show_rates" do


### PR DESCRIPTION
This moves the charging responsibility from chargeback downto chargeback_rate_detail.

This series of refactorings are the ground works for dynamic charging (needed to charge differently per different storage types). Once we have this, the rate_detail can charge per dynamic field i.e. storate_allocated_ssd_cost, storage_allocated_hiperf_cost (that is related to #12501).

@miq-bot add_label chargeback, refactoring
@miq-bot assign @gtanzillo 