### PR TITLE
[Testing][OpenStack] Adds order to Host.all at OS infra refresh test

### DIFF
--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -44,7 +44,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
       EmsRefresh.refresh(@ems.network_manager)
       @ems.reload
 
-      @host = ManageIQ::Providers::Openstack::InfraManager::Host.all.detect { |x| x.name.include?('(NovaCompute)') }
+      @host = ManageIQ::Providers::Openstack::InfraManager::Host.all.order(:ems_ref).detect { |x| x.name.include?('(NovaCompute)') }
 
       expect(@host.maintenance).to eq(false)
       expect(@host.maintenance_reason).to eq(nil)


### PR DESCRIPTION
This change modifies looking up Hosts at OpenStack Infra Manager
Refresher test for testing maintenance mode by adding order clause.
Without that order the test is brittle b/c db is not bound to return
records in any particular order.

Links [Optional]
----------------
* should solve failure at https://travis-ci.org/ManageIQ/manageiq/jobs/176624003
* should be applied instead of https://github.com/ManageIQ/manageiq/pull/12669

Steps for Testing/QA [Optional]
-------------------------------
The issue manifested itself when running just that one test without
`rake test:vmdb:setup` beforehand. Even though tables were clean after
test this test failed each other time it was run.

* run `bundle exec rake test:vmdb SPEC="spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb:35"` more times in a row - without this patch this fails each second time when using postgresql as db



