### PR TITLE
Fix for service dialog refreshing every time a dropdown item is selected

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -15,7 +15,7 @@ var dialogFieldRefresh = {
       $('#' + fieldName).selectpicker('val', selectedValue);
     }
     miqSelectPickerEvent(fieldName, url, {callback: function() {
-      dialogFieldRefresh.triggerAutoRefresh(fieldId, triggerAutoRefresh || "true");
+      dialogFieldRefresh.triggerAutoRefresh(fieldId, triggerAutoRefresh);
       return true;
     }});
   },
@@ -168,7 +168,7 @@ var dialogFieldRefresh = {
 
 
   triggerAutoRefresh: function(fieldId, trigger) {
-    if (trigger === "true") {
+    if (Boolean(trigger) === true) {
       parent.postMessage({fieldId: fieldId}, '*');
     }
   },

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -423,14 +423,36 @@ describe('dialogFieldRefresh', function() {
       expect(window.miqSelectPickerEvent).toHaveBeenCalledWith('fieldName', 'url', {callback: jasmine.any(Function)});
     });
 
-    it('triggers the auto refresh when the drop down changes', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
+    it('triggers autorefresh with true only when triggerAutoRefresh arg is true', function() {
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url, 'true');
       expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'true');
     });
+  });
 
-    it('triggers autorefresh with "false" when triggerAutoRefresh arg is false', function() {
-      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url, 'false');
-      expect(dialogFieldRefresh.triggerAutoRefresh).toHaveBeenCalledWith(fieldId, 'false');
+  describe('#triggerAutoRefresh', function() {
+    beforeEach(function() {
+      spyOn(parent, 'postMessage');
+    });
+
+    context('when the trigger passed in falsy', function() {
+      it('does not post any messages', function() {
+        dialogFieldRefresh.triggerAutoRefresh(123, "");
+        expect(parent.postMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    context('when the trigger passed in is the string "true"', function() {
+      it('posts a message', function() {
+        dialogFieldRefresh.triggerAutoRefresh(123, "true");
+        expect(parent.postMessage).toHaveBeenCalledWith({fieldId: 123}, '*');
+      });
+    });
+
+    context('when the trigger passed in is true', function() {
+      it('posts a message', function() {
+        dialogFieldRefresh.triggerAutoRefresh(123, true);
+        expect(parent.postMessage).toHaveBeenCalledWith({fieldId: 123}, '*');
+      });
     });
   });
 });


### PR DESCRIPTION
The problem in the below linked BZ was that `""` was being passed in as the `trigger_auto_refresh` property, and then was getting `||`'d with `"true"`, and so it was always causing a refresh.

This fix will ensure that the triggerAutoRefresh method will be able to handle any values that come through even if they are not explicitly "false" or "true", and coerce them into `false` or `true`.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1396167

@miq-bot assign @gmcculloug 

/cc @syncrou Can you review this for me, please?