### PR TITLE
Display parent tenant only when it is allowed by RBAC

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -320,6 +320,10 @@ class Tenant < ApplicationRecord
     data_tenant
   end
 
+  def allowed?
+    Rbac::Filterer.filtered_object(self).present?
+  end
+
   private
 
   # when a root tenant has an attribute with a nil value,

--- a/app/views/ops/_rbac_tenant_details.html.haml
+++ b/app/views/ops/_rbac_tenant_details.html.haml
@@ -15,7 +15,7 @@
       .col-md-8
         = h(@tenant.description)
     - parent = @tenant.parent
-    - if parent
+    - if parent && parent.allowed?
       .form-group
         %label.control-label.col-md-2
           = _("Parent")


### PR DESCRIPTION
in detail of tenant, we are displaying parent tenant always but displaying parent should restricted by
RBAC

This user is not able to see parent tenant:
before
![screen shot 2016-11-24 at 18 18 06](https://cloud.githubusercontent.com/assets/14937244/20606661/be62c1a6-b272-11e6-840f-3587c9b691e6.png)

after
![screen shot 2016-11-24 at 18 20 20](https://cloud.githubusercontent.com/assets/14937244/20606665/c979fc76-b272-11e6-80a5-660a7e9c4696.png)


@miq-bot add_label ui, bug
