### PR TITLE
Fix alert definition: compare Middleware NonHeap with NonCommitted

### DIFF
--- a/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/alert_manager.rb
@@ -76,7 +76,9 @@ module ManageIQ::Providers
 
     def generate_mw_jvm_conditions(eval_method, options)
       data_id = mw_server_metrics_by_column[eval_method]
-      data2_id = mw_server_metrics_by_column["mw_heap_max"]
+      data2_id = if eval_method == "mw_heap_used" then mw_server_metrics_by_column["mw_heap_max"]
+                 else mw_server_metrics_by_column["mw_non_heap_committed"]
+                 end
       c = []
       c[0] = generate_mw_compare_condition(data_id, data2_id, :GT, options[:value_mw_greater_than].to_f / 100)
       c[1] = generate_mw_compare_condition(data_id, data2_id, :LT, options[:value_mw_less_than].to_f / 100)

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -431,8 +431,8 @@ class MiqAlert < ApplicationRecord
         ]},
       {:name => "mw_non_heap_used", :description => _("JVM Non Heap Used"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
         :options => [
-          {:name => :value_mw_greater_than, :description => _("> Non Heap Max (%)"), :numeric => true},
-          {:name => :value_mw_less_than, :description => _("< Non Heap Max (%)"), :numeric => true}
+          {:name => :value_mw_greater_than, :description => _("> Non Heap Committed (%)"), :numeric => true},
+          {:name => :value_mw_less_than, :description => _("< Non Heap Committed (%)"), :numeric => true}
         ]},
       {:name => "mw_accumulated_gc_duration", :description => _("JVM Accumulated GC Duration"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_event",
         :options => [


### PR DESCRIPTION
NonHeap metric was compared with HeapMax in previous Alert definition.
This is not correct.
It should be compared against metric from same pool.
This fix the UI and send the correct metric into the Hawkular backend.

https://bugzilla.redhat.com/show_bug.cgi?id=1398665