### PR TITLE
Fix tooltips for C&U pie charts

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1637,7 +1637,7 @@ function chartData(type, data, data2) {
       data.axis.y.tick.values = [0, max];
     }
 
-    if (data.miq.reporting_chart) {
+    if (data.miq.expand_tooltip) {
       data.tooltip.format.name = function (_name, _ratio, id, _index) {
         return data.miq.name_table[id];
       };
@@ -1667,6 +1667,7 @@ function chartData(type, data, data2) {
   // some PatternFly default configs define size of chart
   config.size = {};
   var ret = _.defaultsDeep({}, data, config, data2);
+  console.log(ret);
   return ret;
 }
 

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -158,12 +158,17 @@ module ReportFormatter
     end
 
     def build_reporting_chart(_maxcols, _divider)
-      mri.chart[:miq][:reporting_chart] = true
+      mri.chart[:miq][:expand_tooltip] = true
       super
     end
 
     def build_reporting_chart_numeric(_maxcols, _divider)
-      mri.chart[:miq][:reporting_chart] = true
+      mri.chart[:miq][:expand_tooltip] = true
+      super
+    end
+
+    def build_performance_chart_pie(_maxcols, _divider)
+      mri.chart[:miq][:expand_tooltip] = true
       super
     end
   end


### PR DESCRIPTION
Fix tooltips for C&U charts, just like in #11762 for reporting charts.

Screenshots
----------------
Before:
![screenshot from 2016-11-21 11-40-13](https://cloud.githubusercontent.com/assets/9535558/20479780/ca824d5c-afdf-11e6-8b4b-9e1980e1248e.png)

After:

![screenshot from 2016-11-21 11-38-37](https://cloud.githubusercontent.com/assets/9535558/20479773/c1051944-afdf-11e6-95b0-30f681302681.png)
Steps for Testing/QA
-------------------------------

Goto: Compute -> Infrastructure -> Host/VM/Cluster -> Utilization -> In chart menu select -> Chart -> Top VMs on this day
