### PR TITLE
Show correct textual operation system name

### DIFF
--- a/app/helpers/textual_mixins/textual_os_info.rb
+++ b/app/helpers/textual_mixins/textual_os_info.rb
@@ -1,12 +1,18 @@
 module TextualMixins::TextualOsInfo
   def textual_osinfo
     h = {:label => _("Operating System")}
-    os = @record.operating_system.nil? ? nil : @record.operating_system.product_name
-    if os.blank?
-      h[:value] = _("Unknown")
+    product_name = @record.product_name
+    if product_name.blank?
+      os_image_name = @record.os_image_name
+      if os_image_name.blank?
+        h[:value] = _("Unknown")
+      else
+        h[:image] = "os-#{os_image_name.downcase}"
+        h[:value] = os_image_name
+      end
     else
       h[:image] = "os-#{@record.os_image_name.downcase}"
-      h[:value] = os
+      h[:value] = product_name
       h[:title] = _("Show OS container information")
       h[:explorer] = true
       h[:link] = url_for(:action => 'show', :id => @record, :display => 'os_info')


### PR DESCRIPTION
Even without operation_system relation, we can show the
operation system, using os_image_name, which uses guest_os
among others.

os_image_name is also used for quadicon's OS image, so this
becomes more consistent

Steps for Testing/QA [Optional]
-------------------------------

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1393547

Note: operating system is inferred from Image location, so Image needs to be refreshed and it needs to contain the OS name. Works well for Public images