### PR TITLE
[WIP] [Depends on #12949] Add support for provisioning Openstack instances from cloud volumes and snapshots

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -17,7 +17,22 @@ class CloudVolume < ApplicationRecord
   has_many   :hardwares, :through => :attachments
   has_many   :vms, :through => :hardwares, :foreign_key => :vm_or_template_id
 
+  # it's permissable to provision vms with cloud volumes as a source
+  has_many   :miq_provision_requests, :as => :source
+  virtual_column :cloud, :type => :boolean
+  def cloud
+    true
+  end
+
   acts_as_miq_taggable
+
+  def my_zone
+    ext_management_system.try(:my_zone) || MiqServer.my_zone
+  end
+
+  def self.eligible_for_provisioning
+    where(:type => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume", :bootable => true)
+  end
 
   def self.available
     left_outer_joins(:attachments).where("disks.backing_id" => nil)

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -10,10 +10,22 @@ class CloudVolumeSnapshot < ApplicationRecord
   belongs_to :cloud_volume
   has_many   :based_volumes, :class_name => 'CloudVolume'
 
+  # it's permissable to provision vms with cloud volume snapshots as a source
+  has_many   :miq_provision_requests, :as => :source
+  virtual_column :cloud, :type => :boolean
+  def cloud
+    true
+  end
+
   virtual_total :total_based_volumes, :based_volumes
 
   def self.class_by_ems(ext_management_system)
     ext_management_system && ext_management_system.class::CloudVolumeSnapshot
+  end
+
+  def self.eligible_for_provisioning
+    joins(:cloud_volume).where("cloud_volumes.bootable = ?", true)
+                        .where(:type => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot")
   end
 
   def self.my_zone(ems)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -598,6 +598,10 @@ class ExtManagementSystem < ApplicationRecord
     User.super_admin.tap { |u| u.current_group = tenant.default_miq_group }
   end
 
+  def top_level_manager
+    try(:parent_manager) || self
+  end
+
   private
 
   def build_connection(options = {})

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -34,6 +34,9 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def allowed_guest_access_key_pairs(_options = {})
     source = load_ar_obj(get_source_vm)
     ems = source.try(:ext_management_system)
+    # if the source is related directly to a sub-manager like networkmanager
+    # or storagemanager, we might need to get the parent manager
+    ems = ems.try(:parent_manager) || ems
 
     return {} if ems.nil?
     ems.key_pairs.each_with_object({}) { |kp, h| h[kp.id] = kp.name }
@@ -42,7 +45,8 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def allowed_security_groups(_options = {})
     return {} unless (src = provider_or_tenant_object)
 
-    src_obj = get_targets_for_source(src, :cloud_filter, SecurityGroup, 'security_groups')
+    parent_source = src.try(:parent_manager) || src
+    src_obj = get_targets_for_source(parent_source, :cloud_filter, SecurityGroup, 'security_groups')
 
     src_obj.each_with_object({}) do |sg, h|
       h[sg.id] = display_name_for_name_description(sg)
@@ -51,8 +55,8 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
   def allowed_floating_ip_addresses(_options = {})
     return {} unless (src_obj = provider_or_tenant_object)
-
-    src_obj.floating_ips.available.each_with_object({}) do |ip, h|
+    parent_source = src_obj.try(:parent_manager) || src_obj
+    parent_source.floating_ips.available.each_with_object({}) do |ip, h|
       h[ip.id] = ip.address
     end
   end
@@ -109,7 +113,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def get_targets_for_ems(src, filter_name, klass, relats)
-    ems = src.try(:ext_management_system)
+    ems = src.try(:ext_management_system).try(:top_level_manager)
 
     return {} if ems.nil?
     process_filter(filter_name, klass, ems.deep_send(relats))

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -12,13 +12,17 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
     validate_volume(ext_management_system)
   end
 
+  def self.eligible_for_provisioning
+    super.where(:type => %w(ManageIQ::Providers::Openstack::CloudManager::CloudVolume), :bootable => true)
+  end
+
   def self.raw_create_volume(ext_management_system, options)
     cloud_tenant = options.delete(:cloud_tenant)
     volume = nil
 
     # provide display_name for Cinder V1
     options[:display_name] |= options[:name]
-    ext_management_system.with_provider_connection(cinder_connection_options(cloud_tenant)) do |service|
+    ext_management_system.with_provider_connection(self.cinder_connection_options(cloud_tenant)) do |service|
       volume = service.volumes.new(options)
       volume.save
     end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/cloning.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
   def do_clone_task_check(clone_task_ref)
-    source.with_provider_connection do |openstack|
+    manager = source.ext_management_system.top_level_manager
+    manager.with_provider_connection do |openstack|
       instance = openstack.handled_list(:servers).detect { |s| s.id == clone_task_ref }
       status   = instance.state.downcase.to_sym
 
@@ -42,7 +43,13 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::Cloning
 
   def start_clone(clone_options)
     connection_options = {:tenant_name => options[:cloud_tenant][1]} if options[:cloud_tenant].kind_of? Array
-    source.with_provider_connection(connection_options) do |openstack|
+    # If basing a new vm on an snapshot or volume, there's no image so remove it
+    if (source.class.kind_of? CloudVolume) || (source.class.kind_of? CloudVolumeSnapshot)
+      clone_options.delete :image_ref
+    end
+    # try to navigate up from the storage manager to the cloud manager if there is one
+    manager = source.ext_management_system.top_level_manager
+    manager.with_provider_connection(connection_options) do |openstack|
       instance = openstack.servers.create(clone_options)
       return instance.id
     end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
@@ -30,7 +30,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
   end
 
   def default_volume_attributes
-    {
+    attrs = {
       :name                  => "root",
       :size                  => instance_type.root_disk_size / 1.gigabyte,
       :source_type           => "image",
@@ -39,5 +39,15 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
       :delete_on_termination => true,
       :uuid                  => source.ems_ref
     }
+    if source.class.kind_of? CloudVolume
+      attrs[:destination_type] = "volume"
+      attrs[:source_type] = "volume"
+      attrs[:delete_on_termination] = false
+    elsif source.class.kind_of? CloudVolumeSnapshot
+      attrs[:destination_type] = "volume"
+      attrs[:source_type] = "snapshot"
+      attrs[:size] = [instance_type.root_disk_size, source.size].max / 1.gigabyte
+    end
+    attrs
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -5,8 +5,16 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     source                  = load_ar_obj(get_source_vm)
     flavors                 = get_targets_for_ems(source, :cloud_filter, Flavor, 'flavors')
     return {} if flavors.blank?
-    minimum_disk_required   = [source.hardware.size_on_disk.to_i, source.hardware.disk_size_minimum.to_i].max
-    minimum_memory_required = source.hardware.memory_mb_minimum.to_i * 1.megabyte
+    minimum_disk_required = if (source.class.kind_of? CloudVolume) || (source.class.kind_of? CloudVolumeSnapshot)
+                              0
+                            else
+                              [source.hardware.size_on_disk.to_i, source.hardware.disk_size_minimum.to_i].max
+                            end
+    minimum_memory_required = if (source.class.kind_of? CloudVolume) || (source.class.kind_of? CloudVolumeSnapshot)
+                                0
+                              else
+                                source.hardware.memory_mb_minimum.to_i * 1.megabyte
+                              end
     flavors.each_with_object({}) do |flavor, h|
       next if flavor.root_disk_size <= minimum_disk_required
       next if flavor.memory         <= minimum_memory_required
@@ -54,7 +62,8 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     # We want only non external networks to be connectable directly to the Vm
     return {} unless (src_obj = provider_or_tenant_object)
 
-    src_obj.all_private_networks.each_with_object({}) do |cn, hash|
+    networks = src_obj.try(:all_private_networks) || src_obj.try(:parent_manager).try(:all_private_networks)
+    networks.each_with_object({}) do |cn, hash|
       hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
     end
   end

--- a/app/models/miq_provision/helper.rb
+++ b/app/models/miq_provision/helper.rb
@@ -1,6 +1,6 @@
 module MiqProvision::Helper
   def hostname_cleanup(name)
-    hostname_length = (source.platform == 'linux') ? 63 : 15
+    hostname_length = (source.try(:platform) == 'linux') ? 63 : 15
     name.strip.gsub(/ +|_+/, "-")[0, hostname_length]
   end
 end

--- a/app/models/miq_provision/options_helper.rb
+++ b/app/models/miq_provision/options_helper.rb
@@ -25,12 +25,13 @@ module MiqProvision::OptionsHelper
 
   def get_source
     source_id = get_option(:src_vm_id)
-    source = VmOrTemplate.find_by(:id => source_id)
+    source_type = get_option(:src_type)
+    source = MiqProvisionSource.get_provisioning_request_source(source_id, source_type)
     if source.nil?
       raise MiqException::MiqProvisionError,
             _("Unable to find source Template/Vm with id [%{number}]") % {:number => source_id}
     end
-    ems = source.ext_management_system
+    ems = source.ext_management_system.top_level_manager
     if ems.nil?
       raise MiqException::MiqProvisionError,
             _("%{class_name} [%{name}] is not attached to a Management System") % {:class_name => source.class.name,
@@ -56,7 +57,7 @@ module MiqProvision::OptionsHelper
   end
 
   def get_hostname(dest_vm_name)
-    name_key = (source.platform == 'windows') ? :sysprep_computer_name : :linux_host_name
+    name_key = (source.try(:platform) == 'windows') ? :sysprep_computer_name : :linux_host_name
     computer_name = (get_option(:number_of_vms) > 1) ? nil : get_option(name_key).to_s.strip
     computer_name = dest_vm_name if computer_name.blank?
     hostname_cleanup(computer_name)

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -3,22 +3,24 @@ class MiqProvisionRequest < MiqRequest
   alias_attribute :provision_type, :request_type
   alias_attribute :miq_provisions, :miq_request_tasks
   alias_attribute :src_vm_id,      :source_id
+  alias_attribute :src_type,       :source_type
 
   delegate :my_zone, :to => :source
 
-  TASK_DESCRIPTION  = 'VM Provisioning'
-  SOURCE_CLASS_NAME = 'Vm'
+  TASK_DESCRIPTION  = 'VM Provisioning'.freeze
+  SOURCE_CLASS_NAME = "Vm".freeze
   ACTIVE_STATES     = %w(migrated) + base_class::ACTIVE_STATES
 
   validates_inclusion_of :request_state,
                          :in      => %w(pending provisioned finished) + ACTIVE_STATES,
                          :message => "should be pending, #{ACTIVE_STATES.join(", ")}, provisioned, or finished"
-  validates_presence_of  :source_id,      :message => "must have valid template"
-  validate               :must_have_valid_vm
+  validates_presence_of  :source_id, :message => "must have valid provisioning source"
+  validate               :must_have_valid_source
   validate               :must_have_user
 
   default_value_for :options,      :number_of_vms => 1
   default_value_for(:src_vm_id)    { |r| r.get_option(:src_vm_id) }
+  default_value_for(:src_type)     { |r| r.get_option(:src_type) || "VmOrTemplate" }
 
   virtual_column :provision_type, :type => :string
 
@@ -26,12 +28,16 @@ class MiqProvisionRequest < MiqRequest
   include MiqProvisionQuotaMixin
 
   def self.request_task_class_from(attribs)
-    source_id = MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])
-    vm_or_template = VmOrTemplate.find_by(:id => source_id)
-    raise MiqException::MiqProvisionError, "Unable to find source Template/Vm with id [#{source_id}]" if vm_or_template.nil?
+    source_id = MiqRequestMixin.get_option(:source_id, nil, attribs['options'])
+    source_type = MiqRequestMixin.get_option(:source_type, nil, attribs['options'])
+    source_id ||= MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])
+    source_type ||= MiqRequestMixin.get_option(:src_type, nil, attribs['options'])
+    provisioning_source = MiqProvisionSource.get_provisioning_request_source(source_id, source_type)
+    raise MiqException::MiqProvisionError, "Unable to find source #{source_type} with id [#{source_id}]" if provisioning_source.nil?
 
     via = MiqRequestMixin.get_option(:provision_type, nil, attribs['options'])
-    vm_or_template.ext_management_system.class.provision_class(via)
+    manager = provisioning_source.ext_management_system.top_level_manager
+    manager.class.provision_class(via)
   end
 
   def self.new_request_task(attribs)
@@ -39,8 +45,8 @@ class MiqProvisionRequest < MiqRequest
     klass.new(attribs)
   end
 
-  def must_have_valid_vm
-    errors.add(:vm_template, "must have valid VM (must be in vmdb)") if vm_template.nil?
+  def must_have_valid_source
+    errors.add(:source, "must have valid provisioning source") if source.nil?
   end
 
   def set_description(force = false)
@@ -82,9 +88,9 @@ class MiqProvisionRequest < MiqRequest
 
     return false if dept.empty? || env.empty?
 
-    prov.options[:environment] = "prod" # Set env to prod to get service levels
-    svc  = prov.allowed(:service_level) # Get service levels
-    return false if env.include?("prod") && svc.empty?  # Make sure we have at least one
+    prov.options[:environment] = "prod"                # Set env to prod to get service levels
+    svc = prov.allowed(:service_level)                 # Get service levels
+    return false if env.include?("prod") && svc.empty? # Make sure we have at least one
 
     true
   end
@@ -115,17 +121,20 @@ class MiqProvisionRequest < MiqRequest
   end
 
   def validate_template
-    return {:valid   => false,
-            :message => "Unable to find VM with Id [#{source_id}]"
+    return {
+      :valid   => false,
+      :message => "Unable to find #{source_type} with Id [#{source_id}]"
     } if source.nil?
 
-    return {:valid   => false,
-            :message => "VM/Template <#{source.name}> with Id <#{source.id}> is archived and cannot be used with provisioning."
-    } if source.archived?
+    return {
+      :valid   => false,
+      :message => "#{source_type} <#{source.name}> with Id <#{source.id}> is archived and cannot be used with provisioning."
+    } if source.try(:archived?)
 
-    return {:valid   => false,
-            :message => "VM/Template <#{source.name}> with Id <#{source.id}> is orphaned and cannot be used with provisioning."
-    } if source.orphaned?
+    return {
+      :valid   => false,
+      :message => "#{source_type} <#{source.name}> with Id <#{source.id}> is orphaned and cannot be used with provisioning."
+    } if source.try(:orphaned?)
 
     {:valid => true, :message => nil}
   end

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -28,7 +28,8 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
              else VmOrTemplate.find_by(:id => source_or_id)
              end
     return nil if source.nil?
-    source.class.manager_class.provision_workflow_class
+    source.class.try(:manager_class).try(:provision_workflow_class) ||
+      source.ext_management_system.top_level_manager.class.provision_workflow_class
   end
 
   def self.encrypted_options_fields

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -231,6 +231,10 @@ module MiqProvisionMixin
   def source_type
     if vm_template.kind_of?(MiqTemplate)
       return 'template'
+    elsif vm_template.kind_of?(CloudVolume)
+      return 'cloudvolume'
+    elsif vm_template.kind_of?(CloudVolumeSnapshot)
+      return 'cloudvolumesnapshot'
     else
       return 'vm'
     end

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -229,7 +229,11 @@ module MiqProvisionMixin
   end
 
   def source_type
-    vm_template.kind_of?(MiqTemplate) ? 'template' : 'vm'
+    if vm_template.kind_of?(MiqTemplate)
+      return 'template'
+    else
+      return 'vm'
+    end
   end
 
   def set_nic_settings(idx, nic_hash, value = nil)

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -307,7 +307,7 @@ module MiqProvisionQuotaMixin
         result[:count] += num_vms_for_request
         result[:memory] += pr.get_option(:vm_memory).to_i * num_vms_for_request
         result[:cpu] += pr.get_option(:number_of_cpus).to_i * num_vms_for_request
-        result[:storage] += (pr.vm_template.allocated_disk_storage.to_i + new_disk_storage_size) * num_vms_for_request
+        result[:storage] += (pr.source.allocated_disk_storage.to_i + new_disk_storage_size) * num_vms_for_request
         result[:ids] << pr.id
 
         # Include a resource breakdown for actively provisioning records
@@ -317,7 +317,7 @@ module MiqProvisionQuotaMixin
           active = result[:active]
           active[:memory_by_host_id][host_id] += p.get_option(:vm_memory).to_i
           active[:cpu_by_host_id][host_id] += p.get_option(:number_of_cpus).to_i
-          active[:storage_by_id][storage_id] += p.vm_template.allocated_disk_storage.to_i + new_disk_storage_size
+          active[:storage_by_id][storage_id] += p.source.allocated_disk_storage.to_i + new_disk_storage_size
           active[:vms_by_storage_id][storage_id] << p.id
           active[:ids] << p.id
         end

--- a/lib/miq_provision_source.rb
+++ b/lib/miq_provision_source.rb
@@ -1,6 +1,13 @@
 module MiqProvisionSource
-  def self.get_provisioning_request_source_class(_src_type_string)
-    VmOrTemplate
+  def self.get_provisioning_request_source_class(src_type_string)
+    case src_type_string
+    when "CloudVolumeSnapshot"
+      CloudVolumeSnapshot
+    when "CloudVolume"
+      CloudVolume
+    else
+      VmOrTemplate
+    end
   end
 
   def self.get_provisioning_request_source(src_id, src_type_string)

--- a/lib/miq_provision_source.rb
+++ b/lib/miq_provision_source.rb
@@ -1,0 +1,10 @@
+module MiqProvisionSource
+  def self.get_provisioning_request_source_class(_src_type_string)
+    VmOrTemplate
+  end
+
+  def self.get_provisioning_request_source(src_id, src_type_string)
+    kls = get_provisioning_request_source_class(src_type_string)
+    kls.find_by_id(src_id)
+  end
+end

--- a/spec/lib/miq_provision_source_spec.rb
+++ b/spec/lib/miq_provision_source_spec.rb
@@ -1,0 +1,50 @@
+describe MiqProvisionSource do
+  context "get_provisioning_request_source_class" do
+    it "returns CloudVolumeSnapshot" do
+      kls = described_class.get_provisioning_request_source_class("CloudVolumeSnapshot")
+      expect(kls).to eq(CloudVolumeSnapshot)
+    end
+
+    it "returns CloudVolume" do
+      kls = described_class.get_provisioning_request_source_class("CloudVolume")
+      expect(kls).to eq(CloudVolume)
+    end
+
+    it "defaults to VmOrTemplate for unknown values" do
+      kls = described_class.get_provisioning_request_source_class("some_class")
+      expect(kls).to eq(VmOrTemplate)
+      kls = described_class.get_provisioning_request_source_class(nil)
+      expect(kls).to eq(VmOrTemplate)
+    end
+  end
+
+  context "get_provisioning_request_source" do
+    it "returns a CloudVolume when given the right id and src type" do
+      cloud_volume = FactoryGirl.create(:cloud_volume_openstack)
+
+      src = described_class.get_provisioning_request_source(cloud_volume.id, "CloudVolume")
+      expect(src).to eq(cloud_volume)
+    end
+
+    it "returns a CloudVolumeSnapshot when given the right id and src type" do
+      cloud_volume_snapshot = FactoryGirl.create(:cloud_volume_snapshot_openstack)
+
+      src = described_class.get_provisioning_request_source(cloud_volume_snapshot.id, "CloudVolumeSnapshot")
+      expect(src).to eq(cloud_volume_snapshot)
+    end
+
+    it "returns a VmOrTemplate when given the right id and any other src value" do
+      vm_or_template = FactoryGirl.create(:vm_openstack)
+
+      src = described_class.get_provisioning_request_source(vm_or_template.id, nil)
+      expect(src).to eq(vm_or_template)
+    end
+
+    it "returns nil when given an invalid id" do
+      FactoryGirl.create(:cloud_volume_openstack)
+
+      src = described_class.get_provisioning_request_source("invalid_id", "CloudVolume")
+      expect(src).to eq(nil)
+    end
+  end
+end

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -137,6 +137,240 @@ describe MiqProvision do
         end
       end
     end
+
+    context "with Openstack cloud" do
+      before(:each) do
+        @ems         = FactoryGirl.create(:ems_openstack_with_authentication)
+        @storage_ems = FactoryGirl.create(:ems_cinder, :parent_manager => @ems)
+        @volume_source = FactoryGirl.create(:cloud_volume_openstack,
+                                            :name                  => "volume1",
+                                            :ext_management_system => @storage_ems)
+        @snapshot_source = FactoryGirl.create(:cloud_volume_snapshot_openstack,
+                                              :name                  => "snapshot1",
+                                              :ext_management_system => @storage_ems,
+                                              :cloud_volume          => @volume_source)
+      end
+
+      context "with a valid userid and source volume," do
+        before(:each) do
+          @pr = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @volume_source.id, :src_type => "CloudVolume")
+          @options[:src_vm_id] = [@volume_source.id, @volume_source.name]
+          @options[:src_type] = "CloudVolume"
+          @vm_prov = FactoryGirl.create(:miq_provision, :userid => @admin.userid, :miq_request => @pr, :source => @volume_source, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
+        end
+
+        it "should get values out of an arrays in the options hash" do
+          expect(@vm_prov.options[:src_vm_id]).to be_kind_of(Array)
+          expect(@vm_prov.get_option(:src_vm_id)).to eq(@volume_source.id)
+          expect(@vm_prov.get_option_last(:src_vm_id)).to eq(@volume_source.name)
+          expect(@vm_prov.get_option_last(:number_of_vms)).to eq(1)
+          expect(@vm_prov.get_option(nil, @vm_prov.options[:src_vm_id])).to eq(@volume_source.id)
+        end
+
+        it "should return a user object" do
+          user = @vm_prov.get_user
+          expect(user).to be_kind_of(User)
+          expect(user).to eq(@admin)
+        end
+
+        it "should return a description" do
+          expect(@vm_prov.class.get_description(@vm_prov, nil)).not_to be_blank
+        end
+
+        it "should populate description, target_name and target_hostname" do
+          @vm_prov.after_request_task_create
+          expect(@vm_prov.description).not_to be_nil
+          expect(@vm_prov.get_option(:vm_target_name)).not_to be_nil
+          expect(@vm_prov.get_option(:vm_target_hostname)).not_to be_nil
+        end
+
+        it "should create a valid target_name and hostname" do
+          MiqRegion.seed
+          @vm_prov.after_request_task_create
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(@target_vm_name)
+
+          @vm_prov.options[:number_of_vms] = 2
+          @vm_prov.after_request_task_create
+          name_001 = "#{@target_vm_name}001"
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(name_001)
+          # Hostname cannot contain spaces or underscores, they should be replaces with (-)
+          expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_001.gsub(/ +|_+/, "-"))
+
+          @vm_prov.options[:pass] = 2
+          @vm_prov.after_request_task_create
+          name_002 = "#{@target_vm_name}002"
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(name_002)
+          # Hostname cannot contain spaces or underscores, they should be replaces with (-)
+          expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_002.gsub(/ +|_+/, "-"))
+        end
+
+        context "when auto naming sequence exceeds the range" do
+          before do
+            region = MiqRegion.seed
+            region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
+            region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
+          end
+
+          it "should advance to next range but based on the existing sequence number for the new range" do
+            @vm_prov.options[:number_of_vms] = 2
+            @vm_prov.after_request_task_create
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}999")  # 3 digits
+
+            @vm_prov.options[:pass] = 2
+            @vm_prov.after_request_task_create
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}0011") # 4 digits
+          end
+        end
+
+        it "should create a hostname with a safe length since volumes don't have known operating systems" do
+          # Hostname lengths by platform:
+          #   Linux   : 63
+          #   Windows : 15
+          #                                      1         2         3         4         5         6
+          @vm_prov.options[:vm_name] = '123456789012345678901234567890123456789012345678901234567890123456789'
+          @vm_prov.after_request_task_create
+          expect(@vm_prov.get_option(:vm_target_hostname).length).to eq(15)
+        end
+
+        it "should select a different IP address for multiple provisions" do
+          expect(@vm_prov.set_static_ip_address(1)).to be_nil
+          @vm_prov.options[:ip_addr] = '127.0.0.100'
+          @vm_prov.set_static_ip_address(1)
+          expect(@vm_prov.get_option(:ip_addr)).to eq('127.0.0.100')
+          @vm_prov.set_static_ip_address(2)
+          expect(@vm_prov.get_option(:ip_addr)).to eq('127.0.0.101')
+        end
+
+        it "should skip post-provisioning if the request is finished or in error" do
+          expect(@vm_prov.prematurely_finished?).to be_falsey
+
+          init_state = @vm_prov.state
+          @vm_prov.state = 'finished'
+          expect(@vm_prov.prematurely_finished?).to be_truthy
+
+          @vm_prov.state = init_state
+          @vm_prov.status = 'Error'
+          expect(@vm_prov.prematurely_finished?).to be_truthy
+
+          @vm_prov.state = 'finished'
+          expect(@vm_prov.prematurely_finished?).to be_truthy
+        end
+
+        it "#my_zone" do
+          expect(@vm_prov.my_zone).to eq(@vm_prov.source.ext_management_system.my_zone)
+        end
+      end
+
+      context "with a valid userid and source volume snapshot," do
+        before(:each) do
+          @pr = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @snapshot_source.id, :src_type => "CloudVolumeSnapshot")
+          @options[:src_vm_id] = [@snapshot_source.id, @snapshot_source.name]
+          @options[:src_type] = "CloudVolumeSnapshot"
+          @vm_prov = FactoryGirl.create(:miq_provision, :userid => @admin.userid, :miq_request => @pr, :source => @snapshot_source, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
+        end
+
+        it "should get values out of an arrays in the options hash" do
+          expect(@vm_prov.options[:src_vm_id]).to be_kind_of(Array)
+          expect(@vm_prov.get_option(:src_vm_id)).to eq(@snapshot_source.id)
+          expect(@vm_prov.get_option_last(:src_vm_id)).to eq(@snapshot_source.name)
+          expect(@vm_prov.get_option_last(:number_of_vms)).to eq(1)
+          expect(@vm_prov.get_option(nil, @vm_prov.options[:src_vm_id])).to eq(@snapshot_source.id)
+        end
+
+        it "should return a user object" do
+          user = @vm_prov.get_user
+          expect(user).to be_kind_of(User)
+          expect(user).to eq(@admin)
+        end
+
+        it "should return a description" do
+          expect(@vm_prov.class.get_description(@vm_prov, nil)).not_to be_blank
+        end
+
+        it "should populate description, target_name and target_hostname" do
+          @vm_prov.after_request_task_create
+          expect(@vm_prov.description).not_to be_nil
+          expect(@vm_prov.get_option(:vm_target_name)).not_to be_nil
+          expect(@vm_prov.get_option(:vm_target_hostname)).not_to be_nil
+        end
+
+        it "should create a valid target_name and hostname" do
+          MiqRegion.seed
+          @vm_prov.after_request_task_create
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(@target_vm_name)
+
+          @vm_prov.options[:number_of_vms] = 2
+          @vm_prov.after_request_task_create
+          name_001 = "#{@target_vm_name}001"
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(name_001)
+          # Hostname cannot contain spaces or underscores, they should be replaces with (-)
+          expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_001.gsub(/ +|_+/, "-"))
+
+          @vm_prov.options[:pass] = 2
+          @vm_prov.after_request_task_create
+          name_002 = "#{@target_vm_name}002"
+          expect(@vm_prov.get_option(:vm_target_name)).to eq(name_002)
+          # Hostname cannot contain spaces or underscores, they should be replaces with (-)
+          expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_002.gsub(/ +|_+/, "-"))
+        end
+
+        context "when auto naming sequence exceeds the range" do
+          before do
+            region = MiqRegion.seed
+            region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
+            region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
+          end
+
+          it "should advance to next range but based on the existing sequence number for the new range" do
+            @vm_prov.options[:number_of_vms] = 2
+            @vm_prov.after_request_task_create
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}999")  # 3 digits
+
+            @vm_prov.options[:pass] = 2
+            @vm_prov.after_request_task_create
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}0011") # 4 digits
+          end
+        end
+
+        it "should create a hostname with a safe length since volumes don't have known operating systems" do
+          # Hostname lengths by platform:
+          #   Linux   : 63
+          #   Windows : 15
+          #                                      1         2         3         4         5         6
+          @vm_prov.options[:vm_name] = '123456789012345678901234567890123456789012345678901234567890123456789'
+          @vm_prov.after_request_task_create
+          expect(@vm_prov.get_option(:vm_target_hostname).length).to eq(15)
+        end
+
+        it "should select a different IP address for multiple provisions" do
+          expect(@vm_prov.set_static_ip_address(1)).to be_nil
+          @vm_prov.options[:ip_addr] = '127.0.0.100'
+          @vm_prov.set_static_ip_address(1)
+          expect(@vm_prov.get_option(:ip_addr)).to eq('127.0.0.100')
+          @vm_prov.set_static_ip_address(2)
+          expect(@vm_prov.get_option(:ip_addr)).to eq('127.0.0.101')
+        end
+
+        it "should skip post-provisioning if the request is finished or in error" do
+          expect(@vm_prov.prematurely_finished?).to be_falsey
+
+          init_state = @vm_prov.state
+          @vm_prov.state = 'finished'
+          expect(@vm_prov.prematurely_finished?).to be_truthy
+
+          @vm_prov.state = init_state
+          @vm_prov.status = 'Error'
+          expect(@vm_prov.prematurely_finished?).to be_truthy
+
+          @vm_prov.state = 'finished'
+          expect(@vm_prov.prematurely_finished?).to be_truthy
+        end
+
+        it "#my_zone" do
+          expect(@vm_prov.my_zone).to eq(@vm_prov.source.ext_management_system.my_zone)
+        end
+      end
+    end
   end
 
   context "#eligible_resources" do

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -20,8 +20,7 @@ describe MiqProvisionVirtWorkflow do
     end
 
     it "sets initial_pass equal to true when values are empty and initial_pass => true is passed in as an option" do
-      # once for src_vm_id, once for src_type
-      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:get_value).with(nil).twice
+      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:get_value).twice
 
       init_options = {:use_pre_dialog => false, :skip_dialog_load => true, :request_type => :clone_to_vm, :initial_pass => true}
       p = MiqProvisionVirtWorkflow.new({}, user, init_options)
@@ -66,7 +65,7 @@ describe MiqProvisionVirtWorkflow do
     end
   end
 
-  context 'network selection' do
+  context 'network selection vm' do
     before do
       @ems    = FactoryGirl.create(:ems_vmware)
       @host1  = FactoryGirl.create(:host_vmware, :ems_id => @ems.id)
@@ -319,6 +318,50 @@ describe MiqProvisionVirtWorkflow do
 
     it 'updates soruce_id' do
       expect(request.source_id).to eq(template.id)
+    end
+  end
+
+  context '#make_request (update) with cloud volume' do
+    let(:volume) do
+      FactoryGirl.create(
+        :cloud_volume_openstack,
+        :name                  => "volume1",
+        :ext_management_system => FactoryGirl.create(:ems_cinder, :parent_manager => FactoryGirl.create(:ems_openstack))
+      )
+    end
+    let(:values)  { {:src_vm_id => [volume.id, volume.name], :src_type => 'CloudVolume'} }
+    let(:request) { workflow.make_request(nil, :src_vm_id => [999, 'old_template']) }
+    before { workflow.make_request(request, values) }
+
+    it 'updates options' do
+      expect(request.options).to include(values)
+    end
+
+    it 'updates source_id and source_type' do
+      expect(request.source_id).to eq(volume.id)
+      expect(request.source_type).to eq("cloudvolume")
+    end
+  end
+
+  context '#make_request (update) with cloud volume snapshot' do
+    let(:snapshot) do
+      FactoryGirl.create(
+        :cloud_volume_snapshot_openstack,
+        :name                  => "snapshot1",
+        :ext_management_system => FactoryGirl.create(:ems_cinder, :parent_manager => FactoryGirl.create(:ems_openstack))
+      )
+    end
+    let(:values)  { {:src_vm_id => [snapshot.id, snapshot.name], :src_type => 'CloudVolumeSnapshot'} }
+    let(:request) { workflow.make_request(nil, :src_vm_id => [999, 'old_template']) }
+    before { workflow.make_request(request, values) }
+
+    it 'updates options' do
+      expect(request.options).to include(values)
+    end
+
+    it 'updates source_id and source_type' do
+      expect(request.source_id).to eq(snapshot.id)
+      expect(request.source_type).to eq("cloudvolumesnapshot")
     end
   end
 end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -20,7 +20,8 @@ describe MiqProvisionVirtWorkflow do
     end
 
     it "sets initial_pass equal to true when values are empty and initial_pass => true is passed in as an option" do
-      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:get_value).once
+      # once for src_vm_id, once for src_type
+      expect_any_instance_of(MiqProvisionVirtWorkflow).to receive(:get_value).with(nil).twice
 
       init_options = {:use_pre_dialog => false, :skip_dialog_load => true, :request_type => :clone_to_vm, :initial_pass => true}
       p = MiqProvisionVirtWorkflow.new({}, user, init_options)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -381,7 +381,7 @@ describe ServiceTemplate do
       it 'not existing template' do
         @ptr.update_attributes(:src_vm_id => 999)
         expect(@st1.template_valid?).to be_falsey
-        expect(@st1.template_valid_error_message).to include("Unable to find VM with Id [999]")
+        expect(@st1.template_valid_error_message).to include("Unable to find vm with Id [999]")
       end
 
       it 'generic' do
@@ -426,7 +426,7 @@ describe ServiceTemplate do
       it 'not existing template' do
         @ptr.update_attributes(:src_vm_id => 999)
         expect(@st2.template_valid?).to be_falsey
-        expect(@st2.template_valid_error_message).to include("Unable to find VM with Id [999]")
+        expect(@st2.template_valid_error_message).to include("Unable to find vm with Id [999]")
       end
     end
   end


### PR DESCRIPTION
This PR is to add support for provisioning Nova instances based on volumes and volume snapshots in addition to VM images.

See also:
* https://github.com/ManageIQ/manageiq/pull/12949 (refactoring the provisioning workflow to more easily allow these changes)
* https://github.com/ManageIQ/manageiq/pull/11691 (the original pull request that these changes were split out from)
