### PR TITLE
Remove show and list permission from MiqProductFeatures for Tenants

### DIFF
--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -36,7 +36,7 @@ class TreeBuilderOpsRbac < TreeBuilder
     if ApplicationHelper.role_allows?(:feature => "rbac_role_view", :any => true)
       objects.push(:id => "ur", :text => _("Roles"), :image => "miq_user_role", :tip => _("Roles"))
     end
-    if ApplicationHelper.role_allows?(:feature => "rbac_tenant_view", :any => true)
+    if ApplicationHelper.role_allows?(:feature => "rbac_tenant_view")
       objects.push(:id => "tn", :text => _("Tenants"), :image => "tenant", :tip => _("Tenants"))
     end
     objects

--- a/app/views/ops/_rbac_group_details.html.haml
+++ b/app/views/ops/_rbac_group_details.html.haml
@@ -58,7 +58,7 @@
           - if @group.tenant
             - tenant = @group.tenant
             - params = {:class => "product product-#{tenant.divisible ? "tenant" : "project"}"}
-            - if role_allows?(:feature => "rbac_tenant_show")
+            - if role_allows?(:feature => "rbac_tenant_view")
               - params[:class] = "#{params[:class]} pointer"
               - params[:onclick] = "miqTreeActivateNode('rbac_tree', 'tn-#{to_cid(tenant.id)}');"
               - params[:title] = tenant.divisible ? _("View this Tenant") : _("View this Project")

--- a/config/api.yml
+++ b/config/api.yml
@@ -1666,10 +1666,10 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: rbac_tenant_show_list
+        :identifier: rbac_tenant_view
       :post:
       - :name: query
-        :identifier: rbac_tenant_show_list
+        :identifier: rbac_tenant_view
       - :name: create
         :identifier: rbac_tenant_add
       - :name: edit
@@ -1679,7 +1679,7 @@
     :resource_actions:
       :get:
       - :name: read
-        :identifier: rbac_tenant_show
+        :identifier: rbac_tenant_view
       :post:
       - :name: edit
         :identifier: rbac_tenant_edit

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2752,15 +2752,6 @@
         :description: View Tenants
         :feature_type: view
         :identifier: rbac_tenant_view
-        :children:
-        - :name: List
-          :description: Display Lists of Tenants
-          :feature_type: view
-          :identifier: rbac_tenant_show_list
-        - :name: Show
-          :description: Display Individual Tenants
-          :feature_type: view
-          :identifier: rbac_tenant_show
       - :name: Modify
         :description: Modify Tenant/Project
         :feature_type: admin

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -249,7 +249,7 @@ describe "Rest API Collections" do
     end
 
     it "query Tenants" do
-      api_basic_authorize "rbac_tenant_show_list"
+      api_basic_authorize "rbac_tenant_view"
       Tenant.seed
       test_collection_query(:tenants, tenants_url, Tenant)
     end
@@ -494,7 +494,7 @@ describe "Rest API Collections" do
     end
 
     it "bulk query Tenants" do
-      api_basic_authorize "rbac_tenant_show_list"
+      api_basic_authorize "rbac_tenant_view"
       Tenant.seed
       test_collection_bulk_query(:tenants, tenants_url, Tenant)
     end


### PR DESCRIPTION
- they have same purpose
- list of tenants are controlled by tenant descendants strategy
in RBAC
before
![screen shot 2016-11-24 at 16 39 19](https://cloud.githubusercontent.com/assets/14937244/20604033/aa2ab5e4-b264-11e6-936f-f0a43e1d6ce7.png)

after
![screen shot 2016-11-24 at 16 12 47](https://cloud.githubusercontent.com/assets/14937244/20603937/2ddde646-b264-11e6-8119-3d63c6916c09.png)

Links [Optional]
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1342600


cc @h-kataria 

@miq-bot assign @mzazrivec 

@miq-bot add_label ui, bug

