### PR TITLE
Use delayed translations for constants

### DIFF
--- a/app/controllers/application_controller/timelines/options.rb
+++ b/app/controllers/application_controller/timelines/options.rb
@@ -1,5 +1,5 @@
 module ApplicationController::Timelines
-  SELECT_EVENT_TYPE = [[_('Management Events'), 'timeline'], [_('Policy Events'), 'policy_timeline']].freeze
+  SELECT_EVENT_TYPE = [[N_('Management Events'), 'timeline'], [N_('Policy Events'), 'policy_timeline']].freeze
   SELECT_RESULT_TYPE = {_('Both') => 'both', _('True') => 'success', _('False') => 'failure'}.freeze
   EVENT_COLORS = ['#CD051C', '#005C25', '#035CB1', '#FF3106', '#FF00FF', '#000000'].freeze
 

--- a/app/views/layouts/_tl_options.html.haml
+++ b/app/views/layouts/_tl_options.html.haml
@@ -17,7 +17,7 @@
             .form-group
               %div{'class' => 'timeline-filterbar'}
                 = select_tag("tl_show",
-                  options_for_select(ApplicationController::Timelines::SELECT_EVENT_TYPE, nil),
+                  options_for_select(ApplicationController::Timelines::SELECT_EVENT_TYPE.map {|key, value| [_(key), value]}, nil),
                   'ng-model'                    => 'reportModel.tl_show',
                   "selectpicker-for-select-tag" => '',
                   :class                        => 'selectpicker',


### PR DESCRIPTION
We cannot use a plain `_()` for constants, since these are being evaluated at the app load
time (rather than run time). We need to use `N_()` here (delayed translation) and apply
the gettext where needed in run-time (in this case, in the view).

Reproducer:
1. Switch to non-English locale
2. Storages -> Storage Manager -> Monitoring -> Timelines, look at the first dropdown
3. The strings in the first dropdown are in English

https://bugzilla.redhat.com/show_bug.cgi?id=1393310