### PR TITLE
Pass 'zoomed' attribute to sample chart

### DIFF
--- a/app/views/report/_form_chart_sample.html.haml
+++ b/app/views/report/_form_chart_sample.html.haml
@@ -8,4 +8,4 @@
                         :rand   => "#{rand(999_999_999)}"),
                         :id => 'my_chart', :bgcolor => '#f2f2f2', :width => 400, :height => 250)
       - elsif Charting.backend == :c3
-        = chart_remote('report', :action => 'sample_chart', :id => "my_chart")
+        = chart_remote('report', :action => 'sample_chart', :id => "my_chart", :zoomed => false)

--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -49,7 +49,8 @@ class C3Charting < Charting
           ['data3', 10, 25, 10, 250, 10, 30]
         ],
       },
-      :miqChart => _options[:graph_type]
+      :miqChart => _options[:graph_type],
+      :miq      => { :zoomed => false }
     }
     sample[:data][:groups] = [['data1','data2', 'data3']] if _options[:graph_type].include? 'Stacked'
     sample


### PR DESCRIPTION
When adding chart to report.
In https://github.com/ManageIQ/manageiq/blob/master/app/helpers/c3_helper.rb#L8

-  `data.miq` is undefined so I added it [here 
](https://github.com/ManageIQ/manageiq/commit/817a15979c381e2ca007ec6242fcf1538d560e4d#diff-3a7cfea81fa6a8f04d1ce0aa468d65f9L52) to get it from server
- and also `opts[:zoomed]` was empty so I added it [here](https://github.com/ManageIQ/manageiq/commit/817a15979c381e2ca007ec6242fcf1538d560e4d#diff-353eff503befc1f607d40cfda320eda8L11) 
 
Links [Optional]
----------------
* Introduced in https://github.com/ManageIQ/manageiq/pull/12811

Steps for Testing/QA [Optional]
-------------------------------
![ljzc7amp19](https://cloud.githubusercontent.com/assets/14937244/20668858/4dc927e4-b571-11e6-92b6-241bd39d67c6.gif)

@miq-bot add_label ui, bug
@miq-bot assign @martinpovolny 
cc @PanSpagetka 

