### PR TITLE
Add Cores and Memory of Infra Provider list view

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -138,6 +138,8 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
 
+  virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
+  virtual_aggregate :total_memory, :hosts, :sum, :ram_size
   virtual_aggregate :total_cloud_vcpus, :vms, :sum, :cpu_total_cores
   virtual_aggregate :total_cloud_memory, :vms, :sum, :ram_size
 

--- a/product/views/ManageIQ_Providers_InfraManager.yaml
+++ b/product/views/ManageIQ_Providers_InfraManager.yaml
@@ -25,6 +25,8 @@ cols:
 - emstype_description
 - port
 - total_hosts
+- total_vcpus
+- total_memory
 - total_storages
 - total_vms
 - total_miq_templates
@@ -49,10 +51,22 @@ col_order:
 - emstype_description
 - zone.name
 - total_hosts
+- total_vcpus
+- total_memory
 - total_storages
 - total_vms
 - total_miq_templates
 - region_description
+
+# Format of columns
+col_formats:
+-
+-
+-
+-
+-
+-
+- :megabytes_human
 
 # Column titles, in order
 headers:
@@ -62,6 +76,8 @@ headers:
 - Type
 - EVM Zone
 - Hosts
+- VCores
+- Memory
 - Datastores
 - VMs
 - Templates

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -265,6 +265,13 @@ describe ExtManagementSystem do
                                                                         :cpu1x2,
                                                                         :ram1GB))
       end
+      2.times do
+        FactoryGirl.create(:host,
+                           :ext_management_system => @ems,
+                           :hardware              => FactoryGirl.create(:hardware,
+                                                                        :cpu2x2,
+                                                                        :ram1GB))
+      end
     end
 
     it "#total_cloud_vcpus" do
@@ -273,6 +280,14 @@ describe ExtManagementSystem do
 
     it "#total_cloud_memory" do
       expect(@ems.total_cloud_memory).to eq(2048)
+    end
+
+    it "#total_vcpus" do
+      expect(@ems.total_vcpus).to eq(8)
+    end
+
+    it "#total_memory" do
+      expect(@ems.total_memory).to eq(2048)
     end
 
     it "#total_vms_on" do


### PR DESCRIPTION
**Depend of PR #13124**

This is a simple change in the visual of Infrastructure list View of providers, now we can see Total Cores and Total Memory of each Provider of Hosts. 

@sergio-ocon I didn't work with vms because that not represent the total capacity, we don't know if hosts are in 100% of use. Anyway we can make this changes for Cloud Providers to know how many cores and memory are allocated in AWS, Google, Azure or OpenStack instances.

<img width="1009" alt="captura de pantalla 2016-11-19 a las 23 06 19" src="https://cloud.githubusercontent.com/assets/3019213/20458836/3c9d3932-aeb0-11e6-9eeb-12b1d9a920b0.png">

I only need how to improve that view making a total sum of all providers in the list, maybe UI team can help with that.
