### PR TITLE
Support a separate auth URL for external authentication

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -841,6 +841,27 @@ function miqAjaxAuthSso(url) {
   });
 }
 
+// Send External Authentication via ajax
+function miqAjaxExtAuth(url) {
+  miqEnableLoginFields(false);
+  miqSparkleOn();
+
+  // Note: /dashboard/external_authenticate creates an API token
+  //       based on the authenticated external user
+  //       and stores it in sessionStore.miq_token
+
+  var credentials = {
+    login: $('#user_name').val(),
+    password: $('#user_password').val(),
+    serialized: miqSerializeForm('login_div'),
+  }
+
+  miqJqueryRequest(url || '/dashboard/external_authenticate', {
+    beforeSend: true,
+    data: credentials.serialized,
+  });
+}
+
 // add a flash message to an existing #flash_msg_div
 // levels are error, warning, info, success
 function add_flash(msg, level, options) {

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -49,7 +49,7 @@
             = text_field_tag('user_name', @user_name,
                              :class => "form-control",
                              :placeholder => _('Username'),
-                             :onkeypress => "if (miqEnterPressed(event)) miqAjaxAuth();")
+                             :onkeypress => ext_auth? ? "if (miqEnterPressed(event)) miqAjaxExtAuth();" : "if (miqEnterPressed(event)) miqAjaxAuth();")
             = javascript_tag(javascript_focus('user_name'))
 
         .form-group
@@ -57,7 +57,7 @@
           .col-md-9
             = password_field_tag('user_password',
               @user_password,
-              :onkeypress => "if (miqEnterPressed(event)) miqAjaxAuth();",
+              :onkeypress => ext_auth? ? "if (miqEnterPressed(event)) miqAjaxExtAuth();" : "if (miqEnterPressed(event)) miqAjaxAuth();",
               :autocomplete => "off",
               :placeholder => (auth_mode == "httpd" ? _('Password or Password+One-Time-Password') : _('Password')),
               :class => "form-control")
@@ -98,7 +98,7 @@
                       :class                => "btn btn-primary",
                       :alt                  => _("Login"),
                       :title                => _("Login"),
-                      :onclick              => "miqAjaxAuth('#{j login_url}'); return false;")
+                      :onclick              => ext_auth? ? "miqAjaxExtAuth(); return false;" : "miqAjaxAuth('#{j login_url}'); return false;")
 
             = link_to(_("SSO Login"), '',
                       :id                    => "sso_login",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -988,6 +988,7 @@ Vmdb::Application.routes.draw do
         widget_to_pdf
       ),
       :post => %w(
+        external_authenticate
         kerberos_authenticate
         initiate_saml_login
         authenticate


### PR DESCRIPTION
This will allow external auth to only do a single auth at
login, which is requried by OTP configurations.

https://bugzilla.redhat.com/show_bug.cgi?id=1390349