### PR TITLE
Using the right icon for load balancer for the network provider.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,6 +25,7 @@
  *= require topology
  *= require container_topology
  *= require middleware_topology
+ *= require network_topology
  *= require service_dialogs
  *= require xml_display
  *= require patternfly-timeline/dist/timeline

--- a/app/assets/stylesheets/network_topology.css
+++ b/app/assets/stylesheets/network_topology.css
@@ -1,0 +1,4 @@
+.kube-topology g.EntityLegend.Network.LoadBalancer text.glyph {
+    font-family: IcoMoon;
+    fill: #000;
+}

--- a/app/models/mixins/ui_service_mixin.rb
+++ b/app/models/mixins/ui_service_mixin.rb
@@ -27,7 +27,7 @@ module UiServiceMixin
       :FloatingIp              => {:type => "glyph", :icon => "\uF041", :fontfamily => "FontAwesome"},             # fa-map-marker
       :CloudNetwork            => {:type => "glyph", :icon => "\uE62c", :fontfamily => "IcoMoon"},
       :CloudTenant             => {:type => "glyph", :icon => "\uE904", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-cloud-tenant
-      :LoadBalancer            => {:type => "glyph", :icon => "\uE608", :fontfamily => "PatternFlyIcons-webfont"}, # pficon-load-balancer
+      :LoadBalancer            => {:type => "glyph", :icon => "\uE637", :fontfamily => "IcoMoon"},                 # load_balancer
       :Tag                     => {:type => "glyph", :icon => "\uF02b", :fontfamily => "FontAwesome"},
       :Openstack               => {:type => "image", :icon => provider_icon(:Openstack)},
       :Amazon                  => {:type => "image", :icon => provider_icon(:Amazon)},

--- a/app/views/network_topology/show.html.haml
+++ b/app/views/network_topology/show.html.haml
@@ -74,8 +74,8 @@
         %svg.kube-topology
           %g.EntityLegend.Network.LoadBalancer
             %circle{:r => "17"}
-            -# pficon-network
-            %text{:y => "8"} &#xE909;
+            -# load_balancer
+            %text{:y => "8", :class => "glyph"} &#xE637;
         %label
           = _("Load Balancer")
 


### PR DESCRIPTION
It's a follow-up for https://github.com/ManageIQ/manageiq/pull/12261

![screenshot from 2016-11-21 18-20-24](https://cloud.githubusercontent.com/assets/535866/20493519/765587aa-b019-11e6-909f-1f8b56a38ca9.png)

cc @epwinchell (euwe yes, right?)

@miq-bot add_labels providers/network, bug, euwe/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1387612
