### PR TITLE
remove to_a from vim_performance_analysis

### DIFF
--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -83,10 +83,10 @@ class BottleneckEvent < ApplicationRecord
     # =>  :limit_attr_value => value of limit attr
     # => }
 
-    recs = VimPerformanceAnalysis.find_perf_for_time_period(obj, options[:interval], options)
-    return if recs.blank?
+    # TODO: remove `to_a` when `calc_timestamp_at_trend` / `slope` no longer sorts or iterates multiple times
+    recs = VimPerformanceAnalysis.find_perf_for_time_period(obj, options[:interval], options).to_a
 
-    limit_value = recs.last.send(options[:limit_attr])
+    limit_value = recs.last.try(options[:limit_attr])
     return if limit_value.nil?
 
     limit_value = (limit_value * options[:limit_pct] / 100.0) if options[:limit_pct]

--- a/app/models/miq_report/generator/utilization.rb
+++ b/app/models/miq_report/generator/utilization.rb
@@ -23,7 +23,7 @@ module MiqReport::Generator::Utilization
       # Roll up results by timestamp
       results = VimPerformanceAnalysis.group_perf_by_timestamp(resource, results, cols)
     else
-      results = VimPerformanceAnalysis.find_perf_for_time_period(resource, db_options[:interval], db_options.merge(:ext_options => {:tz => tz, :time_profile => time_profile}))
+      results = VimPerformanceAnalysis.find_perf_for_time_period(resource, db_options[:interval], db_options.merge(:ext_options => {:tz => tz, :time_profile => time_profile})).to_a
     end
 
     # Return rpt object:

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -437,7 +437,6 @@ module VimPerformanceAnalysis
                   .where(:timestamp => Metric::Helper.time_range_from_hash(options), :resource => obj)
                   .where(options[:conditions]).order("timestamp")
                   .select(options[:select])
-                  .to_a
   end
 
   # @param obj base object


### PR DESCRIPTION
`find_perf_for_time_period` is used to bring back `Metrics`/`MetricRollups` that are then used to calculate averages / min / max.

Aiming to convert these to use database aggregation, or at the very least use `pluck`.

Currently, there is a `to_a` at the end of the code.
This will remove the `to_a`, allowing us to 
I added external `to_a` in a few places that I was not ready to tackle (yet)

https://bugzilla.redhat.com/show_bug.cgi?id=1395743

/cc @NickLaMuro 