### PR TITLE
Another small step to clean-up Filter mixin

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -119,14 +119,7 @@ module ApplicationController::Filter
         page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
 
         if @edit[@expkey][:exp_key] && @edit[@expkey][:exp_field]
-          if @edit[@expkey][:val1][:type]
-            page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"
-            page << "ManageIQ.expEditor.first.title = '#{@edit[@expkey][:val1][:title]}';"
-          end
-          if @edit[@expkey][:val2][:type]
-            page << "ManageIQ.expEditor.second.type = '#{@edit[@expkey][:val2][:type]}';"
-            page << "ManageIQ.expEditor.second.title = '#{@edit[@expkey][:val2][:title]}';"
-          end
+          @edit[@expkey].render_values_to(page)
         end
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
@@ -420,14 +413,7 @@ module ApplicationController::Filter
         page.replace("exp_atom_editor_div", :partial => "layouts/exp_atom/editor")
 
         page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
-        if @edit.fetch_path(@expkey, :val1, :type)
-          page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"
-          page << "ManageIQ.expEditor.first.title = '#{@edit[@expkey][:val1][:title]}';"
-        end
-        if @edit.fetch_path(@expkey, :val2, :type)
-          page << "ManageIQ.expEditor.second.type = '#{@edit[@expkey][:val2][:type]}';"
-          page << "ManageIQ.expEditor.second.title = '#{@edit[@expkey][:val2][:title]}';"
-        end
+        @edit[@expkey].render_values_to(page)
         page << "miqSparkle(false);" # Need to turn off sparkle in case original ajax element gets replaced
       end
     end
@@ -454,14 +440,7 @@ module ApplicationController::Filter
         page.replace("adv_search_footer", :partial => "layouts/adv_search_footer")
         page << "$('#adv_search_img').prop('src', '#{ActionController::Base.helpers.image_path('toolbars/squashed-false.png')}')"
         page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
-        if @edit.fetch_path(@expkey, :val1, :type)
-          page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"
-          page << "ManageIQ.expEditor.first.title = '#{@edit[@expkey][:val1][:title]}';"
-        end
-        if @edit.fetch_path(@expkey, :val2, :type)
-          page << "ManageIQ.expEditor.second.type = '#{@edit[@expkey][:val2][:type]}';"
-          page << "ManageIQ.expEditor.second.title = '#{@edit[@expkey][:val2][:title]}';"
-        end
+        @edit[@expkey].render_values_to(page)
       end
       page << set_spinner_off
       # Rememeber this settting in the model settings

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -249,14 +249,6 @@ module ApplicationController::Filter
           unless params[:chosen_field] == "<Choose>"
             @edit[@expkey][:exp_skey] = nil unless MiqExpression.get_col_operators(@edit[@expkey][:exp_field]).include?(@edit[@expkey][:exp_skey])  # Remove if not in list
             @edit[@expkey][:exp_skey] ||= MiqExpression.get_col_operators(@edit[@expkey][:exp_field]).first # Default to first operator
-            @edit[@expkey][:exp_available_cfields] = []      # Create the check fields pulldown array
-            MiqExpression.miq_adv_search_lists(@edit[@expkey][:exp_model], :exp_available_finds).each do |af|
-              unless af.last == @edit[@expkey][:exp_field]
-                if af.last.split("-").first == @edit[@expkey][:exp_field].split("-").first
-                  @edit[@expkey][:exp_available_cfields].push([af.first.split(":").last, af.last])
-                end
-              end
-            end
             @edit[@expkey].prefill_val_types
             process_datetime_expression_field(:val1, :exp_skey, :exp_value)
           else
@@ -1066,12 +1058,6 @@ module ApplicationController::Filter
       skey = @edit[@expkey][:exp_skey] = exp[key]["search"].keys.first  # Get the search operator
       @edit[@expkey][:exp_field] = exp[key]["search"][skey]["field"]    # Get the search field
       @edit[@expkey][:alias] = exp[key]["search"][skey]["alias"]        # Get the field alias
-      @edit[@expkey][:exp_available_cfields] = []                # Create the check fields pulldown array
-      MiqExpression.miq_adv_search_lists(@edit[@expkey][:exp_model], :exp_available_finds).each do |af|
-        if af.last.split("-").first == @edit[@expkey][:exp_field].split("-").first
-          @edit[@expkey][:exp_available_cfields].push([af.first.split(":").last, af.last]) # Include fields from the chosen table
-        end
-      end
       @edit[@expkey][:exp_value] = exp[key]["search"][skey]["value"]    # Get the search value
       if exp[key].key?("checkall")                        # Find the check hash key
         chk = @edit[@expkey][:exp_check] = "checkall"

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1023,22 +1023,22 @@ module ApplicationController::Filter
     @edit[@expkey][:val1][:type] = nil
     @edit[@expkey][:val2][:type] = nil
     if @edit[@expkey][:exp_typ] == "field"
-      if @edit[@expkey][:exp_key] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
-        @edit[@expkey][:val1][:type] = :date
-      else
-        @edit[@expkey][:val1][:type] = @edit[@expkey].val_type_for(:exp_key, :exp_field)
-      end
+      @edit[@expkey][:val1][:type] = if @edit[@expkey][:exp_key] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
+                                       :date
+                                     else
+                                       @edit[@expkey].val_type_for(:exp_key, :exp_field)
+                                     end
     elsif @edit[@expkey][:exp_typ] == "find"
-      if @edit[@expkey][:exp_skey] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
-        @edit[@expkey][:val1][:type] = :date
-      else
-        @edit[@expkey][:val1][:type] = @edit[@expkey].val_type_for(:exp_skey, :exp_field)
-      end
-      if @edit[@expkey][:exp_ckey] && @edit[@expkey][:exp_ckey] == EXP_IS && @edit[@expkey][:val2][:date_format] == 's'
-        @edit[@expkey][:val2][:type] = :date
-      else
-        @edit[@expkey][:val2][:type] = @edit[@expkey][:exp_check] == "checkcount" ? :integer : @edit[@expkey].val_type_for(:exp_ckey, :exp_cfield)
-      end
+      @edit[@expkey][:val1][:type] = if @edit[@expkey][:exp_skey] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
+                                       :date
+                                     else
+                                       @edit[@expkey].val_type_for(:exp_skey, :exp_field)
+                                     end
+      @edit[@expkey][:val2][:type] = if @edit[@expkey][:exp_ckey] && @edit[@expkey][:exp_ckey] == EXP_IS && @edit[@expkey][:val2][:date_format] == 's'
+                                       :date
+                                     else
+                                       @edit[@expkey][:exp_check] == "checkcount" ? :integer : @edit[@expkey].val_type_for(:exp_ckey, :exp_cfield)
+                                     end
     elsif @edit[@expkey][:exp_typ] == "count"
       @edit[@expkey][:val1][:type] = :integer
     elsif @edit[@expkey][:exp_typ] == "regkey"

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1,10 +1,6 @@
 # Filter/search/expression methods included in application.rb
 module ApplicationController::Filter
   extend ActiveSupport::Concern
-  included do
-    helper_method :calendar_needed?  # because it is being called inside a render block
-  end
-
   include MiqExpression::FilterSubstMixin
   include ApplicationController::ExpressionHtml
 
@@ -120,7 +116,7 @@ module ApplicationController::Filter
           page << javascript_show("exp_buttons_on")
         end
 
-        page << ENABLE_CALENDAR if calendar_needed?
+        page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
 
         if @edit[@expkey][:exp_key] && @edit[@expkey][:exp_field]
           if @edit[@expkey][:val1][:type]
@@ -423,7 +419,7 @@ module ApplicationController::Filter
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace("exp_atom_editor_div", :partial => "layouts/exp_atom/editor")
 
-        page << ENABLE_CALENDAR if calendar_needed?
+        page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
         if @edit.fetch_path(@expkey, :val1, :type)
           page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"
           page << "ManageIQ.expEditor.first.title = '#{@edit[@expkey][:val1][:title]}';"
@@ -457,7 +453,7 @@ module ApplicationController::Filter
         page.replace("adv_search_body", :partial => "layouts/adv_search_body")
         page.replace("adv_search_footer", :partial => "layouts/adv_search_footer")
         page << "$('#adv_search_img').prop('src', '#{ActionController::Base.helpers.image_path('toolbars/squashed-false.png')}')"
-        page << ENABLE_CALENDAR if calendar_needed?
+        page << ENABLE_CALENDAR if @edit[@expkey].calendar_needed?
         if @edit.fetch_path(@expkey, :val1, :type)
           page << "ManageIQ.expEditor.first.type = '#{@edit[@expkey][:val1][:type]}';"
           page << "ManageIQ.expEditor.first.title = '#{@edit[@expkey][:val1][:title]}';"
@@ -1613,9 +1609,4 @@ module ApplicationController::Filter
   end
 
   ENABLE_CALENDAR = "miqBuildCalendar();".freeze
-  def calendar_needed?
-    return true if [:date, :datetime].include?(@edit.fetch_path(@expkey, :val1, :type))
-    return true if [:date, :datetime].include?(@edit.fetch_path(@expkey, :val2, :type))
-    false
-  end
 end

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1026,18 +1026,18 @@ module ApplicationController::Filter
       if @edit[@expkey][:exp_key] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
         @edit[@expkey][:val1][:type] = :date
       else
-        @edit[@expkey][:val1][:type] = exp_prefill_type(@edit[@expkey][:exp_key], @edit[@expkey][:exp_field])
+        @edit[@expkey][:val1][:type] = @edit[@expkey].val_type_for(:exp_key, :exp_field)
       end
     elsif @edit[@expkey][:exp_typ] == "find"
       if @edit[@expkey][:exp_skey] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
         @edit[@expkey][:val1][:type] = :date
       else
-        @edit[@expkey][:val1][:type] = exp_prefill_type(@edit[@expkey][:exp_skey], @edit[@expkey][:exp_field])
+        @edit[@expkey][:val1][:type] = @edit[@expkey].val_type_for(:exp_skey, :exp_field)
       end
       if @edit[@expkey][:exp_ckey] && @edit[@expkey][:exp_ckey] == EXP_IS && @edit[@expkey][:val2][:date_format] == 's'
         @edit[@expkey][:val2][:type] = :date
       else
-        @edit[@expkey][:val2][:type] = @edit[@expkey][:exp_check] == "checkcount" ? :integer : exp_prefill_type(@edit[@expkey][:exp_ckey], @edit[@expkey][:exp_cfield])
+        @edit[@expkey][:val2][:type] = @edit[@expkey][:exp_check] == "checkcount" ? :integer : @edit[@expkey].val_type_for(:exp_ckey, :exp_cfield)
       end
     elsif @edit[@expkey][:exp_typ] == "count"
       @edit[@expkey][:val1][:type] = :integer
@@ -1046,18 +1046,6 @@ module ApplicationController::Filter
     end
     @edit[@expkey][:val1][:title] = MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:title] if @edit[@expkey][:val1][:type]
     @edit[@expkey][:val2][:title] = MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:title] if @edit[@expkey][:val2][:type]
-  end
-
-  # Get the field type for miqExpressionPrefill using the operator key and field
-  def exp_prefill_type(key, field)
-    return nil unless key && field
-    return :regex if key.starts_with?("REG")
-    typ = MiqExpression.get_col_info(field)[:format_sub_type] # :human_data_type?
-    if MiqExpression::FORMAT_SUB_TYPES.keys.include?(typ)
-      return typ
-    else
-      return :string
-    end
   end
 
   # Remove :token keys from an expression before setting in a record

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -150,13 +150,13 @@ module ApplicationController::Filter
       when "count"
         @edit[@expkey][:exp_count] = nil
         @edit[@expkey][:exp_key] = MiqExpression.get_col_operators(:count).first
-        exp_get_prefill_types                         # Get the field type
+        @edit[@expkey].prefill_val_types
       when "tag"
         @edit[@expkey][:exp_tag] = nil
         @edit[@expkey][:exp_key] = "CONTAINS"
       when "regkey"
         @edit[@expkey][:exp_key] = MiqExpression.get_col_operators(:regkey).first
-        exp_get_prefill_types                         # Get the field type
+        @edit[@expkey].prefill_val_types
       when "find"
         @edit[@expkey][:exp_field] = nil
         @edit[@expkey][:exp_key] = "FIND"
@@ -177,7 +177,7 @@ module ApplicationController::Filter
               @edit[@expkey][:exp_key] = nil unless MiqExpression.get_col_operators(@edit[@expkey][:exp_field]).include?(@edit[@expkey][:exp_key])  # Remove if not in list
               @edit[@expkey][:exp_key] ||= MiqExpression.get_col_operators(@edit[@expkey][:exp_field]).first  # Default to first operator
             end
-            exp_get_prefill_types                                   # Get the field type
+            @edit[@expkey].prefill_val_types
             process_datetime_expression_field(:val1, :exp_key, :exp_value)
           else
             @edit[@expkey][:exp_field] = nil
@@ -239,7 +239,7 @@ module ApplicationController::Filter
         end
         # Did the key change?, Save the key
         @edit[@expkey][:exp_key] = params[:chosen_key] if params[:chosen_key] && params[:chosen_key] != @edit[@expkey][:exp_key]
-        exp_get_prefill_types                         # Get the field type
+        @edit[@expkey].prefill_val_types
 
       when "find"
         if params[:chosen_field] && params[:chosen_field] != @edit[@expkey][:exp_field] # Did the field change?
@@ -257,7 +257,7 @@ module ApplicationController::Filter
                 end
               end
             end
-            exp_get_prefill_types                                   # Get the field types
+            @edit[@expkey].prefill_val_types
             process_datetime_expression_field(:val1, :exp_skey, :exp_value)
           else
             @edit[@expkey][:exp_field] = nil
@@ -293,7 +293,7 @@ module ApplicationController::Filter
           unless params[:chosen_cfield] == "<Choose>"
             @edit[@expkey][:exp_ckey] = nil unless MiqExpression.get_col_operators(@edit[@expkey][:exp_cfield]).include?(@edit[@expkey][:exp_ckey]) # Remove if not in list
             @edit[@expkey][:exp_ckey] ||= MiqExpression.get_col_operators(@edit[@expkey][:exp_cfield]).first  # Default to first operator
-            exp_get_prefill_types                                 # Get the field types
+            @edit[@expkey].prefill_val_types
             process_datetime_expression_field(:val2, :exp_ckey, :exp_cvalue)
           else
             @edit[@expkey][:exp_cfield] = nil
@@ -424,7 +424,7 @@ module ApplicationController::Filter
 
     # Rebuild the pulldowns if opening the search box
     adv_search_build_lists unless @edit[:adv_search_open]
-    exp_get_prefill_types unless @edit[:adv_search_open]
+    @edit[@expkey].prefill_val_types unless @edit[:adv_search_open]
 
     render :update do |page|
       page << javascript_prologue
@@ -718,7 +718,7 @@ module ApplicationController::Filter
 
     when "cancel"
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Rebuild the existing expression table
-      exp_get_prefill_types                                     # Get the prefill field type
+      @edit[@expkey].prefill_val_types
     end
 
     # Reset fields if delete or reset ran
@@ -1016,38 +1016,6 @@ module ApplicationController::Filter
     tc[0..tc.index(from_choice)]
   end
 
-  # Get the prefill types of the fields for the current expression
-  def exp_get_prefill_types
-    @edit[@expkey][:val1] ||= {}
-    @edit[@expkey][:val2] ||= {}
-    @edit[@expkey][:val1][:type] = nil
-    @edit[@expkey][:val2][:type] = nil
-    if @edit[@expkey][:exp_typ] == "field"
-      @edit[@expkey][:val1][:type] = if @edit[@expkey][:exp_key] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
-                                       :date
-                                     else
-                                       @edit[@expkey].val_type_for(:exp_key, :exp_field)
-                                     end
-    elsif @edit[@expkey][:exp_typ] == "find"
-      @edit[@expkey][:val1][:type] = if @edit[@expkey][:exp_skey] == EXP_IS && @edit[@expkey][:val1][:date_format] == 's'
-                                       :date
-                                     else
-                                       @edit[@expkey].val_type_for(:exp_skey, :exp_field)
-                                     end
-      @edit[@expkey][:val2][:type] = if @edit[@expkey][:exp_ckey] && @edit[@expkey][:exp_ckey] == EXP_IS && @edit[@expkey][:val2][:date_format] == 's'
-                                       :date
-                                     else
-                                       @edit[@expkey][:exp_check] == "checkcount" ? :integer : @edit[@expkey].val_type_for(:exp_ckey, :exp_cfield)
-                                     end
-    elsif @edit[@expkey][:exp_typ] == "count"
-      @edit[@expkey][:val1][:type] = :integer
-    elsif @edit[@expkey][:exp_typ] == "regkey"
-      @edit[@expkey][:val1][:type] = :string
-    end
-    @edit[@expkey][:val1][:title] = MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:title] if @edit[@expkey][:val1][:type]
-    @edit[@expkey][:val2][:title] = MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:title] if @edit[@expkey][:val2][:type]
-  end
-
   # Remove :token keys from an expression before setting in a record
   def exp_remove_tokens(exp)
     if exp.kind_of?(Array)         # Is this and AND or OR
@@ -1122,8 +1090,7 @@ module ApplicationController::Filter
     @edit[@expkey][:exp_key] = key.upcase
     @edit[@expkey][:exp_orig_key] = key.upcase        # Hang on to the original key for commit
     @edit[@expkey][:exp_typ] = typ
-
-    exp_get_prefill_types                             # Get the format sub types of the fields in this atom
+    @edit[@expkey].prefill_val_types
 
     @edit[:suffix] = @edit[:suffix2] = nil
     unless @edit[@expkey][:exp_value] == :user_input  # Ignore user input fields
@@ -1522,7 +1489,7 @@ module ApplicationController::Filter
     end
 
     @edit[@expkey][exp_key] = params[chosen_key]  # Save the key
-    exp_get_prefill_types # Prefill type may change based on selected key for date/time fields
+    @edit[@expkey].prefill_val_types
 
     # Convert to/from "<date>" and "<date time>" strings in the exp_value array for specific date/times
     if @edit[@expkey][exp_valx][:date_format] == "s"

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -51,6 +51,38 @@ module ApplicationController::Filter
       end
     end
 
+    def prefill_val_types
+      self.val1 ||= {}
+      self.val2 ||= {}
+      val1[:type] = case exp_typ
+                    when 'field'
+                      if exp_key == EXP_IS && val1[:date_format] == 's'
+                        :date
+                      else
+                        val_type_for(:exp_key, :exp_field)
+                      end
+                    when 'find'
+                      if exp_skey == EXP_IS && val1[:date_format] == 's'
+                        :date
+                      else
+                        val_type_for(:exp_skey, :exp_field)
+                      end
+                    when 'count'
+                      :integer
+                    when 'regkey'
+                      :string
+                    end
+      val2[:type] = if exp_typ == 'find'
+                      if exp_ckey && val2[:date_format] == 's'
+                        :date
+                      else
+                        exp_check == 'checkcount' ? :integer : val_type_for(:exp_ckey, :exp_cfield)
+                      end
+                    end
+      val1[:title] = MiqExpression::FORMAT_SUB_TYPES[val1[:type]][:title] if val1[:type]
+      val2[:title] = MiqExpression::FORMAT_SUB_TYPES[val2[:type]][:title] if val2[:type]
+    end
+
     def val_type_for(key, field)
       if !self[key] || !self[field]
         nil

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -36,6 +36,9 @@ module ApplicationController::Filter
     :val2,
     :record_filter
   ) do
+    def calendar_needed?
+      [val1, val2].compact.any? { |val| [:date, :datetime].include? val[:type] }
+    end
   end
   # TODO: expression is now manipulated with fetch_path
   # We need to extract methods using fetch_path to Expression to avoid the fetch_path call

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -50,6 +50,21 @@ module ApplicationController::Filter
         page << "ManageIQ.expEditor.second.title = '#{val2[:title]}';"
       end
     end
+
+    def val_type_for(key, field)
+      if !self[key] || !self[field]
+        nil
+      elsif self[key].starts_with?('REG')
+        :regexp
+      else
+        typ = MiqExpression.get_col_info(self[field])[:format_sub_type]
+        if MiqExpression::FORMAT_SUB_TYPES.keys.include?(typ)
+          typ
+        else
+          :string
+        end
+      end
+    end
   end
   # TODO: expression is now manipulated with fetch_path
   # We need to extract methods using fetch_path to Expression to avoid the fetch_path call

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -39,6 +39,17 @@ module ApplicationController::Filter
     def calendar_needed?
       [val1, val2].compact.any? { |val| [:date, :datetime].include? val[:type] }
     end
+
+    def render_values_to(page)
+      if val1.try(:type)
+        page << "ManageIQ.expEditor.first.type = '#{val1[:type]}';"
+        page << "ManageIQ.expEditor.first.title = '#{val1[:title]}';"
+      end
+      if val2.try(:type)
+        page << "ManageIQ.expEditor.second.type = '#{val2[:type]}';"
+        page << "ManageIQ.expEditor.second.title = '#{val2[:title]}';"
+      end
+    end
   end
   # TODO: expression is now manipulated with fetch_path
   # We need to extract methods using fetch_path to Expression to avoid the fetch_path call

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -34,6 +34,7 @@ module ApplicationController::Filter
     :selected,
     :val1,
     :val2,
+    :record_filter
   ) do
   end
   # TODO: expression is now manipulated with fetch_path

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -4,7 +4,6 @@ module ApplicationController::Filter
     :expression,
     :exp_array,
     :exp_available_tags,
-    :exp_available_cfields,
     :exp_available_fields,
     :exp_cfield,
     :exp_check,
@@ -36,6 +35,14 @@ module ApplicationController::Filter
     :val2,
     :record_filter
   ) do
+    def exp_available_cfields # fields on exp_model for check_all, check_any, and check_count operation
+      MiqExpression.miq_adv_search_lists(exp_model, :exp_available_finds).each_with_object([]) do |af, res|
+        next if af.last == exp_field
+        next unless af.last.split('-').first == exp_field.split('-').first
+        res.push([af.first.split(':').last, af.last])
+      end
+    end
+
     def calendar_needed?
       [val1, val2].compact.any? { |val| [:date, :datetime].include? val[:type] }
     end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1061,7 +1061,7 @@ class MiqPolicyController < ApplicationController
   def build_expression(parent, model)
     @edit[:new][:expression] = parent.expression.kind_of?(MiqExpression) ? parent.expression.exp : nil
     # Populate exp editor fields for the expression column
-    @edit[:expression] ||= {}                                     # Create hash for this expression, if needed
+    @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
     @edit[:expression][:exp_idx] = 0                                    # Start at first exp
     if @edit[:new][:expression].blank?

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -370,7 +370,7 @@ module MiqPolicyController::Alerts
   end
 
   def alert_build_blank_exp
-    @edit[:expression] ||= {}                                     # Create hash for this expression, if needed
+    @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
     @edit[:expression][:exp_idx] = 0                                    # Start at first exp
     @edit[:expression][:expression] = {"???" => "???"}                    # Set as new exp element

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -180,7 +180,7 @@ module MiqPolicyController::Conditions
     @edit[:new][:applies_to_exp] = @condition.applies_to_exp.kind_of?(MiqExpression) ? @condition.applies_to_exp.exp : nil
 
     # Populate exp editor fields for the expression column
-    @edit[:expression] ||= {}                                     # Create hash for this expression, if needed
+    @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
     @edit[:expression][:exp_idx] = 0                                    # Start at first exp
     if @edit[:new][:expression].blank?

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -198,7 +198,7 @@ module ReportController::Reports::Editor
         # Initialize the exp array
         exp_array(:init, @edit[:record_filter][:expression]) if @edit[:record_filter][:exp_array].nil?
         @edit[:record_filter][:exp_table] = exp_build_table(@edit[:record_filter][:expression])
-        exp_get_prefill_types # Build prefill lists
+        @edit[:record_filter].prefill_val_types
         @edit[:record_filter][:exp_model] = @edit[:new][:model] # Set the model for the expression editor
       end
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -1308,7 +1308,7 @@ module ReportController::Reports::Editor
     end
 
     expkey = :record_filter
-    @edit[expkey] ||= {}                                                # Create hash for this expression, if needed
+    @edit[expkey] ||= ApplicationController::Filter::Expression.new
     @edit[expkey][:record_filter] = []                               # Store exps in an array
     @edit[expkey][:exp_idx] ||= 0
     @edit[expkey][:expression] = {"???" => "???"}                           # Set as new exp element
@@ -1325,7 +1325,7 @@ module ReportController::Reports::Editor
     # Get the display_filter MiqExpression
     @edit[:new][:display_filter] = @rpt.display_filter.nil? ? nil : @rpt.display_filter.exp
     expkey = :display_filter
-    @edit[expkey] ||= {}                                                # Create hash for this expression, if needed
+    @edit[expkey] ||= ApplicationController::Filter::Expression.new
     @edit[expkey][:expression] = []                                    # Store exps in an array
     @edit[expkey][:exp_idx] ||= 0                                           # Start at first exp
     @edit[expkey][:expression] = {"???" => "???"}                           # Set as new exp element

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -136,7 +136,7 @@
     "data-miq_sparkle_off" => true)
   - if @edit[@expkey][:exp_check] != "checkcount"
     = select_tag('chosen_cfield',
-      options_for_select(["<Choose>"] + @edit[@expkey][:exp_available_cfields], @edit[@expkey][:exp_cfield]),
+      options_for_select(["<Choose>"] + @edit[@expkey].exp_available_cfields, @edit[@expkey][:exp_cfield]),
       :multiple              => false,
       :class                 => 'selectpicker',
       "data-miq_sparkle_on"  => true,


### PR DESCRIPTION
Follow-up on #11641.

ApplicationController::Filter is very complex.

One of the reasons is that Filter operates on nested hash that represents Expression and context of editing this expression. We start by encapsulating this object and its logic into one place, than we can divide what represents the actual expression and what represents merely the state of the expression edit.

@miq-bot add_label technical debt, ui
