### PR TITLE
Automate - Remove user_message updates in 4 methods.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Provisioning/StateMachines/Methods.class/__methods__/provision.rb
@@ -13,6 +13,5 @@ begin
 rescue => err
   $evm.root['ae_result'] = 'error'
   $evm.root['ae_reason'] = err.message
-  task.miq_request.user_message = err.message.truncate(255)
   $evm.log("error", "Stack #{service.stack_name} creation failed. Reason: #{err.message}")
 end

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/check_provisioned.rb
@@ -31,7 +31,6 @@ class AnsibleTowerCheckProvisioned
       @handle.log("info", "Please examine job console output for more details") if @handle.root['ae_result'] == 'error'
 
       job.refresh_ems
-      task.miq_request.user_message = @handle.root['ae_reason'].truncate(255) unless @handle.root['ae_reason'].blank?
     end
   end
 

--- a/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/provision.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/ConfigurationManagement/AnsibleTower/Service/Provisioning/StateMachines/Provision.class/__methods__/provision.rb
@@ -31,7 +31,6 @@ class AnsibleTowerProvision
   rescue => err
     @handle.root['ae_result'] = 'error'
     @handle.root['ae_reason'] = err.message
-    task.miq_request.user_message = err.message.truncate(255)
     @handle.log("error", "Template #{service.job_template.name} launching failed. Reason: #{err.message}")
   end
 end

--- a/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_check_provisioned_spec.rb
@@ -1,0 +1,54 @@
+describe "Orchestration check_provisioned Method Validation" do
+  let(:deploy_result)           { "deploy result" }
+  let(:ems_amazon)              { FactoryGirl.create(:ems_amazon, :last_refresh_date => Time.now - 100) }
+  let(:failure_msg)             { "failure message" }
+  let(:long_failure_msg)        { "t" * 300 }
+  let(:miq_request_task)        { FactoryGirl.create(:miq_request_task, :destination => service_orchestration, :miq_request => request) }
+  let(:request)                 { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+  let(:service_orchestration)   { FactoryGirl.create(:service_orchestration, :orchestration_manager => ems_amazon) }
+  let(:stack_ems_ref)           { "12345" }
+  let(:user)                    { FactoryGirl.create(:user_with_group) }
+  let(:ws)                      { MiqAeEngine.instantiate(ws_url, user) }
+  let(:ws_url)                  { "/Cloud/Orchestration/Provisioning/StateMachines/Methods/CheckProvisioned?MiqRequestTask::service_template_provision_task=#{miq_request_task.id}" }
+  let(:ws_with_refresh_started) { MiqAeEngine.instantiate("#{ws_url}&ae_state_data=#{URI.escape(YAML.dump('provider_last_refresh' => Time.now.to_i, 'deploy_result' => deploy_result))}", user) }
+
+  it "waits for the deployment to complete" do
+    allow_any_instance_of(ServiceOrchestration).to receive(:orchestration_stack_status) { ['CREATING', nil] }
+    expect(ws.root['ae_result']).to eq('retry')
+  end
+
+  it "catches the error during stack deployment" do
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status).and_return(['CREATE_FAILED', failure_msg])
+    expect(ws.root['ae_result']).to eq('error')
+    expect(ws.root['ae_reason']).to eq(failure_msg)
+  end
+
+  it "considers rollback as provision error" do
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status) { ['ROLLBACK_COMPLETE', 'Stack was rolled back'] }
+    expect(ws.root['ae_result']).to eq('error')
+    expect(ws.root['ae_reason']).to eq('Stack was rolled back')
+  end
+
+  it "refreshes the provider and waits for it to complete" do
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack_status) { ['CREATE_COMPLETE', nil] }
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_amazon) }
+    expect_any_instance_of(ManageIQ::Providers::Amazon::CloudManager).to receive(:refresh_ems)
+    expect(ws.root['ae_result']).to eq('retry')
+  end
+
+  it "waits the refresh to complete" do
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack) { FactoryGirl.build(:orchestration_stack_amazon) }
+    expect(ws_with_refresh_started.root['ae_result']).to eq("retry")
+  end
+
+  it "completes check_provisioned step when refresh is done" do
+    allow_any_instance_of(ServiceOrchestration)
+      .to receive(:orchestration_stack) { FactoryGirl.create(:orchestration_stack_amazon, :status => "success") }
+    expect(ws_with_refresh_started.root['ae_result']).to eq(deploy_result)
+  end
+end

--- a/spec/automation/unit/method_validation/orchestration_provision_spec.rb
+++ b/spec/automation/unit/method_validation/orchestration_provision_spec.rb
@@ -14,7 +14,7 @@ describe "Orchestration provision Method Validation" do
     allow_any_instance_of(ServiceOrchestration).to receive(:deploy_orchestration_stack) { raise "test failure" }
     expect(ws.root['ae_result']).to eq("error")
     expect(ws.root['ae_reason']).to eq("test failure")
-    expect(request.reload.message).to eq("test failure")
+    expect(request.reload.message).to eq("Service_Template_Provisioning - Request Created")
   end
 
   it "truncates the error message exceeding 255 character limits" do
@@ -22,6 +22,6 @@ describe "Orchestration provision Method Validation" do
     allow_any_instance_of(ServiceOrchestration).to receive(:deploy_orchestration_stack) { raise long_error }
     expect(ws.root['ae_result']).to eq("error")
     expect(ws.root['ae_reason']).to eq(long_error)
-    expect(request.reload.message).to eq('t' * 252 + '...')
+    expect(request.reload.message).to eq("Service_Template_Provisioning - Request Created")
   end
 end


### PR DESCRIPTION
Modified check_provisioned and provision methods in Cloud/Orchestration and ConfigurationManagement/Ansible provision classes.

Enhanced messaging replaces these messages.

https://www.pivotaltracker.com/story/show/134512481