### PR TITLE
Add flash message for miqJqueryRequest errors

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -737,7 +737,10 @@ function miqAjax(url, serialize_fields, options) {
     complete: true,
   };
 
-  miqJqueryRequest(url, _.extend(defaultOptions, options || {}, { data: data }));
+  miqJqueryRequest(url, _.extend(defaultOptions, options || {}, { data: data })).then(function(arg) {
+  }, function(err) {
+    add_flash(__("Error requesting data from server"), 'error');
+  });
 }
 
 // Function to generate an Ajax request for EVM async processing
@@ -1051,7 +1054,10 @@ function miq_tabs_init(id, url) {
     } else if (typeof(url) != 'undefined') {
       // Load remote tab if an URL is specified
       var currTabTarget = $(e.target).attr('href').substring(1);
-      miqJqueryRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true});
+      miqJqueryRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true}).then(function(arg) {
+      }, function(err) {
+        add_flash(__("Error requesting data from server"), 'error');
+      });
     }
   });
 
@@ -1182,6 +1188,7 @@ function miqProcessObserveQueue() {
     request.deferred.resolve(arg);
   }, function(err) {
     ManageIQ.observe.processing = false;
+    add_flash(__("Error requesting data from server"), 'error');
     request.deferred.reject(err);
   });
 }

--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -737,10 +737,12 @@ function miqAjax(url, serialize_fields, options) {
     complete: true,
   };
 
-  miqJqueryRequest(url, _.extend(defaultOptions, options || {}, { data: data })).then(function(arg) {
-  }, function(err) {
-    add_flash(__("Error requesting data from server"), 'error');
-  });
+  miqJqueryRequest(url, _.extend(defaultOptions, options || {}, { data: data }))
+    .catch(function(err){
+      add_flash(__("Error requesting data from server"), 'error');
+      console.log(err);
+      return Promise.reject(err)
+    });
 }
 
 // Function to generate an Ajax request for EVM async processing
@@ -1054,9 +1056,11 @@ function miq_tabs_init(id, url) {
     } else if (typeof(url) != 'undefined') {
       // Load remote tab if an URL is specified
       var currTabTarget = $(e.target).attr('href').substring(1);
-      miqJqueryRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true}).then(function(arg) {
-      }, function(err) {
-        add_flash(__("Error requesting data from server"), 'error');
+      miqJqueryRequest(url + '/?tab_id=' + currTabTarget, {beforeSend: true})
+        .catch(function(err){
+          add_flash(__("Error requesting data from server"), 'error');
+          console.log(err);
+          return Promise.reject(err)
       });
     }
   });
@@ -1189,6 +1193,7 @@ function miqProcessObserveQueue() {
   }, function(err) {
     ManageIQ.observe.processing = false;
     add_flash(__("Error requesting data from server"), 'error');
+    console.log(err);
     request.deferred.reject(err);
   });
 }

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -297,6 +297,13 @@ describe('miq_application.js', function() {
         miqProcessObserveQueue();
         expect(deferred.reject).toHaveBeenCalled();
       });
+
+      it('displays an alert message', function() {
+        spyOn(window, 'add_flash');
+
+        miqProcessObserveQueue();
+        expect(add_flash).toHaveBeenCalled();
+      });
     });
   });
 
@@ -330,6 +337,26 @@ describe('miq_application.js', function() {
 
     it('returns a Promise', function() {
       expect(miqObserveRequest('/foo')).toEqual(jasmine.any(Promise));
+    });
+  });
+
+  describe('miqAjax', function() {
+    context('on failure', function() {
+      beforeEach(function () {
+        spyOn(window, 'miqJqueryRequest').and.callFake(function () {
+          return {
+            then: function (ok, err) {
+              err()
+            }
+          };
+        });
+      });
+
+      it('displays an alert on error', function () {
+        spyOn(window, 'add_flash');
+        miqAjax('/foo', false, {});
+        expect(add_flash).toHaveBeenCalled();
+      });
     });
   });
 

--- a/spec/javascripts/miq_application_spec.js
+++ b/spec/javascripts/miq_application_spec.js
@@ -345,7 +345,7 @@ describe('miq_application.js', function() {
       beforeEach(function () {
         spyOn(window, 'miqJqueryRequest').and.callFake(function () {
           return {
-            then: function (ok, err) {
+            catch: function (err) {
               err()
             }
           };


### PR DESCRIPTION
miqJQueryRequest should handle errors and display an alert to the user. For this blocker BZ - fix to handle and display errors for a select calls to miqJqueryRequest. Upstream, we will need to handle these in miqJQueryRequest - as in this PR: https://github.com/ManageIQ/manageiq/pull/12727

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1378481

Steps for Testing/QA 
-------------------------------

Select a VM - choose Migrate, then the Environment tab. 
Stop the appliance or the ui worker
Change the selection in the dropdowns 
An error is not displayed without the changes in this PR.


