### PR TITLE
Scope the dialog label uniqueness validation by region

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -12,7 +12,7 @@ class Dialog < ApplicationRecord
   virtual_has_one :content, :class_name => "Hash"
 
   before_destroy          :reject_if_has_resource_actions
-  validates_uniqueness_of :label
+  validates :label, :uniqueness => {:conditions => -> { in_my_region } }
 
   alias_attribute  :name, :label
 

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -124,7 +124,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   def validate(_values = nil)
-    @dialog.try(:validate)
+    validate_dialog.blank?
   end
 
   private


### PR DESCRIPTION
This was failing a service provision from the global region because there were dialogs from separate regions in the database with the same label.

The call to validate in question is [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/resource_action_workflow.rb#L126-L128)

https://bugzilla.redhat.com/show_bug.cgi?id=1400277

Paired with @bdunne on this
@gmcculloug please review
