### PR TITLE
Code Climate: Limit the duplication engine's concurrency to 1

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -35,6 +35,7 @@ engines:
   duplication:
     enabled: true
     config:
+      concurrency: 1
       languages:
       - ruby
       - javascript


### PR DESCRIPTION
We're doing this to see if this helps resolve a possible concurrency
issue that causes the duplication engine to create NOISE in the rss feed
where a very small subset of files will drop in grade and soon after
return to the same grade.

Code Climate's support suggested we try it out and let them know if it
helps.

Related: https://github.com/codeclimate/flay/pull/3

[skip ci]

Example noise:
![image](https://cloud.githubusercontent.com/assets/19339/20405675/2dcb1fd4-acd8-11e6-8222-5d0c7b81bda1.png)

