### PR TITLE
[WIP] add hosts and vms as an association

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -24,6 +24,8 @@ module ManageIQ::Providers
     has_many :load_balancer_listener_pools,       :through => :load_balancer_listeners
     has_many :load_balancer_health_checks,        :foreign_key => :ems_id, :dependent => :destroy
     has_many :load_balancer_health_check_members, :through => :load_balancer_health_checks
+    has_many :hosts,                              :through => :parent_manager
+    has_many :vms,                                :through => :parent_manager
 
     # Uses "ext_management_systems"."parent_ems_id" instead of "ext_management_systems"."id"
     #
@@ -68,9 +70,7 @@ module ManageIQ::Providers
              :orchestration_stacks_resources,
              :direct_orchestration_stacks,
              :resource_groups,
-             :vms,
              :total_vms,
-             :hosts,
              :to        => :parent_manager,
              :allow_nil => true
 

--- a/spec/models/manageiq/providers/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/network_manager_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::NetworkManager do
+  it "has .hosts and .vms even without a parent_manager" do
+    # a NetworkManager doesn't necessarily have a parent_manager, but some methods in ExtManagementSystem
+    # require .hosts and .vms to return a relation
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1393675
+    manager = FactoryGirl.build(:ems_network)
+    expect(manager.hosts).be_a(ActiveRecord::Relation)
+    expect(manager.vms).be_a(ActiveRecord::Relation)
+  end
+end


### PR DESCRIPTION
some [methods](https://github.com/ManageIQ/manageiq/blob/70191e702c944d20c3307167c44cbb810c3d5005/app/models/ext_management_system.rb#L420-L426) in ExtManagementSystem expect these to return an
association and as we can have NetworkManagers without a parent_manager (e.g. Nuage)
we must not delegate those methods

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1393675

@miq-bot add_labels bug, euwe/yes
@miq-bot assign Ladas

@Ladas please review