### PR TITLE
Refactor Middleware controllers using mixins.

### DIFF
--- a/app/controllers/ems_block_storage_controller.rb
+++ b/app/controllers/ems_block_storage_controller.rb
@@ -1,4 +1,6 @@
 class EmsBlockStorageController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_cinder_controller.rb
+++ b/app/controllers/ems_cinder_controller.rb
@@ -1,4 +1,5 @@
 class EmsCinderController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_cinder_controller.rb
+++ b/app/controllers/ems_cinder_controller.rb
@@ -1,4 +1,5 @@
 class EmsCinderController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -1,4 +1,5 @@
 class EmsCloudController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud controllers
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -1,4 +1,5 @@
 class EmsCloudController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud controllers
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -143,7 +143,7 @@ module EmsCommon
     @lastaction = "show"
     session[:tl_record_id] = @record.id
 
-    replace_gtl_main_div if is_gtl_request?
+    replace_gtl_main_div if gtl_request?
     render :template => "shared/views/ems_common/show" if params[:action] == 'show' && !performed?
   end
 

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -1,23 +1,6 @@
 module EmsCommon
   extend ActiveSupport::Concern
 
-  def gtl_url
-    restful? ? '/' : '/show'
-  end
-
-  def show_download
-    get_tagdata(@ems)
-    drop_breadcrumb(:name => @ems.name + _(" (Summary)"), :url => show_link(@ems))
-    @showtype = "main"
-    set_summary_pdf_data
-  end
-
-  def show_main
-    get_tagdata(@ems)
-    drop_breadcrumb(:name => @ems.name + _(" (Summary)"), :url => show_link(@ems))
-    @showtype = "main"
-  end
-
   def show_props
     drop_breadcrumb(:name => @ems.name + _(" (Properties)"), :url => show_link(@ems, :display  =>  "props"))
   end
@@ -131,15 +114,11 @@ module EmsCommon
   end
 
   def show
-    @display = params[:display] || "main" unless control_selected?
-
+    return unless init_show
     session[:vm_summary_cool] = (settings(:views, :vm_summary_cool).to_s == "summary")
     @summary_view = session[:vm_summary_cool]
-    @ems = @record = identify_record(params[:id])
-    return if record_no_longer_exists?(@ems)
+    @ems = @record
 
-    @gtl_url = gtl_url
-    @showtype = "config"
     drop_breadcrumb({:name => ui_lookup(:tables => @table_name), :url => "/#{@table_name}/show_list?page=#{@current_page}&refresh=y"}, true)
 
     case params[:display]
@@ -164,11 +143,7 @@ module EmsCommon
     @lastaction = "show"
     session[:tl_record_id] = @record.id
 
-    # Came in from outside show_list partial
-    if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]
-      replace_gtl_main_div
-    end
-
+    replace_gtl_main_div if is_gtl_request?
     render :template => "shared/views/ems_common/show" if params[:action] == 'show' && !performed?
   end
 

--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -158,11 +158,6 @@ module EmsCommon
     @showtype = @display = display
   end
 
-  # Show the main MS list view
-  def show_list
-    process_show_list
-  end
-
   def new
     @doc_url = provider_documentation_url
     assert_privileges("#{permission_prefix}_new")

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -1,4 +1,5 @@
 class EmsContainerController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud/Container controllers
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_container_controller.rb
+++ b/app/controllers/ems_container_controller.rb
@@ -1,4 +1,5 @@
 class EmsContainerController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud/Container controllers
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_datawarehouse_controller.rb
+++ b/app/controllers/ems_datawarehouse_controller.rb
@@ -1,6 +1,9 @@
 class EmsDatawarehouseController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
+  include Mixins::GenericSessionMixin
 
   before_action :check_privileges
   before_action :get_session_data
@@ -13,10 +16,6 @@ class EmsDatawarehouseController < ApplicationController
 
   def self.table_name
     @table_name ||= "ems_datawarehouse"
-  end
-
-  def index
-    redirect_to :action => 'show_list'
   end
 
   def show_link(ems, options = {})

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -1,4 +1,5 @@
 class EmsInfraController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud controllers
   include Mixins::EmsCommonAngular
 

--- a/app/controllers/ems_infra_controller.rb
+++ b/app/controllers/ems_infra_controller.rb
@@ -1,4 +1,5 @@
 class EmsInfraController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon        # common methods for EmsInfra/Cloud controllers
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -1,4 +1,5 @@
 class EmsMiddlewareController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include MiddlewareOperationsMixin

--- a/app/controllers/ems_middleware_controller.rb
+++ b/app/controllers/ems_middleware_controller.rb
@@ -1,4 +1,5 @@
 class EmsMiddlewareController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
@@ -15,10 +16,6 @@ class EmsMiddlewareController < ApplicationController
 
   def self.table_name
     @table_name ||= "ems_middleware"
-  end
-
-  def index
-    redirect_to :action => 'show_list'
   end
 
   def show_link(ems, options = {})

--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -1,4 +1,5 @@
 class EmsNetworkController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_network_controller.rb
+++ b/app/controllers/ems_network_controller.rb
@@ -1,4 +1,5 @@
 class EmsNetworkController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_object_storage_controller.rb
+++ b/app/controllers/ems_object_storage_controller.rb
@@ -1,4 +1,6 @@
 class EmsObjectStorageController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -1,4 +1,5 @@
 class EmsStorageController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_storage_controller.rb
+++ b/app/controllers/ems_storage_controller.rb
@@ -1,4 +1,5 @@
 class EmsStorageController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/ems_swift_controller.rb
+++ b/app/controllers/ems_swift_controller.rb
@@ -1,4 +1,5 @@
 class EmsSwiftController < ApplicationController
+  include Mixins::GenericListMixin
   include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular

--- a/app/controllers/ems_swift_controller.rb
+++ b/app/controllers/ems_swift_controller.rb
@@ -1,4 +1,5 @@
 class EmsSwiftController < ApplicationController
+  include Mixins::GenericShowMixin
   include EmsCommon
   include Mixins::EmsCommonAngular
   include Mixins::GenericSessionMixin

--- a/app/controllers/middleware_datasource_controller.rb
+++ b/app/controllers/middleware_datasource_controller.rb
@@ -1,4 +1,6 @@
 class MiddlewareDatasourceController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include MiddlewareCommonMixin
 

--- a/app/controllers/middleware_deployment_controller.rb
+++ b/app/controllers/middleware_deployment_controller.rb
@@ -1,4 +1,6 @@
 class MiddlewareDeploymentController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include MiddlewareCommonMixin
 

--- a/app/controllers/middleware_domain_controller.rb
+++ b/app/controllers/middleware_domain_controller.rb
@@ -1,4 +1,6 @@
 class MiddlewareDomainController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include MiddlewareCommonMixin
 

--- a/app/controllers/middleware_messaging_controller.rb
+++ b/app/controllers/middleware_messaging_controller.rb
@@ -1,4 +1,6 @@
 class MiddlewareMessagingController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include MiddlewareCommonMixin
 

--- a/app/controllers/middleware_server_controller.rb
+++ b/app/controllers/middleware_server_controller.rb
@@ -1,4 +1,6 @@
 class MiddlewareServerController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include MiddlewareCommonMixin
 

--- a/app/controllers/middleware_server_group_controller.rb
+++ b/app/controllers/middleware_server_group_controller.rb
@@ -1,4 +1,6 @@
 class MiddlewareServerGroupController < ApplicationController
+  include Mixins::GenericListMixin
+  include Mixins::GenericShowMixin
   include EmsCommon
   include MiddlewareCommonMixin
 

--- a/app/controllers/mixins/ems_common_angular.rb
+++ b/app/controllers/mixins/ems_common_angular.rb
@@ -2,10 +2,6 @@ module Mixins
   module EmsCommonAngular
     extend ActiveSupport::Concern
 
-    def index
-      redirect_to :action => 'show_list'
-    end
-
     def update
       assert_privileges("#{permission_prefix}_edit")
       case params[:button]

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -1,31 +1,47 @@
 module Mixins
   module GenericShowMixin
     def show
-      @display = params[:display] || "main" unless control_selected?
+      return unless init_show
 
-      @lastaction = "show"
-      @record     = identify_record(params[:id])
-      return if record_no_longer_exists?(@record)
-
-      @gtl_url = "/show"
       case @display
-      when "download_pdf", "main", "summary_only"
-        get_tagdata(@record)
-        drop_breadcrumb({:name => "#{self.class.table_name}s",
-                         :url  => "/#{self.class.table_name}/show_list?page=#{@current_page}&refresh=y"},
-                        true)
-        drop_breadcrumb(:name =>  _("%{name} (Summary)") % {:name => @record.name},
-                        :url  => "/#{self.class.table_name}/show/#{@record.id}")
-        @showtype = "main"
-        set_summary_pdf_data if ["download_pdf", "summary_only"].include?(@display)
-      when *self.class.display_methods
-        display_nested_list(@display)
+      when "download_pdf", "summary_only" then show_download
+      when "main"                         then show_main
+      when *self.class.display_methods    then display_nested_list(@display)
       end
 
-      # Came in from outside show_list partial
-      if params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]
-        replace_gtl_main_div
-      end
+      replace_gtl_main_div if is_gtl_request?
+    end
+
+    def is_gtl_request?
+      params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]
+    end
+
+    def show_download
+      show_main
+      set_summary_pdf_data
+    end
+
+    def show_main
+      get_tagdata(@record)
+      drop_breadcrumb({:name => "#{self.class.table_name}s",
+                       :url  => "/#{self.class.table_name}/show_list?page=#{@current_page}&refresh=y"},
+                      true)
+      drop_breadcrumb(:name =>  _("%{name} (Summary)") % {:name => @record.name},
+                      :url  => "/#{self.class.table_name}/show/#{@record.id}")
+      @showtype = "main"
+    end
+
+    def gtl_url
+      restful? ? '/' : '/show'
+    end
+
+    def init_show
+      @record = identify_record(params[:id], model_class)
+      return false if record_no_longer_exists?(@record)
+      @lastaction = 'show'
+      @gtl_url = gtl_url
+      @display = params[:display] || 'main' unless control_selected?
+      true
     end
 
     def nested_list_method(display)

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -9,10 +9,10 @@ module Mixins
       when *self.class.display_methods    then display_nested_list(@display)
       end
 
-      replace_gtl_main_div if is_gtl_request?
+      replace_gtl_main_div if gtl_request?
     end
 
-    def is_gtl_request?
+    def gtl_request?
       params[:ppsetting] || params[:searchtag] || params[:entry] || params[:sort_choice]
     end
 

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -23,11 +23,15 @@ module Mixins
 
     def show_main
       get_tagdata(@record)
-      drop_breadcrumb({:name => "#{self.class.table_name}s",
+      drop_breadcrumb({:name => ui_lookup(:tables => self.class.table_name),
                        :url  => "/#{self.class.table_name}/show_list?page=#{@current_page}&refresh=y"},
                       true)
+
+      show_url = restful? ? "/#{self.class.table_name}/" :
+                            "/#{self.class.table_name}/show/"
+
       drop_breadcrumb(:name =>  _("%{name} (Summary)") % {:name => @record.name},
-                      :url  => "/#{self.class.table_name}/show/#{@record.id}")
+                      :url  => "#{show_url}#{@record.id}")
       @showtype = "main"
     end
 

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -35,7 +35,7 @@ module Mixins
       restful? ? '/' : '/show'
     end
 
-    def init_show
+    def init_show(model_class = self.class.model)
       @record = identify_record(params[:id], model_class)
       return false if record_no_longer_exists?(@record)
       @lastaction = 'show'

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -2,14 +2,6 @@ module MiddlewareCommonMixin
   extend ActiveSupport::Concern
   include MiddlewareOperationsMixin
 
-  def show_list
-    process_show_list
-  end
-
-  def index
-    redirect_to :action => 'show_list'
-  end
-
   def show
     return unless init_show
     show_middleware

--- a/app/controllers/mixins/middleware_common_mixin.rb
+++ b/app/controllers/mixins/middleware_common_mixin.rb
@@ -4,6 +4,9 @@ module MiddlewareCommonMixin
 
   def show
     return unless init_show
+    @ems = @record
+    clear_topology_breadcrumb
+
     show_middleware
   end
 
@@ -26,16 +29,6 @@ module MiddlewareCommonMixin
     if @breadcrumbs.present? && (@breadcrumbs.last[:name].eql? 'Topology')
       @breadcrumbs.clear
     end
-  end
-
-  def init_show(model_class = self.class.model)
-    @ems = @record = identify_record(params[:id], model_class)
-    return false if record_no_longer_exists?(@record)
-    clear_topology_breadcrumb
-    @lastaction = 'show'
-    @gtl_url = '/show'
-    @display = params[:display] || 'main' unless control_selected?
-    true
   end
 
   def show_middleware

--- a/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_network_controller.rb
@@ -37,7 +37,7 @@ shared_examples :shared_examples_for_cloud_network_controller do |providers|
           get :show, :params => {:id => @cloud_network.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "cloud_networks",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Cloud Networks",
                                                 :url  => "/cloud_network/show_list?page=&refresh=y"},
                                                {:name => "Cloud Network (Summary)",
                                                 :url  => "/cloud_network/show/#{@cloud_network.id}"}])

--- a/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_cloud_subnet_controller.rb
@@ -37,7 +37,7 @@ shared_examples :shared_examples_for_cloud_subnet_controller do |providers|
           get :show, :params => {:id => @cloud_subnet.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "cloud_subnets",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Cloud Subnets",
                                                 :url  => "/cloud_subnet/show_list?page=&refresh=y"},
                                                {:name => "Cloud Subnet (Summary)",
                                                 :url  => "/cloud_subnet/show/#{@cloud_subnet.id}"}])

--- a/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_floating_ip_controller.rb
@@ -36,7 +36,7 @@ shared_examples :shared_examples_for_floating_ip_controller do |providers|
           get :show, :params => {:id => @floating_ip.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "floating_ips",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Floating IPs",
                                                 :url  => "/floating_ip/show_list?page=&refresh=y"},
                                                {:name => "192.0.2.1 (Summary)",
                                                 :url  => "/floating_ip/show/#{@floating_ip.id}"}])

--- a/spec/shared/controllers/shared_examples_for_network_port_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_port_controller.rb
@@ -36,7 +36,7 @@ shared_examples :shared_examples_for_network_port_controller do |providers|
           get :show, :params => {:id => @network_port.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "network_ports",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Ports",
                                                 :url  => "/network_port/show_list?page=&refresh=y"},
                                                {:name => "eth0 (Summary)",
                                                 :url  => "/network_port/show/#{@network_port.id}"}])

--- a/spec/shared/controllers/shared_examples_for_network_router_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_network_router_controller.rb
@@ -37,7 +37,7 @@ shared_examples :shared_examples_for_network_router_controller do |providers|
           get :show, :params => {:id => @network_router.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "network_routers",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Routers",
                                                 :url  => "/network_router/show_list?page=&refresh=y"},
                                                {:name => "Network Router (Summary)",
                                                 :url  => "/network_router/show/#{@network_router.id}"}])

--- a/spec/shared/controllers/shared_examples_for_security_group_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_security_group_controller.rb
@@ -37,7 +37,7 @@ shared_examples :shared_examples_for_security_group_controller do |providers|
           get :show, :params => {:id => @security_group.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "security_groups",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Security Groups",
                                                 :url  => "/security_group/show_list?page=&refresh=y"},
                                                {:name => "Security Group (Summary)",
                                                 :url  => "/security_group/show/#{@security_group.id}"}])


### PR DESCRIPTION
The goal is to make all the `show/list/button` methods share the same code. 

In this PR I try to reduce the difference between `MiddlewareCommonMixin` users and users of `GenericShowMixin` and `GenericListMixin`.

With sharing the same code we should have more consistent behavior such as breadcrumbs and it's urls and names.