### PR TITLE
[EUWE] Require a description when creating Snapshot

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations/snapshot.rb
@@ -39,6 +39,10 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations::Snapshot
     true
   end
 
+  def snapshot_description_required?
+    true
+  end
+
   def validate_remove_all_snapshots
     {:available => false, :message => "Removing all snapshots is currently not supported"}
   end


### PR DESCRIPTION
Back porting:
https://github.com/ManageIQ/manageiq/pull/12637

When creating a snapshot on RHV one has to write a description else
the operation will fail.
So one should not be able to start the "create snapshot" operation
without writing the description.

https://bugzilla.redhat.com/show_bug.cgi?id=1384517