### PR TITLE
[WIP] Cache TimeProfiles when building reports (kinda a hack...)

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -169,7 +169,9 @@ module Metric::Common
 
     # @param :time_profile_or_tz [TimeProfile|Timezone] (default: DEFAULT_TIMEZONE)
     def with_time_profile_or_tz(time_profile_or_tz = nil)
-      if (time_profile = TimeProfile.default_time_profile(time_profile_or_tz))
+      if Thread.current[:default_time_profile_ids_cache]
+        where(:time_profile_id => Thread.current[:default_time_profile_ids_cache])
+      elsif (time_profile = TimeProfile.default_time_profile(time_profile_or_tz))
         tp_ids = time_profile.profile_for_each_region
         where(:time_profile => tp_ids)
       else

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -369,9 +369,12 @@ module MiqReport::Generator
     objs = build_add_missing_timestamps(objs)
 
     data = build_includes(objs)
-    result = data.collect do|entry|
-      build_reportable_data(entry, {:only => only_cols, "include" => include}, nil)
-    end.flatten
+
+    result = TimeProfile.with_cached_time_profile_ids do
+      data.collect do |entry|
+        build_reportable_data(entry, {:only => only_cols, "include" => include}, nil)
+      end.flatten
+    end
 
     if rpt_options && rpt_options[:pivot]
       result = build_pivot(result)

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -33,6 +33,19 @@ class TimeProfile < ApplicationRecord
     end
   end
 
+  def self.with_cached_time_profile_ids(profile = nil)
+    ids = begin
+            profile ||= TimeProfile.default_time_profile(nil)
+            profile.profile_for_each_region.pluck(:id)
+          rescue NoMethodError
+            nil
+          end
+    Thread.current[:default_time_profile_ids_cache] = ids
+    result = yield if block_given?
+    Thread.current[:default_time_profile_ids_cache] = nil
+    result
+  end
+
   def global?
     profile_type == "global"
   end

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -223,7 +223,9 @@ module Rbac
       end
 
       if search_filter && targets && (!exp_attrs || !exp_attrs[:supported_by_sql])
-        rejects     = targets.reject { |obj| matches_search_filters?(obj, search_filter, tz) }
+        rejects = TimeProfile.with_cached_time_profile_ids do
+          targets.reject { |obj| matches_search_filters?(obj, search_filter, tz) }
+        end
         auth_count -= rejects.length unless options[:skip_counts]
         targets -= rejects
       end


### PR DESCRIPTION
Provides a "not so graceful" hack to cache the values for `Metric::Common::with_time_profile_or_tz`, which can be requested and fetched 10s of times more then the number of records required in the report, and each time require a substantial amount of CPU overhead because the `profile` column is a serialized yaml text blob.

Note:  While the metrics for this are promising, the caching could potentially backfire and cause this to incorrectly generate report data.

Metrics
-------
Taken from a database with 20k VMs building a report with columns like `overallocated_vcpus_pct `, `cpu_usagemhz_rate_average_max_over_time_period`, `mem_cpu`, `overallocated_mem_pct`, and `derived_memory_used_max_over_time_period`.

|        ms |  queries | query (ms) |      rows |        |
|      ---: |     ---: |       ---: |      ---: |   ---: |
|   1,137,891 |   542,954 |     385,744 |   1,395,910 | before |
|    502,562 |   314,478 |     304,318 |    279,290 |  after |

```
                              Rows by Class

              Before                |                 After
                                    |
MiqReport: 2                        |   MiqReport: 2
MiqQueue: 2                         |   MiqQueue: 2
MiqTask: 2                          |   MiqTask: 2
User: 8                             |   User: 8
MiqGroup: 4                         |   MiqGroup: 4
Entitlement: 4                      |   Entitlement: 4
Tenant: 2                           |   Tenant: 2
MiqUserRole: 2                      |   MiqUserRole: 2
Vm: 45,608                          |   Vm: 45,608
Hardware: 45,606                    |   Hardware: 45,606
VimPerformanceOperatingRange: 47,268|   VimPerformanceOperatingRange: 47,268
Disk: 140,738                       |   Disk: 140,738
TimeProfile: 1,116,660   <<<<<      |   TimeProfile: 40   <<<<<
MetricRollup: 0                     |   MetricRollup: 0
MiqReportResult: 4                  |   MiqReportResult: 4
BinaryBlob: 0                       |   BinaryBlob: 0
```

One thing to also note about this database:  There was a grand total of 7 unique `TimeProfile` records, and from what I can guess, only 5 were actually be requested (there are 5 regions in this DB as well).  This means prior to this change, for this report and this DB, we were requesting the 5 `TimeProfile`s 200k+ times for a single report.

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1395743