### PR TITLE
Selected selectpicker item should undergo `encodeURI` for proper URL encoding

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1308,7 +1308,7 @@ function miqSelectPickerEvent(element, url, options) {
 
   $('#' + element).on('change', _.debounce(function() {
     var selected = $(this).val();
-    var finalUrl = url + (firstarg ? '?' : '&') + element + '=' + escape(selected);
+    var finalUrl = url + (firstarg ? '?' : '&') + element + '=' + encodeURIComponent(selected);
 
     if (typeof $(this).attr('data-miq_sparkle_on') != 'undefined')
       options.beforeSend = $(this).attr('data-miq_sparkle_on') == 'true';


### PR DESCRIPTION
A selectpicker item with special characters in it like the French grave accent `è, à, ù` or the acute accent `é` when selected causes the following error -

```
[----] I, [2016-11-18T20:05:48.522544 #28581:51bf774]  INFO -- : Started POST "/ops/rbac_group_field_changed/new?ldap_groups_user=SR-APP-EPM-Membre-%E9quipe" for ::1 at 2016-11-18 20:05:48 +0100
[----] F, [2016-11-18T20:05:48.548252 #28581:51bf774] FATAL -- :   
[----] F, [2016-11-18T20:05:48.548329 #28581:51bf774] FATAL -- : ActionController::BadRequest (Invalid query parameters: Non UTF-8 value: SR-APP-EPM-Membre-<E9>quipe):
[----] F, [2016-11-18T20:05:48.548366 #28581:51bf774] FATAL -- :   
[----] F, [2016-11-18T20:05:48.548399 #28581:51bf774] FATAL -- : actionpack (5.0.0.1) lib/action_dispatch/request/utils.rb:26:in `check_param_encoding'
[----] F, [2016-11-18T20:05:48.548430 #28581:51bf774] FATAL -- : actionpack (5.0.0.1) lib/action_dispatch/request/utils.rb:21:in `block in check_param_encoding'
[----] F, [2016-11-18T20:05:48.548461 #28581:51bf774] FATAL -- : actionpack (5.0.0.1) lib/action_dispatch/request/utils.rb:21:in `each_value'
[----] F, [2016-11-18T20:05:48.548494 #28581:51bf774] FATAL -- : actionpack (5.0.0.1) lib/action_dispatch/request/utils.rb:21:in `check_param_encoding'
```

The PR fixes the above issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1382764