### PR TITLE
Chargeback calculation :: Filter rates by need

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -67,7 +67,7 @@ class Chargeback < ActsAsArModel
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
 
     rates.each do |rate|
-      rate.chargeback_rate_details.each do |r|
+      rate.rate_details_relevant_to(relevant_fields).each do |r|
         r.charge(relevant_fields, consumption).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = (self[field] || 0) + value
@@ -135,6 +135,6 @@ class Chargeback < ActsAsArModel
   private
 
   def relevant_fields
-    @relevant_fields ||= self.class.report_col_options.keys.to_set
+    @relevant_fields ||= (@options.report_cols || self.class.report_col_options.keys).to_set
   end
 end # class Chargeback

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -7,6 +7,7 @@ class Chargeback
     :owner,                # userid
     :tenant_id,
     :tag,                  # like /managed/environment/prod (Mutually exclusive with :user)
+    :report_cols,          # cols visible in the final report
     :provide_id,
     :entity_id,            # 1/2/3.../all rails id of entity
     :service_id,

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -25,6 +25,11 @@ class ChargebackRate < ApplicationRecord
 
   VALID_CB_RATE_TYPES = ["Compute", "Storage"]
 
+  def rate_details_relevant_to(report_cols)
+    # we can memoize, as we get the same report_cols thrrough the life of the object
+    @relevant ||= chargeback_rate_details.select { |r| r.affects_report_fields(report_cols) }
+  end
+
   def self.validate_rate_type(type)
     unless VALID_CB_RATE_TYPES.include?(type.to_s.capitalize)
       raise "Chargeback rate type '#{type}' is not supported"

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -140,7 +140,7 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def affects_report_fields(report_cols)
-    (metric_keys & report_cols).present? || ((cost_keys & report_cols).present? && !gratis?)
+    (metric_keys.to_set & report_cols).present? || ((cost_keys.to_set & report_cols).present? && !gratis?)
   end
 
   def rate_name

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -139,6 +139,10 @@ class ChargebackRateDetail < ApplicationRecord
     end
   end
 
+  def affects_report_fields(report_cols)
+    (metric_keys & report_cols).present? || ((cost_keys & report_cols).present? && !gratis?)
+  end
+
   def rate_name
     "#{group}_#{source}"
   end
@@ -211,6 +215,10 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   private
+
+  def gratis?
+    chargeback_tiers.all?(&:gratis?)
+  end
 
   def metric_keys
     ["#{rate_name}_metric", # metric value (e.g. Storage [Used|Allocated|Fixed])

--- a/app/models/chargeback_tier.rb
+++ b/app/models/chargeback_tier.rb
@@ -25,6 +25,10 @@ class ChargebackTier < ApplicationRecord
     finish == Float::INFINITY
   end
 
+  def gratis?
+    fixed_rate.zero? && variable_rate.zero?
+  end
+
   def continuity?
     is_continuous = start < finish
     errors.add(:finish, "value must be greater than start value.") unless is_continuous

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -194,7 +194,9 @@ module MiqReport::Generator
     if custom_results_method
       if klass.respond_to?(custom_results_method)
         # Use custom method in DB class to get report results if defined
-        results, ext = klass.send(custom_results_method, db_options[:options].merge(:userid => options[:userid], :ext_options => ext_options))
+        results, ext = klass.send(custom_results_method, db_options[:options].merge(:userid      => options[:userid],
+                                                                                    :ext_options => ext_options,
+                                                                                    :report_cols => cols))
       elsif self.respond_to?(custom_results_method)
         # Use custom method in MiqReport class to get report results if defined
         results, ext = send(custom_results_method, options)


### PR DESCRIPTION
Let's use only those ChargebackRateDetails that are needed by calculated report.

In the database we always store all the rate_details. This is first step to get away of them, first we stop using them for calculation, then we can drop them.

We need report_cols in the chargeback anyway, to properly implement charging per dynamic storage types.

As a side effect we will get performance boost.

@miq-bot add_label wip, chargeback, refactoring, euwe/no
@miq-bot assign @gtanzillo 