### PR TITLE
service order copy API

### DIFF
--- a/app/controllers/api/service_orders_controller.rb
+++ b/app/controllers/api/service_orders_controller.rb
@@ -47,6 +47,13 @@ module Api
       {:user => @auth_user_obj, :tenant => @auth_user_obj.current_tenant}
     end
 
+    def copy_resource(type, id, data)
+      service_order = resource_search(id, type, collection_class(type))
+      service_order.deep_copy(data)
+    rescue => err
+      raise BadRequestError, "Could not copy service order - #{err}"
+    end
+
     private
 
     def add_request_to_cart(workflow)

--- a/config/api.yml
+++ b/config/api.yml
@@ -1276,6 +1276,8 @@
         :identifier: svc_catalog_provision
       - :name: delete
         :identifier: svc_catalog_provision
+      - :name: copy
+        :identifier: svc_catalog_provision
     :resource_actions:
       :get:
       - :name: read
@@ -1288,6 +1290,8 @@
       - :name: clear
         :identifier: svc_catalog_provision
       - :name: order
+        :identifier: svc_catalog_provision
+      - :name: copy
         :identifier: svc_catalog_provision
       :delete:
       - :name: delete


### PR DESCRIPTION
API for copying a service order. Dependent on #12945 

Links
----------------
* [Pivotal Tracker Ticket](https://www.pivotaltracker.com/story/show/134071933)

@miq-bot add_label enhancement, api, euwe/no, wip
@miq-bot assign @abellotti 