### PR TITLE
[EUWE] Move VM/Web console toolbar buttons to an Access dropdown

### DIFF
--- a/app/helpers/application_helper/toolbar/x_vm_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_center.rb
@@ -228,34 +228,43 @@ class ApplicationHelper::Toolbar::XVmCenter < ApplicationHelper::Toolbar::Basic
           :options => {:feature => :reset}),
       ]
     ),
-    button(
-      :vm_console,
-      'pficon pficon-screen fa-lg',
-      N_('Open a web-based console for this VM'),
-      nil,
-      :url     => "console",
-      :confirm => N_("Opening a VM web-based console can take a while and requires that the VMware MKS plugin version configured for Management Engine already be installed and working.  Are you sure?")),
-    button(
-      :vm_vnc_console,
-      'fa fa-html5 fa-lg',
-      N_('Open a web-based VNC or SPICE console for this VM'),
-      nil,
-      :url     => "html5_console",
-      :confirm => N_("Opening a web-based VM VNC or SPICE console requires that the Provider is pre-configured to allow VNC connections.  Are you sure?")),
-    button(
-      :vm_vmrc_console,
-      'pficon pficon-screen fa-lg',
-      N_('Open a web-based VMRC console for this VM.  This requires that VMRC is pre-configured to work in your browser.'),
-      nil,
-      :url     => "vmrc_console",
-      :confirm => N_("Opening a VM web-based VMRC console requires that VMRC is pre-configured to work in your browser.  Are you sure?")),
-    button(
-      :cockpit_console,
-      nil,
-      N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
-      nil,
-      :image   => "cockpit",
-      :url     => "launch_cockpit"),
+  ])
+  button_group('vm_access', [
+    select(
+      :vm_remote_access_choice,
+      'fa pficon-screen fa-lg',
+      N_('VM Remote Access'),
+      N_('Access'),
+      :items => [
+        button(
+          :vm_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a web-based console for this VM'),
+          N_('VM Console'),
+          :url     => "console",
+          :confirm => N_("Opening a VM web-based console can take a while and requires that the VMware MKS plugin version configured for Management Engine already be installed and working.  Are you sure?")),
+        button(
+          :vm_vnc_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a web-based VNC or SPICE console for this VM'),
+          N_('VM Console'),
+          :url     => "html5_console"),
+        button(
+          :vm_vmrc_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a web-based VMRC console for this VM.  This requires that VMRC is pre-configured to work in your browser.'),
+          N_('VM Console'),
+          :url     => "vmrc_console",
+          :confirm => N_("Opening a VM web-based VMRC console requires that VMRC is pre-configured to work in your browser.  Are you sure?")),
+        button(
+          :cockpit_console,
+          'pficon pficon-screen fa-lg',
+          N_('Open a new browser window with Cockpit for this VM.  This requires that Cockpit is pre-configured on the VM.'),
+          N_('Web Console'),
+          # :image   => "cockpit",
+          :url     => "launch_cockpit"),
+      ]
+    ),
   ])
   button_group('snapshot_tasks', [
     button(

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -626,7 +626,8 @@ class ApplicationHelper::ToolbarBuilder
       type = get_vmdb_config.fetch_path(:server, :remote_console_type)
       return type != 'MKS' || !@record.console_supported?(type)
     when "vm_vnc_console"
-      return !@record.console_supported?('vnc')
+      type = get_vmdb_config.fetch_path(:server, :remote_console_type)
+      return type != 'VNC' || !@record.console_supported?(type)
     when "vm_vmrc_console"
       type = get_vmdb_config.fetch_path(:server, :remote_console_type)
       return type != 'VMRC' || !@record.console_supported?(type)


### PR DESCRIPTION
Moved MKS/VNC/VMRC and Cockpit toolbar buttons to an Access dropdown. Additional UX changes per the screenshot in the BZ link below.

This is the Euwe specific PR for #12720. 

https://bugzilla.redhat.com/show_bug.cgi?id=1396524