### PR TITLE
CI > Reports - don't crash trying to unlock a tree the user has no rights to see

### DIFF
--- a/app/assets/javascripts/miq_explorer.js
+++ b/app/assets/javascripts/miq_explorer.js
@@ -24,6 +24,13 @@ ManageIQ.explorer.buildCalendar = function(options) {
 
 ManageIQ.explorer.lock_tree = function(tree_name, lock) {
   var tree = miqTreeObject(tree_name);
+  if (!tree || "length" in tree) {
+    // "length" in tree - because miqTreeObject returns a jquery array when the element doesn't exist
+    // https://github.com/patternfly/patternfly-bootstrap-treeview/issues/16
+    console.warn("Attempting to lock_tree a tree which doesn't exist", tree_name, lock);
+    return;
+  }
+
   lock ? tree.disableAll({silent: true, keepState: true}) : tree.enableAll();
   miqDimDiv('#' + tree_name + '_div', lock);
 };

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -44,7 +44,7 @@ module ApplicationController::TreeSupport
   end
 
   def tree_exists?(tree_name)
-    @sb[:trees].key?(tree_name.to_s)
+    @sb[:trees].try(:key?, tree_name.to_s)
   end
 
   private ############################

--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -43,6 +43,10 @@ module ApplicationController::TreeSupport
     TreeBuilder.convert_bs_tree(nodes)
   end
 
+  def tree_exists?(tree_name)
+    @sb[:trees].key?(tree_name.to_s)
+  end
+
   private ############################
 
   # Build the H&C or V&T tree with nodes selected

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -877,7 +877,7 @@ class ReportController < ApplicationController
     else
       presenter.lock_tree(x_active_tree, false)
       [:db_tree, :reports_tree, :savedreports_tree, :schedules_tree, :widgets_tree, :roles_tree].each do |tree|
-        presenter.lock_tree(tree, false)
+        presenter.lock_tree(tree, false) if tree_exists?(tree)
       end
     end
 


### PR DESCRIPTION
Log in as a non-admin user (for example, one in the `EvmGroup-approver` group).
Go to CI > Reports.

Without this, you'll get an infinispinner...

ReportController tries to unlock all the trees (`[:db_tree, :reports_tree, :savedreports_tree, :schedules_tree, :widgets_tree, :roles_tree]`), but such a user can only see `savedreports`, `reports` and `schedules`.

That causes `ManageIQ.explorer.lock_tree` to be called with a tree name that does not exist in the DOM, and because of https://github.com/patternfly/patternfly-bootstrap-treeview/issues/16, return a jquery array instead of a tree instance. And then we try to call `enableAll()` on that, which throws.

This PR updates `lock_tree` to only warn in such a case, not throw, and changes ReportController to only attempt to lock/unlock trees that have actually been initialized.

https://bugzilla.redhat.com/show_bug.cgi?id=1397392