### PR TITLE
Fix retirement menu for cloud provider orchestration stacks

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -193,7 +193,7 @@ module ApplicationController::CiProcessing
   def retirevms
     assert_privileges(params[:pressed])
     vms = find_checked_items
-    if !%w(orchestration_stack service).include?(request.parameters["controller"]) &&
+    if !%w(orchestration_stack service).include?(request.parameters["controller"]) && !%w(orchestration_stacks).include?(params[:display]) &&
        VmOrTemplate.find(vms).any? { |vm| !vm.supports_retire? }
       add_flash(_("Set Retirement Date does not apply to selected %{model}") %
         {:model => ui_lookup(:table => "miq_template")}, :error)
@@ -207,7 +207,7 @@ module ApplicationController::CiProcessing
     elsif request.parameters[:controller] == "service"
       rec_cls =  "service"
       bc_msg = _("Retire Service")
-    elsif request.parameters[:controller] == "orchestration_stack"
+    elsif request.parameters[:controller] == "orchestration_stack" || %w(orchestration_stacks).include?(params[:display])
       rec_cls = "orchestration_stack"
       bc_msg = _("Retire Orchestration Stack")
     end
@@ -2781,6 +2781,8 @@ module ApplicationController::CiProcessing
       return "instance"
     elsif params[:pressed].starts_with?("miq_template_")
       return "miq_template"
+    elsif params[:pressed].starts_with?("orchestration_stack_")
+      return "orchestration_stack"
     else
       return "vm"
     end

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -393,7 +393,7 @@ module EmsCommon
   def button
     @edit = session[:edit]                                  # Restore @edit for adv search box
 
-    params[:display] = @display if ["vms", "hosts", "storages", "instances", "images"].include?(@display)  # Were we displaying vms/hosts/storages
+    params[:display] = @display if ["vms", "hosts", "storages", "instances", "images", "orchestration_stacks"].include?(@display)  # Were we displaying vms/hosts/storages
     params[:page] = @current_page unless @current_page.nil?   # Save current page for list refresh
 
     # Handle buttons from sub-items screen

--- a/spec/controllers/ems_common_controller_spec.rb
+++ b/spec/controllers/ems_common_controller_spec.rb
@@ -142,6 +142,15 @@ describe EmsCloudController do
         expect(response.status).to eq 200
         expect(response.body).to include('vm/retire')
       end
+
+      it "when Retire Button is pressed for an Orchestration Stack" do
+        allow(controller).to receive(:role_allows?).and_return(true)
+        ems = FactoryGirl.create("ems_amazon")
+        ost = FactoryGirl.create(:orchestration_stack_cloud, :ext_management_system => ems)
+        post :button, :params => { :pressed => "orchestration_stack_retire", "check_#{ost.id}" => "1", :format => :js, :id => ems.id, :display => 'orchestration_stacks' }
+        expect(response.status).to eq 200
+        expect(response.body).to include('orchestration_stack/retire')
+      end
     end
   end
 


### PR DESCRIPTION
 Fix retirement menu for cloud provider orchestration stacks


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1396944

Steps for Testing/QA 
-------------------------------
1.Go to Cloud Providers details page 
2.In Relationships section click on Orchestration stacks 
3.Choose any stacks then click on set retirement dates 
