### PR TITLE
[DARGA] Restore missing Add Child Tenant/Add Project buttons on Tenants

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1502,6 +1502,8 @@ module ApplicationHelper
     case pressed
     when "rbac_project_add", "rbac_tenant_add"
       "rbac_tenant_add"
+    else
+      pressed
     end
   end
 

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -403,10 +403,8 @@ class ApplicationHelper::ToolbarBuilder
         return true
       end
     when :rbac_tree
-      common_buttons = %w(rbac_project_add rbac_tenant_add)
-      feature = common_buttons.include?(id) ? rbac_common_feature_for_buttons(id) : id
-      return true unless role_allows(:feature => feature)
-      return true if common_buttons.include?(id) && @record.project?
+      return true unless role_allows(:feature => rbac_common_feature_for_buttons(id))
+      return true if %w(rbac_project_add rbac_tenant_add).include?(id) && @record.project?
       return false
     when :vmdb_tree
       return ["db_connections", "db_details", "db_indexes", "db_settings"].include?(@sb[:active_tab]) ? false : true

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,6 +115,18 @@ describe ApplicationHelper do
     end
   end
 
+  describe "#rbac_common_feature_for_buttons" do
+    %w(rbac_project_add rbac_tenant_add).each do |pressed|
+      it "returns the correct common button" do
+        expect(rbac_common_feature_for_buttons(pressed)).to eql("rbac_tenant_add")
+      end
+    end
+
+    it "returns the passed in argument if no common buttons are found" do
+      expect(rbac_common_feature_for_buttons("rbac_tenant_edit")).to eql("rbac_tenant_edit")
+    end
+  end
+
   describe "#model_to_controller" do
     subject { helper.model_to_controller(@record) }
 


### PR DESCRIPTION
Common button id's were not being accounted for in some role_allows? calls causing the Add Project button to go missing in some instances.

https://bugzilla.redhat.com/show_bug.cgi?id=1395272
