### PR TITLE
Fixed selectpicker directive to apply initialization irrespective of the model value

### DIFF
--- a/app/assets/javascripts/directives/selectpickerForSelectTag.js
+++ b/app/assets/javascripts/directives/selectpickerForSelectTag.js
@@ -5,15 +5,15 @@ ManageIQ.angular.app.directive('selectpickerForSelectTag', function() {
       scope['form_' + ctrl.$name] = elem[0];
 
       scope.$watch(attr.ngModel, function() {
-        $(scope['form_' + ctrl.$name]).selectpicker({
-          dropupAuto: false
+        angular.element(scope['form_' + ctrl.$name]).selectpicker({
+          dropupAuto: false,
         });
-        $(scope['form_' + ctrl.$name]).selectpicker('show');
-        $(scope['form_' + ctrl.$name]).selectpicker('refresh');
-        $(scope['form_' + ctrl.$name]).addClass('span12').selectpicker('setStyle');
+        angular.element(scope['form_' + ctrl.$name]).selectpicker('show');
+        angular.element(scope['form_' + ctrl.$name]).selectpicker('refresh');
+        angular.element(scope['form_' + ctrl.$name]).addClass('span12').selectpicker('setStyle');
       });
       scope.$watch('loaded.bs.select', function() {
-        $('.bootstrap-select button').removeAttr('title');
+        angular.element('.bootstrap-select button').removeAttr('title');
       });
 
       scope.$on('$destroy', function () {

--- a/app/assets/javascripts/directives/selectpickerForSelectTag.js
+++ b/app/assets/javascripts/directives/selectpickerForSelectTag.js
@@ -5,14 +5,12 @@ ManageIQ.angular.app.directive('selectpickerForSelectTag', function() {
       scope['form_' + ctrl.$name] = elem[0];
 
       scope.$watch(attr.ngModel, function() {
-        if((ctrl.$modelValue != undefined)) {
-          $(scope['form_' + ctrl.$name]).selectpicker({
-            dropupAuto: false
-          });
-          $(scope['form_' + ctrl.$name]).selectpicker('show');
-          $(scope['form_' + ctrl.$name]).selectpicker('refresh');
-          $(scope['form_' + ctrl.$name]).addClass('span12').selectpicker('setStyle');
-        }
+        $(scope['form_' + ctrl.$name]).selectpicker({
+          dropupAuto: false
+        });
+        $(scope['form_' + ctrl.$name]).selectpicker('show');
+        $(scope['form_' + ctrl.$name]).selectpicker('refresh');
+        $(scope['form_' + ctrl.$name]).addClass('span12').selectpicker('setStyle');
       });
       scope.$watch('loaded.bs.select', function() {
         $('.bootstrap-select button').removeAttr('title');

--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -1,4 +1,4 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Attach Volume')

--- a/app/views/cloud_volume/attach.html.haml
+++ b/app/views/cloud_volume/attach.html.haml
@@ -3,14 +3,14 @@
   %h3
     = _('Attach Volume')
   .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
+    .form-group{"ng-class" => "{'has-error': angularForm.vm_id.$invalid}"}
+      %label.col-md-2.control-label{"for" => "vm_id"}
         = _('Instance')
       .col-md-8
         = select_tag("vm_id",
-                      options_for_select(@vm_choices.sort),
+                      options_for_select([["<#{_('Choose')}>", nil]] + @vm_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
                       "ng-model"                    => "cloudVolumeModel.vm_id",
-                      :miqrequired                  => true,
+                      "required"                    => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
     .form-group

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -1,4 +1,4 @@
-%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController"}
+%form#form_div{:name => "angularForm", 'ng-controller' => "cloudVolumeFormController", "ng-cloak" => ""}
   = render :partial => "layouts/flash_msg"
   %h3
     = _('Detach Volume')

--- a/app/views/cloud_volume/detach.html.haml
+++ b/app/views/cloud_volume/detach.html.haml
@@ -3,14 +3,14 @@
   %h3
     = _('Detach Volume')
   .form-horizontal
-    .form-group
-      %label.col-md-2.control-label
+    .form-group{"ng-class" => "{'has-error': angularForm.vm_id.$invalid}"}
+      %label.col-md-2.control-label{"for" => "vm_id"}
         = _('Instance')
       .col-md-8
         = select_tag("vm_id",
-                      options_for_select(@vm_choices.sort),
+                      options_for_select([["<#{_('Choose')}>", nil]] + @vm_choices.sort, disabled: ["<#{_('Choose')}>", nil]),
                       "ng-model"                    => "cloudVolumeModel.vm_id",
-                      :miqrequired                  => true,
+                      "required"                    => true,
                       :checkchange                  => true,
                       "selectpicker-for-select-tag" => "")
 


### PR DESCRIPTION
Fixed `selectpicker-for-select-tag` directive to apply initialization irrespective of the model value.
Other than that, also added `"<Choose>"` as the first element in the selectpicker. 
Adding `"<Choose>"` will guarantee a localized `"<Choose>"` as opposed to an unlocalized `"Nothing selected"` which is PF's default string when nothing in the dropdown is selected.

Fixes #12840

Before:
<img width="1424" alt="screen shot 2016-11-28 at 12 11 08 pm" src="https://cloud.githubusercontent.com/assets/1538216/20684722/1105af68-b566-11e6-9516-f2cfaddffd40.png">

After (with fix to only the selectpicker directive):
<img width="1419" alt="screen shot 2016-11-28 at 12 10 07 pm" src="https://cloud.githubusercontent.com/assets/1538216/20684748/320224a8-b566-11e6-8922-727f73d9532a.png">

After (the final version, guarantees a localized `"<Choose>"`):
<img width="1420" alt="screen shot 2016-11-28 at 12 09 12 pm" src="https://cloud.githubusercontent.com/assets/1538216/20684763/440f4252-b566-11e6-8805-12eb9703f294.png">



