### PR TITLE
Avoid memory bloat

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -116,7 +116,7 @@ module EmsRefresh::SaveInventory
 
         found.save!
         h[:id] = found.id
-        found.send(:clear_association_cache)
+        found.reload
         h[:_object] = found
       rescue => err
         # If a vm failed to process, mark it as invalid and log an error

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -112,7 +112,7 @@ module EmsRefresh::SaveInventoryHelper
     hashes.each do |h|
       r = records.detect { |r| keys.all? { |k| r.send(k) == r.class.type_for_attribute(k.to_s).cast(h[k]) } }
       h[:id]      = r.id
-      r.send(:clear_association_cache)
+      r.reload if r.id
       h[:_object] = r
     end
   end


### PR DESCRIPTION
The clear_association_cache is not really making the object any
smaller. Refreshing 70k Images takes up 10gb in memory.

With reload, we have a little longer refresh (1s per record) but
70k Images takes only 3.2GB in memory.

Partially Reverts PR:
#11678

Partially Reverts commit:
aeb38d4

Steps for Testing/QA [Optional]
-------------------------------

For bigger number of records (e.g. 70k of amazon public images), the refresh worker should take around 3Gb of ram, no more.