### PR TITLE
Fix entity name in Policies & Conditions lists

### DIFF
--- a/app/views/miq_policy/_condition_list.html.haml
+++ b/app/views/miq_policy/_condition_list.html.haml
@@ -3,10 +3,11 @@
     %div{:style => "padding-top: 10px;"}
     = render :partial => "layouts/flash_msg"
     - if @conditions.empty?
+      - model = ui_lookup(:model => @sb[:folder].camelize)
       - if @search_text.blank?
-        - msg = _("No %{model} Conditions are defined.") % {:model => ui_lookup(:model => @sb[:folder])}
+        - msg = _("No %{model} Conditions are defined.") % {:model => model}
       - else
-        - msg = _("No %{model} Conditions are defined that match the entered search string.") % {:model => ui_lookup(:model => @sb[:folder])}
+        - msg = _("No %{model} Conditions are defined that match the entered search string.") % {:model => model}
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       %table.table.table-striped.table-bordered.table-hover

--- a/app/views/miq_policy/_policy_list.html.haml
+++ b/app/views/miq_policy/_policy_list.html.haml
@@ -1,10 +1,13 @@
 #policy_list_div
   - if x_active_tree == :policy_tree && @view
     - if @view.table.data.empty?
+      - mode, model = @sb[:folder].split('-')
+      - mode = _(mode.titleize)
+      - model = ui_lookup(:model => model.camelize)
       - if @search_text.blank?
-        - msg = _("No %{model} %{mode} Policies are defined.") % {:model => ui_lookup(:model => @sb[:folder]), :mode => @mode}
+        - msg = _("No %{model} %{mode} Policies are defined.") % {:model => model, :mode => mode}
       - else
-        - msg = _("No %{model} %{mode} Policies are defined that match the entered search string.") % {:model => ui_lookup(:model => @sb[:folder]), :mode => @mode}
+        - msg = _("No %{model} %{mode} Policies are defined that match the entered search string.") % {:model => model, :mode => mode}
       = render :partial => 'layouts/info_msg', :locals => {:message => msg}
     - else
       #main_div


### PR DESCRIPTION
Correct & translatable entity name in Policies & Conditions lists

Another nodeid case bug...

Control -> Policies accordion -> Compliance/Control -> any entity type with 0 policies:
Before: »No Compliance Ext Management System Policies are defined.«
After: »No »Provider« »Compliance« Policies are defined.«

Control -> Conditions accordion -> any entity type with 0 conditions:
Before: »No Container Group Conditions are defined.«
After: »No »Pod« Conditions are defined.«

Links [Optional]
----------------

Fixes #10540 - yet another manifestation of
https://bugzilla.redhat.com/show_bug.cgi?id=1359909 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1397248 (euwe)

@miq-bot add-label control, ui, bug, euwe/yes
