### PR TITLE
Add missing "Provider Compliance/Control Policies" texts

### DIFF
--- a/app/views/miq_policy/_policy_folders.html.haml
+++ b/app/views/miq_policy/_policy_folders.html.haml
@@ -1,18 +1,21 @@
 - if @folders
-  - folders_i18n = {"Compliance"                      => _("Compliance Policies"),
-                    "Control"                         => _("Control Policies"),
-                    "Host Compliance"                 => _("Host Compliance Policies"),
-                    "Vm Compliance"                   => _("Vm Compliance Policies"),
-                    "Container Replicator Compliance" => _("Replicator Compliance Policies"),
-                    "Container Group Compliance"      => _("Pod Compliance Policies"),
-                    "Container Node Compliance"       => _("Container Node Compliance Policies"),
-                    "Container Image Compliance"      => _("Container Image Compliance Policies"),
-                    "Host Control"                    => _("Host Control Policies"),
-                    "Vm Control"                      => _("Vm Control Policies"),
-                    "Container Replicator Control"    => _("Replicator Control Policies"),
-                    "Container Group Control"         => _("Pod Control Policies"),
-                    "Container Node Control"          => _("Container Node Control Policies"),
-                    "Container Image Control"         => _("Container Image Control Policies")}
+  - folders_i18n = {"Compliance"                       => _("Compliance Policies"),
+                    "Control"                          => _("Control Policies"),
+                    "Host Compliance"                  => _("Host Compliance Policies"),
+                    "Vm Compliance"                    => _("Vm Compliance Policies"),
+                    "Container Replicator Compliance"  => _("Replicator Compliance Policies"),
+                    "Container Group Compliance"       => _("Pod Compliance Policies"),
+                    "Container Node Compliance"        => _("Container Node Compliance Policies"),
+                    "Container Image Compliance"       => _("Container Image Compliance Policies"),
+                    "Ext Management System Compliance" => _("Provider Compliance Policies"),
+                    "Host Control"                     => _("Host Control Policies"),
+                    "Vm Control"                       => _("Vm Control Policies"),
+                    "Container Replicator Control"     => _("Replicator Control Policies"),
+                    "Container Group Control"          => _("Pod Control Policies"),
+                    "Container Node Control"           => _("Container Node Control Policies"),
+                    "Container Image Control"          => _("Container Image Control Policies"),
+                    "Ext Management System Control"    => _("Provider Control Policies"),
+                    }
   = render :partial => "layouts/flash_msg"
   %table.table.table-striped.table-bordered.table-hover
     %tbody


### PR DESCRIPTION
Control -> Policies accordion -> Compliance/Control
explorer has correct child, but right side list had empty last row:

![provider-policies](https://cloud.githubusercontent.com/assets/273688/20545638/ee2b30b8-b118-11e6-9c41-60f355dbf765.png)

Links
----------------

Follow up to #11002.

@miq-bot add-label control, ui, bug, euwe/yes
cc @alongoldboim 