### PR TITLE
Add managers in before_create callback instead of before_validation

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
 
   delegate :api_cached?, :ensure_api_cached, :to => :connect
 
-  before_validation :ensure_managers
+  before_create :ensure_managers
 
   validates :name, :presence => true, :uniqueness => true
   validates :url,  :presence => true

--- a/app/models/manageiq/providers/google/cloud_manager.rb
+++ b/app/models/manageiq/providers/google/cloud_manager.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::Google::CloudManager < ManageIQ::Providers::CloudMana
   supports :provisioning
   supports :regions
 
-  before_validation :ensure_managers
+  before_create :ensure_managers
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Google::NetworkManager') unless network_manager

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -46,7 +46,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   supports :swift_service
   supports :create_host_aggregate
 
-  before_validation :ensure_managers,
+  before_create :ensure_managers,
                     :ensure_cinder_managers,
                     :ensure_swift_managers
 

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ::EmsInfra
 
   before_save :ensure_parent_provider
   before_destroy :destroy_parent_provider
-  before_validation :ensure_managers
+  before_create :ensure_managers
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager

--- a/app/models/manageiq/providers/vmware/cloud_manager.rb
+++ b/app/models/manageiq/providers/vmware/cloud_manager.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Vmware::CloudManager < ManageIQ::Providers::CloudMana
   include ManageIQ::Providers::Vmware::CloudManager::ManagerEventsMixin
   include HasNetworkManagerMixin
 
-  before_validation :ensure_managers
+  before_create :ensure_managers
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::Vmware::NetworkManager') unless network_manager

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -163,7 +163,7 @@ describe ProviderForemanController do
     controller.instance_variable_set(:@provider_cfgmgmt, provider2)
     allow(controller).to receive(:render_flash)
     controller.save_provider_foreman
-    expect(assigns(:flash_array).first[:message]).to include("Configuration_manager.name has already been taken")
+    expect(assigns(:flash_array).first[:message]).to include("Name has already been taken")
   end
 
   context "#edit" do


### PR DESCRIPTION
otherwise it could happen that one process deletes the manager
and another one saves it and the saving one would add back
a deleted manager.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1389459
* https://bugzilla.redhat.com/show_bug.cgi?id=1393675
* https://github.com/ManageIQ/manageiq-providers-azure/pull/13
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/87

Steps for Testing/QA 
-------------------------------
```ruby
    ems = FactoryGirl.create(:ems_azure)
    same_ems = ExtManagementSystem.find(ems.id)

    ems.destroy
    expect(ExtManagementSystem.count).to eq(0)

    same_ems.save!
    expect(ExtManagementSystem.count).to eq(0)
```

credits to @jameswnl for finding this condition