### PR TITLE
Fix Dashboard chart zoom

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1667,6 +1667,12 @@ function chartData(type, data, data2) {
         return data.miq.category_table[x];
       };
     }
+    if(data.miq.zoomed){
+      data.size = { height: $('#lightbox-panel').height() - 200 };
+      data.data.names = data.miq.name_table;
+      data.legend = { position : 'bottom'};
+
+    }
   }
 
   // set formating function for tooltip and y tick labels

--- a/app/assets/stylesheets/template.scss
+++ b/app/assets/stylesheets/template.scss
@@ -149,9 +149,10 @@ img.timeline-event-bubble-image { width: 64px; height: 64px;}
   left: 50%;
   z-index: 1001;
   display: none;
-  margin-left: -350px;
+  margin-left: -35%;
   padding: 10px 15px 10px 15px;
-  width: 700px;
+  width: 80%;
+  height: 85%;
   border: 2px solid #CCC;
   background: #fff;
 }

--- a/app/helpers/c3_helper.rb
+++ b/app/helpers/c3_helper.rb
@@ -5,6 +5,7 @@ module C3Helper
     content_tag(:div, '', :id => chart_id) +
       javascript_tag(<<-EOJ)
 $.get("#{url}").success(function(data) {
+  data.miq.zoomed = "#{opts[:zoomed]}";
   var chart = c3.generate(chartData(data.miqChart, data, { bindto: "##{chart_id}" }));
   ManageIQ.charts.c3["#{chart_id}"] = chart;
   miqSparkleOff();

--- a/app/helpers/charting_helper.rb
+++ b/app/helpers/charting_helper.rb
@@ -11,7 +11,7 @@ module ChartingHelper
     when :c3
       c3chart_remote(url_for(:controller => a_controller,
                              :action     => options[:action] || 'render_chart'),
-                     options.slice(:id))
+                     options.slice(:id, :zoomed))
     end
   end
 

--- a/app/views/dashboard/_zoomed_chart.html.haml
+++ b/app/views/dashboard/_zoomed_chart.html.haml
@@ -10,5 +10,5 @@
             :onclick => "miqSparkle(false);$('#lightbox-panel').fadeOut(300);"}
           %i.fa.fa-close.pull-right
     .card-pf-body
-      = chart_remote('dashboard', :id => 'my_chart',:bgcolor => "#f2f2f2")
+      = chart_remote('dashboard', :id => 'my_chart', :bgcolor => "#f2f2f2", :zoomed => true)
     = render :partial => 'widget_footer', :locals => {:widget => widget}


### PR DESCRIPTION
Make Widget chart actually zoom and use full names in legend. Also move legend to bottom when zoomed, because legend can be looong and make chart small.

Screenshots
----------------
Before:
![firefox_screenshot_2016-11-23t13-32-26 642z](https://cloud.githubusercontent.com/assets/9535558/20563636/b936bb54-b189-11e6-9976-82dfad1b60a6.png)

After:
![firefox_screenshot_2016-11-23t13-31-32 280z](https://cloud.githubusercontent.com/assets/9535558/20563637/bacc8c78-b189-11e6-95c2-c308bfe04e4f.png)

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1382714


Steps for Testing/QA 
-------------------------------
Show dashboard.


https://bugzilla.redhat.com/show_bug.cgi?id=1382714