### PR TITLE
[WIP] Add support for configuring the server settings via REST API

### DIFF
--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -13,6 +13,29 @@ module Api
       render_resource :settings, ::Settings.to_hash.slice(*Array(selected_sections).collect(&:to_sym))
     end
 
+    def update
+      if @req.c_id == "server"
+        edit_server_settings(json_body_resource)
+      else
+        raise BadRequestError, "Could not update #{@req.c_id} settings. Only server settings update is supported"
+      end
+    end
+
+    def edit_server_settings(data)
+      server = data["id"] ? MiqServer.find(data["id"]) : MiqServer.my_server(true)
+      update = server.get_config("vmdb")
+      data = data.symbolize_keys.except(:id)
+      data.each do |k, v|
+        update.config[:server][k] = v
+      end
+      if update.validate
+        server.set_config(update)
+      end
+      render_resource :settings, ::Settings.to_hash.slice(*Array("server").collect(&:to_sym))
+    rescue => err
+      raise BadRequestError, "Could not update server settings - #{err}"
+    end
+
     private
 
     def exposed_settings

--- a/config/api.yml
+++ b/config/api.yml
@@ -1490,17 +1490,24 @@
     :options:
     - :arbitrary_resource_path
     - :collection
-    :verbs: *g
+    :verbs: *gp
     :categories:
       - product
+      - server
     :collection_actions:
       :get:
       - :name: read
         :identifier: ops_settings
+      :post:
+      - :name: edit
+        :identifier: ops_settings_admin
     :resource_actions:
       :get:
       - :name: read
         :identifier: ops_settings
+      :post:
+      - :name: edit
+        :identifier: ops_settings_admin
   :software:
     :description: Software
     :options:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2462,6 +2462,10 @@
     :feature_type: node
     :identifier: ops_settings
     :children:
+    - :name: Server Roles
+      :description: Server Roles
+      :feature_type: admin
+      :identifier: ops_settings_admin
     - :name: Analysis Profiles
       :description: Analysis Profiles
       :feature_type: node

--- a/spec/requests/api/settings_spec.rb
+++ b/spec/requests/api/settings_spec.rb
@@ -39,4 +39,18 @@ describe "Settings API" do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  context "Settings Update" do
+    it "tests editing server roles" do
+      api_basic_authorize action_identifier(:settings, :edit, :resource_actions, :post)
+      new_server_roles = "ems_metrics_collector,ems_metrics_coordinator,ems_metrics_processor"
+
+      run_post(
+        settings_url("server"),
+        gen_request(:edit, "role" => new_server_roles))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["server"]["role"]).to eq(new_server_roles)
+    end
+  end
 end


### PR DESCRIPTION
Currently, it is only possible to query the settings product category.
This change adds the option to edit the server settings, as well as query the server category .
Passing the server id is optional, if missing `MiqServer.my_server` is picked.

Usage example:

url:
`<manageiq_url>/api/settings/server` 
(`POST`)

body:
```
{
  "action" : "edit",
  "resource": {
    "id": 1,
    "role": "ems_metrics_collector,ems_metrics_coordinator,ems_metrics_processor,database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,websocket,web_services,automate"
  }
}
```