### PR TITLE
Refactor CloudSubnets to use SupportsFeatureMixin

### DIFF
--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -82,7 +82,7 @@ class CloudSubnetController < ApplicationController
       @subnet = CloudSubnet.new
       options = form_params
       ems = ExtManagementSystem.find(options[:ems_id])
-      if CloudSubnet.class_by_ems(ems).supports_create_subnet?
+      if CloudSubnet.class_by_ems(ems).supports_create?
         begin
           CloudSubnet.create_subnet(ems, options)
           # TODO: To replace with targeted refresh when avail. or either use tasks
@@ -98,7 +98,7 @@ class CloudSubnetController < ApplicationController
         javascript_redirect :action => "show_list"
       else
         @in_a_form = true
-        add_flash(_(CloudSubnet.unsupported_reason(:create_subnet)), :error)
+        add_flash(_(CloudSubnet.unsupported_reason(:create)), :error)
         drop_breadcrumb(
           :name => _("Add New Subnet") % {:model => ui_lookup(:table => 'cloud_subnet')},
           :url  => "/cloud_subnet/new"
@@ -126,12 +126,12 @@ class CloudSubnetController < ApplicationController
       subnet = CloudSubnet.find_by_id(s)
       if subnet.nil?
         add_flash(_("Cloud Subnet no longer exists."), :error)
-      elsif subnet.supports_delete_subnet?
+      elsif subnet.supports_delete?
         subnets_to_delete.push(subnet)
       else
         add_flash(_("Couldn't initiate deletion of Subnet \"%{name}\": %{details}") % {
           :name    => subnet.name,
-          :details => delete_details
+          :details => subnet.unsupported_reason(:delete)
         }, :error)
       end
     end

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -82,8 +82,7 @@ class CloudSubnetController < ApplicationController
       @subnet = CloudSubnet.new
       options = form_params
       ems = ExtManagementSystem.find(options[:ems_id])
-      valid_action, action_details = CloudSubnet.validate_create_subnet(ems)
-      if valid_action
+      if CloudSubnet.class_by_ems(ems).supports_create_subnet?
         begin
           CloudSubnet.create_subnet(ems, options)
           # TODO: To replace with targeted refresh when avail. or either use tasks
@@ -99,7 +98,7 @@ class CloudSubnetController < ApplicationController
         javascript_redirect :action => "show_list"
       else
         @in_a_form = true
-        add_flash(_(action_details), :error) unless action_details.nil?
+        add_flash(_(CloudSubnet.unsupported_reason(:create_subnet)), :error)
         drop_breadcrumb(
           :name => _("Add New Subnet") % {:model => ui_lookup(:table => 'cloud_subnet')},
           :url  => "/cloud_subnet/new"
@@ -127,15 +126,13 @@ class CloudSubnetController < ApplicationController
       subnet = CloudSubnet.find_by_id(s)
       if subnet.nil?
         add_flash(_("Cloud Subnet no longer exists."), :error)
+      elsif subnet.supports_delete_subnet?
+        subnets_to_delete.push(subnet)
       else
-        valid_delete, delete_details = subnet.validate_delete_subnet
-        if valid_delete
-          subnets_to_delete.push(subnet)
-        else
-          add_flash(_("Couldn't initiate deletion of Subnet \"%{name}\": %{details}") % {
-            :name    => subnet.name,
-            :details => delete_details}, :error)
-        end
+        add_flash(_("Couldn't initiate deletion of Subnet \"%{name}\": %{details}") % {
+          :name    => subnet.name,
+          :details => delete_details
+        }, :error)
       end
     end
     unless subnets_to_delete.empty?

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -5,6 +5,7 @@ class CloudSubnet < ApplicationRecord
   include ProviderObjectMixin
   include AsyncDeleteMixin
   include VirtualTotalMixin
+  include SupportsFeatureMixin
 
   acts_as_miq_taggable
 
@@ -62,19 +63,8 @@ class CloudSubnet < ApplicationRecord
     klass.raw_create_subnet(ext_management_system, options)
   end
 
-  def self.validate_create_subnet(ext_management_system)
-    klass = class_by_ems(ext_management_system)
-    return klass.validate_create_subnet(ext_management_system) if ext_management_system &&
-                                                                  klass.respond_to?(:validate_create_subnet)
-    validate_unsupported("Create Subnet Operation")
-  end
-
   def delete_subnet
     raw_delete_subnet
-  end
-
-  def validate_delete_subnet
-    validate_unsupported("Delete Subnet Operation")
   end
 
   def raw_delete_subnet

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -1,13 +1,13 @@
 class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubnet
-  supports :create_subnet
-  supports :delete_subnet do
+  supports :create
+  supports :delete do
     if ext_management_system.nil?
       unsupported_reason_add(:delete_subnet, _("The subnet is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
       })
     end
   end
-  supports :update_subnet do
+  supports :update do
     if ext_management_system.nil?
       unsupported_reason_add(:update_subnet, _("The subnet is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -72,14 +72,12 @@ module SupportsFeatureMixin
     :create_host_aggregate      => 'Host Aggregate Creation',
     :create_network_router      => 'Network Router Creation',
     :create_security_group      => 'Security Group Creation',
-    :create_subnet              => 'Cloud Subnet Creation',
     :swift_service              => 'Swift storage service',
     :delete                     => 'Deletion',
     :delete_aggregate           => 'Host Aggregate Deletion',
     :delete_floating_ip         => 'Floating IP Deletion',
     :delete_network_router      => 'Network Router Deletion',
     :delete_security_group      => 'Security Group Deletion',
-    :delete_subnet              => 'Cloud Subnet Deletion',
     :disassociate_floating_ip   => 'Disassociate a Floating IP',
     :discovery                  => 'Discovery of Managers for a Provider',
     :evacuate                   => 'Evacuation',
@@ -112,7 +110,6 @@ module SupportsFeatureMixin
     :update_network_router      => 'Network Router Update',
     :ems_network_new            => 'New EMS Network Provider',
     :update_security_group      => 'Security Group Update',
-    :update_subnet              => 'Cloud Subnet Update',
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -72,12 +72,14 @@ module SupportsFeatureMixin
     :create_host_aggregate      => 'Host Aggregate Creation',
     :create_network_router      => 'Network Router Creation',
     :create_security_group      => 'Security Group Creation',
+    :create_subnet              => 'Cloud Subnet Creation',
     :swift_service              => 'Swift storage service',
     :delete                     => 'Deletion',
     :delete_aggregate           => 'Host Aggregate Deletion',
     :delete_floating_ip         => 'Floating IP Deletion',
     :delete_network_router      => 'Network Router Deletion',
     :delete_security_group      => 'Security Group Deletion',
+    :delete_subnet              => 'Cloud Subnet Deletion',
     :disassociate_floating_ip   => 'Disassociate a Floating IP',
     :discovery                  => 'Discovery of Managers for a Provider',
     :evacuate                   => 'Evacuation',
@@ -110,6 +112,7 @@ module SupportsFeatureMixin
     :update_network_router      => 'Network Router Update',
     :ems_network_new            => 'New EMS Network Provider',
     :update_security_group      => 'Security Group Update',
+    :update_subnet              => 'Cloud Subnet Update',
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -141,7 +141,8 @@ describe CloudSubnetController do
     before do
       stub_user(:features => :all)
       EvmSpecHelper.create_guid_miq_server_zone
-      @subnet = FactoryGirl.create(:cloud_subnet_openstack)
+      @ems = FactoryGirl.create(:ems_openstack).network_manager
+      @subnet = FactoryGirl.create(:cloud_subnet_openstack, :ext_management_system => @ems)
     end
 
     it "deletes itself" do


### PR DESCRIPTION
This is a refactor to excise the old "validate_<action>" code from CloudSubnets and have it use SupportsFeatureMixin instead. I have another pull request which is dependent on CloudSubnet capability testing, so this seemed like an appropriate time to refactor.