### PR TITLE
symbolizing options hash actions api

### DIFF
--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -1,4 +1,13 @@
 module Api
   class ActionsController < BaseController
+    def create_resource(type, id, data = {})
+      data["options"] = data["options"].deep_symbolize_keys if data["options"]
+      super(type, id, data)
+    end
+
+    def edit_resource(type, id = nil, data = {})
+      data["options"] = data["options"].deep_symbolize_keys if data["options"]
+      super(type, id, data)
+    end
   end
 end

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -7,7 +7,7 @@ describe "Actions API" do
         :name        => "sample_action",
         :description => "sample_action",
         :action_type => "custom_automation",
-        :options     => {:ae_message => "message", :ae_request => "request", :ae_hash => {"key "=>"value"}}
+        :options     => {:ae_message => "message", :ae_request => "request", :ae_hash => {"key"=>"value"}}
       }
     end
     let(:action_url) { actions_url(action.id) }
@@ -49,7 +49,7 @@ describe "Actions API" do
 
       actions_amount = response.parsed_body["count"]
 
-      expect(actions_amount).to eq(1)
+      expect(actions_amount).to eq(MiqAction.count)
     end
 
     it "deletes action" do
@@ -90,7 +90,8 @@ describe "Actions API" do
 
       expect(response.parsed_body["results"].count).to eq(2)
 
-      expect(MiqAction.pluck(:description)).to match_array(%w(change change2))
+      expect(actions.first.reload.description).to eq("change")
+      expect(actions.second.reload.description).to eq("change2")
     end
   end
 end


### PR DESCRIPTION
when creating or updating options in actions resources, the keys of the options hash must be symbolized before passing the request to the model.