### PR TITLE
Automate - Generic service retirement option.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/generic.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/ServiceRetirement.class/generic.yaml
@@ -1,0 +1,24 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: Generic
+    inherits: 
+    description: 
+  fields:
+  - pre1:
+      value: "# Not Applicable"
+  - pre2:
+      value: "# Not Applicable"
+  - RetireService:
+      value: "# Not Applicable"
+  - CheckServiceRetired:
+      value: "# Not Applicable"
+  - post1:
+      value: "# Not Applicable"
+  - post2:
+      value: "# Not Applicable"
+  - DeleteServiceFromVMDB:
+      value: "# Not Applicable"


### PR DESCRIPTION
This one instance allows setting retirement for Service items.

Some things like Ansible jobs that don't actually have Virtual machines

as part of the service item can now be retired.

https://www.pivotaltracker.com/story/show/134284625

https://bugzilla.redhat.com/show_bug.cgi?id=1363897