### PR TITLE
Use Settings in VmOrTemplate::RightSizing

### DIFF
--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -36,14 +36,12 @@ module VmOrTemplate::RightSizing
   end
 
   module ClassMethods
-    DEFAULT_CPU_RECOMMENDATION_MINIMUM = 1
     def cpu_recommendation_minimum
-      VMDB::Config.new("vmdb").config.fetch_path(:recommendations, :cpu_minimum) || DEFAULT_CPU_RECOMMENDATION_MINIMUM
+      ::Settings.recommendations.cpu_minimum
     end
 
-    DEFAULT_MEM_RECOMMENDATION_MINIMUM = 32.megabytes
     def mem_recommendation_minimum
-      min = (VMDB::Config.new("vmdb").config.fetch_path(:recommendations, :mem_minimum) || DEFAULT_MEM_RECOMMENDATION_MINIMUM).to_i_with_method
+      min = ::Settings.recommendations.mem_minimum.to_i_with_method
       min / 1.megabyte
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1013,6 +1013,9 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
+:recommendations:
+  :cpu_minimum: 1
+  :mem_minimum: 32.megabytes
 :reporting:
   :format_by_class:
     :Fixnum:


### PR DESCRIPTION
Purpose
-------
Use `Settings` over `VMDB::Config.new` for speed improvements for `VmOrTemplate::RightSizing`.


Metrics
-------
The following metrics were taking in the same fashion as gathered in #12737, and included the speed ups from there in both runs (because I didn't care to wait around for this to run without them):

|       ms |  queries | query (ms) |     rows |        |
|     ---: |     ---: |       ---: |     ---: |   ---: |
|   502,562 |   314,478 |     304,318 |   279,290 | before |
|   458,084 |   319,630 |     309,396 |   279,290 |  after |

A savings of about 1 min in total.

Specifically, looking at some stackprof analysis output prior to the fix:


```
$ stackprof ...
==================================
  Mode: wall(1000)
  Samples: 585620 (0.07% miss rate)
  GC: 155747 (26.60%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    129891  (22.2%)      129886  (22.2%)     block in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache
     34620   (5.9%)       34620   (5.9%)     block in ManageIQPerformance::StacktraceCleaners::Simple#call
     17728   (3.0%)       17728   (3.0%)     block in ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute
    100153  (17.1%)       14663   (2.5%)     block in Config::Options#to_hash
     10558   (1.8%)       10558   (1.8%)     block in ManageIQPerformance::StacktraceCleaners::Simple#call
      8787   (1.5%)        8787   (1.5%)     OpenStruct#marshal_dump
      6061   (1.0%)        6061   (1.0%)     block in Config::Options#descend_array
```


The two mentions of `Config` and the `OpenStruc#marshal_dump` are all from calling these two methods to fetch the config.  Because there is no memoization, and these are instance methods, this means it could be called multiple times per model instantiation.


Extra info
----------
The Settings API was added in the following pull request:  https://github.com/ManageIQ/manageiq/pull/7432

And deprecated the `VMDB::Config.new` workflow.  While this still exists heavily in the application in other places, this one specifically caused a lot of slow down when generating large reports using columns under the `VmOrTemplate::RightSizing` module.


Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1395743
* https://github.com/ManageIQ/manageiq/pull/7432
* https://github.com/ManageIQ/manageiq/pull/12737