### PR TITLE
Add option to hide resources in REST API

### DIFF
--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -72,6 +72,11 @@ module Api
           expand_requested.include?(what.to_s)
         end
 
+        def hide?(thing)
+          @hide ||= @params["hide"].to_s.split(",")
+          @hide.include?(thing)
+        end
+
         def json_body
           @json_body ||= begin
                            body = @request.body.read if @request.body

--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -53,11 +53,13 @@ module Api
           [:name, :count, :subcount].each do |opt_name|
             json.set! opt_name.to_s, opts[opt_name] if opts[opt_name]
           end
-          json.resources resources.collect do |resource|
-            if opts[:expand_resources]
-              add_hash json, resource_to_jbuilder(type, reftype, resource, opts).attributes!
-            else
-              json.href normalize_href(reftype, resource["id"])
+          unless @req.hide?("resources")
+            json.resources resources.collect do |resource|
+              if opts[:expand_resources]
+                add_hash json, resource_to_jbuilder(type, reftype, resource, opts).attributes!
+              else
+                json.href normalize_href(reftype, resource["id"])
+              end
             end
           end
           cspec = collection_config[type]

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -415,6 +415,15 @@ describe "Querying" do
       expect_query_result(:vms, 1, 1)
       expect_result_resources_to_include_keys("resources", %w(id href guid name vendor software))
     end
+
+    it "supports suppressing resources" do
+      FactoryGirl.create(:vm)
+
+      run_get(vms_url, :hide => "resources")
+
+      expect(response.parsed_body).not_to include("resources")
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "Querying resources" do

--- a/tools/rest_api.rb
+++ b/tools/rest_api.rb
@@ -44,7 +44,7 @@ class RestApi
     METHODS_NEEDING_DATA = %w(put post patch).freeze
     SCRIPTDIR_ACTIONS    = %w(ls run).freeze
     SUB_COMMANDS         = ACTIONS + %w(edit vi) + SCRIPTDIR_ACTIONS
-    API_PARAMETERS       = %w(expand attributes decorators limit offset
+    API_PARAMETERS       = %w(expand hide attributes decorators limit offset
                               depth search_options
                               sort_by sort_order sort_options
                               filter by_tag provider_class requester_type).freeze


### PR DESCRIPTION
The requester may only want the count/subcount from a query. If the
number of resources to be rendered is very large, iterating over them
on the backend unnecessarily carries a performance penalty, as well as
generating a large response body to go over the network. Adding an
option to hide the resources addresses both issues.

/cc @AllenBW 
@miq-bot add-label api, enhancement
@miq-bot assign @abellotti 
