### PR TITLE
account for resource_action in a dialog_field on update

### DIFF
--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -19,6 +19,12 @@ class DialogGroup < ApplicationRecord
     fields.each do |field|
       if field.key?('id')
         DialogField.find(field['id']).tap do |dialog_field|
+          resource_action_fields = field.delete('resource_action') || {}
+          if resource_action_fields.key?('id')
+            dialog_field.resource_action.update_attributes(resource_action_fields.except('id'))
+          elsif resource_action_fields.present?
+            dialog_field.resource_action = ResourceAction.create(resource_action_fields)
+          end
           dialog_field.update_attributes(field)
           updated_fields << dialog_field
         end

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -24,19 +24,38 @@ describe DialogGroup do
   describe '#update_dialog_fields' do
     let(:dialog_fields) { FactoryGirl.create_list(:dialog_field, 2) }
     let(:dialog_group) { FactoryGirl.create(:dialog_group, :dialog_fields => dialog_fields) }
+    let(:resource_action) { FactoryGirl.create(:resource_action) }
 
     context 'a collection of dialog fields containing two objects with ids and one without an id' do
       let(:updated_fields) do
         [
-          { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label' },
-          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label' },
+          { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label'},
+          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label'},
           { 'name' => 'new field', 'label' => 'new field label' }
         ]
       end
       it 'creates or updates the dialog fields' do
         dialog_group.update_dialog_fields(updated_fields)
         dialog_group.reload
-        expect(dialog_group.dialog_fields.collect(&:label)).to match_array(['updated_field_label', 'updated_field_label', 'new field label'])
+        expect(dialog_group.dialog_fields.collect(&:label))
+          .to match_array(['updated_field_label', 'updated_field_label', 'new field label'])
+      end
+    end
+
+    context 'a collection of dialog fields with resource actions' do
+      let(:updated_fields) do
+        [
+          { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label', 'resource_action' =>
+            {'resource_type' => 'DialogField', 'ae_attributes' => {}} },
+          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label', 'resource_action' =>
+            {'id' => resource_action.id, 'resource_type' => 'DialogField'} }
+        ]
+      end
+      it 'updates the dialog fields' do
+        dialog_group.update_dialog_fields(updated_fields)
+        dialog_group.reload
+        expect(dialog_group.dialog_fields.collect(&:resource_action).collect(&:resource_type))
+          .to match_array(%w(DialogField DialogField))
       end
     end
 


### PR DESCRIPTION
This was brought to my attention by @romanblanco who found this error when using the API.

The update of a dialog_field needs to account for a resource_action: if an `id` is provided, update the resource_action; if no `id` is provided, set the resource action to a new one

@miq-bot add_label bug
@miq-bot assign @gmcculloug 