### PR TITLE
Introduce new catalog item type named Container

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -132,8 +132,9 @@ class CatalogController < ApplicationController
       "amazon"                => "Amazon",
       "azure"                 => "Azure",
       "generic"               => "Generic",
-      "generic_orchestration" => "Orchestration",
       "generic_ansible_tower" => "AnsibleTower",
+      "generic_container"     => "Container",
+      "generic_orchestration" => "Orchestration",
       "google"                => "Google",
       "microsoft"             => "SCVMM",
       "openstack"             => "OpenStack",
@@ -896,6 +897,7 @@ class CatalogController < ApplicationController
     common_st_record_vars(st)
     add_orchestration_template_vars(st) if st.kind_of?(ServiceTemplateOrchestration)
     add_ansible_tower_job_template_vars(st) if st.kind_of?(ServiceTemplateAnsibleTower)
+    add_container_template_vars(st) if st.kind_of?(ServiceTemplateContainer)
     st.service_type = "atomic"
 
     if request
@@ -1291,6 +1293,7 @@ class CatalogController < ApplicationController
     @edit[:new][:available_catalogs] = @edit[:new][:available_catalogs].sort
     available_orchestration_templates if @record.kind_of?(ServiceTemplateOrchestration)
     available_ansible_tower_managers if @record.kind_of?(ServiceTemplateAnsibleTower)
+    available_container_managers if @record.kind_of?(ServiceTemplateContainer)
 
     # initialize fqnames
     @edit[:new][:fqname] = @edit[:new][:reconfigure_fqname] = @edit[:new][:retire_fqname] = ""
@@ -1432,6 +1435,7 @@ class CatalogController < ApplicationController
 
     get_form_vars_orchestration if @edit[:new][:st_prov_type] == 'generic_orchestration'
     get_form_vars_ansible_tower if @edit[:new][:st_prov_type] == 'generic_ansible_tower'
+    get_form_vars_container     if @edit[:new][:st_prov_type] == 'generic_container'
   end
 
   def get_form_vars_orchestration
@@ -1457,6 +1461,20 @@ class CatalogController < ApplicationController
       else
         @edit[:new][:manager_id] = params[:manager_id]
         available_ansible_tower_job_templates(params[:manager_id])
+      end
+    end
+    @edit[:new][:template_id] = params[:template_id] if params[:template_id]
+  end
+
+  def get_form_vars_container
+    if params[:manager_id]
+      if params[:manager_id] == ""
+        @edit[:new][:available_templates] = []
+        @edit[:new][:template_id]         = nil
+        @edit[:new][:manager_id]          = nil
+      else
+        @edit[:new][:manager_id] = params[:manager_id]
+        available_container_templates(params[:manager_id])
       end
     end
     @edit[:new][:template_id] = params[:template_id] if params[:template_id]
@@ -1498,6 +1516,19 @@ class CatalogController < ApplicationController
     available_ansible_tower_job_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
   end
 
+  def available_container_templates(manager_id)
+    @edit[:new][:available_templates] =
+      ExtManagementSystem.find_by(:id => manager_id).container_templates.collect { |t| [t.name, t.id] }.sort
+  end
+
+  def available_container_managers
+    @edit[:new][:available_managers] =
+      ManageIQ::Providers::ContainerManager.all.collect { |t| [t.name, t.id] }.sort
+    @edit[:new][:template_id] = @record.container_template.try(:id)
+    @edit[:new][:manager_id] = @record.container_manager.try(:id)
+    available_container_templates(@edit[:new][:manager_id]) if @edit[:new][:manager_id]
+  end
+
   def add_orchestration_template_vars(st)
     st.orchestration_template = @edit[:new][:template_id].nil? ?
       nil : OrchestrationTemplate.find_by_id(@edit[:new][:template_id])
@@ -1508,6 +1539,11 @@ class CatalogController < ApplicationController
   def add_ansible_tower_job_template_vars(st)
     st.job_template = @edit[:new][:template_id].nil? ?
       nil : ConfigurationScript.find_by(:id => @edit[:new][:template_id])
+  end
+
+  def add_container_template_vars(st)
+    st.container_template = @edit[:new][:template_id].nil? ?
+      nil : ContainerTemplate.find_by(:id => @edit[:new][:template_id])
   end
 
   def st_get_form_vars

--- a/app/models/mixins/service_container_mixin.rb
+++ b/app/models/mixins/service_container_mixin.rb
@@ -1,0 +1,20 @@
+module ServiceContainerMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :container_templates, :through => :service_resources, :source => :resource, :source_type => 'ContainerTemplate'
+    private :container_templates, :container_templates=
+  end
+
+  def container_template
+    container_templates.take
+  end
+
+  def container_template=(template)
+    self.container_templates = [template].compact
+  end
+
+  def container_manager
+    container_template.try(:ext_management_system)
+  end
+end

--- a/app/models/service_container.rb
+++ b/app/models/service_container.rb
@@ -1,0 +1,30 @@
+class ServiceContainer < Service
+  include ServiceContainerMixin
+
+  # The live status of the deployment from provider
+  def deployment_status
+    # TODO
+  end
+
+  def deploy_container_template
+    # TODO
+  ensure
+    # create options may never be saved before unless they were overridden
+    save_deployment_options
+  end
+
+  def build_deployment_options_from_dialog(_dialog_options)
+    # TODO
+  end
+
+  # This is called when provision is completed
+  def post_provision_configure
+    # TODO
+  end
+
+  private
+
+  def save_create_options
+    # TODO
+  end
+end

--- a/app/models/service_template_container.rb
+++ b/app/models/service_template_container.rb
@@ -1,0 +1,27 @@
+class ServiceTemplateContainer < ServiceTemplate
+  include ServiceContainerMixin
+
+  before_save :remove_invalid_resource
+
+  def remove_invalid_resource
+    # remove the resource from both memory and table
+    service_resources.to_a.delete_if { |r| r.destroy unless r.resource(true) }
+  end
+
+  def create_subtasks(_parent_service_task, _parent_service)
+    # no sub task is needed for this service
+    []
+  end
+
+  def self.default_provisioning_entry_point(_service_type)
+    '/Container/Service/Provisioning/StateMachines/Provision/CatalogItemInitialization'
+  end
+
+  def self.default_reconfiguration_entry_point
+    nil
+  end
+
+  def self.default_retirement_entry_point
+    nil
+  end
+end

--- a/app/views/catalog/_form_basic_info.html.haml
+++ b/app/views/catalog/_form_basic_info.html.haml
@@ -116,6 +116,30 @@
                           :class                => "selectpicker")
             :javascript
               miqSelectPickerEvent('template_id', '#{url}')
+    - elsif @edit[:new][:st_prov_type] == "generic_container"
+      - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_managers]
+      .form-group
+        %label.col-md-2.control-label
+          = _('Provider')
+        .col-md-8
+          = select_tag('manager_id',
+                       options_for_select(opts, @edit[:new][:manager_id]),
+                       "data-miq_sparkle_on" => true,
+                       :class                => "selectpicker")
+          :javascript
+            miqSelectPickerEvent('manager_id', '#{url}')
+      - if @edit[:new][:manager_id]
+        - opts = [["<#{_('Choose')}>", nil]] + @edit[:new][:available_templates]
+        .form-group
+          %label.col-md-2.control-label
+            = _('Container Template')
+          .col-md-8
+            = select_tag('template_id',
+                          options_for_select(opts, @edit[:new][:template_id]),
+                          "data-miq_sparkle_on" => true,
+                          :class                => "selectpicker")
+            :javascript
+              miqSelectPickerEvent('template_id', '#{url}')
     .form-group
       %label.col-md-2.control-label{:title => _("Provisioning Entry Point (NameSpace/Class/Instance)")}
         = _('Provisioning Entry Point')

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -64,6 +64,12 @@
               = _('Ansible Tower Job Template')
             .col-md-8
               = h(@record.try(:job_template).try(:name))
+        - elsif @record.prov_type == "generic_container"
+          .form-group
+            %label.col-md-2.control-label
+              = _('Container Template')
+            .col-md-8
+              = h(@record.try(:container_template).try(:name))
         - entry_points = [[_("Provisioning"), :fqname]]
         - unless @record.prov_type.try(:start_with?, "generic_")
           - entry_points.push([_("Reconfigure"),  :reconfigure_fqname],

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_container.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_container.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceContainer < MiqAeServiceService
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_container.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_container.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceTemplateContainer < MiqAeServiceServiceTemplate
+  end
+end


### PR DESCRIPTION
This work add new models and service models that allow to do provisioning through container templates, following the examples for Orchestration or AnsibleTower.

It also modified the controller and ui to allow to define a new catalog item type Container.

This request provides sufficient code to create a catalog item, together with #12598 ordering such service runs completed but does no actual container template deployment. The actual deployment logic is yet to be added in following up PRs.

No spec tests are added in the PR. They should be added together with the future PRs for container template deployment.