### PR TITLE
Hide 'Add/Edit a New Network Provider' buttons

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -574,6 +574,8 @@ class ApplicationHelper::ToolbarBuilder
 
     return false if id.starts_with?("miq_capacity_") && @sb[:active_tab] == "report"
 
+    return true if %w(ems_network_new ems_network_edit).include?(id) && ::Settings.product.nuage != true
+
     # don't check for feature RBAC if id is miq_request_approve/deny
     unless %w(miq_policy catalogs).include?(@layout)
       return true if !role_allows?(:feature => id) && !["miq_request_approve", "miq_request_deny"].include?(id) &&

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -329,6 +329,20 @@ describe ApplicationHelper do
       end
     end
 
+    context "when with ems_network_new" do
+      it "with product nuage not set to true" do
+        @id = 'ems_network_new'
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when with ems_network_edit" do
+      it "with product nuage not set to true" do
+        @id = 'ems_network_edit'
+        expect(subject).to be_truthy
+      end
+    end
+
     context "when with miq_task_canceljob" do
       before do
         @id = 'miq_task_canceljob'


### PR DESCRIPTION
Hiding 'Add/Edit a New Network Provider' buttons behind an advanced configuration until Nuage is supported.

https://bugzilla.redhat.com/show_bug.cgi?id=1396276
