### PR TITLE
Fix sorting container managers by port

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -20,6 +20,8 @@ module ManageIQ::Providers
     has_many :container_templates, :foreign_key => :ems_id, :dependent => :destroy
     has_one :container_deployment, :foreign_key => :deployed_ems_id, :inverse_of => :deployed_ems
 
+    virtual_column :port_show, :type => :string
+
     # required by aggregate_hardware
     def all_computer_system_ids
       MiqPreloader.preload(container_nodes, :computer_system)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1392413
This fixes sorting by port  for container managers
![screencapture-localhost-3000-ems_container-show_list-1479209151288](https://cloud.githubusercontent.com/assets/11256940/20304133/5c51ce0e-ab37-11e6-9678-ccda49ad0bc3.png)

@h-kataria Please review
cc @simon3z 