### PR TITLE
Fix require path for miq-wmi

### DIFF
--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -73,7 +73,7 @@ class Vm < VmOrTemplate
     end
 
     begin
-      require 'miq-wmi'
+      require 'win32/miq-wmi'
       cred = my_zone_obj.auth_user_pwd(:windows_domain)
       ipaddresses.each do |ipaddr|
         break unless pl.blank?


### PR DESCRIPTION
Since 'win32' isn't on the load path by default, we have to explicitly add it for miq-wmi.rb now that this is in manageiq-gems-pending.