### PR TITLE
[EUWE] Isolate MiqSchedule ui attributes

### DIFF
--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -74,8 +74,7 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.object_request  = data.object_request;
         $scope.scheduleModel.target_class    = data.target_class;
         $scope.scheduleModel.target_id       = data.target_id;
-        $scope.scheduleModel.readonly        = data.readonly;
-        $scope.scheduleModel.attrs           = data.attrs;
+        $scope.scheduleModel.ui_attrs        = data.ui_attrs;
 
         $scope.setTimerType();
 
@@ -214,12 +213,11 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
         $scope.scheduleModel.instance_name   = data.instance_name;
         $scope.scheduleModel.object_message  = data.object_message;
         $scope.scheduleModel.object_request  = data.request;
-        $scope.scheduleModel.target_class    = data.object_class;
-        $scope.scheduleModel.target_id       = data.object_id;
-        $scope.scheduleModel.readonly        = data.readonly;
+        $scope.scheduleModel.target_class    = data.target_class;
+        $scope.scheduleModel.target_id       = data.target_id;
         $scope.scheduleModel.targets         = [];
         $scope.scheduleModel.filter_typ      = null;
-        $scope.scheduleModel.attrs           = data.attrs;
+        $scope.scheduleModel.ui_attrs        = data.ui_attrs;
         miqService.sparkleOff();
       });
     } else {

--- a/app/controllers/ops_controller/settings/automate_schedules.rb
+++ b/app/controllers/ops_controller/settings/automate_schedules.rb
@@ -12,9 +12,8 @@ module OpsController::Settings::AutomateSchedules
       :object_request  => automate_request[:object_request],
       :target_class    => automate_request[:object_class],
       :target_classes  => automate_request[:target_classes],
-      :target_id       => automate_request[:object_id],
-      :attrs           => automate_request[:attrs],
-      :readonly        => automate_request[:readonly]
+      :target_id       => automate_request[:target_id],
+      :ui_attrs        => automate_request[:ui_attrs]
     }
   end
 
@@ -34,7 +33,7 @@ module OpsController::Settings::AutomateSchedules
   def fetch_automate_request_vars(schedule)
     automate_request = {}
     # incase changing type of schedule
-    filter = schedule.filter && schedule.filter.kind_of?(Hash) ? schedule.filter : {:uri_parts => {}, :parameters => {}}
+    filter = prebuild_automate_schedule(schedule)
     filter[:parameters].symbolize_keys!
     automate_request[:starting_object] = filter[:uri_parts][:namespace] || "SYSTEM/PROCESS"
     matching_instances = MiqAeClass.find_distinct_instances_across_domains(current_user,
@@ -43,7 +42,7 @@ module OpsController::Settings::AutomateSchedules
     automate_request[:instance_name]  = filter[:parameters][:instance_name] || "Request"
     automate_request[:object_message] = filter[:parameters][:object_message] || "create"
     automate_request[:object_request] = filter[:parameters][:request] || ""
-    automate_request[:target_class]   = filter[:parameters][:object_class] || nil
+    automate_request[:target_class]   = filter[:ui][:ui_object][:target_class] || nil
     automate_request[:target_classes] = {}
     CustomButton.button_classes.each { |db| automate_request[:target_classes][db] = ui_lookup(:model => db) }
     automate_request[:target_classes] = Array(automate_request[:target_classes].invert).sort
@@ -51,17 +50,23 @@ module OpsController::Settings::AutomateSchedules
       targets = Rbac.filtered(automate_request[:target_class]).select(:id, :name)
       automate_request[:targets] = targets.sort_by { |t| t.name.downcase }.collect { |t| [t.name, t.id.to_s] }
     end
-    automate_request[:target_id]      = filter[:parameters][:object_id] || ""
-    automate_request[:readonly]       = filter[:parameters][:readonly] || true
-    automate_request[:attrs]          = filter[:parameters][:attrs] || []
+    automate_request[:target_id]      = filter[:ui][:ui_object][:target_id] || ""
+    automate_request[:ui_attrs]       = filter[:ui][:ui_attrs] || []
 
-    if automate_request[:attrs].empty?
-      AE_MAX_RESOLUTION_FIELDS.times { automate_request[:attrs].push([]) }
+    if automate_request[:ui_attrs].empty?
+      AE_MAX_RESOLUTION_FIELDS.times { automate_request[:ui_attrs].push([]) }
     else
       # add empty array if @resolve[:new][:attrs] length is less than AE_MAX_RESOLUTION_FIELDS
-      len = automate_request[:attrs].length
-      AE_MAX_RESOLUTION_FIELDS.times { automate_request[:attrs].push([]) if len < AE_MAX_RESOLUTION_FIELDS }
+      len = automate_request[:ui_attrs].length
+      AE_MAX_RESOLUTION_FIELDS.times { automate_request[:ui_attrs].push([]) if len < AE_MAX_RESOLUTION_FIELDS }
     end
     automate_request
+  end
+
+  def prebuild_automate_schedule(schedule)
+    schedule.filter && schedule.filter.kind_of?(Hash) ? schedule.filter : {:uri_parts  => {},
+                                                                           :ui         => { :ui_attrs  => [],
+                                                                                            :ui_object => {}},
+                                                                           :parameters => {}}
   end
 end

--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -23,9 +23,9 @@ module OpsController::Settings::Schedules
                   @selected_schedule.run_at[:tz] : session[:user_tz]
 
     if @selected_schedule.sched_action[:method] == 'automation_request'
-      params = @selected_schedule.filter[:parameters]
-      @object_class = ui_lookup(:model => params[:object_class])
-      @object_name = params[:object_class].constantize.find_by(:id => params[:object_id]).name if params[:object_class]
+      params = @selected_schedule.filter[:ui][:ui_object]
+      @object_class = ui_lookup(:model => params[:target_class])
+      @object_name = params[:target_class].constantize.find_by(:id => params[:target_id]).name if params[:target_class]
     end
 
     if @selected_schedule.filter.kind_of?(MiqExpression)
@@ -175,8 +175,7 @@ module OpsController::Settings::Schedules
         :target_classes  => automate_request[:target_classes],
         :targets         => automate_request[:targets],
         :target_id       => automate_request[:target_id],
-        :attrs           => automate_request[:attrs],
-        :readonly        => automate_request[:readonly],
+        :ui_attrs        => automate_request[:ui_attrs],
         :filter_type     => nil
       )
     end
@@ -500,12 +499,12 @@ module OpsController::Settings::Schedules
       uri_settings[:save] = true
       schedule.verify_file_depot(uri_settings)
     elsif params[:action_typ] == "automation_request"
-      attrs = []
+      ui_attrs = []
       AE_MAX_RESOLUTION_FIELDS.times do |i|
-        next unless params[:attrs] && params[:attrs][i.to_s]
-        attrs[i] = []
-        attrs[i][0] = params[:attrs][i.to_s][0]
-        attrs[i][1] = params[:attrs][i.to_s][1]
+        next unless params[:ui_attrs] && params[:ui_attrs][i.to_s]
+        ui_attrs[i] = []
+        ui_attrs[i][0] = params[:ui_attrs][i.to_s][0]
+        ui_attrs[i][1] = params[:ui_attrs][i.to_s][1]
       end
       schedule.filter = {
         :uri_parts  => {
@@ -513,14 +512,14 @@ module OpsController::Settings::Schedules
           :instance  => params[:instance_name],
           :message   => params[:object_message]
         },
+        :ui         => {:ui_attrs  => ui_attrs,
+                        :ui_object => {:target_class => params[:target_class].present? ? params[:target_class] : nil,
+                                       :target_id    => params[:target_id]}},
         :parameters => {
           :request        => params[:object_request],
           :instance_name  => params[:instance_name],
           :object_message => params[:object_message],
-          :attrs          => attrs,
-          :object_class   => params[:target_class] == "" ? nil : params[:target_class],
-          :object_id      => params[:target_id]
-        }.merge!(attrs.to_h)
+        }.merge!(ui_attrs.to_h).merge!(build_attrs_from_params(params))
       }
     elsif %w(global my).include?(params[:filter_typ])  # Search filter chosen, set up relationship
       schedule.filter     = nil  # Clear out existing filter expression
@@ -529,6 +528,13 @@ module OpsController::Settings::Schedules
       schedule.filter     = MiqExpression.new(build_search_filter_from_params)
       schedule.miq_search = nil if schedule.miq_search  # Clear out any search relationship
     end
+  end
+
+  def build_attrs_from_params(params)
+    return {} if params[:target_class].empty?
+    klass = params[:target_class].constantize
+    object = klass.find_by_id(params[:target_id])
+    { MiqAeEngine.create_automation_attribute_key(object).to_s => MiqAeEngine.create_automation_attribute_value(object) }
   end
 
   def build_search_filter_from_params

--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -27,7 +27,9 @@ class AutomationRequest < MiqRequest
     options[:class_name]    = (options.delete(:class) || DEFAULT_CLASS).strip.gsub(/(^\/|\/$)/, "")
     options[:instance_name] = (options.delete(:instance) || DEFAULT_INSTANCE).strip
 
+    object_parameters = parse_out_objects(parameters)
     attrs = MiqRequestWorkflow.parse_ws_string(parameters)
+    attrs.merge!(object_parameters)
 
     attrs[:userid]     = user.userid
     options[:user_id]  = user.id
@@ -43,6 +45,13 @@ class AutomationRequest < MiqRequest
     uri_parts.stringify_keys!
     parameters.stringify_keys!
     create_from_ws("1.1", user, uri_parts, parameters, approval)
+  end
+
+  def self.parse_out_objects(parameters)
+    object_hash = parameters.select { |key, _v| key.to_s.include?(MiqAeEngine::MiqAeObject::CLASS_SEPARATOR) }
+    object_hash.each do |key, _v|
+      parameters.delete(key)
+    end
   end
 
   def self.zone(options)

--- a/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
+++ b/app/views/layouts/angular-bootstrap/_ae_resolve_options.html.haml
@@ -75,16 +75,16 @@
 
   %div
     = _("Attribute/Value Pairs")
-    .form-group{"ng-repeat" => "key_val in scheduleModel.attrs track by $index"}
+    .form-group{"ng-repeat" => "key_val in scheduleModel.ui_attrs track by $index"}
       %label.col-md-2.control-label{"for" => "key_val"}
         {{$index+1}}
       .col-md-2
         %input.form-control{"type"        => "text",
                             "name"        => "attrs",
-                            "ng-model"    => "scheduleModel.attrs[$index][0]",
+                            "ng-model"    => "scheduleModel.ui_attrs[$index][0]",
                             "checkchange" => ""}
       .col-md-2
         %input.form-control{"type"        => "text",
                             "name"        => "attrs",
-                            "ng-model"    => "scheduleModel.attrs[$index][1]",
+                            "ng-model"    => "scheduleModel.ui_attrs[$index][1]",
                             "checkchange" => ""}

--- a/app/views/ops/_schedule_show.html.haml
+++ b/app/views/ops/_schedule_show.html.haml
@@ -77,24 +77,18 @@
             %p.form-control-static
               = h(@object_name)
 
-      %div
-        = _("Simulation Parameters")
-        .form-group
-          %label.col-md-2.control-label= _("Execute Methods")
-          .col-md-10
-            %p.form-control-static
-              = h(@selected_schedule.filter[:parameters][:readonly].to_s.titleize)
-      %div
-        = _("Attribute/Value Pairs")
-        - @selected_schedule.filter[:parameters][:attrs].each_with_index do |attr, i|
-          .form-group
-            %label.control-label.col-md-2
-              = (i + 1).to_s
-            - if attr
-              .col-md-2
-                = h(attr[0])
-              .col-md-2
-                = h(attr[1])
+      - if @selected_schedule.filter[:ui][:ui_attrs].present?
+        %div
+          = _("Attribute/Value Pairs")
+          - @selected_schedule.filter[:ui][:ui_attrs].each_with_index do |attr, i|
+            .form-group
+              %label.control-label.col-md-2
+                = (i + 1).to_s
+              - if attr
+                .col-md-2
+                  = h(attr[0])
+                .col-md-2
+                  = h(attr[1])
 
     - if @selected_schedule.sched_action[:method] != 'db_backup'
       %div

--- a/spec/factories/miq_schedule.rb
+++ b/spec/factories/miq_schedule.rb
@@ -20,7 +20,7 @@ FactoryGirl.define do
   factory :miq_automate_schedule, :class => :MiqSchedule do
     run_at = {:start_time   => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}}
     sched_action = {:method => "automation_request"}
-    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :parameters => {'request' => 'test_request', 'key1' => 'value1'}}
+    filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :ui => { :ui_attrs => [], :ui_object => {} }, :parameters => {'request' => 'test_request', 'key1' => 'value1'}}
     sequence(:name)     { |n| "automate_schedule_#{seq_padded_for_sorting(n)}" }
     description         "test_automation"
     towhat              "AutomationRequest"

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -601,8 +601,9 @@ describe('scheduleFormController', function() {
         request: 'test_request',
         instance_name: 'TestRequest',
         object_message: 'create',
-        object_class: 'test',
-        object_id:    '10',
+        target_class: 'test',
+        target_id:    '10',
+        ui_attrs:     [],
         uri: 'uri',
         uri_prefix: 'uriPrefix'
       };
@@ -619,8 +620,9 @@ describe('scheduleFormController', function() {
         expect($scope.scheduleModel.instance_name).toEqual(data.instance_name);
         expect($scope.scheduleModel.object_message).toEqual(data.object_message);
         expect($scope.scheduleModel.object_request).toEqual(data.request);
-        expect($scope.scheduleModel.target_class).toEqual(data.object_class);
-        expect($scope.scheduleModel.target_id).toEqual(data.object_id);
+        expect($scope.scheduleModel.target_class).toEqual(data.target_class);
+        expect($scope.scheduleModel.ui_attrs).toEqual(data.ui_attrs);
+        expect($scope.scheduleModel.target_id).toEqual(data.target_id);
       });
     });
 


### PR DESCRIPTION
Euwe Backport of #12722 

`AutomateRequest.create_from_ws` was downcasing and symbolizing MiqSchedule objects that were passed in via the `filter[:parameters] hash`.

This PR isolates all Ui attributes into their own `[:ui]` hash structure and modifies how `AutomateRequest.create_from_ws` parses objects in the `[:parameters]` hash.

e.g. Any key including `MiqAeEngine::MiqAeObject::CLASS_SEPARATOR` is isolated away from the other parameters and merged back in after calling `MiqRequestWorkflow.parse_ws_string(parameters)`

Links

PT #134531729
https://bugzilla.redhat.com/show_bug.cgi?id=1391979
Steps for Testing/QA

Build a Scheduled Automate Job with Type and Selection of Object Attributes filled in.
Run the scheduled job and verify the job runs with the expected Object Attributes

<img width="1008" alt="manageiq_pr_image" src="https://cloud.githubusercontent.com/assets/697347/20683288/63627814-b579-11e6-8cb5-8169896cf7aa.png">

