### PR TITLE
Send back IDs in content of Service Dialog subcollection

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -101,7 +101,7 @@ class Dialog < ApplicationRecord
       # Accessing dialog_field.values forces an update for any values coming from automate
       dialog_field.values = dialog_field.values
     end
-    DialogSerializer.new.serialize(Array[workflow.dialog])
+    DialogSerializer.new.serialize(Array[workflow.dialog], all_attributes)
   end
 
   # Allows you to pass dialog tabs as a hash

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -272,12 +272,15 @@ describe "Service Dialogs API" do
       expect_result_resources_to_include_data("resources", "label" => dialogs.pluck(:label))
     end
 
-    it "queries service dialogs content with the template and related resource action specified" do
-      expect_any_instance_of(Dialog).to receive(:content).with(template, ra1, true)
-
+    it "queries service dialogs content with the template and related resource action specified and returns IDs" do
       run_get "#{service_templates_url(template.id)}/service_dialogs/#{dialog1.id}", :attributes => "content"
+      expected = {
+        'content' => a_collection_including(
+          a_hash_including('id' => dialog1.id)
+        )}
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
     end
   end
 


### PR DESCRIPTION
Fixes bug where IDs are not being passed back in the Service Dialog subcollection and adds a test for ensuring an ID is present in the content.

closes #12658 

@miq-bot add_label bug, api
@miq-bot assign @abellotti 