### PR TITLE
Docker run MIQ container unprivileged update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,11 +167,11 @@ LABEL name="manageiq" \
       url="http://manageiq.org/" \
       summary="ManageIQ appliance image" \
       description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
-      INSTALL='docker run -ti --privileged \
+      INSTALL='docker run -ti \
                 --name ${NAME}_volume \
                 --entrypoint /usr/bin/docker_initdb \
                 $IMAGE' \
-      RUN='docker run -di --privileged \
+      RUN='docker run -di \
             --name ${NAME}_run \
             -v /etc/localtime:/etc/localtime:ro \
             --volumes-from ${NAME}_volume \

--- a/docker-assets/README.md
+++ b/docker-assets/README.md
@@ -24,7 +24,7 @@ docker build -t manageiq/manageiq:darga-1-beta1 --build-arg REF=darga-1-beta1 . 
 ```
 
 
-The image has been tested and validated under docker-1.10 (Fedora23)
+The image has been tested and validated under docker-1.10.3 (Fedora24)
 
 
 ## Run
@@ -32,11 +32,13 @@ The image has been tested and validated under docker-1.10 (Fedora23)
 ### On standard distribution
 
 The first time you run the container, it will initialize the database, **please allow 2-4 mins** for MIQ to respond.
+
+_**Note:**_ As of recent versions of docker-1.10.3 you can run the MIQ container unprivileged
+
 ```
-docker run --privileged -di -p 80:80 -p 443:443 manageiq/manageiq
+docker run -di -p 80:80 -p 443:443 manageiq/manageiq
 ```
 Please note you can ommit some ports from the run command if you don't need to use them
-
 
 ### On Atomic host
 
@@ -52,7 +54,7 @@ atomic uninstall -n <name> manageiq
 
 ### On standard distribution
 ```
-docker run --privileged -di -p 80:80 -p 443:443 docker.io/manageiq/manageiq
+docker run -di -p 80:80 -p 443:443 docker.io/manageiq/manageiq
 ```
 
 ### On Atomic host
@@ -75,4 +77,68 @@ https://<your-ip-address>
 For console access, please use docker exec from docker host :
 ```
 docker exec -ti <container-id> bash -l
+```
+
+## Logging
+We can display systemd container journal logs on the docker host thanks to OCI systemd hooks
+
+Ensure the MIQ container has been registered with machinectl on docker host :
+```bash
+machinectl
+MACHINE                          CLASS     SERVICE
+79c9df0368a8e83c7dc7ed915d0b7f7d container docker
+
+1 machines listed.
+```
+Use machinectl to show status of container :
+```bash
+machinectl status 79c9df0368a8e83c7dc7ed915d0b7f7d
+79c9df0368a8e83c7dc7ed915d0b7f7d(37396339646630333638613865383363)
+           Since: Tue 2016-11-15 12:59:36 EST; 3h 2min ago
+          Leader: 7978 (systemd)
+         Service: docker; class container
+            Root: /var/lib/docker/devicemapper/mnt/e3c30d2e34cca063633f12d461e56f6b88cb4e155d09cf9da7049739f7db3a51/rootfs
+            Unit: docker-79c9df0368a8e83c7dc7ed915d0b7f7dbdfff15a9366b12272110e5331e5c54e.scope
+                  ├─7978 /usr/sbin/init
+                  └─system.slice
+                    ├─dbus.service
+                    │ └─8159 /bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
+                    ├─evmserverd.service
+                    │ ├─8446 MIQ Server                                                                     
+                    │ ├─8665 MIQ: MiqGenericWorker id: 1, queue: generic                                    
+                    │ ├─8673 MIQ: MiqGenericWorker id: 2, queue: generic                                    
+                    │ ├─8683 MIQ: MiqPriorityWorker id: 3, queue: generic                                   
+                    │ ├─8691 MIQ: MiqPriorityWorker id: 4, queue: generic                                   
+                    │ ├─8701 MIQ: MiqScheduleWorker id: 5                                                   
+                    │ ├─8722 MIQ: MiqEventHandler id: 6, queue: ems                                         
+                    │ ├─8731 MIQ: MiqReportingWorker id: 7, queue: reporting                                
+                    │ ├─8739 MIQ: MiqReportingWorker id: 8, queue: reporting                                
+                    │ ├─8750 puma 3.3.0 (tcp://127.0.0.1:5000) [MIQ: Web Server Worker]                     
+                    │ ├─8781 puma 3.3.0 (tcp://127.0.0.1:3000) [MIQ: Web Server Worker]                     
+                    │ └─8795 puma 3.3.0 (tcp://127.0.0.1:4000) [MIQ: Web Server Worker]                     
+                    ├─memcached.service
+                    │ └─8639 /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -I 1
+...
+```
+Use journalctl to display container journal from docker host :
+```bash
+journalctl -M 79c9df0368a8e83c7dc7ed915d0b7f7d
+-- Logs begin at Tue 2016-11-15 12:59:38 EST, end at Tue 2016-11-15 13:04:02 EST. --
+Nov 15 12:59:38 79c9df0368a8 systemd-journal[20]: Runtime journal is using 4.0M (max allowed 8.0M, trying to leave 9.6M free of 59.9M available → current limit 8.0M).
+Nov 15 12:59:38 79c9df0368a8 systemd-journal[20]: Permanent journal is using 8.0M (max allowed 1022.2M, trying to leave 1.4G free of 8.3G available → current limit 1022.2M).
+Nov 15 12:59:38 79c9df0368a8 systemd-journal[20]: Time spent on flushing to /var is 1.491ms for 2 entries.
+Nov 15 12:59:38 79c9df0368a8 systemd-journal[20]: Journal started
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Started Create Volatile Files and Directories.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Dependency failed for Update UTMP about System Runlevel Changes.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Job systemd-update-utmp-runlevel.service/start failed with result 'dependency'.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Reached target System Initialization.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Starting System Initialization.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Started Daily Cleanup of Temporary Directories.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Starting Daily Cleanup of Temporary Directories.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Reached target Timers.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Starting Timers.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Listening on D-Bus System Message Bus Socket.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Starting D-Bus System Message Bus Socket.
+Nov 15 12:59:38 79c9df0368a8 systemd[1]: Reached target Sockets.
+...
 ```

--- a/docker-assets/README.md
+++ b/docker-assets/README.md
@@ -38,7 +38,7 @@ docker run --privileged -di -p 80:80 -p 443:443 manageiq/manageiq
 ```
 Please note you can ommit some ports from the run command if you don't need to use them
 
-_**Note:**_ If you are running a RHEL family docker host you can now run the MIQ container unprivileged as recent versions of docker (1.10.3)
+_**Note:**_ If you are running a RHEL family docker host you can now run the MIQ container unprivileged as recent versions of docker (1.10.3). Please ensure oci-systemd-hook and oci-register-machine packages are installed in your system.
 ```
 docker run -di -p 80:80 -p 443:443 manageiq/manageiq
 ```

--- a/docker-assets/README.md
+++ b/docker-assets/README.md
@@ -33,12 +33,15 @@ The image has been tested and validated under docker-1.10.3 (Fedora24)
 
 The first time you run the container, it will initialize the database, **please allow 2-4 mins** for MIQ to respond.
 
-_**Note:**_ As of recent versions of docker-1.10.3 you can run the MIQ container unprivileged
+```
+docker run --privileged -di -p 80:80 -p 443:443 manageiq/manageiq
+```
+Please note you can ommit some ports from the run command if you don't need to use them
 
+_**Note:**_ If you are running a RHEL family docker host you can now run the MIQ container unprivileged as recent versions of docker (1.10.3)
 ```
 docker run -di -p 80:80 -p 443:443 manageiq/manageiq
 ```
-Please note you can ommit some ports from the run command if you don't need to use them
 
 ### On Atomic host
 
@@ -49,12 +52,11 @@ atomic stop -n <name>  manageiq
 atomic uninstall -n <name> manageiq
 ```
 
-
 ## Pull and use latest image from Docker Hub
 
 ### On standard distribution
 ```
-docker run -di -p 80:80 -p 443:443 docker.io/manageiq/manageiq
+docker run --privileged -di -p 80:80 -p 443:443 docker.io/manageiq/manageiq
 ```
 
 ### On Atomic host
@@ -80,7 +82,7 @@ docker exec -ti <container-id> bash -l
 ```
 
 ## Logging
-We can display systemd container journal logs on the docker host thanks to OCI systemd hooks
+We can display systemd container journal logs on the docker host thanks to OCI systemd hooks on RHEL family systems
 
 Ensure the MIQ container has been registered with machinectl on docker host :
 ```bash


### PR DESCRIPTION
@bazulay @Fryguy @simaishi @carbonin Please review, it is now possible to docker run unprivileged systemd based containers, recent docker releases (1.10.3) along with OCI systemd hooks facilitate this.
Keep in mind the container will still run as root but without the privileged capabilities.
I also added a logging section on README that details how to extract container systemd journals from the docker host, this is available already in Fed24 probably soon also on RHEL7 (pending updates).

I tested and validated on Fedora24 and RHEL7 with the following sw stacks : 

Fed24 : 
docker-1.10.3-53.gite03ddb8.fc24.x86_64
oci-systemd-hook-0.1.4-1.fc24.x86_64
oci-register-machine-0-2.4.git352a2a2.fc24.x86_64

RHEL7 : 
docker-1.10.3-57.el7.x86_64 
oci-systemd-hook-0.1.4-6.git337078c.el7.x86_64
oci-register-machine-0-1.8.gitaf6c129.el7.x86_64
