### PR TITLE
allow adding custom attributes with sections

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -89,7 +89,7 @@ module Api
       if CustomAttribute::ALLOWED_API_VALUE_TYPES.include? attribute["field_type"]
         attribute["value"] = attribute.delete("field_type").safe_constantize.parse(attribute["value"])
       end
-      attribute["section"] = "metadata" unless @req.action == "edit"
+      attribute["section"] ||= "metadata" unless @req.action == "edit"
       attribute
     rescue => err
       raise BadRequestError, "Invalid provider custom attributes specified - #{err}"

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -183,11 +183,11 @@ describe "Providers API" do
       api_basic_authorize action_identifier(:providers, :edit)
 
       run_post(provider_ca_url, gen_request(:add, [{"name" => "name1", "value" => "value1"},
-                                                   {"name" => "name2", "value" => "value2"}]))
+                                                   {"name" => "name2", "value" => "value2", "section" => "section2"}]))
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including("name" => "name1", "value" => "value1", "section" => "metadata"),
-          a_hash_including("name" => "name2", "value" => "value2", "section" => "metadata")
+          a_hash_including("name" => "name2", "value" => "value2", "section" => "section2")
         )
       }
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
Allows adding Custom Attributes through the api with sections that are
not 'metadata'. 'metadata' will be the default if no section is set.


cc @alongoldboim @dkorn 