### PR TITLE
Sanitize regex expressions from /s and #{}s

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1000,7 +1000,17 @@ class MiqExpression
     end
   end
 
-  # TODO: update this to use the more nuanced .sanitize_regular_expression
+  # TODO: update this to use the more nuanced
+  # .sanitize_regular_expression after performing Regexp.escape. The
+  # extra substitution is required because, although the result from
+  # Regexp.escape is fine to pass to Regexp.new, it is not when eval'd
+  # as we do:
+  #
+  # ```ruby
+  # regexp_string = Regexp.escape("/") # => "/"
+  # # ...
+  # eval("/" + regexp_string + "/")
+  # ```
   def self.re_escape(s)
     Regexp.escape(s).gsub(/\//, '\/')
   end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -484,7 +484,23 @@ class MiqExpression
       clause = "!(" + clause + ")" if operator.downcase == "not like"
     when "regular expression matches", "regular expression does not match"
       operands = operands2rubyvalue(operator, exp[operator], context_type)
-      operands[1] = "/" + operands[1].to_s + "/" unless operands[1].starts_with?("/") && (operands[1].ends_with?("/") || operands[1][-2..-2] == "/")
+
+      # If it looks like a regular expression, sanitize from forward
+      # slashes and interpolation
+      #
+      # Regular expressions with a single option are also supported,
+      # e.g. "/abc/i"
+      #
+      # Otherwise sanitize the whole string and add the delimiters
+      #
+      # TODO: support regexes with more than one option
+      if operands[1].starts_with?("/") && operands[1].ends_with?("/")
+        operands[1][1..-2] = sanitize_regular_expression(operands[1][1..-2])
+      elsif operands[1].starts_with?("/") && operands[1][-2] == "/"
+        operands[1][1..-3] = sanitize_regular_expression(operands[1][1..-3])
+      else
+        operands[1] = "/" + sanitize_regular_expression(operands[1].to_s) + "/"
+      end
       clause = operands.join(" #{normalize_ruby_operator(operator)} ")
     when "and", "or"
       clause = "(" + exp[operator].collect { |operand| _to_ruby(operand, context_type, tz) }.join(" #{normalize_ruby_operator(operator)} ") + ")"
@@ -984,8 +1000,14 @@ class MiqExpression
     end
   end
 
+  # TODO: update this to use the more nuanced .sanitize_regular_expression
   def self.re_escape(s)
     Regexp.escape(s).gsub(/\//, '\/')
+  end
+
+  # Escape any unescaped forward slashes and/or interpolation
+  def self.sanitize_regular_expression(string)
+    string.gsub(%r{\\*/}, "\\/").gsub(/\\*#/, "\\\#")
   end
 
   def self.preprocess_managed_tag(tag)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -657,6 +657,90 @@ describe MiqExpression do
       expect(exp.to_ruby).to eq('<value ref=host, type=numeric_set>/virtual/enabled_inbound_ports</value> == [22,427,5988,5989]')
     end
 
+    it "escapes forward slashes for values in REGULAR EXPRESSION MATCHES expressions" do
+      value = "//; puts 'Hi, mom!';//"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/; puts 'Hi, mom!';\\//"
+      expect(actual).to eq(expected)
+    end
+
+    it "preserves the delimiters when escaping forward slashes in case-insensitive REGULAR EXPRESSION MATCHES expressions" do
+      value = "//; puts 'Hi, mom!';//i"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/; puts 'Hi, mom!';\\//i"
+      expect(actual).to eq(expected)
+    end
+
+    it "escapes forward slashes for non-Regexp literal values in REGULAR EXPRESSION MATCHES expressions" do
+      value = ".*/; puts 'Hi, mom!';/.*"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /.*\\/; puts 'Hi, mom!';\\/.*/"
+      expect(actual).to eq(expected)
+    end
+
+    it "does not escape escaped forward slashes for values in REGULAR EXPRESSION MATCHES expressions" do
+      value = "\/foo\/bar"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/foo\\/bar/"
+      expect(actual).to eq(expected)
+    end
+
+    it "handles arbitarily long escaping of forward " do
+      value = "\\\\\\/foo\\\\\\/bar"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\/foo\\/bar/"
+      expect(actual).to eq(expected)
+    end
+
+    it "escapes interpolation in REGULAR EXPRESSION MATCHES expressions" do
+      value = "/\#{puts 'Hi, mom!'}/"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\\#{puts 'Hi, mom!'}/"
+      expect(actual).to eq(expected)
+    end
+
+    it "handles arbitrarily long escaping of interpolation in REGULAR EXPRESSION MATCHES expressions" do
+      value = "/\\\\\#{puts 'Hi, mom!'}/"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\\#{puts 'Hi, mom!'}/"
+      expect(actual).to eq(expected)
+    end
+
+    it "escapes interpolation in non-Regexp literal values in REGULAR EXPRESSION MATCHES expressions" do
+      value = "\#{puts 'Hi, mom!'}"
+      actual = described_class.new("REGULAR EXPRESSION MATCHES" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> =~ /\\\#{puts 'Hi, mom!'}/"
+      expect(actual).to eq(expected)
+    end
+
+    it "escapes forward slashes for values in REGULAR EXPRESSION DOES NOT MATCH expressions" do
+      value = "//; puts 'Hi, mom!';//"
+      actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /\\/; puts 'Hi, mom!';\\//"
+      expect(actual).to eq(expected)
+    end
+
+    it "preserves the delimiters when escaping forward slashes in case-insensitive REGULAR EXPRESSION DOES NOT MATCH expressions" do
+      value = "//; puts 'Hi, mom!';//i"
+      actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /\\/; puts 'Hi, mom!';\\//i"
+      expect(actual).to eq(expected)
+    end
+
+    it "escapes forward slashes for non-Regexp literal values in REGULAR EXPRESSION DOES NOT MATCH expressions" do
+      value = ".*/; puts 'Hi, mom!';/.*"
+      actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /.*\\/; puts 'Hi, mom!';\\/.*/"
+      expect(actual).to eq(expected)
+    end
+
+    it "does not escape escaped forward slashes for values in REGULAR EXPRESSION DOES NOT MATCH expressions" do
+      value = "\/foo\/bar"
+      actual = described_class.new("REGULAR EXPRESSION DOES NOT MATCH" => {"field" => "Vm-name", "value" => value}).to_ruby
+      expected = "<value ref=vm, type=string>/virtual/name</value> !~ /\\/foo\\/bar/"
+      expect(actual).to eq(expected)
+    end
+
     # Note: To debug these tests, the following may be helpful:
     # puts "Expression Raw:      #{filter.exp.inspect}"
     # puts "Expression in Human: #{filter.to_human}"


### PR DESCRIPTION
Both REGULAR EXPRESSION MATCHES and REGULAR EXPRESSION DOES NOT MATCH
have a vulnerability whereby a regular expression can be terminated in
the first part of the string that gets eval'd, allowing any arbitrary
Ruby code to be run.

They are also vulnerable to interpolation, wherein any arbitrary Ruby
code can get executed.

Unfortunately it is not possible to run these values through the
existing `MiqExpression.re_escape` method, since it also escapes special
characters which are essential to the user's forming real regular
expressions through the UI.

Because we are currently supporting values with or without the actual
bona fide delimiters present, and also regular expressions with one
option (e.g. `/abc/i`), we have to code several paths to ensure that we
escape only unescaped forward slashes that are not part of the bona fide
regular expression literal syntax.

Addresses CVE-2016-7040

This is ported from the downstream fix, which has already been
cherry-picked in Darga (92d5b5e8ed0777c42f4cdd5a79c18780320c518c) and
Euwe (a1db51172c7720f54fd6c0063c24d294a40e3ed5).

Here's the original BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1376887

@miq-bot add-label core, bug
@miq-bot assign @Fryguy 