### PR TITLE
Allow apostrophes in email address

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
 
   validates_presence_of   :name, :userid
   validates :userid, :uniqueness => {:conditions => -> { in_my_region } }
-  validates_format_of     :email, :with => /\A([\w\.\-\+]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i,
+  validates_format_of     :email, :with => /\A([\w\.\-\+']+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i,
     :allow_nil => true, :message => "must be a valid email address"
   validates_inclusion_of  :current_group, :in => proc { |u| u.miq_groups }, :allow_nil => true
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,6 +23,10 @@ describe User do
     it "should reject invalid characters in email address" do
       expect(FactoryGirl.build(:user, :email => "{{that.guy}}@manageiq.com")).not_to be_valid
     end
+
+    it "allows apostrophes in email address" do
+      expect(FactoryGirl.build(:user, :email => "timmy.o'toole@manageiq.com")).to be_valid
+    end
   end
 
   describe "#change_password" do


### PR DESCRIPTION
The email validation regex is too restrictive and does not allow
apostrophes.

Even with this change, the regex is probably still too
restrictive. I am personally in favor of advice outlined in
[this post](https://davidcel.is/posts/stop-validating-email-addresses-with-regex/),
which is, to summarize:

1) Don't validate emails with regex, send an email to it instead
2) If you must, use a very permissive one

Since both (1) is probably beyond the scope of this bugfix, and (2)
breaks existing tests (and I don't know if there are good reasons for
their being there), I want to recommend that we fix the specific problem
outlined in the BZ first, and try to address the general problem in a
follow up.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1379420

@miq-bot add-label bug, core, blocker
@miq-bot assign @gtanzillo 