### PR TITLE
Update Azure provision template to restrict VM names

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -225,16 +225,18 @@
           :notes_display: :hide
         :vm_name: 
           :description: Instance Name
-          :required_method: :validate_vm_name
-          :required_regex: !ruby/regex /^[^-_][a-zA-Z0-9_-]{1,15}(?<![-_])$/
+          :required_method:
+            - :validate_vm_name
+            - :validate_regex
+          :required_regex: !ruby/regexp /^[^-_][a-zA-Z0-9_-]{1,15}(?<![-_])$/
           :required_regex_fail_details: The name must be composed only of 1-15 English alphabet characters (a-z), numbers (0-9), dashes (-) or underscores (_). The first and last character must be an English alphabet character.
           :required: true
           :notes: 
           :display: :edit
           :data_type: :string
           :notes_display: :show
-          :min_length: 
-          :max_length:
+          :min_length: 1
+          :max_length: 15
       :display: :show
     :schedule:
       :description: Schedule

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -226,6 +226,8 @@
         :vm_name: 
           :description: Instance Name
           :required_method: :validate_vm_name
+          :required_regex: !ruby/regex /^[^-_][a-zA-Z0-9_-]{1,15}(?<![-_])$/
+          :required_regex_fail_details: The name must be composed only of 1-15 English alphabet characters (a-z), numbers (0-9), dashes (-) or underscores (_). The first and last character must be an English alphabet character.
           :required: true
           :notes: 
           :display: :edit


### PR DESCRIPTION
This adds a VM name constraint to the Azure provisioning dialog, restricting it to alphanumeric characters, hyphens and underscores, with a range of 1-15 characters. Some additional restrictions have also been included regarding leading and trailing characters.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1377889

![image](https://cloud.githubusercontent.com/assets/78529/20805813/85555d68-b7b5-11e6-9dc2-1ae4f9756f4a.png)