### PR TITLE
Memory checkbox will not show when VM is not up

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -540,6 +540,7 @@ module VmCommon
     @name = @description = ""
     @in_a_form = true
     @button_group = "snap"
+    @show_snapshot_memory_checkbox = show_snapshot_memory_checkbox?(@vm)
     drop_breadcrumb(:name    => _("Snapshot VM '%{name}''") % {:name => @record.name},
                     :url     => "/vm_common/snap",
                     :display => "snapshot_info")
@@ -564,6 +565,11 @@ module VmCommon
     else
       render :action => "snap"
     end
+  end
+
+  def show_snapshot_memory_checkbox?(vm)
+    return true unless vm.respond_to?(:snapshotting_memory_allowed?)
+    vm.snapshotting_memory_allowed?
   end
 
   def snap_vm

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -56,6 +56,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     current_state == 'off'
   end
 
+  def snapshotting_memory_allowed?
+    current_state == 'on'
+  end
+
   private
 
   def with_snapshots_service(vm_uid_ems)

--- a/app/views/vm_common/_snap.html.haml
+++ b/app/views/vm_common/_snap.html.haml
@@ -16,7 +16,7 @@
           = _('Description')
         .col-md-8
           = text_area_tag("description", @description, :size => "50x4")
-      .form-group
+      %div{:class => "form-group #{@show_snapshot_memory_checkbox ? "" : "hidden"}"}
         %label.control-label.col-md-2
           = _('Snapshot VM memory')
         .col-md-8


### PR DESCRIPTION
When a VM is powered off there should not be a "save memory" checkbox:
![memory box 1](https://cloud.githubusercontent.com/assets/3274731/20929729/b05ccaa6-bbd3-11e6-82de-2ef6fdcc0af4.png)

When a VM is powered off there should be a "save memory" checkbox:
![memory box 2](https://cloud.githubusercontent.com/assets/3274731/20929912/4d39fc40-bbd4-11e6-8b6e-65d6d35f0533.png)

When creating a snapshot there is not reason to show
the option to save run time memory if the VM is down.

https://bugzilla.redhat.com/show_bug.cgi?id=1375850