### PR TITLE
Missing buttons Graph view, Hybrid view, Table view and missing option Show full screen report

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -464,8 +464,7 @@ class ApplicationHelper::ToolbarBuilder
       when "miq_report_copy", "miq_report_new", "miq_report_run", "miq_report_only", "miq_report_schedule_add"
         return @sb[:active_tab] == "saved_reports"
       when "view_graph", "view_hybrid", "view_tabular"
-        return @ght_type && @report && @report.graph &&
-          !(@zgraph || (@ght_type == "tabular" && @html))
+        return @ght_type == "tabular" && @report.try(:graph).nil? && !@zgraph
       end
     when :savedreports_tree
       if %w(saved_report_delete).include?(id)
@@ -475,8 +474,7 @@ class ApplicationHelper::ToolbarBuilder
       when "reload"
         return x_node != "root"
       when "view_graph", "view_hybrid", "view_tabular"
-        return @ght_type && @report && @report.graph &&
-          !(@zgraph || (@ght_type == "tabular" && @html))
+        return @ght_type == "tabular" && @report.try(:graph).nil? && !@zgraph
       end
     else
       return false

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1382,6 +1382,21 @@
       :feature_type: view
       :identifier: miq_report_view
       :children:
+      - :name: View Graph
+        :description: Show Report Graph
+        :feature_type: admin
+        :hidden: true
+        :identifier: view_graph
+      - :name: View Hybrid
+        :description: Show Report Hybrid
+        :feature_type: admin
+        :hidden: true
+        :identifier: view_hybrid
+      - :name: View Tabular
+        :description: Show Report Tabular
+        :feature_type: admin
+        :hidden: true
+        :identifier: view_tabular
       - :name: Download CSV Format
         :description: Download Report in CSV Format
         :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1596,6 +1596,11 @@
       :feature_type: admin
       :hidden: true
       :identifier: chargeback_download_text
+    - :name: Show Full Screen Report
+      :description: Show Full Screen Report
+      :feature_type: admin
+      :hidden: true
+      :identifier: chargeback_report_only
   - :name: Rates
     :description: Rates Accordion
     :feature_type: node


### PR DESCRIPTION
**Problem**: Graph view, Hybrid view, Table view buttons and option Show full screen report not available in 5.7
**Solution**: Added `View Graph`, `View Hybrid`, `View Tabular` and `Show Full Screen Report` to Miq Product Features and modified their visibility condition to be visible only when there is a graph available.

(Cloud Intel -> Reports -> Saved Reports -> Click a Saved Report)
![view_buttons](https://cloud.githubusercontent.com/assets/5737996/20628008/f3771fc0-b323-11e6-9454-78f4ae0d8f11.png)

(Cloud Intel -> Chargeback -> Reports -> Click a Saved Chargeback Report)
<img width="1440" alt="screen shot 2016-11-25 at 15 22 36 copy" src="https://cloud.githubusercontent.com/assets/5737996/20627916/697dafc8-b323-11e6-952d-207fdca582dd.png">

# Links

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1397335
