### PR TITLE
[DARGA] Generate timelines if flash message was not set.

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -70,7 +70,9 @@ module ApplicationController::Timelines
         end
       end
       add_flash(_("At least one filter must be selected"), :warning) if flg
-    else
+    end
+
+    unless @flash_array
       tl_gen_timeline_data(refresh = "n")
       return unless @timeline
     end


### PR DESCRIPTION
Previously this code was not re-generating Policy timelines when Policy timelines options were changed on the screen. This issue does not exist on upstream or EUWE, it was addressed with PF timeline upgrade changes

https://bugzilla.redhat.com/show_bug.cgi?id=1398276

@dclarizio please review this is a Darga only fix.

before:
![before](https://cloud.githubusercontent.com/assets/3450808/20773366/677f7828-b71f-11e6-942c-422693396815.png)

after:
![after](https://cloud.githubusercontent.com/assets/3450808/20773370/6c1fc266-b71f-11e6-8cf8-688e248d4e2d.png)
![after2](https://cloud.githubusercontent.com/assets/3450808/20773373/6d98a9aa-b71f-11e6-9a0f-a08913a29ecb.png)


