### PR TITLE
Use proper MiqExp operators for datetime filtering

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -25,9 +25,9 @@ module Api
           "!=" => {:default => "!=", :regex => "REGULAR EXPRESSION DOES NOT MATCH", :null => "IS NOT NULL"},
           "<=" => {:default => "<="},
           ">=" => {:default => ">="},
-          "<"  => {:default => "<"},
-          ">"  => {:default => ">"},
-          "="  => {:default => "=", :regex => "REGULAR EXPRESSION MATCHES", :null => "IS NULL"}
+          "<"  => {:default => "<", :datetime => "BEFORE"},
+          ">"  => {:default => ">", :datetime => "AFTER"},
+          "="  => {:default => "=", :datetime => "IS", :regex => "REGULAR EXPRESSION MATCHES", :null => "IS NULL"}
         }
 
         and_expressions = []
@@ -73,6 +73,7 @@ module Api
               "Unknown operator specified in filter #{filter}" if operator.blank?
 
         filter_attr, _, filter_value = filter.partition(operator)
+        filter_attr.strip!
         filter_value.strip!
         str_method = filter_value =~ /%|\*/ && methods[:regex] || methods[:default]
 
@@ -85,7 +86,15 @@ module Api
                       when /^(NULL|nil)$/i
                         [nil, methods[:null] || methods[:default]]
                       else
-                        [filter_value, methods[:default]]
+                        model = collection_class(@req.subcollection || @req.collection)
+                        if column_type(model, filter_attr) == :datetime
+                          unless methods[:datetime]
+                            raise BadRequestError, "Unsupported operator for datetime: #{operator}"
+                          end
+                          [filter_value, methods[:datetime]]
+                        else
+                          [filter_value, methods[:default]]
+                        end
                       end
 
         if filter_value =~ /%|\*/
@@ -93,7 +102,7 @@ module Api
           filter_value.gsub!(/%|\\\*/, ".*")
         end
 
-        {:logical_or => logical_or, :operator => method, :attr => filter_attr.strip, :value => filter_value}
+        {:logical_or => logical_or, :operator => method, :attr => filter_attr, :value => filter_value}
       end
 
       def by_tag_param

--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -91,6 +91,9 @@ module Api
                           unless methods[:datetime]
                             raise BadRequestError, "Unsupported operator for datetime: #{operator}"
                           end
+                          unless Time.zone.parse(filter_value)
+                            raise BadRequestError, "Bad format for datetime: #{filter_value}"
+                          end
                           [filter_value, methods[:datetime]]
                         else
                           [filter_value, methods[:default]]

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -395,6 +395,13 @@ describe "Querying" do
       expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: !=")
       expect(response).to have_http_status(:bad_request)
     end
+
+    it "will handle poorly formed datetimes in the filter" do
+      run_get(vms_url, :filter => ["retires_on > foobar"])
+
+      expect(response.parsed_body).to include_error_with_message("Bad format for datetime: foobar")
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "Querying vm attributes" do

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -314,6 +314,87 @@ describe "Querying" do
       expect_query_result(:vms, 1, 2)
       expect_result_resources_to_match_hash([{"name" => vm_2.name, "guid" => vm_2.guid}])
     end
+
+    it "supports = with dates mixed with virtual attributes" do
+      _vm_1 = FactoryGirl.create(:vm, :retires_on => "2016-01-01", :vendor => "vmware")
+      vm_2 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "vmware")
+      _vm_3 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "openstack")
+
+      run_get(vms_url, :filter => ["retires_on = 2016-01-02", "vendor_display = VMware"])
+
+      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.id))}]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "supports > with dates mixed with virtual attributes" do
+      _vm_1 = FactoryGirl.create(:vm, :retires_on => "2016-01-01", :vendor => "vmware")
+      vm_2 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "vmware")
+      _vm_3 = FactoryGirl.create(:vm, :retires_on => "2016-01-03", :vendor => "openstack")
+
+      run_get(vms_url, :filter => ["retires_on > 2016-01-01", "vendor_display = VMware"])
+
+      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.id))}]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "supports > with datetimes mixed with virtual attributes" do
+      _vm_1 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T07:59:59Z", :vendor => "vmware")
+      vm_2 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T08:00:00Z", :vendor => "vmware")
+      _vm_3 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T08:00:00Z", :vendor => "openstack")
+
+      run_get(vms_url, :filter => ["last_scan_on > 2016-01-01T07:59:59Z", "vendor_display = VMware"])
+
+      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.id))}]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "supports < with dates mixed with virtual attributes" do
+      _vm_1 = FactoryGirl.create(:vm, :retires_on => "2016-01-01", :vendor => "openstack")
+      vm_2 = FactoryGirl.create(:vm, :retires_on => "2016-01-02", :vendor => "vmware")
+      _vm_3 = FactoryGirl.create(:vm, :retires_on => "2016-01-03", :vendor => "vmware")
+
+      run_get(vms_url, :filter => ["retires_on < 2016-01-03", "vendor_display = VMware"])
+
+      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.id))}]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "supports < with datetimes mixed with virtual attributes" do
+      _vm_1 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T07:59:59Z", :vendor => "openstack")
+      vm_2 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T07:59:59Z", :vendor => "vmware")
+      _vm_3 = FactoryGirl.create(:vm, :last_scan_on => "2016-01-01T08:00:00Z", :vendor => "vmware")
+
+      run_get(vms_url, :filter => ["last_scan_on < 2016-01-01T08:00:00Z", "vendor_display = VMware"])
+
+      expected = {"resources" => [{"href" => a_string_matching(vms_url(vm_2.id))}]}
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not support filtering with <= with datetimes" do
+      run_get(vms_url, :filter => ["retires_on <= 2016-01-03"])
+
+      expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: <=")
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "does not support filtering with >= with datetimes" do
+      run_get(vms_url, :filter => ["retires_on >= 2016-01-03"])
+
+      expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: >=")
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "does not support filtering with != with datetimes" do
+      run_get(vms_url, :filter => ["retires_on != 2016-01-03"])
+
+      expect(response.parsed_body).to include_error_with_message("Unsupported operator for datetime: !=")
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "Querying vm attributes" do


### PR DESCRIPTION
Filtering results in the API on date/datetime attributes can be done,
but there's not exactly a 1-1 relationship between the syntax of the
filtering API and that of MiqExpression, which supports it.

Using comparison operators to filter on dates just *happens* to work
because arel, which is in turn supporting MiqExpression, knows how to
deal with it. But it's not officially supported - the documented way to
form expressions with datetimes is by using the date time operators:
"IS", "BEFORE", "AFTER", "FROM", "IS EMPTY", and "IS NOT EMPTY". Using
an unsupported operator in an expression that has to be evaluated in the
context of Ruby (i.e. it can't be completely evaluated in SQL because of
the presence of one or more virtual attributes) will break.

The best we can do most immediately is to provide a simple mapping for a
subset of the operators:

| Filter API | MiqExpression |
| ---        | ---           |
| `>`        | `AFTER`       |
| `<`        | `BEFORE`      |
| `=`        | `IS`          |

Anything else will result in a bad request, which is better than a 500.

Fixes https://github.com/ManageIQ/manageiq/issues/12648

@miq-bot add-label api, bug
@miq-bot assign @abellotti 