### PR TITLE
Change Message to Messages in jms queue

### DIFF
--- a/product/charts/miq_reports/vim_perf_daily_middleware_messaging_jms_queue.yaml
+++ b/product/charts/miq_reports/vim_perf_daily_middleware_messaging_jms_queue.yaml
@@ -41,8 +41,8 @@ col_order:
 # Column titles, in order
 headers:
 - Date/Time
-- Delivering Message Count
-- Message Count
+- Delivering Messages Count
+- Messages Count
 - Messages Added
 - Consumers Count
 

--- a/product/charts/miq_reports/vim_perf_hourly_middleware_messaging_jms_queue.yaml
+++ b/product/charts/miq_reports/vim_perf_hourly_middleware_messaging_jms_queue.yaml
@@ -41,8 +41,8 @@ col_order:
 # Column titles, in order
 headers:
 - Date/Time
-- Delivering Message Count
-- Message Count
+- Delivering Messages Count
+- Messages Count
 - Messages Added
 - Consumers Count
 

--- a/product/charts/miq_reports/vim_perf_realtime_middleware_messaging_jms_queue.yaml
+++ b/product/charts/miq_reports/vim_perf_realtime_middleware_messaging_jms_queue.yaml
@@ -41,8 +41,8 @@ col_order:
 # Column titles, in order
 headers:
 - Date/Time
-- Delivering Message Count
-- Message Count
+- Delivering Messages Count
+- Messages Count
 - Messages Added
 - Consumers Count
 


### PR DESCRIPTION
In JMS queue titles of reports were in mixed plural and singular form. So change this to plural only.

@miq-bot add_label providers/hawkular, bug, ui, euwe/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1392514