### PR TITLE
jquery_overrides - log exceptions from jsonPayload as well as the old js eval

### DIFF
--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -15,7 +15,7 @@ function logError(fn) {
 
 jQuery.jsonPayload = function (text, fallback) {
   var parsed_json = jQuery.parseJSON(text);
-  if (parsed_json['explorer']) {
+  if (parsed_json.explorer) {
     return ManageIQ.explorer.process(parsed_json); // ExplorerPresenter payload
   } else {
     return fallback(text);
@@ -24,22 +24,26 @@ jQuery.jsonPayload = function (text, fallback) {
 
 $.ajaxSetup({
   accepts: {
-    json: "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"
+    json: "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript",
   },
   contents: {
-    json: /application\/json/
+    json: /application\/json/,
   },
   converters: {
     "text json": logError(function (text) {
-      return jQuery.jsonPayload(text, function (text) { return jQuery.parseJSON(text); });
+      return jQuery.jsonPayload(text, function (text) {
+        return jQuery.parseJSON(text);
+      });
     }),
     "text script": logError(function (text) {
       if (text.match(/^{/)) {
-        return jQuery.jsonPayload(text, function (text) { return text; });
+        return jQuery.jsonPayload(text, function (text) {
+          return text;
+        });
       } else { // JavaScript payload
         jQuery.globalEval(text.slice('throw "error";'.length));
         return text;
       }
     }),
-  }
+  },
 });

--- a/app/assets/javascripts/jquery_overrides.js
+++ b/app/assets/javascripts/jquery_overrides.js
@@ -1,15 +1,15 @@
 function logError(fn) {
   return function (text) {
     try {
-      fn(text);
+      return fn(text);
     } catch (ex) {
       if (typeof console !== "undefined" && typeof console.error !== "undefined") {
         console.error('exception caught evaling RJS');
         console.error(ex);
         console.debug('script follows:', text);
       }
+      return text;
     }
-    return text;
   };
 }
 


### PR DESCRIPTION
Previously we would only log exceptions that happen in the received javascript, but for explorer json, we would get no such log.

Updating jquery_overrides to log both.

Cc @martinpovolny 

(only the first commit changes stuff, the second is just commas and newlines.. (and the third is a fix of the first one :)))

---

before:

![before](https://cloud.githubusercontent.com/assets/289743/20603578/172b695a-b25a-11e6-9189-c576a3ba47a0.png)

after:

![after](https://cloud.githubusercontent.com/assets/289743/20603580/1a6e7b84-b25a-11e6-9e09-4357b73c2f99.png)
