### PR TITLE
Only enable git import submit button when a branch or tag is selected

### DIFF
--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -215,11 +215,8 @@ var Automate = {
 
   setUpGitRefreshClickHandlers: function() {
     var toggleSubmitButton = function() {
-      if ($('.git-branch-or-tag').val() !== "") {
-        $('.git-import-submit').prop('disabled', false);
-      } else {
-        $('.git-import-submit').prop('disabled', true);
-      }
+      var branchOrTagSelected = $('.git-branch-or-tag').val() === '';
+      $('.git-import-submit').prop('disabled', branchOrTagSelected);
     };
 
     $('.git-branch-or-tag-select').on('change', function(event) {

--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -118,10 +118,10 @@ var Automate = {
 
   setUpAutomateImportClickHandlers: function() {
     var tearDownGitImportOptions = function() {
-      $('.git-branches').find('option').remove().end();
-      $('.git-tags').find('option').remove().end();
-      $('.git-branches').selectpicker('refresh');
-      $('.git-tags').selectpicker('refresh');
+      $('select.git-branches').find('option').remove().end();
+      $('select.git-tags').find('option').remove().end();
+      $('select.git-branches').selectpicker('refresh');
+      $('select.git-tags').selectpicker('refresh');
 
       $('.import-or-export').show();
       $('.git-import-data').hide();
@@ -158,6 +158,7 @@ var Automate = {
 
     $('.git-retreive-datastore').click(function() {
       miqSparkleOn();
+      $('.git-import-submit').prop('disabled', true);
     });
 
     $('.git-import-submit').click(function(event) {
@@ -213,6 +214,14 @@ var Automate = {
   },
 
   setUpGitRefreshClickHandlers: function() {
+    var toggleSubmitButton = function() {
+      if ($('.git-branch-or-tag').val() !== "") {
+        $('.git-import-submit').prop('disabled', false);
+      } else {
+        $('.git-import-submit').prop('disabled', true);
+      }
+    };
+
     $('.git-branch-or-tag-select').on('change', function(event) {
       event.preventDefault();
       if ($(event.currentTarget).val() === "Branch") {
@@ -224,14 +233,17 @@ var Automate = {
         $('.git-tag-group').show();
         $('.git-branch-or-tag').val($('select.git-tags').val());
       }
+      toggleSubmitButton();
     });
 
     $('select.git-branches').on('change', function(event) {
       $('.git-branch-or-tag').val($('select.git-branches').val());
+      toggleSubmitButton();
     });
 
     $('select.git-tags').on('change', function(event) {
       $('.git-branch-or-tag').val($('select.git-tags').val());
+      toggleSubmitButton();
     });
   }
 };

--- a/app/assets/javascripts/automate_import_export.js
+++ b/app/assets/javascripts/automate_import_export.js
@@ -64,11 +64,24 @@ var Automate = {
         addToDropDown('tags', child);
       });
 
+      Automate.selectDefaultBranch();
+
       $('select.git-branches').selectpicker('refresh');
       $('select.git-tags').selectpicker('refresh');
     }
 
     miqSparkleOff();
+  },
+
+  selectDefaultBranch: function() {
+    if ($('select.git-branches').find('option[value="origin/master"]').length === 0) {
+      $('select.git-branches').prop('selectedIndex', 0);
+    } else {
+      $('select.git-branches').val('origin/master');
+    }
+
+    $('.git-branch-or-tag').val($('select.git-branches').val());
+    $('.git-import-submit').prop('disabled', false);
   },
 
   addDomainOptions: function(domains) {
@@ -158,7 +171,6 @@ var Automate = {
 
     $('.git-retreive-datastore').click(function() {
       miqSparkleOn();
-      $('.git-import-submit').prop('disabled', true);
     });
 
     $('.git-import-submit').click(function(event) {

--- a/app/views/miq_ae_tools/_import_export.html.haml
+++ b/app/views/miq_ae_tools/_import_export.html.haml
@@ -91,9 +91,9 @@
           = _('Branch/Tag')
         .col-md-8
           = select_tag("branch_or_tag",
-                       options_for_select(["Please select 'Branch' or 'Tag'", "Branch", "Tag"]),
+                       options_for_select(["Branch", "Tag"]),
                        :class => "git-branch-or-tag-select selectpicker")
-      .form-group.git-branch-group{:style => "display: none;"}
+      .form-group.git-branch-group
         %label.col-md-2.control-label
           = _('Branches')
         .col-md-8

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -20,6 +20,66 @@ describe('Automate', function() {
     });
   });
 
+  describe('#selectDefaultBranch', function() {
+    context('when "origin/master" does not exist as a branch', function() {
+      beforeEach(function() {
+        var html = '';
+        html += '<input type="hidden" class="git-branch-or-tag"></input>';
+        html += '<select class="git-branches selectpicker">';
+        html += '  <option value="1">Branch 1</option>';
+        html += '  <option value="2" selected="selected">Branch 2</option>';
+        html += '</select>';
+        html += '<button class="git-import-submit" disabled="true"/>';
+        html += '';
+        setFixtures(html);
+
+        miqInitSelectPicker();
+        Automate.selectDefaultBranch();
+      });
+
+      it('defaults to the first option', function() {
+        expect($('select.git-branches').val()).toEqual('1');
+      });
+
+      it('sets the hidden input to the correct value', function() {
+        expect($('.git-branch-or-tag').val()).toEqual('1');
+      });
+
+      it('sets the disabled property on the submit button to false', function() {
+        expect($('.git-import-submit').prop('disabled')).toEqual(false);
+      });
+    });
+
+    context('when "origin/master" does exist as a branch', function() {
+      beforeEach(function() {
+        var html = '';
+        html += '<input type="hidden" class="git-branch-or-tag"></input>';
+        html += '<select class="git-branches selectpicker">';
+        html += '  <option value="1">Branch 1</option>';
+        html += '  <option value="origin/master">origin/master</option>';
+        html += '</select>';
+        html += '<button class="git-import-submit" disabled="true"/>';
+        html += '';
+        setFixtures(html);
+
+        miqInitSelectPicker();
+        Automate.selectDefaultBranch();
+      });
+
+      it('selects "origin/master" as the value', function() {
+        expect($('select.git-branches').val()).toEqual('origin/master');
+      });
+
+      it('sets the hidden input to the correct value', function() {
+        expect($('.git-branch-or-tag').val()).toEqual('origin/master');
+      });
+
+      it('sets the disabled property on the submit button to false', function() {
+        expect($('.git-import-submit').prop('disabled')).toEqual(false);
+      });
+    });
+  });
+
   describe('#setUpGitRefreshClickHandlers', function() {
     beforeEach(function() {
       var html = '';

--- a/spec/javascripts/automate_import_export_spec.js
+++ b/spec/javascripts/automate_import_export_spec.js
@@ -38,6 +38,7 @@ describe('Automate', function() {
       html += '  <option value="1" selected="selected">Tag 1</option>';
       html += '  <option value="2">Tag 2</option>';
       html += '</select>';
+      html += '<button class="git-import-submit"/>';
       html += '';
       setFixtures(html);
 
@@ -64,6 +65,10 @@ describe('Automate', function() {
         it('copies the value of the git-branches select into the hidden field', function() {
           expect($('.git-branch-or-tag').val()).toEqual("2");
         });
+
+        it('toggles the submit button', function() {
+          expect($('.git-import-submit').prop('disabled')).toEqual(false);
+        });
       });
 
       describe('when "Tag" is selected', function() {
@@ -83,6 +88,10 @@ describe('Automate', function() {
         it('copies the value of the git-tag select into the hidden field', function() {
           expect($('.git-branch-or-tag').val()).toEqual("1");
         });
+
+        it('toggles the submit button', function() {
+          expect($('.git-import-submit').prop('disabled')).toEqual(false);
+        });
       });
     });
 
@@ -95,6 +104,10 @@ describe('Automate', function() {
       it('copies the value of the git-branches select into the hidden field', function() {
         expect($('.git-branch-or-tag').val()).toEqual("1");
       });
+
+      it('toggles the submit button', function() {
+        expect($('.git-import-submit').prop('disabled')).toEqual(false);
+      });
     });
 
     describe('when the select.git-tags field changes', function() {
@@ -105,6 +118,10 @@ describe('Automate', function() {
 
       it('copies the value of the git-tags select into the hidden field', function() {
         expect($('.git-branch-or-tag').val()).toEqual("2");
+      });
+
+      it('toggles the submit button', function() {
+        expect($('.git-import-submit').prop('disabled')).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
This is an addendum to the actual fix for the bug by @mkanoor. This PR will simply disable the submit button until a branch or tag has been selected, but if someone were to manually enable the button and attempt to submit without a branch or tag, that error is caught and shown to the user.

It also includes a more targeted selector for the `.git-branches` and `.git-tags` elements, as the selectpicker javascript generates a ul/li combination alongside the actual select element.

We also decided it would be best to default to the "origin/master" branch, if it's available, otherwise the first branch in the drop-down, instead of having the user pick between branch or tag at first.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1386296