### PR TITLE
ServiceOrder deep copy

### DIFF
--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -97,4 +97,27 @@ describe ServiceOrder do
     error_message = "Invalid operation [remove_from_cart] for Service Order in state [ordered]"
     expect { ServiceOrder.remove_from_cart(request, user) }.to raise_error(RuntimeError, error_message)
   end
+
+  context '#deep_copy' do
+    it 'should copy the miq_requests' do
+      service_order.miq_requests << [request, request2]
+      service_order_copy = service_order.deep_copy
+      expect(service_order_copy.miq_requests.count).to eq(2)
+    end
+
+    it 'should have its order ID in the name unless specified' do
+      service_order_copy = service_order.deep_copy
+      expect(service_order_copy.name).to eq("Order # #{service_order_copy.id}")
+    end
+
+    it 'should accept new attributes' do
+      service_order_copy = service_order.deep_copy(:name => "foo bar")
+      expect(service_order_copy.name).to eq("foo bar")
+    end
+
+    it 'should be in the cart state' do
+      service_order_copy = service_order.deep_copy
+      expect(service_order_copy.state).to eq(ServiceOrder::STATE_CART)
+    end
+  end
 end


### PR DESCRIPTION
The SUI will be adding the ability to re-order / duplicate an order (see [here](https://www.pivotaltracker.com/story/show/134071933) and [here](https://www.pivotaltracker.com/story/show/134071915)). As a result, we need a way to deep copy a service order to include its requests.

It only copies the necessary attributes of an miq_request so that it resets attributes such as `approval_state` and `request_state` to the defaults.

@miq-bot add_label enhancement, services
@miq-bot assign @gmcculloug 
cc: @syncrou 
