### PR TITLE
Fix OpenStack object creation when specifying non-default tenant

### DIFF
--- a/app/controllers/cloud_network_controller.rb
+++ b/app/controllers/cloud_network_controller.rb
@@ -274,7 +274,7 @@ class CloudNetworkController < ApplicationController
     # options[:port_security_enabled] = params[:port_security_enabled] if params[:port_security_enabled]
     options[:qos_policy_id] = params[:qos_policy_id] if params[:qos_policy_id]
     options[:provider_network_type] = params[:provider_network_type] if params[:provider_network_type]
-    options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
+    options[:cloud_tenant] = find_by_id_filtered(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]
     options
   end
 

--- a/app/controllers/cloud_subnet_controller.rb
+++ b/app/controllers/cloud_subnet_controller.rb
@@ -215,7 +215,7 @@ class CloudSubnetController < ApplicationController
     options[:cidr] = params[:cidr] if params[:cidr]
     options[:gateway] = params[:gateway] if params[:gateway]
     options[:ip_version] = params[:ip_version]
-    options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
+    options[:cloud_tenant] = find_by_id_filtered(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]
     options[:network_id] = params[:network_id] if params[:network_id]
     # TODO: Adds following fields for create/update
     options[:dhcp_enabled] = params[:dhcp_enabled]

--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -280,6 +280,7 @@ class CloudVolumeController < ApplicationController
       @volume = CloudVolume.new
       options = form_params
       cloud_tenant = find_by_id_filtered(CloudTenant, options[:cloud_tenant_id])
+      options[:cloud_tenant] = cloud_tenant
       valid_action, action_details = CloudVolume.validate_create_volume(cloud_tenant.ext_management_system)
       if valid_action
         begin

--- a/app/controllers/network_router_controller.rb
+++ b/app/controllers/network_router_controller.rb
@@ -240,7 +240,7 @@ class NetworkRouterController < ApplicationController
     options[:admin_state_up] = params[:admin_state_up] if params[:admin_state_up]
 
     # Relationships
-    options[:cloud_tenant_id] = params[:cloud_tenant_id] if params[:cloud_tenant_id]
+    options[:cloud_tenant] = find_by_id_filtered(CloudTenant, params[:cloud_tenant_id]) if params[:cloud_tenant_id]
     options[:cloud_network_id] = params[:cloud_network_id].gsub(/number:/, '') if params[:cloud_network_id]
     options[:cloud_group_id] = params[:cloud_group_id] if params[:cloud_group_id]
     options


### PR DESCRIPTION
the cloud_tenant parameter was not being specified in options
properly, resulting in all cloud objects being created in the default
tenant

https://bugzilla.redhat.com/show_bug.cgi?id=1396186