### PR TITLE
Fix not passing zoomed attribute to chart_remote

### DIFF
--- a/app/views/report/_form_preview.html.haml
+++ b/app/views/report/_form_preview.html.haml
@@ -19,7 +19,8 @@
           :width   => width,
           :height  => height,
           :bgcolor => "#f2f2f2",
-          :id      => 'my_chart')
+          :id      => 'my_chart',
+          :zoomed  => false)
     - if @html
       %fieldset
         %h3

--- a/app/views/report/_report_list.html.haml
+++ b/app/views/report/_report_list.html.haml
@@ -12,7 +12,8 @@
           :width   => width,
           :height  => height,
           :bgcolor => "#f2f2f2",
-          :id      => 'my_chart')
+          :id      => 'my_chart',
+          :zoomed  => false)
 
         - if !@html && @report.filter_summary
           = @report.filter_summary

--- a/app/views/shared/_report_chart_and_html.html.haml
+++ b/app/views/shared/_report_chart_and_html.html.haml
@@ -6,7 +6,8 @@
                  :width   => width,
                  :height  => height,
                  :id      => 'my_chart',
-                 :bgcolor => '#f2f2f2')
+                 :bgcolor => '#f2f2f2',
+                 :zoomed  => false)
 
   - if !html && report.filter_summary
     = report.filter_summary


### PR DESCRIPTION
Add `:zoomed` attribute to all `chart_remote` calls

Links [Optional]
----------------
Fix issue introduced in  #12811 and partially fixed here #12875


