### PR TITLE
fix openstack cpu util meter name

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::Providers::Openstack::BaseMetricsCapture
-  CPU_METERS     = %w(hardware.system_stats.cpu.util)
+  CPU_METERS     = %w(hardware.cpu.util)
   MEMORY_METERS  = %w(hardware.memory.used
                       hardware.memory.total)
   SWAP_METERS    = %w(hardware.memory.swap.avail

--- a/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
@@ -26,7 +26,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
     end
 
     it "treats openstack timestamp as UTC" do
-      ts_as_utc = api_time_as_utc(@mock_stats_data.get_statistics("hardware.system_stats.cpu.util").last)
+      ts_as_utc = api_time_as_utc(@mock_stats_data.get_statistics("hardware.cpu.util").last)
       _counters, values_by_id_and_ts = @host.perf_collect_metrics("realtime")
       ts = Time.parse(values_by_id_and_ts[@host.ems_ref].keys.max)
 
@@ -124,11 +124,11 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
     # Check that samples are correctly normalized into 20s intervals.
     #
     # the first two openstack metrics should look like:
-    #   ts: 2013-08-28T11:01:09 => hardware.system_stats.cpu.util: 50
-    #   ts: 2013-08-28T11:02:12 => hardware.system_stats.cpu.util: 100
-    #   ts: 2013-08-28T11:03:15 => hardware.system_stats.cpu.util: 25
-    #   ts: 2013-08-28T11:04:18 => hardware.system_stats.cpu.util: 50
-    #   ts: 2013-08-28T11:05:21 => hardware.system_stats.cpu.util: 20
+    #   ts: 2013-08-28T11:01:09 => hardware.cpu.util: 50
+    #   ts: 2013-08-28T11:02:12 => hardware.cpu.util: 100
+    #   ts: 2013-08-28T11:03:15 => hardware.cpu.util: 25
+    #   ts: 2013-08-28T11:04:18 => hardware.cpu.util: 50
+    #   ts: 2013-08-28T11:05:21 => hardware.cpu.util: 20
     #
     # after capture and processing, the first six statistics should look like:
     #   ts: 2013-08-28T11:01:40 => cpu_usage_rate_average: 100
@@ -588,7 +588,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
     it "checks that the net_usage_rate_average should have last incomplete stat not saved" do
       # Ensure that the first 21 statistics match nil. This happens because there is one more stat of
-      # hardware.system_stats.cpu.util, but net usage stat has been incomplete, so we store nil values, those nil
+      # hardware.cpu.util, but net usage stat has been incomplete, so we store nil values, those nil
       # values has been filled with the right value in previous collection period.
       # !!!!!!! It's up to saving mechanism to not overwrite the old values with nil. !!!!!!!!!!!
       (0..20).each { |i| expect(@values_by_ts[@ts_keys[i]]["net_usage_rate_average"]).to eq nil }
@@ -893,7 +893,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
 
     it "checks that the mem_usage_absolute_average should have last incomplete stat not saved" do
       # Ensure that the first 21 statistics match nil. This happens because there is one more stat of
-      # hardware.system_stats.cpu.util, but net usage stat has been incomplete, so we store nil values, those nil
+      # hardware.cpu.util, but net usage stat has been incomplete, so we store nil values, those nil
       # values has been filled with the right value in previous collection period.
       # !!!!!!! It's up to saving mechanism to not overwrite the old values with nil. !!!!!!!!!!!
       (0..20).each { |i| expect(@values_by_ts[@ts_keys[i]]["mem_usage_absolute_average"]).to eq nil }

--- a/spec/tools/openstack_data/openstack_perf_data/aggregate.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/aggregate.yml
@@ -604,7 +604,7 @@
     period_start: "2013-08-28T11:23:24"
     avg: 196711321.0
     sum: 196711321.0
-  hardware.system_stats.cpu.util:
+  hardware.cpu.util:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"

--- a/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
@@ -527,7 +527,7 @@
     period_start: "2013-08-28T11:14:20"
     avg: 1338
     sum: 58234626048.0
-  hardware.system_stats.cpu.util:
+  hardware.cpu.util:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"

--- a/spec/tools/openstack_data/openstack_perf_data/metadata_counters.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/metadata_counters.yml
@@ -29,7 +29,7 @@
   unit: "packet"
 -
   user_id: "62992b0399a34653907ded01238a9b2b"
-  name: "hardware.system_stats.cpu.util"
+  name: "hardware.cpu.util"
   resource_id: "998f6beb-825c-44f3-9fad-6f3270cab1d8"
   project_id: "3bbc20f34655462d8112ef8db50e5a19"
   type: "gauge"

--- a/spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
@@ -672,7 +672,7 @@
     period_start: "2013-08-28T12:44:20"
     avg: 196911321.0
     sum: 89.74293759622134
-  hardware.system_stats.cpu.util:
+  hardware.cpu.util:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"

--- a/spec/tools/openstack_data/openstack_perf_data/standard.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/standard.yml
@@ -604,7 +604,7 @@
     period_start: "2013-08-28T11:10:00"
     avg: 196711321.0
     sum: 196711321.0
-  hardware.system_stats.cpu.util:
+  hardware.cpu.util:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"


### PR DESCRIPTION
OpenStack CPU Util meter name was incorrect; this fixes that.

https://bugzilla.redhat.com/show_bug.cgi?id=1364584