### PR TITLE
Dont cache dynamic report fields

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1139,7 +1139,10 @@ class MiqExpression
 
     result = []
     unless opts[:typ] == "count" || opts[:typ] == "find"
-      result = get_column_details(relats[:columns], model, model, opts).sort! { |a, b| a.to_s <=> b.to_s }
+      @column_cache ||= {}
+      key = "#{model}_#{opts[:interval]}_#{opts[:include_model] || false}"
+      @column_cache[key] ||= get_column_details(relats[:columns], model, model, opts).sort! { |a, b| a.to_s <=> b.to_s }
+      result.concat(@column_cache[key])
 
       unless opts[:disallow_loading_virtual_custom_attributes]
         custom_details = _custom_details_for(model, opts)
@@ -1234,18 +1237,15 @@ class MiqExpression
   def self.reporting_available_fields(model, interval = nil)
     @reporting_available_fields ||= {}
     if model.to_s == "VimPerformanceTrend"
-      @reporting_available_fields[model.to_s] ||= {}
-      @reporting_available_fields[model.to_s][interval.to_s] ||= VimPerformanceTrend.trend_model_details(interval.to_s)
+      VimPerformanceTrend.trend_model_details(interval.to_s)
     elsif model.ends_with?("Performance")
-      @reporting_available_fields[model.to_s] ||= {}
-      @reporting_available_fields[model.to_s][interval.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true, :interval => interval)
+      MiqExpression.model_details(model, :include_model => false, :include_tags => true, :interval => interval)
     elsif Chargeback.db_is_chargeback?(model)
       cb_model = Chargeback.report_cb_model(model)
-      @reporting_available_fields[model.to_s] ||=
         MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) } +
         MiqExpression.tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
     else
-      @reporting_available_fields[model.to_s] ||= MiqExpression.model_details(model, :include_model => false, :include_tags => true)
+      MiqExpression.model_details(model, :include_model => false, :include_tags => true)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/12465
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1392379
because new custom attributes and tags could be added, we should refetch them when asking for available report fields.

This is a basic outline of how we can do this. I dont think the overhead from fetching just those fields is too bad. 
@lpichler @gtanzillo @cben What do you think?

cc @simon3z @bazulay 
@miq-bot add_label bug, ui, wip