### PR TITLE
Consolidate Chargeback.initialize

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -103,20 +103,11 @@ class Chargeback < ActsAsArModel
                    else
                      self.class.get_extra_fields(metric_rollup_record)
                    end
-    super(self.class.date_fields(metric_rollup_record).merge(extra_fields))
-  end
-
-  def self.date_fields(metric_rollup_record)
-    start_ts, end_ts, display_range = @options.report_step_range(metric_rollup_record.timestamp)
-
-    {
-      'start_date'       => start_ts,
-      'end_date'         => end_ts,
-      'display_range'    => display_range,
-      'interval_name'    => @options.interval,
-      'chargeback_rates' => '',
-      'entity'           => metric_rollup_record.resource
-    }
+    super(extra_fields)
+    self.start_date, self.end_date, self.display_range = options.report_step_range(metric_rollup_record.timestamp)
+    self.interval_name = options.interval
+    self.chargeback_rates = ''
+    self.entity = metric_rollup_record.resource
   end
 
   def self.get_tag_fields(perf)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -60,7 +60,7 @@ class Chargeback < ActsAsArModel
         rates_to_apply = rates.get(metric_rollup_record)
 
         key = report_row_key(metric_rollup_record)
-        data[key] ||= new(options, fields(metric_rollup_record))
+        data[key] ||= new(options, metric_rollup_record)
 
         chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
         data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')
@@ -96,18 +96,14 @@ class Chargeback < ActsAsArModel
     @options.tag_hash[tag]
   end
 
-  def initialize(options, *args)
+  def initialize(options, metric_rollup_record)
     @options = options
-    super(*args)
-  end
-
-  def self.fields(metric_rollup_record)
     extra_fields = if @options[:groupby_tag].present?
-                     get_tag_fields(metric_rollup_record)
+                     self.class.get_tag_fields(metric_rollup_record)
                    else
-                     get_extra_fields(metric_rollup_record)
+                     self.class.get_extra_fields(metric_rollup_record)
                    end
-    date_fields(metric_rollup_record).merge(extra_fields)
+    super(self.class.date_fields(metric_rollup_record).merge(extra_fields))
   end
 
   def self.date_fields(metric_rollup_record)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -98,12 +98,12 @@ class Chargeback < ActsAsArModel
 
   def initialize(options, metric_rollup_record)
     @options = options
+    super()
     if @options[:groupby_tag].present?
-      super()
       classification = self.class.classification_for_perf(metric_rollup_record)
       self.tag_name = classification.present? ? classification.description : _('<Empty>')
     else
-      super(self.class.get_extra_fields(metric_rollup_record))
+      init_extra_fields(metric_rollup_record)
     end
     self.start_date, self.end_date, self.display_range = options.report_step_range(metric_rollup_record.timestamp)
     self.interval_name = options.interval

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -60,7 +60,7 @@ class Chargeback < ActsAsArModel
         rates_to_apply = rates.get(metric_rollup_record)
 
         key = report_row_key(metric_rollup_record)
-        data[key] ||= new(fields(metric_rollup_record))
+        data[key] ||= new(options, fields(metric_rollup_record))
 
         chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
         data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')
@@ -94,6 +94,11 @@ class Chargeback < ActsAsArModel
     tag = metric_rollup_record.tag_names.split('|').find { |x| x.starts_with?(@options[:groupby_tag]) } # 'department/*'
     tag = tag.split('/').second unless tag.blank? # 'department/finance' -> 'finance'
     @options.tag_hash[tag]
+  end
+
+  def initialize(options, *args)
+    @options = options
+    super(*args)
   end
 
   def self.fields(metric_rollup_record)

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -53,16 +53,22 @@ class ChargebackContainerImage < Chargeback
     @options[:groupby] == 'project' ? "#{project.id}_#{ts_key}" : "#{project.id}_#{image.id}_#{ts_key}"
   end
 
+  def self.image(perf)
+    @data_index.fetch_path(:container_image, :by_container_id, perf.resource_id)
+  end
+
+  def self.project(perf)
+    @data_index.fetch_path(:container_project, :by_container_id, perf.resource_id)
+  end
+
   def self.get_extra_fields(perf)
-    project = @data_index.fetch_path(:container_project, :by_container_id, perf.resource_id)
-    image = @data_index.fetch_path(:container_image, :by_container_id, perf.resource_id)
     {
-      "project_name"  => project.name,
-      "image_name"    => image.try(:full_name) || _("Deleted"), # until image archiving is implemented
-      "project_uid"   => project.ems_ref,
+      "project_name"  => project(perf).name,
+      "image_name"    => image(perf).try(:full_name) || _("Deleted"), # until image archiving is implemented
+      "project_uid"   => project(perf).ems_ref,
       "provider_name" => perf.parent_ems.try(:name),
       "provider_uid"  => perf.parent_ems.try(:name),
-      "archived"      => project.archived? ? _("Yes") : _("No")
+      "archived"      => project(perf).archived? ? _("Yes") : _("No")
     }
   end
 

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -61,17 +61,6 @@ class ChargebackContainerImage < Chargeback
     @data_index.fetch_path(:container_project, :by_container_id, perf.resource_id)
   end
 
-  def self.get_extra_fields(perf)
-    {
-      "project_name"  => project(perf).name,
-      "image_name"    => image(perf).try(:full_name) || _("Deleted"), # until image archiving is implemented
-      "project_uid"   => project(perf).ems_ref,
-      "provider_name" => perf.parent_ems.try(:name),
-      "provider_uid"  => perf.parent_ems.try(:name),
-      "archived"      => project(perf).archived? ? _("Yes") : _("No")
-    }
-  end
-
   def self.where_clause(records, _options)
     records.where(:resource_type => Container.name, :resource_id => @containers.pluck(:id))
   end
@@ -94,5 +83,16 @@ class ChargebackContainerImage < Chargeback
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}
     }
+  end
+
+  private
+
+  def init_extra_fields(perf)
+    self.project_name  = self.class.project(perf).name
+    self.image_name    = self.class.image(perf).try(:full_name) || _('Deleted') # until image archiving is implemented
+    self.project_uid   = self.class.project(perf).ems_ref
+    self.provider_name = perf.parent_ems.try(:name)
+    self.provider_uid  = perf.parent_ems.try(:name)
+    self.archived      = self.class.project(perf).archived? ? _('Yes') : _('No')
   end
 end # class ChargebackContainerImage

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -44,17 +44,14 @@ class ChargebackContainerProject < Chargeback
     build_results_for_report_chargeback(options)
   end
 
-  def self.get_keys_and_extra_fields(perf, ts_key)
-    key = "#{perf.resource_id}_#{ts_key}"
-    extra_fields = {
+  def self.get_extra_fields(perf)
+    {
       "project_name"  => perf.resource_name,
       "project_uid"   => perf.resource.ems_ref,
       "provider_name" => perf.parent_ems.try(:name),
       "provider_uid"  => perf.parent_ems.try(:guid),
       "archived"      => perf.resource.archived? ? _("Yes") : _("No")
     }
-
-    [key, extra_fields]
   end
 
   def self.where_clause(records, _options)

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -44,16 +44,6 @@ class ChargebackContainerProject < Chargeback
     build_results_for_report_chargeback(options)
   end
 
-  def self.get_extra_fields(perf)
-    {
-      "project_name"  => perf.resource_name,
-      "project_uid"   => perf.resource.ems_ref,
-      "provider_name" => perf.parent_ems.try(:name),
-      "provider_uid"  => perf.parent_ems.try(:guid),
-      "archived"      => perf.resource.archived? ? _("Yes") : _("No")
-    }
-  end
-
   def self.where_clause(records, _options)
     records.where(:resource_type => ContainerProject.name, :resource_id => @projects.select(:id))
   end
@@ -76,5 +66,15 @@ class ChargebackContainerProject < Chargeback
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}
     }
+  end
+
+  private
+
+  def init_extra_fields(perf)
+    self.project_name  = perf.resource_name
+    self.project_uid   = perf.resource.ems_ref
+    self.provider_name = perf.parent_ems.try(:name)
+    self.provider_uid  = perf.parent_ems.try(:guid)
+    self.archived      = perf.resource.archived? ? _('Yes') : _('No')
   end
 end # class Chargeback

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -45,18 +45,6 @@ class ChargebackVm < Chargeback
     build_results_for_report_chargeback(options)
   end
 
-  def self.get_extra_fields(perf)
-    {
-      "vm_id"         => perf.resource_id,
-      "vm_name"       => perf.resource_name,
-      "vm_uid"        => perf.resource.ems_ref,
-      "vm_guid"       => perf.resource.try(:guid),
-      "owner_name"    => vm_owner(perf),
-      "provider_name" => perf.parent_ems.try(:name),
-      "provider_uid"  => perf.parent_ems.try(:guid)
-    }
-  end
-
   def self.where_clause(records, options)
     scope = records.where(:resource_type => "VmOrTemplate")
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
@@ -142,5 +130,17 @@ class ChargebackVm < Chargeback
           raise _("must provide options :owner or :tag")
         end
       end
+  end
+
+  private
+
+  def init_extra_fields(perf)
+    self.vm_id         = perf.resource_id
+    self.vm_name       = perf.resource_name
+    self.vm_uid        = perf.resource.ems_ref
+    self.vm_guid       = perf.resource.try(:guid)
+    self.owner_name    = self.class.vm_owner(perf)
+    self.provider_name = perf.parent_ems.try(:name)
+    self.provider_uid  = perf.parent_ems.try(:guid)
   end
 end # class Chargeback

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -76,11 +76,9 @@ class ChargebackVm < Chargeback
     build_results_for_report_chargeback(options)
   end
 
-  def self.get_keys_and_extra_fields(perf, ts_key)
-    key = "#{perf.resource_id}_#{ts_key}"
+  def self.get_extra_fields(perf)
     @vm_owners[perf.resource_id] ||= perf.resource.evm_owner_name
-
-    extra_fields = {
+    {
       "vm_id"         => perf.resource_id,
       "vm_name"       => perf.resource_name,
       "vm_uid"        => perf.resource.ems_ref,
@@ -89,8 +87,6 @@ class ChargebackVm < Chargeback
       "provider_name" => perf.parent_ems.try(:name),
       "provider_uid"  => perf.parent_ems.try(:guid)
     }
-
-    [key, extra_fields]
   end
 
   def self.where_clause(records, options)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -93,7 +93,7 @@ class ChargebackVm < Chargeback
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
       scope.where.not(:resource_id => nil).for_tag_names(options[:tag].split("/")[2..-1])
     else
-      scope.where(:resource_id => @vm_owners.keys)
+      scope.where(:resource => @vms)
     end
   end
 

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -48,29 +48,29 @@ class ChargebackVm < Chargeback
         _log.error("Unable to find user '#{options[:owner]}'. Calculating chargeback costs aborted.")
         raise MiqException::Error, _("Unable to find user '%{name}'") % {:name => options[:owner]}
       end
-      vms = user.vms
+      @vms = user.vms
     elsif options[:tag]
-      vms = Vm.find_tagged_with(:all => options[:tag], :ns => "*")
-      vms &= @report_user.accessible_vms if @report_user && @report_user.self_service?
+      @vms = Vm.find_tagged_with(:all => options[:tag], :ns => "*")
+      @vms &= @report_user.accessible_vms if @report_user && @report_user.self_service?
     elsif options[:tenant_id]
       tenant = Tenant.find(options[:tenant_id])
       if tenant.nil?
         _log.error("Unable to find tenant '#{options[:tenant_id]}'. Calculating chargeback costs aborted.")
         raise MiqException::Error, "Unable to find tenant '#{options[:tenant_id]}'"
       end
-      vms = tenant.vms
+      @vms = tenant.vms
     elsif options[:service_id]
       service = Service.find(options[:service_id])
       if service.nil?
         _log.error("Unable to find service '#{options[:service_id]}'. Calculating chargeback costs aborted.")
         raise MiqException::Error, "Unable to find service '#{options[:service_id]}'"
       end
-      vms = service.vms
+      @vms = service.vms
     else
       raise _("must provide options :owner or :tag")
     end
 
-    @vm_owners = vms.inject({}) { |h, v| h[v.id] = v.evm_owner_name; h }
+    @vm_owners = @vms.inject({}) { |h, v| h[v.id] = v.evm_owner_name; h }
 
     build_results_for_report_chargeback(options)
   end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -69,7 +69,6 @@ class ChargebackVm < Chargeback
     else
       raise _("must provide options :owner or :tag")
     end
-    return [[]] if vms.empty?
 
     @vm_owners = vms.inject({}) { |h, v| h[v.id] = v.evm_owner_name; h }
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -819,7 +819,8 @@ describe ChargebackVm do
     it { is_expected.to eq("#{metric_rollup.resource_id}_#{beginning_of_day}") }
   end
 
-  describe '.get_extra_fields' do
+  describe '#initialize' do
+    let(:report_options) { Chargeback::ReportOptions.new }
     let(:vm_owners)     { {@vm1.id => @vm1.evm_owner_name} }
     let(:metric_rollup) do
       FactoryGirl.build(:metric_rollup_vm_hr, :tag_names => 'environment/prod',
@@ -832,13 +833,13 @@ describe ChargebackVm do
       ChargebackVm.instance_variable_set(:@vm_owners, vm_owners)
     end
 
-    it "returns extra fields" do
-      extra_fields = ChargebackVm.get_extra_fields(metric_rollup)
+    it 'sets extra fields' do
+      extra_fields = ChargebackVm.new(report_options, metric_rollup).attributes
       expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => @ems.name,
                          "provider_uid" => @ems.guid, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
                          "vm_id" => @vm1.id}
 
-      expect(extra_fields).to eq(expected_fields)
+      expect(extra_fields).to include(expected_fields)
     end
 
     let(:metric_rollup_without_ems) do
@@ -848,13 +849,13 @@ describe ChargebackVm do
                         :resource => @vm1, :resource_name => @vm1.name)
     end
 
-    it "return extra fields when parent ems is missing" do
-      extra_fields = ChargebackVm.get_extra_fields(metric_rollup_without_ems)
+    it 'sets extra fields when parent ems is missing' do
+      extra_fields = ChargebackVm.new(report_options, metric_rollup_without_ems).attributes
       expected_fields = {"vm_name" => @vm1.name, "owner_name" => @admin.name, "provider_name" => nil,
                          "provider_uid" => nil, "vm_uid" => "ems_ref", "vm_guid" => @vm1.guid,
                          "vm_id" => @vm1.id}
 
-      expect(extra_fields).to eq(expected_fields)
+      expect(extra_fields).to include(expected_fields)
     end
   end
 


### PR DESCRIPTION
## What
Put all the initialization of `Chargeback` instance into one method.

## Why?
Previously the initialization was indirect. We created hashes and then we passed them to `ChargebackX.new`. That was harded to comprehend by new comers. It was written this way as intialization depends on `@options`, and we did not have it passed to the instance.

However, main reason i am doing this is that I need `@options` in the instance for other reason. Thus, once we have `@options` in the instance, there is no excuse for the indirection. Thus, as I need `@options` in the instance, I drop the indirection as well.

Also, previously we calculated extra_fields together with key. Potentially dropping unneeded extra_fields.

@miq-bot add_label chargeback, refactoring, euwe/no
@miq-bot assign @gtanzillo 