### PR TITLE
MiqPolicyController.replace_right_cell: set @right_cell_text

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -665,7 +665,7 @@ class MiqPolicyController < ApplicationController
                           msg % {:name => @alert.description, :model => "#{pfx} #{ui_lookup(:model => "MiqAlert")}"}
                         end
     end
-    presenter[:right_cell_text] = right_cell_text
+    presenter[:right_cell_text] = @right_cell_text = right_cell_text
 
     presenter.reload_toolbars(:history => h_tb, :center => c_tb)
 


### PR DESCRIPTION
This makes no functional difference (well, I hope) but helps when debugging.
Other methods around here that affect the right side title all set
`@right_cell_text`, so I was very perplexed when it stayed "wrong" while
stepping to the very end of the controller code and then browser
magically showed another title...

@miq-bot add-label control, ui, euwe/no