### PR TITLE
Add the button to list of features to enable RBAC

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1372,6 +1372,11 @@
         :description: Delete a Saved Report
         :feature_type: admin
         :identifier: saved_report_delete
+      - :name: Show full screen Report
+        :description: Show full screen Report
+        :feature_type: admin
+        :hidden: true
+        :identifier: report_only
   - :name: Reports
     :description: Everything under Reports Accordion
     :feature_type: node


### PR DESCRIPTION
This fixes the issue with missing button on Saved Reports page, that is now always hidden in toolbar, because RBAC check won't pass

Before:
![screenshot from 2016-11-28 13-26-30](https://cloud.githubusercontent.com/assets/1187051/20668302/736edfa0-b56e-11e6-83ef-83d79ab82b84.png)

After:
![screenshot from 2016-11-28 13-31-47](https://cloud.githubusercontent.com/assets/1187051/20668422/15868914-b56f-11e6-9f1b-20d347e0bb42.png)



Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1393593

Steps for Testing/QA
-------------------------------
Cloud intel -> Reports -> Select report