### PR TITLE
Be less restrictive of when to show title for VM quadicon.

### DIFF
--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -804,18 +804,12 @@ module QuadiconHelper
   def quadicon_vt_img_options(item, size: 72)
     options = {
       :width  => size,
-      :height => size
+      :height => size,
+      :title  => item.name
     }
 
-    if quadicon_hide_links? && quadicon_policy_sim?
+    if quadicon_hide_links? && quadicon_policy_sim? && !quadicon_edit_key?(:explorer)
       options = {:title => _("Show policy details for #{h(item.name)}")}
-    end
-
-    if quadicon_show_links? && quadicon_in_explorer_view? &&
-       quadicon_service_ctrlr_and_vm_view_db? &&
-       !quadicon_vm_attributes_present?(item)
-
-      options = {:title => item.name}
     end
 
     options

--- a/spec/helpers/quadicon_helper_spec.rb
+++ b/spec/helpers/quadicon_helper_spec.rb
@@ -91,6 +91,12 @@ RSpec.shared_examples :vm_or_template_compliance do
   end
 end
 
+RSpec.shared_examples :has_name_in_title_attr do
+  it 'has a title attribute equal to the name' do
+    expect(subject).to have_selector("img[title='#{item.name}']")
+  end
+end
+
 # FIXME: complex describe blocks mirror the existing complex control flow
 
 describe QuadiconHelper do
@@ -1267,6 +1273,8 @@ describe QuadiconHelper do
               helper.request.parameters[:controller] = "service"
             end
 
+            include_examples :has_name_in_title_attr
+
             it 'does not build a remote link' do
               expect(vm_quad).not_to have_selector("a[data-remote]")
               expect(vm_quad).not_to have_selector("a[data-method='post']")
@@ -1318,6 +1326,7 @@ describe QuadiconHelper do
             end
 
             include_examples :has_remote_link
+            include_examples :has_name_in_title_attr
           end
         end
 
@@ -1325,6 +1334,8 @@ describe QuadiconHelper do
           before(:each) do
             @explorer = false
           end
+
+          include_examples :has_name_in_title_attr
 
           it 'links to the record' do
             expect(vm_quad).to have_selector("a[href^='/vm_or_template/show']")
@@ -1353,6 +1364,7 @@ describe QuadiconHelper do
 
             include_examples :has_remote_link
             include_examples :has_sparkle_link
+            include_examples :has_name_in_title_attr
           end
 
           context "and when @edit or @edit[:explorer] is not present" do
@@ -1378,6 +1390,8 @@ describe QuadiconHelper do
           it 'links to an inferred url' do
             expect(vm_quad).to have_selector("a[href^='/vm_or_template/show']")
           end
+
+          include_examples :has_name_in_title_attr
         end
       end
     end


### PR DESCRIPTION
VM quadicons are missing tooltips in some instances. This change adds the title attribute most of the time (and specs).

**Before**
![screen shot 2016-11-21 at 5 31 34 pm](https://cloud.githubusercontent.com/assets/39493/20507663/eeaf0266-b010-11e6-9b84-27e41ac83c0b.png)

**After**
![screen shot 2016-11-21 at 5 30 25 pm](https://cloud.githubusercontent.com/assets/39493/20507667/f621acce-b010-11e6-8120-9894635a2d7b.png)

@dclarizio This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1396964

@miq-bot add_label ui, bug
