### PR TITLE
Require a description when creating Snapshot

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -558,6 +558,20 @@ module VmCommon
   end
   alias_method :vm_snapshot_add, :snap
 
+  def render_missing_field(session, missing_field_name)
+    add_flash(_("%{missing_field_name} is required") %
+              {:missing_field_name => missing_field_name}, :error)
+    @in_a_form = true
+    drop_breadcrumb(:name => _("Snapshot VM '%{name}'") % {:name => @record.name},
+                    :url  => "/vm_common/snap")
+    if session[:edit] && session[:edit][:explorer]
+      @edit = session[:edit] # saving it to use in next transaction
+      javascript_flash(:spinner_off => true)
+    else
+      render :action => "snap"
+    end
+  end
+
   def snap_vm
     @vm = @record = identify_record(params[:id], VmOrTemplate)
     if params["cancel"] || params[:button] == "cancel"
@@ -573,15 +587,9 @@ module VmCommon
       @name = params[:name]
       @description = params[:description]
       if params[:name].blank? && !@record.try(:snapshot_name_optional?)
-        add_flash(_("Name is required"), :error)
-        @in_a_form = true
-        drop_breadcrumb(:name => _("Snapshot VM '%{name}'") % {:name => @record.name}, :url => "/vm_common/snap")
-        if session[:edit] && session[:edit][:explorer]
-          @edit = session[:edit]    # saving it to use in next transaction
-          javascript_flash(:spinner_off => true)
-        else
-          render :action => "snap"
-        end
+        render_missing_field(session, "Name")
+      elsif params[:description].blank? && @record.try(:snapshot_description_required?)
+        render_missing_field(session, "Description")
       else
         flash_error = false
         #       audit = {:event=>"vm_genealogy_change", :target_id=>@record.id, :target_class=>@record.class.base_class.name, :userid => session[:userid]}

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -39,6 +39,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     true
   end
 
+  def snapshot_description_required?
+    true
+  end
+
   def validate_remove_all_snapshots
     {:available => false, :message => _("Removing all snapshots is currently not supported")}
   end


### PR DESCRIPTION
When creating a snapshot on RHV one has to write a description else
the operation will fail.
So one should not be able to start the "create snapshot" operation
without writing the description.

https://bugzilla.redhat.com/show_bug.cgi?id=1384517