### PR TITLE
Explicitly disable cloning for templates.

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/template.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/template.rb
@@ -7,6 +7,8 @@ class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Provide
     end
   end
 
+  supports_not :clone, :reason => 'Cloning templates is not supported for SCVMM'
+
   def proxies4job(_job = nil)
     {
       :proxies => [MiqServer.my_server],

--- a/app/models/manageiq/providers/microsoft/infra_manager/template.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/template.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Provide
     end
   end
 
-  supports_not :clone, :reason => 'Cloning templates is not supported for SCVMM'
+  supports_not :clone
 
   def proxies4job(_job = nil)
     {


### PR DESCRIPTION
This explicitly removes support for cloning for SCVMM templates. Instead of an internal error and a blank page, it will display "Clone does not apply to at least one of the selected items".

https://bugzilla.redhat.com/show_bug.cgi?id=1395742