### PR TITLE
Add textual summary for orchestration_stack on the service summary page

### DIFF
--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -95,13 +95,16 @@ module ServiceHelper::TextualSummary
 
   def textual_orchestration_stack
     ost = @record.try(:orchestration_stack)
-    {
-      :label => _("Orchestration Stack"),
-      :image => "orchestration_stack",
-      :value => ost.name,
-      :title => _("Show this Service's Orchestration Stack"),
-      :link  => url_for(:controller => 'orchestration_stack', :action => 'show', :id => ost.id)
-    } if ost
+    if ost && !ost.id.present?
+      {
+        :label => _("Orchestration Stack"),
+        :image => "100/orchestration_stack.png",
+        :value => ost.name,
+        :title => _("Invalid Stack")
+      }
+    elsif ost
+      ost
+    end
   end
 
   def textual_job

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -96,10 +96,10 @@ module ServiceHelper::TextualSummary
   def textual_orchestration_stack
     ost = @record.try(:orchestration_stack)
     {
-      :label => _("Stack"),
+      :label => _("Orchestration Stack"),
       :image => "orchestration_stack",
       :value => ost.name,
-      :title => _("Show this Service's Stack"),
+      :title => _("Show this Service's Orchestration Stack"),
       :link  => url_for(:controller => 'orchestration_stack', :action => 'show', :id => ost.id)
     } if ost
   end

--- a/app/helpers/service_helper/textual_summary.rb
+++ b/app/helpers/service_helper/textual_summary.rb
@@ -94,7 +94,14 @@ module ServiceHelper::TextualSummary
   end
 
   def textual_orchestration_stack
-    @record.try(:orchestration_stack)
+    ost = @record.try(:orchestration_stack)
+    {
+      :label => _("Stack"),
+      :image => "orchestration_stack",
+      :value => ost.name,
+      :title => _("Show this Service's Stack"),
+      :link  => url_for(:controller => 'orchestration_stack', :action => 'show', :id => ost.id)
+    } if ost
   end
 
   def textual_job

--- a/spec/helpers/service_helper/textual_summary_spec.rb
+++ b/spec/helpers/service_helper/textual_summary_spec.rb
@@ -1,22 +1,30 @@
 describe ServiceHelper::TextualSummary do
-  context ".textual_orchestration_stack" do
+  describe ".textual_orchestration_stack" do
+    let(:os_cloud) { FactoryGirl.create(:orchestration_stack_cloud, :name => "cloudstack1") }
+    let(:os_infra) { FactoryGirl.create(:orchestration_stack_openstack_infra, :name => "infrastack1") }
+
     before do
-      login_as @user = FactoryGirl.create(:user)
+      login_as FactoryGirl.create(:user)
     end
 
     subject { textual_orchestration_stack }
-    it 'contains the link to the associated stack' do
-      @os_cloud  = FactoryGirl.create(:orchestration_stack_cloud, :name => "cloudstack1")
+    it 'contains the link to the associated cloud stack' do
       @record = FactoryGirl.create(:service)
-      allow(@record).to receive(:orchestration_stack).and_return(@os_cloud)
-      expect(textual_orchestration_stack[:link]).to eq("/orchestration_stack/show/#{@os_cloud.id}")
+      allow(@record).to receive(:orchestration_stack).and_return(os_cloud)
+      expect(textual_orchestration_stack).to eq(os_cloud)
     end
 
-    it 'contains the link to the associated stack' do
-      @os_infra  = FactoryGirl.create(:orchestration_stack_openstack_infra, :name => "infrastack1")
+    it 'contains the link to the associated infra stack' do
       @record = FactoryGirl.create(:service)
-      allow(@record).to receive(:orchestration_stack).and_return(@os_infra)
-      expect(textual_orchestration_stack[:link]).to eq("/orchestration_stack/show/#{@os_infra.id}")
+      allow(@record).to receive(:orchestration_stack).and_return(os_infra)
+      expect(textual_orchestration_stack).to eq(os_infra)
+    end
+
+    it 'contains no link for an invalid stack' do
+      os_infra.id = nil
+      @record = FactoryGirl.create(:service)
+      allow(@record).to receive(:orchestration_stack).and_return(os_infra)
+      expect(textual_orchestration_stack[:link]).to be_nil
     end
   end
 end

--- a/spec/helpers/service_helper/textual_summary_spec.rb
+++ b/spec/helpers/service_helper/textual_summary_spec.rb
@@ -1,0 +1,22 @@
+describe ServiceHelper::TextualSummary do
+  context ".textual_orchestration_stack" do
+    before do
+      login_as @user = FactoryGirl.create(:user)
+    end
+
+    subject { textual_orchestration_stack }
+    it 'contains the link to the associated stack' do
+      @os_cloud  = FactoryGirl.create(:orchestration_stack_cloud, :name => "cloudstack1")
+      @record = FactoryGirl.create(:service)
+      allow(@record).to receive(:orchestration_stack).and_return(@os_cloud)
+      expect(textual_orchestration_stack[:link]).to eq("/orchestration_stack/show/#{@os_cloud.id}")
+    end
+
+    it 'contains the link to the associated stack' do
+      @os_infra  = FactoryGirl.create(:orchestration_stack_openstack_infra, :name => "infrastack1")
+      @record = FactoryGirl.create(:service)
+      allow(@record).to receive(:orchestration_stack).and_return(@os_infra)
+      expect(textual_orchestration_stack[:link]).to eq("/orchestration_stack/show/#{@os_infra.id}")
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/13089

Handle empty orchestration stack link in the service summary page. 
A service for RHOS can contain an empty orchestration stack. This PR changes the summary page for the service to handle this.

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1394485

Steps for Testing
------------------------------

1.Create a Service for RHOS using a non-existing stack name
2.The link for the stack in the service's summary page is invalid - this PR removes the link

Before:
![screenshot from 2016-12-07 16-07-38](https://cloud.githubusercontent.com/assets/12769982/20986748/e80bb15a-bc97-11e6-8c64-446d743729ba.png)

After:

![screenshot from 2016-12-07 16-02-49](https://cloud.githubusercontent.com/assets/12769982/20986760/f2b194bc-bc97-11e6-8923-ed596e3c575f.png)

 
