### PR TITLE
[DARGA] Fix display of OS info

### DIFF
--- a/app/helpers/vm_cloud_helper/textual_summary.rb
+++ b/app/helpers/vm_cloud_helper/textual_summary.rb
@@ -98,15 +98,21 @@ module VmCloudHelper::TextualSummary
 
   def textual_osinfo
     h = {:label => _("Operating System")}
-    os = @record.operating_system.nil? ? nil : @record.operating_system.product_name
-    if os.blank?
-      h[:value] = _("Unknown")
+    product_name = @record.product_name
+    if product_name.blank?
+      os_image_name = @record.os_image_name
+      if os_image_name.blank?
+        h[:value] = _("Unknown")
+      else
+        h[:image] = "os-#{os_image_name.downcase}"
+        h[:value] = os_image_name
+      end
     else
       h[:image] = "os-#{@record.os_image_name.downcase}"
-      h[:value] = os
+      h[:value] = product_name
       h[:title] = _("Show OS container information")
       h[:explorer] = true
-      h[:link]  = url_for(:action => 'show', :id => @record, :display => 'os_info')
+      h[:link] = url_for(:action => 'show', :id => @record, :display => 'os_info')
     end
     h
   end


### PR DESCRIPTION
This is a Darga version of this fix: https://github.com/ManageIQ/manageiq/pull/12677

A cloud instance quadicon might show the OS as being linux, but the detail page might display "unknown" for the address.

**Before**

![screen shot 2016-11-29 at 2 03 44 pm](https://cloud.githubusercontent.com/assets/39493/20731443/4c36f400-b63f-11e6-85c3-76cb0b0fcd11.png)

![screen shot 2016-11-29 at 2 04 03 pm](https://cloud.githubusercontent.com/assets/39493/20731452/53181556-b63f-11e6-8855-61c2dd463652.png)

**After**

![screen shot 2016-11-29 at 2 11 30 pm](https://cloud.githubusercontent.com/assets/39493/20731459/5ba1f78c-b63f-11e6-94ab-8bfcb9620516.png)


Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1396264

/cc @dclarizio 