### PR TITLE
Remove confirmation when opening the HTML5 vnc/spice console.

### DIFF
--- a/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
+++ b/app/helpers/application_helper/toolbar/cloud/instance_operations_button_group_mixin.rb
@@ -104,8 +104,7 @@ module ApplicationHelper::Toolbar::Cloud::InstanceOperationsButtonGroupMixin
         'fa fa-html5 fa-lg',
         N_('Open a web-based VNC or SPICE console for this VM'),
         nil,
-        :url     => "html5_console",
-        :confirm => N_("Opening a web-based VM VNC or SPICE console requires that the Provider is pre-configured to allow VNC connections.  Are you sure?")),
+        :url => "html5_console"),
     ])
   end
 end

--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -240,8 +240,7 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
       'fa fa-html5 fa-lg',
       N_('Open a web-based VNC or SPICE console for this VM'),
       nil,
-      :url     => "html5_console",
-      :confirm => N_("Opening a web-based VM VNC or SPICE console requires that the Provider is pre-configured to allow VNC connections.  Are you sure?")),
+      :url     => "html5_console"),
     button(
       :vm_vmrc_console,
       'pficon pficon-screen fa-lg',


### PR DESCRIPTION
Testing: Try clicking on the vnc/spice console. There should be no confirmation.

https://bugzilla.redhat.com/show_bug.cgi?id=1348721