### PR TITLE
Fix the form field 'Save search as' of an Advanced Search

### DIFF
--- a/app/views/layouts/_adv_search_body.html.haml
+++ b/app/views/layouts/_adv_search_body.html.haml
@@ -69,7 +69,7 @@
           .col-md-6
             %span#search_name_span
               = text_field_tag("search_name",
-                               h(@edit[:adv_search_name]),
+                               h(@edit[:new_search_name]) || h(@edit[:adv_search_name]),
                                :maxlength         => 30,
                                :class             => "form-control",
                                "data-miq_focus"   => true,


### PR DESCRIPTION
When user tries to save already saved search (i.e. with different name) and leave empty field 'Save this #{model_name} search as:', then he got error "Search Name is required", but the previous name of the search is displayed again. This PR is fixing the empty name of the search and not displaying the old value.

https://bugzilla.redhat.com/show_bug.cgi?id=1349519
https://bugzilla.redhat.com/show_bug.cgi?id=1349511
https://bugzilla.redhat.com/show_bug.cgi?id=1349499
