### PR TITLE
Use relations and scopes for ems and miq servers

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -34,7 +34,7 @@ class EmsCluster < ApplicationRecord
 
   virtual_has_many :storages,       :uses => {:hosts => :storages}
   virtual_has_many :resource_pools, :uses => :all_relationships
-  virtual_has_many :failover_hosts, :uses => :hosts
+  has_many :failover_hosts, -> { failover }, :class_name => "Host"
 
   virtual_has_many :base_storage_extents, :class_name => "CimStorageExtent"
   virtual_has_many :storage_systems,      :class_name => "CimComputerSystem"
@@ -118,15 +118,6 @@ class EmsCluster < ApplicationRecord
   alias_method :all_vm_ids,             :vm_ids
   alias_method :all_miq_templates,      :miq_templates
   alias_method :all_miq_template_ids,   :miq_template_ids
-
-  # Host relationship methods
-  def failover_hosts(_options = {})
-    hosts.select(&:failover)
-  end
-
-  def failover_host_ids
-    failover_hosts.collect(&:id)
-  end
 
   # Direct Vm relationship methods
   def direct_vm_rels

--- a/app/models/ems_cluster/capacity_planning.rb
+++ b/app/models/ems_cluster/capacity_planning.rb
@@ -130,7 +130,7 @@ module EmsCluster::CapacityPlanning
   def capacity_failover_host_resources(profile, resource)
     return 0 if capacity_failover_rule == 'none' || (capacity_failover_rule == 'discovered' && !self.ha_enabled?)
 
-    if failover_hosts.length > 0
+    if failover_hosts.size > 0
       capacity_failover_host_resources_with_failover_hosts(profile, resource)
     else
       # TODO: Support the other ways to specify failover

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -32,6 +32,8 @@ class ExtManagementSystem < ApplicationRecord
   has_many :endpoints, :as => :resource, :dependent => :destroy, :autosave => true
 
   has_many :hosts, :foreign_key => "ems_id", :dependent => :nullify, :inverse_of => :ext_management_system
+  has_many :non_clustered_hosts, -> { non_clustered }, :class_name => "Host", :foreign_key => "ems_id"
+  has_many :clustered_hosts, -> { clustered }, :class_name => "Host", :foreign_key => "ems_id"
   has_many :vms_and_templates, :foreign_key => "ems_id", :dependent => :nullify,
            :class_name => "VmOrTemplate", :inverse_of => :ext_management_system
   has_many :miq_templates,     :foreign_key => :ems_id, :inverse_of => :ext_management_system
@@ -415,14 +417,6 @@ class ExtManagementSystem < ApplicationRecord
     inputs[:vm]   = target if target.kind_of?(Vm)
     inputs[:host] = target if target.kind_of?(Host)
     MiqEvent.raise_evm_event(target, event, inputs)
-  end
-
-  def non_clustered_hosts
-    hosts.where(:ems_cluster_id => nil)
-  end
-
-  def clustered_hosts
-    hosts.where.not(:ems_cluster_id => nil)
   end
 
   alias_method :all_storages,           :storages

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -191,6 +191,14 @@ class Host < ApplicationRecord
     true
   end
 
+  def self.non_clustered
+    where(:ems_cluster_id => nil)
+  end
+
+  def self.clustered
+    where.not(:ems_cluster_id => nil)
+  end
+
   def authentication_check_role
     'smartstate'
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -199,6 +199,10 @@ class Host < ApplicationRecord
     where.not(:ems_cluster_id => nil)
   end
 
+  def self.failover
+    where(:failover => true)
+  end
+
   def authentication_check_role
     'smartstate'
   end

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -19,12 +19,11 @@ module ManageIQ::Providers
     has_many :container_build_pods, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_templates, :foreign_key => :ems_id, :dependent => :destroy
     has_one :container_deployment, :foreign_key => :deployed_ems_id, :inverse_of => :deployed_ems
+    has_many :computer_systems, :through => :container_nodes
 
     # required by aggregate_hardware
-    def all_computer_system_ids
-      MiqPreloader.preload(container_nodes, :computer_system)
-      container_nodes.collect { |n| n.computer_system.id }
-    end
+    alias :all_computer_systems :computer_systems
+    alias :all_computer_system_ids :computer_system_ids
 
     def aggregate_cpu_total_cores(targets = nil)
       aggregate_hardware(:computer_systems, :cpu_total_cores, targets)

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -15,7 +15,9 @@ class Zone < ApplicationRecord
   has_many :ldap_regions
   has_many :providers
 
-  virtual_has_many :hosts,              :uses => {:ext_management_systems => :hosts}
+  has_many :hosts,               :through => :ext_management_systems
+  has_many :clustered_hosts,     :through => :ext_management_systems
+  has_many :non_clustered_hosts, :through => :ext_management_systems
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
   virtual_has_many :vms_and_templates,  :uses => {:ext_management_systems => :vms_and_templates}
 
@@ -120,16 +122,6 @@ class Zone < ApplicationRecord
 
   def self.hosts_without_a_zone
     Host.where(:ems_id => nil).to_a
-  end
-
-  def non_clustered_hosts
-    MiqPreloader.preload(self, :ext_management_systems => :hosts)
-    ext_management_systems.flat_map(&:non_clustered_hosts)
-  end
-
-  def clustered_hosts
-    MiqPreloader.preload(self, :ext_management_systems => :hosts)
-    ext_management_systems.flat_map(&:clustered_hosts)
   end
 
   def ems_clusters

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -18,8 +18,11 @@ class Zone < ApplicationRecord
   has_many :hosts,               :through => :ext_management_systems
   has_many :clustered_hosts,     :through => :ext_management_systems
   has_many :non_clustered_hosts, :through => :ext_management_systems
+  has_many :vms_and_templates,   :through => :ext_management_systems
+  has_many :vms,                 :through => :ext_management_systems
+  has_many :miq_templates,       :through => :ext_management_systems
+  has_many :ems_clusters,        :through => :ext_management_systems
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
-  virtual_has_many :vms_and_templates,  :uses => {:ext_management_systems => :vms_and_templates}
 
   before_destroy :check_zone_in_use_on_destroy
   after_save     :queue_ntp_reload_if_changed
@@ -111,22 +114,8 @@ class Zone < ApplicationRecord
     miq_servers.any? { |s| s.log_collection_active_recently?(since) }
   end
 
-  def host_ids
-    hosts.collect(&:id)
-  end
-
-  def hosts
-    MiqPreloader.preload(self, :ext_management_systems => :hosts)
-    ext_management_systems.flat_map(&:hosts)
-  end
-
   def self.hosts_without_a_zone
     Host.where(:ems_id => nil).to_a
-  end
-
-  def ems_clusters
-    MiqPreloader.preload(self, :ext_management_systems => :ems_clusters)
-    ext_management_systems.flat_map(&:ems_clusters)
   end
 
   def self.clusters_without_a_zone
@@ -170,35 +159,8 @@ class Zone < ApplicationRecord
     ems_clouds.flat_map(&:availability_zones)
   end
 
-  def vms_and_templates
-    MiqPreloader.preload(self, :ext_management_systems => :vms_and_templates)
-    ext_management_systems.flat_map(&:vms_and_templates)
-  end
-
-  def vms
-    MiqPreloader.preload(self, :ext_management_systems => :vms)
-    ext_management_systems.flat_map(&:vms)
-  end
-
   def self.vms_without_a_zone
     Vm.where(:ems_id => nil).to_a
-  end
-
-  def miq_templates
-    MiqPreloader.preload(self, :ext_management_systems => :miq_templates)
-    ext_management_systems.flat_map(&:miq_templates)
-  end
-
-  def vm_or_template_ids
-    vms_and_templates.collect(&:id)
-  end
-
-  def vm_ids
-    vms.collect(&:id)
-  end
-
-  def miq_template_ids
-    miq_templates.collect(&:id)
   end
 
   def storages

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -600,4 +600,26 @@ describe Host do
       end
     end
   end
+
+  describe ".clustered" do
+    let(:host_with_cluster) { FactoryGirl.create(:host, :ems_cluster => FactoryGirl.create(:ems_cluster)) }
+    let(:host) { FactoryGirl.create(:host) }
+
+    it "detects clustered hosts" do
+      host_with_cluster ; host
+
+      expect(Host.clustered).to eq([host_with_cluster])
+    end
+  end
+
+  describe ".non_clustered" do
+    let(:host_with_cluster) { FactoryGirl.create(:host, :ems_cluster => FactoryGirl.create(:ems_cluster)) }
+    let(:host) { FactoryGirl.create(:host) }
+
+    it "detects non_clustered hosts" do
+      host_with_cluster ; host
+
+      expect(Host.non_clustered).to eq([host])
+    end
+  end
 end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -62,6 +62,34 @@ describe Zone do
     end
   end
 
+  describe "#clustered_hosts" do
+    let(:zone) { FactoryGirl.create(:zone) }
+    let(:ems) { FactoryGirl.create(:ems_vmware, :zone => zone) }
+    let(:cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => ems)}
+    let(:host_with_cluster) { FactoryGirl.create(:host, :ext_management_system => ems, :ems_cluster => cluster) }
+    let(:host) { FactoryGirl.create(:host, :ext_management_system => ems) }
+
+    it "returns clustered hosts" do
+      host ; host_with_cluster
+
+      expect(zone.clustered_hosts).to eq([host_with_cluster])
+    end
+  end
+
+  describe "#non_clustered_hosts" do
+    let(:zone) { FactoryGirl.create(:zone) }
+    let(:ems) { FactoryGirl.create(:ems_vmware, :zone => zone) }
+    let(:cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => ems)}
+    let(:host_with_cluster) { FactoryGirl.create(:host, :ext_management_system => ems, :ems_cluster => cluster) }
+    let(:host) { FactoryGirl.create(:host, :ext_management_system => ems) }
+
+    it "returns clustered hosts" do
+      host ; host_with_cluster
+
+      expect(zone.non_clustered_hosts).to eq([host])
+    end
+  end
+
   context ".determine_queue_zone" do
     subject           { described_class }
 


### PR DESCRIPTION
extracted from #12427

The goal is to move from virtual attributes and methods to relations and scopes

This allows us to delegate across the relations and avoid downloading data when we simply want to count.

I did not check test coverage.

You can find general numbers in the related PR