### PR TITLE
Updating API versioning to 2.4.0-pre

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -3,12 +3,12 @@
   :module: api
   :name: API
   :description: REST API
-  :version: '2.3.0'
+  :version: '2.4.0-pre'
 :version:
   :regex: !ruby/regexp /^v[0-9]+(?>\\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?/
   :definitions:
-  - :name: '2.3.0'
-    :ident: 'v2.3.0'
+  - :name: '2.4.0-pre'
+    :ident: 'v2.4.0-pre'
 :verb:
   :names:
   - :get

--- a/tools/rest_api.rb
+++ b/tools/rest_api.rb
@@ -19,7 +19,7 @@ require 'faraday'
 require 'faraday_middleware'
 
 class RestApi
-  VERSION = "2.3.0-pre".freeze
+  VERSION = "2.4.0-pre".freeze
   API_CMD = File.basename($PROGRAM_NAME)
 
   class Cli


### PR DESCRIPTION

With the F-release related API enhancements made, we need to identify the API as such as compared to the Euwe release of the v2.3.0 API.