### PR TITLE
[darga] Revert name of AutomationSpecHelper

### DIFF
--- a/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
+++ b/spec/views/miq_ae_class/_class_fields.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe "miq_ae_class/_class_fields.html.haml" do
-  include Spec::Support::AutomationHelper
+  include AutomationSpecHelper
 
   context 'display class fields' do
     before do


### PR DESCRIPTION
Upstream constant name found its way back to Darga. This reverts name back to Darga version.

@chessbyte This should make Darga vmdb tests run again.