### PR TITLE
Give policy event sample reports better names

### DIFF
--- a/product/reports/520_Events - Policy/110_Policy Events.yaml
+++ b/product/reports/520_Events - Policy/110_Policy Events.yaml
@@ -3,7 +3,7 @@ where_clause:
 dims: 
 created_on: 2009-04-03 16:56:10 Z
 reserved: 
-title: Policy Events for Last Week - Sample 1
+title: Policy Events for Last Week
 conditions: !ruby/object:MiqExpression
   exp:
     "IS":
@@ -12,7 +12,7 @@ conditions: !ruby/object:MiqExpression
 updated_on: 2009-04-06 20:19:27 Z
 order: Ascending
 graph: 
-menu_name: Policy Events for Last Week - Sample 1
+menu_name: Policy Events for Last Week
 rpt_group: Custom
 priority: 
 col_order: 

--- a/product/reports/520_Events - Policy/120_Policy Events2.yaml
+++ b/product/reports/520_Events - Policy/120_Policy Events2.yaml
@@ -3,7 +3,7 @@ where_clause:
 dims: 
 created_on: 2009-04-03 23:04:39 Z
 reserved: 
-title: Policy Events for Last Week - Sample 2
+title: Policy Events for the Last 7 Days
 conditions: !ruby/object:MiqExpression
   exp:
     ">=":
@@ -12,7 +12,7 @@ conditions: !ruby/object:MiqExpression
 updated_on: 2009-04-06 20:18:30 Z
 order: Ascending
 graph: 
-menu_name: Policy Events for Last Week - Sample 2
+menu_name: Policy Events for the Last 7 Days
 rpt_group: Custom
 priority: 
 col_order: 


### PR DESCRIPTION
Original report names simply had "Sample 1" and "Sample 2" suffixes.  Changed these to be more descriptive as one report is for events for last week (Sun through Sat) and the other is for events from the last 7 days.

https://bugzilla.redhat.com/show_bug.cgi?id=1391900