### PR TITLE
Added container components for service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_container.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container.rb
@@ -1,0 +1,20 @@
+module MiqAeMethodService
+  class MiqAeServiceContainer < MiqAeServiceModelBase
+    expose :container_group,          :association => true
+    expose :ext_management_system,    :association => true
+    expose :container_node,           :association => true
+    expose :container_replicator,     :association => true
+    expose :container_project,        :association => true
+    expose :old_container_project,    :association => true
+    expose :container_definition,     :association => true
+    expose :container_image,          :association => true
+    expose :container_image_registry, :association => true
+    expose :security_context,         :association => true
+    expose :metrics
+    expose :metric_rollups
+    expose :vim_performance_states
+
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_build.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_build.rb
@@ -1,0 +1,11 @@
+
+module MiqAeMethodService
+  class MiqAeServiceContainerBuild < MiqAeServiceModelBase
+    expose :ext_management_system,  :association => true
+    expose :container_project,      :association => true
+    expose :labels,                 :association => true
+    expose :container_build_pods,   :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_build_pod.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_build_pod.rb
@@ -1,0 +1,11 @@
+
+module MiqAeMethodService
+  class MiqAeServiceContainerBuildPod < MiqAeServiceModelBase
+    expose :ext_management_system,  :association => true
+    expose :container_build,        :association => true
+    expose :labels,                 :association => true
+    expose :container_group,        :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_condition.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_condition.rb
@@ -1,0 +1,6 @@
+
+module MiqAeMethodService
+  class MiqAeServiceContainerCondition < MiqAeServiceModelBase
+    expose :container_entity, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_definition.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_definition.rb
@@ -1,0 +1,12 @@
+
+module MiqAeMethodService
+  class MiqAeServiceContainerDefinition < MiqAeServiceModelBase
+    expose :container_group,        :association => true
+    expose :ext_management_system,  :association => true
+    expose :container_port_configs, :association => true
+    expose :container_env_vars,     :association => true
+    expose :container,              :association => true
+    expose :security_context,       :association => true
+    expose :container_image,        :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_env_var.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_env_var.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerEnvVar < MiqAeServiceModelBase
+    expose :container_definition, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_group.rb
@@ -1,0 +1,21 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerGroup < MiqAeServiceModelBase
+    expose :containers,             :association => true
+    expose :container_definitions,  :association => true
+    expose :container_images,       :association => true
+    expose :ext_management_system,  :association => true
+    expose :labels,                 :association => true
+    expose :node_selector_parts,    :association => true
+    expose :container_node,         :association => true
+    expose :container_services,     :association => true
+    expose :container_replicator,   :association => true
+    expose :container_project,      :association => true
+    expose :container_build_pod,    :association => true
+    expose :container_volumes,      :association => true
+    expose :metrics,                :association => true
+    expose :metric_rollups,         :association => true
+    expose :vim_performance_states, :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_image.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_image.rb
@@ -1,0 +1,19 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerImage < MiqAeServiceModelBase
+    expose :container_image_registry,     :association => true
+    expose :ext_management_system,        :association => true
+    expose :containers,                   :association => true
+    expose :container_nodes,              :association => true
+    expose :container_groups,             :association => true
+    expose :container_projects,           :association => true
+    expose :guest_applications,           :association => true
+    expose :computer_system,              :association => true
+    expose :operating_system,             :association => true
+    expose :openscap_result,              :association => true
+    expose :openscap_rule_results,        :association => true
+    expose :exposed_ports,                :association => true
+    expose :environment_variables,        :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_image_registry.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_image_registry.rb
@@ -1,0 +1,11 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerImageRegistry < MiqAeServiceModelBase
+    expose :ext_management_system,    :association => true
+    expose :container_images,         :association => true
+    expose :containers,               :association => true
+    expose :container_services,       :association => true
+    expose :container_groups,         :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_limit.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_limit.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerLimit < MiqAeServiceModelBase
+    expose :ext_management_system,  :association => true
+    expose :container_project,      :association => true
+    expose :container_limit_items,  :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_limit_item.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_limit_item.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerLimitItem < MiqAeServiceModelBase
+    expose :container_limit, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_node.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_node.rb
@@ -1,0 +1,20 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerNode < MiqAeServiceModelBase
+    expose :ext_management_system,    :association => true
+    expose :container_groups,         :association => true
+    expose :container_conditions,     :association => true
+    expose :containers,               :association => true
+    expose :container_images,         :association => true
+    expose :container_services,       :association => true
+    expose :container_routes,         :association => true
+    expose :container_replicators,    :association => true
+    expose :labels,                   :association => true
+    expose :computer_system,          :association => true
+    expose :lives_on,                 :association => true
+    expose :hardware,                 :association => true
+    expose :metrics,                  :association => true
+    expose :metric_rollups,           :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_port_config.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_port_config.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerPortConfig < MiqAeServiceModelBase
+    expose :container_definition, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_project.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_project.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerProject < MiqAeServiceModelBase
+    expose :ext_management_system,  :association => true
+    expose :container_groups,       :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_quota.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_quota.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerQuota < MiqAeServiceModelBase
+    expose :ext_management_system,    association => true
+    expose :container_project,        association => true
+    expose :container_quota_items,    association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_replicator.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_replicator.rb
@@ -1,0 +1,14 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerReplicator < MiqAeServiceModelBase
+    expose :ext_management_system,    :association => true
+    expose :container_groups,         :association => true
+    expose :container_project,        :association => true
+    expose :labels,                   :association => true
+    expose :selector_parts,           :association => true
+    expose :container_nodes,          :association => true
+    expose :metrics,                  :association => true
+    expose :metric_zones,             :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_route.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_route.rb
@@ -1,0 +1,12 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerRoute < MiqAeServiceModelBase
+    expose :ext_management_system,    :association => true
+    expose :container_project,        :association => true
+    expose :container_service,        :association => true
+    expose :container_nodes,          :association => true
+    expose :container_groups,         :association => true
+    expose :labels,                   :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_service.rb
@@ -1,0 +1,17 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerService < MiqAeServiceModelBase
+    expose :ext_management_system,          :association => true
+    expose :container_groups,               :association => true
+    expose :container_routes,               :association => true
+    expose :container_service_port_configs, :association => true
+    expose :container_project,              :association => true
+    expose :labels,                         :association => true
+    expose :selector_parts,                 :association => true
+    expose :container_nodes,                :association => true
+    expose :container_image_registry,       :association => true
+    expose :metrics,                        :association => true
+    expose :metric_rollups,                 :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_volume.rb
@@ -1,0 +1,8 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerVolume < MiqAeServiceModelBase
+    expose :parent,                   :association => true
+    expose :persistent_volume_claim,  :association => true
+    expose :is_tagged_with?
+    expose :tags
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_volume_kubernetes.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_volume_kubernetes.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceContainerVolumeKubernetes < MiqAeServiceContainerVolume
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-kubernetes-container_manager-container.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-kubernetes-container_manager-container.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Kubernetes_ContainerManager_Container < MiqAeServiceContainer
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-kubernetes-container_manager-container_group.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-kubernetes-container_manager-container_group.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Kubernetes_ContainerManager_ContainerGroup < MiqAeServiceProvider
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-kubernetes-container_manager-container_node.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-kubernetes-container_manager-container_node.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Kubernetes_ContainerManager_ContainerNode < MiqAeServiceContainerNode
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openshift_enterprise-container_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openshift_enterprise-container_manager.rb
@@ -1,4 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_OpenshiftEnterprise_ContainerManager < MiqAeServiceManageIQ_Providers_ContainerManager
+    expose :container_image_registries, :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_persistent_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_persistent_volume.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServicePersistentVolume < MiqAeServiceModelBase
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_persistent_volume_claim.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_persistent_volume_claim.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServicePersistentVolumeClaim < MiqAeServiceModelBase
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_build_pod_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_build_pod_spec.rb
@@ -1,0 +1,11 @@
+module MiqAeServiceContainerBuildPodSpec
+  describe MiqAeMethodService::MiqAeServiceContainerBuildPod do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_build" do
+      expect(described_class.instance_methods).to include(:container_build)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_build_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_build_spec.rb
@@ -1,0 +1,15 @@
+module MiqAeServiceContainerBuildSpec
+  describe MiqAeMethodService::MiqAeServiceContainerBuild do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#container_build_pods" do
+      expect(described_class.instance_methods).to include(:container_build_pods)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_condition_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_condition_spec.rb
@@ -1,0 +1,7 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerCondition do
+    it "#container_entity" do
+      expect(described_class.instance_methods).to include(:container_entity)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_definition_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_definition_spec.rb
@@ -1,0 +1,31 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerDefinition do
+    it "#container_group" do
+      expect(described_class.instance_methods).to include(:container_group)
+    end
+
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_port_configs" do
+      expect(described_class.instance_methods).to include(:container_port_configs)
+    end
+
+    it "#container_env_vars" do
+      expect(described_class.instance_methods).to include(:container_env_vars)
+    end
+
+    it "#container" do
+      expect(described_class.instance_methods).to include(:container)
+    end
+
+    it "#security_context" do
+      expect(described_class.instance_methods).to include(:security_context)
+    end
+
+    it "#container_image" do
+      expect(described_class.instance_methods).to include(:container_image)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_env_var_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_env_var_spec.rb
@@ -1,0 +1,7 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerEnvVar do
+    it "#container_definition" do
+      expect(described_class.instance_methods).to include(:container_definition)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_group_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_group_spec.rb
@@ -1,0 +1,63 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerGroup do
+    it "#containers" do
+      expect(described_class.instance_methods).to include(:containers)
+    end
+
+    it "#container_definitions" do
+      expect(described_class.instance_methods).to include(:container_definitions)
+    end
+
+    it "#container_images" do
+      expect(described_class.instance_methods).to include(:container_images)
+    end
+
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#labels" do
+      expect(described_class.instance_methods).to include(:labels)
+    end
+
+    it "#node_selector_parts" do
+      expect(described_class.instance_methods).to include(:node_selector_parts)
+    end
+
+    it "#container_node" do
+      expect(described_class.instance_methods).to include(:container_node)
+    end
+
+    it "#container_services" do
+      expect(described_class.instance_methods).to include(:container_services)
+    end
+
+    it "#container_replicator" do
+      expect(described_class.instance_methods).to include(:container_replicator)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#container_build_pod" do
+      expect(described_class.instance_methods).to include(:container_build_pod)
+    end
+
+    it "#container_volumes" do
+      expect(described_class.instance_methods).to include(:container_volumes)
+    end
+
+    it "#metrics" do
+      expect(described_class.instance_methods).to include(:metrics)
+    end
+
+    it "#metric_rollups" do
+      expect(described_class.instance_methods).to include(:metric_rollups)
+    end
+
+    it "#vim_performance_states" do
+      expect(described_class.instance_methods).to include(:vim_performance_states)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_image_registry_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_image_registry_spec.rb
@@ -1,0 +1,23 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerImageRegistry do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_images" do
+      expect(described_class.instance_methods).to include(:container_images)
+    end
+
+    it "#containers" do
+      expect(described_class.instance_methods).to include(:containers)
+    end
+
+    it "#container_services" do
+      expect(described_class.instance_methods).to include(:container_services)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_image_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_image_spec.rb
@@ -1,0 +1,55 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerImage do
+    it "#container_image_registry" do
+      expect(described_class.instance_methods).to include(:container_image_registry)
+    end
+
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#containers" do
+      expect(described_class.instance_methods).to include(:containers)
+    end
+
+    it "#container_nodes" do
+      expect(described_class.instance_methods).to include(:container_nodes)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+
+    it "#container_projects" do
+      expect(described_class.instance_methods).to include(:container_projects)
+    end
+
+    it "#guest_applications" do
+      expect(described_class.instance_methods).to include(:guest_applications)
+    end
+
+    it "#computer_system" do
+      expect(described_class.instance_methods).to include(:computer_system)
+    end
+
+    it "#operating_system" do
+      expect(described_class.instance_methods).to include(:operating_system)
+    end
+
+    it "#openscap_result" do
+      expect(described_class.instance_methods).to include(:openscap_result)
+    end
+
+    it "#openscap_rule_results" do
+      expect(described_class.instance_methods).to include(:openscap_rule_results)
+    end
+
+    it "#exposed_ports" do
+      expect(described_class.instance_methods).to include(:exposed_ports)
+    end
+
+    it "#environment_variables" do
+      expect(described_class.instance_methods).to include(:environment_variables)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_limit_item_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_limit_item_spec.rb
@@ -1,0 +1,7 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerLimitItem do
+    it "#container_limit" do
+      expect(described_class.instance_methods).to include(:container_limit)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_limit_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_limit_spec.rb
@@ -1,0 +1,15 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerLimit do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#container_limit_items" do
+      expect(described_class.instance_methods).to include(:container_limit_items)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_node_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_node_spec.rb
@@ -1,0 +1,59 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerNode do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+
+    it "#container_conditions" do
+      expect(described_class.instance_methods).to include(:container_conditions)
+    end
+
+    it "#containers" do
+      expect(described_class.instance_methods).to include(:containers)
+    end
+
+    it "#container_images" do
+      expect(described_class.instance_methods).to include(:container_images)
+    end
+
+    it "#container_services" do
+      expect(described_class.instance_methods).to include(:container_services)
+    end
+
+    it "#container_routes" do
+      expect(described_class.instance_methods).to include(:container_routes)
+    end
+
+    it "#container_replicators" do
+      expect(described_class.instance_methods).to include(:container_replicators)
+    end
+
+    it "#labels" do
+      expect(described_class.instance_methods).to include(:labels)
+    end
+
+    it "#computer_system" do
+      expect(described_class.instance_methods).to include(:computer_system)
+    end
+
+    it "#lives_on" do
+      expect(described_class.instance_methods).to include(:lives_on)
+    end
+
+    it "#hardware" do
+      expect(described_class.instance_methods).to include(:hardware)
+    end
+
+    it "#metrics" do
+      expect(described_class.instance_methods).to include(:metrics)
+    end
+
+    it "#metric_rollups" do
+      expect(described_class.instance_methods).to include(:metric_rollups)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_port_config_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_port_config_spec.rb
@@ -1,0 +1,7 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerPortConfig do
+    it "#container_definition" do
+      expect(described_class.instance_methods).to include(:container_definition)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_project_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_project_spec.rb
@@ -1,0 +1,11 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerProject do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_quota_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_quota_spec.rb
@@ -1,0 +1,15 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerQuota do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#container_quota_items" do
+      expect(described_class.instance_methods).to include(:container_quota_items)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_replicator_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_replicator_spec.rb
@@ -1,0 +1,35 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerReplicator do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#labels" do
+      expect(described_class.instance_methods).to include(:labels)
+    end
+
+    it "#selector_parts" do
+      expect(described_class.instance_methods).to include(:selector_parts)
+    end
+
+    it "#container_nodes" do
+      expect(described_class.instance_methods).to include(:container_nodes)
+    end
+
+    it "#metrics" do
+      expect(described_class.instance_methods).to include(:metrics)
+    end
+
+    it "#metric_zones" do
+      expect(described_class.instance_methods).to include(:metric_zones)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_route_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_route_spec.rb
@@ -1,0 +1,27 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerRoute do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#container_service" do
+      expect(described_class.instance_methods).to include(:container_service)
+    end
+
+    it "#container_nodes" do
+      expect(described_class.instance_methods).to include(:container_nodes)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+
+    it "#labels" do
+      expect(described_class.instance_methods).to include(:labels)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_service_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_service_spec.rb
@@ -1,0 +1,47 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerService do
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_groups" do
+      expect(described_class.instance_methods).to include(:container_groups)
+    end
+
+    it "#container_routes" do
+      expect(described_class.instance_methods).to include(:container_routes)
+    end
+
+    it "#container_service_port_configs" do
+      expect(described_class.instance_methods).to include(:container_service_port_configs)
+    end
+
+    it "#container_project" do
+      expect(described_class.instance_methods).to include(:container_project)
+    end
+
+    it "#labels" do
+      expect(described_class.instance_methods).to include(:labels)
+    end
+
+    it "#selector_parts" do
+      expect(described_class.instance_methods).to include(:selector_parts)
+    end
+
+    it "#container_nodes" do
+      expect(described_class.instance_methods).to include(:container_nodes)
+    end
+
+    it "#container_image_registry" do
+      expect(described_class.instance_methods).to include(:container_image_registry)
+    end
+
+    it "#metrics" do
+      expect(described_class.instance_methods).to include(:metrics)
+    end
+
+    it "#metric_rollups" do
+      expect(described_class.instance_methods).to include(:metric_rollups)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_spec.rb
@@ -1,0 +1,17 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainer do
+    let(:container) { FactoryGirl.create(:container) }
+
+    it "#ext_management_system" do
+      expect(described_class.instance_methods).to include(:ext_management_system)
+    end
+
+    it "#container_node" do
+      expect(described_class.instance_methods).to include(:container_node)
+    end
+
+    it "#container_image" do
+      expect(described_class.instance_methods).to include(:container_image)
+    end
+  end
+end

--- a/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_volume_spec.rb
+++ b/spec/lib/miq_automation_engine/service_methods/miq_ae_service_container_volume_spec.rb
@@ -1,0 +1,11 @@
+module MiqAeServiceContainerSpec
+  describe MiqAeMethodService::MiqAeServiceContainerVolume do
+    it "#parent" do
+      expect(described_class.instance_methods).to include(:parent)
+    end
+
+    it "#persistent_volume_claim" do
+      expect(described_class.instance_methods).to include(:persistent_volume_claim)
+    end
+  end
+end


### PR DESCRIPTION
OpenShift (and theoretically other container platforms) objects should be treated as first class citizens in the Automate Service Model in ManageIQ.  This will enable customized workflows using these objects.

This pull request only adds code that allows one to Read the objects.  Future work will be made to allow an automate workflow to Create, Update, and Delete the objects.

https://bugzilla.redhat.com/show_bug.cgi?id=1378190