### PR TITLE
Fix policy x_node after create/copy/delete

### DIFF
--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -71,7 +71,7 @@ module MiqPolicyController::Policies
         when :policy_tree
           @nodetype = "p"
           if params[:button] == "add"
-            self.x_node = @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.camelize(:lower)}_p-#{to_cid(policy.id)}"
+            self.x_node = @new_policy_node = policy_node(policy)
             get_node_info(@new_policy_node)
           end
           replace_right_cell("p", params[:button] == "save" ? [:policy_profile, :policy] : [:policy])
@@ -106,7 +106,7 @@ module MiqPolicyController::Policies
                          :message      => "New Policy ID %{new_id} was copied from Policy ID %{old_id}" %
                                           {:new_id => new_pol.id, :old_id => policy.id})
       add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc})
-      @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.camelize(:lower)}_p-#{to_cid(policy.id)}"
+      @new_policy_node = policy_node(policy)
       get_node_info(@new_policy_node)
       replace_right_cell("p", [:policy])
     end
@@ -122,7 +122,7 @@ module MiqPolicyController::Policies
                 :error)
     else
       policies.push(params[:id])
-      self.x_node = @new_policy_node = "xx-#{pol.mode.downcase}_xx-#{pol.mode.downcase}-#{pol.towhat.camelize(:lower)}"
+      self.x_node = @new_policy_node = policies_node(pol.mode, pol.towhat)
     end
     process_policies(policies, "destroy") unless policies.empty?
     add_flash(_("The selected %{models} was deleted") %
@@ -160,6 +160,15 @@ module MiqPolicyController::Policies
 
   def policy_get_all
     peca_get_all('policy', -> { get_view(MiqPolicy, :conditions => ["mode = ? and towhat = ?", @sb[:mode].downcase, @sb[:nodeid].camelize]) })
+  end
+
+  def policies_node(mode, towhat)
+    ["xx-#{mode.downcase}",
+     "xx-#{mode.downcase}-#{towhat.camelize(:lower)}"].join("_")
+  end
+
+  def policy_node(policy)
+    [policies_node(policy.mode, policy.towhat), "p-#{to_cid(policy.id)}"].join("_")
   end
 
   private

--- a/app/controllers/miq_policy_controller/policies.rb
+++ b/app/controllers/miq_policy_controller/policies.rb
@@ -71,7 +71,7 @@ module MiqPolicyController::Policies
         when :policy_tree
           @nodetype = "p"
           if params[:button] == "add"
-            self.x_node = @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{to_cid(policy.id)}"
+            self.x_node = @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.camelize(:lower)}_p-#{to_cid(policy.id)}"
             get_node_info(@new_policy_node)
           end
           replace_right_cell("p", params[:button] == "save" ? [:policy_profile, :policy] : [:policy])
@@ -106,7 +106,7 @@ module MiqPolicyController::Policies
                          :message      => "New Policy ID %{new_id} was copied from Policy ID %{old_id}" %
                                           {:new_id => new_pol.id, :old_id => policy.id})
       add_flash(_("%{model} \"%{name}\" was added") % {:model => ui_lookup(:model => "MiqPolicy"), :name => new_desc})
-      @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.downcase}_p-#{to_cid(policy.id)}"
+      @new_policy_node = "xx-#{policy.mode.downcase}_xx-#{policy.mode.downcase}-#{policy.towhat.camelize(:lower)}_p-#{to_cid(policy.id)}"
       get_node_info(@new_policy_node)
       replace_right_cell("p", [:policy])
     end
@@ -122,7 +122,7 @@ module MiqPolicyController::Policies
                 :error)
     else
       policies.push(params[:id])
-      self.x_node = @new_policy_node = "xx-#{pol.mode.downcase}_xx-#{pol.mode.downcase}-#{pol.towhat.downcase}"
+      self.x_node = @new_policy_node = "xx-#{pol.mode.downcase}_xx-#{pol.mode.downcase}-#{pol.towhat.camelize(:lower)}"
     end
     process_policies(policies, "destroy") unless policies.empty?
     add_flash(_("The selected %{models} was deleted") %

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -7,7 +7,7 @@ describe MiqPolicyController do
       render_views
 
       before :each do
-        event = FactoryGirl.create(:miq_event_definition, :name => "host_compliance_check")
+        event = FactoryGirl.create(:miq_event_definition, :name => "containergroup_compliance_check")
         action = FactoryGirl.create(:miq_action, :name => "compliance_failed")
         allow(controller).to receive(:policy_get_node_info)
         allow(controller).to receive(:get_node_info)
@@ -16,15 +16,15 @@ describe MiqPolicyController do
       it "Correct active tree node is saved in @sb after Policy is added" do
         new = {}
         new[:mode] = "compliance"
-        new[:towhat] = "Host"
+        new[:towhat] = "ContainerGroup"
         new[:description] = "Test_description"
-        new[:expression] =  {">" => {"count" => "Host.advanced_settings", "value" => "1"}}
+        new[:expression] =  {">" => {"count" => "ContainerGroup.advanced_settings", "value" => "1"}}
         controller.instance_variable_set(:@edit, {:new     => new,
                                                   :current => new,
                                                   :typ     => "basic",
                                                   :key     => "policy_edit__new"})
         session[:edit] = assigns(:edit)
-        active_node = "xx-compliance_xx-compliance-host"
+        active_node = "xx-compliance_xx-compliance-containerGroup"
         allow(controller).to receive(:replace_right_cell)
         controller.instance_variable_set(:@sb, {:trees       => {:policy_tree => {:active_node => active_node}},
                                                 :active_tree => :policy_tree})
@@ -36,11 +36,11 @@ describe MiqPolicyController do
       end
 
       it "Renders the control policy creation form correctly" do
-        session[:sandboxes] = {"miq_policy" => {:trees       => {:policy_tree => {:active_node => "xx-compliance_xx-compliance-host"}},
+        session[:sandboxes] = {"miq_policy" => {:trees       => {:policy_tree => {:active_node => "xx-compliance_xx-compliance-containerGroup"}},
                                                 :active_tree => :policy_tree,
-                                                :folder      => "compliance-host",
-                                                :nodeid      => "host"}}
-        session[:edit] = {:new => {:mode => "compliance", :towhat => "Host"}}
+                                                :folder      => "compliance-containerGroup",
+                                                :nodeid      => "containerGroup"}}
+        session[:edit] = {:new => {:mode => "compliance", :towhat => "ContainerGroup"}}
         post :x_button, :pressed => "policy_new", :typ => "basic"
         expect(response).to render_template("layouts/exp_atom/_editor")
         expect(response).to render_template("layouts/_exp_editor")

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -7,8 +7,8 @@ describe MiqPolicyController do
       render_views
 
       before :each do
-        event = FactoryGirl.create(:miq_event_definition, :name => "containergroup_compliance_check")
-        action = FactoryGirl.create(:miq_action, :name => "compliance_failed")
+        FactoryGirl.create(:miq_event_definition, :name => "containergroup_compliance_check")
+        FactoryGirl.create(:miq_action, :name => "compliance_failed")
         allow(controller).to receive(:policy_get_node_info)
         allow(controller).to receive(:get_node_info)
       end
@@ -36,7 +36,8 @@ describe MiqPolicyController do
       end
 
       it "Renders the control policy creation form correctly" do
-        session[:sandboxes] = {"miq_policy" => {:trees       => {:policy_tree => {:active_node => "xx-compliance_xx-compliance-containerGroup"}},
+        active_node = "xx-compliance_xx-compliance-containerGroup"
+        session[:sandboxes] = {"miq_policy" => {:trees       => {:policy_tree => {:active_node => active_node}},
                                                 :active_tree => :policy_tree,
                                                 :folder      => "compliance-containerGroup",
                                                 :nodeid      => "containerGroup"}}


### PR DESCRIPTION
In Control explorer, fixes "Containernode", "Containergroup" etc
in right side titles to be "Node", "Pod" etc (or their translations)
immediately after creating, copying or deleting a policy.

Fixes #10500, which was the last known instance of
https://bugzilla.redhat.com/show_bug.cgi?id=1359909

Steps for Testing/QA
--------------------

- Create a new Pod (control or compliance) policy, verify right side title says "Pod".
- Configure -> Copy Policy, verify right side title says "Pod".
- Configure -> Delete Policy, verify right side title says "Pod".

Bonus points for doing this in non-english locale and verifying the
entity name (Pod in this example) is translated (I did and it is).

@miq-bot add-label control, ui, bug

----

P.S. Would anyone object if I put this lowerCamelize nonsense to the
torch throughout the Control UI?  (In separate PR of course.)

It seems the code started from simple `Host` -> `host` downcasing then
(mostly) switched to reversible `FooBar` -> `fooBar` in attempt to keep `host`
unchanged, but I've by now spent ~2 weeks of my life debugging that :cry:
and simply using `FooBar` in node ids won't really anger the javascriptGods...