### PR TITLE
Correct task icon styling

### DIFF
--- a/app/views/miq_task/_tasks_options.html.haml
+++ b/app/views/miq_task/_tasks_options.html.haml
@@ -43,23 +43,28 @@
       .col-md-8
         = check_box_tag("queued", "1", @tasks_options[@tabform][:queued], "data-miq_observe_checkbox" => {:url => url}.to_json)
         &nbsp;
-        %img{:src => image_path('16/job-queued.png'), :valign => "middle", :title => _("Queued")}= _("Queued")
+        %i.fa.fa-step-forward
+        = _("Queued")
         &nbsp;
         = check_box_tag("running", "1", @tasks_options[@tabform][:running], "data-miq_observe_checkbox" => {:url => url}.to_json)
         &nbsp;
-        %img{:src => image_path('16/job-running.png'), :valign => "middle", :title => _("Warn")}= _("Running")
+        %i.pficon.pficon-running
+        = _("Running")
         &nbsp;
         = check_box_tag("ok", "1", @tasks_options[@tabform][:ok], "data-miq_observe_checkbox" => {:url => url}.to_json)
         &nbsp;
-        %img{:src => image_path('100/checkmark.png'), :valign => "middle", :title => _("Ok"), :style => "height: 16px;"}= _("Ok")
+        %i.pficon.pficon-ok
+        = _("Ok")
         &nbsp;
         = check_box_tag("error", "1", @tasks_options[@tabform][:error], "data-miq_observe_checkbox" => {:url => url}.to_json)
         &nbsp;
-        %img{:src => image_path('100/x.png'), :valign => "middle", :title => _("Error"), :style => "height: 16px;"}= _("Error")
+        %i.pficon.pficon-error-circle-o
+        = _("Error")
         &nbsp;
         = check_box_tag("warn", "1", @tasks_options[@tabform][:warn], "data-miq_observe_checkbox" => {:url => url}.to_json)
         &nbsp;
-        %img{:src => image_path('16/warning.png'), :valign => "middle", :title => _("Warn")}= _("Warn")
+        %i.pficon.pficon-warning-triangle-o
+        = _("Warn")
     .form-group
       %label.control-label.col-md-2
         = _("Task State")


### PR DESCRIPTION
The PR fixes some alignment problems with images on the Task screens and also converts the PNGs to font icons.

Old
https://bugzilla.redhat.com/show_bug.cgi?id=1393881
https://www.pivotaltracker.com/n/projects/1613907/stories/123185601

![screen shot 2016-11-17 at 10 18 44 am](https://cloud.githubusercontent.com/assets/1287144/20394941/3dbad21e-acaf-11e6-9c4b-56750b27ccba.png)

New
![screen shot 2016-11-17 at 10 02 32 am](https://cloud.githubusercontent.com/assets/1287144/20394929/3272d0f0-acaf-11e6-8d75-6bf98477a25a.png)
