### PR TITLE
Use target instead of model for sql support check

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -38,7 +38,7 @@ class MiqExpression::Field
   end
 
   def attribute_supported_by_sql?
-    !custom_attribute_column? && model.attribute_supported_by_sql?(column)
+    !custom_attribute_column? && target.attribute_supported_by_sql?(column)
   end
 
   def plural?


### PR DESCRIPTION
Purpose
-------
Fixes a merge bug caused when merging #11445 and #12438.


Overview
--------
In https://github.com/ManageIQ/manageiq/pull/11445, support was added to MiqExpression for greater usage of SQL when possible with virtual attributes.

At the same time https://github.com/ManageIQ/manageiq/pull/12438 was added to fix issues where SQL was being generated for bugus columns.

The first PR was merged in first and added `attribute_supported_by_sql?` method to `MiqExpression::Field` class.  But by using `model`, it didn't actually make checks against to model that actually own the column, but the base model this field check was being made against.  This worked fine when #12438 was not in place, but once it was, that column was treated as a bugus column by this new code.

By using target, we make a field check against the model that is actually the owner of the column.


Links [Optional]
----------------
* https://github.com/ManageIQ/manageiq/pull/11445
* https://github.com/ManageIQ/manageiq/pull/12438