### PR TITLE
Cleanup start_url manipulation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2439,5 +2439,4 @@ class ApplicationController < ActionController::Base
     @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
     @settings[:display][:startpage]
   end
-  helper_method :start_url_for_user
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2420,23 +2420,4 @@ class ApplicationController < ActionController::Base
     @accords = allowed_features.map(&:accord_hash)
     set_active_elements(allowed_features.first)
   end
-
-  def start_url_for_user(start_url)
-    return url_for(start_url) unless start_url.nil?
-    return url_for(:controller => "dashboard", :action => "show") unless self.helpers.settings(:display, :startpage)
-
-    first_allowed_url = nil
-    startpage_already_set = nil
-    MiqShortcut.start_pages.each do |url, _description, rbac_feature_name|
-      allowed = start_page_allowed?(rbac_feature_name)
-      first_allowed_url ||= url if allowed
-      # if default startpage is set, check if it is allowed
-      startpage_already_set = true if @settings[:display][:startpage] == url && allowed
-      break if startpage_already_set
-    end
-
-    # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
-    @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
-    @settings[:display][:startpage]
-  end
 end

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -1,5 +1,7 @@
 require 'miq_bulk_import'
 class ConfigurationController < ApplicationController
+  include StartUrl
+
   logo_dir = File.expand_path(File.join(Rails.root, "public/upload"))
   Dir.mkdir logo_dir unless File.exist?(logo_dir)
   @@logo_file = File.join(logo_dir, "custom_logo.png")

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -535,11 +535,6 @@ class ConfigurationController < ApplicationController
         new_tz = 'UTC' if new_tz.blank?
         @edit.store_path(:current, :display, :timezone, new_tz)
       end
-
-      # Build the start pages pulldown list
-      session[:start_pages] = MiqShortcut.start_pages.each_with_object([]) do |page, pages|
-        pages.push([page[1], page[0]]) if start_page_allowed?(page[2])
-      end
     when 'ui_2'
       @edit = {
         :current => init_settings,

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class DashboardController < ApplicationController
   include DashboardHelper
+  include StartUrl
 
   menu_section :vi
 

--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -1,6 +1,18 @@
 module StartUrl
   extend ActiveSupport::Concern
 
+  STORAGE_START_PAGES = %w(cim_storage_extent_show_list
+                           ontap_file_share_show_list
+                           ontap_logical_disk_show_list
+                           ontap_storage_system_show_list
+                           ontap_storage_volume_show_list
+                           storage_manager_show_list).to_set.freeze
+  CONTAINERS_START_PAGES = %w(ems_container_show_list
+                              container_node_show_list
+                              container_group_show_list
+                              container_service_show_list
+                              container_view).to_set.freeze
+
   def start_url_for_user(start_url)
     return url_for(start_url) unless start_url.nil?
     return url_for(:controller => 'dashboard', :action => 'show') unless helpers.settings(:display, :startpage)
@@ -23,19 +35,8 @@ module StartUrl
   private
 
   def start_page_allowed?(start_page)
-    storage_start_pages = %w(cim_storage_extent_show_list
-                             ontap_file_share_show_list
-                             ontap_logical_disk_show_list
-                             ontap_storage_system_show_list
-                             ontap_storage_volume_show_list
-                             storage_manager_show_list)
-    return false if storage_start_pages.include?(start_page) && !::Settings.product.storage
-    containers_start_pages = %w(ems_container_show_list
-                                container_node_show_list
-                                container_group_show_list
-                                container_service_show_list
-                                container_view)
-    return false if containers_start_pages.include?(start_page) && !::Settings.product.containers
+    return false if STORAGE_START_PAGES.include?(start_page) && !::Settings.product.storage
+    return false if CONTAINERS_START_PAGES.include?(start_page) && !::Settings.product.containers
     role_allows?(:feature => start_page, :any => true)
   end
 end

--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -1,0 +1,22 @@
+module StartUrl
+  extend ActiveSupport::Concern
+
+  def start_url_for_user(start_url)
+    return url_for(start_url) unless start_url.nil?
+    return url_for(:controller => 'dashboard', :action => 'show') unless helpers.settings(:display, :startpage)
+
+    first_allowed_url = nil
+    startpage_already_set = nil
+    MiqShortcut.start_pages.each do |url, _description, rbac_feature_name|
+      allowed = start_page_allowed?(rbac_feature_name)
+      first_allowed_url ||= url if allowed
+      # if default startpage is set, check if it is allowed
+      startpage_already_set = true if @settings[:display][:startpage] == url && allowed
+      break if startpage_already_set
+    end
+
+    # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
+    @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
+    @settings[:display][:startpage]
+  end
+end

--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -19,4 +19,23 @@ module StartUrl
     @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
     @settings[:display][:startpage]
   end
+
+  private
+
+  def start_page_allowed?(start_page)
+    storage_start_pages = %w(cim_storage_extent_show_list
+                             ontap_file_share_show_list
+                             ontap_logical_disk_show_list
+                             ontap_storage_system_show_list
+                             ontap_storage_volume_show_list
+                             storage_manager_show_list)
+    return false if storage_start_pages.include?(start_page) && !::Settings.product.storage
+    containers_start_pages = %w(ems_container_show_list
+                                container_node_show_list
+                                container_group_show_list
+                                container_service_show_list
+                                container_view)
+    return false if containers_start_pages.include?(start_page) && !::Settings.product.containers
+    role_allows?(:feature => start_page, :any => true)
+  end
 end

--- a/app/controllers/mixins/start_url.rb
+++ b/app/controllers/mixins/start_url.rb
@@ -13,6 +13,10 @@ module StartUrl
                               container_service_show_list
                               container_view).to_set.freeze
 
+  included do
+    helper_method :start_page_options
+  end
+
   def start_url_for_user(start_url)
     return url_for(start_url) unless start_url.nil?
     return url_for(:controller => 'dashboard', :action => 'show') unless helpers.settings(:display, :startpage)
@@ -30,6 +34,12 @@ module StartUrl
     # user first_allowed_url in start_pages to be default page, if default startpage is not allowed
     @settings.store_path(:display, :startpage, first_allowed_url) unless startpage_already_set
     @settings[:display][:startpage]
+  end
+
+  def start_page_options
+    MiqShortcut.start_pages.each_with_object([]) do |(url, description, rbac_feature_name), result|
+      result.push([description, url]) if start_page_allowed?(rbac_feature_name)
+    end
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1609,23 +1609,6 @@ module ApplicationHelper
     record.openstack_cluster? ? _("Deployment Role") : _("Cluster")
   end
 
-  def start_page_allowed?(start_page)
-    storage_start_pages = %w(cim_storage_extent_show_list
-                             ontap_file_share_show_list
-                             ontap_logical_disk_show_list
-                             ontap_storage_system_show_list
-                             ontap_storage_volume_show_list
-                             storage_manager_show_list)
-    return false if storage_start_pages.include?(start_page) && !::Settings.product.storage
-    containers_start_pages = %w(ems_container_show_list
-                                container_node_show_list
-                                container_group_show_list
-                                container_service_show_list
-                                container_view)
-    return false if containers_start_pages.include?(start_page) && !::Settings.product.containers
-    role_allows?(:feature => start_page, :any => true)
-  end
-
   def miq_tab_header(id, active = nil, options = {}, &_block)
     content_tag(:li,
                 :class     => "#{options[:class]} #{active == id ? 'active' : ''}",

--- a/app/views/configuration/_ui_1.html.haml
+++ b/app/views/configuration/_ui_1.html.haml
@@ -51,7 +51,7 @@
               = _('Show at Login')
             .col-md-8
               = select_tag("start_page",
-                           options_for_select(session[:start_pages], @edit[:new][:display][:startpage]),
+                           options_for_select(start_page_options, @edit[:new][:display][:startpage]),
                            "data-live-search" => "true",
                            :class             => "selectpicker")
 

--- a/spec/controllers/dashboard_controller/start_url_spec.rb
+++ b/spec/controllers/dashboard_controller/start_url_spec.rb
@@ -1,0 +1,40 @@
+describe DashboardController do
+  describe '#start_page_allowed?' do
+    let(:controller) { described_class.new }
+    let(:subj) { ->(page) { controller.send(:start_page_allowed?, page) } }
+
+    before do
+      stub_user(:features => :all)
+    end
+
+    context 'cim_storage_extent_show_list' do
+      subject { subj.call('cim_storage_extent_show_list') }
+
+      it 'should return true for storage start pages when product flag is set' do
+        stub_settings(:product => {:storage => true})
+        is_expected.to be_truthy
+      end
+
+      it 'should return false for storage start pages when product flag is not set' do
+        is_expected.to be_falsey
+      end
+    end
+
+    context 'ems_container_show_list' do
+      subject { subj.call('ems_container_show_list') }
+
+      it 'should return true for containers start pages when product flag is set' do
+        stub_settings(:product => {:containers => true})
+        is_expected.to be_truthy
+      end
+
+      it 'should return false for containers start pages when product flag is not set' do
+        is_expected.to be_falsey
+      end
+    end
+
+    it 'should return true for host start page' do
+      expect(subj.call('host_show_list')).to be_truthy
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1328,41 +1328,6 @@ describe ApplicationHelper do
     end
   end
 
-  context "#start_page_allowed?" do
-    before do
-      stub_user(:features => :all)
-    end
-
-    it "should return true for storage start pages when product flag is set" do
-      stub_settings(:product => { :storage => true })
-
-      result = helper.start_page_allowed?("cim_storage_extent_show_list")
-      expect(result).to be_truthy
-    end
-
-    it "should return false for storage start pages when product flag is not set" do
-      result = helper.start_page_allowed?("cim_storage_extent_show_list")
-      expect(result).to be_falsey
-    end
-
-    it "should return true for containers start pages when product flag is set" do
-      stub_settings(:product => { :containers => true })
-
-      result = helper.start_page_allowed?("ems_container_show_list")
-      expect(result).to be_truthy
-    end
-
-    it "should return false for containers start pages when product flag is not set" do
-      result = helper.start_page_allowed?("ems_container_show_list")
-      expect(result).to be_falsey
-    end
-
-    it "should return true for host start page" do
-      result = helper.start_page_allowed?("host_show_list")
-      expect(result).to be_truthy
-    end
-  end
-
   context "#tree_with_advanced_search?" do
     it 'should return true for explorer trees with advanced search' do
       controller.instance_variable_set(:@sb,


### PR DESCRIPTION
Start url is used/manipulated on two places.
 * On first login
 * In *My Settings* for each user to manipulate his own

This pr:
 * drops start_pages from session
 * limits scope of some global methods
 * consolidates all the manipulation to single place

@miq-bot add_label refactoring, ui, euwe/no
@miq-bot assign @martinpovolny 

Please refrain from comments :spiral_notepad:  until you read commit messages. :nerd_face: