### PR TITLE
Fix "Editing ... Condition" title

### DIFF
--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -618,7 +618,7 @@ class MiqPolicyController < ApplicationController
       right_cell_text = if @condition.id.blank?
                           _("Adding a new %{model}") % {:model => ui_lookup(:model => 'Condition')}
                         else
-                          if @right_cell_text == @edit
+                          if @edit
                             _("Editing %{model} Condition \"%{name}\"") %
                             {:name  => @condition.description,
                              :model => ui_lookup(:model => @edit[:new][:towhat])}


### PR DESCRIPTION
Control explorer -> Conditions -> Create a Condition, then Configuration -> Edit this Condition.
Before: »»Host / Node« Condition "cond"«
After: »Editing »Host / Node« Condition "cond"«

Got accidentally broken in fd47e8d18121b43d6739985d481a94d2fb86b3e7 (#6732).
@ZitaNemeckova please review.

@miq-bot add-label control, ui, bug