### PR TITLE
Add configuration_scripts to the list of trees with advanced search

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1552,6 +1552,7 @@ module ApplicationHelper
     %i(containers
        containers_filter
        cs_filter
+       configuration_scripts
        foreman_providers
        images
        images_filter

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1343,6 +1343,20 @@ describe ApplicationHelper do
       expect(result).to be_truthy
     end
 
+    it 'should return true for the configuration scripts tree' do
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :configuration_scripts_tree,
+                                       :trees       => {
+                                         :configuration_scripts_tree => {
+                                           :tree => :configuration_scripts_tree,
+                                           :type => :configuration_scripts
+                                         }
+                                       }
+                                      )
+      result = helper.tree_with_advanced_search?
+      expect(result).to be_truthy
+    end
+
     it 'should return false for tree w/o advanced search' do
       controller.instance_variable_set(:@sb,
                                        :active_tree => :reports_tree,


### PR DESCRIPTION
Add configuration_scripts to the list of trees with advanced search

Links
----------------

Euwe PR:
https://github.com/ManageIQ/manageiq/pull/12717

https://bugzilla.redhat.com/show_bug.cgi?id=1395744

Steps for Testing/QA
-------------------------------
1. Add Tower provider, navigate to Ansible Tower Jobs
2. Navigate to Compute -> Cloud -> Providers
3. Navigate back to Ansible Tower Jobs
