### PR TITLE
Fix (hidden) VNC console button

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -591,8 +591,12 @@ class ApplicationHelper::ToolbarBuilder
       type = ::Settings.server.remote_console_type
       return type != 'MKS' || !@record.console_supported?(type)
     when "vm_vnc_console"
-      type = ::Settings.server.remote_console_type
-      return type != 'VNC' || !@record.console_supported?(type)
+      if @record.vendor == 'vmware'
+        # remote_console_type is only useful for vmware consoles
+        type = ::Settings.server.remote_console_type
+        return type != 'VNC' || !@record.console_supported?(type)
+      end
+      return !@record.console_supported?('vnc')
     when "vm_vmrc_console"
       type = ::Settings.server.remote_console_type
       return type != 'VMRC' || !@record.console_supported?(type)

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -413,6 +413,7 @@ describe ApplicationHelper do
         @id = "vm_vnc_console"
         stub_user(:features => :all)
         allow(@record).to receive_messages(:console_supported? => false)
+        allow(@record).to receive_messages(:vendor => "vmware")
       end
 
       it "and record is not console supported" do
@@ -432,6 +433,12 @@ describe ApplicationHelper do
       it "and record is console supported and server's remote_console_type is VNC" do
         allow(@record).to receive_messages(:console_supported? => true)
         stub_settings(:server => {:remote_console_type => "VNC"})
+        expect(subject).to be_falsey
+      end
+
+      it "and record is console supported and not vmware" do
+        allow(@record).to receive_messages(:console_supported? => true)
+        allow(@record).to receive_messages(:vendor => "not_vmware")
         expect(subject).to be_falsey
       end
     end


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/manageiq/pull/12720.

The VNC console button was never supposed to check the preffered vmware console type from user settings, since it has nothing to do with vmware.

EDIT: it does, it is one of the options for vmware too. So.. we just don't want to check it unless the record is indeed a vmware vm.

Undoing [that change](https://github.com/ManageIQ/manageiq/pull/12720/files#diff-68677a7d5d33ee19b2fd378d150a1c73R602) and adding a comment.

https://bugzilla.redhat.com/show_bug.cgi?id=1395382

Cc @matobet, @bmclaughlin 