### PR TITLE
Toolbar refactoring: Pxe

### DIFF
--- a/app/controllers/mixins/sandbox.rb
+++ b/app/controllers/mixins/sandbox.rb
@@ -194,6 +194,10 @@ module Sandbox
     x_node_set(node, x_active_tree)
   end
 
+  def nodes(delimiter = '-')
+    x_node.split(delimiter)
+  end
+
   def x_node_set(node, tree)
     sandbox.store_path(:trees, tree, :active_node, node)
   end

--- a/app/helpers/application_helper/button/customization_template.rb
+++ b/app/helpers/application_helper/button/customization_template.rb
@@ -1,0 +1,15 @@
+class ApplicationHelper::Button::CustomizationTemplate < ApplicationHelper::Button::Basic
+  def visible?
+    !root? && !system?
+  end
+
+  private
+
+  def root?
+    @view_context.nodes.first == 'root'
+  end
+
+  def system?
+    @view_context.nodes.last == 'system' || @record.try(:system)
+  end
+end

--- a/app/helpers/application_helper/button/customization_template_copy.rb
+++ b/app/helpers/application_helper/button/customization_template_copy.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::CustomizationTemplateCopy < ApplicationHelper::Button::CustomizationTemplate
+  def visible?
+    !root?
+  end
+end

--- a/app/helpers/application_helper/button/customization_template_new.rb
+++ b/app/helpers/application_helper/button/customization_template_new.rb
@@ -1,0 +1,5 @@
+class ApplicationHelper::Button::CustomizationTemplateNew < ApplicationHelper::Button::CustomizationTemplate
+  def visible?
+    !system?
+  end
+end

--- a/app/helpers/application_helper/toolbar/customization_template_center.rb
+++ b/app/helpers/application_helper/toolbar/customization_template_center.rb
@@ -10,19 +10,22 @@ class ApplicationHelper::Toolbar::CustomizationTemplateCenter < ApplicationHelpe
           :customization_template_copy,
           'fa fa-files-o fa-lg',
           t = N_('Copy this Customization Template'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::CustomizationTemplateCopy),
         button(
           :customization_template_edit,
           'pficon pficon-edit fa-lg',
           t = N_('Edit this Customization Template'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::CustomizationTemplate),
         button(
           :customization_template_delete,
           'pficon pficon-delete fa-lg',
           t = N_('Remove this Customization Template'),
           t,
           :url_parms => "&refresh=y",
-          :confirm   => N_("Warning: This Customization Template will be permanently removed!")),
+          :confirm   => N_("Warning: This Customization Template will be permanently removed!"),
+          :klass     => ApplicationHelper::Button::CustomizationTemplate),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/customization_templates_center.rb
+++ b/app/helpers/application_helper/toolbar/customization_templates_center.rb
@@ -10,7 +10,8 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           :customization_template_new,
           'pficon pficon-add-circle-o fa-lg',
           t = N_('Add a New Customization Template'),
-          t),
+          t,
+          :klass => ApplicationHelper::Button::CustomizationTemplateNew),
         button(
           :customization_template_copy,
           'fa fa-files-o fa-lg',
@@ -18,7 +19,8 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           N_('Copy Selected Customization Templates'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1"),
+          :onwhen    => "1",
+          :klass     => ApplicationHelper::Button::CustomizationTemplateCopy),
         button(
           :customization_template_edit,
           'pficon pficon-edit fa-lg',
@@ -26,7 +28,8 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           N_('Edit Selected Customization Templates'),
           :url_parms => "main_div",
           :enabled   => false,
-          :onwhen    => "1"),
+          :onwhen    => "1",
+          :klass     => ApplicationHelper::Button::CustomizationTemplate),
         button(
           :customization_template_delete,
           'pficon pficon-delete fa-lg',
@@ -35,7 +38,8 @@ class ApplicationHelper::Toolbar::CustomizationTemplatesCenter < ApplicationHelp
           :url_parms => "main_div",
           :confirm   => N_("Warning: The selected Customization Templates will be permanently removed!"),
           :enabled   => false,
-          :onwhen    => "1+"),
+          :onwhen    => "1+",
+          :klass     => ApplicationHelper::Button::CustomizationTemplate),
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -422,23 +422,6 @@ class ApplicationHelper::ToolbarBuilder
     end
   end
 
-  def hide_button_pxe(id)
-    case x_active_tree
-    when :customization_templates_tree
-      return true unless role_allows?(:feature => id)
-      nodes = x_node.split('-')
-      if nodes.first == "root"
-        # show only add button on root node
-        id != "customization_template_new"
-      elsif nodes.last == "system" || (@record && @record.system)
-        # allow only copy button for system customization templates
-        id != "customization_template_copy"
-      else
-        false
-      end
-    end
-  end
-
   def hide_button_report(id)
     if %w(miq_report_copy miq_report_delete miq_report_edit
           miq_report_new miq_report_run miq_report_schedule_add).include?(id) ||
@@ -556,11 +539,6 @@ class ApplicationHelper::ToolbarBuilder
 
     if @layout == "ops"
       res = hide_button_ops(id)
-      return res
-    end
-
-    if @layout == "pxe" || id.starts_with?("pxe_", "customization_template_")
-      res = hide_button_pxe(id)
       return res
     end
 

--- a/spec/helpers/application_helper/buttons/customization_template_copy_spec.rb
+++ b/spec/helpers/application_helper/buttons/customization_template_copy_spec.rb
@@ -1,0 +1,27 @@
+describe ApplicationHelper::Button::CustomizationTemplateCopy do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  let(:record) { nil }
+  subject { described_class.new(view_context, {}, {'record' => record}, {}) }
+
+  before { allow(view_context).to receive(:x_node).and_return(x_node) }
+
+  describe '#visible?' do
+    context 'when root node is active' do
+      let(:x_node) { 'root' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when system node is active' do
+      let(:x_node) { 'xx-xx-system' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+    context 'when record has system' do
+      let(:x_node) { 'does-not-matter' }
+      let(:record) { FactoryGirl.create(:customization_template_cloud_init, :system => true) }
+      it { expect(subject.visible?).to be_truthy }
+    end
+    context 'when other node is active' do
+      let(:x_node) { 'xx-xx-10r3' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/customization_template_new_spec.rb
+++ b/spec/helpers/application_helper/buttons/customization_template_new_spec.rb
@@ -1,0 +1,21 @@
+describe ApplicationHelper::Button::CustomizationTemplateNew do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  subject { described_class.new(view_context, {}, {}, {}) }
+
+  before { allow(view_context).to receive(:x_node).and_return(x_node) }
+
+  describe '#visible?' do
+    context 'when root node is active' do
+      let(:x_node) { 'root' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+    context 'when system node is active' do
+      let(:x_node) { 'xx-xx-system' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when other node is active' do
+      let(:x_node) { 'xx-xx-10r3' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end

--- a/spec/helpers/application_helper/buttons/customization_template_spec.rb
+++ b/spec/helpers/application_helper/buttons/customization_template_spec.rb
@@ -1,0 +1,21 @@
+describe ApplicationHelper::Button::CustomizationTemplate do
+  let(:view_context) { setup_view_context_with_sandbox({}) }
+  subject { described_class.new(view_context, {}, {}, {}) }
+
+  before { allow(view_context).to receive(:x_node).and_return(x_node) }
+
+  describe '#visible?' do
+    context 'when root node is active' do
+      let(:x_node) { 'root' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when system node is active' do
+      let(:x_node) { 'xx-xx-system' }
+      it { expect(subject.visible?).to be_falsey }
+    end
+    context 'when other node is active' do
+      let(:x_node) { 'xx-xx-10r3' }
+      it { expect(subject.visible?).to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
Deleted the `hide_button_pxe` method and its [calling block](https://github.com/ManageIQ/manageiq/blob/aac988fcb41cd2c78555be976a5f9c50ba294ca3/app/helpers/application_helper/toolbar_builder.rb#L562-L565) and created separate button classes for `customization_template_*` buttons. All other `PXE` buttons have the same behavior as `Basic`. There was no need of creating a specific class for them.

`@layout == "pxe"` does not need to be checked, since all the toolbars related to `pxe_` and `customazition_template_` prefixed buttons are rendered only if that condition is evaluated as true - that condition is already checked in [`toolbar_chooser.rb`](https://github.com/ManageIQ/manageiq/blob/aac988fcb41cd2c78555be976a5f9c50ba294ca3/app/helpers/application_helper/toolbar_chooser.rb#L121).

| Toolbar button ids | Toolbar button classes created |
| --- | --- |
| customization_template_edit, customization_template_delete | CustomizationTemplate < Basic |
| customization_template_new  | CustomizationTemplateNew < CustomizationTemplate |
| customization_template_copy | CustomizationTemplateCopy < CustomizationTemplate |

# Links

Parent issue: #6259
Related issue: #6554
Pivotal Tracker: https://www.pivotaltracker.com/story/show/133670419
