### PR TITLE
Fix Audit Log to record settings/values when creating new user

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -773,10 +773,10 @@ class OpsController < ApplicationController
                    :old_value => @edit[:current][k].keys.join(","),
                    :new_value => @edit[:new][k].keys.join(",")}
           else
-            msg = _("%{message} %{key}:[%{old_value}] to [new_value]") % {:message   => msg,
-                                                                          :key       => k.to_s,
-                                                                          :old_value => @edit[:current][k].to_s,
-                                                                          :new_value => @edit[:new][k].to_s}
+            msg = _("%{message} %{key}:[%{old_value}] to [%{new_value}]") % {:message   => msg,
+                                                                             :key       => k.to_s,
+                                                                             :old_value => @edit[:current][k].to_s,
+                                                                             :new_value => @edit[:new][k].to_s}
           end
         end
       end


### PR DESCRIPTION
Corrected syntax when building Audit Log message/entry.

Screen shots attached:

![audit log when adding new user values](https://cloud.githubusercontent.com/assets/552686/20506628/2e7fa9a6-b00a-11e6-9459-60a7a97b544e.png)
 
![development log adding new user event](https://cloud.githubusercontent.com/assets/552686/20506633/3ee55d04-b00a-11e6-8a63-0c00c6aea254.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1394593