### PR TITLE
Another small step to clean-up ApplicationController::Filter [4/19]

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -672,7 +672,7 @@ module ApplicationController::Filter
 
   # Set advanced search filter text
   def adv_search_set_text
-    if @edit[@expkey][:exp_idx] == 0                          # Are we pointing at the first exp
+    if @edit[@expkey].history.idx == 0                          # Are we pointing at the first exp
       if @edit[:adv_search_name]
         @edit[:adv_search_applied][:text] = _(" - Filtered by \"%{text}\"") % {:text => @edit[:adv_search_name]}
       else
@@ -1040,14 +1040,14 @@ module ApplicationController::Filter
     end
   end
 
-  # Method to maintain the expression undo array in @edit[@expkey][:exp_array]
+  # Method to maintain the expression undo array in @edit[@expkey].history.array
   def exp_array(func, exp = nil)
-    @edit[@expkey][:exp_array] ||= []
-    exp_ary = @edit[@expkey][:exp_array]          # Put exp array in local var
-    exp_idx = @edit[@expkey][:exp_idx]            # Put exp index in local var
+    @edit[@expkey].history.array ||= []
+    exp_ary = @edit[@expkey].history.array        # Put exp array in local var
+    exp_idx = @edit[@expkey].history.idx          # Put exp index in local var
     case func
     when :init
-      exp_ary = @edit[@expkey][:exp_array] = []      # Clear/create the exp array
+      exp_ary = @edit[@expkey].history.array = [] # Clear/create the exp array
       exp_idx = 0                                 # Initialize the exp index
       exp_ary.push(copy_hash(exp))                # Push the exp onto the array
     when :push
@@ -1056,16 +1056,16 @@ module ApplicationController::Filter
       exp_ary.push(copy_hash(exp))                    # Push the new exp onto the array
     when :undo
       if exp_idx > 0                              # If not on first element
-        @edit[@expkey][:exp_idx] -= 1                     # Decrement exp index
+        @edit[@expkey].history.idx -= 1           # Decrement exp index
         return copy_hash(exp_ary[exp_idx - 1])    # Return the prior exp
       end
     when :redo
       if exp_idx < exp_ary.length - 1             # If not on last element
-        @edit[@expkey][:exp_idx] += 1                     # Increment exp index
+        @edit[@expkey].history.idx += 1           # Increment exp index
         return copy_hash(exp_ary[exp_idx + 1])    # Return the next exp
       end
     end
-    @edit[@expkey][:exp_idx] = exp_idx                      # Save local index back to @edit object
+    @edit[@expkey].history.idx = exp_idx          # Save local index back to @edit object
     nil                                    # Return nil if no exp was returned
   end
 
@@ -1088,7 +1088,7 @@ module ApplicationController::Filter
       @edit = {}
       @edit[@expkey] ||= Expression.new
       @edit[@expkey][:expression] = []                           # Store exps in an array
-      @edit[@expkey][:exp_idx] = 0                                      # Start at first exp
+      @edit[@expkey].history.idx = 0                                    # Start at first exp
       @edit[@expkey][:expression] = {"???" => "???"}                      # Set as new exp element
       @edit[@expkey][:use_mytags] = true                                # Include mytags in tag search atoms
       @edit[:custom_search] = false                                     # setting default to false

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -213,7 +213,7 @@ module ApplicationController::Filter
     @edit[:adv_search_applied] = nil
     @edit[@expkey][:expression] = {"???" => "???"}                            # Set as new exp element
     @edit[:new][@expkey] = copy_hash(@edit[@expkey][:expression])             # Copy to new exp
-    exp_array(:init, @edit[@expkey][:expression])                             # Initialize the exp array
+    @edit[@expkey].history.reset(@edit[@expkey][:expression])
     @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Rebuild the expression table
     @edit[@expkey][:selected] = {:id => 0}                                    # Save the last search loaded
     @edit[:adv_search_name] = nil                                             # Clear search name
@@ -237,7 +237,7 @@ module ApplicationController::Filter
     @edit[:new_search_name] = @edit[:adv_search_name] = @edit.fetch_path(@expkey, :selected, :description)
     @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
     @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Build the expression table
-    exp_array(:init, @edit[@expkey][:expression])
+    @edit[@expkey].history.reset(@edit[@expkey][:expression])
     @edit[@expkey][:exp_token] = nil                                        # Clear the current selected token
     @edit[:adv_search_applied] = {}
 
@@ -254,7 +254,7 @@ module ApplicationController::Filter
     @edit[:adv_search_applied] = nil
     @edit[@expkey][:expression] = {"???" => "???"}                              # Set as new exp element
     @edit[:new][@expkey] = @edit[@expkey][:expression]                        # Copy to new exp
-    exp_array(:init, @edit[@expkey][:expression])                             # Initialize the exp array
+    @edit[@expkey].history.reset(@edit[@expkey][:expression])
     @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression]) # Rebuild the expression table
     # @edit[@expkey][:exp_last_loaded] = nil                                   # Clear the last search loaded
     @edit[:adv_search_name] = nil                                             # Clear search name
@@ -277,7 +277,7 @@ module ApplicationController::Filter
       @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:selected].nil? ? nil : @edit[@expkey][:selected][:description]
       @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])       # Build the expression table
-      exp_array(:init, @edit[@expkey][:expression])
+      @edit[@expkey].history.reset(@edit[@expkey][:expression])
       @edit[@expkey][:exp_token] = nil                                        # Clear the current selected token
       @edit[:adv_search_applied] = {}
       adv_search_set_text # Set search text filter suffix
@@ -313,7 +313,7 @@ module ApplicationController::Filter
           @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
           # Build the expression table
           @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])
-          exp_array(:init, @edit[@expkey][:expression])
+          @efit[@expkey].history.reset(@edit[@expkey][:expression])
           # Clear the current selected token
           @edit[@expkey][:exp_token] = nil
         else
@@ -340,7 +340,7 @@ module ApplicationController::Filter
       @edit[:new_search_name] = @edit[:adv_search_name] = @edit[@expkey][:exp_last_loaded].nil? ? nil : @edit[@expkey][:exp_last_loaded][:description]
       @edit[@expkey][:expression] = copy_hash(@edit[:new][@expkey])
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])       # Build the expression table
-      exp_array(:init, @edit[@expkey][:expression])
+      @edit[@expkey].history.reset(@edit[@expkey][:expression])
       @edit[@expkey][:exp_token] = nil                                        # Clear the current selected token
       add_flash(_("%{model} search \"%{name}\" was successfully loaded") %
         {:model => ui_lookup(:model => @edit[@expkey][:exp_model]), :name => @edit[:new_search_name]})
@@ -413,7 +413,7 @@ module ApplicationController::Filter
     if ["delete", "reset"].include?(params[:button])
       @edit[@expkey][:expression] = {"???" => "???"}              # Set as new exp element
       @edit[:new][@expkey] = @edit[@expkey][:expression]        # Copy to new exp
-      exp_array(:init, @edit[@expkey][:expression])             # Initialize the exp array
+      @edit[@expkey].history.reset(@edit[@expkey][:expression])
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])       # Rebuild the expression table
       @edit[@expkey][:exp_last_loaded] = nil                    # Clear the last search loaded
       @edit[:adv_search_name] = nil                             # Clear search name
@@ -1046,10 +1046,6 @@ module ApplicationController::Filter
     exp_ary = @edit[@expkey].history.array        # Put exp array in local var
     exp_idx = @edit[@expkey].history.idx          # Put exp index in local var
     case func
-    when :init
-      exp_ary = @edit[@expkey].history.array = [] # Clear/create the exp array
-      exp_idx = 0                                 # Initialize the exp index
-      exp_ary.push(copy_hash(exp))                # Push the exp onto the array
     when :push
       exp_idx = exp_ary.blank? ? 0 : exp_idx + 1      # Increment index to next array element
       exp_ary.slice!(exp_idx..-1) if exp_ary[exp_idx] # Remove exp_idx element and above
@@ -1093,7 +1089,7 @@ module ApplicationController::Filter
       @edit[:custom_search] = false                                     # setting default to false
       @edit[:new] = {}
       @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp
-      exp_array(:init, @edit[@expkey][:expression])                     # Initialize the exp array
+      @edit[@expkey].history.reset(@edit[@expkey][:expression])
       @edit[:adv_search_open] = false
       @edit[@expkey][:exp_model] = model.to_s
     end

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1088,7 +1088,6 @@ module ApplicationController::Filter
       @edit = {}
       @edit[@expkey] ||= Expression.new
       @edit[@expkey][:expression] = []                           # Store exps in an array
-      @edit[@expkey].history.idx = 0                                    # Start at first exp
       @edit[@expkey][:expression] = {"???" => "???"}                      # Set as new exp element
       @edit[@expkey][:use_mytags] = true                                # Include mytags in tag search atoms
       @edit[:custom_search] = false                                     # setting default to false

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -9,7 +9,7 @@ module ApplicationController::Filter
     @edit = session[:edit]
     case params[:pressed]
     when "undo", "redo"
-      @edit[@expkey][:expression] = exp_array(params[:pressed].to_sym)
+      @edit[@expkey][:expression] = @edit[@expkey].history.rewind(params[:pressed])
       @edit[:new][@expkey] = copy_hash(@edit[@expkey][:expression])
     when "not"
       exp_add_not(@edit[@expkey][:expression], @edit[@expkey][:exp_token])
@@ -1038,27 +1038,6 @@ module ApplicationController::Filter
       exp.delete(deletekey)                             # Remove the AND or OR hash
       return false                                      # Done removing item, return
     end
-  end
-
-  # Method to maintain the expression undo array in @edit[@expkey].history.array
-  def exp_array(func, exp = nil)
-    @edit[@expkey].history.array ||= []
-    exp_ary = @edit[@expkey].history.array        # Put exp array in local var
-    exp_idx = @edit[@expkey].history.idx          # Put exp index in local var
-    case func
-    when :undo
-      if exp_idx > 0                              # If not on first element
-        @edit[@expkey].history.idx -= 1           # Decrement exp index
-        return copy_hash(exp_ary[exp_idx - 1])    # Return the prior exp
-      end
-    when :redo
-      if exp_idx < exp_ary.length - 1             # If not on last element
-        @edit[@expkey].history.idx += 1           # Increment exp index
-        return copy_hash(exp_ary[exp_idx + 1])    # Return the next exp
-      end
-    end
-    @edit[@expkey].history.idx = exp_idx          # Save local index back to @edit object
-    nil                                    # Return nil if no exp was returned
   end
 
   # Build advanced search expression

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -53,7 +53,7 @@ module ApplicationController::Filter
         copy = copy_hash(@edit[@expkey][:expression])
         copy.deep_delete :token
         @edit[:new][@expkey] = copy
-        exp_array(:push, @edit[:new][@expkey])
+        @edit[@expkey].history.push(@edit[:new][@expkey])
       end
       unless ["and", "or"].include?(params[:pressed]) # Unless adding an AND or OR token
         @edit[@expkey][:exp_token] = nil                        #   clear the current selected token
@@ -1046,10 +1046,6 @@ module ApplicationController::Filter
     exp_ary = @edit[@expkey].history.array        # Put exp array in local var
     exp_idx = @edit[@expkey].history.idx          # Put exp index in local var
     case func
-    when :push
-      exp_idx = exp_ary.blank? ? 0 : exp_idx + 1      # Increment index to next array element
-      exp_ary.slice!(exp_idx..-1) if exp_ary[exp_idx] # Remove exp_idx element and above
-      exp_ary.push(copy_hash(exp))                    # Push the new exp onto the array
     when :undo
       if exp_idx > 0                              # If not on first element
         @edit[@expkey].history.idx -= 1           # Decrement exp index

--- a/app/controllers/application_controller/filter/expression.rb
+++ b/app/controllers/application_controller/filter/expression.rb
@@ -2,7 +2,6 @@ module ApplicationController::Filter
   Expression = Struct.new(
     :alias,
     :expression,
-    :exp_array,
     :exp_available_tags,
     :exp_available_fields,
     :exp_cfield,
@@ -13,7 +12,6 @@ module ApplicationController::Filter
     :exp_cvalue,
     :exp_count,
     :exp_field,
-    :exp_idx,
     :exp_key,
     :exp_last_loaded,
     :exp_mode,
@@ -28,6 +26,7 @@ module ApplicationController::Filter
     :exp_token,
     :exp_typ,
     :exp_value,
+    :history,
     :pre_qs_selected,
     :use_mytags,
     :selected,
@@ -37,6 +36,11 @@ module ApplicationController::Filter
     :val2_suffix,
     :record_filter
   ) do
+    def initialize(*args)
+      super
+      self.history ||= ExpressionEditHistory.new
+    end
+
     def exp_available_cfields # fields on exp_model for check_all, check_any, and check_count operation
       MiqExpression.miq_adv_search_lists(exp_model, :exp_available_finds).each_with_object([]) do |af, res|
         next if af.last == exp_field

--- a/app/controllers/application_controller/filter/expression_edit_history.rb
+++ b/app/controllers/application_controller/filter/expression_edit_history.rb
@@ -7,5 +7,10 @@ module ApplicationController::Filter
       super
       self.idx ||= 0
     end
+
+    def reset(value)
+      self.array = [copy_hash(value)]
+      self.idx = 0
+    end
   end
 end

--- a/app/controllers/application_controller/filter/expression_edit_history.rb
+++ b/app/controllers/application_controller/filter/expression_edit_history.rb
@@ -12,5 +12,11 @@ module ApplicationController::Filter
       self.array = [copy_hash(value)]
       self.idx = 0
     end
+
+    def push(value)
+      self.idx += 1
+      array.slice!(idx..-1) if array[idx]
+      array.push(copy_hash(value))
+    end
   end
 end

--- a/app/controllers/application_controller/filter/expression_edit_history.rb
+++ b/app/controllers/application_controller/filter/expression_edit_history.rb
@@ -3,5 +3,9 @@ module ApplicationController::Filter
     :array,
     :idx
   ) do
+    def initialize(*args)
+      super
+      self.idx ||= 0
+    end
   end
 end

--- a/app/controllers/application_controller/filter/expression_edit_history.rb
+++ b/app/controllers/application_controller/filter/expression_edit_history.rb
@@ -18,5 +18,20 @@ module ApplicationController::Filter
       array.slice!(idx..-1) if array[idx]
       array.push(copy_hash(value))
     end
+
+    def rewind(direction)
+      case direction
+      when 'undo'
+        if idx > 0
+          self.idx -= 1
+          return copy_hash(array[idx])
+        end
+      when 'redo'
+        if idx < array.length - 1
+          self.idx += 1
+          return copy_hash(array[idx])
+        end
+      end
+    end
   end
 end

--- a/app/controllers/application_controller/filter/expression_edit_history.rb
+++ b/app/controllers/application_controller/filter/expression_edit_history.rb
@@ -1,0 +1,7 @@
+module ApplicationController::Filter
+  ExpressionEditHistory = Struct.new(
+    :array,
+    :idx
+  ) do
+  end
+end

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1063,7 +1063,7 @@ class MiqPolicyController < ApplicationController
     # Populate exp editor fields for the expression column
     @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
-    @edit[:expression][:exp_idx] = 0                                    # Start at first exp
+    @edit[:expression].history.idx = 0                                  # Start at first exp
     if @edit[:new][:expression].blank?
       @edit[:expression][:expression] = {"???" => "???"}                  # Set as new exp element
       @edit[:new][:expression] = copy_hash(@edit[:expression][:expression])   # Copy to new exp

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1063,7 +1063,6 @@ class MiqPolicyController < ApplicationController
     # Populate exp editor fields for the expression column
     @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
-    @edit[:expression].history.idx = 0                                  # Start at first exp
     if @edit[:new][:expression].blank?
       @edit[:expression][:expression] = {"???" => "???"}                  # Set as new exp element
       @edit[:new][:expression] = copy_hash(@edit[:expression][:expression])   # Copy to new exp

--- a/app/controllers/miq_policy_controller.rb
+++ b/app/controllers/miq_policy_controller.rb
@@ -1072,7 +1072,7 @@ class MiqPolicyController < ApplicationController
     @edit[:expression_table] = @edit[:expression][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:expression][:expression])
 
     @expkey = :expression                                               # Set expression key to expression
-    exp_array(:init, @edit[:expression][:expression])                   # Initialize the exp array
+    @edit[@expkey].history.reset(@edit[:expression][:expression])
     @edit[:expression][:exp_table] = exp_build_table(@edit[:expression][:expression])
     @edit[:expression][:exp_model] = model                              # Set model for the exp editor
   end

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -372,7 +372,6 @@ module MiqPolicyController::Alerts
   def alert_build_blank_exp
     @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
-    @edit[:expression].history.idx = 0                                    # Start at first exp
     @edit[:expression][:expression] = {"???" => "???"}                    # Set as new exp element
     @edit[:new][:expression] = copy_hash(@edit[:expression][:expression]) # Copy to new exp
     @edit[:expression_table] = @edit[:expression][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:expression][:expression])

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -377,7 +377,7 @@ module MiqPolicyController::Alerts
     @edit[:expression_table] = @edit[:expression][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:expression][:expression])
 
     @expkey = :expression                                               # Set expression key to expression
-    exp_array(:init, @edit[:expression][:expression])                   # Initialize the exp array
+    @edit[@expkey].history.reset(@edit[:expression][:expression])
     @edit[:expression][:exp_table] = exp_build_table(@edit[:expression][:expression])
     @edit[:expression][:exp_model] = @edit[:new][:db]                   # Set model for the exp editor
   end

--- a/app/controllers/miq_policy_controller/alerts.rb
+++ b/app/controllers/miq_policy_controller/alerts.rb
@@ -372,7 +372,7 @@ module MiqPolicyController::Alerts
   def alert_build_blank_exp
     @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
-    @edit[:expression][:exp_idx] = 0                                    # Start at first exp
+    @edit[:expression].history.idx = 0                                    # Start at first exp
     @edit[:expression][:expression] = {"???" => "???"}                    # Set as new exp element
     @edit[:new][:expression] = copy_hash(@edit[:expression][:expression]) # Copy to new exp
     @edit[:expression_table] = @edit[:expression][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:expression][:expression])

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -197,7 +197,7 @@ module MiqPolicyController::Conditions
     @edit[:expression][:exp_model] = @edit[:new][:towhat]               # Set model for the exp editor
 
     # Populate exp editor fields for the applies_to_exp column
-    @edit[:applies_to_exp] ||= {}                                   # Create hash for this expression, if needed
+    @edit[:applies_to_exp] ||= ApplicationController::Filter::Expression.new
     @edit[:applies_to_exp][:expression] = []                       # Store exps in an array
     @edit[:applies_to_exp][:exp_idx] = 0                                  # Start at first exp
     if @edit[:new][:applies_to_exp].blank?

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -191,7 +191,7 @@ module MiqPolicyController::Conditions
     @edit[:expression_table] = @edit[:expression][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:expression][:expression])
 
     @expkey = :expression                                               # Set expression key to expression
-    exp_array(:init, @edit[:expression][:expression])                   # Initialize the exp array
+    @edit[@expkey].history.reset(@edit[:expression][:expression])
     @edit[:expression][:exp_table] = exp_build_table(@edit[:expression][:expression])
     @edit[:expression][:exp_model] = @edit[:new][:towhat]               # Set model for the exp editor
 
@@ -207,7 +207,7 @@ module MiqPolicyController::Conditions
     @edit[:scope_table] = @edit[:applies_to_exp][:expression] == {"???" => "???"} ? nil : exp_build_table(@edit[:applies_to_exp][:expression])
 
     @expkey = :applies_to_exp                                             # Set temporarily while building applies_to_exp exp editor vars
-    exp_array(:init, @edit[:applies_to_exp][:expression])                 # Initialize the exp array
+    @edit[@expkey].history.reset(@edit[:applies_to_exp][:expression])
     @edit[:applies_to_exp][:exp_table] = exp_build_table(@edit[:applies_to_exp][:expression])
     @expkey = :expression                                                 # Reset to default to editing the expression column
     @edit[:applies_to_exp][:exp_model] = @edit[:new][:towhat]             # Set model for the exp editor

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -182,7 +182,6 @@ module MiqPolicyController::Conditions
     # Populate exp editor fields for the expression column
     @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
-    @edit[:expression].history.idx = 0                                    # Start at first exp
     if @edit[:new][:expression].blank?
       @edit[:expression][:expression] = {"???" => "???"}                  # Set as new exp element
       @edit[:new][:expression] = copy_hash(@edit[:expression][:expression])   # Copy to new exp
@@ -199,7 +198,6 @@ module MiqPolicyController::Conditions
     # Populate exp editor fields for the applies_to_exp column
     @edit[:applies_to_exp] ||= ApplicationController::Filter::Expression.new
     @edit[:applies_to_exp][:expression] = []                       # Store exps in an array
-    @edit[:applies_to_exp].history.idx = 0                                  # Start at first exp
     if @edit[:new][:applies_to_exp].blank?
       @edit[:applies_to_exp][:expression] = {"???" => "???"}                # Set as new exp element
       @edit[:new][:applies_to_exp] = copy_hash(@edit[:applies_to_exp][:expression]) # Copy to new exp

--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -182,7 +182,7 @@ module MiqPolicyController::Conditions
     # Populate exp editor fields for the expression column
     @edit[:expression] ||= ApplicationController::Filter::Expression.new
     @edit[:expression][:expression] = []                         # Store exps in an array
-    @edit[:expression][:exp_idx] = 0                                    # Start at first exp
+    @edit[:expression].history.idx = 0                                    # Start at first exp
     if @edit[:new][:expression].blank?
       @edit[:expression][:expression] = {"???" => "???"}                  # Set as new exp element
       @edit[:new][:expression] = copy_hash(@edit[:expression][:expression])   # Copy to new exp
@@ -199,7 +199,7 @@ module MiqPolicyController::Conditions
     # Populate exp editor fields for the applies_to_exp column
     @edit[:applies_to_exp] ||= ApplicationController::Filter::Expression.new
     @edit[:applies_to_exp][:expression] = []                       # Store exps in an array
-    @edit[:applies_to_exp][:exp_idx] = 0                                  # Start at first exp
+    @edit[:applies_to_exp].history.idx = 0                                  # Start at first exp
     if @edit[:new][:applies_to_exp].blank?
       @edit[:applies_to_exp][:expression] = {"???" => "???"}                # Set as new exp element
       @edit[:new][:applies_to_exp] = copy_hash(@edit[:applies_to_exp][:expression]) # Copy to new exp

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -194,7 +194,7 @@ module ReportController::Reports::Editor
         @expkey = :record_filter
 
         # Initialize the exp array
-        exp_array(:init, @edit[:record_filter][:expression]) if @edit[:record_filter].history.array.nil?
+        @edit[@expkey].history.reset(@edit[:record_filter][:expression]) if @edit[:record_filter].history.array.nil?
         @edit[:record_filter][:exp_table] = exp_build_table(@edit[:record_filter][:expression])
         @edit[:record_filter].prefill_val_types
         @edit[:record_filter][:exp_model] = @edit[:new][:model] # Set the model for the expression editor
@@ -206,7 +206,7 @@ module ReportController::Reports::Editor
       @expkey = :display_filter
 
       # Initialize the exp array
-      exp_array(:init, @edit[:display_filter][:expression]) if @edit[:display_filter].history.array.nil?
+      @edit[@expkey].history.reset(@edit[:display_filter][:expression]) if @edit[:display_filter].history.array.nil?
 
       @edit[:display_filter][:exp_table] = exp_build_table(@edit[:display_filter][:expression])
 

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -188,7 +188,7 @@ module ReportController::Reports::Editor
       if @edit[:miq_exp] || # Is this stored as an MiqExp object
          ["new", "copy", "create"].include?(request.parameters["action"])        # or it's a new condition
 
-        @edit[:record_filter][:exp_idx] ||= 0 # Start at first exp
+        @edit[:record_filter].history.idx ||= 0 # Start at first exp
 
         new_record_filter = @edit[:new][:record_filter]
         @edit[:record_filter][:expression] = copy_hash(new_record_filter) unless new_record_filter.blank?
@@ -196,14 +196,14 @@ module ReportController::Reports::Editor
         @expkey = :record_filter
 
         # Initialize the exp array
-        exp_array(:init, @edit[:record_filter][:expression]) if @edit[:record_filter][:exp_array].nil?
+        exp_array(:init, @edit[:record_filter][:expression]) if @edit[:record_filter].history.array.nil?
         @edit[:record_filter][:exp_table] = exp_build_table(@edit[:record_filter][:expression])
         @edit[:record_filter].prefill_val_types
         @edit[:record_filter][:exp_model] = @edit[:new][:model] # Set the model for the expression editor
       end
 
       # Build display filter expression
-      @edit[:display_filter][:exp_idx] ||= 0 # Start at first exp
+      @edit[:display_filter].history.idx ||= 0 # Start at first exp
 
       new_display_filter = @edit[:new][:display_filter]
       @edit[:display_filter][:expression] = copy_hash(new_display_filter) unless new_display_filter.blank?
@@ -211,7 +211,7 @@ module ReportController::Reports::Editor
       @expkey = :display_filter
 
       # Initialize the exp array
-      exp_array(:init, @edit[:display_filter][:expression]) if @edit[:display_filter][:exp_array].nil?
+      exp_array(:init, @edit[:display_filter][:expression]) if @edit[:display_filter].history.array.nil?
 
       @edit[:display_filter][:exp_table] = exp_build_table(@edit[:display_filter][:expression])
 
@@ -1310,7 +1310,7 @@ module ReportController::Reports::Editor
     expkey = :record_filter
     @edit[expkey] ||= ApplicationController::Filter::Expression.new
     @edit[expkey][:record_filter] = []                               # Store exps in an array
-    @edit[expkey][:exp_idx] ||= 0
+    @edit[expkey].history.idx ||= 0
     @edit[expkey][:expression] = {"???" => "???"}                           # Set as new exp element
     # Get the conditions MiqExpression
     if @rpt.conditions.kind_of?(MiqExpression)
@@ -1327,7 +1327,7 @@ module ReportController::Reports::Editor
     expkey = :display_filter
     @edit[expkey] ||= ApplicationController::Filter::Expression.new
     @edit[expkey][:expression] = []                                    # Store exps in an array
-    @edit[expkey][:exp_idx] ||= 0                                           # Start at first exp
+    @edit[expkey].history.idx ||= 0                                           # Start at first exp
     @edit[expkey][:expression] = {"???" => "???"}                           # Set as new exp element
     # Build display filter expression
     @edit[:new][:display_filter] = @edit[expkey][:expression] if @edit[:new][:display_filter].nil?              # Copy to new exp

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -188,8 +188,6 @@ module ReportController::Reports::Editor
       if @edit[:miq_exp] || # Is this stored as an MiqExp object
          ["new", "copy", "create"].include?(request.parameters["action"])        # or it's a new condition
 
-        @edit[:record_filter].history.idx ||= 0 # Start at first exp
-
         new_record_filter = @edit[:new][:record_filter]
         @edit[:record_filter][:expression] = copy_hash(new_record_filter) unless new_record_filter.blank?
 
@@ -201,9 +199,6 @@ module ReportController::Reports::Editor
         @edit[:record_filter].prefill_val_types
         @edit[:record_filter][:exp_model] = @edit[:new][:model] # Set the model for the expression editor
       end
-
-      # Build display filter expression
-      @edit[:display_filter].history.idx ||= 0 # Start at first exp
 
       new_display_filter = @edit[:new][:display_filter]
       @edit[:display_filter][:expression] = copy_hash(new_display_filter) unless new_display_filter.blank?
@@ -1310,7 +1305,6 @@ module ReportController::Reports::Editor
     expkey = :record_filter
     @edit[expkey] ||= ApplicationController::Filter::Expression.new
     @edit[expkey][:record_filter] = []                               # Store exps in an array
-    @edit[expkey].history.idx ||= 0
     @edit[expkey][:expression] = {"???" => "???"}                           # Set as new exp element
     # Get the conditions MiqExpression
     if @rpt.conditions.kind_of?(MiqExpression)
@@ -1327,7 +1321,6 @@ module ReportController::Reports::Editor
     expkey = :display_filter
     @edit[expkey] ||= ApplicationController::Filter::Expression.new
     @edit[expkey][:expression] = []                                    # Store exps in an array
-    @edit[expkey].history.idx ||= 0                                           # Start at first exp
     @edit[expkey][:expression] = {"???" => "???"}                           # Set as new exp element
     # Build display filter expression
     @edit[:new][:display_filter] = @edit[expkey][:expression] if @edit[:new][:display_filter].nil?              # Copy to new exp

--- a/app/views/layouts/_exp_editor.html.haml
+++ b/app/views/layouts/_exp_editor.html.haml
@@ -9,7 +9,7 @@
 #exp_editor_div
   %fieldset{:style => "width: auto; padding-left: 6px; padding-top: 6px"}
     %ul.searchtoolbar
-      - if @edit[@expkey][:exp_idx] > 0
+      - if @edit[@expkey].history.idx > 0
         %li
           = link_to(image_tag(image_path('toolbars/undo.png'),
                               :alt => _('Undo the last change')),
@@ -24,7 +24,7 @@
         %li.dimmed
           = image_tag(image_path('toolbars/undo.png'))
 
-      - if @edit[@expkey][:exp_idx] < @edit[@expkey][:exp_array].length - 1
+      - if @edit[@expkey].history.idx < @edit[@expkey].history.array.length - 1
         %li
           = link_to(image_tag(image_path('toolbars/redo.png'),
                               :alt => _('Re-apply the previous change')),


### PR DESCRIPTION
Follow-up on #11641, #12849, #12867. --- This time we get a rid of `exp_array()`.

ApplicationController::Filter is very complex.

One of the reasons is that Filter operates on nested hash that represents Expression and context of editing this expression. We start by encapsulating this object and its logic into one place, than we can divide what represents the actual expression and what represents merely the state of the expression edit.

@miq-bot add_label technical debt, ui
@miq-bot assign @mzazrivec