### PR TITLE
Return url according to controller for Vm or Templates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,7 +177,9 @@ module ApplicationHelper
 
   def url_for_record(record, action = "show") # Default action is show
     @id = to_cid(record.id)
-    db  = if record.kind_of?(VmOrTemplate)
+    db  = if controller.kind_of?(VmOrTemplateController)
+            "vm_or_template"
+          elsif record.kind_of?(VmOrTemplate)
             controller_for_vm(model_for_vm(record))
           elsif record.class.respond_to?(:db_name)
             record.class.db_name


### PR DESCRIPTION
Fixes the issue with wrong url for quadicon

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1388440

Steps for Testing/QA
-------------------------------
from BZ:

> 1. Manage a Infra provider
> 2. Navigate to Services ==> Workloads
> 3. Click on any of the virtual machine
> 