### PR TITLE
i18n fixes in container node summary screen

### DIFF
--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -5,8 +5,8 @@ module ContainerNodeHelper::TextualSummary
 
   def textual_group_properties
     %i(name creation_timestamp resource_version num_cpu_cores memory
-       max_container_groups identity_system identity_machine identity_infra runtime_version
-       kubelet_version proxy_version os_distribution kernel_version)
+       max_container_groups identity_system identity_machine identity_infra container_runtime_version
+       kubernetes_kubelet_version kubernetes_proxy_version os_distribution kernel_version)
   end
 
   def textual_group_relationships
@@ -88,15 +88,15 @@ module ContainerNodeHelper::TextualSummary
     }
   end
 
-  def textual_runtime_version
+  def textual_container_runtime_version
     @record.container_runtime_version || _("N/A")
   end
 
-  def textual_kubelet_version
+  def textual_kubernetes_kubelet_version
     @record.kubernetes_kubelet_version || _("N/A")
   end
 
-  def textual_proxy_version
+  def textual_kubernetes_proxy_version
     @record.kubernetes_proxy_version || _("N/A")
   end
 

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -94,7 +94,7 @@ module ContainerSummaryHelper
   end
 
   def textual_creation_timestamp
-    format_timezone(@record.ems_created_on)
+    {:label => _("Creation timestamp"), :value => format_timezone(@record.ems_created_on)}
   end
 
   def textual_guest_applications


### PR DESCRIPTION
The model attributes we want to display are already translated, we just need to use correct
attribute names for them to be automatically picked up.

Before:
![container-node-before](https://cloud.githubusercontent.com/assets/6648365/20309414/2d7bf0bc-ab48-11e6-90ea-32d5a0d8becb.jpg)

After:
![container-node-after](https://cloud.githubusercontent.com/assets/6648365/20309417/337b65a6-ab48-11e6-891d-2b18c4f46520.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1393452