### PR TITLE
Add dynamic dropdown list support for orchestration service dialog

### DIFF
--- a/app/models/orchestration_template/orchestration_parameter_allowed_dynamic.rb
+++ b/app/models/orchestration_template/orchestration_parameter_allowed_dynamic.rb
@@ -1,0 +1,5 @@
+class OrchestrationTemplate
+  class OrchestrationParameterAllowedDynamic < OrchestrationParameterConstraint
+    attr_accessor :fqname
+  end
+end


### PR DESCRIPTION
This patchs adds a new orchestration template parameter constraint
referencing the required method from the automate. Contrary to stack
parameters of the orchestration template service dialog where dynamic
dropdowns are supported via `resource_actions`. However, for additional
template parameters, the values for the presented dropdowns are created
using a static list of values (static at the time of dialog creation).

With this patch, it is possible to construct a parameter whose allowed
values are retrieved when the dialog is opened, i.e. when the user wants
to order the orchestration service.

The patch is required in order to allow the VMware vCloud provider to
create dropdowns for the available networks that can be set for each VM
that is part of the vApp template (orchestration template).

@miq-bot add_label orchestration, ui, enhancement