### PR TITLE
Drop currency column when editing chargeback rates

### DIFF
--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -189,21 +189,7 @@ class ChargebackController < ApplicationController
       page << javascript_prologue
       changed = (@edit[:new] != @edit[:current])
       # Update the new column with the code of the currency selected by the user
-      first_new_detail = @edit[:new][:details].first
-      new_rate_detail_currency = ChargebackRateDetailCurrency.find_by(:id => first_new_detail[:currency])
-      @edit[:new][:details].each_with_index do |_detail, i|
-        new_rate_details = @edit[:new][:details][i]
-        current_rate_details = @edit[:current][:details][i]
-        next if new_rate_details[:currency] == current_rate_details[:currency]
-
-        current_rate_details[:currency] = new_rate_details[:currency]
-        locals = {
-          :code_currency => new_rate_detail_currency.code,
-          :id_column => i,
-          :num_tiers => @edit[:new][:num_tiers][i]
-        }
-        page.replace("column_currency_#{i}", :partial => "cb_new_currency_column", :locals => locals)
-      end
+      page.replace('chargeback_rate_currency', :partial => 'cb_rate_currency')
       page << javascript_for_miq_button_visibility(changed)
     end
   end
@@ -574,6 +560,9 @@ class ChargebackController < ApplicationController
   # Get variables from edit form
   def cb_rate_get_form_vars
     @edit[:new][:description] = params[:description] if params[:description]
+    if params[:currency]
+      @edit[:new][:code_currency] = ChargebackRateDetailCurrency.find(params[:currency]).code
+    end
     @edit[:new][:details].each_with_index do |detail, detail_index|
       %i{per_time per_unit}.each do |measure|
         key = "#{measure}_#{detail_index}".to_sym

--- a/app/views/chargeback/_cb_new_currency_column.html.haml
+++ b/app/views/chargeback/_cb_new_currency_column.html.haml
@@ -1,3 +1,0 @@
-/In this view, the currency column is updated with the code of the currency selected by the user
-%td{:id => "column_currency_#{id_column}", :rowspan => num_tiers}
- = code_currency

--- a/app/views/chargeback/_cb_rate_currency.html.haml
+++ b/app/views/chargeback/_cb_rate_currency.html.haml
@@ -1,0 +1,2 @@
+%th{:colspan => "2", :id => 'chargeback_rate_currency'}
+  = _('Rate (in %{currency})') % {:currency => @edit[:new][:code_currency]}

--- a/app/views/chargeback/_cb_rate_edit_table.html.haml
+++ b/app/views/chargeback/_cb_rate_edit_table.html.haml
@@ -7,9 +7,8 @@
       %th{:rowspan => "2"}= _('Per Time')
       %th{:rowspan => "2"}= _('Per Unit')
       %th{:colspan => "2"}= _('Range')
-      %th{:colspan => "2"}= _('Rate')
+      = render :partial => 'cb_rate_currency'
       %th{:rowspan => "2"}= _('Actions')
-      %th{:rowspan => "2"}= _('Currency')
     %tr
       %th= _("Start")
       %th= _("Finish")
@@ -48,9 +47,6 @@
                                  :onclick => "miqAjaxButton('#{url_for(:action => "cb_tier_add",
                                                                        :detail_index => detail_index,
                                                                        :button => "add")}');")
-        /Show the code of the currency selected by the user
-        %td{:id => "column_currency_#{detail_index}", :rowspan => num_tiers}
-          = @edit[:new][:code_currency]
       - (1..num_tiers.to_i - 1).each do |tier_index|
         - tier = @edit[:new][:tiers][detail_index][tier_index]
         %tr.rdetail{:id => "rate_detail_row_#{detail_index}_#{tier_index}"}

--- a/app/views/chargeback/_tier_first_row.haml
+++ b/app/views/chargeback/_tier_first_row.haml
@@ -30,6 +30,3 @@
                  :onclick => "miqAjaxButton('#{url_for(:action       => "cb_tier_add",
                                                        :detail_index => i,
                                                        :button       => "add")}');")
-  /Show the code of the currency selected by the user
-  %td{:id => "column_currency_#{i}", :rowspan => n.to_s}
-    = code_currency


### PR DESCRIPTION
The table is long enough already... and we have one more columns coming. Let's make space for new column.

## Before
![before](https://cloud.githubusercontent.com/assets/6666052/20598849/62aef72a-b24b-11e6-83aa-53528a5a787b.jpg)

## After
![after](https://cloud.githubusercontent.com/assets/6666052/20598856/6b09cbfc-b24b-11e6-8096-d80c77f84901.jpg)


@miq-bot add_label ui, chargeback
@miq-bot assign @gtanzillo 