### PR TITLE
Remove incorrect virtual_attribute uses

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -27,10 +27,10 @@ class EmsCluster < ApplicationRecord
   virtual_column :v_parent_datacenter, :type => :string,  :uses => :all_relationships
   virtual_column :v_qualified_desc,    :type => :string,  :uses => :all_relationships
   virtual_column :last_scan_on,        :type => :time,    :uses => :last_drift_state_timestamp
-  virtual_total  :total_vms,           :vms,              :uses => :all_relationships
-  virtual_total  :total_miq_templates, :miq_templates,    :uses => :all_relationships
-  virtual_total  :total_vms_and_templates, :vms_and_templates, :uses => :all_relationships
-  virtual_total  :total_hosts,         :hosts,            :uses => :all_relationships
+  virtual_total  :total_vms,               :vms
+  virtual_total  :total_miq_templates,     :miq_templates
+  virtual_total  :total_vms_and_templates, :vms_and_templates
+  virtual_total  :total_hosts,             :hosts
 
   virtual_has_many :storages,       :uses => {:hosts => :storages}
   virtual_has_many :resource_pools, :uses => :all_relationships

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -13,9 +13,9 @@ class MiqRegion < ApplicationRecord
   virtual_has_many :miq_servers,            :class_name => "MiqServer"
   virtual_has_many :active_miq_servers,     :class_name => "MiqServer"
 
-  virtual_has_many :vms_and_templates,      :uses => :all_relationships
-  virtual_has_many :miq_templates,          :uses => :all_relationships
-  virtual_has_many :vms,                    :uses => :all_relationships
+  virtual_has_many :vms_and_templates
+  virtual_has_many :miq_templates
+  virtual_has_many :vms
 
   after_save :clear_my_region_cache
 

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -54,6 +54,9 @@ describe EmsCluster do
 
     it('ResourcePool#v_direct_miq_templates') { expect(@rp1.v_direct_vms).to eq(1) }
     it('ResourcePool#v_total_miq_templates')  { expect(@rp1.v_total_vms).to eq(2) }
+    it('#hosts') { expect(@cluster.hosts).to match_array [@host1, @host2] }
+    it('#all_hosts') { expect(@cluster.all_hosts).to match_array [@host1, @host2] }
+    it('#total_hosts') { expect(@cluster.total_hosts).to eq(2) }
   end
 
   context("RedHat") do
@@ -106,6 +109,9 @@ describe EmsCluster do
     it('#all_miq_templates')    { expect(@cluster.all_miq_templates).to    match_array [@template1, @template2] }
     it('#all_miq_template_ids') { expect(@cluster.all_miq_template_ids).to match_array [@template1.id, @template2.id] }
     it('#total_miq_templates')  { expect(@cluster.total_miq_templates).to eq(2) }
+    it('#hosts')                { expect(@cluster.hosts).to match_array [@host1, @host2] }
+    it('#all_hosts')            { expect(@cluster.all_hosts).to match_array [@host1, @host2] }
+    it('#total_hosts')          { expect(@cluster.total_hosts).to eq(2) }
   end
 
   it "#save_drift_state" do


### PR DESCRIPTION
extracted from #12427

- Ems cluster `vms` is a regular relation, it is not dependent upon `:all_relationships`.
- MiqRegion did properly note that `vms` is a virtual collection, but it is not based upon `all_relationships`.

@jrafanie I assigned to you because the original PR was assigned to you. If you want to pass onto someone else (i.e.: GT/Jason), feel free.