### PR TITLE
Manage quadicon methods to consider special cases for the x_show method

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -1093,7 +1093,8 @@ class ProviderForemanController < ApplicationController
     unassigned_configuration_profile.description = unassigned_configuration_profile_desc
 
     unassigned_profile_row =
-      {'description'                    => unassigned_configuration_profile_desc,
+      {'x_show_id'                      => "-#{provider_id}-unassigned",
+       'description'                    => unassigned_configuration_profile_desc,
        'total_configured_systems'       => unprovisioned_configured_systems,
        'configuration_environment_name' => unassigned_configuration_profile.configuration_environment_name,
        'my_zone'                        => unassigned_configuration_profile.my_zone,

--- a/app/helpers/quadicon_helper.rb
+++ b/app/helpers/quadicon_helper.rb
@@ -106,9 +106,9 @@ module QuadiconHelper
   # Currently can't use `url_for_record` because it attempts to guess the
   # controller and guesses incorrectly for some situations.
   #
-  def quadicon_url_to_xshow_from_cid(item)
+  def quadicon_url_to_xshow_from_cid(item, options = {})
     # Previously: {:action => 'x_show', :id => controller.send(:list_row_id, item)}
-    {:action => 'x_show', :id => to_cid(item.id)}
+    {:action => 'x_show', :id => to_cid(item.id) || options[:x_show_id]}
   end
 
   # Currently only used once
@@ -263,7 +263,7 @@ module QuadiconHelper
     else
       attrs[:controller] = controller_name
       attrs[:action]  = 'x_show'
-      attrs[:id]      = to_cid(row['id'])
+      attrs[:id]      = to_cid(row['id']) || row['x_show_id']
     end
 
     url_for(attrs)
@@ -593,7 +593,7 @@ module QuadiconHelper
       if quadicon_show_links?
         if quadicon_in_explorer_view?
           img_opts.delete(:path)
-          url = quadicon_url_to_xshow_from_cid(item)
+          url = quadicon_url_to_xshow_from_cid(item, options)
           link_opts = {:sparkle => true, :remote => true}
         else
           url = url_for_record(item)

--- a/app/views/layouts/gtl/_grid.html.haml
+++ b/app/views/layouts/gtl/_grid.html.haml
@@ -16,7 +16,9 @@
                                   :class   => "listcheckbox list-grid-checkbox",
                                   :onchange => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
               %td
-                = render_quadicon(item, :mode => :icon)
+                - options = {:mode => :icon}
+                - options[:x_show_id] = row['x_show_id'] if item.id.nil?
+                = render_quadicon(item, options)
             %tr
               %td{:colspan => "2", :style => "text-align: center; padding-top: 0px; margin-top: 0px;color: #000;"}
                 = render_quadicon_text(item, row)

--- a/app/views/layouts/gtl/_tile.html.haml
+++ b/app/views/layouts/gtl/_tile.html.haml
@@ -21,7 +21,9 @@
                                       :class   => "listcheckbox list-grid-checkbox",
                                       :onchange => "miqGridOnCheck(this, '#{button_div}', 'gtl_div');")
                   %td
-                    = render_quadicon(item, :mode => :icon)
+                    - options = {:mode => :icon}
+                    - options[:x_show_id] = row['x_show_id'] if item.id.nil?
+                    = render_quadicon(item, options)
                 %tr
                   %td{:colspan => "2", :style => "padding-top: 0px; margin-top: 0px;"}
                     = render_quadicon_text(item, row)


### PR DESCRIPTION
The GTL view sometimes contains items that are not exactly individual records but are a collection of records like the `"Unassigned Profiles Group"` in the Provider Foreman List view as shown in the sceenshot below:

<img width="1418" alt="screen shot 2016-11-30 at 4 19 52 pm" src="https://cloud.githubusercontent.com/assets/1538216/20777025/1594a4bc-b719-11e6-9a89-2567458d8849.png">

Clicking on the `"Unassigned Profiles Group"` in the Grid and Tile view (where the quadicons exist) did not work and had to be fixed. List view works fine without any issues.

Fixed some of the quadicon methods to address this special case, and made a few adjustments around that in the Provider Foreman controller and the grid and tile hamls.

Note that, this is the second fix for the same BZ. The first fix https://github.com/ManageIQ/manageiq/pull/12224 fixed the issue for the List View, while this fix is specifically targeted for the Grid/Tile view.

https://bugzilla.redhat.com/show_bug.cgi?id=1388431