### PR TITLE
Add ipv4 ipv6 selection to Subnet view

### DIFF
--- a/app/views/cloud_subnet/edit.html.haml
+++ b/app/views/cloud_subnet/edit.html.haml
@@ -22,6 +22,7 @@
                             'ng-model'     => "cloudSubnetModel.cidr",
                             'ng-maxlength' => 20,
                             :miqrequired   => false,
+                            :disabled      => true,
                             :checkchange   => true}
     .form-group
       %label.col-md-2.control-label
@@ -42,6 +43,7 @@
                             'ng-model'     => "cloudSubnetModel.ip_version",
                             'ng-maxlength' => 2,
                             :miqrequired   => true,
+                            :disabled      => true,
                             :checkchange   => true}
 
 

--- a/app/views/cloud_subnet/new.html.haml
+++ b/app/views/cloud_subnet/new.html.haml
@@ -60,6 +60,17 @@
                             'ng-maxlength' => 20,
                             :miqrequired   => false,
                             :checkchange   => true}
+    .form-group
+      %label.col-md-2.control-label
+        = _('IP Version')
+      .col-md-8
+        = select_tag("ip_version",
+                      options_for_select([4, 6]),
+                      "ng-model"                    => "cloudSubnetModel.ip_version",
+                      "required"                    => "",
+                      :miqrequired                  => true,
+                      :checkchange                  => true,
+                      "selectpicker-for-select-tag" => "")
   %h3
     = _('Placement')
   .form-horizontal


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1394286
1. Added a ipv4/ipv6 selection field to Subnet create page
![ip_version](https://cloud.githubusercontent.com/assets/8054645/20880948/554164fa-bada-11e6-92d6-e86b8ccc2281.jpg)


2. Locked ipv4/ipv6 and CIDR fields on Subnet edit page
![lock](https://cloud.githubusercontent.com/assets/8054645/20425548/53ee04f8-ad7b-11e6-9075-0e5b6ad40654.jpg)


