### PR TITLE
Change plural to singular

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4789,11 +4789,11 @@
       :feature_type: admin
       :identifier: container_service_delete
     - :name: Edit
-      :description: Edit a Container Services
+      :description: Edit a Container Service
       :feature_type: admin
       :identifier: container_service_edit
     - :name: Add
-      :description: Add a Container Services
+      :description: Add a Container Service
       :feature_type: admin
       :identifier: container_service_new
   - :name: Operate


### PR DESCRIPTION
Addressing complaints from translators:

`Edit a Container Services` -> `Edit a Container Service`
`Add a Container Services` -> `Add a Container Service`