### PR TITLE
[DARGA] Fix calculation of average for used metrics

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -136,8 +136,8 @@ class Chargeback < ActsAsArModel
 
     rates.each do |rate|
       rate.chargeback_rate_details.each do |r|
-        metric_value = r.metric_value_by(metric_rollup_records)
         r.hours_in_interval = hours_in_interval
+        metric_value = r.metric_value_by(metric_rollup_records)
         cost = r.cost(metric_value) * hours_in_interval
 
         # add values to hash and sum

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -18,9 +18,8 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def avg_of_metric_from(metric_rollup_records)
-    record_count = metric_rollup_records.count
     metric_sum = metric_rollup_records.sum(&metric.to_sym)
-    metric_sum / record_count
+    metric_sum / @hours_in_interval
   end
 
   def metric_value_by(metric_rollup_records)

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -37,6 +37,10 @@ describe ChargebackContainerProject do
     Timecop.return
   end
 
+  def used_average_for(metric, hours_in_interval)
+    @project.metric_rollups.sum(&metric) / hours_in_interval
+  end
+
   context "Daily" do
     let(:hours_in_day) { 24 }
 
@@ -75,8 +79,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * hours_in_day)
+      metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day)
+      expect(subject.cpu_cores_used_metric).to eq(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
     end
 
     it "memory" do
@@ -92,8 +97,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.memory_used_metric).to eq(@memory_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(@memory_used * @hourly_rate * hours_in_day)
+      metric_used = used_average_for(:derived_memory_used, hours_in_day)
+      expect(subject.memory_used_metric).to eq(metric_used)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
     end
 
     it "net io" do
@@ -109,8 +115,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.net_io_used_metric).to eq(@net_usage_rate)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(@net_usage_rate * @hourly_rate * hours_in_day)
+      metric_used = used_average_for(:net_usage_rate_average, hours_in_day)
+      expect(subject.net_io_used_metric).to eq(metric_used)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * hours_in_day)
     end
   end
 
@@ -159,8 +166,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
 
     it "memory" do
@@ -176,8 +184,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.memory_used_metric).to eq(@memory_used)
-      expect(subject.memory_used_cost).to be_within(0.01).of(@memory_used * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:derived_memory_used, @hours_in_month)
+      expect(subject.memory_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.memory_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
 
     it "net io" do
@@ -193,8 +202,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.net_io_used_metric).to eq(@net_usage_rate)
-      expect(subject.net_io_used_cost).to be_within(0.01).of(@net_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:net_usage_rate_average, @hours_in_month)
+      expect(subject.net_io_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.net_io_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
   end
 
@@ -241,8 +251,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
     end
   end
 
@@ -291,8 +302,9 @@ describe ChargebackContainerProject do
       cbrd.chargeback_tiers = [cbt]
       cbrd.save
 
-      expect(subject.cpu_cores_used_metric).to eq(@cpu_usage_rate)
-      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(@cpu_usage_rate * @hourly_rate * @hours_in_month)
+      metric_used = used_average_for(:cpu_usage_rate_average, @hours_in_month)
+      expect(subject.cpu_cores_used_metric).to be_within(0.01).of(metric_used)
+      expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * @hourly_rate * @hours_in_month)
       expect(subject.tag_name).to eq('Production')
     end
   end


### PR DESCRIPTION
Darga version of: https://github.com/ManageIQ/manageiq/pull/12582

@miq-bot add_label bug, chargeback, blocker, darga/yes

## Links

https://bugzilla.redhat.com/show_bug.cgi?id=1396665

## Steps for Testing/QA

Example from BZ:
Report interval: daily
3 metric rollups records with cpu_usagemhz_rate_average values: 2685.44444444444, 2674.81111111111, 2675.01111111111

Average of CPU used for report interval: (2685.44444444444 + 2674.81111111111 + 2675.01111111111) / 24 (report daily interval) = 334.8027777777775

cost: 334.8027777777775 (Average of CPU used ) * $0.02(rate) * 24(daily report) = $160.70533333333321

