### PR TITLE
Fix weekly chargeback with monthly rate

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -7,5 +7,18 @@ class Chargeback
     def hours_in_interval
       @hours_in_interval ||= (@end_time - @start_time).round / 1.hour
     end
+
+    def hours_in_month
+      # If the interval is monthly, we have use exact number of days in interval (i.e. 28, 29, 30, or 31)
+      # othewise (for weekly and daily intervals) we assume month equals to 30 days
+      monthly? ? hours_in_interval : (1.month / 1.hour)
+    end
+
+    private
+
+    def monthly?
+      # A heuristic. Is the interval lenght about 30 days?
+      (hours_in_interval * 1.hour - 1.month).abs < 3.days
+    end
   end
 end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -19,8 +19,6 @@ class ChargebackRateDetail < ApplicationRecord
     "monthly" => _("Monthly")
   }.freeze
 
-  attr_accessor :hours_in_interval
-
   def charge(relevant_fields, consumption)
     result = {}
     if (relevant_fields & [metric_keys[0], cost_keys[0]]).present?

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -93,7 +93,7 @@ class ChargebackRateDetail < ApplicationRecord
                   when "hourly"  then rate
                   when "daily"   then rate / 24
                   when "weekly"  then rate / 24 / 7
-                  when "monthly" then rate / consumption.hours_in_interval
+                  when "monthly" then rate / consumption.hours_in_month
                   when "yearly"  then rate / 24 / 365
                   else raise "rate time unit of '#{per_time}' not supported"
                   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -90,6 +90,12 @@ describe ChargebackRateDetail do
       expect { annual_rate.hourly(rate, consumption) }.to raise_error(RuntimeError,
                                                                       "rate time unit of 'annually' not supported")
     end
+
+    let(:monthly_rate) { FactoryGirl.build(:chargeback_rate_detail, :per_time => 'monthly') }
+    let(:weekly_consumption) { Chargeback::ConsumptionWithRollups.new([], Time.current - 1.week, Time.current) }
+    it 'monhtly rate returns correct hourly(_rate) when consumption slice is weekly' do
+      expect(monthly_rate.hourly(rate, weekly_consumption)).to eq(rate / (1.month / 1.hour))
+    end
   end
 
   it "#rate_adjustment" do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -35,10 +35,10 @@ describe ChargebackRateDetail do
     per_time = 'monthly'
     per_unit = 'megabytes'
     cbd = FactoryGirl.build(:chargeback_rate_detail,
-                            :per_time          => per_time,
-                            :per_unit          => per_unit,
-                            :enabled           => true,
-                            :hours_in_interval => hours_in_month)
+                            :per_time => per_time,
+                            :per_unit => per_unit,
+                            :enabled  => true)
+    cbd.instance_variable_set(:@hours_in_interval, hours_in_month)
     cbt = FactoryGirl.create(:chargeback_tier,
                              :chargeback_rate_detail_id => cbd.id,
                              :start                     => tier_start,
@@ -75,12 +75,11 @@ describe ChargebackRateDetail do
       'yearly',   'megabytes',  rate / 24 / 365
     ].each_slice(3) do |per_time, per_unit, hourly_rate|
       cbd = FactoryGirl.build(:chargeback_rate_detail,
-                               :per_time                          => per_time,
-                               :per_unit                          => per_unit,
-                               :metric                            => 'derived_memory_available',
-                               :chargeback_rate_detail_measure_id => cbdm.id,
-                               :hours_in_interval                 => hours_in_month
-                              )
+                              :per_time                          => per_time,
+                              :per_unit                          => per_unit,
+                              :metric                            => 'derived_memory_available',
+                              :chargeback_rate_detail_measure_id => cbdm.id)
+      cbd.instance_variable_set(:@hours_in_interval, hours_in_month)
       expect(cbd.hourly(rate)).to eq(hourly_rate)
     end
     cbd = FactoryGirl.build(:chargeback_rate_detail, :per_time => 'annually')
@@ -195,14 +194,14 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
                                   :per_unit                          => 'bytes',
                                   :metric                            => 'derived_memory_available',
                                   :per_time                          => 'monthly',
-                                  :chargeback_rate_detail_measure_id => cbdm.id,
-                                  :hours_in_interval                 => hours_in_month)
+                                  :chargeback_rate_detail_measure_id => cbdm.id)
+    cbd_bytes.instance_variable_set(:@hours_in_interval, hours_in_month)
     cbd_gigabytes = FactoryGirl.build(:chargeback_rate_detail,
                                       :per_unit                          => 'gigabytes',
                                       :metric                            => 'derived_memory_available',
                                       :per_time                          => 'monthly',
-                                      :chargeback_rate_detail_measure_id => cbdm.id,
-                                      :hours_in_interval                 => hours_in_month)
+                                      :chargeback_rate_detail_measure_id => cbdm.id)
+    cbd_gigabytes.instance_variable_set(:@hours_in_interval, hours_in_month)
     expect(cbd_bytes.hourly_cost(100)).to eq(cbd_gigabytes.hourly_cost(100))
   end
 

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -24,8 +24,7 @@ describe ChargebackRateDetail do
     end
   end
 
-  let(:hours_in_month) { 720 }
-  let(:consumption) { instance_double('Consumption', :hours_in_interval => hours_in_month) }
+  let(:consumption) { instance_double('Consumption', :hours_in_month => (1.month / 1.hour)) }
 
   it '#hourly_cost' do
     cvalue   = 42.0


### PR DESCRIPTION
## Problem was
We over-used @hours_in_interval variable. In case of monthly rate_detail and monthly report period it was calculating fine, based on how many days are in given month. However in case of weekly or daily report, the monthly rate_detail was many times more expensive way to run your infrastructure.

I tried to put some more details in respective commit messages.

@miq-bot add_label chargeback, bug, wip
@miq-bot assign @gtanzillo 