### PR TITLE
[EUWE] Add Storage Product Features for Adding Roles

### DIFF
--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -89,8 +89,6 @@ class OpsController
       rbac_features_tree_add_node("all_vm_rules", root_node[:key], @all_vm_node[:select])
 
       Menu::Manager.each do |section|
-        # skip storage node unless it's enabled in product setting
-        next if section.id == :sto && !VMDB::Config.new("vmdb").config[:product][:storage]
         next if section.id == :cons && !Settings.product.consumption
         next unless Vmdb::PermissionStores.instance.can?(section.id)
 

--- a/app/presenters/menu/default_menu.rb
+++ b/app/presenters/menu/default_menu.rb
@@ -187,7 +187,6 @@ module Menu
                                            'cloud_object_store_container',
                                            {:feature => 'cloud_object_store_container_show_list'},
                                            '/cloud_object_store_container'),
-                            netapp_enabled ? netapp_storage_menu_section : empty_menu_section
                           ])
       end
 

--- a/spec/presenters/menu/default_menu_spec.rb
+++ b/spec/presenters/menu/default_menu_spec.rb
@@ -87,12 +87,11 @@ describe Menu::DefaultMenu do
     context "when the configuration storage product setting is set to true" do
       let(:product_setting) { true }
 
-      it "contains the generic objects item" do
+      it "still does not contain the NetApp item" do
         expect(menu.storage_menu_section.items.map(&:name)).to include(
           "Storage Providers",
           "Volumes",
           "Object Stores",
-          "NetApp"
         )
       end
     end


### PR DESCRIPTION
In accordance with Bugzilla ticket https://bugzilla.redhat.com/show_bug.cgi?id=1395528
the Storage entries are missing from the list of Product Features shown
when attempting to add a new role.

This simple fix restores the Storage entries to the list of Product Features.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1395528
* https://github.com/ManageIQ/manageiq/pull/12701


Steps for Testing/QA
-------------------------------

1. Click on "Configuration" in the menu in the upper right-hand side of the screen.
2. Click on "Access Control" in the accordion menu on the left, then click on "Roles".
3. Configuration -> Add a New Role in the left-hand side drop-down menu.
4. "Storage" should be visible under "Product Features (Editing)", as well as sub-items under Storage.

@chessbyte just having fun with git and github.  All is ready to go.