### PR TITLE
Switch wrong method names in Network Manager model

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -125,7 +125,7 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
     }
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'create_security_group',
+      :method_name => 'create_floating_ip',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
@@ -146,7 +146,7 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
     }
     queue_opts = {
       :class_name  => self.class.name,
-      :method_name => 'create_floating_ip',
+      :method_name => 'create_security_group',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',


### PR DESCRIPTION
In Network Manager model inside `create_floating_ip_queue` method, was a line, which specified `:method_name => 'create_security_group'` and vice versa. Fixed.
https://bugzilla.redhat.com/show_bug.cgi?id=1394280