### PR TITLE
[DARGA] Support a separate auth URL for external authentication

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -922,6 +922,28 @@ function miqAjaxAuthSso(url) {
   });
 }
 
+
+// Send External Authentication via ajax
+function miqAjaxExtAuth(url) {
+  miqEnableLoginFields(false);
+  miqSparkleOn();
+
+  // Note: /dashboard/external_authenticate creates an API token
+  //       based on the authenticated external user
+  //       and stores it in sessionStore.miq_token
+
+  var credentials = {
+    login: $('#user_name').val(),
+    password: $('#user_password').val(),
+    serialized: miqSerializeForm('login_div'),
+  }
+
+  miqJqueryRequest(url || '/dashboard/external_authenticate', {
+    beforeSend: true,
+    data: credentials.serialized,
+  });
+}
+
 // add a flash message to an existing #flash_msg_div
 // levels are error, warning, info, success
 function add_flash(msg, level, options) {

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,11 +1,14 @@
 class DashboardController < ApplicationController
   @@items_per_page = 8
 
-  before_action :check_privileges, :except => [:csp_report, :window_sizes, :authenticate, :kerberos_authenticate,
+  before_action :check_privileges, :except => [:csp_report, :window_sizes, :authenticate,
+                                               :external_authenticate, :kerberos_authenticate,
                                                :logout, :login, :login_retry, :wait_for_task,
                                                :saml_login, :initiate_saml_login]
   before_action :get_session_data, :except => [:csp_report, :window_sizes,
-                                               :authenticate, :kerberos_authenticate, :saml_login]
+                                               :authenticate,
+                                               :external_authenticate, :kerberos_authenticate,
+                                               :saml_login]
   after_action :cleanup_action,    :except => [:csp_report]
   after_action :set_session_data,  :except => [:csp_report, :window_sizes]
 
@@ -420,13 +423,14 @@ class DashboardController < ApplicationController
     end
   end
 
+  # Handle external-auth signon from login screen
+  def external_authenticate
+    authenticate_external_user_generate_api_token
+  end
+
   # Handle single-signon from login screen
   def kerberos_authenticate
-    if @user_name.blank? && request.headers["X-Remote-User"].present?
-      @user_name = params[:user_name] = request.headers["X-Remote-User"].split("@").first
-    end
-
-    authenticate(true)
+    authenticate_external_user_generate_api_token
   end
 
   # Handle user credentials from login screen
@@ -620,6 +624,15 @@ class DashboardController < ApplicationController
   end
 
   private
+
+  # Authenticate external user and generate API token
+  def authenticate_external_user_generate_api_token
+    if @user_name.blank? && request.headers["X-Remote-User"].present?
+      @user_name = params[:user_name] = request.headers["X-Remote-User"].split("@").first
+    end
+
+    authenticate(true)
+  end
 
   def tl_toggle_button_enablement(button_id, enablement, typ)
     if enablement == :enabled

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -49,7 +49,7 @@
             = text_field_tag('user_name', @user_name,
                              :class => "form-control",
                              :placeholder => _('Username'),
-                             :onkeypress => "if (miqEnterPressed(event)) miqAjaxAuth();")
+                             :onkeypress => ext_auth? ? "if (miqEnterPressed(event)) miqAjaxExtAuth();" : "if (miqEnterPressed(event)) miqAjaxAuth();")
             = javascript_tag(javascript_focus('user_name'))
 
         .form-group
@@ -57,7 +57,7 @@
           .col-md-9
             = password_field_tag('user_password',
               @user_password,
-              :onkeypress => "if (miqEnterPressed(event)) miqAjaxAuth();",
+              :onkeypress => ext_auth? ? "if (miqEnterPressed(event)) miqAjaxExtAuth();" : "if (miqEnterPressed(event)) miqAjaxAuth();",
               :autocomplete => "off",
               :placeholder => (auth_mode == "httpd" ? _('Password or Password+One-Time-Password') : _('Password')),
               :class => "form-control")
@@ -98,7 +98,7 @@
                       :class                => "btn btn-primary",
                       :alt                  => "Login",
                       :title                => _("Login"),
-                      :onclick              => "miqAjaxAuth('#{j login_url}'); return false;")
+                      :onclick              => ext_auth? ? "miqAjaxExtAuth(); return false;" : "miqAjaxAuth('#{j login_url}'); return false;")
 
             = link_to(_("SSO Login"), '',
                       :id                    => "sso_login",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -881,6 +881,7 @@ Vmdb::Application.routes.draw do
         widget_to_pdf
       ),
       :post => %w(
+        external_authenticate
         kerberos_authenticate
         initiate_saml_login
         authenticate


### PR DESCRIPTION
This is the darga backport of:
  https://github.com/ManageIQ/manageiq/pull/12697

This will allow external auth to only do a single auth at
login, which is requried by OTP configurations.

https://bugzilla.redhat.com/show_bug.cgi?id=1390349