### PR TITLE
Remove the FQDN from group names for ext auth.

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -36,7 +36,7 @@ module Authenticator
 
     def groups_for(identity)
       _user_attrs, membership_list = identity
-      membership_list
+      MiqGroup.strip_group_domains(membership_list)
     end
 
     def update_user_attributes(user, _username, identity)

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -93,6 +93,10 @@ class MiqGroup < ApplicationRecord
     end
   end
 
+  def self.strip_group_domains(group_list)
+    group_list.collect { |group| group.gsub(/@.*/, '') }
+  end
+
   def self.get_ldap_groups_by_user(user, bind_dn, bind_pwd)
     auth = VMDB::Config.new("vmdb").config[:authentication]
     auth[:group_memberships_max_depth] ||= User::DEFAULT_GROUP_MEMBERSHIPS_MAX_DEPTH
@@ -124,7 +128,7 @@ class MiqGroup < ApplicationRecord
     rescue => err
       raise _("Unable to get groups for user %{user_name} - %{error}") % {:user_name => username, :error => err}
     end
-    user_groups.first
+    strip_group_domains(user_groups.first)
   end
 
   def get_filters(type = nil)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -64,7 +64,7 @@ describe Authenticator::Httpd do
     end
 
     let(:username) { 'alice' }
-    let(:user_groups) { 'wibble:bubble' }
+    let(:user_groups) { 'wibble@fqdn:bubble@fqdn' }
 
     context "with user details" do
       context "using local authorization" do

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -82,6 +82,15 @@ describe MiqGroup do
 
       expect(MiqGroup.get_httpd_groups_by_user('user')).to eq(memberships.first)
     end
+
+    it "should remove FQDN from the groups by user name with external authentication" do
+      ifp_memberships = [%w(foo@fqdn bar@fqdn)]
+      memberships = [%w(foo bar)]
+
+      allow(@ifp_interface).to receive(:GetUserGroups).with('user').and_return(ifp_memberships)
+
+      expect(MiqGroup.get_httpd_groups_by_user('user')).to eq(memberships.first)
+    end
   end
 
   describe "#get_ldap_groups_by_user" do


### PR DESCRIPTION
A new version of SSSD, 1-14, was introduced in RHEL 7.3. A change in this version of
SSSD is to store fully qualified group names in the SSSD cache.

This PR will remove the domain portion of the fully qualified group names.

Steps for Testing/QA [Optional]
-------------------------------

One way to test this is to configure an appliance with External Auth/SSSD/LDAP
and attempt to add a group under:

**_Configuration/Access Control/Groups/Configuration (pull down)/Add a new Group_**

check: **_(Look up External Authentication Groups)_**

Enter a valid user in: **_User to Look Up_**

click the **_Retrieve_** button

The dropdown: **_LDAP Groups for User_** should be populated with group names that do not include the fully qualified domain.


https://bugzilla.redhat.com/show_bug.cgi?id=1394425