### PR TITLE
No revert for "active" snapshot

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -928,6 +928,7 @@ class ApplicationHelper::ToolbarBuilder
       when "vm_snapshot_delete_all"
         return @record.is_available_now_error_message(:remove_all_snapshots) unless @record.is_available?(:remove_all_snapshots)
       when "vm_snapshot_revert"
+        return N_("Select a snapshot that is not the active one") if @active
         return @record.is_available_now_error_message(:revert_to_snapshot) unless @record.is_available?(:revert_to_snapshot)
       end
     when "MiqTemplate"


### PR DESCRIPTION
In the snapshot screen when the "active" snapshot is selected
the revert button should be disabled.

https://bugzilla.redhat.com/show_bug.cgi?id=1396068