### PR TITLE
[WIP] Add virtual_attributes to VimPerformanceOperatingRange (#ROFLSCALE)

### DIFF
--- a/app/models/metric/ci_mixin/long_term_averages.rb
+++ b/app/models/metric/ci_mixin/long_term_averages.rb
@@ -13,10 +13,11 @@ module Metric::CiMixin::LongTermAverages
   private
 
   def averages_over_time_period(col, typ)
-    # there is only ever 1 of these. It has days = 30 (AVG_DAYS)
-    vpor = vim_performance_operating_ranges.detect do |rec|
-      rec.days == Metric::LongTermAverages::AVG_DAYS
-    end
+    vpor_col = "#{col}_#{typ}_over_time_period"
+    vpor     = vim_performance_operating_ranges.select(:id, :updated_at, vpor_col)
+                                               .where(:time_profile => nil)
+                                               .where(:days => Metric::LongTermAverages::AVG_DAYS)
+                                               .first
 
     if vpor.nil? || vpor.updated_at.utc < 1.day.ago.utc
       vpor ||= vim_performance_operating_ranges.build(:days => Metric::LongTermAverages::AVG_DAYS)
@@ -26,6 +27,6 @@ module Metric::CiMixin::LongTermAverages
       vpor.update_attributes(:values => averages)
     end
 
-    vpor.values_to_metrics["#{col}_#{typ}_over_time_period"]
+    vpor.send(vpor_col)
   end
 end

--- a/app/models/vim_performance_operating_range.rb
+++ b/app/models/vim_performance_operating_range.rb
@@ -5,6 +5,7 @@ class VimPerformanceOperatingRange < ApplicationRecord
   serialize   :values
 
   DEFAULT_STD_DEV_MULT = 1
+  SUB_YAML_REGEX_PARTIAL=("[^\\n]*\\n" * 5).freeze
 
   def values_to_metrics(options = {})
     options[:std_dev_mult] ||= DEFAULT_STD_DEV_MULT
@@ -24,4 +25,60 @@ class VimPerformanceOperatingRange < ApplicationRecord
 
     metrics
   end
+
+  def self.virtual_attribute_avg_for_col(col)
+    lambda { |t| avg_value_arel(col) }
+  end
+
+  def self.virtual_attribute_low_for_col(col)
+    lambda do |t|
+      zero      = Arel::Nodes::SqlLiteral.new('0')
+      low_value = Arel::Nodes::Subtraction.new avg_value_arel(col), dev_value_arel(col)
+      t.grouping(Arel::Nodes::NamedFunction.new("GREATEST", [ low_value, zero ]))
+    end
+  end
+
+  def self.virtual_attribute_high_for_col(col)
+    lambda do |t|
+      t.grouping(Arel::Nodes::Addition.new avg_value_arel(col), dev_value_arel(col))
+    end
+  end
+
+  Metric::LongTermAverages::AVG_METHODS_INFO.each do |meth, info|
+    virtual_attribute meth, :float,
+      :arel => send("virtual_attribute_#{info[:type]}_for_col", info[:column])
+
+    define_method(meth) do
+      if has_attribute?(meth.to_s)
+        self[meth.to_s]
+      elsif has_attribute?("values")
+        values_to_metrics[meth]
+      else
+        0
+      end
+    end
+  end
+
+  def self.avg_value_arel(col)
+    sub_yaml_col_select("avg", col)
+  end
+
+  def self.dev_value_arel(col)
+    sub_yaml_col_select("dev", col)
+  end
+
+  def self.sub_yaml_col_select(section, col)
+    avg_yaml_match = Arel::Nodes::SqlLiteral.new(%Q{#{arel_table_col_as_string(:values)} from '#{section}:#{SUB_YAML_REGEX_PARTIAL}'})
+    inner_substring = Arel::Nodes::NamedFunction.new("substring", [avg_yaml_match])
+
+    number_match    = Arel::Nodes::SqlLiteral.new("#{inner_substring.to_sql} from '#{col}: ([0-9\.]+)'")
+    outer_substring = Arel::Nodes::NamedFunction.new("substring", [number_match])
+    Arel::Nodes::NamedFunction.new("CAST", [outer_substring.as("double precision")])
+  end
+
+  def self.arel_table_col_as_string(col)
+    visitor = Arel::Visitors::ToSql.new(connection)
+    visitor.accept(arel_table[col], Arel::Collectors::SQLString.new).value
+  end
+  private_class_method :arel_table_col_as_string
 end


### PR DESCRIPTION
Prevent yaml serialization when averages_over_time_period calls to `VimPerformanceOperatingRange`s.


Metrics
-------
For a report that was scoped to around 1.1k VMs, the following is a before and after:


**Before:**

|         |      ms | queries | query (ms) |    rows |
|   ---: |    ---: |    ---: |       ---: |    ---: |
| before |   36,678 |   19,972 |      20,642 |   86,584 |
|  after |   30,595 |   15,252 |      16,145 |   84,726 |
|        | 17% | N/A | N/A | N/A |



Rows returned:

```
- Before                                        - After

:rows_by_class:                                 :rows_by_class:                        
  MiqQueue: 2                                     MiqQueue: 2
  MiqTask: 2                                      MiqTask: 2
  User: 8                                         User: 8
  MiqGroup: 4                                     MiqGroup: 4
  Entitlement: 4                                  Entitlement: 4
  Tenant: 2                                       Tenant: 2
  MiqUserRole: 2                                  MiqUserRole: 2
  Vm: 18984                                       Vm: 18984
  Hardware: 2290                                  Hardware: 2290
  VimPerformanceOperatingRange: 11088             VimPerformanceOperatingRange: 11088
  Disk: 9056                                      Disk: 9056
  TimeProfile: 64                                 TimeProfile: 64
  MetricRollup: 12930                             MetricRollup: 11072
  Classification: 32144                           Classification: 32144
  MiqReportResult: 4                              MiqReportResult: 4
  BinaryBlob: 0                                   BinaryBlob: 0
:total_queries: 19972                           :total_queries: 15252
:total_rows: 86584                              :total_rows: 84726
```

_NOTE:  There always seems to be a variation in the number of reports returned when running/profiling a report, but basically, there should be almost no difference before and after on the queries returned, and the performance is gained by not having to serialized yaml on existing `VimPerformanceOperatingRange` records that don't need to be updated._

Description
-----------
Okay Mr. or Mrs. Reviewer, take a deep breath.  Don't panic... it's going to be okay...

So one of the biggest pain points when building reports that use the metric associated tables is deserializing yaml, so avoiding that increases performance significantly.  Unfortunately doing that is not so easy, and some... special... yaml "parsing" SQL queries are used in this PR to fetch the data without needing to use `VimPerformanceOperatingRange#values_to_metrics`.

To start off, the `values` column usually is formatted like this:


```yaml
 ---
:avg:
  :cpu_usagemhz_rate_average: 111.11
  :derived_memory_used: 222.22
  :max_cpu_usage_rate_average: 333.33
  :max_mem_usage_absolute_average: 444.44
:dev:
  :cpu_usagemhz_rate_average: 111.11
  :derived_memory_used: 222.22
  :max_cpu_usage_rate_average: 333.33
  :max_mem_usage_absolute_average: 444.44
```

The many data values derived from the `values` column (using `VimPerformanceOperatingRange#values_to_metrics`) require taking both the value from the `avg` (average) and the `dev` (standard deviation) sections of the yaml and doing some light calculations to return the needed values.

I have done this in `SQL` by parsing out the necessary values from the text blob and doing the math in the query itself.  An example query for the `max_mem_usage_absolute_average_low_over_time_period` value would look something like this:


```SQL
SELECT  "vim_performance_operating_ranges"."id",
        "vim_performance_operating_ranges"."updated_at",
        (
          GREATEST(
            CAST(
              substring(
                substring("vim_performance_operating_ranges"."values" from 'avg:[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n')
                from 'max_mem_usage_absolute_average: ([0-9.]+)'
              )
            AS double precision) -
            CAST(
              substring(
                substring("vim_performance_operating_ranges"."values" from 'dev:[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n')
                from 'max_mem_usage_absolute_average: ([0-9.]+)'
              )
            AS double precision),
          0)
        ) AS max_mem_usage_absolute_average_low_over_time_period
FROM "vim_performance_operating_ranges"
```

To break this down, this is basically doing the following:

* For both the `avg` and `dev` sections of the yaml blob, we are finding the `max_cpu_usage_rate_average` for each of those sections using two `substring()`
  1. The inner `substring()` isolates either the `avg` or the `dev` section of the blob
  2. The outer `substring()` grabs the specific data value for the `max_cpu_usage_rate_average` in that blob (the value of the capture group in the regexp in the substring is actually all that is returned)
* The values from the `avg` are then subtracted by the values from the `dev` section after they are casted as `double precision` (floats).
* For the `low` type data values, the `GREATEST` function is used to prevent negative numbers, so a 0 is returned in that case.
* The column is returned as a column aliased named after the expected value (the `AS` part).


The `virtual_attribute` then has a corresponding ruby method that will then check to see if the data returned from the DB includes this column, otherwise it falls back to trying to fetch it via the `values_to_metrics` method.



Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1395743#c13
* https://github.com/ManageIQ/manageiq/pull/12737
* https://github.com/ManageIQ/manageiq/blob/2d3e2f7a/app/models/metric/ci_mixin/long_term_averages.rb#L15-L30