### PR TITLE
Add hover text for Help dropdown

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -20,7 +20,7 @@
             &#8226
       %li.dropdown
         %a{:class => "dropdown-toggle nav-item-iconic", :id => "dropdownMenu1",  "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "true"}
-          %span.fa.pficon-help
+          %span.fa.pficon-help{:title => _("Help")}
           %span.caret
         %ul.dropdown-menu{"aria-labelledby" => "dropdownMenu1"}
           %li


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1383390

<img width="434" alt="screen shot 2016-11-18 at 10 16 46 am" src="https://cloud.githubusercontent.com/assets/1287144/20434965/31bcd2f4-ad78-11e6-9b3c-2f4e659cb229.png">
