### PR TITLE
Call x_node_right_cell method to get correct active node id

### DIFF
--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -441,7 +441,7 @@ module VmCommon
   def snap_pressed
     session[:snap_selected] = from_cid(params[:id])
     @snap_selected = Snapshot.find_by_id(session[:snap_selected])
-    @vm = @record = identify_record(x_node.split('-').last, VmOrTemplate)
+    @vm = @record = identify_record(x_node_right_cell.split('-').last, VmOrTemplate)
     if @snap_selected.nil?
       @display = "snapshot_info"
       add_flash(_("Last selected Snapshot no longer exists"), :error)


### PR DESCRIPTION
Call x_node_right_cell method to get correct active node id back based upon whether VMs are hidden from explorer tree or not, need an id of selected VM to reset @record when user selects a snapshot in snapshot tree.

https://bugzilla.redhat.com/show_bug.cgi?id=1393318

@dclarizio please review.