### PR TITLE
Fix for undefined method `editable_property?`

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2098,7 +2098,7 @@ class MiqAeClassController < ApplicationController
 
   # Get variables from edit form
   def get_ns_form_vars
-    @ae_ns = MiqAeNamespace.find_by_id(from_cid(@edit[:ae_ns_id]))
+    @ae_ns = @edit[:typ].constantize.find_by_id(from_cid(@edit[:ae_ns_id]))
     [:ns_name, :ns_description, :enabled].each do |field|
       if field == :enabled
         @edit[:new][field] = params[:ns_enabled] == "1" if params[:ns_enabled]


### PR DESCRIPTION
Fix for `[----] F, [2016-11-15T06:34:17.569006 #2933:fc9f2c] FATAL -- : Error caught: [ActionView::Template::Error] undefined method 'editable_property?' for #<MiqAeNamespace:0x00000017da9d20>`

when Reset button is clicked while editing an existing Automate domain.

https://bugzilla.redhat.com/show_bug.cgi?id=1395192