### PR TITLE
Use ::Settings in app/models - part 2

### DIFF
--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -151,7 +151,7 @@ class GenericMailer < ActionMailer::Base
 
   def prepare_generic_email(options)
     _log.info("options: #{options.inspect}")
-    options[:from] = VMDB::Config.new("vmdb").config.fetch_path(:smtp, :from) if options[:from].blank?
+    options[:from] = ::Settings.smtp.from if options[:from].blank?
     @content = options[:body]
     options[:attachment] ||= []
     options[:attachment].each do |a|
@@ -166,7 +166,7 @@ class GenericMailer < ActionMailer::Base
   AUTHENTICATION_SMTP_KEYS = [:authentication, :user_name, :password]
   OPTIONAL_SMTP_KEYS = [:enable_starttls_auto, :openssl_verify_mode]
   def set_mailer_smtp(evm_settings = nil)
-    evm_settings ||= VMDB::Config.new("vmdb").config[:smtp]
+    evm_settings ||= ::Settings.smtp
     am_settings =  {}
 
     DESTINATION_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] }
@@ -179,7 +179,7 @@ class GenericMailer < ActionMailer::Base
     else                  raise ArgumentError, "authentication value #{evm_settings[:authentication].inspect} must be one of: 'none', 'plain', 'login'"
     end
 
-    OPTIONAL_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] if evm_settings.key?(key) }
+    OPTIONAL_SMTP_KEYS.each { |key| am_settings[key] = evm_settings[key] if evm_settings[key] }
 
     ActionMailer::Base.smtp_settings = am_settings
     log_smtp_settings = am_settings.dup

--- a/app/models/ems_cluster/capacity_planning.rb
+++ b/app/models/ems_cluster/capacity_planning.rb
@@ -34,22 +34,8 @@ module EmsCluster::CapacityPlanning
     end
   end
 
-  module ClassMethods
-    def capacity_settings
-      VMDB::Config.new('capacity').config
-    end
-  end
-
-  #
-  # Settings methods
-  #
-
-  def capacity_settings
-    @capacity_settings ||= self.class.capacity_settings
-  end
-
   def capacity_profile_settings(profile)
-    capacity_settings.fetch_path(:profile, profile.to_s.to_sym) || {}
+    ::Settings.capacity.profile[profile.to_s] || {}
   end
 
   def capacity_profile_method(profile, resource)
@@ -86,7 +72,7 @@ module EmsCluster::CapacityPlanning
 
   def capacity_failover_rule
     @capacity_failover_rule ||= begin
-      failover_rule = capacity_settings.fetch_path(:failover, :rule).to_s.downcase.strip
+      failover_rule = ::Settings.capacity.failover.rule.downcase
       failover_rule = 'discovered' unless ['none', 'discovered'].include?(failover_rule)
       failover_rule
     end

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -140,19 +140,12 @@ class LogFile < ApplicationRecord
                    :description => "Default logfile")
   end
 
-  # Added tcp ping stuff here until ftp is refactored into a separate class
-  def self.get_ping_depot_options
-    @@ping_depot_options ||= VMDB::Config.new("vmdb").config[:log][:collection]
-  end
-
   def self.ping_timeout
-    get_ping_depot_options
-    @@ping_timeout ||= (@@ping_depot_options[:ping_depot_timeout] || 20)
+    ::Settings.log.collection.ping_depot_timeout
   end
 
   def self.do_ping?
-    get_ping_depot_options
-    @@do_ping ||= @@ping_depot_options[:ping_depot] == true
+    ::Settings.log.collection.ping_depot == true
   end
 
   def upload_log_file_ftp

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -24,7 +24,7 @@ module ManageIQ::Providers
     #     :service
     #        :read_timeout: 1.hour
     #
-    cache_with_timeout(:ems_config, 2.minutes) { VMDB::Config.new("vmdb").config[:ems] || {} }
+    cache_with_timeout(:ems_config, 2.minutes) { ::Settings.ems }
 
     def self.ems_timeouts(type, service = nil)
       read_timeout = open_timeout = nil

--- a/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/scanning/job.rb
@@ -47,9 +47,7 @@ class ManageIQ::Providers::Kubernetes::ContainerManager::Scanning::Job < Job
     return queue_signal(:abort_job, "no image found", "error") unless image
     return queue_signal(:abort_job, "cannot analyze non docker images", "error") unless image.docker_id
 
-    ems_configs = VMDB::Config.new('vmdb').config[:ems]
-
-    namespace = ems_configs.fetch_path(:ems_kubernetes, :miq_namespace)
+    namespace = ::Settings.ems.ems_kubernetes.miq_namespace
     namespace = INSPECTOR_NAMESPACE_FALLBACK if namespace.blank?
 
     update!(:options => options.merge(

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -221,7 +221,6 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
 
     _log.info("Queuing provide of #{log_target}")
-    timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_manageable, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
     MiqQueue.put(
       :class_name   => self.class.name,
@@ -229,7 +228,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       :args         => [task.id],
       :method_name  => "manageable",
       :miq_callback => cb,
-      :msg_timeout  => timeout,
+      :msg_timeout  => ::Settings.host_manageable.queue_timeout.to_i_with_method,
       :zone         => my_zone
     )
   end
@@ -287,7 +286,6 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
 
     _log.info("Queuing introspection of #{log_target}")
-    timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_introspect, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
     MiqQueue.put(
       :class_name   => self.class.name,
@@ -295,7 +293,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       :args         => [task.id],
       :method_name  => "introspect",
       :miq_callback => cb,
-      :msg_timeout  => timeout,
+      :msg_timeout  => ::Settings.host_introspect.queue_timeout.to_i_with_method,
       :zone         => my_zone
     )
   end
@@ -362,7 +360,6 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
 
     _log.info("Queuing provide of #{log_target}")
-    timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_provide, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name => task.class.name, :instance_id => task.id, :method_name => :queue_callback_on_exceptions, :args => ['Finished']}
     MiqQueue.put(
       :class_name   => self.class.name,
@@ -370,7 +367,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       :args         => [task.id],
       :method_name  => "provide",
       :miq_callback => cb,
-      :msg_timeout  => timeout,
+      :msg_timeout  => ::Settings.host_provide.queue_timeout.to_i_with_method,
       :zone         => my_zone
     )
   end
@@ -473,7 +470,6 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     end
 
     _log.info("Queuing destroy_ironic of #{log_target}")
-    timeout = (VMDB::Config.new("vmdb").config.fetch_path(:host_delete, :queue_timeout) || 20.minutes).to_i_with_method
     cb = {:class_name  => task.class.name,
           :instance_id => task.id,
           :method_name => :queue_callback_on_exceptions,
@@ -484,7 +480,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       :args         => [task.id],
       :method_name  => "destroy_ironic",
       :miq_callback => cb,
-      :msg_timeout  => timeout,
+      :msg_timeout  => ::Settings.host_delete.queue_timeout.to_i_with_method,
       :zone         => my_zone
     )
   end

--- a/app/models/manageiq/providers/openstack/infra_manager/host_operations_mixin.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host_operations_mixin.rb
@@ -19,7 +19,7 @@ module ManageIQ::Providers::Openstack::InfraManager::HostOperationsMixin
     end
 
     _log.info("Queuing #{power_state_text} for #{log_target}")
-    timeout = (VMDB::Config.new("vmdb").config.fetch_path(feature, :queue_timeout) || 20.minutes).to_i_with_method
+    timeout = ::Settings[feature].queue_timeout.to_i_with_method
     cb = {:class_name  => task.class.name,
           :instance_id => task.id,
           :method_name => :queue_callback_on_exceptions,

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -38,10 +38,9 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       username = options[:user] || authentication_userid(options[:auth_type])
       password = options[:pass] || authentication_password(options[:auth_type])
 
-      vmdb_config = VMDB::Config.new("vmdb").config
       extra_options = {
-        :ssl_ca_file    => vmdb_config.fetch_path(:ssl, :ssl_ca_file),
-        :ssl_ca_path    => vmdb_config.fetch_path(:ssl, :ssl_ca_path),
+        :ssl_ca_file    => ::Settings.ssl.ssl_ca_file,
+        :ssl_ca_path    => ::Settings.ssl.ssl_ca_path,
         :ssl_cert_store => OpenSSL::X509::Store.new
       }
       extra_options[:domain_id] = keystone_v3_domain_id

--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -62,7 +62,7 @@ module ManageIQ::Providers
 
     def self.use_vim_broker?
       return false unless MiqVimBrokerWorker.has_required_role?
-      cfg = VMDB::Config.new("vmdb").config[:webservices][:use_vim_broker]
+      cfg = ::Settings.webservices.use_vim_broker
       return true if cfg == "force"
       return true if cfg && Sys::Platform::OS == :unix
       false
@@ -332,55 +332,50 @@ module ManageIQ::Providers
     end
 
     def vm_create_snapshot(vm, options = {})
-      config = VMDB::Config.new('vmdb').config
       defaults = {
         :memory             => false,
         :quiesce            => "false",
         :wait               => true,
-        :free_space_percent => config.fetch_path(:snapshots, :create_free_percent) || 100
+        :free_space_percent => ::Settings.snapshots.create_free_percent
       }
       options = defaults.merge(options)
       invoke_vim_ws(:createSnapshot, vm, options[:user_event], options[:name], options[:desc], options[:memory], options[:quiesce], options[:wait], options[:free_space_percent])
     end
 
     def vm_create_evm_snapshot(vm, options = {})
-      config = VMDB::Config.new('vmdb').config
       defaults = {
         :quiesce            => "false",
         :wait               => true,
-        :free_space_percent => config.fetch_path(:snapshots, :create_free_percent) || 100
+        :free_space_percent => ::Settings.snapshots.create_free_percent
       }
       options = defaults.merge(options)
       invoke_vim_ws(:createEvmSnapshot, vm, options[:user_event], options[:desc], options[:quiesce], options[:wait], options[:free_space_percent])
     end
 
     def vm_remove_snapshot(vm, options = {})
-      config = VMDB::Config.new('vmdb').config
       defaults = {
         :subTree            => "false",
         :wait               => true,
-        :free_space_percent => config.fetch_path(:snapshots, :remove_free_percent) || 100
+        :free_space_percent => ::Settings.snapshots.remove_free_percent
       }
       options = defaults.merge(options)
       invoke_vim_ws(:removeSnapshot, vm, options[:user_event], options[:snMor], options[:subTree], options[:wait], options[:free_space_percent])
     end
 
     def vm_remove_snapshot_by_description(vm, options = {})
-      config = VMDB::Config.new('vmdb').config
       defaults = {
         :subTree            => "false",
         :refresh            => false,
         :wait               => true,
-        :free_space_percent => config.fetch_path(:snapshots, :remove_free_percent) || 100
+        :free_space_percent => ::Settings.snapshots.remove_free_percent
       }
       options.reverse_merge!(defaults)
       invoke_vim_ws(:removeSnapshotByDescription, vm, options[:user_event], options[:description], options[:refresh], options[:subTree], options[:wait], options[:free_space_percent])
     end
 
     def vm_remove_all_snapshots(vm, options = {})
-      config = VMDB::Config.new('vmdb').config
       defaults = {
-        :free_space_percent => config.fetch_path(:snapshots, :remove_free_percent) || 100
+        :free_space_percent => ::Settings.snapshots.remove_free_percent
       }
       options.reverse_merge!(defaults)
       invoke_vim_ws(:removeAllSnapshots, vm, options[:user_event], options[:free_space_percent])

--- a/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/metrics_capture.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Vmware::InfraManager::MetricsCapture < ManageIQ::Prov
   #
 
   cache_with_timeout(:perf_history_results,
-                     -> { (VMDB::Config.new("vmdb").config.fetch_path(:performance, :vim_cache_ttl) || 1.hour).to_i_with_method }
+                     -> { ::Settings.performance.vim_cache_ttl.to_i_with_method }
                     ) { Hash.new }
 
   def self.intervals(ems, vim_hist)

--- a/app/models/metric/config_settings.rb
+++ b/app/models/metric/config_settings.rb
@@ -1,15 +1,15 @@
 module Metric::ConfigSettings
   def self.host_overhead
-    VMDB::Config.new("vmdb").config.fetch_path(:performance, :host_overhead) || {}
+    ::Settings.performance.host_overhead
   end
 
   def self.host_overhead_memory
     # NOTE: VMware specific
-    (host_overhead[:memory] || 2.01).to_f_with_method
+    ::Settings.performance.host_overhead.memory.to_f_with_method
   end
 
   def self.host_overhead_cpu
     # NOTE: VMware specific
-    (host_overhead[:cpu] || 0.15).to_f_with_method
+    ::Settings.performance.host_overhead.cpu.to_f_with_method
   end
 end

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -48,8 +48,7 @@ module MiqReport::Generator
     end
 
     def default_queue_timeout
-      value = VMDB::Config.new("vmdb").config.fetch_path(:reporting, :queue_timeout) || 3600
-      value.to_i_with_method
+      ::Settings.reporting.queue_timeout.to_i_with_method
     end
   end
 
@@ -124,7 +123,7 @@ module MiqReport::Generator
     options[:mode] ||= "async"
     options[:report_source] ||= "Requested by user"
 
-    sync = options.delete(:report_sync) || VMDB::Config.new("vmdb").config[:product][:report_sync]
+    sync = options.delete(:report_sync) || ::Settings.product.report_sync
 
     task = MiqTask.create(:name => "Generate Report: '#{name}'")
 

--- a/app/models/miq_report/generator/async.rb
+++ b/app/models/miq_report/generator/async.rb
@@ -3,7 +3,7 @@ module MiqReport::Generator::Async
   module ClassMethods
     def async_generate_tables(options = {})
       options[:userid] ||= "system"
-      sync = VMDB::Config.new("vmdb").config[:product][:report_sync]
+      sync = ::Settings.product.report_sync
 
       task = MiqTask.create(:name => "Generate Reports: #{options[:reports].collect(&:name).inspect}")
       MiqQueue.put(
@@ -48,7 +48,7 @@ module MiqReport::Generator::Async
 
   def async_generate_table(options = {})
     options[:userid] ||= "system"
-    sync = VMDB::Config.new("vmdb").config[:product][:report_sync]
+    sync = ::Settings.product.report_sync
 
     task = MiqTask.create(:name => _("Generate Report: '%{name}'") % {:name => name})
     unless sync # Only queued if sync reporting disabled (default)

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -15,9 +15,7 @@ module MiqReport::Generator::Html
       # Following line commented for now - for not showing repeating column values
       #       prev_data = String.new                # Initialize the prev_data variable
 
-      cfg = VMDB::Config.new("vmdb").config[:reporting]       # Read in the reporting column precisions
-      default_precision = cfg[:precision][:default]           # Set the default
-      precision_by_column = cfg[:precision_by_column]         # get the column overrides
+      precision_by_column = ::Settings.reporting.precision_by_column # get the column overrides
       precisions = {}                                         # Hash to store columns we hit
       hide_detail_rows = self.rpt_options.fetch_path(:summary, :hide_detail_rows) || false
 

--- a/app/models/miq_report/notification.rb
+++ b/app/models/miq_report/notification.rb
@@ -4,7 +4,7 @@ module MiqReport::Notification
     url = options[:email_url_prefix]
 
     user = User.find_by_userid(userid)
-    from = options[:email] && !options[:email][:from].blank? ? options[:email][:from] : VMDB::Config.new("vmdb").config[:smtp][:from]
+    from = options[:email] && !options[:email][:from].blank? ? options[:email][:from] : ::Settings.smtp.from
     to   = options[:email] ? options[:email][:to] : user.try(:email)
 
     msg = nil
@@ -47,7 +47,7 @@ module MiqReport::Notification
     # When this happens, the addresses on the end spill over into the headers and cause the content and mime information to be ignored.
     #
     # Split recipient list into groups whose total length in bytes is around 100 bytes or the configured limit
-    cut_off = VMDB::Config.new("vmdb").config.fetch_path(:smtp, :recipient_address_byte_limit) || 100
+    cut_off = ::Settings.smtp.recipient_address_byte_limit
     sub_group = []
     grouped_tos = to.uniq.inject([]) do |g, t|
       sub_group << t

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -50,7 +50,7 @@ module MiqServer::RoleManagement
   end
 
   def set_assigned_roles
-    self.role = VMDB::Config.new("vmdb").config[:server][:role]
+    self.role = ::Settings.server.role
   end
 
   def deactivate_all_roles
@@ -181,7 +181,7 @@ module MiqServer::RoleManagement
 
   def licensed_roles
     roles = ServerRole.all.to_a
-    unless VMDB::Config.new("vmdb").config[:product][:storage]
+    unless ::Settings.product.storage
       roles.delete_if { |r| r.name.starts_with?('storage_') }
       roles.delete_if { |r| r.name == 'vmdb_storage_bridge' }
     end

--- a/app/models/miq_widget/rss_content.rb
+++ b/app/models/miq_widget/rss_content.rb
@@ -28,7 +28,8 @@ class MiqWidget::RssContent < MiqWidget::ContentGeneration
   end
 
   def external_feed
-    proxy = VMDB::Config.new("vmdb").config[:http_proxy]
-    SimpleRSS.parse(Net::HTTP::Proxy(proxy[:host], proxy[:port], proxy[:user], proxy[:password]).get(URI.parse(widget_options[:url])))
+    proxy = ::Settings.http_proxy
+    SimpleRSS.parse(Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password)
+      .get(URI.parse(widget_options[:url])))
   end
 end

--- a/app/models/mixins/ontap_derived_metric_mixin.rb
+++ b/app/models/mixins/ontap_derived_metric_mixin.rb
@@ -23,10 +23,6 @@ module OntapDerivedMetricMixin
       @basedCounterNames  = nil
       @baseCounterNames = nil
       @metadataClass    = (name + "Metadata").constantize
-
-      cfg = VMDB::Config.new("vmdb").config
-      @storageMetricsCollectionInterval = cfg.fetch_path(:storage, :metrics_collection, :collection_interval).to_i_with_method
-      @storageMetricsMaxGapToFill       = cfg.fetch_path(:storage, :metrics_collection, :max_gap_to_fill).to_i_with_method
     end
 
     def metadataClass
@@ -62,12 +58,12 @@ module OntapDerivedMetricMixin
 
       deltaSecs = vinst1.timestamp.to_i - vinst0.timestamp.to_i
 
-      return [] if deltaSecs < 0 || deltaSecs > @storageMetricsMaxGapToFill
+      return [] if deltaSecs < 0 || deltaSecs > ::Settings.storage.metrics_collection.max_gap_to_fill.to_i_with_method
 
       counters0 = vinst0.counters
       counters1 = vinst1.counters
 
-      interval = @storageMetricsCollectionInterval.to_f
+      interval = ::Settings.storage.metrics_collection.collection_interval.to_i_with_method.to_f
       nInterval = (deltaSecs / interval + 0.5).to_i
       _log.info "nIntrval = #{nInterval}"
       deltaSecs /= nInterval

--- a/app/models/policy_event/purging.rb
+++ b/app/models/policy_event/purging.rb
@@ -5,11 +5,11 @@ class PolicyEvent < ApplicationRecord
 
     module ClassMethods
       def purge_date
-        (purge_config(:keep_policy_events) || 6.months).to_i_with_method.seconds.ago.utc
+        ::Settings.policy_events.history.keep_policy_events.to_i_with_method.seconds.ago.utc
       end
 
       def purge_window_size
-        purge_config(:purge_window_size) || 1000
+        ::Settings.policy_events.history.purge_window_size
       end
 
       def purge_queue
@@ -28,12 +28,6 @@ class PolicyEvent < ApplicationRecord
 
       def purge_associated_records(ids)
         PolicyEventContent.where(:policy_event_id => ids).delete_all
-      end
-
-      private
-
-      def purge_config(key)
-        VMDB::Config.new("vmdb").config.fetch_path(:policy_events, :history, key)
       end
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1042,8 +1042,6 @@
   :history:
     :keep_reports: 6.months
     :purge_window_size: 100
-  :precision:
-    :default: 2
   :precision_by_column:
     :slope: 4
   :queue_timeout: 1.hour

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1100,6 +1100,7 @@
   :host: localhost
   :password: ''
   :port: '25'
+  :recipient_address_byte_limit: 100
   :user_name: evmadmin
 :snapshots:
   :create_free_percent: 100

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -921,7 +921,19 @@
     - MoveIntoResourcePool
     :VmSuspendedEvent:
     - SuspendVM_Task
+:host_delete:
+  :queue_timeout: 20.minutes
+:host_introspect:
+  :queue_timeout: 20.minutes
+:host_manageable:
+  :queue_timeout: 20.minutes
+:host_provide:
+  :queue_timeout: 20.minutes
 :host_scan:
+  :queue_timeout: 20.minutes
+:host_start:
+  :queue_timeout: 20.minutes
+:host_stop:
   :queue_timeout: 20.minutes
 :http_proxy:
   :default:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1018,6 +1018,7 @@
   :host_overhead:
     :memory: 2.01.percent
     :cpu: 0.15.percent
+  :vim_cache_ttl: 1.hour
 :policy_events:
   :history:
     :keep_policy_events: 6.months

--- a/lib/report_formatter/html.rb
+++ b/lib/report_formatter/html.rb
@@ -50,10 +50,8 @@ module ReportFormatter
         # Following line commented for now - for not showing repeating column values
         #       prev_data = String.new                # Initialize the prev_data variable
 
-        cfg = VMDB::Config.new("vmdb").config[:reporting]       # Read in the reporting column precisions
-        default_precision = cfg[:precision][:default]           # Set the default
-        precision_by_column = cfg[:precision_by_column]         # get the column overrides
-        precisions = {}                                         # Hash to store columns we hit
+        precision_by_column = ::Settings.reporting.precision_by_column # get the column overrides
+        precisions = {} # Hash to store columns we hit
 
         # derive a default precision by looking at the suffixes of the column hearers
         zero_precision_suffixes = ["(ms)", "(mb)", "(seconds)", "(b)"]

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -80,7 +80,7 @@ describe GenericMailer do
   end
 
   it "call deliver for generic_notification without a 'from' address" do
-    stub_server_configuration(:smtp => {:from => "test@123.com"})
+    stub_settings(:smtp => {:from => "test@123.com"})
     new_args = @args.dup
     new_args.delete(:from)
     msg = GenericMailer.deliver(:generic_notification, new_args)

--- a/spec/models/metric/config_settings_spec.rb
+++ b/spec/models/metric/config_settings_spec.rb
@@ -9,10 +9,6 @@ describe Metric::ConfigSettings do
       expect(described_class.host_overhead_cpu).to eq(1.23)
     end
 
-    it "missing from configuration" do
-      stub_settings(:performance => {})
-      expect(described_class.host_overhead_cpu).to eq(0.15)
-    end
   end
 
   describe ".host_overhead_memory" do
@@ -21,9 +17,5 @@ describe Metric::ConfigSettings do
       expect(described_class.host_overhead_memory).to eq(1.23)
     end
 
-    it "missing from configuration" do
-      stub_settings(:performance => {})
-      expect(described_class.host_overhead_memory).to eq(2.01)
-    end
   end
 end

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -5,7 +5,7 @@ describe PurgingMixin do
 
   describe ".purge_date" do
     it "purge_date should not raise exception" do
-      allow(example_class).to receive(:purge_config).with(:keep_policy_events).and_return(120)
+      stub_settings(:policy_events => {:history => {:keep_policy_events => 120}})
       expect(example_class.purge_date).to be_within(1.second).of(120.seconds.ago.utc)
     end
   end


### PR DESCRIPTION
Removed deprecated calls to VMDB::Config.new in app/models. Default values were moved from code to ```settings.yml```

@miq-bot add-label wip, core