### PR TITLE
Added 'ContainerBuilds' to RBAC filterer to fix bug 1379951

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -12,6 +12,7 @@ module Rbac
       ConfigurationProfile
       ConfiguredSystem
       Container
+      ContainerBuild
       ContainerGroup
       ContainerImage
       ContainerImageRegistry


### PR DESCRIPTION
bz: https://bugzilla.redhat.com/show_bug.cgi?id=1379951 

Fix for bug 1379951 - container builds did not follow tag visibility.
I have added the class ContainerBuilds to filterer in RBAC, thus solving this issue.
Before: 
![screenshot from 2016-11-24 15-36-03](https://cloud.githubusercontent.com/assets/8366181/20600469/7d9c2204-b25c-11e6-83a8-456f75054272.png)
After:
![screenshot from 2016-11-24 15-35-24](https://cloud.githubusercontent.com/assets/8366181/20600476/8334ca68-b25c-11e6-84b9-2f09dcf280af.png)
cc: @zeari @simon3z 