### PR TITLE
Add settings key to disable console proxy

### DIFF
--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -24,8 +24,8 @@ class SystemConsole < ApplicationRecord
   end
 
   def self.allocate_port
-    port_range_start = ::Settings.server.proxy_port.try(:start) || 6000
-    port_range_end   = ::Settings.server.proxy_port.try(:end) || 7000
+    port_range_start = ::Settings.server.proxy_port.start || 6000
+    port_range_end   = ::Settings.server.proxy_port.end || 7000
 
     used_ports = SystemConsole.where.not(:proxy_pid => nil).where(:host_name => local_address).order(:port).pluck(:port)
 
@@ -93,7 +93,7 @@ class SystemConsole < ApplicationRecord
   end
 
   def self.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
-    proxy_disabled = ::Settings.server.try(:console_proxy_disabled)
+    proxy_disabled = ::Settings.server.console_proxy_disabled
     proxy_disabled = proxy_disabled.present? && !proxy_disabled
 
     _log.info "Originating server: #{originating_server}, local server: #{MiqServer.my_server.id}"

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -93,8 +93,12 @@ class SystemConsole < ApplicationRecord
   end
 
   def self.launch_proxy_if_not_local(console_args, originating_server, host_address, host_port)
+    proxy_disabled = ::Settings.server.try(:console_proxy_disabled)
+    proxy_disabled = proxy_disabled.present? && !proxy_disabled
+
     _log.info "Originating server: #{originating_server}, local server: #{MiqServer.my_server.id}"
-    if SystemConsole.is_local?(originating_server)
+
+    if proxy_disabled || SystemConsole.is_local?(originating_server)
       console_args.update(
         :host_name  => host_address,
         :port       => host_port,


### PR DESCRIPTION
Using 'server.console_proxy_disabled' set to 'true' the proxying can be
disabled even if the display ticket is being requested by a different
server than the one that originated the request.

This allows the server to behave the same as before Euwe.

This is an addition to the 2 keys:

'server.proxy_port.start', defaults to 6000
'server.proxy_port.end', defaults to 7000

that allow setting of the port range for the console proxy.


ping @skateman 