### PR TITLE
Fix Stack charts

### DIFF
--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -70,18 +70,19 @@ module ReportFormatter
         }
       end
 
+      if chart_is_stacked?
+        mri.chart[:data][:groups] = [[]]
+      end
+
       # chart is numeric
       if mri.graph[:mode] == 'values'
         custom_format   = Array(mri[:col_formats])[Array(mri[:col_order]).index(raw_column_name)]
         format, options = javascript_format(mri.graph[:column].split(/(?<!:):(?!:)/)[0], custom_format)
-        return unless format
 
-        axis_formatter = {:function => format, :options => options}
-        mri.chart[:axis][:y] = {:tick => {:format => axis_formatter}}
-      end
-
-      if chart_is_stacked?
-        mri.chart[:data][:groups] = [[]]
+        if format
+          axis_formatter = {:function => format, :options => options}
+          mri.chart[:axis][:y] = {:tick => {:format => axis_formatter}}
+        end
       end
 
       # C&U chart

--- a/spec/lib/report_formater/c3_formatter_spec.rb
+++ b/spec/lib/report_formater/c3_formatter_spec.rb
@@ -5,6 +5,14 @@ describe ReportFormatter::C3Formatter do
     allow(Charting).to receive(:backend).and_return(:c3)
     allow(Charting).to receive(:format).and_return(:c3)
   end
+
+  describe "#add_series" do
+    it "does not raise error for 'stack' chart" do
+      report = numeric_chart_3d(true)
+      expect { render_report(report) }.to_not raise_error
+    end
+  end
+
   context '#build_numeric_chart_grouped' do
     [true, false].each do |other|
       it "builds 2d numeric charts from summaries #{other ? 'with' : 'without'} 'other'" do


### PR DESCRIPTION
Thanks to [nil format variable](https://github.com/ManageIQ/manageiq/blob/a0c644b3c308e1d6eb09dd07d21165c54f1ee3d3/lib/report_formatter/c3.rb#L78), initialization code `mri.chart[:data][:groups] ||= [[]]`
was not reached in build_document_header.

I moved initialization to the [add_series ](https://github.com/ManageIQ/manageiq/commit/a0c644b3c308e1d6eb09dd07d21165c54f1ee3d3#diff-c2c03f74f973d30a1860cfcd8f9f2557R41)method.

To reproduce, just create report with chart Bars, Stacked (2D),...  and generate preview.

@miq-bot add_label ui, bug
@miq-bot assign @martinpovolny 

please review @PanSpagetka
