### PR TITLE
Fixed code to set categories correctly for policy timelines.

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -5,7 +5,6 @@ module ApplicationController::Timelines
   def tl_chooser
     @record = identify_tl_or_perf_record
     @tl_record = @record.kind_of?(MiqServer) ? @record.vm : @record # Use related server vm record
-    @tl_options.tl_show = params[:tl_show] ? params[:tl_show] : "timeline"
     tl_build_timeline
     @tl_options.date.update_from_params(params)
 
@@ -121,9 +120,9 @@ module ApplicationController::Timelines
       @tl_options.date.typ = 'Daily'
       @tl_options.date.days = '7'
       @tl_options[:model] = @tl_record.class.base_class.to_s
-      @tl_options[:tl_show] = "timeline"
       @tl_options.policy.categories = []
     end
+    @tl_options.tl_show = params[:tl_show] || "timeline"
     sdate, edate = @tl_record.first_and_last_event(@tl_options.evt_type)
     @tl_options.date.update_start_end(sdate, edate)
 
@@ -184,15 +183,13 @@ module ApplicationController::Timelines
       event_set = @tl_options.event_set
       if !event_set.empty?
         if @tl_options.policy_events? && @tl_options.policy.result != "both"
-          ftype = @tl_options.management_events? ? "event_type" : "miq_event_definition_id"
-          where_clause = [") and (timestamp >= ? and timestamp <= ?) and (#{ftype} in (?)) and (result = ?)",
+          where_clause = [") and (timestamp >= ? and timestamp <= ?) and (event_type in (?)) and (result = ?)",
                           from_dt,
                           to_dt,
                           event_set.flatten,
                           @tl_options.policy.result]
         else
-          ftype = @tl_options.management_events? ? "event_type" : "miq_event_definition_id"
-          where_clause = [") and (timestamp >= ? and timestamp <= ?) and (#{ftype} in (?))",
+          where_clause = [") and (timestamp >= ? and timestamp <= ?) and (event_type in (?))",
                           from_dt,
                           to_dt,
                           event_set.flatten]
@@ -208,7 +205,8 @@ module ApplicationController::Timelines
       params = params.concat(params2)
       @report.where_clause = [cond, *params]
       @report.rpt_options ||= {}
-      @report.rpt_options[:categories] = @tl_options.mngt.categories
+      @report.rpt_options[:categories] = @tl_options.management_events? ?
+        @tl_options.mngt.categories : @tl_options.policy.categories
       @title = @report.title
     end
   end

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -9,12 +9,13 @@ module ApplicationController::Timelines
     @tl_options.date.update_from_params(params)
 
     if @tl_options.management_events?
-      @tl_options.mngt.update_from_params(params)
+      @tl_options.management.update_from_params(params)
     else
       @tl_options.policy.update_from_params(params)
     end
 
-    if (@tl_options.management_events? && !@tl_options.mngt.categories.blank?) || (@tl_options.policy_events? && !@tl_options.policy.categories.blank?)
+    if (@tl_options.management_events? && !@tl_options.management.categories.blank?) ||
+       (@tl_options.policy_events? && !@tl_options.policy.categories.blank?)
       tl_gen_timeline_data(refresh = "n")
       return unless @timeline
     end
@@ -139,11 +140,8 @@ module ApplicationController::Timelines
           end
         end
       end
-    else
-      @tl_options.mngt.level = "critical" if @tl_options.mngt.level.nil?
-      # if @tl_options.mngt.filter1.nil?
-      #   @tl_options.mngt.filter1 = "Power Activity"
-      # end
+    elsif @tl_options.management.level.nil?
+      @tl_options.management.level = "critical"
     end
   end
 
@@ -205,8 +203,8 @@ module ApplicationController::Timelines
       params = params.concat(params2)
       @report.where_clause = [cond, *params]
       @report.rpt_options ||= {}
-      @report.rpt_options[:categories] = @tl_options.management_events? ?
-        @tl_options.mngt.categories : @tl_options.policy.categories
+      @report.rpt_options[:categories] =
+        @tl_options.management_events? ? @tl_options.management.categories : @tl_options.policy.categories
       @title = @report.title
     end
   end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -127,15 +127,15 @@ module ApplicationController::Timelines
   Options = Struct.new(
     :date,
     :model,
-    :mngt,
+    :management,
     :policy,
     :tl_show,
   ) do
     def initialize(*args)
       super
-      self.date = DateOptions.new
-      self.mngt = ManagementEventsOptions.new
-      self.policy = PolicyEventsOptions.new
+      self.date       = DateOptions.new
+      self.management = ManagementEventsOptions.new
+      self.policy     = PolicyEventsOptions.new
     end
 
     def management_events?
@@ -151,11 +151,11 @@ module ApplicationController::Timelines
     end
 
     def event_set
-      (policy_events? ? policy : mngt).event_set
+      (policy_events? ? policy : management).event_set
     end
 
     def drop_cache
-      [policy, mngt].each(&:drop_cache)
+      [policy, management].each(&:drop_cache)
     end
   end
 end

--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -83,25 +83,18 @@ module ApplicationController::Timelines
     :result
   ) do
     def update_from_params(params)
-      self.result = if params[:showSuccessfulEvents] == "true" && params[:showFailedEvents] == "true"
-                      "both"
-                    elsif params[:showSuccessfulEvents] == "true"
-                      "success"
-                    elsif params[:showFailedEvents] == "true"
-                      "failure"
-                    end
-
+      self.result = params[:tl_result] || "success"
       self.categories = {}
       if params[:tl_categories]
         params[:tl_categories].each do |category|
-          categories[events[category]] = {:display_name => category}
+          categories[category] = {:display_name => category, :event_groups => events[category]}
         end
       end
     end
 
     def events
       @events ||= MiqEventDefinitionSet.all.each_with_object({}) do |event, hash|
-        hash[event.description] = event.members.collect(&:id)
+        hash[event.description] = event.members.collect(&:name)
       end
     end
 
@@ -115,7 +108,7 @@ module ApplicationController::Timelines
     end
 
     def event_set
-      applied_filters.blank? ? [] : applied_filters.collect { |e| events[e] }
+      categories.blank? ? [] : categories.collect { |_, e| e[:event_groups] }
     end
 
     private

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -24,7 +24,7 @@
                   'ng-change'                   => 'eventTypeUpdated()')
                 %span{'ng-if' => 'reportModel.tl_show === "timeline"'}
                   = select_tag("tl_category_management",
-                    options_for_select(@tl_options.mngt.events.keys.sort, nil),
+                    options_for_select(@tl_options.management.events.keys.sort, nil),
                     'ng-model'                    => 'reportModel.tl_categories',
                     "selectpicker-for-select-tag" => '',
                     'data-live-search'            => 'true',
@@ -92,5 +92,5 @@
 :javascript
   ManageIQ.angular.app.value('recordId', '#{@record.id}');
   ManageIQ.angular.app.value('url', '#{url}');
-  ManageIQ.angular.app.value('categories', '#{@tl_options.mngt.events.keys.sort}');
+  ManageIQ.angular.app.value('categories', '#{@tl_options.management.events.keys.sort}');
   miq_bootstrap('#form_div');

--- a/spec/controllers/application_controller/timelines_spec.rb
+++ b/spec/controllers/application_controller/timelines_spec.rb
@@ -23,6 +23,21 @@ describe ApplicationController, "#Timelines" do
         expect(options.date[:start]).to eq(nil)
         expect(options.date[:end]).to eq(nil)
       end
+
+      it "sets categories for policy timelines correctly" do
+        ems = FactoryGirl.create(:ems_openstack_infra)
+        controller.instance_variable_set(:@tl_options,
+                                         ApplicationController::Timelines::Options.new)
+
+        controller.instance_variable_set(:@_params,
+                                         :id            => ems.id,
+                                         :tl_show       => "policy_timeline",
+                                         :tl_categories => ["VM Operation"])
+        expect(controller).to receive(:render)
+        controller.send(:tl_chooser)
+        options = assigns(:tl_options)
+        expect(options.policy[:categories]).to include('VM Operation')
+      end
     end
   end
 end


### PR DESCRIPTION
When switching to Policy Timelines set categories and events under each category correctly, display events on timelines based on event_type columns of policy event records.

https://bugzilla.redhat.com/show_bug.cgi?id=1395292

@dclarizio please review

screesnhot after fix:
![after](https://cloud.githubusercontent.com/assets/3450808/20324506/dcf38cac-ab4e-11e6-9d2f-a2597fbe8491.png)
