### PR TITLE
Disable Add Cloud Subnet button when no provider supports it.

### DIFF
--- a/app/helpers/application_helper/button/cloud_subnet_new.rb
+++ b/app/helpers/application_helper/button/cloud_subnet_new.rb
@@ -1,0 +1,13 @@
+class ApplicationHelper::Button::CloudSubnetNew < ApplicationHelper::Button::Basic
+  def calculate_properties
+    super
+    if disabled?
+      self[:title] = _("No cloud providers support creating cloud subnets.")
+    end
+  end
+
+  # disable button if no active providers support create action
+  def disabled?
+    EmsNetwork.all.none? { |ems| CloudSubnet.class_by_ems(ems).supports_create? }
+  end
+end

--- a/app/helpers/application_helper/toolbar/cloud_subnets_center.rb
+++ b/app/helpers/application_helper/toolbar/cloud_subnets_center.rb
@@ -11,6 +11,7 @@ class ApplicationHelper::Toolbar::CloudSubnetsCenter < ApplicationHelper::Toolba
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a new Cloud Subnet'),
           t,
+          :klass => ApplicationHelper::Button::CloudSubnetNew
         ),
         separator,
         button(

--- a/app/models/aliases/ems_network.rb
+++ b/app/models/aliases/ems_network.rb
@@ -1,0 +1,1 @@
+::EmsNetwork = ::ManageIQ::Providers::NetworkManager

--- a/spec/helpers/application_helper/buttons/cloud_subnet_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/cloud_subnet_new_spec.rb
@@ -1,0 +1,33 @@
+describe ApplicationHelper::Button::CloudSubnetNew do
+  describe '#disabled?' do
+    it "when at least one provider supports subnet create then the button is not disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be false
+    end
+
+    it "when no provider supports subnet create then the button is disabled" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      expect(button.disabled?).to be true
+    end
+  end
+
+  describe '#calculate_properties' do
+    it "when no provider supports subnet create the button has an error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to eq("No cloud providers support creating cloud subnets.")
+    end
+
+    it "when at least one provider supports subnet create, the button has no error in the title" do
+      view_context = setup_view_context_with_sandbox({})
+      FactoryGirl.create(:ems_openstack)
+      button = described_class.new(view_context, {}, {}, {})
+      button.calculate_properties
+      expect(button[:title]).to be nil
+    end
+  end
+end


### PR DESCRIPTION
This PR causes the Add Cloud Subnet to become disabled if none of the available providers support it. This is to satisfy the requirement in https://bugzilla.redhat.com/show_bug.cgi?id=1383239.

This PR is dependent on https://github.com/ManageIQ/manageiq/pull/12691, which implements SupportsFeatureMixin for CloudSubnets.

Links
----------------
* https://github.com/ManageIQ/manageiq/pull/12691
* https://bugzilla.redhat.com/show_bug.cgi?id=1383239
