### PR TITLE
Fix history button for nodes present in tree with hidden VMs

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -5,6 +5,8 @@ module ApplicationController::Explorer
   # Historical tree item selected
   def x_history
     @hist = x_tree_history[params[:item].to_i]  # Set instance var so we know hist button was pressed
+    # remove id that is used in replace_right_cell method in vm_common
+    @sb[@sb[:active_accord]] = nil if @sb.fetch_path(@sb[:active_accord]) && @sb[@sb[:active_accord]] != @hist[:id]
     if @hist[:button]         # Button press from show screen
       self.x_node = @hist[:id]
       params[:id] = parse_nodetype_and_id(x_node).last


### PR DESCRIPTION
Last selected hidden VM/Template stored in `@sb[@sb[:active_accord]]` replaced `@hist[:id]` in `replace_right_cell`. So it has to be changed in `x_history`.

Introduced by https://github.com/ManageIQ/manageiq/pull/12504 .

Effected trees:
Compute -> Infrastructure -> Virtual Machines -> VMs & Templates
Compute -> Clouds -> Instances -> Instances by Provider
Compute -> Clouds -> Instances -> Images by Provider

Before:
If History button was used when on summary page of a VM/Template it never changed right side to correct info.
After:
Shows info corresponding to object selected in History button.

@miq-bot add_label ui, bug

@h-kataria please review. BZ has no blocker flag or euwe/yes so I didn't add blocker and euwe/yes labels. Please add them if they are needed. Thanks.

https://bugzilla.redhat.com/show_bug.cgi?id=1395795