### PR TITLE
[EUWE] When no disks are found gracefully return

### DIFF
--- a/gems/pending/appliance_console/logfile_configuration.rb
+++ b/gems/pending/appliance_console/logfile_configuration.rb
@@ -29,6 +29,7 @@ module ApplianceConsole
     private
 
     def confirm_selection
+      return false unless disk
       agree("Continue with disk: #{disk.path}: #{disk.size.to_i / 1.megabyte} MB (Y/N):")
     end
 

--- a/gems/pending/spec/appliance_console/logfile_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/logfile_configuration_spec.rb
@@ -28,6 +28,14 @@ describe ApplianceConsole::LogfileConfiguration do
 
       expect(subject.ask_questions).to be false
     end
+
+    it "returns false when no disk is found" do
+      expect(subject).to receive(:agree).with("Configure a new logfile disk volume? (Y/N):").and_return(true)
+      expect(subject).to_not receive(:agree).with(/Continue with disk:/)
+      expect(subject).to receive(:ask_for_disk).and_return(nil)
+
+      expect(subject.ask_questions).to be false
+    end
   end
 
   describe "#activate" do


### PR DESCRIPTION
## This change is only needed in, and should only be applied to, the euwe branch.

If an administrator attempts to configure a new disk volume for storing .log files
but failed to add a disk volume to use, the appliance_console would exit
with a traceback. This PR enables the appliance_console to gracefully handle
this predicament.

https://bugzilla.redhat.com/show_bug.cgi?id=1391929