### PR TITLE
Force unique endpoint hostname only for same type

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -71,10 +71,11 @@ class ExtManagementSystem < ApplicationRecord
   def hostname_uniqueness_valid?
     return unless hostname_required?
     return unless hostname.present? # Presence is checked elsewhere
+    # check uniqueness per provider type
 
-    existing_hostnames = Endpoint.where.not(:resource_id => id).pluck(:hostname).compact.map(&:downcase)
+    existing_hostnames = (self.class.all - [self]).map(&:hostname).compact.map(&:downcase)
 
-    errors.add(:hostname, "has already been taken") if existing_hostnames.include?(hostname.downcase)
+    errors.add(:hostname, N_("has to be unique per provider type")) if existing_hostnames.include?(hostname.downcase)
   end
 
   include NewWithTypeStiMixin

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -355,10 +355,15 @@ describe ExtManagementSystem do
         end.to_not raise_error
       end
 
-      it "not allowing duplicate hostname" do
+      it "not allowing duplicate hostname for same type provider" do
         expect do
           FactoryGirl.create(:ems_vmware, :hostname => @ems.hostname, :tenant => @tenant2)
         end.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "allowing duplicate hostname for different type providers" do
+        FactoryGirl.create(:ems_microsoft, :hostname => @ems.hostname, :tenant => @tenant2)
+        expect(ExtManagementSystem.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
In the use case of a provider of alerts/metrics for other providers added in #12205, our prominent use case in the beginning (cm-ops) would include two providers from the same host - a container provider and a datawarehouse provider running inside it.