### PR TITLE
Display value of 'Deprecated' column in provisioning grids.

### DIFF
--- a/app/views/miq_request/_pre_prov.html.haml
+++ b/app/views/miq_request/_pre_prov.html.haml
@@ -42,7 +42,7 @@
           %td
             = h(number_to_human_size(row.allocated_disk_storage))
           %td
-            = h(row.deprecated)
+            = h(row.deprecated ? _("true") : _("false"))
           %td
             - if row.ext_management_system
               = h(row.ext_management_system.name)

--- a/app/views/miq_request/_prov_vm_grid.html.haml
+++ b/app/views/miq_request/_prov_vm_grid.html.haml
@@ -53,7 +53,7 @@
             %td
               = h(number_to_human_size(row.allocated_disk_storage))
             %td
-              = h(row.deprecated)
+              = h(row.deprecated ? _("true") : _("false"))
             %td
               - if row.ext_management_system
                 = h(row.ext_management_system.name)
@@ -85,6 +85,8 @@
             = h(number_to_human_size(@vm.mem_cpu.to_i * 1024 * 1024))
           %td
             = h(number_to_human_size(@vm.allocated_disk_storage))
+          %td
+            = h(@vm.deprecated ? _("true") : _("false"))
           %td
             - if @vm.ext_management_system
               = h(@vm.ext_management_system.name)

--- a/spec/views/miq_request/_prov_vm_grid.html.erb_spec.rb
+++ b/spec/views/miq_request/_prov_vm_grid.html.erb_spec.rb
@@ -36,6 +36,7 @@ describe 'miq_request/_prov_vm_grid.html.haml' do
       allow(@vm).to receive(:mem_cpu).and_return('2048')
       allow(@vm).to receive(:allocated_disk_storage).and_return('4096')
       allow(@vm).to receive(:v_total_snapshots).and_return('128')
+      allow(@vm).to receive(:deprecated).and_return(true)
       allow(@vm).to receive(:ext_management_system)
       allow(@vm).to receive(:cloud_tenant).and_return(cloud_tenant)
 


### PR DESCRIPTION
Not displaying value when deprectaed column value is nil is causing confusuion on screen, it is difficult to tell if grid results were changed when Hode Deprectaed  checkbox is checked/unchecked

https://bugzilla.redhat.com/show_bug.cgi?id=1393451

before:
![before](https://cloud.githubusercontent.com/assets/3450808/20310739/112812ec-ab1b-11e6-8cba-d42822fda75e.png)
![before1](https://cloud.githubusercontent.com/assets/3450808/20310742/1596645a-ab1b-11e6-819c-5278836362e5.png)

after:
![after1](https://cloud.githubusercontent.com/assets/3450808/20310753/1c049258-ab1b-11e6-8d37-f8135b56d306.png)
![after2](https://cloud.githubusercontent.com/assets/3450808/20310757/1eb7e748-ab1b-11e6-8312-b2997f6e8113.png)
![after3](https://cloud.githubusercontent.com/assets/3450808/20310760/22061da2-ab1b-11e6-9296-7bd72cd418b6.png)

