### PR TITLE
Respond 400 if filtering is unsupported

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -165,6 +165,9 @@ module Api
         miq_expression = filter_param(klass)
 
         if miq_expression
+          if is_subcollection && !res.respond_to?(:where)
+            raise BadRequestError, "Filtering is not supported on #{type} subcollection"
+          end
           sql, _, attrs = miq_expression.to_sql
           res = res.where(sql) if attrs[:supported_by_sql]
         end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -402,6 +402,17 @@ describe "Querying" do
       expect(response.parsed_body).to include_error_with_message("Bad format for datetime: foobar")
       expect(response).to have_http_status(:bad_request)
     end
+
+    it "does not support filtering vms as a subcollection" do
+      service = FactoryGirl.create(:service)
+      service << FactoryGirl.create(:vm_vmware, :name => "foo")
+      service << FactoryGirl.create(:vm_vmware, :name => "bar")
+
+      run_get("#{services_url(service.id)}/vms", :filter => ["name=foo"])
+
+      expect(response.parsed_body).to include_error_with_message("Filtering is not supported on vms subcollection")
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "Querying vm attributes" do


### PR DESCRIPTION
With certain subcollections (e.g. vms) the object returned is an array,
not a relation. That means we can't tack on additional scopes as we do
when filtering. Since we can't easily enforce returning relations for
all subcollections, the best we can do is to return a 400 instead of a
500, indicating that filtering is not supported for affected
subcollections.

@miq-bot add-label api, bug
@miq-bot assign @abellotti 