### PR TITLE
More precise tooltip values in C&U charts

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1654,9 +1654,15 @@ function chartData(type, data, data2) {
       _.isObject(data.axis.y.tick) &&
       _.isObject(data.axis.y.tick.format) &&
       data.axis.y.tick.format.function) {
-    var o = data.axis.y.tick.format;
-    data.axis.y.tick.format = ManageIQ.charts.formatters[o.function].c3(o.options);
-    data.tooltip.format.value = ManageIQ.charts.formatters[o.function].c3(o.options);
+    var format = data.axis.y.tick.format;
+    data.axis.y.tick.format = ManageIQ.charts.formatters[format.function].c3(format.options);
+
+    var title_format = _.cloneDeep(format);
+    title_format.options.precision += 2;
+    data.tooltip.format.value = function (value, _ratio, _id) {
+      var format = ManageIQ.charts.formatters[title_format.function].c3(title_format.options);
+      return format(value);
+    }
   }
 
   var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
@@ -1667,6 +1673,7 @@ function chartData(type, data, data2) {
   // some PatternFly default configs define size of chart
   config.size = {};
   var ret = _.defaultsDeep({}, data, config, data2);
+  console.log(ret);
   return ret;
 }
 

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1673,7 +1673,6 @@ function chartData(type, data, data2) {
   // some PatternFly default configs define size of chart
   config.size = {};
   var ret = _.defaultsDeep({}, data, config, data2);
-  console.log(ret);
   return ret;
 }
 

--- a/app/assets/javascripts/miq_formatters.js
+++ b/app/assets/javascripts/miq_formatters.js
@@ -83,10 +83,6 @@
         fmt += '0';
       }
     }
-    //console.log(val);
-    //console.log(numeral(val).format(fmt));
-    //var a = numeral(val).format(fmt).replace(/(?:\.0+|(\.\d+?)0+)$/, "$1");
-    //return numeral(a).format(' b');
     return numeral(val).format(fmt + ' b');
   };
 

--- a/app/assets/javascripts/miq_formatters.js
+++ b/app/assets/javascripts/miq_formatters.js
@@ -6,7 +6,6 @@
   function apply_format_precision(val, precision) {
     if (val == null || ! _.isNumber(val))
       return val;
-
     return sprintf("%." + (~~ precision) + "f", val);
   };
 
@@ -22,7 +21,6 @@
 
   function number_with_delimiter(val, options) {
     options = _.extend({ delimiter: ',', separator: '.' }, options || {});
-
     var intpart, floatpart, minus;
     if (_.isNumber(val)) {
       intpart = ~~ val;
@@ -81,11 +79,14 @@
       fmt = "0";
     } else {
       var p = options.precision - 1;
-      while (p > 0) {
+      while (p-- > 0) {
         fmt += '0';
       }
     }
-
+    //console.log(val);
+    //console.log(numeral(val).format(fmt));
+    //var a = numeral(val).format(fmt).replace(/(?:\.0+|(\.\d+?)0+)$/, "$1");
+    //return numeral(a).format(' b');
     return numeral(val).format(fmt + ' b');
   };
 
@@ -112,6 +113,11 @@
     return numeral(val).format('0o');
   };
 
+  function remove_right_side_zeros(str_val, separator) {
+    var v = str_val.split(separator);
+    return v[0].replace(/(?:\.0+|(\.\d+?)0+)$/, "$1") + separator + v[1];
+  };
+
   var format = {
     number_with_delimiter: function(val, options) {
       options = options || {};
@@ -131,21 +137,21 @@
 
     bytes_to_human_size: function(val, options) {
       options = options || {};
-      var av_options = { precision: options.precision || 1 };  // Precision of 0 returns the significant digits
+      var av_options = { precision: options.precision || 0 };  // Precision of 0 returns the significant digits
       val = number_to_human_size(val, av_options);
-      return apply_prefix_and_suffix(val, options);
+      return remove_right_side_zeros(apply_prefix_and_suffix(val, options), ' ');
     },
 
     kbytes_to_human_size: function(val, options) {
-      return format.bytes_to_human_size(val * 1024, options);
+      return remove_right_side_zeros(format.bytes_to_human_size(val * 1024, options), ' ');
     },
 
     mbytes_to_human_size: function(val, options) {
-      return format.kbytes_to_human_size(val * 1024, options);
+      return remove_right_side_zeros(format.kbytes_to_human_size(val * 1024, options), ' ');
     },
 
     gbytes_to_human_size: function(val, options) {
-      return format.mbytes_to_human_size(val * 1024, options);
+      return remove_right_side_zeros(format.mbytes_to_human_size(val * 1024, options), ' ');
     },
 
     mhz_to_human_size: function(val, options) {

--- a/spec/javascripts/miq_formatters_spec.js
+++ b/spec/javascripts/miq_formatters_spec.js
@@ -136,7 +136,20 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234, options)).toEqual('1.2 KB');
+      expect(fn(123, options)).toEqual('123 B');
+    });
+  });
+
+  describe('.bytes_to_human_size', function() {
+    it('Suffixed Bytes (B, KB, MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Bytes (B, KB, MB, GB)',
+        name: 'bytes_to_human_size',
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name];
+
+      expect(fn(1234, options)).toEqual('1.21 KiB');
     });
   });
 
@@ -149,7 +162,20 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(234, options)).toEqual('234 KB');
+      expect(fn(234, options)).toEqual('234 KiB');
+    });
+  });
+
+  describe('.kbytes_to_human_size', function() {
+    it('Suffixed Kilobytes (KB, MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Kilobytes (KB, MB, GB)',
+        name: 'kbytes_to_human_size',
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name];
+
+      expect(fn(234.09, options)).toEqual('234.1 KiB');
     });
   });
 
@@ -162,7 +188,33 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(2, options)).toEqual('2 MB');
+      expect(fn(2, options)).toEqual('2 MiB');
+    });
+  });
+
+  describe('.mbytes_to_human_size', function() {
+    it('Suffixed Megabytes (MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Megabytes (MB, GB)',
+        name: 'mbytes_to_human_size',
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name];
+
+      expect(fn(2, options)).toEqual('2 MiB');
+    });
+  });
+
+  describe('.mbytes_to_human_size', function() {
+    it('Suffixed Megabytes (MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Megabytes (MB, GB)',
+        name: 'mbytes_to_human_size',
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name];
+
+      expect(fn(2.12, options)).toEqual('2.12 MiB');
     });
   });
 
@@ -175,7 +227,20 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(0.1, options)).toEqual('102 MB');
+      expect(fn(0.1, options)).toEqual('102.4 MiB');
+    });
+  });
+
+  describe('.gbytes_to_human_size', function() {
+    it('Suffixed Gigabytes (GB)', function() {
+      var options = {
+        description: 'Suffixed Gigabytes (GB)',
+        name: 'gbytes_to_human_size',
+        precision: 1,
+      };
+      var fn = ManageIQ.charts.formatters[options.name];
+
+      expect(fn(1.19, options)).toEqual('1.2 GiB');
     });
   });
 

--- a/spec/javascripts/services/topology_service_spec.js
+++ b/spec/javascripts/services/topology_service_spec.js
@@ -44,6 +44,3 @@ describe('topologyService', function() {
     });
 
 });
-
-
-

--- a/spec/javascripts/services/topology_service_spec.js
+++ b/spec/javascripts/services/topology_service_spec.js
@@ -34,7 +34,7 @@ describe('topologyService', function() {
       it('to entity pages', function() {
         var d = { id:"2",  item:{display_kind:"Openshift", kind:"ContainerManager", id:"2", miq_id:"37"}};
         expect(testService.geturl(d)).toEqual("/ems_container/37");
-        expect(testService.geturl(mw_manager)).toEqual("/ems_middleware/show/1");
+        expect(testService.geturl(mw_manager)).toEqual("/ems_middleware/1");
         d = { id:"3",  item:{display_kind:"Pod", kind:"ContainerGroup", id:"3", miq_id:"30"}};
         expect(testService.geturl(d)).toEqual("/container_group/show/30");
         d = { id:"4",  item:{display_kind:"VM", kind:"Vm", id:"4", miq_id:"25"}};


### PR DESCRIPTION
Sometimes we have charts with values which are really close to each other(like in first picture) and they are rounded. Our formatting functions are generated when the charts is build, so it is possible to adjust precision of labels base on actual values, but...

Charts are dynamic, you can show/hide individual series of data and chart adapt to this changes(second picture) for this case it would be hard to change dynamically precision on labels base on data which is actually shown.

So I decided use something more simple, in tooltip just show more precise values.


Screenshots 
----------------
![c u_graph_57 3](https://cloud.githubusercontent.com/assets/9535558/20308077/aede2dce-ab42-11e6-9fa6-fc6253e576cc.png)

![screencast from 2016-11-15 15-10-19](https://cloud.githubusercontent.com/assets/9535558/20308793/c23719b4-ab45-11e6-8502-45d8d017d84f.gif)

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1383821

Steps for Testing/QA
-------------------------------

Goto: Compute -> Infrastructure -> Host/VM/Cluster -> Utilization