### PR TITLE
[EUWE] Advanced search not working for the ansible job 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1195,7 +1195,7 @@ module ApplicationHelper
                      ontap_file_share ontap_logical_disk ontap_storage_system ontap_storage_volume
                      ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
                      ems_storage load_balancer
-                     orchestration_stack resource_pool retired service configuration_job
+                     orchestration_stack resource_pool retired service configuration_job configuration_scripts
                      snia_local_file_system storage_manager templates vm)
     (@lastaction == "show_list" && !session[:menu_click] && show_search.include?(@layout) && !@in_a_form) ||
       (@explorer && x_tree && tree_with_advanced_search? && !@record)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1415,6 +1415,22 @@ describe ApplicationHelper do
       result = helper.show_adv_search?
       expect(result).to be_truthy
     end
+
+    it 'should return true for configuration scripts tree' do
+      controller.instance_variable_set(:@explorer, true)
+      controller.instance_variable_set(:@sb,
+                                       :active_tree => :configuration_scripts_tree,
+                                       :trees       => {
+                                         :configuration_scripts_tree => {
+                                           :tree => :configuration_scripts_tree,
+                                           :type => :configuration_scripts
+                                         }
+                                       }
+      )
+      allow(helper).to receive(:tree_with_advanced_search?).and_return(true)
+      result = helper.show_adv_search?
+      expect(result).to be_truthy
+    end
   end
 
   context "#show_advanced_search?" do


### PR DESCRIPTION
Advanced search not working for the Ansible Tower Jobs
- this is a EUWE issue only - does not occur upstream

Links [Optional]
----------------
Depends on https://github.com/ManageIQ/manageiq/pull/12717

https://bugzilla.redhat.com/show_bug.cgi?id=1395722 


Steps for Testing/QA
-------------------------------
1. Add Tower provider which has Job templates defined and refresh it
2. Navigate to Ansible Tower Job templates
3. Click on Advanced Search icon - the dialog does not open
If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.
