### PR TITLE
Isolate MiqSchedule ui attributes

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -74,7 +74,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.object_request  = data.object_request;
         $scope.scheduleModel.target_class    = data.target_class;
         $scope.scheduleModel.target_id       = data.target_id;
-        $scope.scheduleModel.attrs           = data.attrs;
+        $scope.scheduleModel.ui_attrs        = data.ui_attrs;
 
         $scope.setTimerType();
 
@@ -213,11 +213,11 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.instance_name   = data.instance_name;
         $scope.scheduleModel.object_message  = data.object_message;
         $scope.scheduleModel.object_request  = data.request;
-        $scope.scheduleModel.target_class    = data.object_class;
-        $scope.scheduleModel.target_id       = data.object_id;
+        $scope.scheduleModel.target_class    = data.target_class;
+        $scope.scheduleModel.target_id       = data.target_id;
         $scope.scheduleModel.targets         = [];
         $scope.scheduleModel.filter_typ      = null;
-        $scope.scheduleModel.attrs           = data.attrs;
+        $scope.scheduleModel.ui_attrs        = data.ui_attrs;
         miqService.sparkleOff();
       });
     } else {

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -512,11 +512,9 @@ module OpsController::Settings::Schedules
           :instance  => params[:instance_name],
           :message   => params[:object_message]
         },
-        :ui => {:ui_attrs => ui_attrs,
-                :ui_object => {:target_class => params[:target_class].present? ? params[:target_class] : nil,
-                               :target_id    => params[:target_id]
-                              }
-        },
+        :ui         => {:ui_attrs  => ui_attrs,
+                        :ui_object => {:target_class => params[:target_class].present? ? params[:target_class] : nil,
+                                       :target_id    => params[:target_id]}},
         :parameters => {
           :request        => params[:object_request],
           :instance_name  => params[:instance_name],
@@ -536,7 +534,7 @@ module OpsController::Settings::Schedules
     return {} if params[:target_class].empty?
     klass = params[:target_class].constantize
     object = klass.find_by_id(params[:target_id])
-    {"#{MiqAeEngine.create_automation_attribute_key(object)}" => MiqAeEngine.create_automation_attribute_value(object)}
+    { MiqAeEngine.create_automation_attribute_key(object).to_s => MiqAeEngine.create_automation_attribute_value(object) }
   end
 
   def build_search_filter_from_params

--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -27,7 +27,9 @@ class AutomationRequest < MiqRequest
     options[:class_name]    = (options.delete(:class) || DEFAULT_CLASS).strip.gsub(/(^\/|\/$)/, "")
     options[:instance_name] = (options.delete(:instance) || DEFAULT_INSTANCE).strip
 
+    object_parameters = parse_out_objects(parameters)
     attrs = MiqRequestWorkflow.parse_ws_string(parameters)
+    attrs.merge!(object_parameters)
 
     attrs[:userid]     = user.userid
     options[:user_id]  = user.id
@@ -43,6 +45,13 @@ class AutomationRequest < MiqRequest
     uri_parts.stringify_keys!
     parameters.stringify_keys!
     create_from_ws("1.1", user, uri_parts, parameters, approval)
+  end
+
+  def self.parse_out_objects(parameters)
+    object_hash = parameters.select { |key, _v| key.to_s.include?(MiqAeEngine::MiqAeObject::CLASS_SEPARATOR) }
+    object_hash.each do |key, _v|
+      parameters.delete(key)
+    end
   end
 
   def self.zone(options)

--- a/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
+++ b/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
@@ -64,16 +64,16 @@
 
   %div
     = _("Attribute/Value Pairs")
-    .form-group{"ng-repeat" => "key_val in scheduleModel.attrs track by $index"}
+    .form-group{"ng-repeat" => "key_val in scheduleModel.ui_attrs track by $index"}
       %label.col-md-2.control-label{"for" => "key_val"}
         {{$index+1}}
       .col-md-2
         %input.form-control{"type"        => "text",
                             "name"        => "attrs",
-                            "ng-model"    => "scheduleModel.attrs[$index][0]",
+                            "ng-model"    => "scheduleModel.ui_attrs[$index][0]",
                             "checkchange" => ""}
       .col-md-2
         %input.form-control{"type"        => "text",
                             "name"        => "attrs",
-                            "ng-model"    => "scheduleModel.attrs[$index][1]",
+                            "ng-model"    => "scheduleModel.ui_attrs[$index][1]",
                             "checkchange" => ""}

--- a/app/views/ops/_schedule_show.html.haml
+++ b/app/views/ops/_schedule_show.html.haml
@@ -77,10 +77,10 @@
             %p.form-control-static
               = h(@object_name)
 
-      - if @selected_schedule.filter[:parameters][:attrs].present?
+      - if @selected_schedule.filter[:ui][:ui_attrs].present?
         %div
           = _("Attribute/Value Pairs")
-          - @selected_schedule.filter[:parameters][:attrs].each_with_index do |attr, i|
+          - @selected_schedule.filter[:ui][:ui_attrs].each_with_index do |attr, i|
             .form-group
               %label.control-label.col-md-2
                 = (i + 1).to_s

--- a/spec/factories/miq_schedule.rb
+++ b/spec/factories/miq_schedule.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
   factory :miq_automate_schedule, :class => :MiqSchedule do
     run_at = {:start_time   => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}}
     sched_action = {:method => "automation_request"}
-    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :parameters => {'request' => 'test_request', 'key1' => 'value1'}}
+    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :ui => { :ui_attrs => [], :ui_object => {} }, :parameters => {'request' => 'test_request', 'key1' => 'value1'}}
     sequence(:name)     { |n| "automate_schedule_#{seq_padded_for_sorting(n)}" }
     description         "test_automation"
     towhat              "AutomationRequest"

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -601,8 +601,9 @@ describe('scheduleFormController', function() {
         request: 'test_request',
         instance_name: 'TestRequest',
         object_message: 'create',
-        object_class: 'test',
-        object_id:    '10',
+        target_class: 'test',
+        target_id:    '10',
+        ui_attrs:     [],
         uri: 'uri',
         uri_prefix: 'uriPrefix'
       };
@@ -619,8 +620,9 @@ describe('scheduleFormController', function() {
         expect($scope.scheduleModel.instance_name).toEqual(data.instance_name);
         expect($scope.scheduleModel.object_message).toEqual(data.object_message);
         expect($scope.scheduleModel.object_request).toEqual(data.request);
-        expect($scope.scheduleModel.target_class).toEqual(data.object_class);
-        expect($scope.scheduleModel.target_id).toEqual(data.object_id);
+        expect($scope.scheduleModel.target_class).toEqual(data.target_class);
+        expect($scope.scheduleModel.ui_attrs).toEqual(data.ui_attrs);
+        expect($scope.scheduleModel.target_id).toEqual(data.target_id);
       });
     });
 


### PR DESCRIPTION
`AutomateRequest.create_from_ws` was downcasing and symbolizing MiqSchedule objects that were passed in via the `filter[:parameters]` hash.

This PR isolates all Ui attributes into their own `[:ui]` hash structure and modifies how `AutomateRequest.create_from_ws` parses objects in the `[:parameters]` hash.

e.g. Any key including `MiqAeEngine::MiqAeObject::CLASS_SEPARATOR` is isolated away from the other parameters and merged back in after calling `MiqRequestWorkflow.parse_ws_string(parameters)`

Links
----------------

* [PT #134531729](https://www.pivotaltracker.com/story/show/134531729)

Steps for Testing/QA
-------------------------------

1. Build a Scheduled Automate Job with Type and Selection of Object Attributes filled in.
2. Run the scheduled job and verify the job runs with the expected Object Attributes

<img width="1008" alt="screen shot 2016-11-17 at 1 04 07 pm" src="https://cloud.githubusercontent.com/assets/697347/20401357/7ffb830a-acc6-11e6-969c-594453806dfd.png">
