### PR TITLE
add miq_report#menu_name

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -40,6 +40,7 @@ class MiqReport < ApplicationRecord
   belongs_to                :user
   has_many                  :miq_widgets, :as => :resource
 
+  alias_attribute :menu_name, :name
   attr_accessor_that_yamls :table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                            :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
                            :report_run_time, :chart


### PR DESCRIPTION
In a report yaml file, the attribute 'menu_name' is deleted from the yaml and replaced with the attribute 'name'. [[ref]](https://github.com/ManageIQ/manageiq/blob/b4c3b8b7a3b5e49d9dabab63a883b2ff2e4b931e/app/models/miq_report/import_export.rb#L9-L17)

None of this is necessary if `MiqReport` responded to both `menu_name=` and `name=`.

This simplifies parsing/performance testing the yaml files and makes it easier to work with them. (they now work out of the box rather than relying upon half a dozen lines to just load it)