### PR TITLE
Fix the :controller attribute in the quadicon url

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -257,6 +257,7 @@ module QuadiconHelper
         attrs.merge!(quadicon_vm_attributes(item))
       end
     else
+      attrs[:controller] = controller_name
       attrs[:action]  = 'x_show'
       attrs[:id]      = to_cid(row['id'])
     end

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -407,6 +407,7 @@ describe QuadiconHelper do
         allow(controller).to receive(:default_url_options) do
           {:controller => "vm_infra"}
         end
+        allow(controller).to receive(:controller_name).and_return("service")
       end
 
       let(:serv_res) do


### PR DESCRIPTION
In the Services List view, the quadicon in case of a `grid` or a `tile` setting, contains a wrong url with the controller value set to the the `vm` controller name. The `vm` controller name seems to match the type of vm that's contained in the service.

https://bugzilla.redhat.com/show_bug.cgi?id=1394503

Before:
<img width="1344" alt="screen shot 2016-11-15 at 12 52 22 pm_" src="https://cloud.githubusercontent.com/assets/1538216/20324001/cc59d9c0-ab33-11e6-9ad6-e067b7e6d862.png">

After:
<img width="1350" alt="screen shot 2016-11-15 at 12 53 54 pm_" src="https://cloud.githubusercontent.com/assets/1538216/20324028/d9630286-ab33-11e6-864e-63d1bce8bbea.png">
