### PR TITLE
supported_api_versions_from_sdk should not crash

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/api_integration.rb
@@ -60,6 +60,9 @@ module ManageIQ::Providers::Redhat::InfraManager::ApiIntegration
     probe_args = { :host => hostname, :port => port, :username => username, :password => password, :insecure => true }
     probe_results = OvirtSDK4::Probe.probe(probe_args)
     probe_results.map(&:version) if probe_results
+  rescue => error
+    _log.error("Error while probing supported api versions #{error}")
+    []
   end
 
   def supports_the_api_version?(version)


### PR DESCRIPTION
This patch is fixing this issue: https://bugzilla.redhat.com/show_bug.cgi?id=1394021

The problem was that when the supported_api_verions_from_sdk crashes, the supported_api_versions will
return nil causing the .collect to fail in supported_features.

Fixed by returning and empty list instead of crashing.