### PR TITLE
Drop my_server_id as unnecesary indirection

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -239,7 +239,7 @@ class OpsController < ApplicationController
     end
 
     if x_active_tree == :diagnostics_tree
-      x_node_set("svr-#{to_cid(my_server_id)}", :diagnostics_tree) unless x_node(:diagnostics_tree)
+      x_node_set("svr-#{to_cid(my_server.id)}", :diagnostics_tree) unless x_node(:diagnostics_tree)
       @sb[:active_tab] ||= "diagnostics_summary"
     end
 
@@ -343,7 +343,7 @@ class OpsController < ApplicationController
         record_id = @record && @record.id ? @record.id : "new"
       else
         action_url = "old_dialogs_update"
-        record_id = my_server_id
+        record_id = my_server.id
       end
     elsif x_active_tree == :settings_tree
       if %w(settings_import settings_import_tags).include?(@sb[:active_tab])
@@ -617,11 +617,11 @@ class OpsController < ApplicationController
       end
       active_id = from_cid(x_node.split("-").last)
       # server node
-      if x_node.split("-").first == "svr" && my_server_id == active_id.to_i
+      if x_node.split("-").first == "svr" && my_server.id == active_id.to_i
         # show all the tabs if on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
         presenter.one_trans_ie if %w(save reset).include?(params[:button]) && is_browser_ie?
-      elsif x_node.split("-").first == "svr" && my_server_id != active_id.to_i
+      elsif x_node.split("-").first == "svr" && my_server.id != active_id.to_i
         # show only 4 tabs if not on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
       end

--- a/app/controllers/ops_controller/diagnostics.rb
+++ b/app/controllers/ops_controller/diagnostics.rb
@@ -858,7 +858,7 @@ module OpsController::Diagnostics
                           :model => ui_lookup(:model => "MiqRegion")}
     elsif active_node && active_node.split('-').first == "svr"
       @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
-      if @sb[:selected_server_id] == my_server_id
+      if @sb[:selected_server_id] == my_server.id
         if @sb[:active_tab] == "diagnostics_evm_log"
           @log = $log.contents(120, 1000)
           add_flash(_("Logs for this %{product} Server are not available for viewing") % {:product => I18n.t('product.name')}, :warning) if @log.blank?
@@ -891,7 +891,7 @@ module OpsController::Diagnostics
           @sb[:selected_server_id] = @selected_server.id
           @sb[:selected_typ] = "miq_server"
         end
-      elsif @sb[:selected_server_id] == my_server_id || @selected_server.started?
+      elsif @sb[:selected_server_id] == my_server.id || @selected_server.started?
         if @sb[:active_tab] == "diagnostics_workers"
           pm_get_workers
           @record = @selected_server
@@ -916,7 +916,7 @@ module OpsController::Diagnostics
           @sb[:selected_typ] = "miq_server"
         end
       end
-      @right_cell_text = if my_server_id == @sb[:selected_server_id]
+      @right_cell_text = if my_server.id == @sb[:selected_server_id]
                            _("Diagnostics %{model} \"%{name}\" (current)") %
                            {:name  => "#{@selected_server.name} [#{@selected_server.id}]",
                             :model => ui_lookup(:model => @selected_server.class.to_s)}

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -924,7 +924,7 @@ module OpsController::Settings::Common
         _("Settings %{model} \"%{name}\"") % {:name  => @selected_zone.description,
                                               :model => ui_lookup(:model => @selected_zone.class.to_s)}
     else
-      @right_cell_text = my_server_id == @sb[:selected_server_id] ?
+      @right_cell_text = my_server.id == @sb[:selected_server_id] ?
         _("Settings %{model} \"%{name}\" (current)") % {:name  => "#{@selected_server.name} [#{@selected_server.id}]",
                                                         :model => ui_lookup(:model => @selected_server.class.to_s)} :
         _("Settings %{model} \"%{name}\"") % {:name  => "#{@selected_server.name} [#{@selected_server.id}]",

--- a/app/helpers/ops_helper/my_server.rb
+++ b/app/helpers/ops_helper/my_server.rb
@@ -1,6 +1,4 @@
 module OpsHelper::MyServer
-  delegate :id, :to => :my_server, :prefix => true
-
   def my_zone_name
     my_server.my_zone
   end

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -22,7 +22,7 @@
           = _("Authentication")
         = miq_tab_header("settings_workers", @sb[:active_tab]) do
           = _("Workers")
-        - if cur_svr_id == my_server_id
+        - if cur_svr_id == my_server.id
           = miq_tab_header("settings_custom_logos", @sb[:active_tab]) do
             = _("Custom Logos")
           = miq_tab_header("settings_advanced", @sb[:active_tab]) do
@@ -34,7 +34,7 @@
           = render :partial => "settings_authentication_tab"
         = miq_tab_content("settings_workers", @sb[:active_tab]) do
           = render :partial => "settings_workers_tab"
-        - if cur_svr_id == my_server_id
+        - if cur_svr_id == my_server.id
           = miq_tab_content("settings_custom_logos", @sb[:active_tab]) do
             = render :partial => "settings_custom_logos_tab"
           = miq_tab_content("settings_advanced", @sb[:active_tab]) do
@@ -112,14 +112,14 @@
           = render :partial => "diagnostics_cu_repair_tab"
     - elsif x_node.split("-")[0] == "svr"
       %ul.nav.nav-tabs
-        - if @sb[:selected_server_id] == my_server_id || @selected_server.started?
+        - if @sb[:selected_server_id] == my_server.id || @selected_server.started?
           = miq_tab_header("diagnostics_summary", @sb[:active_tab]) do
             = _("Summary")
           = miq_tab_header("diagnostics_workers", @sb[:active_tab]) do
             = _("Workers")
         = miq_tab_header("diagnostics_collect_logs", @sb[:active_tab]) do
           = _("Collect Logs")
-        - if @sb[:selected_server_id] == my_server_id
+        - if @sb[:selected_server_id] == my_server.id
           = miq_tab_header("diagnostics_evm_log", @sb[:active_tab]) do
             = _("%{product} Log") % {:product => I18n.t('product.name')}
           = miq_tab_header("diagnostics_audit_log", @sb[:active_tab]) do
@@ -132,14 +132,14 @@
         = miq_tab_header("diagnostics_timelines", @sb[:active_tab]) do
           = _("Timelines")
       .tab-content
-        - if @sb[:selected_server_id] == my_server_id || @selected_server.started?
+        - if @sb[:selected_server_id] == my_server.id || @selected_server.started?
           = miq_tab_content("diagnostics_summary", @sb[:active_tab]) do
             = render :partial => "diagnostics_summary_tab"
           = miq_tab_content("diagnostics_workers", @sb[:active_tab]) do
             = render :partial => "diagnostics_workers_tab"
         = miq_tab_content("diagnostics_collect_logs", @sb[:active_tab]) do
           = render :partial => "diagnostics_collect_logs_tab"
-        - if @sb[:selected_server_id] == my_server_id
+        - if @sb[:selected_server_id] == my_server.id
           = miq_tab_content("diagnostics_evm_log", @sb[:active_tab]) do
             = render :partial => "diagnostics_evm_log_tab"
           = miq_tab_content("diagnostics_audit_log", @sb[:active_tab]) do

--- a/app/views/ops/_settings_evm_servers_tab.html.haml
+++ b/app/views/ops/_settings_evm_servers_tab.html.haml
@@ -73,7 +73,7 @@
               %td.narrow
                 %i.pficon.pficon-server
               %td
-                - if my_server_id == s.id
+                - if my_server.id == s.id
                   %b
                     = h(ui_lookup(:model => s.class.to_s))
                     \: #{h(s.name)} [#{h(s.id)}] (current)


### PR DESCRIPTION
`my_server_id` is not shorter to write than `my_server.id`.

It is not obvious to find, where it is defined. It is unnecessary indirection. It can only lead to ty#@čo moments.

@miq-bot add_label ui, technical debt, euwe/no
@miq-bot assign @mzazrivec