### PR TITLE
Add Storage Product Features for Adding Roles

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -89,8 +89,6 @@ class OpsController
       rbac_features_tree_add_node("all_vm_rules", root_node[:key], @all_vm_node[:select])
 
       Menu::Manager.each do |section|
-        # skip storage node unless it's enabled in product setting
-        next if section.id == :sto && !VMDB::Config.new("vmdb").config[:product][:storage]
         next if section.id == :cons && !Settings.product.consumption
         next unless Vmdb::PermissionStores.instance.can?(section.id)
 

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -144,7 +144,6 @@ module Menu
           Menu::Item.new('ems_storage',                  N_('Storage Providers'), 'ems_storage',                  {:feature => 'ems_storage_show_list'},                  '/ems_storage'),
           Menu::Item.new('cloud_volume',                 N_('Volumes'),           'cloud_volume',                 {:feature => 'cloud_volume_show_list'},                 '/cloud_volume'),
           Menu::Item.new('cloud_object_store_container', N_('Object Stores'),     'cloud_object_store_container', {:feature => 'cloud_object_store_container_show_list'}, '/cloud_object_store_container'),
-          netapp_enabled ? netapp_storage_menu_section : empty_menu_section
         ])
       end
 

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -80,13 +80,12 @@ describe Menu::DefaultMenu do
     let(:menu) { Menu::DefaultMenu }
 
     context "when the configuration storage product setting is set to true" do
-      it "contains the generic objects item" do
+      it "still does not contain the NetApp item" do
         stub_settings(:product => {:storage => true})
         expect(menu.storage_menu_section.items.map(&:name)).to include(
           "Storage Providers",
           "Volumes",
           "Object Stores",
-          "NetApp"
         )
       end
     end


### PR DESCRIPTION
In accordance with Bugzilla ticket https://bugzilla.redhat.com/show_bug.cgi?id=1395528
the Storage entries are missing from the list of Product Features shown
when attempting to add a new role.

This simple fix restores the Storage entries to the list of Product Features.

![screen shot 2016-11-16 at 5 18 42 pm](https://cloud.githubusercontent.com/assets/6118503/20368158/cabe75ec-ac20-11e6-96fd-baa5e31b0761.png)


Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1395528

Steps for Testing/QA [Optional]
-------------------------------

1. Click on "Configuration" in the menu in the upper right-hand side of the screen.
2. Click on "Access Control" in the accordion menu on the left, then click on "Roles".
3. Configuration -> Add a New Role in the left-hand side drop-down menu.
4. "Storage" should be visible under "Product Features (Editing)", as well as sub-items under Storage.

@h-kataria @dclarizio @roliveri  Please review and merge.  Thanks much.