### PR TITLE
Event collection for the datawarehouse provider

### DIFF
--- a/app/models/manageiq/providers/hawkular/common/event_catcher/runner_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/common/event_catcher/runner_mixin.rb
@@ -1,0 +1,54 @@
+module ManageIQ::Providers::Hawkular::Common::EventCatcher::RunnerMixin
+  extend ActiveSupport::Concern
+
+  def log_handle
+    self.class.log_handle
+  end
+
+  def reset_event_monitor_handle
+    @event_monitor_handle = nil
+  end
+
+  def stop_event_monitor
+    @event_monitor_handle.try(:stop)
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_handle.each_batch do |events|
+      event_monitor_running
+      new_events = events.select { |e| whitelisted?(e) }
+      log_handle.debug("#{log_prefix} Discarding events #{events - new_events}") if new_events.length < events.length
+      if new_events.any?
+        log_handle.debug "#{log_prefix} Queueing events #{new_events}"
+        @queue.enq new_events
+      end
+      # invoke the configured sleep before the next event fetch
+      sleep_poll_normal
+    end
+  ensure
+    reset_event_monitor_handle
+  end
+
+  def event_monitor_handle
+    @event_monitor_handle ||= self.class.event_monitor_class.new(@ems)
+  end
+
+  def process_event(event)
+    log_handle.debug "Processing Event #{event}"
+    event_hash = event_to_hash(event, @cfg[:ems_id])
+
+    if blacklisted?(event_hash[:event_type])
+      log_handle.debug "#{log_prefix} Filtering blacklisted event [#{event}]"
+    else
+      log_handle.debug "#{log_prefix} Adding ems event [#{event_hash}]"
+      EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+    end
+  end
+
+  def blacklisted?(event_type)
+    filtered_events.include?(event_type)
+  end
+end

--- a/app/models/manageiq/providers/hawkular/common/event_catcher/stream_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/common/event_catcher/stream_mixin.rb
@@ -1,0 +1,30 @@
+module ManageIQ::Providers::Hawkular::Common::EventCatcher::StreamMixin
+  extend ActiveSupport::Concern
+
+  def start
+    @collecting_events = true
+  end
+
+  def stop
+    @collecting_events = false
+  end
+
+  def each_batch
+    while @collecting_events
+      yield fetch
+    end
+  end
+
+  def fetch
+    new_alerts = []
+    alert_tenants.each do |tenant|
+      log_handle.debug "Fetching tenant [#{tenant}] events using criteria [#{hawkular_alert_criteria}]"
+      new_alerts.concat(@ems.alerts_client(:tenant => tenant).list_alerts(hawkular_alert_criteria))
+    end
+    post_fetch(new_alerts)
+    new_alerts
+  rescue => err
+    log_handle.error "Error capturing alerts #{err}"
+    []
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers
   class Hawkular::DatawarehouseManager < ManageIQ::Providers::DatawarehouseManager
     require 'hawkular/hawkular_client'
 
+    require_nested :EventCatcher
     require_nested :RefreshParser
     require_nested :RefreshWorker
     require_nested :Refresher
@@ -102,6 +103,10 @@ module ManageIQ::Providers
 
     def self.description
       @description ||= "Hawkular Datawarehouse".freeze
+    end
+
+    def self.event_monitor_class
+      ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -38,7 +38,8 @@ module ManageIQ::Providers
     end
 
     # Hawkular Client
-    def self.raw_connect(hostname, port, token, type = :alerts)
+    def self.raw_connect(hostname, port, token, type)
+      type ||= :alerts
       klass = case type
               when :metrics
                 ::Hawkular::Metrics::Client

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager.rb
@@ -38,39 +38,42 @@ module ManageIQ::Providers
     end
 
     # Hawkular Client
-    def self.raw_connect(hostname, port, token, type)
-      type ||= :alerts
+    def self.raw_connect(options)
+      type = options[:type] || :alerts
+      tenant = options[:tenant] || '_system'
       klass = case type
               when :metrics
                 ::Hawkular::Metrics::Client
               when :alerts
                 ::Hawkular::Alerts::AlertsClient
               else
-                raise ArgumentError, "Client not found for #{type}"
+                raise ArgumentError, "Client not found for [#{type}]"
               end
       klass.new(
-        URI::HTTPS.build(:host => hostname, :port => port.to_i).to_s,
-        { :token => token },
-        { :tenant => '_system', :verify_ssl => verify_ssl_mode }
+        URI::HTTPS.build(:host => options[:hostname], :port => options[:port].to_i).to_s,
+        { :token => options[:token] },
+        { :tenant => tenant, :verify_ssl => verify_ssl_mode }
       )
     end
 
     def connect(options = {})
       @clients ||= {}
-      @clients[options[:type]] ||= self.class.raw_connect(
-        hostname,
-        port,
-        authentication_token('default'),
-        options[:type]
+      memo_options = options.slice(:type, :tenant)
+      @clients[memo_options.freeze] ||= self.class.raw_connect(
+        memo_options.merge(
+          :hostname => hostname,
+          :port     => port,
+          :token    => authentication_token('default'),
+        )
       )
     end
 
-    def alerts_client
-      connect(:type => :alerts)
+    def alerts_client(options = {})
+      connect(options.merge(:type => :alerts))
     end
 
-    def metrics_client
-      connect(:type => :metrics)
+    def metrics_client(options = {})
+      connect(options.merge(:type => :metrics))
     end
 
     def supports_port?

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
+
+  def self.settings_name
+    :event_catcher_hawkular_datawarehouse
+  end
 end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner.rb
@@ -3,6 +3,9 @@ class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Runner 
 
   include ManageIQ::Providers::Hawkular::Common::EventCatcher::RunnerMixin
 
+  TAG_URL  = 'url'.freeze
+  TAG_TYPE = 'type'.freeze
+
   def initialize(cfg = {})
     super
   end
@@ -15,13 +18,58 @@ class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Runner 
     ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream
   end
 
+  def self.find_target(tags)
+    target = case tags[TAG_TYPE].downcase
+             when "node" then OpenStruct.new(
+               :klass_name     => 'ContainerNode',
+               :find_key       => :name,
+               :value_tag_name => 'nodename',
+             )
+             else
+               $datawarehouse_log.error("unexpected target: [#{tags[TAG_TYPE]}]")
+               nil
+             end
+    instance = nil
+    instance = target.klass_name.constantize.find_by(target.find_key => tags[target.value_tag_name]) if target
+    $datawarehouse_log.error("Could not find hawkular alert target from tags: [#{tags}]") unless instance
+    instance
+  end
+
   private
 
-  def whitelist?(_event)
+  def whitelisted?(_event)
     true # we collect event by tags, see stream
   end
 
   def event_to_hash(event, current_ems_id)
-    {}
+    event = event.dup
+    event.severity = map_severity(event.severity) # gets into event.full_data
+    event.url = event.tags[TAG_URL]
+    target = self.class.find_target(event.tags)
+    {
+      :ems_id              => target.try(:ext_management_system).try(:id),
+      :generating_ems_id   => current_ems_id,
+      :source              => 'DATAWAREHOUSE',
+      :timestamp           => Time.zone.at(event.ctime / 1000),
+      :event_type          => 'datawarehouse_alert',
+      :target_type         => target.class.name.underscore,
+      :target_id           => target.id,
+      :container_node_id   => target.id,
+      :container_node_name => target.name,
+      :message             => event.text,
+      :full_data           => event.to_h
+    }
+  end
+
+  def map_severity(hwk_severity)
+    case hwk_severity
+    when "LOW"      then 'info'
+    when "MEDIUM"   then 'warning'
+    when "HIGH"     then 'warning'
+    when "CRITICAL" then 'error'
+    else
+      $datawarehouse_log.error("Could not map hawkular severity [#{hwk_severity}], using error")
+      'error'
+    end
   end
 end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner.rb
@@ -1,0 +1,27 @@
+class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Runner <
+  ManageIQ::Providers::BaseManager::EventCatcher::Runner
+
+  include ManageIQ::Providers::Hawkular::Common::EventCatcher::RunnerMixin
+
+  def initialize(cfg = {})
+    super
+  end
+
+  def self.log_handle
+    $datawarehouse_log
+  end
+
+  def self.event_monitor_class
+    ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream
+  end
+
+  private
+
+  def whitelist?(_event)
+    true # we collect event by tags, see stream
+  end
+
+  def event_to_hash(event, current_ems_id)
+    {}
+  end
+end

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
@@ -14,11 +14,11 @@ class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream
 
   def hawkular_alert_criteria
     # Use "tagQuery" => "type==node AND not seen_by" when that becomes available in HAWKULAR API
-    {}
+    {"tags" => "type|*", "thin" => true}
   end
 
   def alert_tenants
-    []
+    ::Settings.ems.ems_datawarehouse.alertable_tenants
   end
 
   def post_fetch(alerts)

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream
   end
 
   def alert_tenants
-    ::Settings.ems.ems_datawarehouse.alertable_tenants
+    ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher.worker_settings[:alertable_tenants]
   end
 
   def post_fetch(alerts)

--- a/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.rb
@@ -1,0 +1,27 @@
+class ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream
+  include ManageIQ::Providers::Hawkular::Common::EventCatcher::StreamMixin
+
+  def initialize(ems)
+    @ems               = ems
+    @collecting_events = false
+  end
+
+  private
+
+  def log_handle
+    $datawarehouse_log
+  end
+
+  def hawkular_alert_criteria
+    # Use "tagQuery" => "type==node AND not seen_by" when that becomes available in HAWKULAR API
+    {}
+  end
+
+  def alert_tenants
+    []
+  end
+
+  def post_fetch(alerts)
+    # Tag with seen_by => server_UUID when that becomes available through the HAWKULAR API
+  end
+end

--- a/app/models/miq_server/worker_management/monitor/class_names.rb
+++ b/app/models/miq_server/worker_management/monitor/class_names.rb
@@ -46,6 +46,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
+    ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher
     ManageIQ::Providers::Google::CloudManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
@@ -139,6 +140,7 @@ module MiqServer::WorkerManagement::Monitor::ClassNames
     ManageIQ::Providers::Azure::CloudManager::EventCatcher
     ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher
     ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher
+    ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher
     ManageIQ::Providers::Google::CloudManager::EventCatcher
     ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1275,6 +1275,8 @@
         :poll: 15.seconds
       :event_catcher_hawkular:
         :poll: 10.seconds
+      :event_catcher_hawkular_datawarehouse:
+        :poll: 30.seconds
       :event_catcher_google:
         :poll: 15.seconds
       :event_catcher_kubernetes:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,6 +107,8 @@
   :ems_azure:
     :disabled_regions: []
     :additional_regions: {}
+  :ems_datawarehouse:
+    :alertable_tenants: ['_system', '_ops']
 :event_streams:
   :history:
     :keep_events: 6.months

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,8 +107,6 @@
   :ems_azure:
     :disabled_regions: []
     :additional_regions: {}
-  :ems_datawarehouse:
-    :alertable_tenants: ['_system', '_ops']
 :event_streams:
   :history:
     :keep_events: 6.months
@@ -1276,7 +1274,8 @@
       :event_catcher_hawkular:
         :poll: 10.seconds
       :event_catcher_hawkular_datawarehouse:
-        :poll: 30.seconds
+        :alertable_tenants: ['_system', '_ops']
+        :poll: 1.minute
       :event_catcher_google:
         :poll: 15.seconds
       :event_catcher_kubernetes:

--- a/spec/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/runner_spec.rb
@@ -1,0 +1,16 @@
+describe ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Runner do
+  let(:ems) { FactoryGirl.create(:ems_kubernetes, :hostname => 'hostname') }
+
+  context "#find_target" do
+    require 'hawkular/hawkular_client'
+
+    it "find a target container node" do
+      target = FactoryGirl.create(:container_node, :id => 999, :name => 'the_target')
+      tags = {
+        'type'     => 'node',
+        'nodename' => target.name
+      }
+      expect(described_class.find_target(tags)).to eq(target)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream_spec.rb
@@ -1,0 +1,33 @@
+describe ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher::Stream do
+  subject do
+    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    auth                 = AuthToken.new(:auth_key => "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tdmtlN2siLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6Ijg3MDQ5NzNjLWRiMjMtMTFlNi05NDlkLTAwMWE0YTE2MjY3YyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.nuNCehi01GT7sbGGliCjTdwzZjNo4mjsbgGwuyChCxZJhj2Jyb7C2ZUABfgh26g466EReMal5M4F7Nbah_cbZgfrWi1NK0h_f18g8kA_m3jn9CfbfajZAGSMEUrVwHx05IqVqEI4FMJM5XwYBP8pTSEGjYcuk5OOSEK_xXs-Lt_iJYaOUMjWNa-XnI3zjiD5f7eP-FBOek2-YtFlcSJt3lqQyM_fjrocnMF9B3JWYcFLQ-ctuRaOHvaK-eaXz1AzFctBfaBGYXSw0LrH0slWqNC0Fu1AWpKKvwrOwD70DhUgjBGnD3Va_3ewTe5KNwByib6ox6xOQVYnfg7SoSOdCg",
+                                         :userid   => "_")
+    ems                  = FactoryGirl.create(:ems_hawkular_datawarehouse,
+                                              :hostname        => 'metrics.10.35.48.125.xip.io',
+                                              :port            => 443,
+                                              :authentications => [auth],
+                                              :zone            => zone)
+    described_class.new(ems)
+  end
+
+  context "#fetch" do
+    it "yields valid events" do
+      VCR.use_cassette(
+        described_class.name.underscore.to_s,
+        :decode_compressed_response => true,
+        # :record                   => :new_episodes,
+      ) do
+        result = subject.instance_eval('fetch')
+        expect(result.count).to be == 1
+        expect(result.first[:text]).to eq "This text shows up on the alert"
+        expect(result.first[:tags]).to include(
+          "nodename" => "vm-48-124.eng.lab.tlv.redhat.com",
+          "type"     => "node",
+          "url"      => "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+        expect(result.first[:severity]).to eq "HIGH"
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.yml
+++ b/spec/vcr_cassettes/manageiq/providers/hawkular/datawarehouse_manager/event_catcher/stream.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7C*&thin=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Hawkular-Tenant:
+      - _system
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tdmtlN2siLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6Ijg3MDQ5NzNjLWRiMjMtMTFlNi05NDlkLTAwMWE0YTE2MjY3YyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.nuNCehi01GT7sbGGliCjTdwzZjNo4mjsbgGwuyChCxZJhj2Jyb7C2ZUABfgh26g466EReMal5M4F7Nbah_cbZgfrWi1NK0h_f18g8kA_m3jn9CfbfajZAGSMEUrVwHx05IqVqEI4FMJM5XwYBP8pTSEGjYcuk5OOSEK_xXs-Lt_iJYaOUMjWNa-XnI3zjiD5f7eP-FBOek2-YtFlcSJt3lqQyM_fjrocnMF9B3JWYcFLQ-ctuRaOHvaK-eaXz1AzFctBfaBGYXSw0LrH0slWqNC0Fu1AWpKKvwrOwD70DhUgjBGnD3Va_3ewTe5KNwByib6ox6xOQVYnfg7SoSOdCg
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Total-Count:
+      - '1'
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1002'
+      Link:
+      - <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true>;
+        rel="current", <https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7c*&thin=true&page=0>;
+        rel="last"
+      Date:
+      - Mon, 27 Feb 2017 13:13:28 GMT
+      Set-Cookie:
+      - f5489604a2df0d7b0e8c7b7b0a17e360=a491054022ca473f68aaa45b560ca958; path=/;
+        HttpOnly; Secure
+      Cache-Control:
+      - private
+    body:
+      encoding: UTF-8
+      string: '[{"eventType":"ALERT","tenantId":"_system","id":"ops-example-1487798421499-97db796d-b5a1-492c-9153-3b43cc6426d2","ctime":1487798421499,"dataSource":"_none_","dataId":"ops-example","category":"ALERT","text":"This
+        text shows up on the alert","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"},"trigger":{"tenantId":"_system","id":"ops-example","name":"Auto
+        Resolving trigger","description":"Auto resolving trigger example","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":"This
+        text shows up on the alert","severity":"HIGH","tags":{"nodename":"vm-48-124.eng.lab.tlv.redhat.com","type":"node","url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"},"autoDisable":false,"autoEnable":false,"autoResolve":true,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ALL","source":"_none_"},"severity":"HIGH","status":"OPEN","lifecycle":[{"status":"OPEN","user":"system","stime":1487798421499}]}]'
+    http_version: 
+  recorded_at: Mon, 27 Feb 2017 13:13:27 GMT
+- request:
+    method: get
+    uri: https://metrics.10.35.48.125.xip.io/hawkular/alerts/?tags=type%7C*&thin=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Hawkular-Tenant:
+      - _ops
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJtYW5hZ2VtZW50LWluZnJhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im1hbmFnZW1lbnQtYWRtaW4tdG9rZW4tdmtlN2siLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibWFuYWdlbWVudC1hZG1pbiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6Ijg3MDQ5NzNjLWRiMjMtMTFlNi05NDlkLTAwMWE0YTE2MjY3YyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDptYW5hZ2VtZW50LWluZnJhOm1hbmFnZW1lbnQtYWRtaW4ifQ.nuNCehi01GT7sbGGliCjTdwzZjNo4mjsbgGwuyChCxZJhj2Jyb7C2ZUABfgh26g466EReMal5M4F7Nbah_cbZgfrWi1NK0h_f18g8kA_m3jn9CfbfajZAGSMEUrVwHx05IqVqEI4FMJM5XwYBP8pTSEGjYcuk5OOSEK_xXs-Lt_iJYaOUMjWNa-XnI3zjiD5f7eP-FBOek2-YtFlcSJt3lqQyM_fjrocnMF9B3JWYcFLQ-ctuRaOHvaK-eaXz1AzFctBfaBGYXSw0LrH0slWqNC0Fu1AWpKKvwrOwD70DhUgjBGnD3Va_3ewTe5KNwByib6ox6xOQVYnfg7SoSOdCg
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Date:
+      - Mon, 27 Feb 2017 13:13:28 GMT
+      Set-Cookie:
+      - f5489604a2df0d7b0e8c7b7b0a17e360=a491054022ca473f68aaa45b560ca958; path=/;
+        HttpOnly; Secure
+      Cache-Control:
+      - private
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 27 Feb 2017 13:13:27 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
The Datawarehouse manager added in #12205 collects events that end up belonging to other providers. Those events are passed to the target providers/objects based on metadata they contain. A new field was added to event streams to keep track of the ext_management_system that carried the event in.
