### PR TITLE
Bring chargeback rates buttons back

### DIFF
--- a/app/helpers/application_helper/button/chargeback_download.rb
+++ b/app/helpers/application_helper/button/chargeback_download.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::ChargebackDownload < ApplicationHelper::Button::Basic
     def role_allows_feature?
-      role_allows?(:feature => 'chargeback_rates')
+      role_allows?(:feature => 'chargeback_reports')
     end
 
     def visible?

--- a/app/helpers/application_helper/button/chargeback_download.rb
+++ b/app/helpers/application_helper/button/chargeback_download.rb
@@ -4,6 +4,6 @@ class ApplicationHelper::Button::ChargebackDownload < ApplicationHelper::Button:
     end
 
     def visible?
-      @view_context.x_active_tree == :cb_rates_tree
+      @view_context.x_active_tree == :cb_reports_tree
     end
 end

--- a/app/helpers/application_helper/button/chargeback_rates.rb
+++ b/app/helpers/application_helper/button/chargeback_rates.rb
@@ -4,6 +4,6 @@ class ApplicationHelper::Button::ChargebackRates < ApplicationHelper::Button::Ba
     end
 
     def visible?
-      @view_context.x_active_tree == :cb_reports_tree
+      @view_context.x_active_tree == :cb_rates_tree
     end
 end

--- a/app/helpers/application_helper/button/chargeback_rates.rb
+++ b/app/helpers/application_helper/button/chargeback_rates.rb
@@ -1,6 +1,6 @@
 class ApplicationHelper::Button::ChargebackRates < ApplicationHelper::Button::Basic
     def role_allows_feature?
-      role_allows?(:feature => 'chargeback_reports')
+      role_allows?(:feature => 'chargeback_rates')
     end
 
     def visible?


### PR DESCRIPTION
No chargeback rate buttons visible since fd0e99728920fc2ee3491dba1e46349d0d0206a0 (#12442).

@miq-bot add_label bug, ui, euwe/no
@miq-bot assign @martinpovolny 