### PR TITLE
[EUWE] Bump Kubeclient version to 2.2.0

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -22,7 +22,7 @@ gem "hawkular-client",         "=2.7.0",            :require => false
 gem "httpclient",              "~>2.7.1",           :require => false
 gem "image-inspector-client",  "~>1.0.3",           :require => false
 gem "iniparse",                                     :require => false
-gem "kubeclient",              "=2.1.0",            :require => false
+gem "kubeclient",              "=2.2.0",            :require => false
 gem "linux_admin",             "~>0.19.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false


### PR DESCRIPTION
The new Kubeclient version introduces a fix (abonas/kubeclient#209) for undefined 'rindex' method called during discovery.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387614
(Sent a separated PR against master: https://github.com/ManageIQ/manageiq-gems-pending/pull/11)