### PR TITLE
Populate the description field when the LDAP group for a user is selected

### DIFF
--- a/app/controllers/ops_controller/ops_rbac.rb
+++ b/app/controllers/ops_controller/ops_rbac.rb
@@ -825,7 +825,7 @@ module OpsController::OpsRbac
                        :locals  => {:type => "classifications", :action_url => 'rbac_group_field_changed'}) if @refresh_div
 
           # Only update description field value if ldap group user field was selected
-          page << "$('#description').val('#{j_str(@edit[:new][:description])}');" if params[:ldap_groups_user]
+          page << "$('#description').val('#{j_str(@edit[:new][:ldap_groups_user])}');" if params[:ldap_groups_user]
 
           # don't do anything to lookup box when checkboxes on the right side are checked
           page << set_element_visible('group_lookup', @edit[:new][:lookup]) unless params[:check]


### PR DESCRIPTION
Issue introduced in https://github.com/ManageIQ/manageiq/pull/11466

https://bugzilla.redhat.com/show_bug.cgi?id=1389359