### PR TITLE
Refactor provisioning workflow to support other sources

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -598,6 +598,10 @@ class ExtManagementSystem < ApplicationRecord
     User.super_admin.tap { |u| u.current_group = tenant.default_miq_group }
   end
 
+  def top_level_manager
+    try(:parent_manager) || self
+  end
+
   private
 
   def build_connection(options = {})

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -34,6 +34,9 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def allowed_guest_access_key_pairs(_options = {})
     source = load_ar_obj(get_source_vm)
     ems = source.try(:ext_management_system)
+    # if the source is related directly to a sub-manager like networkmanager
+    # or storagemanager, we might need to get the parent manager
+    ems = ems.try(:parent_manager) || ems
 
     return {} if ems.nil?
     ems.key_pairs.each_with_object({}) { |kp, h| h[kp.id] = kp.name }
@@ -42,7 +45,8 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def allowed_security_groups(_options = {})
     return {} unless (src = provider_or_tenant_object)
 
-    src_obj = get_targets_for_source(src, :cloud_filter, SecurityGroup, 'security_groups')
+    parent_source = src.try(:parent_manager) || src
+    src_obj = get_targets_for_source(parent_source, :cloud_filter, SecurityGroup, 'security_groups')
 
     src_obj.each_with_object({}) do |sg, h|
       h[sg.id] = display_name_for_name_description(sg)
@@ -51,8 +55,8 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
   def allowed_floating_ip_addresses(_options = {})
     return {} unless (src_obj = provider_or_tenant_object)
-
-    src_obj.floating_ips.available.each_with_object({}) do |ip, h|
+    parent_source = src_obj.try(:parent_manager) || src_obj
+    parent_source.floating_ips.available.each_with_object({}) do |ip, h|
       h[ip.id] = ip.address
     end
   end
@@ -109,7 +113,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def get_targets_for_ems(src, filter_name, klass, relats)
-    ems = src.try(:ext_management_system)
+    ems = src.try(:ext_management_system).try(:top_level_manager)
 
     return {} if ems.nil?
     process_filter(filter_name, klass, ems.deep_send(relats))

--- a/app/models/miq_provision/helper.rb
+++ b/app/models/miq_provision/helper.rb
@@ -1,6 +1,6 @@
 module MiqProvision::Helper
   def hostname_cleanup(name)
-    hostname_length = (source.platform == 'linux') ? 63 : 15
+    hostname_length = (source.try(:platform) == 'linux') ? 63 : 15
     name.strip.gsub(/ +|_+/, "-")[0, hostname_length]
   end
 end

--- a/app/models/miq_provision/options_helper.rb
+++ b/app/models/miq_provision/options_helper.rb
@@ -25,12 +25,13 @@ module MiqProvision::OptionsHelper
 
   def get_source
     source_id = get_option(:src_vm_id)
-    source = VmOrTemplate.find_by(:id => source_id)
+    source_type = get_option(:src_type)
+    source = MiqProvisionSource.get_provisioning_request_source(source_id, source_type)
     if source.nil?
       raise MiqException::MiqProvisionError,
             _("Unable to find source Template/Vm with id [%{number}]") % {:number => source_id}
     end
-    ems = source.ext_management_system
+    ems = source.ext_management_system.top_level_manager
     if ems.nil?
       raise MiqException::MiqProvisionError,
             _("%{class_name} [%{name}] is not attached to a Management System") % {:class_name => source.class.name,
@@ -56,7 +57,7 @@ module MiqProvision::OptionsHelper
   end
 
   def get_hostname(dest_vm_name)
-    name_key = (source.platform == 'windows') ? :sysprep_computer_name : :linux_host_name
+    name_key = (source.try(:platform) == 'windows') ? :sysprep_computer_name : :linux_host_name
     computer_name = (get_option(:number_of_vms) > 1) ? nil : get_option(name_key).to_s.strip
     computer_name = dest_vm_name if computer_name.blank?
     hostname_cleanup(computer_name)

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -3,22 +3,24 @@ class MiqProvisionRequest < MiqRequest
   alias_attribute :provision_type, :request_type
   alias_attribute :miq_provisions, :miq_request_tasks
   alias_attribute :src_vm_id,      :source_id
+  alias_attribute :src_type,       :source_type
 
   delegate :my_zone, :to => :source
 
-  TASK_DESCRIPTION  = 'VM Provisioning'
-  SOURCE_CLASS_NAME = 'Vm'
+  TASK_DESCRIPTION  = 'VM Provisioning'.freeze
+  SOURCE_CLASS_NAME = "Vm".freeze
   ACTIVE_STATES     = %w(migrated) + base_class::ACTIVE_STATES
 
   validates_inclusion_of :request_state,
                          :in      => %w(pending provisioned finished) + ACTIVE_STATES,
                          :message => "should be pending, #{ACTIVE_STATES.join(", ")}, provisioned, or finished"
-  validates_presence_of  :source_id,      :message => "must have valid template"
-  validate               :must_have_valid_vm
+  validates_presence_of  :source_id, :message => "must have valid provisioning source"
+  validate               :must_have_valid_source
   validate               :must_have_user
 
   default_value_for :options,      :number_of_vms => 1
   default_value_for(:src_vm_id)    { |r| r.get_option(:src_vm_id) }
+  default_value_for(:src_type)     { |r| r.get_option(:src_type) || "VmOrTemplate" }
 
   virtual_column :provision_type, :type => :string
 
@@ -26,12 +28,16 @@ class MiqProvisionRequest < MiqRequest
   include MiqProvisionQuotaMixin
 
   def self.request_task_class_from(attribs)
-    source_id = MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])
-    vm_or_template = VmOrTemplate.find_by(:id => source_id)
-    raise MiqException::MiqProvisionError, "Unable to find source Template/Vm with id [#{source_id}]" if vm_or_template.nil?
+    source_id = MiqRequestMixin.get_option(:source_id, nil, attribs['options'])
+    source_type = MiqRequestMixin.get_option(:source_type, nil, attribs['options'])
+    source_id ||= MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])
+    source_type ||= MiqRequestMixin.get_option(:src_type, nil, attribs['options'])
+    provisioning_source = MiqProvisionSource.get_provisioning_request_source(source_id, source_type)
+    raise MiqException::MiqProvisionError, "Unable to find source #{source_type} with id [#{source_id}]" if provisioning_source.nil?
 
     via = MiqRequestMixin.get_option(:provision_type, nil, attribs['options'])
-    vm_or_template.ext_management_system.class.provision_class(via)
+    manager = provisioning_source.ext_management_system.top_level_manager
+    manager.class.provision_class(via)
   end
 
   def self.new_request_task(attribs)
@@ -39,8 +45,8 @@ class MiqProvisionRequest < MiqRequest
     klass.new(attribs)
   end
 
-  def must_have_valid_vm
-    errors.add(:vm_template, "must have valid VM (must be in vmdb)") if vm_template.nil?
+  def must_have_valid_source
+    errors.add(:source, "must have valid provisioning source") if source.nil?
   end
 
   def set_description(force = false)
@@ -82,9 +88,9 @@ class MiqProvisionRequest < MiqRequest
 
     return false if dept.empty? || env.empty?
 
-    prov.options[:environment] = "prod" # Set env to prod to get service levels
-    svc  = prov.allowed(:service_level) # Get service levels
-    return false if env.include?("prod") && svc.empty?  # Make sure we have at least one
+    prov.options[:environment] = "prod"                # Set env to prod to get service levels
+    svc = prov.allowed(:service_level)                 # Get service levels
+    return false if env.include?("prod") && svc.empty? # Make sure we have at least one
 
     true
   end
@@ -115,17 +121,20 @@ class MiqProvisionRequest < MiqRequest
   end
 
   def validate_template
-    return {:valid   => false,
-            :message => "Unable to find VM with Id [#{source_id}]"
+    return {
+      :valid   => false,
+      :message => "Unable to find #{source_type} with Id [#{source_id}]"
     } if source.nil?
 
-    return {:valid   => false,
-            :message => "VM/Template <#{source.name}> with Id <#{source.id}> is archived and cannot be used with provisioning."
-    } if source.archived?
+    return {
+      :valid   => false,
+      :message => "#{source_type} <#{source.name}> with Id <#{source.id}> is archived and cannot be used with provisioning."
+    } if source.try(:archived?)
 
-    return {:valid   => false,
-            :message => "VM/Template <#{source.name}> with Id <#{source.id}> is orphaned and cannot be used with provisioning."
-    } if source.orphaned?
+    return {
+      :valid   => false,
+      :message => "#{source_type} <#{source.name}> with Id <#{source.id}> is orphaned and cannot be used with provisioning."
+    } if source.try(:orphaned?)
 
     {:valid => true, :message => nil}
   end

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -28,7 +28,8 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
              else VmOrTemplate.find_by(:id => source_or_id)
              end
     return nil if source.nil?
-    source.class.manager_class.provision_workflow_class
+    source.class.try(:manager_class).try(:provision_workflow_class) ||
+      source.ext_management_system.top_level_manager.class.provision_workflow_class
   end
 
   def self.encrypted_options_fields

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -229,7 +229,11 @@ module MiqProvisionMixin
   end
 
   def source_type
-    vm_template.kind_of?(MiqTemplate) ? 'template' : 'vm'
+    if vm_template.kind_of?(MiqTemplate)
+      return 'template'
+    else
+      return 'vm'
+    end
   end
 
   def set_nic_settings(idx, nic_hash, value = nil)

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -307,7 +307,7 @@ module MiqProvisionQuotaMixin
         result[:count] += num_vms_for_request
         result[:memory] += pr.get_option(:vm_memory).to_i * num_vms_for_request
         result[:cpu] += pr.get_option(:number_of_cpus).to_i * num_vms_for_request
-        result[:storage] += (pr.vm_template.allocated_disk_storage.to_i + new_disk_storage_size) * num_vms_for_request
+        result[:storage] += (pr.source.allocated_disk_storage.to_i + new_disk_storage_size) * num_vms_for_request
         result[:ids] << pr.id
 
         # Include a resource breakdown for actively provisioning records
@@ -317,7 +317,7 @@ module MiqProvisionQuotaMixin
           active = result[:active]
           active[:memory_by_host_id][host_id] += p.get_option(:vm_memory).to_i
           active[:cpu_by_host_id][host_id] += p.get_option(:number_of_cpus).to_i
-          active[:storage_by_id][storage_id] += p.vm_template.allocated_disk_storage.to_i + new_disk_storage_size
+          active[:storage_by_id][storage_id] += p.source.allocated_disk_storage.to_i + new_disk_storage_size
           active[:vms_by_storage_id][storage_id] << p.id
           active[:ids] << p.id
         end

--- a/lib/miq_provision_source.rb
+++ b/lib/miq_provision_source.rb
@@ -1,0 +1,10 @@
+module MiqProvisionSource
+  def self.get_provisioning_request_source_class(_src_type_string)
+    VmOrTemplate
+  end
+
+  def self.get_provisioning_request_source(src_id, src_type_string)
+    kls = get_provisioning_request_source_class(src_type_string)
+    kls.find_by_id(src_id)
+  end
+end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -20,7 +20,8 @@ describe MiqProvisionVirtWorkflow do
     end
 
     it "sets initial_pass equal to true when values are empty and initial_pass => true is passed in as an option" do
-      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:get_value).once
+      # once for src_vm_id, once for src_type
+      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:get_value).with(nil).twice
 
       init_options = {:use_pre_dialog => false, :skip_dialog_load => true, :request_type => :clone_to_vm, :initial_pass => true}
       p = MiqProvisionVirtWorkflow.new({}, user, init_options)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -381,7 +381,7 @@ describe ServiceTemplate do
       it 'not existing template' do
         @ptr.update_attributes(:src_vm_id => 999)
         expect(@st1.template_valid?).to be_falsey
-        expect(@st1.template_valid_error_message).to include("Unable to find VM with Id [999]")
+        expect(@st1.template_valid_error_message).to include("Unable to find vm with Id [999]")
       end
 
       it 'generic' do
@@ -426,7 +426,7 @@ describe ServiceTemplate do
       it 'not existing template' do
         @ptr.update_attributes(:src_vm_id => 999)
         expect(@st2.template_valid?).to be_falsey
-        expect(@st2.template_valid_error_message).to include("Unable to find VM with Id [999]")
+        expect(@st2.template_valid_error_message).to include("Unable to find vm with Id [999]")
       end
     end
   end


### PR DESCRIPTION
This PR is refactoring the provisioning workflow to make it easier to add support for provisioning from arbitrary source types.

This is part of the work that was in https://github.com/ManageIQ/manageiq/pull/11691, split up at the request of @gmcculloug and @bdunne