### PR TITLE
Add test for fuzzy matching on strings with /'s in API

### DIFF
--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -413,6 +413,22 @@ describe "Querying" do
       expect(response.parsed_body).to include_error_with_message("Filtering is not supported on vms subcollection")
       expect(response).to have_http_status(:bad_request)
     end
+
+    it "can do fuzzy matching on strings with forward slashes" do
+      tag_1 = FactoryGirl.create(:tag, :name => "/managed/foo")
+      _tag_2 = FactoryGirl.create(:tag, :name => "/managed/bar")
+      api_basic_authorize collection_action_identifier(:tags, :read, :get)
+
+      run_get(tags_url, :filter => ["name='*/foo'"])
+
+      expected = {
+        "count"     => 2,
+        "subcount"  => 1,
+        "resources" => [{"href" => a_string_matching(tags_url(tag_1.id))}]
+      }
+      expect(response.parsed_body).to include(expected)
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "Querying vm attributes" do


### PR DESCRIPTION
This revision originally started life as a workaround, which lead to the
discovery of CVE-2016-7040. Since
https://github.com/ManageIQ/manageiq/pull/12822, which addressed the
security issues, has obviated the need for a workaround on the API side,
this revision serves only to prove that this feature of the API works
properly, preventing future regressions.

Closes https://github.com/ManageIQ/manageiq/issues/11035

Thanks to @rberecka who originally paired with me on this issue!

@miq-bot add-label api, test
@miq-bot assign @abellotti 