### PR TITLE
Fix position of chart menu in C&U when clicking close to right edge

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -656,7 +656,9 @@ function miqBuildChartMenuEx(col, row, _value, category, series, chart_set, char
       $("#" + pid).append("<li><a id='"+btoa(JSON.stringify(row_col_chart_index))+"' href='#' onclick='miqChartMenuClick(this.id)'>" + menu_title + "</a></li>");
     }
 
-    chartmenu_el.css({'left': ManageIQ.mouse.x, 'top': ManageIQ.mouse.y});
+    //chart menu has min-width: 160 a has two levels
+    var x_position = (ManageIQ.mouse.x > $(window).width() - 320) ? $(window).width() - 320 : ManageIQ.mouse.x;
+    chartmenu_el.css({'left': x_position, 'top': ManageIQ.mouse.y});
     chartmenu_el.dropdown('toggle');
     chart_el.find('.overlay').show();
   }


### PR DESCRIPTION
Fix position of chart menu in C&U charts. Previously menu position was fixed to mouse position, but when you clicked near right border of the screen menu was situated outside of screen.

Screenshot
----------------
![screencast from 2016-11-30 14-36-21](https://cloud.githubusercontent.com/assets/9535558/20754326/b8440cc0-b70a-11e6-9441-334baf93cce6.gif)

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1389319

Steps for Testing/QA [Optional]
-------------------------------

Go to C&U and click on chart near right border.

https://bugzilla.redhat.com/show_bug.cgi?id=1389319