### PR TITLE
Container provider: fix topology view

### DIFF
--- a/app/views/shared/views/ems_common/_show.html.haml
+++ b/app/views/shared/views/ems_common/_show.html.haml
@@ -33,3 +33,5 @@
     = render :partial => 'show_dashboard'
   - elsif @showtype == 'ad_hoc_metrics'
     = render :partial => 'show_ad_hoc_metrics'
+  - elsif @showtype == 'topology'
+    = render :file => 'container_topology/show'

--- a/spec/controllers/ems_container_controller_spec.rb
+++ b/spec/controllers/ems_container_controller_spec.rb
@@ -29,6 +29,13 @@ describe EmsContainerController do
         is_expected.to have_http_status 200
         is_expected.to render_template(:partial => "layouts/listnav/_ems_container")
       end
+
+      it "renders topology view" do
+        get :show, :params => { :id => @container.id, :display => 'topology' }
+        expect(response.status).to eq(200)
+        expect(response.body).to_not be_empty
+        expect(response).to render_template('container_topology/show')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes the links from container provider default view to the topology view. 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1398630
Issue was introduced in https://github.com/ManageIQ/manageiq/pull/10895.

1.
![topo1](https://cloud.githubusercontent.com/assets/11769555/20663681/0e5ee694-b561-11e6-9310-96740ab49da9.png)

2.
![topo2](https://cloud.githubusercontent.com/assets/11769555/20663690/124386e8-b561-11e6-9ada-4f667de99eae.png)


cc @simon3z @zeari 
