### PR TITLE
Toolbar refactoring  container buttons

### DIFF
--- a/app/helpers/application_helper/button/container_timeline.rb
+++ b/app/helpers/application_helper/button/container_timeline.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::ContainerTimeline < ApplicationHelper::Button::Container
+  needs :@record
+
+  def disabled?
+    @error_message = _('No Timeline data has been collected for this %{entity}') %
+                     {:entity => @entity} unless proper_events?
+    @error_message.present?
+  end
+
+  private
+
+  def proper_events?
+    @record.has_events? || @record.has_events?(:policy_events)
+  end
+end

--- a/app/helpers/application_helper/button/container_timeline.rb
+++ b/app/helpers/application_helper/button/container_timeline.rb
@@ -1,5 +1,15 @@
-class ApplicationHelper::Button::ContainerTimeline < ApplicationHelper::Button::Container
+class ApplicationHelper::Button::ContainerTimeline < ApplicationHelper::Button::Basic
   needs :@record
+
+  def initialize(view_context, view_binding, instance_data, props)
+    super
+    @entity = props[:options][:entity]
+  end
+
+  def calculate_properties
+    super
+    self[:title] = @error_message if @error_message.present?
+  end
 
   def disabled?
     @error_message = _('No Timeline data has been collected for this %{entity}') %

--- a/app/helpers/application_helper/toolbar/container_center.rb
+++ b/app/helpers/application_helper/toolbar/container_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_vmdb', [
-    select(
-      :container_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Container'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Container from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Container and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_monitoring', [
     select(
       :container_monitoring_choice,

--- a/app/helpers/application_helper/toolbar/container_center.rb
+++ b/app/helpers/application_helper/toolbar/container_center.rb
@@ -34,7 +34,9 @@ class ApplicationHelper::Toolbar::ContainerCenter < ApplicationHelper::Toolbar::
           'product product-timeline fa-lg',
           N_('Show Timelines for this Container'),
           N_('Timelines'),
-          :url_parms => "?display=timeline"),
+          :url_parms => "?display=timeline",
+          :options   => {:entity => 'Container'},
+          :klass     => ApplicationHelper::Button::ContainerTimeline),
         button(
           :container_perf,
           'product product-monitoring fa-lg',

--- a/app/helpers/application_helper/toolbar/container_group_center.rb
+++ b/app/helpers/application_helper/toolbar/container_group_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerGroupCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_group_vmdb', [
-    select(
-      :container_group_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_group_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Pod'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_group_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Pod from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Pod and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_group_monitoring', [
     select(
       :container_group_monitoring_choice,

--- a/app/helpers/application_helper/toolbar/container_group_center.rb
+++ b/app/helpers/application_helper/toolbar/container_group_center.rb
@@ -35,7 +35,9 @@ class ApplicationHelper::Toolbar::ContainerGroupCenter < ApplicationHelper::Tool
           N_('Show Timelines for this Group'),
           N_('Timelines'),
           :url       => "/show",
-          :url_parms => "?display=timeline"),
+          :url_parms => "?display=timeline",
+          :options   => {:entity => 'Group'},
+          :klass     => ApplicationHelper::Button::ContainerTimeline),
         button(
           :container_group_perf,
           'product product-monitoring fa-lg',

--- a/app/helpers/application_helper/toolbar/container_groups_center.rb
+++ b/app/helpers/application_helper/toolbar/container_groups_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerGroupsCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_group_vmdb', [
-    select(
-      :container_group_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_group_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Pod'),
-          t,
-          :url => "/new"),
-        button(
-          :container_group_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Pod to edit'),
-          N_('Edit Selected Pods'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_group_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Pods from the VMDB'),
-          N_('Remove Pods from the VMDB'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Pods and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_group_policy', [
     select(
       :container_group_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_image_registries_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_registries_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerImageRegistriesCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_image_registry_vmdb', [
-    select(
-      :container_image_registry_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_image_registry_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Image Registry'),
-          t,
-          :url => "/new"),
-        button(
-          :container_image_registry_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Image Registry to edit'),
-          N_('Edit Selected Image Registry'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_image_registry_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Image Registries from the VMDB'),
-          N_('Remove Image Registries from the VMDB'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Image Registries and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_image_registry_policy', [
     select(
       :container_image_registry_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_image_registry_center.rb
+++ b/app/helpers/application_helper/toolbar/container_image_registry_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerImageRegistryCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_image_registry_vmdb', [
-    select(
-      :container_image_registry_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_image_registry_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Image Registry'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_image_registry_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Image Registry from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Image Registry and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_image_registry_policy', [
     select(
       :container_image_registry_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -35,7 +35,9 @@ class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolb
           N_('Show Timelines for this Node'),
           N_('Timelines'),
           :url       => "/show",
-          :url_parms => "?display=timeline"),
+          :url_parms => "?display=timeline",
+          :options   => {:entity => 'Node'},
+          :klass     => ApplicationHelper::Button::ContainerTimeline),
         button(
           :container_node_perf,
           'product product-monitoring fa-lg',

--- a/app/helpers/application_helper/toolbar/container_node_center.rb
+++ b/app/helpers/application_helper/toolbar/container_node_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerNodeCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_node_vmdb', [
-    select(
-      :container_node_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_node_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Node'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_node_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Node from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Node and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_node_monitoring', [
     select(
       :container_node_monitoring_choice,

--- a/app/helpers/application_helper/toolbar/container_nodes_center.rb
+++ b/app/helpers/application_helper/toolbar/container_nodes_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerNodesCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_node_vmdb', [
-    select(
-      :container_node_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_node_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Node'),
-          t,
-          :url => "/new"),
-        button(
-          :container_node_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Node to edit'),
-          N_('Edit Selected Node'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_node_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Nodes from the VMDB'),
-          N_('Remove Nodes from the VMDB'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Nodes and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_node_policy', [
     select(
       :container_node_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_project_center.rb
+++ b/app/helpers/application_helper/toolbar/container_project_center.rb
@@ -35,7 +35,9 @@ class ApplicationHelper::Toolbar::ContainerProjectCenter < ApplicationHelper::To
           N_('Show Timelines for this Project'),
           N_('Timelines'),
           :url       => "/show",
-          :url_parms => "?display=timeline"),
+          :url_parms => "?display=timeline",
+          :options   => {:entity => 'Project'},
+          :klass     => ApplicationHelper::Button::ContainerTimeline),
         button(
           :container_project_perf,
           'product product-monitoring fa-lg',

--- a/app/helpers/application_helper/toolbar/container_project_center.rb
+++ b/app/helpers/application_helper/toolbar/container_project_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerProjectCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_project_vmdb', [
-    select(
-      :container_project_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_project_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Project'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_project_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Project from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Project and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_project_monitoring', [
     select(
       :container_project_monitoring_choice,

--- a/app/helpers/application_helper/toolbar/container_projects_center.rb
+++ b/app/helpers/application_helper/toolbar/container_projects_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerProjectsCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_project_vmdb', [
-    select(
-      :container_project_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_service_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Service'),
-          t,
-          :url => "/new"),
-        button(
-          :container_service_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Service to edit'),
-          N_('Edit Selected Service'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_service_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Services from the VMDB'),
-          N_('Remove Services from the VMDB'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_project_policy', [
     select(
       :container_project_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_replicator_center.rb
+++ b/app/helpers/application_helper/toolbar/container_replicator_center.rb
@@ -35,7 +35,9 @@ class ApplicationHelper::Toolbar::ContainerReplicatorCenter < ApplicationHelper:
           N_('Show Timelines for this Replicator'),
           N_('Timelines'),
           :url       => "/show",
-          :url_parms => "?display=timeline"),
+          :url_parms => "?display=timeline",
+          :options   => {:entity => 'Replicator'},
+          :klass     => ApplicationHelper::Button::ContainerTimeline),
         button(
           :container_replicator_perf,
           'product product-monitoring fa-lg',

--- a/app/helpers/application_helper/toolbar/container_replicator_center.rb
+++ b/app/helpers/application_helper/toolbar/container_replicator_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerReplicatorCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_replicator_vmdb', [
-    select(
-      :container_replicator_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_replicator_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Replicator'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_replicator_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Replicator from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Replicator and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_replicator_monitoring', [
     select(
       :container_replicator_monitoring_choice,

--- a/app/helpers/application_helper/toolbar/container_replicators_center.rb
+++ b/app/helpers/application_helper/toolbar/container_replicators_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerReplicatorsCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_replicator_vmdb', [
-    select(
-      :container_replicator_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_replicator_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Replicator'),
-          t,
-          :url => "/new"),
-        button(
-          :container_replicator_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Replicator to edit'),
-          N_('Edit Selected Replicator'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_replicator_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Replicators from the VMDB'),
-          N_('Remove Replicators from the VMDB'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Replicators and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_replicator_policy', [
     select(
       :container_replicator_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_route_center.rb
+++ b/app/helpers/application_helper/toolbar/container_route_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerRouteCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_route_vmdb', [
-    select(
-      :container_route_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_route_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Route'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_route_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Route from the VMDB'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Route and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_route_policy', [
     select(
       :container_route_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_routes_center.rb
+++ b/app/helpers/application_helper/toolbar/container_routes_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerRoutesCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_route_vmdb', [
-    select(
-      :container_route_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_route_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Project'),
-          t,
-          :url => "/new"),
-        button(
-          :container_service_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Project to edit'),
-          N_('Edit Selected Project'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_service_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Projects'),
-          N_('Remove Projects'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Projects and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_route_policy', [
     select(
       :container_route_policy_choice,

--- a/app/helpers/application_helper/toolbar/container_service_center.rb
+++ b/app/helpers/application_helper/toolbar/container_service_center.rb
@@ -1,27 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerServiceCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_service_vmdb', [
-    select(
-      :container_service_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_service_edit,
-          'pficon pficon-edit fa-lg',
-          t = N_('Edit this Service'),
-          t,
-          :url => "/edit"),
-        button(
-          :container_service_delete,
-          'pficon pficon-delete fa-lg',
-          t = N_('Remove this Service'),
-          t,
-          :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Service and ALL of its components will be permanently removed!")),
-      ]
-    ),
-  ])
   button_group('container_service_monitoring', [
     select(
       :container_service_monitoring_choice,

--- a/app/helpers/application_helper/toolbar/container_services_center.rb
+++ b/app/helpers/application_helper/toolbar/container_services_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainerServicesCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_service_vmdb', [
-    select(
-      :container_service_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_service_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Service'),
-          t,
-          :url => "/new"),
-        button(
-          :container_service_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Service to edit'),
-          N_('Edit Selected Service'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_service_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Services'),
-          N_('Remove Services'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Services and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_service_policy', [
     select(
       :container_service_policy_choice,

--- a/app/helpers/application_helper/toolbar/containers_center.rb
+++ b/app/helpers/application_helper/toolbar/containers_center.rb
@@ -1,35 +1,4 @@
 class ApplicationHelper::Toolbar::ContainersCenter < ApplicationHelper::Toolbar::Basic
-  button_group('container_vmdb', [
-    select(
-      :container_vmdb_choice,
-      'fa fa-cog fa-lg',
-      t = N_('Configuration'),
-      t,
-      :items => [
-        button(
-          :container_new,
-          'pficon pficon-add-circle-o fa-lg',
-          t = N_('Add a New Container'),
-          t,
-          :url => "/new"),
-        button(
-          :container_edit,
-          'pficon pficon-edit fa-lg',
-          N_('Select a single Container to edit'),
-          N_('Edit Selected Container'),
-          :url_parms => "main_div",
-          :onwhen    => "1"),
-        button(
-          :container_delete,
-          'pficon pficon-delete fa-lg',
-          N_('Remove selected Containers'),
-          N_('Remove Containers'),
-          :url_parms => "main_div",
-          :confirm   => N_("Warning: The selected Containers and ALL of their components will be permanently removed!"),
-          :onwhen    => "1+"),
-      ]
-    ),
-  ])
   button_group('container_policy', [
     select(
       :container_policy_choice,

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -469,35 +469,6 @@ class ApplicationHelper::ToolbarBuilder
     return false if id.start_with?('history_')
     return true if id == "blank_button" # Always hide the blank button placeholder
 
-    # Hide configuration buttons for specific Container* entities
-    return true if %w(container_node_edit container_node_delete container_node_new).include?(id) &&
-                   (@record.kind_of?(ContainerNode) || @record.nil?)
-
-    return true if %w(container_service_edit container_service_delete container_service_new).include?(id) &&
-                   (@record.kind_of?(ContainerService) || @record.nil?)
-
-    return true if %w(container_group_edit container_group_delete container_group_new).include?(id) &&
-                   (@record.kind_of?(ContainerGroup) || @record.nil?)
-
-    return true if %w(container_edit container_delete container_new).include?(id) &&
-                   (@record.kind_of?(Container) || @record.nil?)
-
-    return true if %w(container_replicator_edit container_replicator_delete container_replicator_new).include?(id) &&
-                   (@record.kind_of?(ContainerReplicator) || @record.nil?)
-
-    return true if %w(container_image_registry_edit container_image_registry_delete
-                      container_image_registry_new).include?(id) &&
-                   (@record.kind_of?(ContainerImageRegistry) || @record.nil?)
-
-    return true if %w(persistent_volume_edit persistent_volume_delete persistent_volume_new).include?(id) &&
-                   (@record.kind_of?(PersistentVolume) || @record.nil?)
-
-    return true if %w(container_build_edit container_build_delete container_build_new).include?(id) &&
-                   (@record.kind_of?(ContainerBuild) || @record.nil?)
-
-    return true if %w(container_template_edit container_template_delete container_template_new).include?(id) &&
-                   (@record.kind_of?(ContainerTemplate) || @record.nil?)
-
     # hide compliance check and comparison buttons rendered for orchestration stack instances
     return true if @record.kind_of?(OrchestrationStack) && @display == "instances" &&
                    %w(instance_check_compliance instance_compare).include?(id)
@@ -686,41 +657,6 @@ class ApplicationHelper::ToolbarBuilder
       when "host_timeline"
         unless @record.has_events? || @record.has_events?(:policy_events)
           return N_("No Timeline data has been collected for this Host")
-        end
-      end
-    when "Container"
-      case id
-      when "container_timeline"
-        unless @record.has_events? || @record.has_events?(:policy_events)
-          return N_("No Timeline data has been collected for this Container")
-        end
-      end
-    when "ContainerNode"
-      case id
-      when "container_node_timeline"
-        unless @record.has_events? || @record.has_events?(:policy_events)
-          return N_("No Timeline data has been collected for this Node")
-        end
-      end
-    when "ContainerGroup"
-      case id
-      when "container_group_timeline"
-        unless @record.has_events? || @record.has_events?(:policy_events)
-          return N_("No Timeline data has been collected for this Pod")
-        end
-      end
-    when "ContainerReplicator"
-      case id
-      when "container_replicator_timeline"
-        unless @record.has_events? || @record.has_events?(:policy_events)
-          return N_("No Timeline data has been collected for this Replicator")
-        end
-      end
-    when "ContainerProject"
-      case id
-      when "container_project_timeline"
-        unless @record.has_events? || @record.has_events?(:policy_events)
-          return N_("No Timeline data has been collected for this Project")
         end
       end
     when "MiqAction"

--- a/app/helpers/application_helper/toolbar_chooser.rb
+++ b/app/helpers/application_helper/toolbar_chooser.rb
@@ -224,7 +224,6 @@ class ApplicationHelper::ToolbarChooser
   end
 
   def center_toolbar_filename_containers
-    # TreeBuilder.get_model_for_prefix(@nodetype) == "Container" ? "containers_center_tb" : "container_center_tb"
     if x_node == "root"
       return "containers_center_tb"
     else

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4475,23 +4475,6 @@
       :description: Show Capacity & Utilization data of Pods
       :feature_type: view
       :identifier: container_group_perf
-  - :name: Modify
-    :description: Modify Pods
-    :feature_type: admin
-    :identifier: container_group_admin
-    :children:
-    - :name: Remove
-      :description: Remove Pod
-      :feature_type: admin
-      :identifier: container_group_delete
-    - :name: Edit
-      :description: Edit a Pod
-      :feature_type: admin
-      :identifier: container_group_edit
-    - :name: Add
-      :description: Add a Pod
-      :feature_type: admin
-      :identifier: container_group_new
   - :name: Operate
     :description: Perform Operations on Pods
     :feature_type: control
@@ -4537,23 +4520,6 @@
       :description: Display Timelines for Container Nodes
       :feature_type: view
       :identifier: container_node_timeline
-  - :name: Modify
-    :description: Modify Container Nodes
-    :feature_type: admin
-    :identifier: container_node_admin
-    :children:
-    - :name: Remove
-      :description: Remove Container Nodes
-      :feature_type: admin
-      :identifier: container_node_delete
-    - :name: Edit
-      :description: Edit a Container Nodes
-      :feature_type: admin
-      :identifier: container_node_edit
-    - :name: Add
-      :description: Add a Container Nodes
-      :feature_type: admin
-      :identifier: container_node_new
   - :name: Operate
     :description: Perform Operations on Container Nodes
     :feature_type: control
@@ -4599,23 +4565,6 @@
       :description: Display Timelines for container Replicators
       :feature_type: view
       :identifier: container_replicator_timeline
-  - :name: Modify
-    :description: Modify Container Nodes
-    :feature_type: admin
-    :identifier: container_replicator_admin
-    :children:
-    - :name: Remove
-      :description: Remove Container Replicator
-      :feature_type: admin
-      :identifier: container_replicator_delete
-    - :name: Edit
-      :description: Edit a Container Replicator
-      :feature_type: admin
-      :identifier: container_replicator_edit
-    - :name: Add
-      :description: Add a Container Replicator
-      :feature_type: admin
-      :identifier: container_replicator_new
   - :name: Operate
     :description: Perform Operations on Container Replicators
     :feature_type: control
@@ -4695,23 +4644,6 @@
       :description: Display Individual Container Image Registries
       :feature_type: view
       :identifier: container_image_registry_show
-  - :name: Modify
-    :description: Modify Container Image Registries
-    :feature_type: admin
-    :identifier: container_image_registry_admin
-    :children:
-    - :name: Remove
-      :description: Remove Container Image Registry
-      :feature_type: admin
-      :identifier: container_image_registry_delete
-    - :name: Edit
-      :description: Edit a Container Image Registry
-      :feature_type: admin
-      :identifier: container_image_registry_edit
-    - :name: Add
-      :description: Add a Container Image Registry
-      :feature_type: admin
-      :identifier: container_image_registry_new
   - :name: Operate
     :description: Perform Operations on Container Image Registries
     :feature_type: control
@@ -4787,23 +4719,6 @@
       :description: Display Individual Container Build
       :feature_type: view
       :identifier: container_build_show
-  - :name: Modify
-    :description: Modify Container Build
-    :feature_type: admin
-    :identifier: container_build_admin
-    :children:
-    - :name: Remove
-      :description: Remove Container Build
-      :feature_type: admin
-      :identifier: container_build_delete
-    - :name: Edit
-      :description: Edit a Container Build
-      :feature_type: admin
-      :identifier: container_build_edit
-    - :name: Add
-      :description: Add a Container Build
-      :feature_type: admin
-      :identifier: container_build_new
   - :name: Operate
     :description: Perform Operations on Container Build
     :feature_type: control
@@ -4866,23 +4781,6 @@
       :description: Show Capacity & Utilization data of Service
       :feature_type: view
       :identifier: container_service_perf
-  - :name: Modify
-    :description: Modify Container Services
-    :feature_type: admin
-    :identifier: container_service_admin
-    :children:
-    - :name: Remove
-      :description: Remove Container Services
-      :feature_type: admin
-      :identifier: container_service_delete
-    - :name: Edit
-      :description: Edit a Container Service
-      :feature_type: admin
-      :identifier: container_service_edit
-    - :name: Add
-      :description: Add a Container Service
-      :feature_type: admin
-      :identifier: container_service_new
   - :name: Operate
     :description: Perform Operations on Container Services
     :feature_type: control
@@ -4997,18 +4895,6 @@
       :feature_type: admin
       :identifier: container_admin
       :children:
-      - :name: Remove Container
-        :description: Remove Container
-        :feature_type: admin
-        :identifier: container_delete
-      - :name: Edit Container
-        :description: Edit a Container
-        :feature_type: admin
-        :identifier: container_edit
-      - :name: Add Container
-        :description: Add a Container
-        :feature_type: admin
-        :identifier: container_new
       - :name: Utilization
         :description: Show Capacity & Utilization data of Containers
         :feature_type: view

--- a/spec/helpers/application_helper/buttons/container_timeline_spec.rb
+++ b/spec/helpers/application_helper/buttons/container_timeline_spec.rb
@@ -1,0 +1,22 @@
+describe ApplicationHelper::Button::ContainerTimeline do
+  let(:record) { FactoryGirl.create(:container) }
+  subject do
+    described_class.new(setup_view_context_with_sandbox({}), {}, {'record' => record},
+                        {:options => {:entity => 'Container'}})
+  end
+
+  before { allow(record).to receive(:has_events?).and_return(has_events) }
+
+  describe '#disabled?' do
+    %i(ems_events policy_events).each do |event_type|
+      context "record has #{event_type}" do
+        let(:has_events) { true }
+        it { expect(subject.disabled?).to be_falsey }
+      end
+    end
+    context 'record has no ems_events or policy_events' do
+      let(:has_events) { false }
+      it { expect(subject.disabled?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -764,58 +764,6 @@ describe ApplicationHelper do
       end
     end
 
-    context "when record class = ContainerProject" do
-      before do
-        @record = ContainerProject.new
-        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
-      end
-
-      context "and id = container_project_timeline" do
-        before { @id = "container_project_timeline" }
-        it_behaves_like 'record without ems events and policy events', "No Timeline data has been collected for this Project"
-        it_behaves_like 'default case'
-      end
-    end
-
-    context "when record class = ContainerGroup" do
-      before do
-        @record = ContainerGroup.new
-        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
-      end
-
-      context "and id = container_group_timeline" do
-        before { @id = "container_group_timeline" }
-        it_behaves_like 'record without ems events and policy events', "No Timeline data has been collected for this Pod"
-        it_behaves_like 'default case'
-      end
-    end
-
-    context "when record class = ContainerNode" do
-      before do
-        @record = ContainerNode.new
-        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
-      end
-
-      context "and id = container_node_timeline" do
-        before { @id = "container_node_timeline" }
-        it_behaves_like 'record without ems events and policy events', "No Timeline data has been collected for this Node"
-        it_behaves_like 'default case'
-      end
-    end
-
-    context "when record class = ContainerReplicator" do
-      before do
-        @record = ContainerReplicator.new
-        allow(@record).to receive_messages(:has_perf_data? => true, :has_events? => true)
-      end
-
-      context "and id = container_replicator_timeline" do
-        before { @id = "container_replicator_timeline" }
-        it_behaves_like 'record without ems events and policy events', "No Timeline data has been collected for this Replicator"
-        it_behaves_like 'default case'
-      end
-    end
-
     context "when record class = Host" do
       before do
         @record = Host.new


### PR DESCRIPTION
Based on #12780, all the buttons that represent an invalid action have been removed. A new button class has been created for the `container_timeline` buttons. Spec has been created and the old spec examples have been removed.

| Toolbar button id | Toolbar buttons class created | in use? | working? |
| --- | --- | --- | --- |
| container_new, container_node_new, container_service_new, container_group_new, container_replicator_new, container_image_registry_new | buttons removed | yes | no |
| container_edit, container_node_edit, container_service_edit, container_group_edit, container_replicator_edit, container_image_registry_edit | buttons removed | yes | no |
| container_delete, container_node_delete, container_service_delete, container_group_delete, container_replicator_delete, container_image_registry_delete | buttons removed | yes | no |
| container_timeline, container_node_timeline, container_group_timeline, container_replicator_timeline, container_project_timeline | ContainerTimeline < Container | yes | yes |
| persistent_volume_edit, persistent_volume_delete, persistent_volume_new, container_build_edit, container_build_delete, container_build_new, container_template_edit, container_template_delete, container_template_new | buttons removed | no | no |

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/133591847
