### PR TITLE
Worker heartbeating: Wrap critical section with read lock

### DIFF
--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -65,6 +65,12 @@ module MiqServer::WorkerManagement::Heartbeat
     processed_worker_ids = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)
+
+      # Note, STATUSES_CURRENT_OR_STARTING doesn't include 'stopping'.
+      # We already restarted 'stopping' workers, so we bail out early here.
+      # 'stopping' workers continue to run and heartbeat through drb, which
+      # updates the in memory @workers.  The last heartbeat in the workers row is
+      # NOT updated because we no longer call validate_heartbeat when we skip validate_worker below.
       next unless MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
       processed_worker_ids << w.id
       next unless validate_worker(w)

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -94,8 +94,6 @@ module MiqServer::WorkerManagement::Heartbeat
   private
 
   def workers_last_heartbeat(pid)
-    return unless @workers_lock
-
     @workers_lock.synchronize(:SH) do
       @workers.fetch_path(pid, :last_heartbeat)
     end

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -83,9 +83,10 @@ module MiqServer::WorkerManagement::Heartbeat
   def validate_heartbeat(w)
     if w.last_heartbeat.nil?
       @workers_lock.synchronize(:SH) do
-        w.last_heartbeat = @workers[w.pid][:last_heartbeat] if @workers.key?(w.pid)
+        last_heartbeat = @workers[w.pid][:last_heartbeat] if @workers.key?(w.pid)
       end unless @workers_lock.nil?
-      w.last_heartbeat ||= Time.now.utc
+      last_heartbeat ||= Time.now.utc
+      w.update_attributes(:last_heartbeat => last_heartbeat)
     else
       @workers_lock.synchronize(:SH) do
         if @workers.key?(w.pid) && !@workers[w.pid][:last_heartbeat].nil? && @workers[w.pid][:last_heartbeat] > w.last_heartbeat

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -77,7 +77,7 @@ module MiqServer::WorkerManagement::Heartbeat
   def validate_heartbeat(w)
     if w.last_heartbeat.nil?
       @workers_lock.synchronize(:SH) do
-        w.last_heartbeat ||= @workers[w.pid][:last_heartbeat] if @workers.key?(w.pid)
+        w.last_heartbeat = @workers[w.pid][:last_heartbeat] if @workers.key?(w.pid)
       end unless @workers_lock.nil?
       w.last_heartbeat ||= Time.now.utc
     else

--- a/spec/models/miq_server/worker_management/heartbeat_spec.rb
+++ b/spec/models/miq_server/worker_management/heartbeat_spec.rb
@@ -1,0 +1,19 @@
+describe MiqServer::WorkerManagement::Heartbeat do
+  context "#validate_heartbeat" do
+    let(:miq_server) { EvmSpecHelper.local_miq_server.tap(&:setup_drb_variables) }
+    let(:pid)        { 1234 }
+    let(:worker)     { FactoryGirl.create(:miq_worker, :miq_server_id => miq_server.id, :pid => pid) }
+
+    it "sets initial and subsequent heartbeats" do
+      2.times do
+        t = Time.now.utc
+        Timecop.freeze(t) do
+          miq_server.worker_heartbeat(pid)
+          miq_server.validate_heartbeat(worker)
+        end
+
+        expect(worker.reload.last_heartbeat).to be_within(1.second).of(t)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Summary**:
A critical section access to the `@workers` hash was not protected with a read lock, meaning a read could occur while another thread was writing to it.  Workers access `@workers` via a DRb thread running on the server process, while the server's main thread is also accessing it.  

Note, this is probably not a huge problem because a slightly incorrect last_heartbeat value will probably not be something anyone would notice.

43e9676 Wrap critical @workers reads with a read lock
fbf7007 last_heartbeat is already nil, don't check it again
18a938f Add explanation of the missing stopping workers.
caf0e77 Initial worker heartbeat wasn't saving the record.
271856d Extract a method to read the last_heartbeat.

This is only partly related to this BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=1395736.
This PR doesn't resolve that BZ.  I'll let @gtanzillo @Fryguy decide if we need euwe/yes on this or if a new BZ is needed...

Please review commit by commit.