### PR TITLE
Change title in drop down menu for Alert profile assignments

### DIFF
--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -447,12 +447,8 @@ module UiConstants
   # This set of assignments was created for miq_alerts
   ASSIGN_TOS["ExtManagementSystem"] = {
     "enterprise"                 => N_("The Enterprise"),
-    "ext_management_system"      => PostponedTranslation.new(N_("Selected %{tables}")) do
-                                      {:tables => ui_lookup(:tables => "ems_infra")}
-                                    end,
-    "ext_management_system-tags" => PostponedTranslation.new(N_("Tagged %{tables}")) do
-                                      {:tables => ui_lookup(:tables => "ems_infra")}
-                                    end
+    "ext_management_system"      => PostponedTranslation.new(N_("Selected Providers")),
+    "ext_management_system-tags" => PostponedTranslation.new(N_("Tagged Providers"))
   }
   ASSIGN_TOS["EmsCluster"] = {
     "ems_cluster"      => PostponedTranslation.new(N_("Selected %{tables}")) do

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -971,8 +971,8 @@ en:
       network_port:                Network Port
       network_router:              Network Router
       evm_owner:                   EVM Owner
-      ext_management_system:       Cloud/Infrastructure Provider
-      ext_management_systems:      Cloud/Infrastructure Providers
+      ext_management_system:       Provider
+      ext_management_systems:      Providers
       filesystem_drivers:          File System Drivers
       filesystems:                 Files
       flavor:                      Flavor

--- a/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair do
     it 'fails create with invalid parameters' do
       expect(subject.class.validate_create_key_pair(nil)).to eq(
         :available => false,
-        :message   => 'The Keypair is not connected to an active Cloud/Infrastructure Provider')
+        :message   => 'The Keypair is not connected to an active Provider')
     end
 
     it 'pass create with valid parameters' do


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1383361

Change 'Selected Infrastructure Providers' and 'Tagged Infrastructure Providers'
in drop down menu to 'Selected Providers' and 'Cloud/Infrastructure Providers'
above the tree to 'Providers' when reaching Control->Explorer and editing
Alert Profile assignments from configuration tab.

Before:
![alert3](https://cloud.githubusercontent.com/assets/13417815/20675018/3024df8e-b58b-11e6-93f1-06573035f68c.png)
![alert4](https://cloud.githubusercontent.com/assets/13417815/20675022/32ebeb04-b58b-11e6-9e8f-321da7e20456.png)

After:
![alert1](https://cloud.githubusercontent.com/assets/13417815/20674850/a199935e-b58a-11e6-8a62-1714400543a2.png)
![alert2](https://cloud.githubusercontent.com/assets/13417815/20674854/a44f1696-b58a-11e6-87e2-60fd8c5628ff.png)
