### PR TITLE
Delegate email validation format to more_core_extensions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,8 +36,8 @@ class User < ApplicationRecord
 
   validates_presence_of   :name, :userid
   validates :userid, :uniqueness => {:conditions => -> { in_my_region } }
-  validates_format_of     :email, :with => MoreCoreExtensions::StringFormats::RE_EMAIL,
-    :allow_nil => true, :message => "must be a valid email address"
+  validates :email, :format => {:with => MoreCoreExtensions::StringFormats::RE_EMAIL,
+                                :allow_nil => true, :message => "must be a valid email address"}
   validates_inclusion_of  :current_group, :in => proc { |u| u.miq_groups }, :allow_nil => true
 
   # use authenticate_bcrypt rather than .authenticate to avoid confusion

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
 
   validates_presence_of   :name, :userid
   validates :userid, :uniqueness => {:conditions => -> { in_my_region } }
-  validates_format_of     :email, :with => /\A([\w\.\-\+']+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i,
+  validates_format_of     :email, :with => MoreCoreExtensions::StringFormats::RE_EMAIL,
     :allow_nil => true, :message => "must be a valid email address"
   validates_inclusion_of  :current_group, :in => proc { |u| u.miq_groups }, :allow_nil => true
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,7 @@ describe User do
     end
 
     it "should reject invalid characters in email address" do
-      expect(FactoryGirl.build(:user, :email => "{{that.guy}}@manageiq.com")).not_to be_valid
+      expect(FactoryGirl.build(:user, :email => "that,guy@manageiq.com")).not_to be_valid
     end
 
     it "allows apostrophes in email address" do


### PR DESCRIPTION
Replaces the regex we've defined in app/models/user.rb with that in
more_core_extensions.

This breaks one of the existing tests that provides curly braces as
invalid characters. These, even though unlikely, are valid, so the test
was updated to use an unquoted comma as an example of an invalid
character.

Addresses https://github.com/ManageIQ/manageiq/issues/12781 (in part)

Note: I intend to follow this up with some more PRs to:

1. separate specs which test *that* it validates properly formatted email address with those that specify what kinds of things are valid/invalid and move the latter into more_core_extensions
2. update the regex in more_core_extensions to be more permissive WRT length of the TLD, which is unbounded before this change and limited to 6 after UPDATE: see https://github.com/ManageIQ/more_core_extensions/pull/31

Thank you @chessbyte for the suggestion and @Fryguy for further suggestions!
@miq-bot add-label core, refactoring
@miq-bot assign @Fryguy 