### PR TITLE
Fixing the bulk operations for associated entities

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -500,6 +500,10 @@ module EmsCommon
       refreshemss if params[:pressed] == "#{@table_name}_refresh"
       #     scanemss if params[:pressed] == "scan"
       tag(model) if params[:pressed] == "#{@table_name}_tag"
+
+      # Edit Tags for Middleware Manager Relationship pages
+      tag(@display.camelize.singularize) if @display && @display != 'main' &&
+                                            params[:pressed] == "#{@display.singularize}_tag"
       assign_policies(model) if params[:pressed] == "#{@table_name}_protect"
       check_compliance(model) if params[:pressed] == "#{@table_name}_check_compliance"
       edit_record if params[:pressed] == "#{@table_name}_edit"

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -1,6 +1,7 @@
 class EmsMiddlewareController < ApplicationController
   include EmsCommon
   include Mixins::EmsCommonAngular
+  include MiddlewareOperationsMixin
 
   before_action :check_privileges
   before_action :get_session_data

--- a/app/controllers/middleware_datasource_controller.rb
+++ b/app/controllers/middleware_datasource_controller.rb
@@ -17,15 +17,8 @@ class MiddlewareDatasourceController < ApplicationController
     }
   }.freeze
 
-  def button
-    selected_operation = params[:pressed].to_sym
-    if OPERATIONS.key?(selected_operation)
-      selected_ds = identify_selected_entities
-      run_operation(OPERATIONS.fetch(selected_operation), selected_ds)
-      javascript_flash
-    else
-      super
-    end
+  def self.operations
+    OPERATIONS
   end
 
   menu_section :mdl

--- a/app/controllers/middleware_deployment_controller.rb
+++ b/app/controllers/middleware_deployment_controller.rb
@@ -38,15 +38,8 @@ class MiddlewareDeploymentController < ApplicationController
     }
   }.freeze
 
-  def button
-    selected_operation = params[:pressed].to_sym
-    if OPERATIONS.key?(selected_operation)
-      selected_archives = identify_selected_entities
-      run_operation(OPERATIONS.fetch(selected_operation), selected_archives)
-      javascript_flash
-    else
-      super
-    end
+  def self.operations
+    OPERATIONS
   end
 
   def trigger_mw_operation(operation, mw_deployment, _params = nil)

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -89,6 +89,10 @@ class MiddlewareServerController < ApplicationController
   DOMAIN_SERVER_OPERATIONS = COMMON_OPERATIONS.merge(DOMAIN_ONLY)
   ALL_OPERATIONS = STANDALONE_SERVER_OPERATIONS.merge(DOMAIN_SERVER_OPERATIONS)
 
+  def self.operations
+    ALL_OPERATIONS
+  end
+
   def add_deployment
     selected_server = identify_selected_entities
     deployment_name = params["runtimeName"]
@@ -278,7 +282,7 @@ class MiddlewareServerController < ApplicationController
     path = mw_server.ems_ref
 
     # in domain mode case we want to run the operation on the server-config DMR resource
-    if mw_server.in_domain?
+    if mw_server.respond_to?(:in_domain?) && mw_server.in_domain?
       path = path.sub(/%2Fserver%3D/, '%2Fserver-config%3D')
     end
 

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -1,5 +1,7 @@
 module MiddlewareCommonMixin
   extend ActiveSupport::Concern
+  include MiddlewareOperationsMixin
+
   def show_list
     process_show_list
   end
@@ -62,75 +64,5 @@ module MiddlewareCommonMixin
                                                       :title => display_name(@display)}
     drop_breadcrumb(:name => breadcrumb_title, :url => show_link(@record, :display => @display))
     @view, @pages = get_view(klass, :parent => @record)
-  end
-
-  def trigger_mw_operation(operation, mw_item, params = nil)
-    mw_manager = mw_item.ext_management_system
-    op = mw_manager.public_method operation
-    if params
-      op.call(mw_item.ems_ref, params)
-    else
-      op.call mw_item.ems_ref
-    end
-  end
-
-  #
-  # Identify the selected entities. When we got the call from the
-  # single entity page, we need to look at :id, otherwise from
-  # the list of entities we need to query :miq_grid_checks
-  #
-  def identify_selected_entities
-    items = params[:miq_grid_checks]
-    return items unless items.nil? || items.empty?
-    params[:id]
-  end
-
-  def run_operation(operation_info, items, success_msg = "%{msg}")
-    if items.nil?
-      add_flash(_("No %{item_type} selected") % {:item_type => controller_name.pluralize})
-      return
-    end
-    operation_triggered = run_operation_batch(operation_info, items)
-    add_flash(_(success_msg) % {:msg => operation_info.fetch(:msg)}) if operation_triggered
-  end
-
-  def run_operation_on_record(operation_info, item_record)
-    if operation_info.key? :param
-      # Fetch param from UI - > see #9462/#8079
-      name = operation_info.fetch(:param)
-      val = params.fetch name || 0 # Default until we can really get it from the UI ( #9462/#8079)
-      trigger_mw_operation operation_info.fetch(:op), item_record, name => val
-    else
-      trigger_mw_operation operation_info.fetch(:op), item_record
-    end
-  end
-
-  def skip_operation?(item_record, operation_info)
-    provider_name = 'Hawkular'
-    if operation_info.fetch(:skip)
-      item_record.try(:product) == provider_name || item_record.try(:middleware_server).try(:product) == provider_name
-    end
-  end
-
-  def run_operation_batch(operation_info, items)
-    operation_triggered = false
-    items.split(/,/).each do |item|
-      item_record = identify_record item
-      if skip_operation?(item_record, operation_info)
-        message = if operation_info.key?(:skip_msg)
-                    operation_info.fetch(:skip_msg)
-                  else
-                    "Not %{operation_name} the provider itself"
-                  end
-        add_flash(_(message) % {
-          :operation_name => operation_info.fetch(:hawk),
-          :record_name    => item_record.name
-        }, :warning)
-      else
-        run_operation_on_record(operation_info, item_record)
-        operation_triggered = true
-      end
-    end
-    operation_triggered
   end
 end

--- a/app/controllers/mixins/middleware_operations_mixin.rb
+++ b/app/controllers/mixins/middleware_operations_mixin.rb
@@ -1,0 +1,99 @@
+module MiddlewareOperationsMixin
+  extend ActiveSupport::Concern
+
+  def button
+    klass = child_entity_controller
+    selected_operation = params[:pressed].to_sym
+    if !klass.try(:operations).nil? && klass.operations.key?(selected_operation)
+      selected_items = params[:miq_grid_checks]
+      selected_entities = identify_selected_entities(selected_items)
+      run_specific_operation(klass.operations.fetch(selected_operation), selected_entities, "%{msg}", klass.model)
+      javascript_flash if @content.nil?
+    else
+      super
+    end
+  end
+
+  private
+
+  def child_entity_controller
+    if @display && @display != 'main'
+      begin
+        return Object.const_get(@display.camelize.singularize + 'Controller')
+      rescue NameError
+        # There is no such a controller for the display url param
+        return self.class
+      end
+    end
+    self.class
+  end
+
+  def trigger_mw_operation(operation, mw_item, params = nil)
+    mw_manager = mw_item.ext_management_system
+    op = mw_manager.public_method operation
+    if params
+      op.call(mw_item.ems_ref, params)
+    else
+      op.call mw_item.ems_ref
+    end
+  end
+
+  #
+  # Identify the selected entities. When we got the call from the
+  # single entity page, we need to look at :id, otherwise from
+  # the list of entities we need to query :miq_grid_checks
+  #
+  def identify_selected_entities(selected_items = params[:miq_grid_checks])
+    return selected_items unless selected_items.nil? || selected_items.empty?
+    params[:id]
+  end
+
+  def run_specific_operation(operation_info, items, success_msg = "%{msg}", klass = self.class.model)
+    if items.nil?
+      add_flash(_("No %{item_type} selected") % {:item_type => controller_name.pluralize})
+      return
+    end
+    operation_triggered = run_operation_batch(operation_info, items, klass)
+    add_flash(_(success_msg) % {:msg => operation_info.fetch(:msg)}) if operation_triggered
+  end
+
+  def run_operation_on_record(operation_info, item_record)
+    if operation_info.key? :param
+      # Fetch param from UI - > see #9462/#8079
+      name = operation_info.fetch(:param)
+      val = params.fetch name || 0 # Default until we can really get it from the UI ( #9462/#8079)
+      trigger_mw_operation operation_info.fetch(:op), item_record, name => val
+    else
+      trigger_mw_operation operation_info.fetch(:op), item_record
+    end
+  end
+
+  def skip_operation?(item_record, operation_info)
+    provider_name = 'Hawkular'
+    if operation_info.fetch(:skip)
+      item_record.try(:product) == provider_name || item_record.try(:middleware_server).try(:product) == provider_name
+    end
+  end
+
+  def run_operation_batch(operation_info, items, klass = self.class.model)
+    operation_triggered = false
+    items.split(/,/).each do |item|
+      item_record = identify_record item, klass
+      if skip_operation?(item_record, operation_info)
+        message = if operation_info.key?(:skip_msg)
+                    operation_info.fetch(:skip_msg)
+                  else
+                    "Not %{operation_name} the provider itself"
+                  end
+        add_flash(_(message) % {
+          :operation_name => operation_info.fetch(:hawk),
+          :record_name    => item_record.name
+        }, :warning)
+      else
+        run_operation_on_record(operation_info, item_record)
+        operation_triggered = true
+      end
+    end
+    operation_triggered
+  end
+end


### PR DESCRIPTION
While all the buttons from toolbar works for entities on their detail pages and if the URL is in the form of `/{entity}/{id}`, it fails if the URL is `/{parent_entity}/{id}?display={child_entity}`. In that case UI says: button is not implemented yet.

@pilhuhn euwe y/n ?

@miq-bot add_labels providers/hawkular, bug
https://bugzilla.redhat.com/show_bug.cgi?id=1393837