### PR TITLE
Move snapshot code to Vm in service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
@@ -11,26 +11,5 @@ module MiqAeMethodService
     def add_disk(disk_name, disk_size_mb, options = {})
       sync_or_async_ems_operation(options[:sync], "add_disk", [disk_name, disk_size_mb])
     end
-
-    def create_snapshot(name, desc = nil, memory = false)
-      snapshot_operation(:create_snapshot, :name => name, :description => desc, :memory => !!memory)
-    end
-
-    def remove_all_snapshots
-      snapshot_operation(:remove_all_snapshots)
-    end
-
-    def remove_snapshot(snapshot_id)
-      snapshot_operation(:remove_snapshot, :snap_selected => snapshot_id)
-    end
-
-    def revert_to_snapshot(snapshot_id)
-      snapshot_operation(:revert_to_snapshot, :snap_selected => snapshot_id)
-    end
-
-    def snapshot_operation(task, options = {})
-      options.merge!(:ids => [id], :task => task.to_s)
-      Vm.process_tasks(options)
-    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -8,5 +8,29 @@ module MiqAeMethodService
     def remove_from_service
       ar_method { wrap_results(@object.direct_service.try(:remove_resource, @object)) }
     end
+
+    def create_snapshot(name, desc = nil, memory = false)
+      snapshot_operation(:create_snapshot, :name => name, :description => desc, :memory => !!memory)
+    end
+
+    def remove_all_snapshots
+      snapshot_operation(:remove_all_snapshots)
+    end
+
+    def remove_snapshot(snapshot_id)
+      snapshot_operation(:remove_snapshot, :snap_selected => snapshot_id)
+    end
+
+    def revert_to_snapshot(snapshot_id)
+      snapshot_operation(:revert_to_snapshot, :snap_selected => snapshot_id)
+    end
+
+    def snapshot_operation(task, options = {})
+      raise "#{task} operation not supported for #{self.class.name}" unless object_send(:supports_snapshots?)
+
+      options[:ids]  = [id]
+      options[:task] = task.to_s
+      Vm.process_tasks(options)
+    end
   end
 end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -1,5 +1,5 @@
-module MiqAeServiceVmVmwareSpec
-  describe MiqAeMethodService::MiqAeServiceUser do
+module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_VmSpec
+  describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm do
     let(:vm)         { FactoryGirl.create(:vm_vmware) }
     let(:service_vm) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
 
@@ -58,28 +58,6 @@ module MiqAeServiceVmVmwareSpec
         @base_queue_options.merge(
           :method_name => 'vm_destroy',
           :args        => [])
-      )
-    end
-
-    it "#create_snapshot without memory" do
-      service_vm.create_snapshot('snap', 'crackle & pop')
-
-      expect(MiqQueue.first.args.first).to have_attributes(
-        :task        => 'create_snapshot',
-        :memory      => false,
-        :name        => 'snap',
-        :description => 'crackle & pop'
-      )
-    end
-
-    it "#create_snapshot with memory" do
-      service_vm.create_snapshot('snap', 'crackle & pop', true)
-
-      expect(MiqQueue.first.args.first).to have_attributes(
-        :task        => 'create_snapshot',
-        :memory      => true,
-        :name        => 'snap',
-        :description => 'crackle & pop'
       )
     end
   end


### PR DESCRIPTION
The snapshot code in automate was moved from VmOrTemplate to VMware specific class by PR https://github.com/ManageIQ/manageiq/pull/3707 when VMware was the only class that supported snapshot.

But snapshot support has been added to RHEVM and Openstack as of version Euwe.
The snapshot code in automate should be made available at Vm level.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1395175

cc @gmcculloug @mkanoor 