### PR TITLE
Orchestration stack naming in case of VMware

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -127,5 +127,15 @@ module ManageIQ::Providers
     def create_cloud_tenant(options)
       CloudTenant.create_cloud_tenant(self, options)
     end
+
+    def self.connected_provider_types
+      types = ManageIQ::Providers::CloudManager.pluck(:type).uniq
+      vcloud_included = types.delete('ManageIQ::Providers::Vmware::CloudManager').present?
+      if vcloud_included && types.blank?
+        :vcloud
+      else
+        :mixed_providers
+      end
+    end
   end
 end

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -260,4 +260,24 @@ describe EmsCloud do
       end
     end
   end
+
+  describe ".connected_provider_types" do
+    it "return :mixed_providers when there is no providers" do
+      result = described_class.connected_provider_types
+      expect(result).to eq(:mixed_providers)
+    end
+
+    it "return :vcloud when there is VMware only provider" do
+      FactoryGirl.create(:ems_vmware_cloud)
+      result = described_class.connected_provider_types
+      expect(result).to eq(:vcloud)
+    end
+
+    it "return :mixed_providers when there is non-VMware provider" do
+      FactoryGirl.create(:ems_vmware_cloud)
+      FactoryGirl.create(:ems_amazon)
+      result = described_class.connected_provider_types
+      expect(result).to eq(:mixed_providers)
+    end
+  end
 end


### PR DESCRIPTION
Each provider should use its own terminology if only a single provider is used. In case of VMware only provider, Stack should be called vApp.

PR for UI part : https://github.com/ManageIQ/manageiq-ui-classic/pull/24

