### PR TITLE
Added #destroy_via_queue to MiqAeDomain

### DIFF
--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -153,6 +153,25 @@ class MiqAeDomain < MiqAeNamespace
     "#{domain_name} (#{ref})"
   end
 
+  def destroy_via_queue(user = User.current_user)
+    raise ArgumentError, "User not provided, to destroy_via_queue" unless user
+
+    task_options = {
+      :action => "Destroy domain",
+      :userid => user.userid
+    }
+
+    queue_options = {
+      :class_name  => self.class.to_s,
+      :method_name => "destroy",
+      :instance_id => id,
+      :role        => git_enabled? ? "git_owner" : nil,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
   private
 
   def squeeze_priorities

--- a/lib/miq_automation_engine/models/miq_ae_domain.rb
+++ b/lib/miq_automation_engine/models/miq_ae_domain.rb
@@ -153,8 +153,8 @@ class MiqAeDomain < MiqAeNamespace
     "#{domain_name} (#{ref})"
   end
 
-  def destroy_via_queue(user = User.current_user)
-    raise ArgumentError, "User not provided, to destroy_via_queue" unless user
+  def destroy_queue(user = User.current_user)
+    raise ArgumentError, "User not provided, to destroy_queue" unless user
 
     task_options = {
       :action => "Destroy domain",

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -434,13 +434,13 @@ describe MiqAeDomain do
       let(:task) { FactoryGirl.create(:miq_task) }
       let(:task_options) { {:action => "Destroy domain", :userid => user.userid} }
       let(:queue_options) do
-      {
-        :class_name  => "MiqAeDomain",
-        :instance_id => domain.id,
-        :method_name => "destroy",
-        :role        => role,
-        :args        => []
-      }
+        {
+          :class_name  => "MiqAeDomain",
+          :instance_id => domain.id,
+          :method_name => "destroy",
+          :role        => role,
+          :args        => []
+        }
       end
     end
 
@@ -453,22 +453,22 @@ describe MiqAeDomain do
 
     context "git enabled domain" do
       include_context "domain_context"
-      let (:domain) { FactoryGirl.create(:miq_ae_git_domain) }
-      let (:role) { "git_owner" }
+      let(:domain) { FactoryGirl.create(:miq_ae_git_domain) }
+      let(:role) { "git_owner" }
 
       it_behaves_like "create queue entry"
     end
 
     context "regular domain" do
       include_context "domain_context"
-      let (:domain) { FactoryGirl.create(:miq_ae_domain) }
-      let (:role) { nil }
+      let(:domain) { FactoryGirl.create(:miq_ae_domain) }
+      let(:role) { nil }
 
       it_behaves_like "create queue entry"
     end
 
     context "raises error if user not provided" do
-      let (:domain) { FactoryGirl.create(:miq_ae_domain) }
+      let(:domain) { FactoryGirl.create(:miq_ae_domain) }
       it "raise ArgumentError" do
         expect { domain.destroy(nil) }.to raise_exception(ArgumentError)
       end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -427,4 +427,51 @@ describe MiqAeDomain do
       end
     end
   end
+
+  describe "#destroy_via_queue" do
+    shared_context "domain_context" do
+      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:task) { FactoryGirl.create(:miq_task) }
+      let(:task_options) { {:action => "Destroy domain", :userid => user.userid} }
+      let(:queue_options) do
+      {
+        :class_name  => "MiqAeDomain",
+        :instance_id => domain.id,
+        :method_name => "destroy",
+        :role        => role,
+        :args        => []
+      }
+      end
+    end
+
+    shared_examples_for "create queue entry" do
+      it "valid queue entry" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain.destroy_via_queue(user)).to eq(task.id)
+      end
+    end
+
+    context "git enabled domain" do
+      include_context "domain_context"
+      let (:domain) { FactoryGirl.create(:miq_ae_git_domain) }
+      let (:role) { "git_owner" }
+
+      it_behaves_like "create queue entry"
+    end
+
+    context "regular domain" do
+      include_context "domain_context"
+      let (:domain) { FactoryGirl.create(:miq_ae_domain) }
+      let (:role) { nil }
+
+      it_behaves_like "create queue entry"
+    end
+
+    context "raises error if user not provided" do
+      let (:domain) { FactoryGirl.create(:miq_ae_domain) }
+      it "raise ArgumentError" do
+        expect { domain.destroy(nil) }.to raise_exception(ArgumentError)
+      end
+    end
+  end
 end

--- a/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_domain_spec.rb
@@ -428,7 +428,7 @@ describe MiqAeDomain do
     end
   end
 
-  describe "#destroy_via_queue" do
+  describe "#destroy_queue" do
     shared_context "domain_context" do
       let(:user) { FactoryGirl.create(:user_with_group) }
       let(:task) { FactoryGirl.create(:miq_task) }
@@ -447,7 +447,7 @@ describe MiqAeDomain do
     shared_examples_for "create queue entry" do
       it "valid queue entry" do
         expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
-        expect(domain.destroy_via_queue(user)).to eq(task.id)
+        expect(domain.destroy_queue(user)).to eq(task.id)
       end
     end
 
@@ -470,7 +470,7 @@ describe MiqAeDomain do
     context "raises error if user not provided" do
       let(:domain) { FactoryGirl.create(:miq_ae_domain) }
       it "raise ArgumentError" do
-        expect { domain.destroy(nil) }.to raise_exception(ArgumentError)
+        expect { domain.destroy_queue(nil) }.to raise_exception(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
Added a destroy_via_queue method will will create a task to destroy the domain instance. The destroy would get queued to either the "git_owner" role for Git domains and to any role for regular domains.
 
We still need to change the controller logic to queue the task and wait for it to end.

Links 
----------------
* https://github.com/ManageIQ/manageiq/issues/12696

