### PR TITLE
Remove get_vmdb_config() and use ::Settings directly in application_helper.rb

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -432,11 +432,6 @@ module ApplicationHelper
                                                                :userid          => session[:userid])
   end
 
-  # Replacing calls to VMDB::Config.new in the views/controllers
-  def get_vmdb_config
-    @vmdb_config ||= VMDB::Config.new("vmdb").config
-  end
-
   # Derive the browser title text based on the layout value
   def title_from_layout(layout)
     # TODO: leave I18n until we have productization capability in gettext

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -42,7 +42,7 @@ class ApplicationHelper::ToolbarBuilder
   private
 
   delegate :request, :current_user, :to => :@view_context
-  delegate :get_vmdb_config, :role_allows?, :model_for_vm, :rbac_common_feature_for_buttons, :to => :@view_context
+  delegate :role_allows?, :model_for_vm, :rbac_common_feature_for_buttons, :to => :@view_context
   delegate :x_tree_history, :x_node, :x_active_tree, :to => :@view_context
   delegate :is_browser?, :is_browser_os?, :to => :@view_context
 
@@ -596,18 +596,18 @@ class ApplicationHelper::ToolbarBuilder
     when "miq_task_canceljob"
       return true unless ["all_tasks", "all_ui_tasks"].include?(@layout)
     when "vm_console"
-      type = get_vmdb_config.fetch_path(:server, :remote_console_type)
+      type = ::Settings.server.remote_console_type
       return type != 'MKS' || !@record.console_supported?(type)
     when "vm_vnc_console"
-      type = get_vmdb_config.fetch_path(:server, :remote_console_type)
+      type = ::Settings.server.remote_console_type
       return type != 'VNC' || !@record.console_supported?(type)
     when "vm_vmrc_console"
-      type = get_vmdb_config.fetch_path(:server, :remote_console_type)
+      type = ::Settings.server.remote_console_type
       return type != 'VMRC' || !@record.console_supported?(type)
     # Check buttons behind SMIS setting
     when "ontap_storage_system_statistics", "ontap_logical_disk_statistics", "ontap_storage_volume_statistics",
         "ontap_file_share_statistics"
-      return true unless get_vmdb_config[:product][:smis]
+      return true unless ::Settings.product.smis
     when "host_register_nodes"
       return true if @record.class != ManageIQ::Providers::Openstack::InfraManager
     when "host_introspect", "host_provide"

--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -29,7 +29,7 @@ module HostHelper::TextualSummary
   end
 
   def textual_group_diagnostics
-    return nil unless get_vmdb_config[:product][:proto]
+    return nil unless ::Settings.product.proto
     %i(esx_logs)
   end
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -342,12 +342,6 @@ class Tenant < ApplicationRecord
     self.name = nil unless name.present?
   end
 
-  def get_vmdb_config
-    Vmdb::Deprecation.deprecation_warning("Tenant#get_vmdb_config",
-                                          "Prefer using ::Settings directly.", caller)
-    @vmdb_config ||= VMDB::Config.new("vmdb").config
-  end
-
   # validates that there is only one tree
   def validate_only_one_root
     unless parent_id || parent

--- a/app/presenters/widget_presenter.rb
+++ b/app/presenters/widget_presenter.rb
@@ -11,7 +11,7 @@ class WidgetPresenter
 
   extend Forwardable
   def_delegators(:@controller, :current_user, :url_for, :initiate_wait_for_task,
-                 :session_init, :session_reset, :get_vmdb_config, :start_url_for_user)
+                 :session_init, :session_reset, :start_url_for_user)
 
   attr_reader :widget
 

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -567,18 +567,18 @@ describe ApplicationHelper do
       end
 
       it "and server's remote_console_type not set" do
-        @vmdb_config = {:server => nil}
+        stub_settings(:server => {})
         expect(subject).to be_truthy
       end
 
       it "and server's remote_console_type is not MKS" do
-        @vmdb_config = {:server => {:remote_console_type => "not_MKS"}}
+        stub_settings(:server => {:remote_console_type => "not_MKS"})
         expect(subject).to be_truthy
       end
 
       it "and record is console supported and server's remote_console_type is MKS" do
         allow(@record).to receive_messages(:console_supported? => true)
-        @vmdb_config = {:server => {:remote_console_type => "MKS"}}
+        stub_settings(:server => {:remote_console_type => "MKS"})
         expect(subject).to be_falsey
       end
     end
@@ -595,18 +595,18 @@ describe ApplicationHelper do
       end
 
       it "and server's remote_console_type not set" do
-        @vmdb_config = {:server => nil}
+        stub_settings(:server => {})
         expect(subject).to be_truthy
       end
 
       it "and server's remote_console_type is not VNC" do
-        @vmdb_config = {:server => {:remote_console_type => "not_VNC"}}
+        stub_settings(:server => {:remote_console_type => "not_VNC"})
         expect(subject).to be_truthy
       end
 
       it "and record is console supported and server's remote_console_type is VNC" do
         allow(@record).to receive_messages(:console_supported? => true)
-        @vmdb_config = {:server => {:remote_console_type => "VNC"}}
+        stub_settings(:server => {:remote_console_type => "VNC"})
         expect(subject).to be_falsey
       end
     end
@@ -623,18 +623,18 @@ describe ApplicationHelper do
       end
 
       it "and server's remote_console_type not set" do
-        @vmdb_config = {:server => nil}
+        stub_settings(:server => {})
         expect(subject).to be_truthy
       end
 
       it "and server's remote_console_type is not VMRC" do
-        @vmdb_config = {:server => {:remote_console_type => "not_VMRC"}}
+        stub_settings(:server => {:remote_console_type => "not_VMRC"})
         expect(subject).to be_truthy
       end
 
       it "and record is console supported and server's remote_console_type is VMRC" do
         allow(@record).to receive_messages(:console_supported? => true)
-        @vmdb_config = {:server => {:remote_console_type => "VMRC"}}
+        stub_settings(:server => {:remote_console_type => "VMRC"})
         expect(subject).to be_falsey
       end
     end
@@ -646,13 +646,13 @@ describe ApplicationHelper do
           stub_user(:features => :all)
         end
 
-        it "and @vmdb_config[:product][:smis] != true " do
-          @vmdb_config = {:product => {:smis => false}}
+        it "and Settings.product.smis != true " do
+          stub_settings(:product => {:smis => false})
           expect(subject).to be_truthy
         end
 
-        it "and @vmdb_config[:product][:smis] = true " do
-          @vmdb_config = {:product => {:smis => true}}
+        it "and Settings.product.smis = true " do
+          stub_settings(:product => {:smis => true})
           expect(subject).to be_falsey
         end
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -528,12 +528,6 @@ describe ApplicationHelper do
     end
   end
 
-  context "#get_vmdb_config" do
-    it "Replaces calls to VMDB::Config.new in the views/controllers" do
-      expect(helper.get_vmdb_config).to eq(VMDB::Config.new("vmdb").config)
-    end
-  end
-
   context "#to_cid" do
     it "converts record id to compressed id" do
       expect(helper.to_cid(12_000_000_000_056)).to eq('12r56')

--- a/spec/views/miq_request/_prov_options.html.erb_spec.rb
+++ b/spec/views/miq_request/_prov_options.html.erb_spec.rb
@@ -56,7 +56,7 @@ describe 'miq_request/_prov_options.html.haml' do
   context 'requester dropdown select box is not visible' do
     before(:each) do
       EvmSpecHelper.create_guid_miq_server_zone
-      allow(view).to receive(:get_vmdb_config).and_return(:server => {}, :session => {})
+      stub_settings(:server => {}, :session => {})
     end
 
     it 'for desktop' do


### PR DESCRIPTION
Replaced calls to ```get_vmdb_config``` with direct usage of ::Settings in ```application_helper.rb```

@miq-bot add-label core, euwe/no

\cc @Fryguy 