### PR TITLE
Topology: change icon for Availability zone

### DIFF
--- a/app/views/cloud_topology/show.html.haml
+++ b/app/views/cloud_topology/show.html.haml
@@ -19,7 +19,7 @@
           %g.EntityLegend.Network.CloudSubnet
             %circle{:r => "17"}
             -# pficon-network
-            %text{:y => "8"} &#xE909;
+            %text{:y => "8"} &#xE911;
         %label
           = _("Availability Zones")
       %kubernetes-topology-icon{tooltipOptions, :kind => "CloudTenant"}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1389335
The icons was different in the selection and the main body for Availability Zones. Now they are the same
![icons](https://cloud.githubusercontent.com/assets/8054645/20669934/fc37a74c-b576-11e6-974d-db3c3119ca56.jpg)
