### PR TITLE
Switched order to render history toolbar in Pxe screen

### DIFF
--- a/app/controllers/pxe_controller.rb
+++ b/app/controllers/pxe_controller.rb
@@ -118,10 +118,6 @@ class PxeController < ApplicationController
 
     replace_trees_by_presenter(presenter, trees)
 
-    # forcing form buttons to turn off, to prevent Abandon changes popup when replacing right cell after form button was pressed
-    presenter[:reload_toolbars][:center] = c_tb if c_tb.present?
-    presenter.set_visibility(c_tb.present?, :toolbar)
-
     # Rebuild the toolbars
     presenter.reload_toolbars(:history => h_tb)
     case x_active_tree
@@ -183,6 +179,10 @@ class PxeController < ApplicationController
         when 'isi'  then _("%{model} \"%{name}\"") % {:name => @img.name, :model => ui_lookup(:model => "IsoImage")}
         end
     end
+
+    # forcing form buttons to turn off, to prevent Abandon changes popup when replacing right cell after form button was pressed
+    presenter[:reload_toolbars][:center] = c_tb if c_tb.present?
+    presenter.set_visibility(c_tb.present?, :toolbar)
 
     # FIXME: check where @right_cell_text is set and replace that with loca variable
     presenter[:right_cell_text] = right_cell_text || @right_cell_text


### PR DESCRIPTION
Fixed consistency issue

Before:
![screenshot from 2016-12-01 11-55-09](https://cloud.githubusercontent.com/assets/1187051/20791414/361bb1cc-b7bd-11e6-94f5-a12532f9f607.png)


After:
![screenshot from 2016-12-01 11-55-50](https://cloud.githubusercontent.com/assets/1187051/20791416/38642626-b7bd-11e6-9464-275c98203a80.png)


Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1393205

Steps for Testing/QA
-------------------------------
Compute -> Infrastructure -> Pxe
