### PR TITLE
remove scrollable tables from provisioning dialog

### DIFF
--- a/app/views/miq_request/_prov_configured_system_grid.html.haml
+++ b/app/views/miq_request/_prov_configured_system_grid.html.haml
@@ -1,7 +1,7 @@
 - options = @edit || @options
 - id = options.try(:[], :req_id) || "new"
 
-#prov_configured_system_div{:style => "height: 150px; overflow: auto;"}
+#prov_configured_system_div
   %table.table.table-bordered.table-striped
     %thead
       %tr

--- a/app/views/miq_request/_prov_ds_grid.html.haml
+++ b/app/views/miq_request/_prov_ds_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_ds_div{:style => "height: 150px; overflow: auto;"}
+#prov_ds_div
   %table.table.table-bordered.table-striped.table-hover.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_prov_host_grid.html.haml
+++ b/app/views/miq_request/_prov_host_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_host_div{:style => "height: 150px; overflow: auto;"}
+#prov_host_div
   %table.table.table-bordered.table-hover.table-striped.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_prov_iso_img_grid.html.haml
+++ b/app/views/miq_request/_prov_iso_img_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_iso_img_div{:style => "height: 150px; overflow: auto;"}
+#prov_iso_img_div
   %table.table.table-bordered.table-striped.table-hover.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_prov_pxe_img_grid.html.haml
+++ b/app/views/miq_request/_prov_pxe_img_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_pxe_img_div{:style => "height: 150px; overflow: auto;"}
+#prov_pxe_img_div
   %table.table.table-bordered.table-hover.table-striped.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_prov_template_grid.html.haml
+++ b/app/views/miq_request/_prov_template_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_template_div{:style => "height: 150px; overflow: auto;"}
+#prov_template_div
   %table.table.table-bordered.table-striped.table-hover.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_prov_vc_grid.html.haml
+++ b/app/views/miq_request/_prov_vc_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_vc_div{:style => "height: 150px; overflow: auto;"}
+#prov_vc_div
   %table.table.table-bordered.table-striped.table-hover.table-selectable
     %thead
       %tr

--- a/app/views/miq_request/_prov_windows_image_grid.html.haml
+++ b/app/views/miq_request/_prov_windows_image_grid.html.haml
@@ -1,4 +1,4 @@
-#prov_windows_image_div{:style => "height: 150px; overflow: auto;"}
+#prov_windows_image_div
   %table.table.table-bordered.table-striped.table-hover.table-selectable
     %thead
       %tr


### PR DESCRIPTION
This PR removes the 150 pixel high scrollable area for Patternfly Tables within Provisioning tabs, instead, allowing the tables to be fully displayed (including the table headers) on the screen.  This is consistent with our effort to remove secondary scrolling content within the main_content area.

https://bugzilla.redhat.com/show_bug.cgi?id=1394726

Old
![screen shot 2016-11-16 at 10 30 53 am](https://cloud.githubusercontent.com/assets/1287144/20353149/d47f4432-abe7-11e6-8cde-3e418d310207.png)

New
![screen shot 2016-11-16 at 10 31 08 am](https://cloud.githubusercontent.com/assets/1287144/20353148/d473fc9e-abe7-11e6-86ec-3de76f8e097f.png)
