### PR TITLE
Fix sporadic failure in action specs

### DIFF
--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -90,7 +90,7 @@ describe "Actions API" do
 
       expect(response.parsed_body["results"].count).to eq(2)
 
-      expect(MiqAction.pluck(:description)).to eq(%w(change change2))
+      expect(MiqAction.pluck(:description)).to match_array(%w(change change2))
     end
   end
 end


### PR DESCRIPTION
Use match_array matcher to be independent on order


@miq-bot add_label bug_sporadic test failure

### Links
https://travis-ci.org/ManageIQ/manageiq/jobs/177001074

### Reproducer
(it is last spec in ./spec/requests/api/actions_spec.rb ):
```ruby
    1000.times do
      it "edits new actions" do
        api_basic_authorize collection_action_identifier(:actions, :edit)
        run_post(actions_url, gen_request(:edit, [{"id" => actions.first.id, "description" => "change"},
                                                  {"id" => actions.second.id, "description" => "change2"}]))
        expect(response).to have_http_status(:ok)

        expect(response.parsed_body["results"].count).to eq(2)

        expect(MiqAction.pluck(:description)).to eq(%w(change change2))
      end
    end
```

cc @isimluk 
@miq-bot assign @abellotti 

