### PR TITLE
use delegate for cpu_total_cores / cpu_cores_per_socket

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -157,8 +157,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :num_hard_disks,                       :type => :integer,    :uses => {:hardware => :hard_disks}
   virtual_column :num_disks,                            :type => :integer,    :uses => {:hardware => :disks}
   virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
-  virtual_column :cpu_total_cores,                      :type => :integer,    :uses => :hardware
-  virtual_column :cpu_cores_per_socket,                 :type => :integer,    :uses => :hardware
+  virtual_delegate :cpu_total_cores, :cpu_cores_per_socket, :to => :hardware, :allow_nil => true, :default => 0
   virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
@@ -1570,14 +1569,6 @@ class VmOrTemplate < ApplicationRecord
 
   def num_cpu
     hardware.nil? ? 0 : hardware.cpu_sockets
-  end
-
-  def cpu_total_cores
-    hardware.nil? ? 0 : hardware.cpu_total_cores
-  end
-
-  def cpu_cores_per_socket
-    hardware.nil? ? 0 : hardware.cpu_cores_per_socket
   end
 
   def num_disks

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -740,6 +740,40 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".cpu_total_cores" do
+    let(:vm) { FactoryGirl.create(:vm) }
+    it "handles no hardware" do
+      expect(vm.cpu_total_cores).to eq(0)
+    end
+
+    it "handles hardware" do
+      FactoryGirl.create(:hardware, :vm => vm, :cpu_total_cores => 8)
+      expect(vm.cpu_total_cores).to eq(8)
+    end
+
+    it "calculates in the database" do
+      FactoryGirl.create(:hardware, :vm => vm, :cpu_total_cores => 8)
+      expect(virtual_column_sql_value(VmOrTemplate, "cpu_total_cores")).to eq(8)
+    end
+  end
+
+  describe ".cpu_cores_per_socket" do
+    let(:vm) { FactoryGirl.create(:vm) }
+    it "handles no hardware" do
+      expect(vm.cpu_cores_per_socket).to eq(0)
+    end
+
+    it "handles hardware" do
+      FactoryGirl.create(:hardware, :vm => vm, :cpu_cores_per_socket => 4)
+      expect(vm.cpu_cores_per_socket).to eq(4)
+    end
+
+    it "calculates in the database" do
+      FactoryGirl.create(:hardware, :vm => vm, :cpu_cores_per_socket => 4)
+      expect(virtual_column_sql_value(VmOrTemplate, "cpu_cores_per_socket")).to eq(4)
+    end
+  end
+
   describe "#disconnect_ems" do
     let(:ems) { FactoryGirl.build(:ext_management_system) }
     let(:vm) do


### PR DESCRIPTION
The goal is to calculate columns like `aggressive_vcpus_recommended_change_pct` in the database.

These columns are calculated from `cpu_total_cores` among others.
Using a delegate here will define the arel for us so it can be a virtual attribute with sql.

(The final solution still requires all the other columns be converted to arel as well...)

related to #12733 

https://bugzilla.redhat.com/show_bug.cgi?id=1395743
/cc @NickLaMuro FYI