### PR TITLE
Set start date explicitly only when changing schedule interval

### DIFF
--- a/app/controllers/report_controller/schedules.rb
+++ b/app/controllers/report_controller/schedules.rb
@@ -197,11 +197,13 @@ module ReportController::Schedules
         page.replace("schedule_email_options_div", :partial => "schedule_email_options")
       end
 
-      # when timer_typ set to hourly set starting date to current day otherwise it's the day after
-      if params[:timer_typ] == 'Hourly'
-        @edit[:new][:timer].start_date = Time.zone.now.strftime("%m/%d/%Y")
-      else
-        @edit[:new][:timer].start_date = (Time.zone.now + 1.day).strftime("%m/%d/%Y")
+      if params[:timer_typ].present?
+        # when timer_typ set to hourly set starting date to current day otherwise it's the day after
+        if params[:timer_typ] == 'Hourly'
+          @edit[:new][:timer].start_date = Time.zone.now.strftime("%m/%d/%Y")
+        else
+          @edit[:new][:timer].start_date = (Time.zone.now + 1.day).strftime("%m/%d/%Y")
+        end
       end
       page << "$('#miq_date_1').val('#{@edit[:new][:timer].start_date}');"
 


### PR DESCRIPTION
Reproducer:
1. Cloud Intel -> Reports -> Schedules -> Edit existing schedule
2. Change schedule start date
3. Notice the start date will be set back to either today (hourly schedule) or tomorrow (all the other).

https://bugzilla.redhat.com/show_bug.cgi?id=1392351