### PR TITLE
Emit notifications only when user is authorized to see concerned object

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -42,6 +42,11 @@ class Notification < ApplicationRecord
 
   def set_notification_recipients
     subscribers = notification_type.subscriber_ids(subject, initiator)
+    if subject
+      subscribers.reject! do |subscriber_id|
+        Rbac.filtered_object(subject, :user => User.find(subscriber_id)).blank?
+      end
+    end
     self.notification_recipients_attributes = subscribers.collect { |id| {:user_id => id } }
   end
 

--- a/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_service_spec.rb
@@ -153,7 +153,10 @@ module MiqAeServiceSpec
       end
     end
     context "create notifications" do
-      before { NotificationType.seed }
+      before do
+        NotificationType.seed
+        allow(User).to receive_messages(:server_timezone => 'UTC')
+      end
 
       let(:options) { {} }
       let(:workspace) do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1394283

We shall not send a notification to the user, who is not authorized to see the object.

In future, we may want to handle the notification's subscribers in async queue.

@miq-bot add_label bug, blocker, core, euwe/no
@miq-bot assign @gtanzillo 