### PR TITLE
Introduce Consumption class to abstract charging from MetricRollups

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -126,12 +126,11 @@ class Chargeback < ActsAsArModel
 
   def calculate_costs(metric_rollup_records, rates, hours_in_interval)
     consumption = Consumption.new(metric_rollup_records, hours_in_interval)
-    chargeback_fields_present = metric_rollup_records.count(&:chargeback_fields_present?)
-    self.fixed_compute_metric = chargeback_fields_present if chargeback_fields_present
+    self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
 
     rates.each do |rate|
       rate.chargeback_rate_details.each do |r|
-        r.charge(relevant_fields, chargeback_fields_present, consumption, hours_in_interval).each do |field, value|
+        r.charge(relevant_fields, consumption, hours_in_interval).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = (self[field] || 0) + value
         end

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -10,9 +10,6 @@ class Chargeback < ActsAsArModel
     :fixed_compute_metric => :integer,
   )
 
-  HOURS_IN_DAY = 24
-  HOURS_IN_WEEK = 168
-
   VIRTUAL_COL_USES = {
     "v_derived_cpu_total_cores_used" => "cpu_usage_rate_average"
   }
@@ -50,7 +47,7 @@ class Chargeback < ActsAsArModel
       next if records.empty?
       _log.info("Found #{records.length} records for time range #{[query_start_time, query_end_time].inspect}")
 
-      hours_in_interval = hours_in_interval(query_start_time, query_end_time, options.interval)
+      hours_in_interval = hours_in_interval(query_start_time, query_end_time)
 
       # we are building hash with grouped calculated values
       # values are grouped by resource_id and timestamp (query_start_time...query_end_time)
@@ -83,11 +80,8 @@ class Chargeback < ActsAsArModel
     [data.values]
   end
 
-  def self.hours_in_interval(query_start_time, query_end_time, interval)
-    return HOURS_IN_DAY if interval == "daily"
-    return HOURS_IN_WEEK if interval == "weekly"
-
-    (query_end_time - query_start_time) / 1.hour
+  def self.hours_in_interval(query_start_time, query_end_time)
+    (query_end_time - query_start_time).round / 1.hour
   end
 
   def self.key_and_fields(metric_rollup_record)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -130,7 +130,7 @@ class Chargeback < ActsAsArModel
 
     rates.each do |rate|
       rate.chargeback_rate_details.each do |r|
-        r.charge(relevant_fields, consumption, hours_in_interval).each do |field, value|
+        r.charge(relevant_fields, consumption).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = (self[field] || 0) + value
         end

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -125,12 +125,13 @@ class Chargeback < ActsAsArModel
   end
 
   def calculate_costs(metric_rollup_records, rates, hours_in_interval)
+    consumption = Consumption.new(metric_rollup_records, hours_in_interval)
     chargeback_fields_present = metric_rollup_records.count(&:chargeback_fields_present?)
     self.fixed_compute_metric = chargeback_fields_present if chargeback_fields_present
 
     rates.each do |rate|
       rate.chargeback_rate_details.each do |r|
-        r.charge(relevant_fields, chargeback_fields_present, metric_rollup_records, hours_in_interval).each do |field, value|
+        r.charge(relevant_fields, chargeback_fields_present, consumption, hours_in_interval).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = (self[field] || 0) + value
         end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -1,0 +1,28 @@
+class Chargeback
+  class Consumption
+    def initialize(metric_rollup_records, hours_in_interval)
+      @rollups = metric_rollup_records
+      @hours_in_interval = hours_in_interval
+    end
+
+    def max(metric)
+      rollups_without_nils(metric).map(&metric.to_sym).max
+    end
+
+    def avg(metric)
+      metric_sum = rollups_without_nils(metric).sum(&metric.to_sym)
+      metric_sum / @hours_in_interval
+    end
+
+    def none?(metric)
+      rollups_without_nils(metric).empty?
+    end
+
+    private
+
+    def rollups_without_nils(metric)
+      @rollups_without_nils ||= {}
+      @rollups_without_nils[metric] ||= @rollups.select { |r| r.send(metric).present? }
+    end
+  end
+end

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -1,5 +1,7 @@
 class Chargeback
   class Consumption
+    attr_reader :hours_in_interval
+
     def initialize(metric_rollup_records, hours_in_interval)
       @rollups = metric_rollup_records
       @hours_in_interval = hours_in_interval

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -1,10 +1,8 @@
 class Chargeback
   class Consumption
-    attr_reader :hours_in_interval
-
-    def initialize(metric_rollup_records, hours_in_interval)
+    def initialize(metric_rollup_records, start_time, end_time)
       @rollups = metric_rollup_records
-      @hours_in_interval = hours_in_interval
+      @start_time, @end_time = start_time, end_time
     end
 
     def max(metric)
@@ -13,7 +11,7 @@ class Chargeback
 
     def avg(metric)
       metric_sum = values(metric).sum
-      metric_sum / @hours_in_interval
+      metric_sum / hours_in_interval
     end
 
     def none?(metric)
@@ -22,6 +20,10 @@ class Chargeback
 
     def chargeback_fields_present
       @chargeback_fields_present ||= @rollups.count(&:chargeback_fields_present?)
+    end
+
+    def hours_in_interval
+      @hours_in_interval ||= (@end_time - @start_time).round / 1.hour
     end
 
     private

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -18,6 +18,10 @@ class Chargeback
       values(metric).empty?
     end
 
+    def chargeback_fields_present
+      @chargeback_fields_present ||= @rollups.count(&:chargeback_fields_present?)
+    end
+
     private
 
     def values(metric)

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -6,23 +6,23 @@ class Chargeback
     end
 
     def max(metric)
-      rollups_without_nils(metric).map(&metric.to_sym).max
+      values(metric).max
     end
 
     def avg(metric)
-      metric_sum = rollups_without_nils(metric).sum(&metric.to_sym)
+      metric_sum = values(metric).sum
       metric_sum / @hours_in_interval
     end
 
     def none?(metric)
-      rollups_without_nils(metric).empty?
+      values(metric).empty?
     end
 
     private
 
-    def rollups_without_nils(metric)
-      @rollups_without_nils ||= {}
-      @rollups_without_nils[metric] ||= @rollups.select { |r| r.send(metric).present? }
+    def values(metric)
+      @values ||= {}
+      @values[metric] ||= @rollups.collect(&metric.to_sym).compact
     end
   end
 end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -21,10 +21,10 @@ class ChargebackRateDetail < ApplicationRecord
 
   attr_accessor :hours_in_interval
 
-  def charge(relevant_fields, consumption, hours_in_interval)
+  def charge(relevant_fields, consumption)
     result = {}
     if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?
-      metric_value, cost = metric_and_cost_by(consumption, hours_in_interval)
+      metric_value, cost = metric_and_cost_by(consumption)
       if !consumption.chargeback_fields_present && fixed?
         cost = 0
       end
@@ -226,10 +226,10 @@ class ChargebackRateDetail < ApplicationRecord
      'total_cost']
   end
 
-  def metric_and_cost_by(consumption, hours_in_interval)
-    @hours_in_interval = hours_in_interval
+  def metric_and_cost_by(consumption)
+    @hours_in_interval = consumption.hours_in_interval
     metric_value = metric_value_by(consumption)
-    [metric_value, hourly_cost(metric_value) * hours_in_interval]
+    [metric_value, hourly_cost(metric_value) * consumption.hours_in_interval]
   end
 
   def first_tier?(tier,tiers)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -21,11 +21,11 @@ class ChargebackRateDetail < ApplicationRecord
 
   attr_accessor :hours_in_interval
 
-  def charge(relevant_fields, chargeback_fields_present, consumption, hours_in_interval)
+  def charge(relevant_fields, consumption, hours_in_interval)
     result = {}
     if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?
       metric_value, cost = metric_and_cost_by(consumption, hours_in_interval)
-      if !chargeback_fields_present && fixed?
+      if !consumption.chargeback_fields_present && fixed?
         cost = 0
       end
       metric_keys.each { |field| result[field] = metric_value }


### PR DESCRIPTION
## What
Encapsulate chargeback's manipulation with metric_rollups to a separate class.

## Why?
When charging we take into account three main inputs
 * consumption (now was `MetricRollup`)
 * rates (`Chargeback::RatesCache` & `ChargebackRate*`)
 * cb type & report user properties (`Chargeback::ReportOptions`)

Now, let's investigate, why we need consumption to be polymorphic:
1. We had assumed that `consumption == single metric_rollup`.
2. However, then @lpichler introduced more clever charging for bunch of rollups. So, until now we have assumed consumption equals  N metric_rollups`
3. I want to introduced charging per dynamic disk types. Then, the consumption will equal to metric_rollups and/or vim_performance_states.
4. Then, @gtanzillo has an idea of charging without metric rollups. Then the consumption will equal to (metric_rollups and/or vim_performance_states) and/or assumed flat consumption.

## Other notes
I have found some irregularities in a way we handle @hours_in_interval. (related to starts/ends of interval & rates interval, vs report interval). The Consumption object will make it easier to address these irregularities.

@miq-bot add_label chargeback, refactoring
@miq-bot assign @gtanzillo