### PR TITLE
Unset the server hostname when it matches `/.*localhost.*/`

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -194,6 +194,7 @@ class MiqServer < ApplicationRecord
     end
 
     unless hostname.blank?
+      hostname = nil if hostname =~ /.*localhost.*/
       server_hash[:hostname] = config_hash[:hostname] = hostname
     end
 


### PR DESCRIPTION
These hostnames are not routable so it makes no sense to expose them as the access point for the server.

Calls to methods like `MiqRegion#remote_ui_hostname` will now properly fallback to using the IP address rather than returning something like "localhost.localdomain" and nearly ensuring the caller's failure.

https://bugzilla.redhat.com/show_bug.cgi?id=1389491

@gtanzillo please review

/cc @Fryguy 