### PR TITLE
Automate - Notification for Service and VM Retirement starting.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/Orchestration/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -3,7 +3,7 @@
 #
 
 $evm.log("info", "Listing Root Object Attributes:")
-$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}")  }
+$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
 $evm.log("info", "===========================================")
 
 stack = $evm.root['orchestration_stack']
@@ -23,5 +23,6 @@ if stack.retiring?
 end
 
 $evm.log('info', "Stack before start_retirement: #{stack.inspect} ")
+$evm.create_notification(:type => :vm_retiring, :subject => stack)
 
 stack.start_retirement

--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -3,7 +3,7 @@
 #
 
 $evm.log("info", "Listing Root Object Attributes:")
-$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}")  }
+$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
 $evm.log("info", "===========================================")
 
 vm = $evm.root['vm']
@@ -23,6 +23,7 @@ if vm.retiring?
 end
 
 $evm.log('info', "VM before start_retirement: #{vm.inspect} ")
+$evm.create_notification(:type => :vm_retiring, :subject => vm)
 
 vm.start_retirement
 

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -3,7 +3,7 @@
 #
 
 $evm.log("info", "Listing Root Object Attributes:")
-$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}")  }
+$evm.root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
 $evm.log("info", "===========================================")
 
 vm = $evm.root['vm']
@@ -24,6 +24,7 @@ end
 
 $evm.log('info', "VM before start_retirement: #{vm.inspect} ")
 
+$evm.create_notification(:type => :vm_retiring, :subject => vm)
 vm.start_retirement
 
 $evm.log('info', "VM after start_retirement: #{vm.inspect} ")

--- a/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Service/Retirement/StateMachines/Methods.class/__methods__/start_retirement.rb
@@ -20,6 +20,7 @@ if service.retiring?
   exit MIQ_ABORT
 end
 
+$evm.create_notification(:type => :service_retiring, :subject => service)
 service.start_retirement
 
 $evm.log('info', "Service after start_retirement: #{service.inspect} ")

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -14,6 +14,11 @@
   :expires_in: 7.days
   :level: :success
   :audience: tenant
+- :name: service_retiring
+  :message: Service %{subject} has started retirement.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
 - :name: automate_vm_provisioned
   :message: Virtual Machine %{subject} has been provisioned.
   :expires_in: 7.days
@@ -21,6 +26,11 @@
   :audience: tenant
 - :name: vm_retired
   :message: Virtual Machine %{subject} has been retired.
+  :expires_in: 7.days
+  :level: :success
+  :audience: tenant
+- :name: vm_retiring
+  :message: Virtual Machine %{subject} has started retirement.
   :expires_in: 7.days
   :level: :success
   :audience: tenant


### PR DESCRIPTION
Notifications will now be sent when a VM or a Service starts retirement.

Modified method start_retirement in Cloud/Orch, Cloud/VM, Infrastructure/VM and

Service classes.  Methods use two new notification types.

https://www.pivotaltracker.com/story/show/133752449
<img width="317" alt="notifiy_retirement_starting" src="https://cloud.githubusercontent.com/assets/11841651/20532338/9bd724c8-b0a7-11e6-894e-2078fedefc6d.png">
