### PR TITLE
Extract RequestParser service from RequestsController

### DIFF
--- a/lib/services/api/request_parser.rb
+++ b/lib/services/api/request_parser.rb
@@ -1,0 +1,24 @@
+module Api
+  class RequestParser
+    def self.parse_user(data)
+      user_name = Hash(data).fetch_path("requester", "user_name")
+      return if user_name.blank?
+      user = User.lookup_by_identity(user_name)
+      raise BadRequestError, "Unknown requester user_name #{user_name} specified" unless user
+      user
+    end
+
+    def self.parse_options(data)
+      raise BadRequestError, "Request is missing options" if data["options"].blank?
+      data["options"].symbolize_keys
+    end
+
+    def self.parse_auto_approve(data)
+      case data["auto_approve"]
+      when TrueClass, "true" then true
+      when FalseClass, "false", nil then false
+      else raise BadRequestError, "Invalid requester auto_approve value #{data["auto_approve"]} specified"
+      end
+    end
+  end
+end

--- a/spec/lib/services/api/request_parser_spec.rb
+++ b/spec/lib/services/api/request_parser_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe Api::RequestParser do
+  describe ".parse_user" do
+    it "returns nil if no username is provided" do
+      expect(described_class.parse_user({})).to be_nil
+    end
+
+    it "returns the user identified with the username" do
+      username = "foo"
+      user = instance_double(User)
+      allow(User).to receive(:lookup_by_identity).with(username).and_return(user)
+
+      actual = described_class.parse_user("requester" => {"user_name" => username})
+
+      expect(actual).to eq(user)
+    end
+
+    it "raises if the user cannot be found" do
+      allow(User).to receive(:lookup_by_identity).and_return(nil)
+
+      expect do
+        described_class.parse_user("requester" => {"user_name" => "foo"})
+      end.to raise_error(Api::BadRequestError, /unknown requester/i)
+    end
+  end
+
+  describe ".parse_options" do
+    it "raises if there are no options" do
+      expect { described_class.parse_options({}) }.to raise_error(Api::BadRequestError, /missing options/)
+    end
+
+    it "symbolizes keys" do
+      actual = described_class.parse_options("options" => {"foo" => "bar"})
+      expected = {:foo => "bar"}
+      expect(actual).to eq(expected)
+    end
+  end
+
+  describe ".parse_auto_approve" do
+    it "returns true if true" do
+      expect(described_class.parse_auto_approve("auto_approve" => true)).to be true
+    end
+
+    it "returns true if 'true'" do
+      expect(described_class.parse_auto_approve("auto_approve" => "true")).to be true
+    end
+
+    it "returns false if false" do
+      expect(described_class.parse_auto_approve("auto_approve" => false)).to be false
+    end
+
+    it "returns false if 'false'" do
+      expect(described_class.parse_auto_approve("auto_approve" => "false")).to be false
+    end
+
+    it "returns false if nil" do
+      expect(described_class.parse_auto_approve({})).to be false
+    end
+
+    it "raises if anything else" do
+      expect do
+        described_class.parse_auto_approve("auto_approve" => "foo")
+      end.to raise_error(Api::BadRequestError, /invalid requester auto_approve value/i)
+    end
+  end
+end


### PR DESCRIPTION
The need for this came out of conversations with @jntullo who needs a way to share code between the requests controller and the service requests controller. Historically (esp with the API) we've shared code using concerns/mixins, but I'm proposing a new way to do this here - extracting services. I personally like this approach because I was able to add some very fine grain (and fast) isolated tests - I was able to detect and fix a regression I introduced in refactoring that was otherwise untested. :tada: 

@jntullo LMK if this meets your needs!
@miq-bot add-label api, refactoring
@miq-bot assign @abellotti 

