### PR TITLE
Fix auto-placement for hosts without a datastore that can hold the new VM

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/microsoft_best_fit_least_utilized.rb
@@ -19,7 +19,8 @@ prov.eligible_hosts.each do |h|
   nvms = h.vms.length
 
   if min_registered_vms.nil? || nvms < min_registered_vms
-    s = h.writable_storages.max_by(&:free_space)
+    storages = h.writable_storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
+    s = storages.max_by(&:free_space)
     unless s.nil?
       host    = h
       storage = s

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_best_fit_least_utilized.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_best_fit_least_utilized.rb
@@ -19,7 +19,8 @@ prov.eligible_hosts.each do |h|
   next unless h.power_state == "on"
   nvms = h.vms.length
   if min_registered_vms.nil? || nvms < min_registered_vms
-    s = h.writable_storages.sort { |a, b| a.free_space <=> b.free_space }.last
+    storages = h.writable_storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
+    s = storages.sort { |a, b| a.free_space <=> b.free_space }.last
     unless s.nil?
       host    = h
       storage = s

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_best_fit_least_utilized.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_best_fit_least_utilized.rb
@@ -20,7 +20,7 @@ prov.eligible_hosts.each do |h|
   nvms = h.vms.length
   if min_registered_vms.nil? || nvms < min_registered_vms
     storages = h.writable_storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
-    s = storages.sort { |a, b| a.free_space <=> b.free_space }.last
+    s = storages.max_by(&:free_space)
     unless s.nil?
       host    = h
       storage = s


### PR DESCRIPTION
Currently the best_fit_least_utilized methods picks the host with the least number of VMs, then the datastore with the most free space.

Consider we want to provision a VM with an 8GB disk:
```
host1 - 1 VM, 1 datastore (1MB free space)
host2 - 2 VMs, 1 datastore (1TB free space)
```

Currently microsoft_best_fit_least_utilized.rb and vmware_best_fit_least_utilized.rb would pick host1 even though it doesn't have a datastore with enough free space to hold the new VM.

This change mirrors what the builtin method [miq_host_and_storage_least_utilized](https://github.com/ManageIQ/manageiq/blob/master/lib/miq_automation_engine/engine/miq_ae_builtin_method.rb#L96) does

https://bugzilla.redhat.com/show_bug.cgi?id=1397951