### PR TITLE
Delegate vm ram_size to hardware

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -26,6 +26,7 @@ class Hardware < ApplicationRecord
   virtual_column :mac_addresses, :type => :string_set, :uses => :nics
   virtual_aggregate :used_disk_storage,      :disks, :sum, :used_disk_storage
   virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+  virtual_attribute :ram_size_in_bytes, :integer, :arel => ->(t) { t.grouping(t[:memory_mb] * 1.megabyte) }
 
   def ipaddresses
     @ipaddresses ||= networks.collect(&:ipaddress).compact.uniq
@@ -37,6 +38,10 @@ class Hardware < ApplicationRecord
 
   def mac_addresses
     @mac_addresses ||= nics.collect(&:address).compact.uniq
+  end
+
+  def ram_size_in_bytes
+    memory_mb * 1.megabyte
   end
 
   @@dh = {"type" => "device_name", "devicetype" => "device_type", "id" => "location", "present" => "present",

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1534,12 +1534,12 @@ class VmOrTemplate < ApplicationRecord
     allocated_disk_storage.to_i + ram_size_in_bytes
   end
 
-  def used_storage(include_ram = true, check_state = false)
-    used_disk_storage.to_i + (include_ram ? ram_size_in_bytes(check_state) : 0)
+  def used_storage
+    used_disk_storage.to_i + ram_size_in_bytes
   end
 
-  def used_storage_by_state(include_ram = true)
-    used_storage(include_ram, true)
+  def used_storage_by_state
+    used_disk_storage.to_i + ram_size_in_bytes_by_state
   end
 
   def uncommitted_storage
@@ -1550,20 +1550,20 @@ class VmOrTemplate < ApplicationRecord
     hardware.nil? ? false : hardware.disks.any? { |d| d.disk_type == 'thin' }
   end
 
-  def ram_size(check_state = false)
-    hardware.nil? || (check_state && state != 'on') ? 0 : hardware.memory_mb
+  def ram_size
+    hardware.try(:memory_mb) || 0
   end
 
   def ram_size_by_state
-    ram_size(true)
+    state == 'on' ? ram_size : 0
   end
 
-  def ram_size_in_bytes(check_state = false)
-    ram_size(check_state).to_i * 1.megabyte
+  def ram_size_in_bytes
+    ram_size * 1.megabyte
   end
 
   def ram_size_in_bytes_by_state
-    ram_size_in_bytes(true)
+    ram_size_by_state * 1.megabyte
   end
 
   alias_method :mem_cpu, :ram_size

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -596,6 +596,47 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".ram_size", ".mem_cpu" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
+    let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 10) }
+
+    it "supports null hardware" do
+      vm = FactoryGirl.create(:vm_vmware)
+      expect(vm.ram_size).to eq(0)
+      expect(vm.mem_cpu).to eq(0)
+    end
+
+    it "calculates in ruby" do
+      expect(vm.ram_size).to eq(10)
+      expect(vm.mem_cpu).to eq(10)
+    end
+
+    it "calculates in the database" do
+      vm.save
+      expect(virtual_column_sql_value(VmOrTemplate, "ram_size")).to eq(10)
+      expect(virtual_column_sql_value(VmOrTemplate, "mem_cpu")).to eq(10)
+    end
+  end
+
+  describe ".ram_size_in_bytes" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
+    let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 10) }
+
+    it "supports null hardware" do
+      vm = FactoryGirl.create(:vm_vmware)
+      expect(vm.ram_size_in_bytes).to eq(0)
+    end
+
+    it "calculates in ruby" do
+      expect(vm.ram_size_in_bytes).to eq(10.megabytes)
+    end
+
+    it "calculates in the database" do
+      vm.save
+      expect(virtual_column_sql_value(VmOrTemplate, "ram_size_in_bytes")).to eq(10.megabytes)
+    end
+  end
+
   describe ".host_name" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
     let(:host) { FactoryGirl.create(:host_vmware, :name => "our host") }


### PR DESCRIPTION
High level:
All `aggressive_vcpus_recommended_change_pct` use `ram_size` or `cpu_total_cores` (see #12911) for calculations.

This sets us up to have 2 of the 3 parameters sql friendly.

Low level:

`ram_size` (also called `memory_mb` and `mem_cpu`) is delegated from `vms` to `hardware`.
Currently this delegate is implemented in ruby, this change exposes it to use a delegator and to implement the arel.

Also, for `ram_size` there is a secondary parameter to look at `vm#state`. I could only ever find this method call from within the `Vm` class itself. Separating these methods apart allows us to simplify the calculation and use pure sql for `ram_size`.

related to #12733 and #12911

https://bugzilla.redhat.com/show_bug.cgi?id=1395743