### PR TITLE
Remove stuff from ApplicationHelper that needs not to be there

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -233,6 +233,13 @@ module ApplicationController::Performance
     end
   end
 
+  def skip_days_from_time_profile(time_profile_days)
+    (1..7).to_a.delete_if do |d|
+      # time_profile_days has 0 for sunday, skip_days needs 7 for sunday
+      time_profile_days.include?(d % 7)
+    end
+  end
+
   # Handle actions for performance chart context menu clicks
   def perf_menu_click
     # Parse the clicked item to get indexes and selection variables

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,6 @@
 class DashboardController < ApplicationController
+  include DashboardHelper
+
   menu_section :vi
 
   @@items_per_page = 8

--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -4,6 +4,7 @@ class OpsController < ApplicationController
   include_concern 'Diagnostics'
   include_concern 'OpsRbac'
   include_concern 'Settings'
+  include OpsHelper::MyServer
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1949,4 +1949,8 @@ module VmCommon
     locals[:continue_button] = true if @edit[:buttons].include?(:continue)
     locals[:submit_button] = true if @edit[:buttons].include?(:submit)
   end
+
+  def breadcrumb_prohibited_for_action?
+    !%w(accordion_select explorer tree_select).include?(action_name)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1652,16 +1652,6 @@ module ApplicationHelper
     !%w(accordion_select explorer tree_select).include?(action_name)
   end
 
-  delegate :id, :to => :my_server, :prefix => true
-
-  def my_zone_name
-    my_server.my_zone
-  end
-
-  def my_server
-    @my_server ||= MiqServer.my_server(true)
-  end
-
   def tree_with_advanced_search?
     %i(containers
        containers_filter

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1860,10 +1860,4 @@ module ApplicationHelper
       _("Database")
     end
   end
-
-  def ext_auth?(auth_option = nil)
-    return false unless ::Settings.authentication.mode == "httpd"
-    auth_option ? ::Settings.authentication[auth_option] : true
-  end
-  public :ext_auth?
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1648,10 +1648,6 @@ module ApplicationHelper
     end
   end
 
-  def breadcrumb_prohibited_for_action?
-    !%w(accordion_select explorer tree_select).include?(action_name)
-  end
-
   def tree_with_advanced_search?
     %i(containers
        containers_filter

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1641,13 +1641,6 @@ module ApplicationHelper
     end
   end
 
-  def skip_days_from_time_profile(time_profile_days)
-    (1..7).to_a.delete_if do |d|
-      # time_profile_days has 0 for sunday, skip_days needs 7 for sunday
-      time_profile_days.include?(d % 7)
-    end
-  end
-
   def tree_with_advanced_search?
     %i(containers
        containers_filter

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1845,19 +1845,4 @@ module ApplicationHelper
     end
     true
   end
-
-  def auth_mode_name
-    case ::Settings.authentication.mode.downcase
-    when "ldap"
-      _("LDAP")
-    when "ldaps"
-      _("LDAPS")
-    when "amazon"
-      _("Amazon")
-    when "httpd"
-      _("External Authentication")
-    when "database"
-      _("Database")
-    end
-  end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,0 +1,6 @@
+module DashboardHelper
+  def ext_auth?(auth_option = nil)
+    return false unless ::Settings.authentication.mode == 'httpd'
+    auth_option ? ::Settings.authentication[auth_option] : true
+  end
+end

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -1,5 +1,6 @@
 module OpsHelper
   include_concern 'TextualSummary'
+  include_concern 'MyServer'
 
   def hide_button(button, opt)
     if opt == "on"

--- a/app/helpers/ops_helper.rb
+++ b/app/helpers/ops_helper.rb
@@ -22,4 +22,19 @@ module OpsHelper
   def selected?(tree_node, key)
     tree_node.split('-').first == key
   end
+
+  def auth_mode_name
+    case ::Settings.authentication.mode.downcase
+    when 'ldap'
+      _('LDAP')
+    when 'ldaps'
+      _('LDAPS')
+    when 'amazon'
+      _('Amazon')
+    when 'httpd'
+      _('External Authentication')
+    when 'database'
+      _('Database')
+    end
+  end
 end

--- a/app/helpers/ops_helper/my_server.rb
+++ b/app/helpers/ops_helper/my_server.rb
@@ -1,0 +1,11 @@
+module OpsHelper::MyServer
+  delegate :id, :to => :my_server, :prefix => true
+
+  def my_zone_name
+    my_server.my_zone
+  end
+
+  def my_server
+    @my_server ||= MiqServer.my_server(true)
+  end
+end

--- a/spec/controllers/application_controller/performance_spec.rb
+++ b/spec/controllers/application_controller/performance_spec.rb
@@ -21,4 +21,20 @@ describe ApplicationController do
       controller.send(:perf_planning_gen_data)
     end
   end
+
+  describe '#skip_days_from_time_profile' do
+    subject { ->(l) { described_class.new.send(:skip_days_from_time_profile, l) } }
+
+    it 'should return empty array for whole week' do
+      expect(subject.call((0..6).to_a)).to eq([])
+    end
+
+    it 'should return whole week for empty array' do
+      expect(subject.call([])).to eq((1..7).to_a)
+    end
+
+    it 'should handle Sundays' do
+      expect(subject.call((1..6).to_a)).to eq([7])
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1471,20 +1471,6 @@ describe ApplicationHelper do
     end
   end
 
-  context '#skip_days_from_time_profile' do
-    it 'should return empty array for whole week' do
-      expect(helper.skip_days_from_time_profile((0..6).to_a)).to eq([])
-    end
-
-    it 'should return whole week for empty array' do
-      expect(helper.skip_days_from_time_profile([])).to eq((1..7).to_a)
-    end
-
-    it 'should handle Sundays' do
-      expect(helper.skip_days_from_time_profile((1..6).to_a)).to eq([7])
-    end
-  end
-
   it 'output of remote_function should not be html_safe' do
     expect(helper.remote_function(:url => {:controller => 'vm_infra', :action => 'explorer'}).html_safe?).to be_falsey
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1663,18 +1663,6 @@ Datasources\" href=\"/ems_middleware/#{ems.id}?display=middleware_datasources\">
     end
   end
 
-  describe "#auth_mode_name" do
-    modes = %w(ldap ldaps amazon httpd database)
-    modes_pretty = %w(LDAP LDAPS Amazon External\ Authentication Database)
-
-    modes.zip modes_pretty.each do |mode, mode_pretty|
-      it "Returns #{mode_pretty} when mode is #{mode}" do
-        stub_settings(:authentication => { :mode => mode }, :server => {})
-        expect(helper.auth_mode_name).to eq(mode_pretty)
-      end
-    end
-  end
-
   describe "#x_gtl_view_tb_render?" do
     class XGtlViewTbRenderTestClass
       include ApplicationHelper

--- a/spec/helpers/ops_helper_spec.rb
+++ b/spec/helpers/ops_helper_spec.rb
@@ -1,0 +1,13 @@
+describe OpsHelper do
+  describe '#auth_mode_name' do
+    modes = %w(ldap ldaps amazon httpd database)
+    modes_pretty = %w(LDAP LDAPS Amazon External\ Authentication Database)
+
+    modes.zip modes_pretty.each do |mode, mode_pretty|
+      it "Returns #{mode_pretty} when mode is #{mode}" do
+        stub_settings(:authentication => {:mode => mode}, :server => {})
+        expect(helper.auth_mode_name).to eq(mode_pretty)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`ApplicationHelper` is included to every controller in the application. Most of the methods are not needed there. Let's move them to more specific places if possible

@miq-bot add_label ui, technical debt, euwe/no
@miq-bot assign @martinpovolny 