### PR TITLE
Removed leftover code around code to build timelines differently for IE.

### DIFF
--- a/app/assets/javascripts/miq_timeline.js
+++ b/app/assets/javascripts/miq_timeline.js
@@ -72,7 +72,7 @@
           data[x].name = json[x].name;
         }
         data[x].data = [];
-        if (json[x].data.length > 0) {
+        if (json[x].data !== undefined && json[x].data.length > 0) {
           var timelinedata = json[x].data[0];
           for (var y in timelinedata) {
             data[x].data.push({});

--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -236,13 +236,7 @@ module ApplicationController::Timelines
           add_flash(_("No records found for this timeline"), :warning)
         else
           @report.extras[:browser_name] = browser_info(:name)
-          if is_browser_ie?
-            blob = BinaryBlob.new(:name => "timeline_results")
-            blob.binary = (@report.to_timeline)
-            session[:tl_xml_blob_id] = blob.id
-          else
-            @tl_json = @report.to_timeline
-          end
+          @tl_json = @report.to_timeline
           #         START of TIMELINE TIMEZONE Code
           session[:tl_position] = @report.extras[:tl_position]
           #         session[:tl_position] = format_timezone(@report.extras[:tl_position],Time.zone,"tl")

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -744,14 +744,7 @@ class DashboardController < ApplicationController
     end
 
     @report.extras[:browser_name] = browser_info(:name)
-    if is_browser_ie?
-      blob = BinaryBlob.new(:name => "timeline_results")
-      blob.binary = @report.to_timeline
-      session[:tl_xml_blob_id] = blob.id
-    else
-      @tl_json = @report.to_timeline
-    end
-
+    @tl_json = @report.to_timeline
     tz = @report.tz || Time.zone
     session[:tl_position] = format_timezone(@report.extras[:tl_position], tz, "tl")
   end

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -736,13 +736,7 @@ class MiqCapacityController < ApplicationController
     else
       tz = @sb[:bottlenecks][:report].tz ? @sb[:bottlenecks][:report].tz : Time.zone
       @sb[:bottlenecks][:report].extras[:browser_name] = browser_info(:name)
-      if is_browser_ie?
-        blob = BinaryBlob.new(:name => "timeline_results")
-        blob.binary = (@sb[:bottlenecks][:report].to_timeline)
-        session[:tl_xml_blob_id] = blob.id
-      else
-        @tl_json = @sb[:bottlenecks][:report].to_timeline
-      end
+      @tl_json = @sb[:bottlenecks][:report].to_timeline
       #         START of TIMELINE TIMEZONE Code
       #     session[:tl_position] = @sb[:bottlenecks][:report].extras[:tl_position]
       session[:tl_position] = format_timezone(@sb[:bottlenecks][:report].extras[:tl_position], tz, "tl")


### PR DESCRIPTION
Fixed JS code to only add events with data, for some reason IE was adding an event with null data causing JS errors.

https://bugzilla.redhat.com/show_bug.cgi?id=1394951

@dclarizio pleasde review.
@dgutride cc

before:
![ie_timelines_before](https://cloud.githubusercontent.com/assets/3450808/20537153/fbe99280-b0b9-11e6-8783-783a0dab8eaa.png)

after:
![ie_timelines_after](https://cloud.githubusercontent.com/assets/3450808/20537164/040bb74a-b0ba-11e6-8a32-c71f20b54d8b.png)

![ie_timelines_after_fix2](https://cloud.githubusercontent.com/assets/3450808/20537167/073a6b8c-b0ba-11e6-9255-15f19d96ab31.png)


