### PR TITLE
[WIP] Allow to display button for showing fullscreen report to be rendered without RBAC check

### DIFF
--- a/app/helpers/application_helper/toolbar/saved_report_center.rb
+++ b/app/helpers/application_helper/toolbar/saved_report_center.rb
@@ -13,6 +13,7 @@ class ApplicationHelper::Toolbar::SavedReportCenter < ApplicationHelper::Toolbar
           t,
           :url     => "/report_only",
           :popup   => true,
+          :klass   => ApplicationHelper::Button::ButtonWithoutRbacCheck,
           :confirm => N_("This will show the entire report (all rows) in your browser.  Do you want to proceed?")),
         button(
           :saved_report_delete,


### PR DESCRIPTION
Fix missing toolbar button in Reports

Before:
![screenshot from 2016-11-21 17-54-22](https://cloud.githubusercontent.com/assets/1187051/20492061/a4372ba2-b013-11e6-9f74-d4477e8d5ae4.png)

After:
![screenshot from 2016-11-21 17-54-31](https://cloud.githubusercontent.com/assets/1187051/20492063/a576f7b8-b013-11e6-833e-1523f6c814fc.png)


Links
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1393590

Steps for Testing/QA
-------------------------------

Cloud Intel -> Reports -> Reports accordion