### PR TITLE
Fix popover styles for the timelines

### DIFF
--- a/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
+++ b/app/assets/javascripts/controllers/timeline/timeline_options_controller.js
@@ -13,7 +13,8 @@ ManageIQ.angular.app.controller('timelineOptionsController', ['$http', '$scope',
         $scope.afterGet  = true;
         $scope.dateOptions = {
             autoclose: true,
-            todayHighlight: true
+            todayHighlight: true,
+            orientation: 'bottom'
         };
         ManageIQ.angular.scope = $scope;
         $scope.availableCategories = categories;

--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -41,8 +41,8 @@
 }
 
 .timeline-container > .popover {
-  max-width: 100%;
-  width: 300px;
+  max-width: 400px;
+  overflow-wrap: break-word;
 }
 
 .timeline-stepper {

--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "moment-timezone": "~0.4.1",
     "numeral": "~1.5.3",
     "patternfly-bootstrap-treeview": "~2.1.1",
-    "patternfly-timeline": "~1.0.2",
+    "patternfly-timeline": "~1.0.3",
     "phantomjs-polyfill": "~0.0.2",
     "qs": "~0.3.10",
     "rx-angular": "rx.angular#~1.1.3",


### PR DESCRIPTION
There were several related bugs that a single change was able to fix related to the timeline popovers.  This addresses the bugs in the link section below and required an update to the patternfly-timeline library.

@dclarizio @h-kataria @serenamarie125 

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1394398
* https://bugzilla.redhat.com/show_bug.cgi?id=1392006
* https://bugzilla.redhat.com/show_bug.cgi?id=1391866
* https://bugzilla.redhat.com/show_bug.cgi?id=1391657

Steps for Testing/QA [Optional]
-------------------------------

Test timeline popovers, the date picker and the mouse hover in Firefox.  All should be fixed with this change.

Before - no wrapping:
![overflowing-text-before](https://cloud.githubusercontent.com/assets/7306953/20390987/48335f32-ac9f-11e6-8d69-04addd436d30.png)

Updated tooltip (with text wrap and slightly wider width:
![screen shot 2016-11-17 at 8 18 34 am](https://cloud.githubusercontent.com/assets/7306953/20390979/37a7a31c-ac9f-11e6-86a0-4a5edde28428.png)

Moved datepicker to open below the input instead of above (which would cause z-index issues)
![datepicker-fix](https://cloud.githubusercontent.com/assets/7306953/20390998/533ecc04-ac9f-11e6-97e6-a884fc49ff01.png)

