### PR TITLE
[WIP] URI.decode the input to _missing_instance so that we can pass job templates with spaces

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -81,7 +81,7 @@ module MiqAeEngine
           if @aei.nil?
             $miq_ae_logger.info("Instance [#{@object_name}] not found in MiqAeDatastore - trying [#{MISSING_INSTANCE}]")
             # Try the .missing instance, if the requested one was not found
-            @attributes['_missing_instance'] = @instance
+            @attributes['_missing_instance'] = URI.decode(@instance)
             @instance = MISSING_INSTANCE
             @aei      = fetch_instance(@instance)
           end


### PR DESCRIPTION
Many Ansible job template names contain spaces. We currently can't use the ${#_missing_instance} functionality in the AnsibleTower/Operations/JobTemplate/.missing instance to pass such job template names to StateMachine/Job/default.

Making a call such as the following will fail:

$evm.instantiate('/ConfigurationManagement/AnsibleTower/Operations/JobTemplate/Install Single Package')

The logical solution is to URI encode the call, as follows:

uri = URI.encode('/ConfigurationManagement/AnsibleTower/Operations/JobTemplate/Install Single Package')
$evm.instantiate(uri)

However this currently passes the URI encoded job template name (Install%20Single%20Package) as the _missing_instance value, and the template name lookup fails.

This PR will allow us to URI encode calls to AnsibleTower/Operations/JobTemplate, and for these to be decoded correctly. The _missing_instance value will contain the string including spaces.

