### PR TITLE
Optimize vm and generic saving code by removing O(n^2)

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -61,80 +61,82 @@ module EmsRefresh::SaveInventory
 
     invalids_found = false
 
-    hashes.each do |h|
-      # Backup keys that cannot be written directly to the database
-      key_backup = backup_keys(h, remove_keys)
+    ActiveRecord::Base.transaction do
+      hashes.each do |h|
+        # Backup keys that cannot be written directly to the database
+        key_backup = backup_keys(h, remove_keys)
 
-      h[:ems_id]                 = ems.id
-      h[:host_id]                = key_backup.fetch_path(:host, :id) || key_backup.fetch_path(:host).try(:id)
-      h[:ems_cluster_id]         = key_backup.fetch_path(:ems_cluster, :id) || key_backup.fetch_path(:ems_cluster).try(:id)
-      h[:storage_id]             = key_backup.fetch_path(:storage, :id)
-      h[:storage_profile_id]     = key_backup.fetch_path(:storage_profile, :id)
-      h[:flavor_id]              = key_backup.fetch_path(:flavor, :id)
-      h[:availability_zone_id]   = key_backup.fetch_path(:availability_zone, :id)
-      h[:cloud_network_id]       = key_backup.fetch_path(:cloud_network, :id)
-      h[:cloud_subnet_id]        = key_backup.fetch_path(:cloud_subnet, :id)
-      h[:cloud_tenant_id]        = key_backup.fetch_path(:cloud_tenant, :id)
-      h[:cloud_tenants]          = key_backup.fetch_path(:cloud_tenants).compact.map { |x| x[:_object] } if key_backup.fetch_path(:cloud_tenants, 0, :_object)
-      h[:orchestration_stack_id] = key_backup.fetch_path(:orchestration_stack, :id)
-      begin
-        raise MiqException::MiqIncompleteData if h[:invalid]
+        h[:ems_id]                 = ems.id
+        h[:host_id]                = key_backup.fetch_path(:host, :id) || key_backup.fetch_path(:host).try(:id)
+        h[:ems_cluster_id]         = key_backup.fetch_path(:ems_cluster, :id) || key_backup.fetch_path(:ems_cluster).try(:id)
+        h[:storage_id]             = key_backup.fetch_path(:storage, :id)
+        h[:storage_profile_id]     = key_backup.fetch_path(:storage_profile, :id)
+        h[:flavor_id]              = key_backup.fetch_path(:flavor, :id)
+        h[:availability_zone_id]   = key_backup.fetch_path(:availability_zone, :id)
+        h[:cloud_network_id]       = key_backup.fetch_path(:cloud_network, :id)
+        h[:cloud_subnet_id]        = key_backup.fetch_path(:cloud_subnet, :id)
+        h[:cloud_tenant_id]        = key_backup.fetch_path(:cloud_tenant, :id)
+        h[:cloud_tenants]          = key_backup.fetch_path(:cloud_tenants).compact.map { |x| x[:_object] } if key_backup.fetch_path(:cloud_tenants, 0, :_object)
+        h[:orchestration_stack_id] = key_backup.fetch_path(:orchestration_stack, :id)
+        begin
+          raise MiqException::MiqIncompleteData if h[:invalid]
 
-        # Find the Vm in the database with the current uid_ems.  In the event
-        #   of duplicates, try to determine which one is correct.
-        found = indexed_vms[h[:uid_ems]] || []
+          # Find the Vm in the database with the current uid_ems.  In the event
+          #   of duplicates, try to determine which one is correct.
+          found = indexed_vms[h[:uid_ems]] || []
 
-        if found.length > 1 || (found.length == 1 && found.first.ems_id)
-          found_dups = found
-          found = found_dups.select { |v| v.ems_id == h[:ems_id] && (v.ems_ref.nil? || v.ems_ref == h[:ems_ref]) }
-          if found.empty?
-            found_dups = found_dups.select { |v| v.ems_id.nil? }
-            found = found_dups.select { |v| v.ems_ref == h[:ems_ref] }
-            found = found_dups if found.empty?
+          if found.length > 1 || (found.length == 1 && found.first.ems_id)
+            found_dups = found
+            found = found_dups.select { |v| v.ems_id == h[:ems_id] && (v.ems_ref.nil? || v.ems_ref == h[:ems_ref]) }
+            if found.empty?
+              found_dups = found_dups.select { |v| v.ems_id.nil? }
+              found = found_dups.select { |v| v.ems_ref == h[:ems_ref] }
+              found = found_dups if found.empty?
+            end
           end
+          found = found.first
+
+          if found.nil?
+            _log.info("#{log_header} Creating Vm [#{h[:name]}] location: [#{h[:location]}] storage id: [#{h[:storage_id]}] uid_ems: [#{h[:uid_ems]}] ems_ref: [#{h[:ems_ref]}]")
+
+            # Handle the off chance that we are adding an "unknown" Vm to the db
+            h[:location] = "unknown" if h[:location].blank?
+
+            # build a type-specific vm or template
+            found = ems.vms_and_templates.build(h)
+          else
+            h.delete(:type)
+
+            _log.info("#{log_header} Updating Vm [#{found.name}] id: [#{found.id}] location: [#{found.location}] storage id: [#{found.storage_id}] uid_ems: [#{found.uid_ems}] ems_ref: [#{h[:ems_ref]}]")
+            found.update_attributes!(h)
+            disconnects_index.delete(found)
+          end
+
+          # Set the raw power state
+          found.raw_power_state = key_backup[:raw_power_state]
+
+          link_habtm(found, key_backup[:storages], :storages, Storage)
+          link_habtm(found, key_backup[:key_pairs], :key_pairs, ManageIQ::Providers::CloudManager::AuthKeyPair)
+          save_child_inventory(found, key_backup, child_keys)
+
+          found.save!
+          h[:id] = found.id
+          found.reload
+          h[:_object] = found
+        rescue => err
+          # If a vm failed to process, mark it as invalid and log an error
+          h[:invalid] = invalids_found = true
+          name = h[:name] || h[:uid_ems] || h[:ems_ref]
+          if err.kind_of?(MiqException::MiqIncompleteData)
+            _log.warn("#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
+          else
+            raise if EmsRefresh.debug_failures
+            _log.error("#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
+            _log.log_backtrace(err)
+          end
+        ensure
+          restore_keys(h, remove_keys, key_backup)
         end
-        found = found.first
-
-        if found.nil?
-          _log.info("#{log_header} Creating Vm [#{h[:name]}] location: [#{h[:location]}] storage id: [#{h[:storage_id]}] uid_ems: [#{h[:uid_ems]}] ems_ref: [#{h[:ems_ref]}]")
-
-          # Handle the off chance that we are adding an "unknown" Vm to the db
-          h[:location] = "unknown" if h[:location].blank?
-
-          # build a type-specific vm or template
-          found = ems.vms_and_templates.build(h)
-        else
-          h.delete(:type)
-
-          _log.info("#{log_header} Updating Vm [#{found.name}] id: [#{found.id}] location: [#{found.location}] storage id: [#{found.storage_id}] uid_ems: [#{found.uid_ems}] ems_ref: [#{h[:ems_ref]}]")
-          found.update_attributes!(h)
-          disconnects_index.delete(found)
-        end
-
-        # Set the raw power state
-        found.raw_power_state = key_backup[:raw_power_state]
-
-        link_habtm(found, key_backup[:storages], :storages, Storage)
-        link_habtm(found, key_backup[:key_pairs], :key_pairs, ManageIQ::Providers::CloudManager::AuthKeyPair)
-        save_child_inventory(found, key_backup, child_keys)
-
-        found.save!
-        h[:id] = found.id
-        found.reload
-        h[:_object] = found
-      rescue => err
-        # If a vm failed to process, mark it as invalid and log an error
-        h[:invalid] = invalids_found = true
-        name = h[:name] || h[:uid_ems] || h[:ems_ref]
-        if err.kind_of?(MiqException::MiqIncompleteData)
-          _log.warn("#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
-        else
-          raise if EmsRefresh.debug_failures
-          _log.error("#{log_header} Processing Vm: [#{name}] failed with error [#{err}]. Skipping Vm.")
-          _log.log_backtrace(err)
-        end
-      ensure
-        restore_keys(h, remove_keys, key_backup)
       end
     end
 

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -42,6 +42,7 @@ module EmsRefresh::SaveInventoryHelper
       deletes.reload
     end
     deletes = deletes.to_a
+    deletes_index = deletes.each_with_object({}) { |x, obj| obj[x] = x }
 
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys
@@ -50,11 +51,12 @@ module EmsRefresh::SaveInventoryHelper
 
     new_records = []
     hashes.each do |h|
-      found = save_inventory_with_findkey(association, h.except(*remove_keys), deletes, new_records, record_index)
+      found = save_inventory_with_findkey(association, h.except(*remove_keys), deletes_index, new_records, record_index)
       save_child_inventory(found, h, child_keys)
     end
 
     # Delete the items no longer found
+    deletes = deletes_index.values
     unless deletes.blank?
       type = association.proxy_association.reflection.name
       _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -42,7 +42,7 @@ module EmsRefresh::SaveInventoryHelper
       deletes.reload
     end
     deletes = deletes.to_a
-    deletes_index = deletes.each_with_object({}) { |x, obj| obj[x] = x }
+    deletes_index = deletes.index_by { |x| x }
 
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys


### PR DESCRIPTION
Remove O(n^2) when updating VMs
The code that does O(n) search on array, is causing O(n^2) in the
VmOrTemplate saving code. Then the refresh of 30k templates and
10k Vms would take 3+hours and about 250ms per saving VmOrTemplate

Using a simple hash instead of an array and a transaction block
for all creates and updates, we save one VmOrTemplate for about 9ms

So the whole saving code is down to 15 minutes, from 3+hours.

Steps for Testing/QA [Optional]
-------------------------------

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1251154

