### PR TITLE
Adding link to Server Group in the summary page of a server

### DIFF
--- a/app/helpers/middleware_server_helper/textual_summary.rb
+++ b/app/helpers/middleware_server_helper/textual_summary.rb
@@ -9,7 +9,7 @@ module MiddlewareServerHelper::TextualSummary
 
   def textual_group_relationships
     # Order of items should be from parent to child
-    %i(ems middleware_deployments middleware_datasources lives_on middleware_messagings)
+    %i(ems middleware_server_group middleware_deployments middleware_datasources lives_on middleware_messagings)
   end
 
   #


### PR DESCRIPTION
When domain mode is enabled, the summary page of a server was not showing
the group owning the server. This information is added under the
relationships block, allowing the user to go to the page of the server
group.

![issue10658fix](https://cloud.githubusercontent.com/assets/23639005/20579498/905a4396-b192-11e6-9d82-2a3883b285c4.png)

No specs are provided, because the modified method returns a constant value and there is nothing to test in this case.

Issue ManageIQ/manageiq#10658

@josejulio 