### PR TITLE
Revert size suffixes to decimal version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "manageiq-ui-components": "~0.0.9",
     "moment-strftime": "~0.2.0",
     "moment-timezone": "~0.4.1",
-    "numeral": "~1.5.3",
+    "numeral": "~1.5.5",
     "patternfly-bootstrap-treeview": "~2.1.1",
     "patternfly-timeline": "~1.0.3",
     "phantomjs-polyfill": "~0.0.2",

--- a/spec/javascripts/miq_formatters_spec.js
+++ b/spec/javascripts/miq_formatters_spec.js
@@ -149,7 +149,7 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1234, options)).toEqual('1.21 KiB');
+      expect(fn(1234, options)).toEqual('1.21 KB');
     });
   });
 
@@ -162,7 +162,7 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(234, options)).toEqual('234 KiB');
+      expect(fn(234, options)).toEqual('234 KB');
     });
   });
 
@@ -175,7 +175,7 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(234.09, options)).toEqual('234.1 KiB');
+      expect(fn(234.09, options)).toEqual('234.1 KB');
     });
   });
 
@@ -188,20 +188,7 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(2, options)).toEqual('2 MiB');
-    });
-  });
-
-  describe('.mbytes_to_human_size', function() {
-    it('Suffixed Megabytes (MB, GB)', function() {
-      var options = {
-        description: 'Suffixed Megabytes (MB, GB)',
-        name: 'mbytes_to_human_size',
-        precision: 2,
-      };
-      var fn = ManageIQ.charts.formatters[options.name];
-
-      expect(fn(2, options)).toEqual('2 MiB');
+      expect(fn(2, options)).toEqual('2 MB');
     });
   });
 
@@ -214,7 +201,20 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(2.12, options)).toEqual('2.12 MiB');
+      expect(fn(2, options)).toEqual('2 MB');
+    });
+  });
+
+  describe('.mbytes_to_human_size', function() {
+    it('Suffixed Megabytes (MB, GB)', function() {
+      var options = {
+        description: 'Suffixed Megabytes (MB, GB)',
+        name: 'mbytes_to_human_size',
+        precision: 2,
+      };
+      var fn = ManageIQ.charts.formatters[options.name];
+
+      expect(fn(2.12, options)).toEqual('2.12 MB');
     });
   });
 
@@ -227,7 +227,7 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(0.1, options)).toEqual('102.4 MiB');
+      expect(fn(0.1, options)).toEqual('102.4 MB');
     });
   });
 
@@ -240,7 +240,7 @@ describe('ManageIQ.charts.formatters', function() {
       };
       var fn = ManageIQ.charts.formatters[options.name];
 
-      expect(fn(1.19, options)).toEqual('1.2 GiB');
+      expect(fn(1.19, options)).toEqual('1.2 GB');
     });
   });
 


### PR DESCRIPTION
A change to C&U charts caused Javascript spec failures. This alters the specs to be inline with current functionality. @PanSpagetka

@chessbyte this should be backported right after https://github.com/ManageIQ/manageiq/pull/12640

Related:
https://bugzilla.redhat.com/show_bug.cgi?id=1383821